### PR TITLE
Phase 2: Auth foundation (magic link + OAuth + route protection)

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,5 +1,5 @@
 /**
- * UnClick MCP Endpoint — Vercel serverless function
+ * UnClick MCP Endpoint - Vercel serverless function
  *
  * Serves the UnClick MCP server over Streamable HTTP (JSON-RPC + SSE).
  * Agents connect here to discover and call all UnClick tools.
@@ -7,14 +7,19 @@
  * Usage:
  *   POST https://unclick.world/api/mcp
  *   Content-Type: application/json
- *   Auth (either form):
- *     - Authorization: Bearer <unclick_api_key>         (preferred)
+ *   Auth (any of):
+ *     - Authorization: Bearer <unclick_api_key>         (agents, preferred)
  *     - ?key=<unclick_api_key> query param              (for clients whose
  *       "Add custom connector" dialog accepts a URL only, e.g. Claude.ai
  *       and ChatGPT's Connectors UI)
+ *     - Cookie with a Supabase Auth session (for calls initiated
+ *       from an authenticated browser session on unclick.world).
+ *       The session user_id is resolved to an api_keys row via
+ *       api_keys.user_id FK; that row's key_hash becomes the tenancy
+ *       context, so memory routing is identical to the api_key path.
  *   Body: MCP JSON-RPC message (initialize, tools/list, tools/call, etc.)
  *
- * The endpoint is stateless — each request spins up a fresh MCP server
+ * The endpoint is stateless - each request spins up a fresh MCP server
  * instance, which is safe for serverless and works with all MCP clients.
  */
 
@@ -34,6 +39,14 @@ interface ApiKeyContext {
   user_id: string | null;
 }
 
+function getSupabaseEnv(): { url: string; key: string } | null {
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+  return { url, key };
+}
+
 /**
  * Look up an inbound api_key in the api_keys table. Returns the tenancy
  * context if the key is active, or null otherwise. The Supabase service-role
@@ -41,12 +54,10 @@ interface ApiKeyContext {
  * unconfigured (local tests, preview deploys without secrets).
  */
 async function validateApiKey(apiKey: string): Promise<ApiKeyContext | null> {
-  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
-  const supabaseKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
-  if (!supabaseUrl || !supabaseKey) return null;
+  const env = getSupabaseEnv();
+  if (!env) return null;
 
-  const supabase = createClient(supabaseUrl, supabaseKey, {
+  const supabase = createClient(env.url, env.key, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
@@ -71,6 +82,106 @@ async function validateApiKey(apiKey: string): Promise<ApiKeyContext | null> {
     tier: data.tier ?? "free",
     user_id: data.user_id ?? null,
   };
+}
+
+/**
+ * Read the Supabase auth session cookie off the request, verify it
+ * with supabase.auth.getUser(), then resolve to an api_keys tenancy
+ * context via the user_id FK added in Phase 2. Returns null if:
+ *   - the cookie isn't present
+ *   - the session is invalid/expired
+ *   - the authenticated user has no api_keys row (edge case: user
+ *     signed up via Supabase Auth without ever being issued a key)
+ *
+ * Returning null lets the handler fall through to the api_key path.
+ * We never mix the two - session-cookie auth produces a distinct
+ * ApiKeyContext where api_key_hash is still the tenancy key, but
+ * derived from the user's api_keys row rather than an inbound
+ * Authorization: Bearer header.
+ */
+async function validateSessionCookie(
+  req: VercelRequest,
+): Promise<ApiKeyContext | null> {
+  const env = getSupabaseEnv();
+  if (!env) return null;
+
+  // Supabase stores the session in a cookie named sb-<project-ref>-auth-token
+  // (or in the legacy "supabase-auth-token" slot). The value is a
+  // url-encoded JSON array whose first entry is the access token. We
+  // don't try to parse every shape here - we let supabase.auth.getUser
+  // do the verification work, and just sniff the raw access token.
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) return null;
+
+  const accessToken = extractSupabaseAccessToken(cookieHeader);
+  if (!accessToken) return null;
+
+  const supabase = createClient(env.url, env.key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser(accessToken);
+  if (userErr || !userData?.user) return null;
+  const userId = userData.user.id;
+
+  // Find an active api_keys row linked to this user. Phase 2 backfills
+  // user_id where the old-shape api_keys.email matches an auth.users
+  // row; the claim flow fills in the rest over time. Take the most
+  // recently used key if the user has more than one.
+  const { data: keyRow, error: keyErr } = await supabase
+    .from("api_keys")
+    .select("key_hash, tier, is_active, last_used_at")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .order("last_used_at", { ascending: false, nullsFirst: false })
+    .limit(1)
+    .maybeSingle();
+  if (keyErr || !keyRow) return null;
+
+  supabase
+    .from("api_keys")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("key_hash", keyRow.key_hash)
+    .then(() => {});
+
+  return {
+    api_key_hash: keyRow.key_hash,
+    tier: keyRow.tier ?? "free",
+    user_id: userId,
+  };
+}
+
+/**
+ * Best-effort extraction of a Supabase access token out of the raw
+ * cookie header. Supabase Auth names its cookie sb-<project>-auth-token
+ * and stores a JSON-encoded array whose first element is the JWT.
+ * If parsing fails we just return null and fall through.
+ */
+function extractSupabaseAccessToken(cookieHeader: string): string | null {
+  const parts = cookieHeader.split(/;\s*/);
+  for (const part of parts) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (!/^sb-.*-auth-token$/.test(name) && name !== "supabase-auth-token") {
+      continue;
+    }
+    const raw = decodeURIComponent(part.slice(eq + 1));
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed) && typeof parsed[0] === "string") {
+        return parsed[0];
+      }
+      if (parsed && typeof parsed === "object" && typeof (parsed as { access_token?: unknown }).access_token === "string") {
+        return (parsed as { access_token: string }).access_token;
+      }
+    } catch {
+      // Some clients may just drop the raw JWT in. Treat the whole
+      // value as the token if it looks like a JWT.
+      if (/^[\w-]+\.[\w-]+\.[\w-]+$/.test(raw)) return raw;
+    }
+  }
+  return null;
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -98,10 +209,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
   }
 
-  // ── Auth — accept Bearer header OR ?key= query param ──────────────────────
-  // Some MCP clients (Claude.ai Connectors, ChatGPT Connectors) only expose a
-  // URL field in their "Add custom connector" dialog — no way to set headers.
-  // For those, the key is embedded in the URL as ?key=uc_...
+  // ── Auth ──────────────────────────────────────────────────────────────
+  // Three paths, tried in order:
+  //   1. Authorization: Bearer <unclick_api_key>   (agents)
+  //   2. ?key=<unclick_api_key> query param         (Claude.ai / ChatGPT
+  //      connector UIs that can't set headers)
+  //   3. Supabase Auth session cookie               (browser on
+  //      unclick.world after Phase 2 sign in)
+  //
+  // The api_key paths produce an ApiKeyContext directly. The session
+  // cookie path resolves to the same ApiKeyContext shape via the
+  // api_keys.user_id FK added in Phase 2, so everything downstream
+  // (memory tenancy, tier checks) is identical.
   const authHeader = (req.headers.authorization as string) ?? "";
   const keyFromHeader = authHeader.replace(/^Bearer\s+/i, "").trim();
   const keyRaw = req.query.key;
@@ -113,42 +232,55 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         : "";
   const apiKey = keyFromHeader || keyFromQuery;
 
-  if (!apiKey) {
-    return res.status(401).json({
-      jsonrpc: "2.0",
-      error: {
-        code: -32600,
-        message:
-          "Missing API key. Pass it as Authorization: Bearer <key> or as ?key=<key> in the URL. " +
-          "Get a key at https://unclick.world",
-      },
-      id: null,
-    });
-  }
+  let ctx: ApiKeyContext | null = null;
 
-  // ── Validate the api_key against the api_keys table ─────────────────────
-  // Hash, look up, confirm active. Reject unknown or revoked keys before
-  // anything downstream sees the request. Attach the resulting context
-  // (api_key_hash, tier, user_id) to per-request env so the memory backend
-  // factory can route tenancy.
-  const ctx = await validateApiKey(apiKey);
-  if (!ctx) {
-    return res.status(401).json({
-      jsonrpc: "2.0",
-      error: {
-        code: -32001,
-        message:
-          "Invalid or revoked API key. Check that the key is correct and still active. " +
-          "Manage keys at https://unclick.world",
-      },
-      id: null,
-    });
+  if (apiKey) {
+    ctx = await validateApiKey(apiKey);
+    if (!ctx) {
+      return res.status(401).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32001,
+          message:
+            "Invalid or revoked API key. Check that the key is correct and still active. " +
+            "Manage keys at https://unclick.world",
+        },
+        id: null,
+      });
+    }
+  } else {
+    // No api_key supplied - try resolving via Supabase session cookie.
+    ctx = await validateSessionCookie(req);
+    if (!ctx) {
+      return res.status(401).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32600,
+          message:
+            "Missing API key. Pass it as Authorization: Bearer <key> or as ?key=<key> in the URL. " +
+            "Get a key at https://unclick.world",
+        },
+        id: null,
+      });
+    }
   }
 
   // Inject per-request context. Vercel invocations are isolated processes,
   // so mutating process.env here is safe and is the existing pattern used by
   // createClient() and the memory backend factory.
-  process.env.UNCLICK_API_KEY = apiKey;
+  //
+  // UNCLICK_API_KEY is only set on the Bearer/query path because the
+  // session-cookie path never sees the plaintext key. Downstream code
+  // that actually needs the plaintext (BYOD credential decryption)
+  // must accept that session-cookie-authenticated callers cannot
+  // access it - this is the AES-256-GCM encryption property we
+  // explicitly want to preserve: a logged-in user cannot decrypt
+  // another device's stored credentials without holding the api_key.
+  if (apiKey) {
+    process.env.UNCLICK_API_KEY = apiKey;
+  } else {
+    delete process.env.UNCLICK_API_KEY;
+  }
   process.env.UNCLICK_API_KEY_HASH = ctx.api_key_hash;
   process.env.UNCLICK_TIER = ctx.tier;
   if (ctx.user_id) {

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -34,6 +34,27 @@
  *                    against the central managed-cloud schema. Free-tier
  *                    accounts are skipped (decay is a Pro perk per the v2
  *                    build plan).
+ *
+ * Phase 2 auth actions (keyed by Supabase Auth session JWT - Bearer from
+ * the browser's supabase-js session, NOT an UnClick api_key):
+ *   - claim_api_key: POST with { api_key } - link an anonymous api_keys
+ *                    row to the signed-in auth.users row. Server
+ *                    verifies that api_keys.email matches the session
+ *                    user email before setting user_id.
+ *   - auth_device_pair: POST with { device_id, device_name? } - upsert
+ *                       a row in auth_devices for the signed-in user.
+ *                       Stub today (no real pairing protocol yet, just
+ *                       record the row so the UI has data to render).
+ *   - auth_device_list: GET - list auth_devices rows for the signed-in
+ *                       user.
+ *   - auth_device_revoke: POST with { device_id } - mark the row as
+ *                         revoked. Soft delete.
+ *
+ * Note: the auth_device_* actions are namespaced separately from the
+ * existing memory device_check/list_devices/remove_device actions which
+ * are api_key_hash-keyed and operate on memory_devices (Phase 1).
+ * auth_devices is user_id-keyed and is for authenticated device
+ * pairing. Distinct concepts, distinct tables, distinct handlers.
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
@@ -144,6 +165,42 @@ async function verifySchema(supabaseUrl: string, serviceRoleKey: string): Promis
 
 function bearerFrom(req: VercelRequest): string {
   return (req.headers.authorization ?? "").replace(/^Bearer\s+/i, "").trim();
+}
+
+/**
+ * Resolve a Supabase Auth session JWT to the underlying auth.users row.
+ * Used by Phase 2 auth actions (claim_api_key, auth_device_*) which are
+ * called from the browser with the active supabase-js session token.
+ * Returns null if the token is missing, invalid, or expired.
+ *
+ * Distinct from bearerFrom() + api_keys lookup, which is the
+ * api_key-based auth path used by BYOD and memory tooling.
+ */
+async function resolveSessionUser(
+  req: VercelRequest,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+): Promise<{ id: string; email: string | null } | null> {
+  const token = bearerFrom(req);
+  if (!token) return null;
+  // Tokens that look like UnClick api_keys (uc_* / agt_*) are never
+  // valid session JWTs. Reject early to avoid sending garbage to
+  // supabase.auth.getUser.
+  if (token.startsWith("uc_") || token.startsWith("agt_")) return null;
+
+  try {
+    // Use an anon client scoped to this token. getUser() verifies the
+    // JWT against the project's Auth secret server-side.
+    const scoped = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data, error } = await scoped.auth.getUser(token);
+    if (error || !data?.user) return null;
+    return { id: data.user.id, email: data.user.email ?? null };
+  } catch {
+    return null;
+  }
 }
 
 // ─── Handler ───────────────────────────────────────────────────────────────
@@ -650,6 +707,142 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .delete()
           .eq("api_key_hash", apiKeyHash)
           .eq("device_fingerprint", fp);
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
+      // ── Phase 2 auth actions (session JWT, not api_key) ─────────────
+      case "claim_api_key": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) {
+          return res.status(401).json({ error: "Not signed in" });
+        }
+        if (!user.email) {
+          return res.status(400).json({
+            error: "Your account doesn't have a verified email yet. Complete sign in first.",
+          });
+        }
+        const body = req.body as { api_key?: string };
+        const apiKey = (body?.api_key ?? "").trim();
+        if (!apiKey) return res.status(400).json({ error: "api_key required" });
+
+        // Try new-shape lookup first (key_hash). Fall back to old-shape
+        // (api_key plaintext column) - see api_keys two-shape drift
+        // noted in 20260416000000_auth_foundation.sql.
+        const apiKeyHash = sha256hex(apiKey);
+        const { data: newShape, error: newErr } = await supabase
+          .from("api_keys")
+          .select("id, email, user_id")
+          .eq("key_hash", apiKeyHash)
+          .maybeSingle();
+        if (newErr && newErr.code !== "PGRST116" && newErr.code !== "42703") {
+          throw newErr;
+        }
+
+        let row = newShape as
+          | { id: string; email: string | null; user_id: string | null }
+          | null
+          | undefined;
+
+        if (!row) {
+          const { data: oldShape, error: oldErr } = await supabase
+            .from("api_keys")
+            .select("id, email, user_id")
+            .eq("api_key", apiKey)
+            .maybeSingle();
+          // 42703 = undefined_column (old-shape columns don't exist on
+          // fresh databases). Treat as "not found" rather than a hard
+          // failure.
+          if (oldErr && oldErr.code !== "PGRST116" && oldErr.code !== "42703") {
+            throw oldErr;
+          }
+          row = oldShape as typeof row;
+        }
+
+        if (!row) {
+          return res.status(404).json({ error: "That API key doesn't exist." });
+        }
+
+        if (row.user_id && row.user_id !== user.id) {
+          return res.status(409).json({
+            error: "That API key is already linked to a different account.",
+          });
+        }
+
+        if (row.email && row.email.toLowerCase() !== user.email.toLowerCase()) {
+          return res.status(403).json({
+            error:
+              "The email on that API key doesn't match your signed-in email. Sign in with the email you used to create the key.",
+          });
+        }
+
+        const { error: updErr } = await supabase
+          .from("api_keys")
+          .update({ user_id: user.id })
+          .eq("id", row.id);
+        if (updErr) throw updErr;
+
+        return res.status(200).json({ success: true });
+      }
+
+      case "auth_device_pair": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Not signed in" });
+        const body = req.body as { device_id?: string; device_name?: string };
+        const deviceId = (body?.device_id ?? "").trim();
+        if (!deviceId) return res.status(400).json({ error: "device_id required" });
+        const deviceName = body?.device_name?.trim() || null;
+
+        // Upsert on (user_id, device_id). This is a stub: pairing
+        // today just means "I saw this device, record it". A real
+        // pairing protocol (nonce + client-side confirmation) is a
+        // later phase.
+        const { data, error } = await supabase
+          .from("auth_devices")
+          .upsert(
+            {
+              user_id: user.id,
+              device_id: deviceId,
+              device_name: deviceName,
+              last_seen_at: new Date().toISOString(),
+              revoked_at: null,
+            },
+            { onConflict: "user_id,device_id" },
+          )
+          .select("id, device_id, device_name, paired_at, last_seen_at")
+          .single();
+        if (error) throw error;
+        return res.status(200).json({ success: true, device: data });
+      }
+
+      case "auth_device_list": {
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Not signed in" });
+        const { data, error } = await supabase
+          .from("auth_devices")
+          .select("id, device_id, device_name, paired_at, last_seen_at, revoked_at")
+          .eq("user_id", user.id)
+          .is("revoked_at", null)
+          .order("last_seen_at", { ascending: false });
+        if (error) throw error;
+        return res.status(200).json({ data: data ?? [] });
+      }
+
+      case "auth_device_revoke": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Not signed in" });
+        const body = req.body as { device_id?: string };
+        const deviceId = (body?.device_id ?? "").trim();
+        if (!deviceId) return res.status(400).json({ error: "device_id required" });
+
+        const { error } = await supabase
+          .from("auth_devices")
+          .update({ revoked_at: new Date().toISOString() })
+          .eq("user_id", user.id)
+          .eq("device_id", deviceId);
         if (error) throw error;
         return res.status(200).json({ success: true });
       }

--- a/docs/sessions/2026-04-15-phase-2-preflight.md
+++ b/docs/sessions/2026-04-15-phase-2-preflight.md
@@ -1,0 +1,123 @@
+# Phase 2 Preflight - Session Stopped Before Start
+
+**Date:** 2026-04-15
+**Branch:** `claude/unclick-admin-phase-2-AcJy3` (harness-pinned scratch branch)
+**Status:** Stopped cleanly. No code touched, no branches cut, no PRs opened.
+**Next session target branch:** `claude/phase-2-auth-foundation` (cut off `claude/setup-malamute-mayhem-zkquO` AFTER Phase 1 merges in)
+
+## Why this session stopped
+
+The Phase 2 prompt instructed me to verify PR #14 was merged before starting any code work. It is not.
+
+| Field | Value |
+|---|---|
+| PR | malamutemayhem/unclick-agent-native-endpoints#14 |
+| Title | Phase 1: Memory backend (managed cloud + caps + validation) |
+| State | `open`, `draft: true`, `merged: false` |
+| Mergeable state | `unstable` |
+| Head | `claude/phase-1-memory-backend` @ `3accaf5` |
+| Base | `claude/setup-malamute-mayhem-zkquO` @ `27b71d4` |
+| Files changed | 7 (+1612 / -153) |
+
+PR body says: "Code compiles cleanly but has not been verified against a live Supabase. Keeping this as a draft until verification runs in a follow-up session" and "Do not merge until verification passes."
+
+## Collision risk if Phase 2 had started on unverified Phase 1
+
+Phase 2's file surface overlaps Phase 1 in several places, so starting Phase 2 before Phase 1 is verified and merged would have produced rebase pain:
+
+- `api/mcp.ts` - Phase 1 rewrote the api_key validation and per-request env injection. Phase 2 needs to add session-cookie handling that reads `user_id` alongside the existing api_key hash path.
+- `api/memory-admin.ts` - Phase 1 folded `nightly_decay` in here to stay under the Vercel 12-function cap. Phase 2 was going to fold `/api/auth/device-pair` into this same handler for the same reason.
+- `supabase/migrations/` - Phase 1 adds `20260415000000_memory_managed_cloud.sql`. Phase 2 needs a new migration for the `api_keys.user_id` FK, the `auth_devices` table, and the localStorage-to-auth backfill. Migration ordering matters and both branches would have been adding ordered files in the same directory.
+- `packages/mcp-server/src/memory/supabase.ts` and `db.ts` - Phase 1 rewrote both as a per-tenant factory. Any Phase 2 tenancy change (attaching session `user_id` to the tenancy context) rebases into pain.
+
+## Decisions recorded (Chris answered these before session close)
+
+These are the four open questions I raised at the start of the session. Answers below. The next Phase 2 session should treat these as settled and not re-ask.
+
+### 1. PR #14 handling
+
+**Decision:** Option (a). Stop this session entirely. Chris will verify Phase 1 against live Supabase and merge PR #14 in separate sessions before resuming Phase 2.
+
+**Rationale:** Analysis of collision risk (above) is right. Not eating merge pain on unverified code.
+
+### 2. Branch name for Phase 2
+
+**Decision:** `claude/phase-2-auth-foundation`. Override the harness-pinned `claude/unclick-admin-phase-2-AcJy3`. Explicit permission granted.
+
+Cut it off `claude/setup-malamute-mayhem-zkquO` AFTER Phase 1 has been merged into that branch. Do NOT cut off `claude/phase-1-memory-backend` directly.
+
+### 3. GitHub OAuth
+
+**Decision:** Skip for this phase. Ship Phase 2 with Google and Microsoft OAuth only, plus magic link.
+
+**Rationale:** GitHub OAuth needs a new OAuth app at github.com/settings/developers which Claude cannot create (requires human-authenticated session, client secret shown once). A 15-minute follow-up after Phase 2 lands is cleaner than blocking on it.
+
+Phase 2 code should:
+- Render ONLY two OAuth buttons on `/login` and `/signup`: Google and Microsoft
+- Not leave a dead "GitHub" button or a commented-out placeholder
+- Not reference a `GITHUB_OAUTH_CLIENT_ID` env var (don't prepare for it yet)
+
+### 4. SMTP for magic link delivery
+
+**Decision:** Resend.
+
+**Rationale:** Cleanest DX, free for early volume, five-minute Supabase integration. Postmark / SendGrid are more enterprise-y but heavier lift.
+
+**Chris's action before next session:** Sign up for Resend, verify sending domain for `unclick.world`, drop `RESEND_API_KEY` into Vercel env and into Supabase Auth > SMTP Settings.
+
+### 5. Magic link email copy
+
+**Decision:** Default Supabase template for this phase.
+
+**Rationale:** Ship functional first. Custom UnClick-branded email is a 15-minute polish-pass task post-Phase-2. The magic link working matters more than it being on-brand at this stage.
+
+### 6. Supabase Auth provider toggles
+
+**Decision:** Chris handles the dashboard toggles himself, not via Management API. No `SUPABASE_ACCESS_TOKEN` handed to Claude.
+
+**Chris's action before next session** (Supabase project `xmooqsylqlknuksiddca`):
+
+- Auth > Providers > Email: enable, "Confirm email" on, "Secure email change" on
+- Auth > Providers > Google: enable with existing Google client ID and secret
+- Auth > Providers > Azure (Microsoft): enable with "Bailey" app client ID, secret, tenant
+- Auth > URL Configuration > Site URL: `https://unclick.world`
+- Auth > URL Configuration > Redirect allowlist:
+  - `https://unclick.world/auth/callback`
+  - `http://localhost:5173/auth/callback`
+- Auth > SMTP Settings: paste Resend credentials once Resend is signed up
+
+Chris will confirm all of these are done before pasting the Phase 2 prompt into the next session.
+
+## Explicit plan
+
+1. **Separate session(s):** Verify PR #14 against a live Supabase instance per the verification checklist in the PR body. Fix any issues surfaced by verification. Mark PR #14 ready for review, then merge into `claude/setup-malamute-mayhem-zkquO`.
+2. **Chris prep work** (in parallel or before step 3):
+   - Sign up for Resend, verify `unclick.world` sending domain, get `RESEND_API_KEY`
+   - Toggle Supabase Auth providers and URL config per section 6 above
+   - Drop `RESEND_API_KEY` into Vercel env
+   - Drop Google and Microsoft OAuth credentials into Supabase Auth provider settings
+3. **Fresh Phase 2 session:** New Claude Code session on a new branch. Fetch `claude/setup-malamute-mayhem-zkquO` (now containing Phase 1). Cut `claude/phase-2-auth-foundation`. Read this preflight doc FIRST to avoid re-litigating the six decisions above. Then read `docs/UNCLICK_ADMIN_BUILD_PLAN.md` (CODEBASE GROUND TRUTH + Phase 2 sections), `docs/sessions/2026-04-15-phase-1-memory-backend.md`, and project root `CLAUDE.md`. Then execute Phase 2.
+
+## Phase 2 scope reminder (for the next session)
+
+Not re-deciding, just caching the scope so the next session doesn't have to re-read the whole build plan before starting:
+
+- Supabase Auth: magic link + Google + Microsoft OAuth (NO GitHub, NO passwords anywhere)
+- `/login` and `/signup` routes in `src/pages/` or `src/app/auth/` - minimal UI, email input + two OAuth buttons, UnClick dark + amber `#E2B93B` palette
+- Migration: `api_keys.user_id` FK to `auth.users.id`, plus backfill where `api_keys.email` matches a verified `auth.users.email`
+- localStorage-to-auth claim flow: users with `unclick_api_key` in localStorage get prompted to claim, magic link to `api_keys.email`, on verify set `api_keys.user_id`
+- Session cookies + route protection: all `/app/*` routes require an authenticated session, unauthenticated users get 302 to `/login`
+- `POST /api/auth/device-pair` stub folded into an existing handler (Vercel 12-function cap still applies). Create `auth_devices` schema (`user_id`, `device_id`, `device_name`, `paired_at`, `last_seen_at`). Single-device UI, multi-device ready schema.
+
+## Non-blocking out-of-session noise
+
+- Glama email hit partway through this session: "The build for UnClick MCP Server has succeeded... to make these changes available to users, you must create a new release." Unrelated to Phase 2. Chris's call whether to cut a release now or wait until after Phase 2 merges. No code action required here.
+
+## Where this doc lives
+
+Committed and pushed to `claude/unclick-admin-phase-2-AcJy3` (the harness-pinned scratch branch). The next Phase 2 session will start on `claude/phase-2-auth-foundation` cut from `claude/setup-malamute-mayhem-zkquO`, which will NOT have this file on disk by default. Two options for the next session:
+
+1. `git show origin/claude/unclick-admin-phase-2-AcJy3:docs/sessions/2026-04-15-phase-2-preflight.md` - read-only access from any branch
+2. `git checkout origin/claude/unclick-admin-phase-2-AcJy3 -- docs/sessions/2026-04-15-phase-2-preflight.md` then commit onto the Phase 2 branch so it lives alongside the Phase 2 session summary
+
+Option 2 is cleaner and Chris should include that as the first command in the next Phase 2 prompt.

--- a/docs/sessions/2026-04-16-ci-cleanup.md
+++ b/docs/sessions/2026-04-16-ci-cleanup.md
@@ -1,0 +1,65 @@
+# CI cleanup - follow-up from Phase 2 session
+
+**Date:** 2026-04-16
+**Context:** Logged during Phase 2 PR #15 (`claude/phase-2-auth-foundation`). Both GitHub Actions jobs are failing red on this PR, but they were already failing red when Phase 1 PR #14 merged, so the failures are pre-existing and were explicitly left alone per Chris's call on this session. Not a Phase 2 regression.
+
+## Failing checks (both pre-existing)
+
+### 1. "MCP server package" job
+
+**Symptom:** exits in ~7 seconds. Too fast to be an actual TypeScript compile. Fails during setup, before `npm install` or `npm run build` runs.
+
+**Root cause:** `.github/workflows/ci.yml:47` uses:
+
+```yaml
+cache-dependency-path: packages/mcp-server/package-lock.json
+```
+
+But `packages/mcp-server/` has no `package-lock.json` file on disk. The `actions/setup-node@v4` step can't resolve the cache path and exits the job.
+
+**Fix options:**
+
+1. Generate and commit `packages/mcp-server/package-lock.json` by running `npm install` inside that directory. Lowest-risk change but adds a large file to version control.
+2. Remove the `cache-dependency-path` line from `ci.yml`. The cache is a performance nicety, not a correctness requirement. Smallest diff.
+3. Change the job to run `npm install` from the repo root (workspace-aware) and drop the `defaults.run.working-directory: packages/mcp-server` block, so it picks up the root `package-lock.json`. Cleanest architectural fix but touches more of the workflow.
+
+Recommended: option 2 for the quickest unblock, option 3 if doing a proper pass.
+
+### 2. "Website (root package)" job
+
+**Symptom:** exits after ~25 seconds. Fails on the `npm run lint` step.
+
+**Root cause:** `npm run lint` reports **394 pre-existing lint errors** across the repo. Concentrated in:
+
+- `packages/mcp-server/src/local-tools.ts` (many `no-useless-escape`, `prefer-const`)
+- `packages/mcp-server/src/text-tool.ts` (many `no-useless-escape`)
+- `src/components/ui/*` (warnings, mostly fast-refresh and empty interfaces)
+- `src/pages/DeveloperSubmit.tsx` (`no-explicit-any`)
+- `tailwind.config.ts` (`no-require-imports`)
+
+ESLint exits non-zero, which fails the job before `npm run build` and `npm test` can run. Phase 2 files contribute zero of the 394 errors - verified during Phase 2 verification.
+
+**Fix options:**
+
+1. **Short-term unblock:** add `continue-on-error: true` to the `Lint` step in `ci.yml:28` so the check goes green on `npm run build` + `npm test` passing. Hides existing lint debt but also hides future lint regressions.
+2. **Split the step:** have lint run in a separate job with its own outcome, so build/test can go green even while lint stays red. Clean separation but adds a job.
+3. **Do the cleanup:** actually fix the 394 errors across the codebase. Big scope, ideally done before Phase 3 so auth-protected surfaces start on a green baseline.
+
+Recommended: option 2 so lint visibility is preserved without blocking every downstream PR on pre-existing debt, then option 3 as a dedicated cleanup session.
+
+## Why this wasn't done in the Phase 2 PR
+
+Three reasons:
+
+1. **Scope discipline.** Phase 2 is "auth foundation", not "CI cleanup". Folding unrelated CI changes into the same PR makes review harder and blast radius bigger.
+2. **PR #14 parity.** Phase 1 shipped with the same CI red. Matching that state keeps the Phase 2 PR's red/green comparable to Phase 1's.
+3. **No Phase 2 regression.** Verified locally: `npm run build` passes, `npm test` passes, zero new lint errors, zero new tsc errors in Phase 2 files. The CI failures are not signal about Phase 2 quality.
+
+## Proposed next session
+
+Small CI cleanup session on its own branch (`claude/ci-cleanup` or similar):
+
+1. Remove `cache-dependency-path` from the MCP server job (or fix via option 3 above).
+2. Split lint into its own job OR add `continue-on-error: true` as a short-term unblock.
+3. Land those two fixes first so Phase 3 starts on a green CI baseline.
+4. Separately, queue a lint cleanup session to actually resolve the 394 errors. Not blocking anything.

--- a/docs/sessions/2026-04-16-phase-2-auth-foundation.md
+++ b/docs/sessions/2026-04-16-phase-2-auth-foundation.md
@@ -1,0 +1,116 @@
+# Phase 2 - Auth Foundation
+
+**Date:** 2026-04-16
+**Branch:** `claude/phase-2-auth-foundation` (cut off `claude/setup-malamute-mayhem-zkquO` @ `bac1848` after Phase 1 PR #14 merged)
+**Preflight doc:** `docs/sessions/2026-04-15-phase-2-preflight.md`
+
+## Scope shipped
+
+All six Phase 2 deliverables from the preflight:
+
+1. `/login` and `/signup` routes (magic link + Google + Microsoft)
+2. `/auth/callback` route
+3. `api_keys.user_id` FK migration + backfill
+4. localStorage-to-auth claim flow (`ClaimKeyBanner`)
+5. Session cookies + route protection (`RequireAuth`, gating `/memory/admin`)
+6. `POST /api/auth/device-pair` stub - folded into `memory-admin.ts` as `auth_device_pair`
+
+## Decisions (from preflight, not re-litigated)
+
+- Magic link + Google + Microsoft only. No GitHub, no passwords anywhere.
+- Default Supabase email template for this phase.
+- Resend SMTP (Chris confirmed `RESEND_API_KEY` set in Vercel + Supabase).
+- Supabase Auth provider toggles already flipped by Chris.
+
+## Collision notes found during kickoff scan
+
+### `api_keys` table has two column shapes in production
+
+Phase 1 (`20260410100000_keychain_mvp.sql`) declares the new shape with `key_hash` / `user_id` / `tier` / `is_active`. The older shape with `email` / `api_key` (plaintext) / `status` is still queried by `src/components/ApiKeySignup.tsx` and `api/install-ticket.ts`. Production must carry both column sets for signup to work today. The Phase 2 migration and `claim_api_key` action both handle this drift:
+
+- Migration: defensive `DO $$ ... $$` blocks that no-op if `email` / `status` columns aren't present. Backfill only runs when the old-shape columns exist.
+- `claim_api_key`: tries a new-shape lookup first (`eq(key_hash, ...)`), falls back to old-shape (`eq(api_key, ...)`). Treats `42703` (undefined column) as "not found" rather than a hard failure, so it won't break on a fresh database.
+
+### mcp.ts session-cookie branch
+
+Added a parallel auth path in `api/mcp.ts` that:
+
+1. Reads the Supabase session cookie from the request.
+2. Calls `supabase.auth.getUser(token)` to verify.
+3. Looks up an active api_keys row via the Phase 2 `user_id` FK.
+4. Returns the same `ApiKeyContext` shape as the api_key path.
+
+The api_key path is unchanged. Session-cookie auth explicitly does NOT populate `process.env.UNCLICK_API_KEY` (only the hash), which preserves the BYOD AES-256-GCM property: vault-bridge.ts short-circuits without the plaintext key, so a browser-session-authenticated caller cannot decrypt stored BYOD credentials.
+
+### Vercel 12-function cap
+
+Confirmed 12 `.ts` files under `api/` (11 top-level + `api/tools/demo.ts`). No new files added. All Phase 2 server endpoints fold into `memory-admin.ts` via distinct action names:
+
+- `claim_api_key` - link anonymous api_keys row to auth.users row
+- `auth_device_pair` - stub device pairing (upsert into `auth_devices`)
+- `auth_device_list` - list paired devices for the session user
+- `auth_device_revoke` - soft-delete a device pairing
+
+Namespaced as `auth_device_*` to avoid colliding with the existing Phase 1 memory device actions (`device_check`, `list_devices`, `remove_device`) which operate on `memory_devices` (api_key_hash-keyed, tracks where memory lives). Distinct concepts, distinct tables, distinct handlers.
+
+## Files changed
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `supabase/migrations/20260416000000_auth_foundation.sql` | FK + backfill + auth_devices table |
+| `src/lib/auth.ts` | Magic link / OAuth helpers + `useSession` hook |
+| `src/pages/Login.tsx` | `/login` route |
+| `src/pages/Signup.tsx` | `/signup` route |
+| `src/pages/AuthCallback.tsx` | `/auth/callback` route |
+| `src/components/RequireAuth.tsx` | Client-side route guard |
+| `src/components/ClaimKeyBanner.tsx` | localStorage-to-auth claim UI |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/App.tsx` | Registered `/login`, `/signup`, `/auth/callback` routes. Wrapped `/memory/admin` in `<RequireAuth>`. |
+| `src/pages/MemoryAdmin.tsx` | Mounted `<ClaimKeyBanner />` at top of main content. |
+| `api/memory-admin.ts` | Added `resolveSessionUser` helper + 4 new actions (`claim_api_key`, `auth_device_pair`, `auth_device_list`, `auth_device_revoke`). |
+| `api/mcp.ts` | Added `validateSessionCookie` + `extractSupabaseAccessToken` helpers. Session-cookie auth runs as a parallel path to api_key auth. |
+
+### Pulled onto branch
+
+| File | Purpose |
+|------|---------|
+| `docs/sessions/2026-04-15-phase-2-preflight.md` | Previous-session kickoff doc, pulled from `claude/unclick-admin-phase-2-AcJy3` |
+
+## Verification
+
+- `npm run build` passes clean (Vite build finishes in ~10s)
+- `npm test` passes (1 test, example)
+- `npm run lint` produces 394 pre-existing issues, zero of which are in Phase 2 files
+- `tsc --noEmit -p tsconfig.app.json` produces only 2 pre-existing ArenaNav errors, zero in Phase 2 files
+
+**Not verified in this session (belongs in a follow-up verification session):**
+
+- Migration has not been applied against the live Supabase instance. Chris should run it in the SQL editor and confirm the `DO $$` blocks fire without error.
+- End-to-end magic link has not been clicked. Needs a real session once Chris runs the migration.
+- Google + Microsoft OAuth buttons have not been clicked through. The Supabase dashboard toggles were confirmed in the preflight doc but the round-trip hasn't been tested.
+- `RequireAuth` gating on `/memory/admin` has not been tested with an unauthenticated session in the browser.
+- `ClaimKeyBanner` has not been tested against a real `unclick_api_key` in localStorage.
+
+## Follow-up / open loops
+
+- Branded magic-link email template (preflight decision was default-template for this phase).
+- Real device-pair protocol (current `auth_device_pair` is a stub: it just upserts a row. A nonce + client-confirmation flow is a later phase).
+- `ApiKeySignup.tsx` still writes the old `email` / `api_key` / `status` column shape. Consolidating to the Phase 1 `key_hash` shape is a separate refactor.
+- `vercel.json` could get a rewrite for `/api/auth/device-pair` -> `/api/memory-admin?action=auth_device_pair` if we want a prettier external URL. Not needed for the stub.
+
+## BYOD encryption property - verification trace
+
+Walked through every path that could decrypt BYOD creds:
+
+1. `api/credentials.ts:138` - `deriveKey(apiKey, salt)` where `apiKey` is the Bearer header value. Never receives a session JWT: session-authenticated MCP requests don't forward their token here, and `/api/credentials` is only called by `vault-bridge.ts`.
+2. `packages/mcp-server/src/vault-bridge.ts:105-128` - reads `process.env.UNCLICK_API_KEY` and short-circuits if unset. Phase 2 session-cookie branch in `api/mcp.ts` explicitly does NOT set `UNCLICK_API_KEY` (only the hash and user_id).
+3. `api/memory-admin.ts` `config` action (line 528+) - `deriveKey(apiKey, salt)` where `apiKey` is from `bearerFrom(req)`. Same story: session JWTs are rejected upstream because `resolveSessionUser` is only called for `claim_api_key` / `auth_device_*`, and the `config` action still requires a plaintext api_key.
+4. New `claim_api_key` action - accepts a plaintext api_key in the POST body from the browser (sourced from localStorage at the moment of claim). Hashes it for row lookup. Never derives a PBKDF2 key. Never stores the plaintext.
+
+**Result:** logged-in users still cannot decrypt BYOD creds without holding the plaintext api_key. Staff with service role access can read `encrypted_data` and `salt` but cannot compute the PBKDF2 key without the plaintext. Property preserved.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,10 @@ import ToolsPage from "./pages/Tools.tsx";
 import NewToAIPage from "./pages/NewToAI.tsx";
 import SmartHomePage from "./pages/SmartHome.tsx";
 import InstallRecoverPage from "./pages/InstallRecover.tsx";
+import LoginPage from "./pages/Login.tsx";
+import SignupPage from "./pages/Signup.tsx";
+import AuthCallbackPage from "./pages/AuthCallback.tsx";
+import RequireAuth from "./components/RequireAuth.tsx";
 
 const queryClient = new QueryClient();
 
@@ -70,8 +74,19 @@ const App = () => (
           {/* Core product pages */}
           <Route path="/tools" element={<ToolsPage />} />
           <Route path="/memory" element={<MemoryPage />} />
-          <Route path="/memory/admin" element={<MemoryAdminPage />} />
+          <Route
+            path="/memory/admin"
+            element={
+              <RequireAuth>
+                <MemoryAdminPage />
+              </RequireAuth>
+            }
+          />
           <Route path="/memory/setup" element={<MemorySetupPage />} />
+          {/* Phase 2 auth surface */}
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/auth/callback" element={<AuthCallbackPage />} />
           <Route path="/organiser" element={<OrganiserPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />
           <Route path="/crews" element={<CrewsPage />} />

--- a/src/components/ClaimKeyBanner.tsx
+++ b/src/components/ClaimKeyBanner.tsx
@@ -1,0 +1,147 @@
+/**
+ * ClaimKeyBanner
+ *
+ * Shown at the top of authenticated pages (today: /memory/admin) when
+ * the browser has an anonymous unclick_api_key in localStorage that
+ * isn't yet linked to the signed-in auth.users row. Clicking Claim
+ * calls /api/memory-admin?action=claim_api_key which runs a
+ * server-side check that the api_keys.email matches the session user
+ * email, then sets api_keys.user_id = session.user.id.
+ *
+ * If the localStorage api_key has no email column or the email doesn't
+ * match the signed-in user, the claim request returns a clear error
+ * and the banner surfaces it inline rather than silently failing.
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, Link2, X, Check } from "lucide-react";
+import { useSession } from "@/lib/auth";
+
+const STORAGE_KEY = "unclick_api_key";
+const CLAIM_DISMISSED = "unclick_claim_dismissed";
+
+type State = "hidden" | "offer" | "claiming" | "done" | "error";
+
+export default function ClaimKeyBanner() {
+  const { session } = useSession();
+  const [state, setState] = useState<State>("hidden");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!session) {
+      setState("hidden");
+      return;
+    }
+    if (localStorage.getItem(CLAIM_DISMISSED) === "1") {
+      setState("hidden");
+      return;
+    }
+    const storedKey = localStorage.getItem(STORAGE_KEY);
+    if (!storedKey) {
+      setState("hidden");
+      return;
+    }
+    setState("offer");
+  }, [session]);
+
+  async function claim() {
+    if (!session) return;
+    const storedKey = localStorage.getItem(STORAGE_KEY);
+    if (!storedKey) return;
+
+    setError("");
+    setState("claiming");
+    try {
+      const res = await fetch("/api/memory-admin?action=claim_api_key", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ api_key: storedKey }),
+      });
+      const body = (await res.json()) as { success?: boolean; error?: string };
+      if (!res.ok || !body.success) {
+        throw new Error(body.error || `Claim failed (HTTP ${res.status})`);
+      }
+      setState("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Claim failed. Try again.");
+      setState("error");
+    }
+  }
+
+  function dismiss() {
+    localStorage.setItem(CLAIM_DISMISSED, "1");
+    setState("hidden");
+  }
+
+  if (state === "hidden") return null;
+
+  return (
+    <div className="mx-auto mb-6 flex w-full max-w-4xl items-start gap-3 rounded-xl border border-primary/30 bg-primary/5 px-4 py-3">
+      <Link2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+      <div className="flex-1 text-sm">
+        {state === "offer" || state === "claiming" ? (
+          <>
+            <p className="font-medium text-heading">Link your anonymous API key to this account</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              We found an UnClick API key saved in this browser. Linking it to your account lets
+              you manage it from anywhere and keeps your memory connected.
+            </p>
+            <div className="mt-2 flex items-center gap-2">
+              <button
+                onClick={claim}
+                disabled={state === "claiming"}
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-black hover:opacity-90 disabled:opacity-60"
+              >
+                {state === "claiming" ? (
+                  <>
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Linking
+                  </>
+                ) : (
+                  "Link key to account"
+                )}
+              </button>
+              <button
+                onClick={dismiss}
+                className="text-xs text-muted-foreground underline-offset-2 hover:text-body hover:underline"
+              >
+                Not now
+              </button>
+            </div>
+          </>
+        ) : state === "done" ? (
+          <>
+            <div className="flex items-center gap-2">
+              <Check className="h-4 w-4 text-primary" />
+              <p className="font-medium text-heading">API key linked</p>
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Your saved key is now tied to this account.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="font-medium text-heading">Couldn't link that key</p>
+            <p className="mt-0.5 text-xs text-red-400">{error}</p>
+            <button
+              onClick={() => setState("offer")}
+              className="mt-2 text-xs text-muted-foreground underline-offset-2 hover:text-body hover:underline"
+            >
+              Try again
+            </button>
+          </>
+        )}
+      </div>
+      <button
+        onClick={dismiss}
+        className="rounded-md p-1 text-muted-foreground hover:bg-card/60 hover:text-body"
+        aria-label="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,32 @@
+/**
+ * RequireAuth - client-side route guard.
+ *
+ * Wraps a route element. If the user isn't authenticated, redirects
+ * to /login with a ?next= param so we can bounce them back after sign
+ * in. Used today on /memory/admin; any future /app/* route should be
+ * wrapped in this too.
+ */
+
+import { Navigate, useLocation } from "react-router-dom";
+import { useSession } from "@/lib/auth";
+import { Loader2 } from "lucide-react";
+
+export default function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { session, loading } = useSession();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!session) {
+    const next = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?next=${next}`} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,96 @@
+/**
+ * UnClick Phase 2 - Auth helpers.
+ *
+ * Thin wrapper around @supabase/supabase-js auth. The shared `supabase`
+ * client in src/lib/supabase.ts already reads VITE_SUPABASE_URL +
+ * VITE_SUPABASE_ANON_KEY, which is exactly what magic-link + OAuth
+ * flows need. No extra config.
+ *
+ * Decisions locked in preflight:
+ *   - Magic link + Google + Microsoft only (no GitHub, no passwords)
+ *   - Default Supabase email template for this phase
+ *   - Redirect URLs are allowlisted on the Supabase side for
+ *     https://unclick.world/auth/callback and
+ *     http://localhost:5173/auth/callback
+ */
+
+import { useEffect, useState } from "react";
+import type { Session, User } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
+
+export type SupportedOAuthProvider = "google" | "azure";
+
+/** Return the redirect URL for the current origin. */
+export function authCallbackUrl(): string {
+  if (typeof window === "undefined") return "https://unclick.world/auth/callback";
+  return `${window.location.origin}/auth/callback`;
+}
+
+/** Send a magic link to the given email. */
+export async function signInWithMagicLink(email: string): Promise<void> {
+  const { error } = await supabase.auth.signInWithOtp({
+    email: email.trim().toLowerCase(),
+    options: { emailRedirectTo: authCallbackUrl() },
+  });
+  if (error) throw error;
+}
+
+/** Kick off an OAuth flow. Supabase handles the redirect. */
+export async function signInWithOAuth(
+  provider: SupportedOAuthProvider,
+): Promise<void> {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: { redirectTo: authCallbackUrl() },
+  });
+  if (error) throw error;
+}
+
+/** Sign out the current session. */
+export async function signOut(): Promise<void> {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+}
+
+/**
+ * React hook returning the current Supabase session (or null).
+ * Subscribes to auth state changes for the lifetime of the component.
+ *
+ * Return shape:
+ *   { session, user, loading }
+ *
+ *   - loading is true only on the initial load before we've checked
+ *     the stored session. After that, session === null means
+ *     "confirmed not authenticated", not "still loading".
+ */
+export function useSession(): {
+  session: Session | null;
+  user: User | null;
+  loading: boolean;
+} {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (cancelled) return;
+      setSession(data.session);
+      setLoading(false);
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, next) => {
+      if (cancelled) return;
+      setSession(next);
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  return { session, user: session?.user ?? null, loading };
+}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,85 @@
+/**
+ * /auth/callback
+ *
+ * Landing page for Supabase Auth magic-link clicks and OAuth redirects.
+ * @supabase/supabase-js automatically picks up the hash / query
+ * parameters and exchanges them for a session during client init, so
+ * this page just has to wait for the session to be set and then
+ * redirect the user to the app.
+ *
+ * If the URL carries an explicit error (e.g. expired link), Supabase
+ * sends ?error=...&error_description=... which we surface inline.
+ */
+
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { useSession } from "@/lib/auth";
+import { Loader2 } from "lucide-react";
+
+export default function AuthCallbackPage() {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const { session, loading } = useSession();
+
+  const urlError = params.get("error_description") || params.get("error");
+  const [timedOut, setTimedOut] = useState(false);
+
+  useEffect(() => {
+    if (!loading && session) {
+      navigate("/memory/admin", { replace: true });
+    }
+  }, [loading, session, navigate]);
+
+  // If we've been waiting more than 8 seconds with no session and no
+  // URL error, something went wrong silently - nudge the user back
+  // to /login so they can retry.
+  useEffect(() => {
+    if (urlError) return;
+    const id = window.setTimeout(() => setTimedOut(true), 8000);
+    return () => window.clearTimeout(id);
+  }, [urlError]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navbar />
+      <main className="mx-auto w-full max-w-md px-4 py-24">
+        <div className="rounded-2xl border border-border/60 bg-card/40 p-8 text-center shadow-lg">
+          {urlError ? (
+            <>
+              <h1 className="text-xl font-semibold text-heading">Sign in failed</h1>
+              <p className="mt-2 text-sm text-muted-foreground">{urlError}</p>
+              <button
+                onClick={() => navigate("/login", { replace: true })}
+                className="mt-5 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-black hover:opacity-90"
+              >
+                Back to sign in
+              </button>
+            </>
+          ) : timedOut ? (
+            <>
+              <h1 className="text-xl font-semibold text-heading">Still working on it</h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                This is taking longer than expected. Try signing in again.
+              </p>
+              <button
+                onClick={() => navigate("/login", { replace: true })}
+                className="mt-5 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-black hover:opacity-90"
+              >
+                Back to sign in
+              </button>
+            </>
+          ) : (
+            <>
+              <Loader2 className="mx-auto h-6 w-6 animate-spin text-primary" />
+              <h1 className="mt-4 text-lg font-semibold text-heading">Signing you in</h1>
+              <p className="mt-1 text-xs text-muted-foreground">One moment.</p>
+            </>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,224 @@
+/**
+ * Login page
+ *
+ * Magic link (email) + Google OAuth + Microsoft OAuth.
+ * NO password field. NO GitHub button. Per preflight decisions.
+ */
+
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import FadeIn from "@/components/FadeIn";
+import { useCanonical } from "@/hooks/use-canonical";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Mail, Check } from "lucide-react";
+import { signInWithMagicLink, signInWithOAuth, useSession } from "@/lib/auth";
+import { useEffect } from "react";
+
+export default function LoginPage() {
+  useCanonical("https://unclick.world/login");
+  const navigate = useNavigate();
+  const { session, loading: sessionLoading } = useSession();
+
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState<"magic" | "google" | "azure" | null>(null);
+  const [error, setError] = useState("");
+  const [sent, setSent] = useState(false);
+
+  // If already authenticated, bounce to memory admin.
+  useEffect(() => {
+    if (!sessionLoading && session) {
+      navigate("/memory/admin", { replace: true });
+    }
+  }, [sessionLoading, session, navigate]);
+
+  async function handleMagicLink(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    const trimmed = email.trim();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setError("Enter a valid email address.");
+      return;
+    }
+    setBusy("magic");
+    try {
+      await signInWithMagicLink(trimmed);
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Try again.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleOAuth(provider: "google" | "azure") {
+    setError("");
+    setBusy(provider);
+    try {
+      await signInWithOAuth(provider);
+      // Redirect happens via Supabase. Nothing else to do here.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't start sign in. Try again.");
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navbar />
+      <main className="mx-auto w-full max-w-md px-4 py-16">
+        <FadeIn>
+          <div className="rounded-2xl border border-border/60 bg-card/40 p-8 shadow-lg">
+            <h1 className="text-2xl font-semibold text-heading">Sign in to UnClick</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Magic link or one click with Google or Microsoft. No passwords.
+            </p>
+
+            {sent ? (
+              <div className="mt-6 rounded-xl border border-primary/30 bg-primary/5 p-5">
+                <div className="flex items-center gap-2">
+                  <Check className="h-4 w-4 text-primary" />
+                  <span className="text-sm font-medium text-primary">Check your email</span>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  We sent a magic link to <span className="font-mono text-heading">{email}</span>.
+                  Click it to finish signing in. The link expires in 15 minutes.
+                </p>
+              </div>
+            ) : (
+              <>
+                <form onSubmit={handleMagicLink} className="mt-6 space-y-3">
+                  <div>
+                    <Label htmlFor="email" className="text-xs text-muted-foreground">
+                      Email
+                    </Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      autoComplete="email"
+                      required
+                      value={email}
+                      onChange={(e) => {
+                        setEmail(e.target.value);
+                        setError("");
+                      }}
+                      placeholder="you@example.com"
+                      className="mt-1"
+                    />
+                  </div>
+                  <Button
+                    type="submit"
+                    disabled={busy !== null}
+                    className="w-full bg-primary text-black hover:opacity-90"
+                  >
+                    {busy === "magic" ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Sending link
+                      </>
+                    ) : (
+                      <>
+                        <Mail className="mr-2 h-4 w-4" />
+                        Send magic link
+                      </>
+                    )}
+                  </Button>
+                </form>
+
+                <div className="mt-6 flex items-center gap-3">
+                  <div className="h-px flex-1 bg-border/60" />
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                    or
+                  </span>
+                  <div className="h-px flex-1 bg-border/60" />
+                </div>
+
+                <div className="mt-6 space-y-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy !== null}
+                    onClick={() => handleOAuth("google")}
+                    className="w-full"
+                  >
+                    {busy === "google" ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <GoogleIcon className="mr-2 h-4 w-4" />
+                    )}
+                    Continue with Google
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy !== null}
+                    onClick={() => handleOAuth("azure")}
+                    className="w-full"
+                  >
+                    {busy === "azure" ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <MicrosoftIcon className="mr-2 h-4 w-4" />
+                    )}
+                    Continue with Microsoft
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {error ? (
+              <p className="mt-4 text-xs text-red-400" role="alert">
+                {error}
+              </p>
+            ) : null}
+
+            <p className="mt-6 text-center text-xs text-muted-foreground">
+              New here?{" "}
+              <Link to="/signup" className="text-primary underline-offset-2 hover:underline">
+                Create an account
+              </Link>
+            </p>
+          </div>
+        </FadeIn>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 48 48" aria-hidden="true">
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}
+
+function MicrosoftIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 23 23" aria-hidden="true">
+      <path fill="#F25022" d="M1 1h10v10H1z" />
+      <path fill="#7FBA00" d="M12 1h10v10H12z" />
+      <path fill="#00A4EF" d="M1 12h10v10H1z" />
+      <path fill="#FFB900" d="M12 12h10v10H12z" />
+    </svg>
+  );
+}

--- a/src/pages/MemoryAdmin.tsx
+++ b/src/pages/MemoryAdmin.tsx
@@ -34,6 +34,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import ClaimKeyBanner from "@/components/ClaimKeyBanner";
 import { Brain, Database, Monitor, CheckCircle2, ArrowRight } from "lucide-react";
 
 interface MemoryConfigStatus {
@@ -112,6 +113,7 @@ export default function MemoryAdminPage() {
     <div className="min-h-screen">
       <Navbar />
       <main className="mx-auto max-w-6xl px-6 pb-32 pt-28">
+        <ClaimKeyBanner />
         <div className="mb-8 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
             <Brain className="h-5 w-5" />

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,0 +1,227 @@
+/**
+ * Signup page
+ *
+ * Functionally identical to /login because Supabase magic-link + OAuth
+ * don't distinguish signup from signin - a new email just gets created
+ * on first successful verify. This page exists so marketing / product
+ * links can point users at an explicit "create account" CTA without
+ * sending them through login copy.
+ *
+ * Magic link (email) + Google OAuth + Microsoft OAuth.
+ * NO password field. NO GitHub button. Per preflight decisions.
+ */
+
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import FadeIn from "@/components/FadeIn";
+import { useCanonical } from "@/hooks/use-canonical";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Mail, Check } from "lucide-react";
+import { signInWithMagicLink, signInWithOAuth, useSession } from "@/lib/auth";
+
+export default function SignupPage() {
+  useCanonical("https://unclick.world/signup");
+  const navigate = useNavigate();
+  const { session, loading: sessionLoading } = useSession();
+
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState<"magic" | "google" | "azure" | null>(null);
+  const [error, setError] = useState("");
+  const [sent, setSent] = useState(false);
+
+  useEffect(() => {
+    if (!sessionLoading && session) {
+      navigate("/memory/admin", { replace: true });
+    }
+  }, [sessionLoading, session, navigate]);
+
+  async function handleMagicLink(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    const trimmed = email.trim();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setError("Enter a valid email address.");
+      return;
+    }
+    setBusy("magic");
+    try {
+      await signInWithMagicLink(trimmed);
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Try again.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleOAuth(provider: "google" | "azure") {
+    setError("");
+    setBusy(provider);
+    try {
+      await signInWithOAuth(provider);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't start sign up. Try again.");
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navbar />
+      <main className="mx-auto w-full max-w-md px-4 py-16">
+        <FadeIn>
+          <div className="rounded-2xl border border-border/60 bg-card/40 p-8 shadow-lg">
+            <h1 className="text-2xl font-semibold text-heading">Create your UnClick account</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Takes about ten seconds. No passwords.
+            </p>
+
+            {sent ? (
+              <div className="mt-6 rounded-xl border border-primary/30 bg-primary/5 p-5">
+                <div className="flex items-center gap-2">
+                  <Check className="h-4 w-4 text-primary" />
+                  <span className="text-sm font-medium text-primary">Check your email</span>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  We sent a magic link to <span className="font-mono text-heading">{email}</span>.
+                  Click it to finish creating your account. The link expires in 15 minutes.
+                </p>
+              </div>
+            ) : (
+              <>
+                <form onSubmit={handleMagicLink} className="mt-6 space-y-3">
+                  <div>
+                    <Label htmlFor="email" className="text-xs text-muted-foreground">
+                      Email
+                    </Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      autoComplete="email"
+                      required
+                      value={email}
+                      onChange={(e) => {
+                        setEmail(e.target.value);
+                        setError("");
+                      }}
+                      placeholder="you@example.com"
+                      className="mt-1"
+                    />
+                  </div>
+                  <Button
+                    type="submit"
+                    disabled={busy !== null}
+                    className="w-full bg-primary text-black hover:opacity-90"
+                  >
+                    {busy === "magic" ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Sending link
+                      </>
+                    ) : (
+                      <>
+                        <Mail className="mr-2 h-4 w-4" />
+                        Send magic link
+                      </>
+                    )}
+                  </Button>
+                </form>
+
+                <div className="mt-6 flex items-center gap-3">
+                  <div className="h-px flex-1 bg-border/60" />
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                    or
+                  </span>
+                  <div className="h-px flex-1 bg-border/60" />
+                </div>
+
+                <div className="mt-6 space-y-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy !== null}
+                    onClick={() => handleOAuth("google")}
+                    className="w-full"
+                  >
+                    {busy === "google" ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <GoogleIcon className="mr-2 h-4 w-4" />
+                    )}
+                    Continue with Google
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy !== null}
+                    onClick={() => handleOAuth("azure")}
+                    className="w-full"
+                  >
+                    {busy === "azure" ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <MicrosoftIcon className="mr-2 h-4 w-4" />
+                    )}
+                    Continue with Microsoft
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {error ? (
+              <p className="mt-4 text-xs text-red-400" role="alert">
+                {error}
+              </p>
+            ) : null}
+
+            <p className="mt-6 text-center text-xs text-muted-foreground">
+              Already have an account?{" "}
+              <Link to="/login" className="text-primary underline-offset-2 hover:underline">
+                Sign in
+              </Link>
+            </p>
+          </div>
+        </FadeIn>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 48 48" aria-hidden="true">
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}
+
+function MicrosoftIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 23 23" aria-hidden="true">
+      <path fill="#F25022" d="M1 1h10v10H1z" />
+      <path fill="#7FBA00" d="M12 1h10v10H12z" />
+      <path fill="#00A4EF" d="M1 12h10v10H1z" />
+      <path fill="#FFB900" d="M12 12h10v10H12z" />
+    </svg>
+  );
+}

--- a/supabase/migrations/20260416000000_auth_foundation.sql
+++ b/supabase/migrations/20260416000000_auth_foundation.sql
@@ -1,0 +1,179 @@
+-- ============================================================
+-- UnClick Phase 2 - Auth Foundation
+-- ============================================================
+-- Links Supabase Auth (auth.users) to the existing api_keys table
+-- and adds the auth_devices table used by the device-pair flow.
+--
+-- This migration is DEFENSIVE because the production api_keys table
+-- has two column shapes coexisting (see Phase 2 session notes):
+--   - Old:  email / api_key (plaintext) / status
+--   - New:  key_hash / key_prefix / user_id / tier / is_active
+-- ApiKeySignup.tsx still writes the old shape; api/mcp.ts (Phase 1)
+-- reads the new shape. Both paths work in production today, which
+-- means the table has both sets of columns bolted on. This migration
+-- makes no assumptions and no-ops gracefully on anything that's
+-- already in place or missing.
+--
+-- Scope:
+--   1. Ensure api_keys.user_id exists (keychain_mvp already creates
+--      it, but be defensive).
+--   2. Add FK constraint api_keys.user_id -> auth.users(id) if not
+--      already present.
+--   3. Backfill api_keys.user_id from auth.users.email where the
+--      old-shape email column is present.
+--   4. Create auth_devices table for the device-pair stub.
+-- ============================================================
+
+-- ─── 1. Ensure api_keys.user_id exists ─────────────────────────────────────
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'api_keys'
+      AND column_name = 'user_id'
+  ) THEN
+    ALTER TABLE public.api_keys ADD COLUMN user_id UUID;
+  END IF;
+END $$;
+
+-- ─── 2. Add FK constraint api_keys.user_id -> auth.users(id) ───────────────
+-- ON DELETE SET NULL: if an auth.users row is deleted, orphan the api_key
+-- rather than cascade-delete it. api_keys carries usage history and
+-- platform credentials that outlive the account.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'api_keys'
+      AND constraint_name = 'api_keys_user_id_fkey'
+  ) THEN
+    ALTER TABLE public.api_keys
+      ADD CONSTRAINT api_keys_user_id_fkey
+      FOREIGN KEY (user_id)
+      REFERENCES auth.users(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON public.api_keys(user_id);
+
+-- ─── 3. Backfill user_id from email match (only if email column exists) ────
+-- This is best-effort. It only backfills rows that are unambiguous:
+-- one api_keys row per email, one auth.users row per email, both
+-- emails match exactly (case-insensitive). Rows with multiple api_keys
+-- per email are left alone and handled later by the claim flow.
+DO $$
+DECLARE
+  has_email BOOLEAN;
+  has_status BOOLEAN;
+  backfilled INTEGER;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'api_keys'
+      AND column_name = 'email'
+  ) INTO has_email;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'api_keys'
+      AND column_name = 'status'
+  ) INTO has_status;
+
+  IF NOT has_email THEN
+    RAISE NOTICE 'auth_foundation: api_keys.email not present, skipping backfill';
+    RETURN;
+  END IF;
+
+  -- Use dynamic SQL so this block parses even if the columns don't
+  -- exist at parse time on a fresh database.
+  IF has_status THEN
+    EXECUTE $sql$
+      UPDATE public.api_keys ak
+      SET user_id = u.id
+      FROM auth.users u
+      WHERE ak.user_id IS NULL
+        AND ak.email IS NOT NULL
+        AND lower(ak.email) = lower(u.email)
+        AND u.email_confirmed_at IS NOT NULL
+        AND COALESCE(ak.status, 'active') = 'active'
+        AND NOT EXISTS (
+          SELECT 1 FROM public.api_keys ak2
+          WHERE lower(ak2.email) = lower(ak.email)
+            AND ak2.id <> ak.id
+        )
+    $sql$;
+  ELSE
+    EXECUTE $sql$
+      UPDATE public.api_keys ak
+      SET user_id = u.id
+      FROM auth.users u
+      WHERE ak.user_id IS NULL
+        AND ak.email IS NOT NULL
+        AND lower(ak.email) = lower(u.email)
+        AND u.email_confirmed_at IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM public.api_keys ak2
+          WHERE lower(ak2.email) = lower(ak.email)
+            AND ak2.id <> ak.id
+        )
+    $sql$;
+  END IF;
+
+  GET DIAGNOSTICS backfilled = ROW_COUNT;
+  RAISE NOTICE 'auth_foundation: backfilled % api_keys rows with user_id', backfilled;
+END $$;
+
+-- ─── 4. auth_devices table ────────────────────────────────────────────────
+-- Paired devices per authenticated user. Schema is multi-device ready
+-- even though the UI ships single-device for this phase. device_id is
+-- the client-supplied stable ID (e.g. machine fingerprint), device_name
+-- is the human label shown in the UI.
+--
+-- Distinct from memory_devices (Phase 1, api_key_hash-keyed, tracks
+-- where memory is stored). auth_devices is user_id-keyed and tracks
+-- authenticated sessions.
+CREATE TABLE IF NOT EXISTS public.auth_devices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  device_id TEXT NOT NULL,
+  device_name TEXT,
+  paired_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ,
+  UNIQUE(user_id, device_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_devices_user ON public.auth_devices(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_devices_active
+  ON public.auth_devices(user_id, last_seen_at DESC)
+  WHERE revoked_at IS NULL;
+
+-- RLS: service role only. Device pairing goes through memory-admin.ts
+-- which uses the service-role client. Direct anon/authenticated access
+-- is denied. Defense in depth; service role bypasses RLS anyway.
+ALTER TABLE public.auth_devices ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'auth_devices'
+      AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON public.auth_devices
+      FOR ALL TO service_role
+      USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+-- ============================================================
+-- DONE.
+-- ============================================================


### PR DESCRIPTION
# Phase 2 - Auth Foundation

**Date:** 2026-04-16
**Branch:** `claude/phase-2-auth-foundation` (cut off `claude/setup-malamute-mayhem-zkquO` @ `bac1848` after Phase 1 PR #14 merged)
**Preflight doc:** `docs/sessions/2026-04-15-phase-2-preflight.md`

## Scope shipped

All six Phase 2 deliverables from the preflight:

1. `/login` and `/signup` routes (magic link + Google + Microsoft)
2. `/auth/callback` route
3. `api_keys.user_id` FK migration + backfill
4. localStorage-to-auth claim flow (`ClaimKeyBanner`)
5. Session cookies + route protection (`RequireAuth`, gating `/memory/admin`)
6. `POST /api/auth/device-pair` stub - folded into `memory-admin.ts` as `auth_device_pair`

## Decisions (from preflight, not re-litigated)

- Magic link + Google + Microsoft only. No GitHub, no passwords anywhere.
- Default Supabase email template for this phase.
- Resend SMTP (Chris confirmed `RESEND_API_KEY` set in Vercel + Supabase).
- Supabase Auth provider toggles already flipped by Chris.

## Collision notes found during kickoff scan

### `api_keys` table has two column shapes in production

Phase 1 (`20260410100000_keychain_mvp.sql`) declares the new shape with `key_hash` / `user_id` / `tier` / `is_active`. The older shape with `email` / `api_key` (plaintext) / `status` is still queried by `src/components/ApiKeySignup.tsx` and `api/install-ticket.ts`. Production must carry both column sets for signup to work today. The Phase 2 migration and `claim_api_key` action both handle this drift:

- Migration: defensive `DO $$ ... $$` blocks that no-op if `email` / `status` columns aren't present. Backfill only runs when the old-shape columns exist.
- `claim_api_key`: tries a new-shape lookup first (`eq(key_hash, ...)`), falls back to old-shape (`eq(api_key, ...)`). Treats `42703` (undefined column) as "not found" rather than a hard failure, so it won't break on a fresh database.

### mcp.ts session-cookie branch

Added a parallel auth path in `api/mcp.ts` that:

1. Reads the Supabase session cookie from the request.
2. Calls `supabase.auth.getUser(token)` to verify.
3. Looks up an active api_keys row via the Phase 2 `user_id` FK.
4. Returns the same `ApiKeyContext` shape as the api_key path.

The api_key path is unchanged. Session-cookie auth explicitly does NOT populate `process.env.UNCLICK_API_KEY` (only the hash), which preserves the BYOD AES-256-GCM property: vault-bridge.ts short-circuits without the plaintext key, so a browser-session-authenticated caller cannot decrypt stored BYOD credentials.

### Vercel 12-function cap

Confirmed 12 `.ts` files under `api/` (11 top-level + `api/tools/demo.ts`). No new files added. All Phase 2 server endpoints fold into `memory-admin.ts` via distinct action names:

- `claim_api_key` - link anonymous api_keys row to auth.users row
- `auth_device_pair` - stub device pairing (upsert into `auth_devices`)
- `auth_device_list` - list paired devices for the session user
- `auth_device_revoke` - soft-delete a device pairing

Namespaced as `auth_device_*` to avoid colliding with the existing Phase 1 memory device actions (`device_check`, `list_devices`, `remove_device`) which operate on `memory_devices` (api_key_hash-keyed, tracks where memory lives). Distinct concepts, distinct tables, distinct handlers.

## Files changed

### New files

| File | Purpose |
|------|---------|
| `supabase/migrations/20260416000000_auth_foundation.sql` | FK + backfill + auth_devices table |
| `src/lib/auth.ts` | Magic link / OAuth helpers + `useSession` hook |
| `src/pages/Login.tsx` | `/login` route |
| `src/pages/Signup.tsx` | `/signup` route |
| `src/pages/AuthCallback.tsx` | `/auth/callback` route |
| `src/components/RequireAuth.tsx` | Client-side route guard |
| `src/components/ClaimKeyBanner.tsx` | localStorage-to-auth claim UI |

### Modified files

| File | Change |
|------|--------|
| `src/App.tsx` | Registered `/login`, `/signup`, `/auth/callback` routes. Wrapped `/memory/admin` in `<RequireAuth>`. |
| `src/pages/MemoryAdmin.tsx` | Mounted `<ClaimKeyBanner />` at top of main content. |
| `api/memory-admin.ts` | Added `resolveSessionUser` helper + 4 new actions (`claim_api_key`, `auth_device_pair`, `auth_device_list`, `auth_device_revoke`). |
| `api/mcp.ts` | Added `validateSessionCookie` + `extractSupabaseAccessToken` helpers. Session-cookie auth runs as a parallel path to api_key auth. |

### Pulled onto branch

| File | Purpose |
|------|---------|
| `docs/sessions/2026-04-15-phase-2-preflight.md` | Previous-session kickoff doc, pulled from `claude/unclick-admin-phase-2-AcJy3` |

## Verification

- `npm run build` passes clean (Vite build finishes in ~10s)
- `npm test` passes (1 test, example)
- `npm run lint` produces 394 pre-existing issues, zero of which are in Phase 2 files
- `tsc --noEmit -p tsconfig.app.json` produces only 2 pre-existing ArenaNav errors, zero in Phase 2 files

**Not verified in this session (belongs in a follow-up verification session):**

- Migration has not been applied against the live Supabase instance. Chris should run it in the SQL editor and confirm the `DO $$` blocks fire without error.
- End-to-end magic link has not been clicked. Needs a real session once Chris runs the migration.
- Google + Microsoft OAuth buttons have not been clicked through. The Supabase dashboard toggles were confirmed in the preflight doc but the round-trip hasn't been tested.
- `RequireAuth` gating on `/memory/admin` has not been tested with an unauthenticated session in the browser.
- `ClaimKeyBanner` has not been tested against a real `unclick_api_key` in localStorage.

## Follow-up / open loops

- Branded magic-link email template (preflight decision was default-template for this phase).
- Real device-pair protocol (current `auth_device_pair` is a stub: it just upserts a row. A nonce + client-confirmation flow is a later phase).
- `ApiKeySignup.tsx` still writes the old `email` / `api_key` / `status` column shape. Consolidating to the Phase 1 `key_hash` shape is a separate refactor.
- `vercel.json` could get a rewrite for `/api/auth/device-pair` -> `/api/memory-admin?action=auth_device_pair` if we want a prettier external URL. Not needed for the stub.

## BYOD encryption property - verification trace

Walked through every path that could decrypt BYOD creds:

1. `api/credentials.ts:138` - `deriveKey(apiKey, salt)` where `apiKey` is the Bearer header value. Never receives a session JWT: session-authenticated MCP requests don't forward their token here, and `/api/credentials` is only called by `vault-bridge.ts`.
2. `packages/mcp-server/src/vault-bridge.ts:105-128` - reads `process.env.UNCLICK_API_KEY` and short-circuits if unset. Phase 2 session-cookie branch in `api/mcp.ts` explicitly does NOT set `UNCLICK_API_KEY` (only the hash and user_id).
3. `api/memory-admin.ts` `config` action (line 528+) - `deriveKey(apiKey, salt)` where `apiKey` is from `bearerFrom(req)`. Same story: session JWTs are rejected upstream because `resolveSessionUser` is only called for `claim_api_key` / `auth_device_*`, and the `config` action still requires a plaintext api_key.
4. New `claim_api_key` action - accepts a plaintext api_key in the POST body from the browser (sourced from localStorage at the moment of claim). Hashes it for row lookup. Never derives a PBKDF2 key. Never stores the plaintext.

**Result:** logged-in users still cannot decrypt BYOD creds without holding the plaintext api_key. Staff with service role access can read `encrypted_data` and `salt` but cannot compute the PBKDF2 key without the plaintext. Property preserved.