### PR TITLE
Phase 3: Five-surface admin shell (/admin)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Dockerfile for @unclick/mcp-server
+# Used by Glama to build, test, and score the MCP server.
+# Does not need to be used in production; serverless /api/mcp is the
+# primary runtime path.
+
+# ---- Build stage ----
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy monorepo root files needed for workspace install
+COPY package.json package-lock.json* ./
+COPY packages/mcp-server/package.json ./packages/mcp-server/
+
+# Install all dependencies (including dev) for the mcp-server workspace
+RUN npm install --workspace=@unclick/mcp-server --include-workspace-root
+
+# Copy source for the mcp-server package
+COPY packages/mcp-server ./packages/mcp-server
+
+# Build TypeScript
+RUN npm run build --workspace=@unclick/mcp-server
+
+# Prune dev dependencies for the runtime copy
+RUN npm prune --production --workspace=@unclick/mcp-server
+
+# ---- Runtime stage ----
+FROM node:20-alpine
+
+# Create a non-root user for the MCP server process
+RUN addgroup -S unclick && adduser -S unclick -G unclick
+
+WORKDIR /app
+
+# Copy built package and pruned dependencies
+COPY --from=builder --chown=unclick:unclick /app/packages/mcp-server/dist ./dist
+COPY --from=builder --chown=unclick:unclick /app/packages/mcp-server/package.json ./
+COPY --from=builder --chown=unclick:unclick /app/packages/mcp-server/node_modules ./node_modules
+COPY --from=builder --chown=unclick:unclick /app/packages/mcp-server/README.md ./
+COPY --from=builder --chown=unclick:unclick /app/packages/mcp-server/server.json ./
+
+# Minimal environment
+ENV NODE_ENV=production
+
+USER unclick
+
+# Stdio MCP server entrypoint
+ENTRYPOINT ["node", "dist/index.js"]

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -50,6 +50,17 @@
  *   - auth_device_revoke: POST with { device_id } - mark the row as
  *                         revoked. Soft delete.
  *
+ * Phase 3 admin shell actions (session JWT, resolves user -> api_key_hash):
+ *   - admin_profile: GET - user info, linked api_key tier/status, email
+ *   - admin_facts: GET - mc_extracted_facts for user's tenant, ?query
+ *                  for search, ?show_all=true for non-active statuses
+ *   - admin_delete_fact: POST with { fact_id } - archive a fact
+ *   - admin_update_fact: POST with { fact_id, fact } - update fact text
+ *   - admin_activity: GET - metering_events summary + recent
+ *                     mc_conversation_log sessions for user's tenant
+ *   - admin_credentials: GET - platform_credentials for user's key_hash
+ *   - admin_storage: GET - storage bytes + fact count via RPCs
+ *
  * Note: the auth_device_* actions are namespaced separately from the
  * existing memory device_check/list_devices/remove_device actions which
  * are api_key_hash-keyed and operate on memory_devices (Phase 1).
@@ -201,6 +212,65 @@ async function resolveSessionUser(
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve a session JWT all the way to the tenant's api_key_hash.
+ * Used by Phase 3 admin_* actions so each surface can query mc_*
+ * tables scoped to the authenticated user's tenant.
+ *
+ * Path: Bearer JWT -> auth.users row -> api_keys.user_id -> key_hash.
+ * Handles both old-shape (api_key plaintext) and new-shape (key_hash)
+ * api_keys rows.
+ */
+async function resolveSessionTenant(
+  req: VercelRequest,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  sb: ReturnType<typeof createClient>,
+): Promise<{ userId: string; email: string | null; apiKeyHash: string; tier: string } | null> {
+  const user = await resolveSessionUser(req, supabaseUrl, serviceRoleKey);
+  if (!user) return null;
+
+  // New shape: key_hash column from Phase 1 keychain_mvp migration
+  const { data: newRow, error: newErr } = await sb
+    .from("api_keys")
+    .select("key_hash, tier")
+    .eq("user_id", user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (!newErr && newRow?.key_hash) {
+    return {
+      userId: user.id,
+      email: user.email,
+      apiKeyHash: newRow.key_hash,
+      tier: newRow.tier ?? "free",
+    };
+  }
+
+  // Old shape fallback: api_key plaintext column, compute hash
+  try {
+    const { data: oldRow } = await sb
+      .from("api_keys")
+      .select("api_key, status")
+      .eq("user_id", user.id)
+      .limit(1)
+      .maybeSingle();
+
+    if (oldRow?.api_key) {
+      return {
+        userId: user.id,
+        email: user.email,
+        apiKeyHash: sha256hex(oldRow.api_key),
+        tier: "free",
+      };
+    }
+  } catch {
+    // 42703 = column doesn't exist on fresh DB, treat as not found
+  }
+
+  return null;
 }
 
 // ─── Handler ───────────────────────────────────────────────────────────────
@@ -845,6 +915,220 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("device_id", deviceId);
         if (error) throw error;
         return res.status(200).json({ success: true });
+      }
+
+      // ── Phase 3 admin shell actions (session JWT -> tenant) ────────
+      case "admin_profile": {
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in or no linked API key" });
+
+        // Fetch api_key row details
+        const { data: keyRow } = await supabase
+          .from("api_keys")
+          .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
+          .eq("user_id", tenant.userId)
+          .limit(1)
+          .maybeSingle();
+
+        return res.status(200).json({
+          user_id: tenant.userId,
+          email: tenant.email,
+          api_key_hash: tenant.apiKeyHash,
+          tier: tenant.tier,
+          api_key: keyRow
+            ? {
+                id: keyRow.id,
+                prefix: keyRow.key_prefix,
+                label: keyRow.label,
+                tier: keyRow.tier,
+                is_active: keyRow.is_active,
+                usage_count: keyRow.usage_count,
+                last_used_at: keyRow.last_used_at,
+                created_at: keyRow.created_at,
+              }
+            : null,
+        });
+      }
+
+      case "admin_facts": {
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in or no linked API key" });
+
+        const query = req.query.query as string;
+        const showAll = req.query.show_all === "true";
+        const limit = Math.min(parseInt(req.query.limit as string) || 100, 500);
+
+        let q = supabase
+          .from("mc_extracted_facts")
+          .select("*")
+          .eq("api_key_hash", tenant.apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+
+        if (!showAll) {
+          q = q.eq("status", "active");
+        }
+
+        const { data, error } = await q;
+        if (error) throw error;
+
+        let results = data ?? [];
+        if (query) {
+          const lower = query.toLowerCase();
+          results = results.filter(
+            (f: { fact: string; category: string }) =>
+              f.fact.toLowerCase().includes(lower) ||
+              f.category.toLowerCase().includes(lower),
+          );
+        }
+
+        return res.status(200).json({ data: results });
+      }
+
+      case "admin_delete_fact": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in or no linked API key" });
+
+        const factId = req.body?.fact_id;
+        if (!factId) return res.status(400).json({ error: "fact_id required" });
+
+        const { error } = await supabase
+          .from("mc_extracted_facts")
+          .update({ status: "archived" })
+          .eq("id", factId)
+          .eq("api_key_hash", tenant.apiKeyHash);
+
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
+      case "admin_update_fact": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in or no linked API key" });
+
+        const { fact_id: fId, fact: newText } = req.body ?? {};
+        if (!fId || !newText) {
+          return res.status(400).json({ error: "fact_id and fact required" });
+        }
+
+        const { error } = await supabase
+          .from("mc_extracted_facts")
+          .update({ fact: newText, updated_at: new Date().toISOString() })
+          .eq("id", fId)
+          .eq("api_key_hash", tenant.apiKeyHash);
+
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
+      case "admin_activity": {
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in or no linked API key" });
+
+        // Metering events (last 200, grouped later client-side)
+        const { data: events } = await supabase
+          .from("metering_events")
+          .select("id, platform, operation, success, response_ms, created_at")
+          .eq("key_hash", tenant.apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(200);
+
+        // Recent conversation sessions (distinct session_ids)
+        const { data: convos } = await supabase
+          .from("mc_conversation_log")
+          .select("session_id, role, created_at")
+          .eq("api_key_hash", tenant.apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(500);
+
+        // Aggregate conversation sessions
+        const sessionMap = new Map<string, { count: number; last_message: string }>();
+        for (const msg of convos ?? []) {
+          const existing = sessionMap.get(msg.session_id);
+          if (existing) {
+            existing.count++;
+          } else {
+            sessionMap.set(msg.session_id, { count: 1, last_message: msg.created_at });
+          }
+        }
+        const sessions = Array.from(sessionMap.entries())
+          .map(([id, info]) => ({
+            session_id: id,
+            message_count: info.count,
+            last_message: info.last_message,
+          }))
+          .slice(0, 20);
+
+        return res.status(200).json({
+          metering_events: events ?? [],
+          conversation_sessions: sessions,
+        });
+      }
+
+      case "admin_credentials": {
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in or no linked API key" });
+
+        const { data, error } = await supabase
+          .from("platform_credentials")
+          .select("id, platform, label, is_valid, last_tested_at, created_at")
+          .eq("key_hash", tenant.apiKeyHash)
+          .order("platform");
+
+        if (error) throw error;
+
+        // Enrich with connector info
+        const { data: connectors } = await supabase
+          .from("platform_connectors")
+          .select("id, name, category, icon");
+
+        const connectorMap = new Map(
+          (connectors ?? []).map((c: { id: string; name: string; category: string; icon: string | null }) => [c.id, c]),
+        );
+
+        const enriched = (data ?? []).map((cred: {
+          id: string;
+          platform: string;
+          label: string;
+          is_valid: boolean;
+          last_tested_at: string | null;
+          created_at: string;
+        }) => ({
+          ...cred,
+          connector: connectorMap.get(cred.platform) ?? null,
+        }));
+
+        return res.status(200).json({ data: enriched });
+      }
+
+      case "admin_storage": {
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in or no linked API key" });
+
+        const [bytesResult, countResult] = await Promise.all([
+          supabase.rpc("mc_get_storage_bytes", { p_api_key_hash: tenant.apiKeyHash }),
+          supabase.rpc("mc_get_fact_count", { p_api_key_hash: tenant.apiKeyHash }),
+        ]);
+
+        const storageBytes = bytesResult.data ?? 0;
+        const factCount = countResult.data ?? 0;
+
+        // Free tier caps
+        const caps = {
+          free: { storage_bytes: 50 * 1024 * 1024, facts: 5000 },
+          pro: { storage_bytes: 500 * 1024 * 1024, facts: 50000 },
+          team: { storage_bytes: 2 * 1024 * 1024 * 1024, facts: 200000 },
+        };
+        const tierCaps = caps[tenant.tier as keyof typeof caps] ?? caps.free;
+
+        return res.status(200).json({
+          storage_bytes: storageBytes,
+          fact_count: factCount,
+          tier: tenant.tier,
+          caps: tierCaps,
+        });
       }
 
       // ── Cron actions ────────────────────────────────────────────────

--- a/docs/sessions/2026-04-15-glama-release.md
+++ b/docs/sessions/2026-04-15-glama-release.md
@@ -1,0 +1,24 @@
+# Session: 2026-04-15 — Glama Release
+
+## Summary
+
+Glama build succeeded for the UnClick MCP Server. Release v0.1.0 published at 17:09 UTC.
+
+## What happened
+
+- Configured the Glama Dockerfile admin with build steps (`npm install -g @unclick/mcp-server`) and CMD (`unclick-mcp`) so the binary lands in PATH and mcp-proxy can find it
+- - First build attempt failed with `sh: 1: unclick-mcp: not found` because npx cache is not on the mcp-proxy search path; global install fixed it
+  - - Second build succeeded in 18.1s — 128 packages installed, server started cleanly on stdio
+    - - Glama proxy connected and detected **9 tools**: `unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call`, plus the five memory tools (`get_startup_context`, `write_session_summary`, `add_fact`, `search_memory`, `set_business_context`)
+      - - Release v0.1.0 auto-created from the successful build
+       
+        - ## Status
+       
+        - - Security, license, and quality scores now auto-populating from the release
+          - - This unblocks the final checkbox on PR #4409 (punkpeye/awesome-mcp-servers)
+            - - No further action needed on the Glama side
+             
+              - ## Open loops
+             
+              - - Monitor score page at `/score` once Glama finishes scanning
+                - - Frank's bot should auto-clear the score checkbox when scores land; if not, drop a comment on PR #4409

--- a/docs/sessions/2026-04-16-phase-3-admin-shell.md
+++ b/docs/sessions/2026-04-16-phase-3-admin-shell.md
@@ -1,0 +1,107 @@
+# Phase 3: Five-Surface Admin Shell
+
+**Date:** 2026-04-16
+**Branch:** `claude/phase-3-admin-shell-sBAZm`
+**PR target:** `claude/setup-malamute-mayhem-zkquO`
+**Base:** Phase 2 auth foundation (PR #15) + CI cleanup (PR #16)
+
+## What landed
+
+### Shell layout (AdminShell.tsx)
+- Persistent sidebar on desktop (md+) with five surface icons/labels
+- Mobile/tablet top bar with hamburger nav
+- Active surface highlighted in amber (#E2B93B)
+- User email + logout button in sidebar footer
+- Floating chat assistant placeholder (bottom-right bubble, "Coming soon" panel)
+- Dark palette: background #0A0A0A, cards #111111, accent #E2B93B
+
+### Five surfaces
+
+1. **You** (`/admin/you`) - Identity surface
+   - User email, auth provider, member-since date
+   - Linked API key info (prefix, tier, status, usage count, last used)
+   - ClaimKeyBanner for unclaimed localStorage keys
+   - Paired devices list (from auth_devices) with revoke
+   - Logout button
+
+2. **Memory** (`/admin/memory`) - Memory facts surface
+   - Storage usage bar (bytes used vs tier cap: 50MB free)
+   - Fact count bar (vs tier cap: 5,000 free)
+   - Search/filter facts with text query
+   - Show archived toggle
+   - Inline edit (textarea) and archive (soft delete) per fact
+   - Decay tier badges (hot/warm/cold), category tags, timestamps
+
+3. **Keychain** (`/admin/keychain`) - Credentials surface
+   - AES-256-GCM encryption notice
+   - Credentials grouped by connector category
+   - Status indicators (active/expired)
+   - Reconnect/remove buttons (placeholder, UI wired but no backend action yet)
+   - Link to BackstagePass for adding new services
+
+4. **Tools** (`/admin/tools`) - Tool catalog surface
+   - Reads platform_connectors (public table, anon-readable)
+   - Category grouping with counts
+   - Search across name, category, description
+   - Auth type badge per tool
+   - External link to setup URL
+
+5. **Activity** (`/admin/activity`) - Usage surface
+   - Stats cards: today, this week, this month API calls, success rate
+   - Metering events grouped by day with status icons
+   - Recent conversation sessions with message counts
+   - Two-column layout (events 3/5, sessions 2/5)
+
+### API additions (api/memory-admin.ts)
+No new Vercel functions created (0 new, still at 11). All folded into
+existing memory-admin.ts via action routing:
+
+- `resolveSessionTenant` helper - JWT -> user_id -> api_key_hash (handles both old/new api_keys shape)
+- `admin_profile` - user info + linked api_key details
+- `admin_facts` - mc_extracted_facts scoped to tenant, with search
+- `admin_delete_fact` - archive a fact (session-authenticated)
+- `admin_update_fact` - update fact text (session-authenticated)
+- `admin_activity` - metering_events + mc_conversation_log summary
+- `admin_credentials` - platform_credentials enriched with connector info
+- `admin_storage` - mc_get_storage_bytes + mc_get_fact_count RPCs with tier caps
+
+### Routing changes
+- `/admin` redirects to `/admin/you`
+- `/memory/admin` redirects to `/admin/memory` (preserves old bookmarks)
+- All five `/admin/*` routes wrapped with RequireAuth
+- Login/Signup/AuthCallback now redirect to `/admin` instead of `/memory/admin`
+- Nested route layout via React Router Outlet
+
+## What's stretch (not in this PR)
+
+- BYOD config panel on Memory surface
+- Tool enable/disable toggles on Tools surface
+- Reconnect/remove credential actions on Keychain surface
+- Chat assistant wiring (currently a stub)
+- Mobile-first responsive refinements
+- Marketplace tools section
+
+## Decisions made
+
+- **Admin is a shell, not a settings page.** Five loosely coupled surfaces, each extractable as a native app. No shared state between surfaces beyond the session.
+- **No new Vercel functions.** All 7 new admin actions folded into memory-admin.ts (still at 11/12 cap).
+- **Session JWT auth for all admin actions.** resolveSessionTenant bridges JWT -> api_key_hash using the Phase 2 claim flow.
+- **Both api_keys shapes handled.** new-shape (key_hash) preferred, old-shape (api_key plaintext, compute hash) as fallback.
+- **Tier caps hardcoded in API.** Free: 50MB/5K facts, Pro: 500MB/50K, Team: 2GB/200K. Will move to a config table later.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `api/memory-admin.ts` | +resolveSessionTenant, +7 admin_* actions |
+| `src/App.tsx` | +admin routes, /memory/admin redirect, admin imports |
+| `src/pages/admin/AdminShell.tsx` | NEW - shell layout |
+| `src/pages/admin/AdminYou.tsx` | NEW - identity surface |
+| `src/pages/admin/AdminMemory.tsx` | NEW - memory facts surface |
+| `src/pages/admin/AdminKeychain.tsx` | NEW - keychain surface |
+| `src/pages/admin/AdminTools.tsx` | NEW - tools catalog surface |
+| `src/pages/admin/AdminActivity.tsx` | NEW - activity surface |
+| `src/pages/Login.tsx` | Redirect to /admin |
+| `src/pages/Signup.tsx` | Redirect to /admin |
+| `src/pages/AuthCallback.tsx` | Redirect to /admin |
+| `docs/sessions/2026-04-16-phase-3-admin-shell.md` | NEW - this doc |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { Toaster } from "@/components/ui/toaster";
@@ -25,7 +25,6 @@ import TermsPage from "./pages/Terms.tsx";
 import PrivacyPage from "./pages/Privacy.tsx";
 import BackstagePassPage from "./pages/BackstagePass.tsx";
 import MemoryPage from "./pages/Memory.tsx";
-import MemoryAdminPage from "./pages/MemoryAdmin.tsx";
 import MemorySetupPage from "./pages/MemorySetup.tsx";
 import PricingPage from "./pages/Pricing.tsx";
 import OrganiserPage from "./pages/Organiser.tsx";
@@ -39,6 +38,12 @@ import LoginPage from "./pages/Login.tsx";
 import SignupPage from "./pages/Signup.tsx";
 import AuthCallbackPage from "./pages/AuthCallback.tsx";
 import RequireAuth from "./components/RequireAuth.tsx";
+import AdminShell from "./pages/admin/AdminShell.tsx";
+import AdminYou from "./pages/admin/AdminYou.tsx";
+import AdminMemory from "./pages/admin/AdminMemory.tsx";
+import AdminKeychain from "./pages/admin/AdminKeychain.tsx";
+import AdminTools from "./pages/admin/AdminTools.tsx";
+import AdminActivity from "./pages/admin/AdminActivity.tsx";
 
 const queryClient = new QueryClient();
 
@@ -74,15 +79,25 @@ const App = () => (
           {/* Core product pages */}
           <Route path="/tools" element={<ToolsPage />} />
           <Route path="/memory" element={<MemoryPage />} />
+          {/* /memory/admin redirects to the new admin shell */}
+          <Route path="/memory/admin" element={<Navigate to="/admin/memory" replace />} />
+          <Route path="/memory/setup" element={<MemorySetupPage />} />
+          {/* Phase 3: Admin shell with five surfaces */}
           <Route
-            path="/memory/admin"
+            path="/admin"
             element={
               <RequireAuth>
-                <MemoryAdminPage />
+                <AdminShell />
               </RequireAuth>
             }
-          />
-          <Route path="/memory/setup" element={<MemorySetupPage />} />
+          >
+            <Route index element={<Navigate to="/admin/you" replace />} />
+            <Route path="you" element={<AdminYou />} />
+            <Route path="memory" element={<AdminMemory />} />
+            <Route path="keychain" element={<AdminKeychain />} />
+            <Route path="tools" element={<AdminTools />} />
+            <Route path="activity" element={<AdminActivity />} />
+          </Route>
           {/* Phase 2 auth surface */}
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -28,7 +28,7 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     if (!loading && session) {
-      navigate("/memory/admin", { replace: true });
+      navigate("/admin", { replace: true });
     }
   }, [loading, session, navigate]);
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -31,7 +31,7 @@ export default function LoginPage() {
   // If already authenticated, bounce to memory admin.
   useEffect(() => {
     if (!sessionLoading && session) {
-      navigate("/memory/admin", { replace: true });
+      navigate("/admin", { replace: true });
     }
   }, [sessionLoading, session, navigate]);
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -35,7 +35,7 @@ export default function SignupPage() {
 
   useEffect(() => {
     if (!sessionLoading && session) {
-      navigate("/memory/admin", { replace: true });
+      navigate("/admin", { replace: true });
     }
   }, [sessionLoading, session, navigate]);
 

--- a/src/pages/admin/AdminActivity.tsx
+++ b/src/pages/admin/AdminActivity.tsx
@@ -1,0 +1,292 @@
+/**
+ * AdminActivity - Activity surface (/admin/activity)
+ *
+ * What the agent has done. Shows metering_events for the user's
+ * api_key grouped by day, recent mc_conversation_log sessions,
+ * and usage stats summary (calls today, this week, this month).
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useSession } from "@/lib/auth";
+import {
+  Activity,
+  Loader2,
+  BarChart3,
+  MessageSquare,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  Zap,
+} from "lucide-react";
+
+interface MeteringEvent {
+  id: string;
+  platform: string;
+  operation: string;
+  success: boolean;
+  response_ms: number | null;
+  created_at: string;
+}
+
+interface ConversationSession {
+  session_id: string;
+  message_count: number;
+  last_message: string;
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function dayKey(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function isWithinDays(iso: string, days: number): boolean {
+  return Date.now() - new Date(iso).getTime() < days * 86_400_000;
+}
+
+export default function AdminActivity() {
+  const { session } = useSession();
+  const [events, setEvents] = useState<MeteringEvent[]>([]);
+  const [sessions, setSessions] = useState<ConversationSession[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!session) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_activity", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!cancelled && res.ok) {
+          const body = await res.json();
+          setEvents(body.metering_events ?? []);
+          setSessions(body.conversation_sessions ?? []);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [session]);
+
+  // Usage stats
+  const stats = useMemo(() => {
+    const today = events.filter((e) => isWithinDays(e.created_at, 1)).length;
+    const week = events.filter((e) => isWithinDays(e.created_at, 7)).length;
+    const month = events.filter((e) => isWithinDays(e.created_at, 30)).length;
+    const successRate = events.length
+      ? Math.round((events.filter((e) => e.success).length / events.length) * 100)
+      : 0;
+    const avgMs = events.length
+      ? Math.round(
+          events.reduce((sum, e) => sum + (e.response_ms ?? 0), 0) /
+            events.filter((e) => e.response_ms != null).length || 0,
+        )
+      : 0;
+    return { today, week, month, successRate, avgMs };
+  }, [events]);
+
+  // Group events by day
+  const eventsByDay = useMemo(() => {
+    const map = new Map<string, MeteringEvent[]>();
+    for (const ev of events) {
+      const key = dayKey(ev.created_at);
+      const arr = map.get(key) ?? [];
+      arr.push(ev);
+      map.set(key, arr);
+    }
+    return Array.from(map.entries());
+  }, [events]);
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-white">Activity</h1>
+        <p className="mt-1 text-sm text-[#888]">
+          Agent usage, API calls, and conversation history
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-12 text-[#666]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading activity...</span>
+        </div>
+      ) : (
+        <>
+          {/* Stats cards */}
+          <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard
+              icon={Zap}
+              label="Today"
+              value={stats.today.toString()}
+              sub="API calls"
+            />
+            <StatCard
+              icon={BarChart3}
+              label="This week"
+              value={stats.week.toString()}
+              sub="API calls"
+            />
+            <StatCard
+              icon={Activity}
+              label="This month"
+              value={stats.month.toString()}
+              sub="API calls"
+            />
+            <StatCard
+              icon={CheckCircle2}
+              label="Success rate"
+              value={`${stats.successRate}%`}
+              sub={stats.avgMs > 0 ? `avg ${stats.avgMs}ms` : "no data"}
+            />
+          </div>
+
+          {/* Two-column layout: events + conversations */}
+          <div className="grid gap-6 lg:grid-cols-5">
+            {/* Recent API calls (3/5 width) */}
+            <div className="lg:col-span-3">
+              <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold text-white">
+                <BarChart3 className="h-4 w-4 text-[#E2B93B]" />
+                Recent API Calls
+              </h2>
+
+              {events.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-white/[0.08] bg-[#111111] p-6 text-center">
+                  <p className="text-xs text-[#666]">
+                    No API calls recorded yet
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {eventsByDay.map(([day, dayEvents]) => (
+                    <div key={day}>
+                      <h4 className="mb-2 text-[11px] font-medium text-[#666]">
+                        {day}
+                        <span className="ml-2 text-[#555]">
+                          ({dayEvents.length} call{dayEvents.length !== 1 ? "s" : ""})
+                        </span>
+                      </h4>
+                      <div className="space-y-1">
+                        {dayEvents.slice(0, 10).map((ev) => (
+                          <div
+                            key={ev.id}
+                            className="flex items-center justify-between rounded-lg border border-white/[0.04] bg-[#111111] px-3 py-2"
+                          >
+                            <div className="flex items-center gap-2">
+                              {ev.success ? (
+                                <CheckCircle2 className="h-3 w-3 text-green-400" />
+                              ) : (
+                                <XCircle className="h-3 w-3 text-red-400" />
+                              )}
+                              <span className="text-xs font-medium text-white">
+                                {ev.platform}
+                              </span>
+                              <span className="text-[11px] text-[#666]">
+                                {ev.operation}
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-3 text-[10px] text-[#555]">
+                              {ev.response_ms != null && (
+                                <span>{ev.response_ms}ms</span>
+                              )}
+                              <span>{timeAgo(ev.created_at)}</span>
+                            </div>
+                          </div>
+                        ))}
+                        {dayEvents.length > 10 && (
+                          <p className="py-1 text-center text-[10px] text-[#555]">
+                            +{dayEvents.length - 10} more
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Recent conversations (2/5 width) */}
+            <div className="lg:col-span-2">
+              <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold text-white">
+                <MessageSquare className="h-4 w-4 text-[#E2B93B]" />
+                Recent Sessions
+              </h2>
+
+              {sessions.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-white/[0.08] bg-[#111111] p-6 text-center">
+                  <p className="text-xs text-[#666]">
+                    No conversation sessions recorded
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {sessions.map((s) => (
+                    <div
+                      key={s.session_id}
+                      className="rounded-xl border border-white/[0.06] bg-[#111111] p-3"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <code className="truncate font-mono text-[11px] text-white">
+                          {s.session_id.length > 20
+                            ? `${s.session_id.slice(0, 20)}...`
+                            : s.session_id}
+                        </code>
+                        <span className="shrink-0 rounded-full border border-white/[0.08] px-2 py-0.5 text-[10px] text-[#888]">
+                          {s.message_count} msg{s.message_count !== 1 ? "s" : ""}
+                        </span>
+                      </div>
+                      <p className="mt-1 flex items-center gap-1 text-[10px] text-[#555]">
+                        <Clock className="h-3 w-3" />
+                        {timeAgo(s.last_message)}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+}: {
+  icon: typeof Activity;
+  label: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-4">
+      <div className="flex items-center gap-2 text-xs text-[#888]">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
+      <p className="mt-0.5 text-[11px] text-[#555]">{sub}</p>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -1,0 +1,205 @@
+/**
+ * AdminKeychain - Keychain surface (/admin/keychain)
+ *
+ * BackstagePass with a face. Lists connected services from
+ * platform_credentials + platform_connectors, shows status
+ * indicators (active/expired), with placeholder reconnect/remove UI.
+ */
+
+import { useEffect, useState } from "react";
+import { useSession } from "@/lib/auth";
+import {
+  KeyRound,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  RefreshCw,
+  Trash2,
+  ExternalLink,
+  Shield,
+} from "lucide-react";
+
+interface Credential {
+  id: string;
+  platform: string;
+  label: string;
+  is_valid: boolean;
+  last_tested_at: string | null;
+  created_at: string;
+  connector: {
+    id: string;
+    name: string;
+    category: string;
+    icon: string | null;
+  } | null;
+}
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return "never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+export default function AdminKeychain() {
+  const { session } = useSession();
+  const [credentials, setCredentials] = useState<Credential[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!session) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_credentials", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!cancelled && res.ok) {
+          const body = await res.json();
+          setCredentials(body.data ?? []);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [session]);
+
+  // Group by category
+  const grouped = credentials.reduce<Record<string, Credential[]>>((acc, cred) => {
+    const cat = cred.connector?.category ?? "Other";
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push(cred);
+    return acc;
+  }, {});
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-white">Keychain</h1>
+        <p className="mt-1 text-sm text-[#888]">
+          Connected services and credentials
+        </p>
+      </div>
+
+      {/* Encryption notice */}
+      <div className="mb-6 flex items-start gap-3 rounded-xl border border-[#E2B93B]/20 bg-[#E2B93B]/5 px-4 py-3">
+        <Shield className="mt-0.5 h-4 w-4 shrink-0 text-[#E2B93B]" />
+        <div>
+          <p className="text-xs font-medium text-[#E2B93B]">
+            End-to-end encrypted
+          </p>
+          <p className="mt-0.5 text-[11px] text-[#888]">
+            All credentials are encrypted with AES-256-GCM using a key derived
+            from your API key. UnClick staff cannot decrypt them.
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-12 text-[#666]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading credentials...</span>
+        </div>
+      ) : credentials.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-white/[0.08] bg-[#111111] p-8 text-center">
+          <KeyRound className="mx-auto h-8 w-8 text-[#333]" />
+          <p className="mt-3 text-sm text-[#666]">No credentials stored</p>
+          <p className="mt-1 text-xs text-[#444]">
+            Connect a platform via{" "}
+            <a
+              href="/backstagepass"
+              className="text-[#E2B93B] underline-offset-2 hover:underline"
+            >
+              BackstagePass
+            </a>{" "}
+            or the MCP server to see it here
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {Object.entries(grouped).map(([category, creds]) => (
+            <div key={category}>
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[#666]">
+                {category}
+              </h3>
+              <div className="space-y-2">
+                {creds.map((cred) => (
+                  <div
+                    key={cred.id}
+                    className="group flex items-center justify-between rounded-xl border border-white/[0.06] bg-[#111111] p-4"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/[0.04] text-sm font-semibold text-[#888]">
+                        {cred.connector?.icon ?? cred.platform.slice(0, 2).toUpperCase()}
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-white">
+                          {cred.connector?.name ?? cred.platform}
+                        </p>
+                        <p className="text-[11px] text-[#666]">
+                          {cred.label} - added {timeAgo(cred.created_at)}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      {/* Status badge */}
+                      {cred.is_valid ? (
+                        <span className="flex items-center gap-1 rounded-full border border-green-500/20 bg-green-500/10 px-2 py-0.5 text-[10px] font-medium text-green-400">
+                          <CheckCircle2 className="h-3 w-3" />
+                          Active
+                        </span>
+                      ) : (
+                        <span className="flex items-center gap-1 rounded-full border border-red-500/20 bg-red-500/10 px-2 py-0.5 text-[10px] font-medium text-red-400">
+                          <XCircle className="h-3 w-3" />
+                          Expired
+                        </span>
+                      )}
+
+                      {/* Action buttons (placeholder) */}
+                      <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                        <button
+                          className="rounded-md p-1.5 text-[#666] transition-colors hover:bg-white/[0.04] hover:text-[#ccc]"
+                          title="Reconnect (coming soon)"
+                          onClick={() => {}}
+                        >
+                          <RefreshCw className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          className="rounded-md p-1.5 text-[#666] transition-colors hover:bg-red-500/10 hover:text-red-400"
+                          title="Remove (coming soon)"
+                          onClick={() => {}}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Connect more link */}
+      <div className="mt-8 text-center">
+        <a
+          href="/backstagepass"
+          className="inline-flex items-center gap-2 rounded-lg border border-white/[0.06] px-4 py-2.5 text-sm text-[#888] transition-colors hover:border-[#E2B93B]/20 hover:text-[#E2B93B]"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          Connect a new service
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminMemory.tsx
+++ b/src/pages/admin/AdminMemory.tsx
@@ -1,0 +1,334 @@
+/**
+ * AdminMemory - Memory surface (/admin/memory)
+ *
+ * 6-layer view of the user's memory. Shows mc_extracted_facts for the
+ * authenticated user's api_key_hash with search/filter. Edit and
+ * delete individual facts. Storage usage vs free-tier caps.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useSession } from "@/lib/auth";
+import {
+  Brain,
+  Search,
+  Trash2,
+  Pencil,
+  Check,
+  X,
+  Loader2,
+  Database,
+  AlertTriangle,
+} from "lucide-react";
+
+interface Fact {
+  id: string;
+  fact: string;
+  category: string;
+  confidence: number;
+  status: string;
+  decay_tier: string;
+  source_type: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface StorageInfo {
+  storage_bytes: number;
+  fact_count: number;
+  tier: string;
+  caps: { storage_bytes: number; facts: number };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export default function AdminMemory() {
+  const { session } = useSession();
+  const [facts, setFacts] = useState<Fact[]>([]);
+  const [storage, setStorage] = useState<StorageInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState("");
+
+  const fetchData = useCallback(async () => {
+    if (!session) return;
+    const headers = { Authorization: `Bearer ${session.access_token}` };
+
+    const params = new URLSearchParams({ action: "admin_facts" });
+    if (query) params.set("query", query);
+    if (showAll) params.set("show_all", "true");
+
+    const [factsRes, storageRes] = await Promise.all([
+      fetch(`/api/memory-admin?${params}`, { headers }),
+      fetch("/api/memory-admin?action=admin_storage", { headers }),
+    ]);
+
+    if (factsRes.ok) {
+      const body = await factsRes.json();
+      setFacts(body.data ?? []);
+    }
+    if (storageRes.ok) {
+      setStorage(await storageRes.json());
+    }
+    setLoading(false);
+  }, [session, query, showAll]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  async function deleteFact(factId: string) {
+    if (!session) return;
+    await fetch("/api/memory-admin?action=admin_delete_fact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ fact_id: factId }),
+    });
+    setFacts((prev) => prev.filter((f) => f.id !== factId));
+  }
+
+  async function saveFact(factId: string) {
+    if (!session || !editText.trim()) return;
+    const res = await fetch("/api/memory-admin?action=admin_update_fact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ fact_id: factId, fact: editText.trim() }),
+    });
+    if (res.ok) {
+      setFacts((prev) =>
+        prev.map((f) => (f.id === factId ? { ...f, fact: editText.trim() } : f)),
+      );
+      setEditingId(null);
+    }
+  }
+
+  const storagePercent = storage
+    ? Math.min((storage.storage_bytes / storage.caps.storage_bytes) * 100, 100)
+    : 0;
+  const factsPercent = storage
+    ? Math.min((storage.fact_count / storage.caps.facts) * 100, 100)
+    : 0;
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-white">Memory</h1>
+        <p className="mt-1 text-sm text-[#888]">
+          Your agent's extracted facts and memory usage
+        </p>
+      </div>
+
+      {/* Storage usage cards */}
+      {storage && (
+        <div className="mb-6 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-4">
+            <div className="flex items-center justify-between">
+              <span className="flex items-center gap-2 text-xs font-medium text-[#888]">
+                <Database className="h-3.5 w-3.5" />
+                Storage
+              </span>
+              <span className="text-xs text-[#666]">
+                {formatBytes(storage.storage_bytes)} / {formatBytes(storage.caps.storage_bytes)}
+              </span>
+            </div>
+            <div className="mt-2 h-1.5 rounded-full bg-white/[0.06]">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  storagePercent > 90 ? "bg-red-400" : "bg-[#E2B93B]"
+                }`}
+                style={{ width: `${storagePercent}%` }}
+              />
+            </div>
+            {storagePercent > 80 && (
+              <p className="mt-1.5 flex items-center gap-1 text-[10px] text-amber-400">
+                <AlertTriangle className="h-3 w-3" />
+                {storagePercent > 90 ? "Storage almost full" : "Approaching storage limit"}
+              </p>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-4">
+            <div className="flex items-center justify-between">
+              <span className="flex items-center gap-2 text-xs font-medium text-[#888]">
+                <Brain className="h-3.5 w-3.5" />
+                Facts
+              </span>
+              <span className="text-xs text-[#666]">
+                {storage.fact_count.toLocaleString()} / {storage.caps.facts.toLocaleString()}
+              </span>
+            </div>
+            <div className="mt-2 h-1.5 rounded-full bg-white/[0.06]">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  factsPercent > 90 ? "bg-red-400" : "bg-[#E2B93B]"
+                }`}
+                style={{ width: `${factsPercent}%` }}
+              />
+            </div>
+            {factsPercent > 80 && (
+              <p className="mt-1.5 flex items-center gap-1 text-[10px] text-amber-400">
+                <AlertTriangle className="h-3 w-3" />
+                {factsPercent > 90 ? "Fact limit almost reached" : "Approaching fact limit"}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Search + filter bar */}
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#666]" />
+          <input
+            type="text"
+            placeholder="Search facts..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full rounded-lg border border-white/[0.06] bg-[#111111] py-2.5 pl-10 pr-4 text-sm text-white placeholder-[#555] outline-none transition-colors focus:border-[#E2B93B]/30"
+          />
+        </div>
+        <label className="flex items-center gap-2 text-xs text-[#888]">
+          <input
+            type="checkbox"
+            checked={showAll}
+            onChange={(e) => setShowAll(e.target.checked)}
+            className="h-3.5 w-3.5 rounded border-white/[0.1] bg-[#111111] accent-[#E2B93B]"
+          />
+          Show archived
+        </label>
+      </div>
+
+      {/* Facts list */}
+      {loading ? (
+        <div className="flex items-center gap-2 py-12 text-[#666]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading facts...</span>
+        </div>
+      ) : facts.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-white/[0.08] bg-[#111111] p-8 text-center">
+          <Brain className="mx-auto h-8 w-8 text-[#333]" />
+          <p className="mt-3 text-sm text-[#666]">
+            {query ? "No facts match your search" : "No facts extracted yet"}
+          </p>
+          <p className="mt-1 text-xs text-[#444]">
+            Facts appear here as your agent learns from conversations
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {facts.map((fact) => (
+            <div
+              key={fact.id}
+              className={`group rounded-xl border bg-[#111111] p-4 transition-colors ${
+                fact.status !== "active"
+                  ? "border-white/[0.03] opacity-60"
+                  : "border-white/[0.06]"
+              }`}
+            >
+              {editingId === fact.id ? (
+                <div className="space-y-2">
+                  <textarea
+                    value={editText}
+                    onChange={(e) => setEditText(e.target.value)}
+                    className="w-full resize-none rounded-lg border border-[#E2B93B]/30 bg-[#0A0A0A] p-3 text-sm text-white outline-none"
+                    rows={3}
+                    autoFocus
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => saveFact(fact.id)}
+                      className="flex items-center gap-1.5 rounded-md bg-[#E2B93B] px-3 py-1.5 text-xs font-medium text-black"
+                    >
+                      <Check className="h-3 w-3" />
+                      Save
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      className="flex items-center gap-1.5 rounded-md border border-white/[0.08] px-3 py-1.5 text-xs text-[#888]"
+                    >
+                      <X className="h-3 w-3" />
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm text-white">{fact.fact}</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-[10px] text-[#888]">
+                        {fact.category}
+                      </span>
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                          fact.decay_tier === "hot"
+                            ? "bg-red-500/10 text-red-400"
+                            : fact.decay_tier === "warm"
+                              ? "bg-amber-500/10 text-amber-400"
+                              : "bg-blue-500/10 text-blue-400"
+                        }`}
+                      >
+                        {fact.decay_tier}
+                      </span>
+                      {fact.status !== "active" && (
+                        <span className="rounded-full bg-white/[0.04] px-2 py-0.5 text-[10px] text-[#666]">
+                          {fact.status}
+                        </span>
+                      )}
+                      <span className="text-[10px] text-[#555]">
+                        {timeAgo(fact.created_at)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                    <button
+                      onClick={() => {
+                        setEditingId(fact.id);
+                        setEditText(fact.fact);
+                      }}
+                      className="rounded-md p-1.5 text-[#666] transition-colors hover:bg-white/[0.04] hover:text-[#ccc]"
+                      title="Edit"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      onClick={() => deleteFact(fact.id)}
+                      className="rounded-md p-1.5 text-[#666] transition-colors hover:bg-red-500/10 hover:text-red-400"
+                      title="Archive"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -1,0 +1,198 @@
+/**
+ * AdminShell - OS shell layout for the five admin surfaces.
+ *
+ * Persistent sidebar (desktop) or top nav (tablet) with surface icons,
+ * user avatar/email, logout. Floating chat assistant stub in the
+ * bottom-right corner. Content rendered via React Router <Outlet>.
+ *
+ * Dark palette: bg #0A0A0A, accent amber #E2B93B.
+ * Each surface is extractable as a native app later.
+ */
+
+import { useState } from "react";
+import { Link, NavLink, Outlet, useNavigate } from "react-router-dom";
+import { useSession, signOut } from "@/lib/auth";
+import {
+  User,
+  Brain,
+  KeyRound,
+  Wrench,
+  Activity,
+  LogOut,
+  MessageCircle,
+  X,
+  Menu,
+} from "lucide-react";
+
+const surfaces = [
+  { path: "/admin/you", label: "You", icon: User },
+  { path: "/admin/memory", label: "Memory", icon: Brain },
+  { path: "/admin/keychain", label: "Keychain", icon: KeyRound },
+  { path: "/admin/tools", label: "Tools", icon: Wrench },
+  { path: "/admin/activity", label: "Activity", icon: Activity },
+] as const;
+
+function SurfaceLink({ path, label, icon: Icon, onClick }: {
+  path: string;
+  label: string;
+  icon: typeof User;
+  onClick?: () => void;
+}) {
+  return (
+    <NavLink
+      to={path}
+      onClick={onClick}
+      className={({ isActive }) =>
+        `flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+          isActive
+            ? "bg-[#E2B93B]/10 text-[#E2B93B]"
+            : "text-[#888] hover:bg-white/[0.04] hover:text-[#ccc]"
+        }`
+      }
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <span>{label}</span>
+    </NavLink>
+  );
+}
+
+export default function AdminShell() {
+  const { user } = useSession();
+  const navigate = useNavigate();
+  const [chatOpen, setChatOpen] = useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  async function handleLogout() {
+    await signOut();
+    navigate("/login", { replace: true });
+  }
+
+  return (
+    <div className="flex min-h-screen bg-[#0A0A0A] text-[#ccc]">
+      {/* ── Desktop sidebar (md+) ──────────────────────────────────── */}
+      <aside className="fixed inset-y-0 left-0 z-40 hidden w-56 flex-col border-r border-white/[0.06] bg-[#0A0A0A] md:flex">
+        <div className="flex h-14 items-center px-5">
+          <Link to="/">
+            <img
+              src="/logo-wordmark.svg"
+              alt="UnClick"
+              style={{ height: "2.5rem" }}
+              className="w-auto"
+            />
+          </Link>
+        </div>
+
+        <nav className="mt-4 flex flex-1 flex-col gap-1 px-3">
+          {surfaces.map((s) => (
+            <SurfaceLink key={s.path} {...s} />
+          ))}
+        </nav>
+
+        <div className="border-t border-white/[0.06] p-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#E2B93B]/10 text-[#E2B93B]">
+              <User className="h-4 w-4" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-xs font-medium text-[#ccc]">
+                {user?.email ?? "Unknown"}
+              </p>
+            </div>
+            <button
+              onClick={handleLogout}
+              className="rounded-md p-1.5 text-[#666] transition-colors hover:bg-white/[0.04] hover:text-[#ccc]"
+              title="Sign out"
+            >
+              <LogOut className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      {/* ── Mobile/tablet top bar (<md) ────────────────────────────── */}
+      <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b border-white/[0.06] bg-[#0A0A0A] px-4 md:hidden">
+        <Link to="/">
+          <img
+            src="/logo-wordmark.svg"
+            alt="UnClick"
+            style={{ height: "2rem" }}
+            className="w-auto"
+          />
+        </Link>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleLogout}
+            className="rounded-md p-2 text-[#666] hover:text-[#ccc]"
+            title="Sign out"
+          >
+            <LogOut className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => setMobileNavOpen((v) => !v)}
+            className="rounded-md p-2 text-[#888] hover:text-[#ccc]"
+          >
+            {mobileNavOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+        </div>
+      </header>
+
+      {/* Mobile nav drawer */}
+      {mobileNavOpen && (
+        <div className="fixed inset-x-0 top-14 z-30 border-b border-white/[0.06] bg-[#0A0A0A] p-3 md:hidden">
+          <nav className="flex flex-col gap-1">
+            {surfaces.map((s) => (
+              <SurfaceLink
+                key={s.path}
+                {...s}
+                onClick={() => setMobileNavOpen(false)}
+              />
+            ))}
+          </nav>
+          <div className="mt-2 border-t border-white/[0.06] pt-2">
+            <p className="truncate px-3 text-xs text-[#666]">
+              {user?.email ?? "Unknown"}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Main content ───────────────────────────────────────────── */}
+      <main className="min-h-screen flex-1 pt-14 md:ml-56 md:pt-0">
+        <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+          <Outlet />
+        </div>
+      </main>
+
+      {/* ── Floating chat assistant placeholder ────────────────────── */}
+      <div className="fixed bottom-6 right-6 z-50">
+        {chatOpen && (
+          <div className="mb-3 w-72 rounded-2xl border border-white/[0.08] bg-[#111111] p-4 shadow-2xl sm:w-80">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-[#ccc]">Assistant</h3>
+              <button
+                onClick={() => setChatOpen(false)}
+                className="rounded-md p-1 text-[#666] hover:text-[#ccc]"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="mt-4 flex flex-col items-center justify-center py-8">
+              <MessageCircle className="h-8 w-8 text-[#E2B93B]/40" />
+              <p className="mt-3 text-xs text-[#666]">Coming soon</p>
+              <p className="mt-1 text-[10px] text-[#444]">
+                Your AI assistant will live here
+              </p>
+            </div>
+          </div>
+        )}
+        <button
+          onClick={() => setChatOpen((v) => !v)}
+          className="flex h-12 w-12 items-center justify-center rounded-full bg-[#E2B93B] text-black shadow-lg transition-transform hover:scale-105 active:scale-95"
+          aria-label="Open assistant"
+        >
+          <MessageCircle className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,0 +1,177 @@
+/**
+ * AdminTools - Tools surface (/admin/tools)
+ *
+ * Full tool catalog fetched from platform_connectors with category
+ * grouping and search/filter. Toggle is a stretch goal.
+ * Marketplace tools bolt on here later.
+ */
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import {
+  Wrench,
+  Search,
+  Loader2,
+  ExternalLink,
+  ChevronRight,
+} from "lucide-react";
+
+interface Connector {
+  id: string;
+  name: string;
+  category: string;
+  auth_type: string;
+  description: string | null;
+  setup_url: string | null;
+  icon: string | null;
+  sort_order: number;
+}
+
+export default function AdminTools() {
+  const [connectors, setConnectors] = useState<Connector[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      // platform_connectors is public (anon_read_connectors policy)
+      const { data } = await supabase
+        .from("platform_connectors")
+        .select("*")
+        .order("sort_order");
+
+      if (!cancelled) {
+        setConnectors(data ?? []);
+        setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, []);
+
+  // Filter
+  const filtered = query
+    ? connectors.filter(
+        (c) =>
+          c.name.toLowerCase().includes(query.toLowerCase()) ||
+          c.category.toLowerCase().includes(query.toLowerCase()) ||
+          (c.description ?? "").toLowerCase().includes(query.toLowerCase()),
+      )
+    : connectors;
+
+  // Group by category
+  const grouped = filtered.reduce<Record<string, Connector[]>>((acc, c) => {
+    if (!acc[c.category]) acc[c.category] = [];
+    acc[c.category].push(c);
+    return acc;
+  }, {});
+
+  const categories = Object.keys(grouped).sort();
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-white">Tools</h1>
+        <p className="mt-1 text-sm text-[#888]">
+          Available integrations and connectors
+        </p>
+      </div>
+
+      {/* Search */}
+      <div className="relative mb-6">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#666]" />
+        <input
+          type="text"
+          placeholder="Search tools..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full rounded-lg border border-white/[0.06] bg-[#111111] py-2.5 pl-10 pr-4 text-sm text-white placeholder-[#555] outline-none transition-colors focus:border-[#E2B93B]/30"
+        />
+      </div>
+
+      {/* Stats bar */}
+      <div className="mb-6 flex items-center gap-4 text-xs text-[#666]">
+        <span>{filtered.length} tools</span>
+        <span>{categories.length} categories</span>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-12 text-[#666]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading tools...</span>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-white/[0.08] bg-[#111111] p-8 text-center">
+          <Wrench className="mx-auto h-8 w-8 text-[#333]" />
+          <p className="mt-3 text-sm text-[#666]">
+            {query ? "No tools match your search" : "No tools available"}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {categories.map((category) => (
+            <div key={category}>
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[#666]">
+                {category}
+                <span className="ml-2 text-[10px] font-normal text-[#555]">
+                  ({grouped[category].length})
+                </span>
+              </h3>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {grouped[category].map((tool) => (
+                  <div
+                    key={tool.id}
+                    className="group flex items-center justify-between rounded-xl border border-white/[0.06] bg-[#111111] p-4 transition-colors hover:border-white/[0.1]"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/[0.04] text-sm font-semibold text-[#888]">
+                        {tool.icon ?? tool.name.slice(0, 2).toUpperCase()}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-white">
+                          {tool.name}
+                        </p>
+                        {tool.description && (
+                          <p className="mt-0.5 truncate text-[11px] text-[#666]">
+                            {tool.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-[10px] text-[#666]">
+                        {tool.auth_type}
+                      </span>
+                      {tool.setup_url && (
+                        <a
+                          href={tool.setup_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="rounded-md p-1.5 text-[#666] opacity-0 transition-all hover:text-[#ccc] group-hover:opacity-100"
+                          title="Setup"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      )}
+                      <ChevronRight className="h-3.5 w-3.5 text-[#444] opacity-0 transition-opacity group-hover:opacity-100" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Marketplace callout */}
+      <div className="mt-8 rounded-xl border border-dashed border-white/[0.08] bg-[#111111] p-6 text-center">
+        <p className="text-xs text-[#666]">
+          Marketplace tools and custom integrations coming soon
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -1,0 +1,279 @@
+/**
+ * AdminYou - Identity surface (/admin/you)
+ *
+ * The Apple ID equivalent. Shows: user email, auth provider, linked
+ * api_key info, paired devices (auth_devices), logout button.
+ * ClaimKeyBanner is shown if the user has an unclaimed localStorage key.
+ */
+
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSession, signOut } from "@/lib/auth";
+import ClaimKeyBanner from "@/components/ClaimKeyBanner";
+import {
+  User,
+  Mail,
+  Shield,
+  KeyRound,
+  Monitor,
+  LogOut,
+  Loader2,
+  Clock,
+} from "lucide-react";
+
+interface DeviceRow {
+  id: string;
+  device_id: string;
+  device_name: string | null;
+  paired_at: string;
+  last_seen_at: string;
+  revoked_at: string | null;
+}
+
+interface ProfileData {
+  user_id: string;
+  email: string | null;
+  tier: string;
+  api_key: {
+    id: string;
+    prefix: string;
+    label: string;
+    tier: string;
+    is_active: boolean;
+    usage_count: number;
+    last_used_at: string | null;
+    created_at: string;
+  } | null;
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return "never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+export default function AdminYou() {
+  const { session, user } = useSession();
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [devices, setDevices] = useState<DeviceRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!session) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const headers = { Authorization: `Bearer ${session.access_token}` };
+        const [profileRes, devicesRes] = await Promise.all([
+          fetch("/api/memory-admin?action=admin_profile", { headers }),
+          fetch("/api/memory-admin?action=auth_device_list", { headers }),
+        ]);
+
+        if (!cancelled && profileRes.ok) {
+          setProfile(await profileRes.json());
+        }
+        if (!cancelled && devicesRes.ok) {
+          const body = await devicesRes.json();
+          setDevices(body.data ?? []);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [session]);
+
+  async function handleLogout() {
+    await signOut();
+    navigate("/login", { replace: true });
+  }
+
+  async function revokeDevice(deviceId: string) {
+    if (!session) return;
+    await fetch("/api/memory-admin?action=auth_device_revoke", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ device_id: deviceId }),
+    });
+    setDevices((prev) => prev.filter((d) => d.device_id !== deviceId));
+  }
+
+  const provider = user?.app_metadata?.provider ?? "email";
+  const providerLabel =
+    provider === "google" ? "Google" :
+    provider === "azure" ? "Microsoft" :
+    provider === "email" ? "Magic link" :
+    provider;
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-white">You</h1>
+        <p className="mt-1 text-sm text-[#888]">Identity, accounts, and devices</p>
+      </div>
+
+      <ClaimKeyBanner />
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-12 text-[#666]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading profile...</span>
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          {/* Identity card */}
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+            <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+              <User className="h-4 w-4 text-[#E2B93B]" />
+              Identity
+            </h2>
+
+            <div className="mt-4 space-y-3">
+              <div className="flex items-center justify-between text-sm">
+                <span className="flex items-center gap-2 text-[#888]">
+                  <Mail className="h-3.5 w-3.5" />
+                  Email
+                </span>
+                <span className="font-mono text-xs text-white">
+                  {user?.email ?? "Unknown"}
+                </span>
+              </div>
+
+              <div className="flex items-center justify-between text-sm">
+                <span className="flex items-center gap-2 text-[#888]">
+                  <Shield className="h-3.5 w-3.5" />
+                  Auth provider
+                </span>
+                <span className="text-xs text-white">{providerLabel}</span>
+              </div>
+
+              <div className="flex items-center justify-between text-sm">
+                <span className="flex items-center gap-2 text-[#888]">
+                  <Clock className="h-3.5 w-3.5" />
+                  Member since
+                </span>
+                <span className="text-xs text-white">
+                  {user?.created_at
+                    ? new Date(user.created_at).toLocaleDateString()
+                    : "Unknown"}
+                </span>
+              </div>
+            </div>
+
+            <button
+              onClick={handleLogout}
+              className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-2.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/10"
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </button>
+          </div>
+
+          {/* API Key card */}
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+            <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+              <KeyRound className="h-4 w-4 text-[#E2B93B]" />
+              API Key
+            </h2>
+
+            {profile?.api_key ? (
+              <div className="mt-4 space-y-3">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-[#888]">Key</span>
+                  <code className="rounded bg-white/[0.04] px-2 py-0.5 font-mono text-xs text-white">
+                    {profile.api_key.prefix}...
+                  </code>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-[#888]">Tier</span>
+                  <span className="inline-flex items-center rounded-full border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[#E2B93B]">
+                    {profile.api_key.tier}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-[#888]">Status</span>
+                  <span className={`text-xs ${profile.api_key.is_active ? "text-green-400" : "text-red-400"}`}>
+                    {profile.api_key.is_active ? "Active" : "Inactive"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-[#888]">Total calls</span>
+                  <span className="font-mono text-xs text-white">
+                    {(profile.api_key.usage_count ?? 0).toLocaleString()}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-[#888]">Last used</span>
+                  <span className="text-xs text-white">
+                    {timeAgo(profile.api_key.last_used_at)}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-4 rounded-lg border border-dashed border-white/[0.08] p-4 text-center">
+                <p className="text-xs text-[#666]">
+                  No API key linked. Use the banner above to claim your key, or{" "}
+                  <a href="/#install" className="text-[#E2B93B] underline-offset-2 hover:underline">
+                    get started
+                  </a>.
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* Devices card (full width) */}
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6 lg:col-span-2">
+            <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+              <Monitor className="h-4 w-4 text-[#E2B93B]" />
+              Paired Devices
+              <span className="ml-auto font-mono text-[11px] text-[#666]">
+                {devices.length} device{devices.length !== 1 ? "s" : ""}
+              </span>
+            </h2>
+
+            {devices.length === 0 ? (
+              <div className="mt-4 rounded-lg border border-dashed border-white/[0.08] p-6 text-center">
+                <p className="text-xs text-[#666]">
+                  No paired devices yet. Devices appear here when you sign in from another browser or machine.
+                </p>
+              </div>
+            ) : (
+              <ul className="mt-4 divide-y divide-white/[0.04]">
+                {devices.map((d) => (
+                  <li key={d.id} className="flex items-center justify-between py-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-white">
+                        {d.device_name ?? d.device_id}
+                      </p>
+                      <p className="text-[11px] text-[#666]">
+                        Paired {timeAgo(d.paired_at)} - Last seen {timeAgo(d.last_seen_at)}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => revokeDevice(d.device_id)}
+                      className="ml-4 shrink-0 rounded-md border border-red-500/20 px-2.5 py-1 text-[11px] font-medium text-red-400 transition-colors hover:bg-red-500/10"
+                    >
+                      Revoke
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Admin OS shell** with persistent sidebar, dark palette (#0A0A0A + amber #E2B93B), floating chat assistant stub, and five loosely coupled surfaces under `/admin`
- **You** (`/admin/you`): identity, auth provider, linked API key info, paired devices with revoke, logout
- **Memory** (`/admin/memory`): mc_extracted_facts with search/filter, inline edit + archive, storage usage bars vs tier caps (50MB / 5K facts free)
- **Keychain** (`/admin/keychain`): platform_credentials grouped by category, active/expired status, reconnect/remove placeholders
- **Tools** (`/admin/tools`): platform_connectors catalog with category grouping, search, auth type badges
- **Activity** (`/admin/activity`): metering_events grouped by day, conversation session list, stats cards (today/week/month/success rate)
- **7 new API actions** folded into `api/memory-admin.ts` via action routing (no new Vercel functions, still at 11/12 cap)
- **resolveSessionTenant** helper bridges session JWT to api_key_hash for all admin queries (handles both old/new api_keys schema)
- `/memory/admin` redirects to `/admin/memory`; Login/Signup/AuthCallback redirect to `/admin`

## Constraints honored

- Zero new Vercel functions (11/12 cap preserved)
- No em dashes anywhere
- Dark palette matches Phase 2 Login/Signup
- BYOD encryption untouched
- MCP server package untouched
- No passwords
- All routes behind RequireAuth

## What's stretch (not in this PR)

- BYOD config panel on Memory surface
- Tool enable/disable toggles
- Credential reconnect/remove backend actions
- Chat assistant wiring (stub only)
- Mobile-first responsive polish

## Test plan

- [ ] Navigate to `/admin` while logged out - should redirect to `/login`
- [ ] Log in - should land on `/admin/you`
- [ ] Verify sidebar navigation between all five surfaces
- [ ] Visit `/memory/admin` - should redirect to `/admin/memory`
- [ ] Test logout button on You surface and in sidebar
- [ ] Verify Memory surface shows facts (if user has claimed key with data)
- [ ] Verify Tools surface loads platform_connectors catalog
- [ ] Verify chat bubble opens/closes the "Coming soon" panel
- [ ] Build passes (`npx vite build`)

https://claude.ai/code/session_01MUWmU2NiNSX6rqFTwc3ZXe