### PR TITLE
fix: restore /api/mcp endpoint to fix agent connection outage

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,0 +1,92 @@
+/**
+ * UnClick MCP Endpoint — Vercel serverless function
+ *
+ * Serves the UnClick MCP server over Streamable HTTP (JSON-RPC + SSE).
+ * Agents connect here to discover and call all UnClick tools.
+ *
+ * Usage:
+ *   POST https://unclick.world/api/mcp
+ *   Authorization: Bearer <unclick_api_key>
+ *   Content-Type: application/json
+ *   Body: MCP JSON-RPC message (initialize, tools/list, tools/call, etc.)
+ *
+ * The endpoint is stateless — each request spins up a fresh MCP server
+ * instance, which is safe for serverless and works with all MCP clients.
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createServer } from "../packages/mcp-server/src/server.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // ── CORS — allow any origin so AI agents can connect from anywhere ──────────
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization, mcp-session-id"
+  );
+  res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
+
+  if (req.method === "OPTIONS") {
+    return res.status(204).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({
+      jsonrpc: "2.0",
+      error: {
+        code: -32601,
+        message: "Method Not Allowed. POST to this endpoint with an MCP JSON-RPC message.",
+      },
+      id: null,
+    });
+  }
+
+  // ── Auth — extract API key from Authorization header ───────────────────────
+  const authHeader = (req.headers.authorization as string) ?? "";
+  const apiKey = authHeader.replace(/^Bearer\s+/i, "").trim();
+
+  if (!apiKey) {
+    return res.status(401).json({
+      jsonrpc: "2.0",
+      error: {
+        code: -32600,
+        message:
+          "Missing API key. Set Authorization: Bearer <your_unclick_api_key>. " +
+          "Get a key at https://unclick.world",
+      },
+      id: null,
+    });
+  }
+
+  // Inject the per-request API key so createClient() picks it up.
+  // Vercel invocations are isolated processes, so this is safe.
+  process.env.UNCLICK_API_KEY = apiKey;
+
+  // ── MCP over Streamable HTTP (stateless per-request) ───────────────────────
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless mode — no sessions in serverless
+  });
+
+  const server = createServer();
+
+  try {
+    await server.connect(transport);
+    // Vercel parses the body automatically; pass it through to avoid re-parsing
+    await transport.handleRequest(req, res, req.body);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[/api/mcp] Unhandled error:", message);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      });
+    }
+  } finally {
+    // Clean up after the response is sent
+    server.close().catch(() => {});
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12477,7 +12477,7 @@
     },
     "packages/mcp-server": {
       "name": "@unclick/mcp-server",
-      "version": "0.1.1",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:api": "npm run test --workspace=apps/api"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",


### PR DESCRIPTION
## Summary

- Creates the missing `api/mcp.ts` Vercel serverless function
- Without it, every MCP agent connection hit the catch-all rewrite and got HTML back (75% error rate)
- Adds `@modelcontextprotocol/sdk` to root `package.json` so Vercel installs it at build time

## What the endpoint does

- Accepts MCP JSON-RPC requests via POST at `/api/mcp`
- Uses `StreamableHTTPServerTransport` in **stateless mode** (safe for serverless — no sessions)
- Reads `Authorization: Bearer <api_key>` and injects it for the `createClient()` call
- Imports `createServer()` from `packages/mcp-server/src/server.ts` (esbuild resolves `.js` → `.ts`)
- Wide-open CORS so any MCP agent can connect

## Test plan

- [ ] `POST /api/mcp` with `Authorization: Bearer <key>` and `{"jsonrpc":"2.0","method":"initialize",...}` returns MCP capabilities JSON (not HTML)
- [ ] `POST /api/mcp` without Authorization returns 401 with JSON error
- [ ] MCP client (`npx @modelcontextprotocol/inspector`) can connect to the hosted endpoint and list tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)