### PR TITLE
Phase 4: Memory UX + Tools surface redesign

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -412,6 +412,258 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({ success: true });
       }
 
+      // ── Phase 4 admin actions ─────────────────────────────────────────
+
+      case "admin_business_context": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const tenant = sha256hex(apiKey);
+        const method = (req.body?.method ?? req.query.method ?? "list") as string;
+
+        switch (method) {
+          case "list": {
+            const { data, error } = await supabase
+              .from("business_context")
+              .select("*")
+              .order("priority", { ascending: true });
+            if (error) throw error;
+            return res.status(200).json({ data: data ?? [] });
+          }
+          case "create": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const { category, key, value } = req.body ?? {};
+            if (!category || !key || value === undefined) {
+              return res.status(400).json({ error: "category, key, and value required" });
+            }
+            // Auto-increment priority
+            const { data: maxRow } = await supabase
+              .from("business_context")
+              .select("priority")
+              .order("priority", { ascending: false })
+              .limit(1);
+            const nextPriority = ((maxRow?.[0]?.priority as number) ?? -1) + 1;
+            const { data, error } = await supabase
+              .from("business_context")
+              .insert({
+                category,
+                key,
+                value: typeof value === "string" ? value : JSON.stringify(value),
+                priority: nextPriority,
+                decay_tier: "hot",
+                updated_at: new Date().toISOString(),
+                last_accessed: new Date().toISOString(),
+              })
+              .select()
+              .single();
+            if (error) throw error;
+            return res.status(200).json({ success: true, data });
+          }
+          case "update": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const { id, ...updates } = req.body ?? {};
+            if (!id) return res.status(400).json({ error: "id required" });
+            const updatePayload: Record<string, unknown> = { updated_at: new Date().toISOString() };
+            if (updates.value !== undefined) updatePayload.value = typeof updates.value === "string" ? updates.value : JSON.stringify(updates.value);
+            if (updates.priority !== undefined) updatePayload.priority = updates.priority;
+            if (updates.category !== undefined) updatePayload.category = updates.category;
+            if (updates.key !== undefined) updatePayload.key = updates.key;
+            const { error } = await supabase
+              .from("business_context")
+              .update(updatePayload)
+              .eq("id", id);
+            if (error) throw error;
+            return res.status(200).json({ success: true });
+          }
+          case "delete": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const delId = req.body?.id;
+            if (!delId) return res.status(400).json({ error: "id required" });
+            const { error } = await supabase
+              .from("business_context")
+              .delete()
+              .eq("id", delId);
+            if (error) throw error;
+            return res.status(200).json({ success: true });
+          }
+          case "reorder": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const items = req.body?.items as Array<{ id: string; priority: number }>;
+            if (!items?.length) return res.status(400).json({ error: "items array required" });
+            for (const item of items) {
+              await supabase
+                .from("business_context")
+                .update({ priority: item.priority, updated_at: new Date().toISOString() })
+                .eq("id", item.id);
+            }
+            return res.status(200).json({ success: true });
+          }
+          default:
+            return res.status(400).json({ error: `Unknown method: ${method}` });
+        }
+      }
+
+      case "admin_sessions": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const method = (req.body?.method ?? req.query.method ?? "list") as string;
+
+        if (method === "list") {
+          const { data, error } = await supabase
+            .from("session_summaries")
+            .select("*")
+            .order("created_at", { ascending: false })
+            .limit(20);
+          if (error) throw error;
+          return res.status(200).json({ data: data ?? [] });
+        }
+
+        if (method === "transcript") {
+          const sessionId = req.body?.session_id ?? req.query.session_id;
+          if (!sessionId) return res.status(400).json({ error: "session_id required" });
+          const { data, error } = await supabase
+            .from("conversation_log")
+            .select("*")
+            .eq("session_id", sessionId)
+            .order("created_at", { ascending: true });
+          if (error) throw error;
+          return res.status(200).json({ data: data ?? [] });
+        }
+
+        return res.status(400).json({ error: `Unknown method: ${method}` });
+      }
+
+      case "admin_library": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const method = (req.body?.method ?? req.query.method ?? "list") as string;
+
+        if (method === "list") {
+          const { data, error } = await supabase
+            .from("knowledge_library")
+            .select("id, slug, title, updated_at, version, decay_tier, category, tags")
+            .order("updated_at", { ascending: false });
+          if (error) throw error;
+          return res.status(200).json({ data: data ?? [] });
+        }
+
+        if (method === "view") {
+          const id = req.body?.id ?? req.query.id;
+          if (!id) return res.status(400).json({ error: "id required" });
+          const { data, error } = await supabase
+            .from("knowledge_library")
+            .select("*")
+            .eq("id", id)
+            .single();
+          if (error) throw error;
+          return res.status(200).json({ data });
+        }
+
+        if (method === "history") {
+          const slug = req.body?.slug ?? req.query.slug;
+          if (!slug) return res.status(400).json({ error: "slug required" });
+          const { data, error } = await supabase
+            .from("knowledge_library_history")
+            .select("*")
+            .eq("slug", slug)
+            .order("version", { ascending: false });
+          if (error) throw error;
+          return res.status(200).json({ data: data ?? [] });
+        }
+
+        return res.status(400).json({ error: `Unknown method: ${method}` });
+      }
+
+      case "admin_memory_activity": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+
+        const [factsResult, statusResult, decayResult, accessedResult] = await Promise.all([
+          // Facts by day (last 30 days)
+          supabase
+            .from("extracted_facts")
+            .select("created_at")
+            .gte("created_at", new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString())
+            .order("created_at", { ascending: true }),
+          // Storage stats
+          supabase
+            .from("extracted_facts")
+            .select("id", { count: "exact", head: true }),
+          // Recent decay transitions
+          supabase
+            .from("extracted_facts")
+            .select("id, fact, category, decay_tier, updated_at")
+            .neq("decay_tier", "hot")
+            .order("updated_at", { ascending: false })
+            .limit(20),
+          // Most accessed facts
+          supabase
+            .from("extracted_facts")
+            .select("id, fact, category, access_count, decay_tier")
+            .eq("status", "active")
+            .order("access_count", { ascending: false })
+            .limit(10),
+        ]);
+
+        // Group facts by day
+        const factsByDay: Record<string, number> = {};
+        for (const f of factsResult.data ?? []) {
+          const day = (f.created_at as string).slice(0, 10);
+          factsByDay[day] = (factsByDay[day] ?? 0) + 1;
+        }
+
+        return res.status(200).json({
+          facts_by_day: factsByDay,
+          total_facts: statusResult.count ?? 0,
+          recent_decay: decayResult.data ?? [],
+          most_accessed: accessedResult.data ?? [],
+        });
+      }
+
+      case "admin_tools": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+
+        // Metering events grouped by operation
+        const { data: metering } = await supabase
+          .from("metering_events")
+          .select("operation")
+          .order("created_at", { ascending: false })
+          .limit(10000);
+
+        const meteringByOp: Record<string, number> = {};
+        for (const m of metering ?? []) {
+          const op = m.operation as string;
+          meteringByOp[op] = (meteringByOp[op] ?? 0) + 1;
+        }
+
+        // Platform connectors with credential status
+        const { data: connectors } = await supabase
+          .from("platform_connectors")
+          .select("*");
+
+        const { data: credentials } = await supabase
+          .from("platform_credentials")
+          .select("platform, is_valid, last_tested_at");
+
+        const credMap: Record<string, { is_valid: boolean; last_tested_at: string | null }> = {};
+        for (const c of credentials ?? []) {
+          credMap[c.platform as string] = {
+            is_valid: c.is_valid as boolean,
+            last_tested_at: c.last_tested_at as string | null,
+          };
+        }
+
+        const enrichedConnectors = (connectors ?? []).map((pc) => ({
+          ...pc,
+          credential: credMap[(pc as Record<string, unknown>).id as string] ?? null,
+        }));
+
+        return res.status(200).json({
+          metering: meteringByOp,
+          connectors: enrichedConnectors,
+        });
+      }
+
       // ── BYOD / wizard actions ────────────────────────────────────────
       case "setup_status": {
         const apiKey = String(req.query.api_key ?? "").trim();

--- a/packages/mcp-server/src/catalog.ts
+++ b/packages/mcp-server/src/catalog.ts
@@ -1917,8 +1917,8 @@ export const CATALOG: ToolDef[] = [
     endpoints: [
       {
         id: "memory.get_startup_context",
-        name: "Get Startup Context",
-        description: "Load business context, recent sessions, and hot facts. Call FIRST in every new session.",
+        name: "Load Session Context",
+        description: "Loads the user's business context, recent sessions, and hot facts at session start. Call FIRST in every new session.",
         method: "POST",
         path: "/v1/memory/startup",
         requiresAuth: false,
@@ -1929,8 +1929,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.search_memory",
-        name: "Search Memory",
-        description: "Full-text search across conversation logs.",
+        name: "Search Conversations",
+        description: "Full-text search across conversation logs from previous sessions.",
         method: "POST",
         path: "/v1/memory/search",
         requiresAuth: false,
@@ -1946,7 +1946,7 @@ export const CATALOG: ToolDef[] = [
       {
         id: "memory.search_facts",
         name: "Search Facts",
-        description: "Search active (non-superseded) extracted facts.",
+        description: "Search active extracted facts by keyword or category.",
         method: "POST",
         path: "/v1/memory/facts/search",
         requiresAuth: false,
@@ -1958,7 +1958,7 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.search_library",
-        name: "Search Library",
+        name: "Search Knowledge Library",
         description: "Search versioned reference documents in the Knowledge Library.",
         method: "POST",
         path: "/v1/memory/library/search",
@@ -1971,8 +1971,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.get_library_doc",
-        name: "Get Library Doc",
-        description: "Get the full content of a library doc by slug.",
+        name: "Read Library Document",
+        description: "Get the full content of a library document by slug.",
         method: "POST",
         path: "/v1/memory/library/get",
         requiresAuth: false,
@@ -1984,7 +1984,7 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.list_library",
-        name: "List Library",
+        name: "Browse Knowledge Library",
         description: "List all documents in the Knowledge Library.",
         method: "POST",
         path: "/v1/memory/library/list",
@@ -1993,8 +1993,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.write_session_summary",
-        name: "Write Session Summary",
-        description: "Save an end-of-session summary. Call BEFORE session ends.",
+        name: "Save Session Summary",
+        description: "Save an end-of-session summary for cross-session continuity. Call BEFORE session ends.",
         method: "POST",
         path: "/v1/memory/session/write",
         requiresAuth: false,
@@ -2014,8 +2014,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.add_fact",
-        name: "Add Fact",
-        description: "Add an atomic fact. One fact = one statement.",
+        name: "Store New Fact",
+        description: "Store a new atomic fact to persistent memory. One fact = one statement.",
         method: "POST",
         path: "/v1/memory/facts/add",
         requiresAuth: false,
@@ -2032,8 +2032,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.supersede_fact",
-        name: "Supersede Fact",
-        description: "Replace an outdated fact with a new version (old one marked superseded, never deleted).",
+        name: "Replace Existing Fact",
+        description: "Replace an outdated fact with a new version. The old fact is marked superseded, never deleted.",
         method: "POST",
         path: "/v1/memory/facts/supersede",
         requiresAuth: false,
@@ -2051,7 +2051,7 @@ export const CATALOG: ToolDef[] = [
       {
         id: "memory.log_conversation",
         name: "Log Conversation",
-        description: "Log a conversation exchange for later search.",
+        description: "Log a conversation exchange for full-text search in future sessions.",
         method: "POST",
         path: "/v1/memory/conversation/log",
         requiresAuth: false,
@@ -2068,8 +2068,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.get_conversation_detail",
-        name: "Get Conversation Detail",
-        description: "Retrieve the full conversation log for a session.",
+        name: "View Conversation Detail",
+        description: "Retrieve the full conversation log for a specific session.",
         method: "POST",
         path: "/v1/memory/conversation/get",
         requiresAuth: false,
@@ -2081,8 +2081,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.store_code",
-        name: "Store Code",
-        description: "Store a code block in the code dump layer.",
+        name: "Store Code Snippet",
+        description: "Store a code block in the code dump layer for future reference.",
         method: "POST",
         path: "/v1/memory/code/store",
         requiresAuth: false,
@@ -2101,7 +2101,7 @@ export const CATALOG: ToolDef[] = [
       {
         id: "memory.get_business_context",
         name: "Get Business Context",
-        description: "Get all business context entries (standing rules).",
+        description: "Get all business context entries - standing rules loaded at every session start.",
         method: "POST",
         path: "/v1/memory/context/get",
         requiresAuth: false,
@@ -2109,8 +2109,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.set_business_context",
-        name: "Set Business Context",
-        description: "Add or update a business context entry (always loaded at session start).",
+        name: "Update Business Context",
+        description: "Add or update a standing rule in business context. Always loaded at session start.",
         method: "POST",
         path: "/v1/memory/context/set",
         requiresAuth: false,
@@ -2127,8 +2127,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.upsert_library_doc",
-        name: "Upsert Library Doc",
-        description: "Create or update a Knowledge Library document (auto-versioned).",
+        name: "Save Library Document",
+        description: "Create or update a Knowledge Library document. Auto-versioned with full history.",
         method: "POST",
         path: "/v1/memory/library/upsert",
         requiresAuth: false,
@@ -2146,8 +2146,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.manage_decay",
-        name: "Manage Decay",
-        description: "Run the memory decay manager. Promotes/demotes items between hot/warm/cold tiers.",
+        name: "Run Memory Decay",
+        description: "Run the memory decay manager. Promotes and demotes items between hot/warm/cold tiers.",
         method: "POST",
         path: "/v1/memory/decay",
         requiresAuth: false,
@@ -2155,8 +2155,8 @@ export const CATALOG: ToolDef[] = [
       },
       {
         id: "memory.memory_status",
-        name: "Memory Status",
-        description: "Get memory usage stats: storage mode, counts per layer, decay tier distribution.",
+        name: "Check Memory Status",
+        description: "Get memory usage stats - storage mode, counts per layer, and decay tier distribution.",
         method: "POST",
         path: "/v1/memory/status",
         requiresAuth: false,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -46,9 +46,9 @@ const META_TOOLS = [
   {
     name: "unclick_search",
     description:
-      "Search the UnClick tool marketplace by keyword or description. " +
+      "Search Available Tools - Search the UnClick tool marketplace by keyword or description. " +
       "Use this to discover which tools are available for a task. " +
-      "Example: 'I need to resize an image' → returns the image tool with its endpoints.",
+      "Example: 'I need to resize an image' returns the image tool with its endpoints.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -68,7 +68,7 @@ const META_TOOLS = [
   {
     name: "unclick_browse",
     description:
-      "Browse all available UnClick tools, optionally filtered by category. " +
+      "Browse Tool Catalog - Browse all available UnClick tools, optionally filtered by category. " +
       "Returns a list of tools with their slugs and descriptions.",
     inputSchema: {
       type: "object" as const,
@@ -84,7 +84,7 @@ const META_TOOLS = [
   {
     name: "unclick_tool_info",
     description:
-      "Get detailed information about a specific UnClick tool including all its endpoints, " +
+      "Get Tool Details - Get detailed information about a specific UnClick tool including all its endpoints, " +
       "required parameters, and response shapes. Use this after unclick_search to understand " +
       "exactly how to call a tool.",
     inputSchema: {
@@ -103,7 +103,7 @@ const META_TOOLS = [
   {
     name: "unclick_call",
     description:
-      "Call any UnClick tool endpoint. Specify the endpoint ID and parameters. " +
+      "Execute Tool - Call any UnClick tool endpoint. Specify the endpoint ID and parameters. " +
       "Use unclick_search or unclick_tool_info to discover endpoint IDs and required params. " +
       "Example: endpoint_id='image.resize', params={image: '<base64>', width: 800, height: 600}",
     inputSchema: {
@@ -129,10 +129,9 @@ const META_TOOLS = [
   {
     name: "get_startup_context",
     description:
-      "Load persistent UnClick Memory at session start. Returns business context (standing rules), " +
-      "recent session summaries, and hot facts. Call this FIRST in every new session to understand " +
-      "the user's ongoing projects, preferences, and open loops. Works zero-config locally, or with " +
-      "Supabase for cross-machine sync.",
+      "Load Session Context - Loads the user's business context, recent sessions, and hot facts at " +
+      "session start. Call this FIRST in every new session to understand the user's ongoing projects, " +
+      "preferences, and open loops. Works zero-config locally, or with Supabase for cross-machine sync.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -147,8 +146,8 @@ const META_TOOLS = [
   {
     name: "write_session_summary",
     description:
-      "Write a session summary at the end of a session. Critical for cross-session continuity. " +
-      "Call this BEFORE the session ends (when the user says goodbye, or context is running low). " +
+      "Save Session Summary - Write a session summary before the session ends. Critical for " +
+      "cross-session continuity. Call this when the user says goodbye or context is running low. " +
       "Include key decisions, open loops, and topics discussed.",
     inputSchema: {
       type: "object" as const,
@@ -167,7 +166,7 @@ const META_TOOLS = [
   {
     name: "add_fact",
     description:
-      "Add a new atomic fact to UnClick Memory. One fact = one statement. " +
+      "Store New Fact - Add a new atomic fact to UnClick Memory. One fact = one statement. " +
       "Use when the user states a preference, makes a decision, or shares important info. " +
       "Good: 'Team prefers Tailwind over CSS modules'. Bad: 'We talked about styling'.",
     inputSchema: {
@@ -188,8 +187,8 @@ const META_TOOLS = [
   {
     name: "search_memory",
     description:
-      "Full-text search across UnClick Memory conversation logs. Use when you need to recall " +
-      "something specific from a previous session.",
+      "Search Conversations - Full-text search across UnClick Memory conversation logs. Use " +
+      "when you need to recall something specific from a previous session.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -202,8 +201,9 @@ const META_TOOLS = [
   {
     name: "set_business_context",
     description:
-      "Add or update a standing rule in UnClick Memory (Layer 1). Business context is ALWAYS loaded " +
-      "at session start. Use for standing rules, client info, and preferences that are always relevant.",
+      "Update Business Context - Add or update a standing rule in UnClick Memory (Layer 1). " +
+      "Business context is ALWAYS loaded at session start. Use for standing rules, client info, " +
+      "and preferences that are always relevant.",
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import OrganiserPage from "./pages/Organiser.tsx";
 import DispatchPage from "./pages/Dispatch.tsx";
 import CrewsPage from "./pages/Crews.tsx";
 import ToolsPage from "./pages/Tools.tsx";
+import AdminToolsPage from "./pages/admin/AdminTools.tsx";
 import NewToAIPage from "./pages/NewToAI.tsx";
 import SmartHomePage from "./pages/SmartHome.tsx";
 import InstallRecoverPage from "./pages/InstallRecover.tsx";
@@ -72,6 +73,7 @@ const App = () => (
           <Route path="/memory" element={<MemoryPage />} />
           <Route path="/memory/admin" element={<MemoryAdminPage />} />
           <Route path="/memory/setup" element={<MemorySetupPage />} />
+          <Route path="/memory/tools" element={<AdminToolsPage />} />
           <Route path="/organiser" element={<OrganiserPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />
           <Route path="/crews" element={<CrewsPage />} />

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/src/pages/MemoryAdmin.tsx
+++ b/src/pages/MemoryAdmin.tsx
@@ -1,258 +1,148 @@
 /**
- * Memory Admin - placeholder page
+ * Memory Admin - 5-tab structured admin dashboard
  *
- * This page will become the visual admin dashboard for UnClick Memory.
- * It connects to /api/memory-admin to read/write all 6 memory layers.
- *
- * API actions available (GET unless noted):
- *   ?action=status - layer counts + decay tier breakdown
- *   ?action=business_context - all business context entries
- *   ?action=sessions&limit=20 - recent session summaries
- *   ?action=facts&query=x&show_all=true - extracted facts (search + filter)
- *   ?action=library - knowledge library index
- *   ?action=library_doc&slug=x - full document by slug
- *   ?action=conversations - session list with message counts
- *   ?action=conversations&session_id=x - messages for a session
- *   ?action=code&session_id=x - code dumps (optional session filter)
- *   ?action=search&query=x - full-text search across conversation logs
- *   ?action=delete_fact - POST: archive a fact (fact_id in body)
- *   ?action=delete_session - POST: delete a session summary (session_id in body)
- *   ?action=update_business_context - POST: upsert business context (category, key, value in body)
- *
- * Tabs planned for the full UI:
- *   1. Overview - counts per layer, decay chart, quick stats
- *   2. Context - business context entries (Layer 1), add/edit
- *   3. Library - knowledge library docs (Layer 2), view/edit
- *   4. Sessions - session summaries (Layer 3), browse/search
- *   5. Facts - extracted facts (Layer 4), search/archive/supersede
- *   6. Logs - conversation log (Layer 5), browse by session
- *   7. Code - code dumps (Layer 6), browse/search
- *   8. Search - full-text search across everything
+ * Tabs: Context | Facts | Sessions | Library | Activity
+ * Route: /memory/admin
  */
 
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-import { Brain, Database, Monitor, CheckCircle2, ArrowRight } from "lucide-react";
+import { Brain, ListOrdered, Lightbulb, MessageSquare, BookOpen, Activity } from "lucide-react";
+import StorageBar from "./admin/memory/StorageBar";
+import ContextTab from "./admin/memory/ContextTab";
+import FactsTab from "./admin/memory/FactsTab";
+import SessionsTab from "./admin/memory/SessionsTab";
+import LibraryTab from "./admin/memory/LibraryTab";
+import MemoryActivityTab from "./admin/memory/MemoryActivityTab";
 
-interface MemoryConfigStatus {
-  configured: boolean;
-  supabase_url?: string;
-  schema_installed?: boolean;
-  last_used_at?: string | null;
+interface StatusData {
+  layers: {
+    business_context: number;
+    knowledge_library: number;
+    session_summaries: number;
+    extracted_facts: number;
+    conversation_log: number;
+    code_dumps: number;
+  };
 }
 
-interface Device {
-  id: string;
-  label: string | null;
-  platform: string | null;
-  storage_mode: "local" | "cloud";
-  first_seen: string;
-  last_seen: string;
-}
+const TABS = [
+  { id: "context", label: "Context", icon: ListOrdered },
+  { id: "facts", label: "Facts", icon: Lightbulb },
+  { id: "sessions", label: "Sessions", icon: MessageSquare },
+  { id: "library", label: "Library", icon: BookOpen },
+  { id: "activity", label: "Activity", icon: Activity },
+] as const;
 
-function formatRelative(iso: string | null | undefined): string {
-  if (!iso) return "never";
-  const ts = new Date(iso).getTime();
-  const diff = Date.now() - ts;
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
+type TabId = (typeof TABS)[number]["id"];
 
 export default function MemoryAdminPage() {
-  const [config, setConfig] = useState<MemoryConfigStatus | null>(null);
-  const [devices, setDevices] = useState<Device[]>([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = (searchParams.get("tab") as TabId) || "context";
+  const [status, setStatus] = useState<StatusData | null>(null);
   const [loading, setLoading] = useState(true);
+  const apiKey = localStorage.getItem("unclick_api_key") ?? "";
+
+  const setTab = (tab: TabId) => {
+    setSearchParams({ tab });
+  };
 
   useEffect(() => {
-    let cancelled = false;
-    const apiKey = localStorage.getItem("unclick_api_key") ?? "";
     if (!apiKey) {
       setLoading(false);
       return;
     }
-
     (async () => {
       try {
-        const [cfgRes, devRes] = await Promise.all([
-          fetch(`/api/memory-admin?action=setup_status&api_key=${encodeURIComponent(apiKey)}`),
-          fetch("/api/memory-admin?action=list_devices", {
-            headers: { Authorization: `Bearer ${apiKey}` },
-          }),
-        ]);
-
-        if (!cancelled && cfgRes.ok) {
-          setConfig((await cfgRes.json()) as MemoryConfigStatus);
-        }
-        if (!cancelled && devRes.ok) {
-          const body = (await devRes.json()) as { data: Device[] };
-          setDevices(body.data ?? []);
+        const res = await fetch("/api/memory-admin?action=status", {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (res.ok) {
+          setStatus(await res.json());
         }
       } finally {
-        if (!cancelled) setLoading(false);
+        setLoading(false);
       }
     })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const localCount = devices.filter((d) => d.storage_mode === "local").length;
-  const cloudCount = devices.filter((d) => d.storage_mode === "cloud").length;
-  const shouldNudge = !config?.configured && devices.length >= 2;
+  if (!apiKey) {
+    return (
+      <div className="min-h-screen">
+        <Navbar />
+        <main className="mx-auto max-w-6xl px-6 pb-32 pt-28">
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-8 text-center">
+            <p className="text-sm text-[#AAAAAA]">
+              Set your API key in{" "}
+              <a href="/settings" className="text-[#61C1C4] underline cursor-pointer transition-colors duration-150 hover:text-[#61C1C4]/80">
+                Settings
+              </a>{" "}
+              to access memory admin.
+            </p>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen">
       <Navbar />
       <main className="mx-auto max-w-6xl px-6 pb-32 pt-28">
-        <div className="mb-8 flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+        {/* Header */}
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#61C1C4]/10 text-[#61C1C4]">
             <Brain className="h-5 w-5" />
           </div>
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Memory Admin</h1>
-            <p className="text-sm text-body">View and manage your agent's persistent memory</p>
+            <h1 className="font-mono text-2xl font-semibold tracking-tight text-white">Memory</h1>
+            <p className="text-sm text-[#AAAAAA]">View and manage your agent's persistent memory</p>
           </div>
         </div>
 
-        {/* Top-level nudge: user has 2+ devices on local storage but no cloud config */}
-        {shouldNudge && (
-          <div className="mb-6 rounded-xl border border-primary/30 bg-primary/5 p-5">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium text-heading">
-                  You're using UnClick on {devices.length} machines.
-                </p>
-                <p className="mt-1 text-xs text-body">
-                  Turn on cloud sync so memory follows you across all of them. Bring your own Supabase - 
-                  we never see your data. One paste, you're done.
-                </p>
-              </div>
-              <Link
-                to="/memory/setup"
-                className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-black transition-opacity hover:opacity-90"
-              >
-                Turn on cloud sync
-                <ArrowRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
+        {/* Storage bar */}
+        {!loading && status && (
+          <div className="mb-6">
+            <StorageBar
+              totalFacts={status.layers.extracted_facts}
+              maxFacts={1000}
+              storageLabel="Supabase"
+            />
           </div>
         )}
 
-        <div className="grid gap-6 md:grid-cols-2">
-          {/* Cloud sync status */}
-          <div className="rounded-xl border border-border/40 bg-card/20 p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="flex items-center gap-2 text-sm font-semibold text-heading">
-                <Database className="h-4 w-4 text-primary" />
-                Cloud sync
-              </h2>
-              {config?.configured && (
-                <span className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 font-mono text-[10px] text-primary">
-                  <CheckCircle2 className="h-3 w-3" /> Connected
-                </span>
-              )}
-            </div>
-
-            {loading ? (
-              <p className="mt-3 text-xs text-muted-foreground">Loading...</p>
-            ) : !config?.configured ? (
-              <div className="mt-4 space-y-3">
-                <p className="text-xs text-body">
-                  Memory's running locally on this device. Turn on cloud sync to share context across
-                  every machine you use.
-                </p>
-                <Link
-                  to="/memory/setup"
-                  className="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
-                >
-                  Set up cloud sync
-                  <ArrowRight className="h-3 w-3" />
-                </Link>
-              </div>
-            ) : (
-              <div className="mt-3 space-y-2 text-xs">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-muted-foreground">Project</span>
-                  <code className="truncate font-mono text-[11px] text-heading">
-                    {config.supabase_url}
-                  </code>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Schema</span>
-                  <span className={config.schema_installed ? "text-primary" : "text-amber-400"}>
-                    {config.schema_installed ? "installed" : "pending"}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Last sync</span>
-                  <span className="text-body">{formatRelative(config.last_used_at)}</span>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Devices */}
-          <div className="rounded-xl border border-border/40 bg-card/20 p-6">
-            <h2 className="flex items-center gap-2 text-sm font-semibold text-heading">
-              <Monitor className="h-4 w-4 text-primary" />
-              Devices
-              <span className="ml-auto font-mono text-[11px] text-muted-foreground">
-                {cloudCount} cloud / {localCount} local
-              </span>
-            </h2>
-
-            {loading ? (
-              <p className="mt-3 text-xs text-muted-foreground">Loading...</p>
-            ) : devices.length === 0 ? (
-              <p className="mt-3 text-xs text-muted-foreground">
-                No devices seen yet. Fire up the MCP server on any machine and it'll appear here.
-              </p>
-            ) : (
-              <ul className="mt-3 divide-y divide-border/20">
-                {devices.map((d) => (
-                  <li key={d.id} className="flex items-center justify-between py-2 text-xs">
-                    <div className="min-w-0">
-                      <p className="truncate font-medium text-heading">{d.label ?? "Unknown device"}</p>
-                      <p className="text-[10px] text-muted-foreground">
-                        {d.platform ?? "unknown"} · seen {formatRelative(d.last_seen)}
-                      </p>
-                    </div>
-                    <span
-                      className={`ml-3 inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px] ${
-                        d.storage_mode === "cloud"
-                          ? "border-primary/30 bg-primary/10 text-primary"
-                          : "border-border/50 bg-card/40 text-muted-foreground"
-                      }`}
-                    >
-                      {d.storage_mode}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+        {/* Tab bar */}
+        <div className="mb-6 flex gap-1 border-b border-white/[0.06] overflow-x-auto">
+          {TABS.map((tab) => {
+            const Icon = tab.icon;
+            const isActive = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                onClick={() => setTab(tab.id)}
+                className={`cursor-pointer flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 text-sm font-medium transition-colors duration-150 ${
+                  isActive
+                    ? "border-[#61C1C4] text-[#61C1C4]"
+                    : "border-transparent text-[#666666] hover:text-[#AAAAAA]"
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                {tab.label}
+              </button>
+            );
+          })}
         </div>
 
-        <div className="mt-6 rounded-xl border border-border/40 bg-card/20 p-8">
-          <p className="text-sm text-body">
-            Full dashboard UI coming soon. Memory layer browsing + editing is wired up at{" "}
-            <code className="rounded bg-muted/20 px-1.5 py-0.5 font-mono text-xs text-primary">
-              /api/memory-admin
-            </code>
-          </p>
-          <div className="mt-6 rounded-lg border border-dashed border-border/50 bg-muted/5 p-6 text-center">
-            <span className="font-mono text-xs text-muted-foreground">
-              Layer browser coming soon
-            </span>
-          </div>
+        {/* Tab content */}
+        <div>
+          {activeTab === "context" && <ContextTab apiKey={apiKey} />}
+          {activeTab === "facts" && <FactsTab apiKey={apiKey} />}
+          {activeTab === "sessions" && <SessionsTab apiKey={apiKey} />}
+          {activeTab === "library" && <LibraryTab apiKey={apiKey} />}
+          {activeTab === "activity" && <MemoryActivityTab apiKey={apiKey} />}
         </div>
       </main>
       <Footer />

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,0 +1,90 @@
+/**
+ * Admin Tools - unified tool control panel
+ *
+ * Three sections:
+ * 1. Your UnClick Tools (memory + utility tools)
+ * 2. Connected Services (platform connectors)
+ * 3. Marketplace (placeholder)
+ *
+ * Route: /memory/tools
+ */
+
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Wrench, Rocket } from "lucide-react";
+import UnClickTools from "./tools/UnClickTools";
+import ConnectedServices from "./tools/ConnectedServices";
+
+export default function AdminToolsPage() {
+  const apiKey = localStorage.getItem("unclick_api_key") ?? "";
+
+  if (!apiKey) {
+    return (
+      <div className="min-h-screen">
+        <Navbar />
+        <main className="mx-auto max-w-6xl px-6 pb-32 pt-28">
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-8 text-center">
+            <p className="text-sm text-[#AAAAAA]">
+              Set your API key in{" "}
+              <a href="/settings" className="text-[#61C1C4] underline cursor-pointer transition-colors duration-150 hover:text-[#61C1C4]/80">
+                Settings
+              </a>{" "}
+              to access the tools dashboard.
+            </p>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <main className="mx-auto max-w-6xl px-6 pb-32 pt-28">
+        {/* Header */}
+        <div className="mb-8 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#61C1C4]/10 text-[#61C1C4]">
+            <Wrench className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="font-mono text-2xl font-semibold tracking-tight text-white">Tools</h1>
+            <p className="text-sm text-[#AAAAAA]">Every tool your agent can use through UnClick</p>
+          </div>
+        </div>
+
+        <div className="space-y-10">
+          {/* Section 1: Your UnClick Tools */}
+          <UnClickTools apiKey={apiKey} />
+
+          {/* Section 2: Connected Services */}
+          <ConnectedServices apiKey={apiKey} />
+
+          {/* Section 3: Marketplace (placeholder) */}
+          <section>
+            <div className="mb-4 flex items-center gap-2">
+              <h2 className="flex items-center gap-2 font-mono text-lg font-semibold text-white">
+                <Rocket className="h-5 w-5 text-[#61C1C4]" />
+                Marketplace
+              </h2>
+            </div>
+            <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-6">
+              <div className="flex items-start gap-4">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white/[0.05] text-[#61C1C4]">
+                  <Rocket className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-white">Community tools and custom integrations</p>
+                  <p className="mt-1 text-xs text-[#AAAAAA]">
+                    Build your own MCP tools or install from the UnClick marketplace. Coming soon.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/admin/memory/ContextTab.tsx
+++ b/src/pages/admin/memory/ContextTab.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from "react";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  ChevronUp,
+  ChevronDown,
+  Save,
+  X,
+  ListOrdered,
+} from "lucide-react";
+import EmptyState from "./EmptyState";
+
+interface ContextEntry {
+  id: string;
+  category: string;
+  key: string;
+  value: string;
+  priority: number;
+  decay_tier: string;
+}
+
+interface ContextTabProps {
+  apiKey: string;
+}
+
+const DECAY_COLORS: Record<string, { dot: string; text: string; label: string }> = {
+  hot: { dot: "bg-red-500", text: "text-red-400", label: "Hot" },
+  warm: { dot: "bg-[#E2B93B]", text: "text-[#E2B93B]", label: "Warm" },
+  cold: { dot: "bg-blue-400", text: "text-blue-400", label: "Cold" },
+};
+
+export default function ContextTab({ apiKey }: ContextTabProps) {
+  const [entries, setEntries] = useState<ContextEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState({ category: "", key: "", value: "" });
+
+  const fetchEntries = async () => {
+    try {
+      const res = await fetch("/api/memory-admin?action=admin_business_context&method=list", {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (res.ok) {
+        const body = await res.json();
+        setEntries(body.data ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchEntries();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleCreate = async () => {
+    if (!form.category || !form.key || !form.value) return;
+    await fetch("/api/memory-admin?action=admin_business_context", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ method: "create", ...form }),
+    });
+    setForm({ category: "", key: "", value: "" });
+    setShowForm(false);
+    fetchEntries();
+  };
+
+  const handleUpdate = async () => {
+    if (!editingId) return;
+    await fetch("/api/memory-admin?action=admin_business_context", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ method: "update", id: editingId, ...form }),
+    });
+    setEditingId(null);
+    setForm({ category: "", key: "", value: "" });
+    fetchEntries();
+  };
+
+  const handleDelete = async (id: string) => {
+    await fetch("/api/memory-admin?action=admin_business_context", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ method: "delete", id }),
+    });
+    fetchEntries();
+  };
+
+  const handleSwap = async (index: number, direction: "up" | "down") => {
+    const targetIndex = direction === "up" ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= entries.length) return;
+    const items = [
+      { id: entries[index].id, priority: entries[targetIndex].priority },
+      { id: entries[targetIndex].id, priority: entries[index].priority },
+    ];
+    await fetch("/api/memory-admin?action=admin_business_context", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ method: "reorder", items }),
+    });
+    fetchEntries();
+  };
+
+  const startEdit = (entry: ContextEntry) => {
+    setEditingId(entry.id);
+    setForm({ category: entry.category, key: entry.key, value: entry.value });
+    setShowForm(false);
+  };
+
+  if (loading) {
+    return <p className="py-8 text-center text-sm text-[#666666]">Loading context...</p>;
+  }
+
+  if (entries.length === 0 && !showForm) {
+    return (
+      <div>
+        <EmptyState
+          icon={<ListOrdered className="h-6 w-6" />}
+          heading="Your master context is empty"
+          description="This is the first thing your agent reads every session. Add your name, role, key projects, and preferences here."
+          cta={
+            <button
+              onClick={() => setShowForm(true)}
+              className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-[#61C1C4] px-4 py-2 text-sm font-semibold text-[#0A0A0A] transition-opacity duration-150 hover:opacity-90"
+            >
+              <Plus className="h-4 w-4" />
+              Add your first context entry
+            </button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {entries.map((entry, i) => (
+        <div
+          key={entry.id}
+          className="flex items-start gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] p-4 transition-colors duration-150 hover:border-white/[0.1]"
+        >
+          {/* Priority number */}
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#E2B93B]/10 font-mono text-xs font-bold text-[#E2B93B]">
+            {i + 1}
+          </span>
+
+          {/* Content */}
+          <div className="min-w-0 flex-1">
+            {editingId === entry.id ? (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  value={form.category}
+                  onChange={(e) => setForm({ ...form, category: e.target.value })}
+                  placeholder="Category"
+                  className="w-full rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-sm text-white placeholder-[#666666] outline-none focus:border-[#61C1C4] transition-colors duration-150"
+                />
+                <input
+                  type="text"
+                  value={form.key}
+                  onChange={(e) => setForm({ ...form, key: e.target.value })}
+                  placeholder="Key"
+                  className="w-full rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-sm text-white placeholder-[#666666] outline-none focus:border-[#61C1C4] transition-colors duration-150"
+                />
+                <textarea
+                  value={form.value}
+                  onChange={(e) => setForm({ ...form, value: e.target.value })}
+                  placeholder="Value"
+                  rows={3}
+                  className="w-full rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-sm text-white placeholder-[#666666] outline-none focus:border-[#61C1C4] transition-colors duration-150"
+                />
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleUpdate}
+                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-[#61C1C4] px-3 py-1.5 text-xs font-semibold text-[#0A0A0A] transition-opacity duration-150 hover:opacity-90"
+                  >
+                    <Save className="h-3 w-3" /> Save
+                  </button>
+                  <button
+                    onClick={() => { setEditingId(null); setForm({ category: "", key: "", value: "" }); }}
+                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-white/[0.1] px-3 py-1.5 text-xs text-[#AAAAAA] transition-colors duration-150 hover:text-white"
+                  >
+                    <X className="h-3 w-3" /> Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <span className="rounded-md bg-white/[0.06] px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-[#AAAAAA]">
+                    {entry.category}
+                  </span>
+                  <span className="text-sm font-semibold text-white">{entry.key}</span>
+                  {DECAY_COLORS[entry.decay_tier] && (
+                    <span className={`flex items-center gap-1 text-[10px] ${DECAY_COLORS[entry.decay_tier].text}`}>
+                      <span className={`inline-block h-1.5 w-1.5 rounded-full ${DECAY_COLORS[entry.decay_tier].dot}`} />
+                      {DECAY_COLORS[entry.decay_tier].label}
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-[#AAAAAA]">{entry.value}</p>
+              </>
+            )}
+          </div>
+
+          {/* Actions */}
+          {editingId !== entry.id && (
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                onClick={() => handleSwap(i, "up")}
+                disabled={i === 0}
+                className="cursor-pointer rounded p-1 text-[#666666] transition-colors duration-150 hover:text-white disabled:cursor-not-allowed disabled:opacity-30"
+                aria-label="Move up"
+              >
+                <ChevronUp className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => handleSwap(i, "down")}
+                disabled={i === entries.length - 1}
+                className="cursor-pointer rounded p-1 text-[#666666] transition-colors duration-150 hover:text-white disabled:cursor-not-allowed disabled:opacity-30"
+                aria-label="Move down"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => startEdit(entry)}
+                className="cursor-pointer rounded p-1 text-[#666666] transition-colors duration-150 hover:text-[#61C1C4]"
+                aria-label="Edit"
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => handleDelete(entry.id)}
+                className="cursor-pointer rounded p-1 text-[#666666] transition-colors duration-150 hover:text-red-400"
+                aria-label="Delete"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Add form */}
+      {showForm ? (
+        <div className="rounded-lg border border-[#61C1C4]/30 bg-white/[0.03] p-4 space-y-2">
+          <input
+            type="text"
+            value={form.category}
+            onChange={(e) => setForm({ ...form, category: e.target.value })}
+            placeholder="Category (e.g. identity, preference, workflow)"
+            className="w-full rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-sm text-white placeholder-[#666666] outline-none focus:border-[#61C1C4] transition-colors duration-150"
+          />
+          <input
+            type="text"
+            value={form.key}
+            onChange={(e) => setForm({ ...form, key: e.target.value })}
+            placeholder="Key (e.g. timezone, preferred_stack)"
+            className="w-full rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-sm text-white placeholder-[#666666] outline-none focus:border-[#61C1C4] transition-colors duration-150"
+          />
+          <textarea
+            value={form.value}
+            onChange={(e) => setForm({ ...form, value: e.target.value })}
+            placeholder="Value"
+            rows={3}
+            className="w-full rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-sm text-white placeholder-[#666666] outline-none focus:border-[#61C1C4] transition-colors duration-150"
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={handleCreate}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-[#61C1C4] px-3 py-1.5 text-xs font-semibold text-[#0A0A0A] transition-opacity duration-150 hover:opacity-90"
+            >
+              <Save className="h-3 w-3" /> Save
+            </button>
+            <button
+              onClick={() => { setShowForm(false); setForm({ category: "", key: "", value: "" }); }}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-white/[0.1] px-3 py-1.5 text-xs text-[#AAAAAA] transition-colors duration-150 hover:text-white"
+            >
+              <X className="h-3 w-3" /> Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => setShowForm(true)}
+          className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed border-white/[0.1] py-3 text-sm text-[#AAAAAA] transition-colors duration-150 hover:border-[#61C1C4]/40 hover:text-[#61C1C4]"
+        >
+          <Plus className="h-4 w-4" />
+          Add Context Entry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/memory/EmptyState.tsx
+++ b/src/pages/admin/memory/EmptyState.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+interface EmptyStateProps {
+  icon: ReactNode;
+  heading: string;
+  description: string;
+  cta?: ReactNode;
+}
+
+export default function EmptyState({ icon, heading, description, cta }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-white/[0.08] bg-white/[0.02] px-6 py-16 text-center">
+      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-white/[0.05] text-[#61C1C4]">
+        {icon}
+      </div>
+      <h3 className="mb-2 font-mono text-sm font-semibold text-white">{heading}</h3>
+      <p className="mb-6 max-w-md text-sm text-[#AAAAAA]">{description}</p>
+      {cta}
+    </div>
+  );
+}

--- a/src/pages/admin/memory/FactsTab.tsx
+++ b/src/pages/admin/memory/FactsTab.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from "react";
+import { Search, Archive, Pencil, Trash2, Filter, Lightbulb } from "lucide-react";
+import EmptyState from "./EmptyState";
+
+interface Fact {
+  id: string;
+  fact: string;
+  category: string;
+  confidence: number;
+  decay_tier: string;
+  status: string;
+  access_count: number;
+  created_at: string;
+}
+
+interface FactsTabProps {
+  apiKey: string;
+}
+
+const DECAY_COLORS: Record<string, { dot: string; text: string; label: string }> = {
+  hot: { dot: "bg-red-500", text: "text-red-400", label: "Hot" },
+  warm: { dot: "bg-[#E2B93B]", text: "text-[#E2B93B]", label: "Warm" },
+  cold: { dot: "bg-blue-400", text: "text-blue-400", label: "Cold" },
+};
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+export default function FactsTab({ apiKey }: FactsTabProps) {
+  const [facts, setFacts] = useState<Fact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
+
+  const fetchFacts = async () => {
+    try {
+      const params = new URLSearchParams({ action: "facts" });
+      if (query) params.set("query", query);
+      if (showAll) params.set("show_all", "true");
+      const res = await fetch(`/api/memory-admin?${params}`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (res.ok) {
+        const body = await res.json();
+        setFacts(body.data ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchFacts();
+  }, [showAll]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    fetchFacts();
+  };
+
+  const handleArchive = async (factId: string) => {
+    await fetch("/api/memory-admin?action=delete_fact", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ fact_id: factId }),
+    });
+    fetchFacts();
+  };
+
+  if (loading) {
+    return <p className="py-8 text-center text-sm text-[#666666]">Loading facts...</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Search bar */}
+      <div className="flex gap-3">
+        <form onSubmit={handleSearch} className="flex flex-1 gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#666666]" />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search facts..."
+              className="w-full rounded-lg border border-white/[0.08] bg-white/[0.03] py-2 pl-10 pr-3 text-sm text-white placeholder-[#666666] outline-none focus:border-[#61C1C4] transition-colors duration-150"
+            />
+          </div>
+          <button
+            type="submit"
+            className="cursor-pointer rounded-lg bg-[#61C1C4] px-4 py-2 text-sm font-semibold text-[#0A0A0A] transition-opacity duration-150 hover:opacity-90"
+          >
+            Search
+          </button>
+        </form>
+        <button
+          onClick={() => setShowAll(!showAll)}
+          className={`cursor-pointer inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs font-medium transition-colors duration-150 ${
+            showAll
+              ? "border-[#61C1C4]/30 bg-[#61C1C4]/10 text-[#61C1C4]"
+              : "border-white/[0.08] text-[#AAAAAA] hover:text-white"
+          }`}
+        >
+          <Filter className="h-3.5 w-3.5" />
+          {showAll ? "All statuses" : "Active only"}
+        </button>
+      </div>
+
+      {/* Facts list */}
+      {facts.length === 0 ? (
+        <EmptyState
+          icon={<Lightbulb className="h-6 w-6" />}
+          heading="No facts found"
+          description={query ? `No facts match "${query}". Try a different search.` : "Facts appear here as your agent learns about you and your projects."}
+        />
+      ) : (
+        <div className="space-y-2">
+          {facts.map((fact) => {
+            const decay = DECAY_COLORS[fact.decay_tier] ?? DECAY_COLORS.cold;
+            return (
+              <div
+                key={fact.id}
+                className="flex items-start gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] p-4 transition-colors duration-150 hover:border-white/[0.1]"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm text-white">{fact.fact}</p>
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px]">
+                    <span className="rounded-md bg-white/[0.06] px-2 py-0.5 font-mono uppercase tracking-wider text-[#AAAAAA]">
+                      {fact.category}
+                    </span>
+                    <span className={`flex items-center gap-1 ${decay.text}`}>
+                      <span className={`inline-block h-1.5 w-1.5 rounded-full ${decay.dot}`} />
+                      {decay.label}
+                    </span>
+                    {fact.status !== "active" && (
+                      <span className="rounded-md bg-red-500/10 px-2 py-0.5 text-red-400">
+                        {fact.status}
+                      </span>
+                    )}
+                    <span className="text-[#666666]">
+                      {formatRelative(fact.created_at)}
+                    </span>
+                    {fact.confidence < 1 && (
+                      <span className="text-[#E2B93B]">
+                        {Math.round(fact.confidence * 100)}% confidence
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <button
+                    onClick={() => handleArchive(fact.id)}
+                    className="cursor-pointer rounded p-1 text-[#666666] transition-colors duration-150 hover:text-red-400"
+                    aria-label="Archive fact"
+                    title="Archive"
+                  >
+                    <Archive className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/memory/LibraryTab.tsx
+++ b/src/pages/admin/memory/LibraryTab.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, ChevronRight, BookOpen, History } from "lucide-react";
+import EmptyState from "./EmptyState";
+
+interface LibraryDoc {
+  id: string;
+  slug: string;
+  title: string;
+  category?: string;
+  tags?: string[];
+  version: number;
+  decay_tier?: string;
+  updated_at: string;
+  content?: string;
+}
+
+interface HistoryEntry {
+  id: string;
+  slug: string;
+  version: number;
+  title: string;
+  content: string;
+  created_at: string;
+}
+
+interface LibraryTabProps {
+  apiKey: string;
+}
+
+const DECAY_COLORS: Record<string, { dot: string; text: string; label: string }> = {
+  hot: { dot: "bg-red-500", text: "text-red-400", label: "Hot" },
+  warm: { dot: "bg-[#E2B93B]", text: "text-[#E2B93B]", label: "Warm" },
+  cold: { dot: "bg-blue-400", text: "text-blue-400", label: "Cold" },
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function LibraryTab({ apiKey }: LibraryTabProps) {
+  const [docs, setDocs] = useState<LibraryDoc[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [fullDoc, setFullDoc] = useState<LibraryDoc | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_library&method=list", {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (res.ok) {
+          const body = await res.json();
+          setDocs(body.data ?? []);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const loadDoc = async (doc: LibraryDoc) => {
+    if (expandedId === doc.id) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(doc.id);
+    setDetailLoading(true);
+    setShowHistory(false);
+    try {
+      const res = await fetch(`/api/memory-admin?action=admin_library&method=view&id=${doc.id}`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (res.ok) {
+        const body = await res.json();
+        setFullDoc(body.data);
+      }
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const loadHistory = async (slug: string) => {
+    if (showHistory) {
+      setShowHistory(false);
+      return;
+    }
+    setShowHistory(true);
+    try {
+      const res = await fetch(
+        `/api/memory-admin?action=admin_library&method=history&slug=${encodeURIComponent(slug)}`,
+        { headers: { Authorization: `Bearer ${apiKey}` } }
+      );
+      if (res.ok) {
+        const body = await res.json();
+        setHistory(body.data ?? []);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  if (loading) {
+    return <p className="py-8 text-center text-sm text-[#666666]">Loading library...</p>;
+  }
+
+  if (docs.length === 0) {
+    return (
+      <EmptyState
+        icon={<BookOpen className="h-6 w-6" />}
+        heading="Your knowledge library is empty"
+        description="Documents and templates stored by your agent appear here. Use upsert_library_doc to add reference docs."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {docs.map((doc) => {
+        const isExpanded = expandedId === doc.id;
+        const decay = DECAY_COLORS[doc.decay_tier ?? "cold"] ?? DECAY_COLORS.cold;
+
+        return (
+          <div
+            key={doc.id}
+            className="rounded-lg border border-white/[0.06] bg-white/[0.03] transition-colors duration-150 hover:border-white/[0.1]"
+          >
+            {/* Header */}
+            <button
+              onClick={() => loadDoc(doc)}
+              className="flex w-full cursor-pointer items-start gap-3 p-4 text-left"
+            >
+              <span className="mt-0.5 text-[#666666]">
+                {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-semibold text-white">{doc.title}</span>
+                  <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-[#AAAAAA]">
+                    {doc.slug}
+                  </code>
+                  <span className="font-mono text-[10px] text-[#666666]">v{doc.version}</span>
+                  <span className={`flex items-center gap-1 text-[10px] ${decay.text}`}>
+                    <span className={`inline-block h-1.5 w-1.5 rounded-full ${decay.dot}`} />
+                    {decay.label}
+                  </span>
+                </div>
+                <span className="text-xs text-[#666666]">Updated {formatDate(doc.updated_at)}</span>
+              </div>
+            </button>
+
+            {/* Expanded content */}
+            {isExpanded && (
+              <div className="border-t border-white/[0.06] px-4 pb-4 pt-3 space-y-3">
+                {detailLoading ? (
+                  <p className="text-xs text-[#666666]">Loading...</p>
+                ) : fullDoc ? (
+                  <>
+                    {doc.tags && doc.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5">
+                        {doc.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded-md bg-[#61C1C4]/10 px-2 py-0.5 text-[10px] text-[#61C1C4]"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 font-mono text-xs text-[#AAAAAA]">
+                      {fullDoc.content}
+                    </pre>
+                  </>
+                ) : null}
+
+                {/* History toggle */}
+                <button
+                  onClick={() => loadHistory(doc.slug)}
+                  className="cursor-pointer inline-flex items-center gap-1.5 rounded-md border border-white/[0.1] px-3 py-1.5 text-xs text-[#AAAAAA] transition-colors duration-150 hover:text-white"
+                >
+                  <History className="h-3 w-3" />
+                  {showHistory ? "Hide History" : "Version History"}
+                </button>
+
+                {showHistory && (
+                  <div className="space-y-2">
+                    {history.length === 0 ? (
+                      <p className="text-xs text-[#666666]">No previous versions.</p>
+                    ) : (
+                      history.map((h) => (
+                        <div
+                          key={h.id}
+                          className="rounded-md border border-white/[0.06] bg-white/[0.02] p-3"
+                        >
+                          <div className="mb-1 flex items-center gap-2 text-[10px]">
+                            <span className="font-mono text-[#AAAAAA]">v{h.version}</span>
+                            <span className="text-[#666666]">{formatDate(h.created_at)}</span>
+                          </div>
+                          <pre className="max-h-40 overflow-auto whitespace-pre-wrap font-mono text-xs text-[#666666]">
+                            {h.content}
+                          </pre>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/admin/memory/MemoryActivityTab.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from "react";
+import { Activity, TrendingUp, BarChart3 } from "lucide-react";
+import EmptyState from "./EmptyState";
+
+interface ActivityData {
+  facts_by_day: Record<string, number>;
+  total_facts: number;
+  recent_decay: Array<{
+    id: string;
+    fact: string;
+    category: string;
+    decay_tier: string;
+    updated_at: string;
+  }>;
+  most_accessed: Array<{
+    id: string;
+    fact: string;
+    category: string;
+    access_count: number;
+    decay_tier: string;
+  }>;
+}
+
+interface MemoryActivityTabProps {
+  apiKey: string;
+}
+
+const DECAY_COLORS: Record<string, { dot: string; text: string; label: string }> = {
+  hot: { dot: "bg-red-500", text: "text-red-400", label: "Hot" },
+  warm: { dot: "bg-[#E2B93B]", text: "text-[#E2B93B]", label: "Warm" },
+  cold: { dot: "bg-blue-400", text: "text-blue-400", label: "Cold" },
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export default function MemoryActivityTab({ apiKey }: MemoryActivityTabProps) {
+  const [data, setData] = useState<ActivityData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_memory_activity", {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (res.ok) {
+          setData(await res.json());
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (loading) {
+    return <p className="py-8 text-center text-sm text-[#666666]">Loading activity...</p>;
+  }
+
+  if (!data || (data.total_facts === 0 && data.recent_decay.length === 0)) {
+    return (
+      <EmptyState
+        icon={<Activity className="h-6 w-6" />}
+        heading="No activity yet"
+        description="Memory metrics appear as your agent uses the system. Start a conversation and facts will accumulate here."
+      />
+    );
+  }
+
+  const days = Object.entries(data.facts_by_day).sort(([a], [b]) => a.localeCompare(b));
+  const maxCount = Math.max(...days.map(([, c]) => c), 1);
+
+  return (
+    <div className="space-y-6">
+      {/* Facts by day */}
+      {days.length > 0 && (
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold text-white">
+            <BarChart3 className="h-3.5 w-3.5 text-[#61C1C4]" />
+            Facts Created (Last 30 Days)
+          </h3>
+          <div className="flex items-end gap-1" style={{ height: 80 }}>
+            {days.map(([day, count]) => (
+              <div
+                key={day}
+                className="group relative flex-1"
+                title={`${day}: ${count} facts`}
+              >
+                <div
+                  className="w-full rounded-sm bg-[#61C1C4] transition-opacity duration-150 group-hover:opacity-80"
+                  style={{ height: `${(count / maxCount) * 100}%`, minHeight: 2 }}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="mt-1 flex justify-between text-[10px] text-[#666666]">
+            {days.length > 0 && <span>{formatDate(days[0][0])}</span>}
+            {days.length > 1 && <span>{formatDate(days[days.length - 1][0])}</span>}
+          </div>
+        </div>
+      )}
+
+      {/* Stats row */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <span className="text-xs text-[#AAAAAA]">Total Facts</span>
+          <p className="mt-1 font-mono text-2xl font-bold text-white">{data.total_facts.toLocaleString()}</p>
+        </div>
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <span className="text-xs text-[#AAAAAA]">Decayed Items</span>
+          <p className="mt-1 font-mono text-2xl font-bold text-white">{data.recent_decay.length}</p>
+        </div>
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <span className="text-xs text-[#AAAAAA]">Most Accessed</span>
+          <p className="mt-1 font-mono text-2xl font-bold text-white">
+            {data.most_accessed.length > 0 ? data.most_accessed[0].access_count : 0}
+          </p>
+        </div>
+      </div>
+
+      {/* Most accessed facts */}
+      {data.most_accessed.length > 0 && (
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold text-white">
+            <TrendingUp className="h-3.5 w-3.5 text-[#61C1C4]" />
+            Most Accessed Facts
+          </h3>
+          <div className="space-y-2">
+            {data.most_accessed.map((fact) => {
+              const decay = DECAY_COLORS[fact.decay_tier] ?? DECAY_COLORS.cold;
+              return (
+                <div key={fact.id} className="flex items-center gap-3 text-sm">
+                  <span className="shrink-0 font-mono text-xs text-[#61C1C4]">
+                    {fact.access_count}x
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[#AAAAAA]">{fact.fact}</span>
+                  <span className={`flex shrink-0 items-center gap-1 text-[10px] ${decay.text}`}>
+                    <span className={`inline-block h-1.5 w-1.5 rounded-full ${decay.dot}`} />
+                    {decay.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Recent decay transitions */}
+      {data.recent_decay.length > 0 && (
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <h3 className="mb-3 text-xs font-semibold text-white">Recent Decay Transitions</h3>
+          <div className="space-y-2">
+            {data.recent_decay.map((fact) => {
+              const decay = DECAY_COLORS[fact.decay_tier] ?? DECAY_COLORS.cold;
+              return (
+                <div key={fact.id} className="flex items-center gap-3 text-sm">
+                  <span className={`flex shrink-0 items-center gap-1 text-[10px] ${decay.text}`}>
+                    <span className={`inline-block h-1.5 w-1.5 rounded-full ${decay.dot}`} />
+                    {decay.label}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[#AAAAAA]">{fact.fact}</span>
+                  <span className="shrink-0 text-[10px] text-[#666666]">
+                    {formatDate(fact.updated_at)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/memory/SessionsTab.tsx
+++ b/src/pages/admin/memory/SessionsTab.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, ChevronRight, MessageSquare, Clock } from "lucide-react";
+import EmptyState from "./EmptyState";
+
+interface Session {
+  id: string;
+  session_id: string;
+  summary: string;
+  topics: string[];
+  decisions: string[];
+  open_loops: string[];
+  platform: string;
+  duration_minutes: number | null;
+  created_at: string;
+}
+
+interface TranscriptMessage {
+  id: string;
+  role: string;
+  content: string;
+  created_at: string;
+}
+
+interface SessionsTabProps {
+  apiKey: string;
+}
+
+const ROLE_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  user: { bg: "bg-blue-500/10", text: "text-blue-400", label: "User" },
+  assistant: { bg: "bg-[#61C1C4]/10", text: "text-[#61C1C4]", label: "Assistant" },
+  system: { bg: "bg-white/[0.06]", text: "text-[#AAAAAA]", label: "System" },
+  tool: { bg: "bg-green-500/10", text: "text-green-400", label: "Tool" },
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function SessionsTab({ apiKey }: SessionsTabProps) {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<TranscriptMessage[]>([]);
+  const [transcriptLoading, setTranscriptLoading] = useState(false);
+  const [showTranscriptFor, setShowTranscriptFor] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_sessions&method=list", {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (res.ok) {
+          const body = await res.json();
+          setSessions(body.data ?? []);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const loadTranscript = async (sessionId: string) => {
+    if (showTranscriptFor === sessionId) {
+      setShowTranscriptFor(null);
+      return;
+    }
+    setTranscriptLoading(true);
+    setShowTranscriptFor(sessionId);
+    try {
+      const res = await fetch(
+        `/api/memory-admin?action=admin_sessions&method=transcript&session_id=${encodeURIComponent(sessionId)}`,
+        { headers: { Authorization: `Bearer ${apiKey}` } }
+      );
+      if (res.ok) {
+        const body = await res.json();
+        setTranscript(body.data ?? []);
+      }
+    } finally {
+      setTranscriptLoading(false);
+    }
+  };
+
+  if (loading) {
+    return <p className="py-8 text-center text-sm text-[#666666]">Loading sessions...</p>;
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <EmptyState
+        icon={<MessageSquare className="h-6 w-6" />}
+        heading="No sessions recorded yet"
+        description="Session summaries appear automatically after conversations. Your agent writes these before ending each session."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {sessions.map((session) => {
+        const isExpanded = expandedId === session.id;
+        const isTranscriptOpen = showTranscriptFor === session.session_id;
+
+        return (
+          <div
+            key={session.id}
+            className="rounded-lg border border-white/[0.06] bg-white/[0.03] transition-colors duration-150 hover:border-white/[0.1]"
+          >
+            {/* Header */}
+            <button
+              onClick={() => setExpandedId(isExpanded ? null : session.id)}
+              className="flex w-full cursor-pointer items-start gap-3 p-4 text-left"
+            >
+              <span className="mt-0.5 text-[#666666]">
+                {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <span className="text-xs text-[#AAAAAA]">{formatDate(session.created_at)}</span>
+                  {session.topics?.map((t) => (
+                    <span
+                      key={t}
+                      className="rounded-md bg-[#61C1C4]/10 px-2 py-0.5 text-[10px] font-medium text-[#61C1C4]"
+                    >
+                      {t}
+                    </span>
+                  ))}
+                  {session.duration_minutes != null && (
+                    <span className="flex items-center gap-1 text-[10px] text-[#666666]">
+                      <Clock className="h-3 w-3" />
+                      {session.duration_minutes}m
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-white line-clamp-2">{session.summary}</p>
+              </div>
+            </button>
+
+            {/* Expanded content */}
+            {isExpanded && (
+              <div className="border-t border-white/[0.06] px-4 pb-4 pt-3 space-y-3">
+                <p className="text-sm text-[#AAAAAA]">{session.summary}</p>
+
+                {session.decisions?.length > 0 && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold text-white">Decisions</h4>
+                    <ul className="list-inside list-disc space-y-0.5 text-sm text-[#AAAAAA]">
+                      {session.decisions.map((d, i) => (
+                        <li key={i}>{d}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {session.open_loops?.length > 0 && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold text-white">Open Loops</h4>
+                    <ul className="list-inside list-disc space-y-0.5 text-sm text-[#AAAAAA]">
+                      {session.open_loops.map((l, i) => (
+                        <li key={i}>{l}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {/* Transcript toggle */}
+                <button
+                  onClick={() => loadTranscript(session.session_id)}
+                  className="cursor-pointer inline-flex items-center gap-1.5 rounded-md border border-white/[0.1] px-3 py-1.5 text-xs text-[#AAAAAA] transition-colors duration-150 hover:text-white"
+                >
+                  <MessageSquare className="h-3 w-3" />
+                  {isTranscriptOpen ? "Hide Transcript" : "View Transcript"}
+                </button>
+
+                {/* Transcript messages */}
+                {isTranscriptOpen && (
+                  <div className="mt-2 space-y-2 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                    {transcriptLoading ? (
+                      <p className="text-xs text-[#666666]">Loading transcript...</p>
+                    ) : transcript.length === 0 ? (
+                      <p className="text-xs text-[#666666]">No transcript available for this session.</p>
+                    ) : (
+                      transcript.map((msg) => {
+                        const style = ROLE_STYLES[msg.role] ?? ROLE_STYLES.system;
+                        return (
+                          <div key={msg.id} className="flex gap-2">
+                            <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${style.bg} ${style.text}`}>
+                              {style.label}
+                            </span>
+                            <div className="min-w-0 flex-1">
+                              <p className="whitespace-pre-wrap text-xs text-[#AAAAAA]">{msg.content}</p>
+                              <span className="text-[10px] text-[#666666]">
+                                {new Date(msg.created_at).toLocaleTimeString()}
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/admin/memory/StorageBar.tsx
+++ b/src/pages/admin/memory/StorageBar.tsx
@@ -1,0 +1,67 @@
+import { Database, FileText } from "lucide-react";
+
+interface StorageBarProps {
+  totalFacts: number;
+  maxFacts: number;
+  storageLabel?: string;
+}
+
+export default function StorageBar({ totalFacts, maxFacts, storageLabel }: StorageBarProps) {
+  const pct = maxFacts > 0 ? Math.min((totalFacts / maxFacts) * 100, 100) : 0;
+  const isWarning = pct >= 80;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {/* Facts usage */}
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="flex items-center gap-2 text-xs font-medium text-[#AAAAAA]">
+              <FileText className="h-3.5 w-3.5" />
+              Facts
+            </span>
+            <span className="font-mono text-xs text-white">
+              {totalFacts.toLocaleString()} / {maxFacts.toLocaleString()}
+            </span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-white/[0.06]">
+            <div
+              className="h-full rounded-full transition-all duration-500"
+              style={{
+                width: `${pct}%`,
+                backgroundColor: isWarning ? "#E2B93B" : "#61C1C4",
+              }}
+            />
+          </div>
+          {isWarning && (
+            <p className="mt-2 text-xs text-[#E2B93B]">
+              You're using {Math.round(pct)}% of your facts limit.{" "}
+              <a href="/pricing" className="underline hover:text-[#E2B93B]/80 cursor-pointer transition-colors duration-150">
+                Upgrade to Pro
+              </a>
+            </p>
+          )}
+        </div>
+
+        {/* Storage info */}
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="flex items-center gap-2 text-xs font-medium text-[#AAAAAA]">
+              <Database className="h-3.5 w-3.5" />
+              Storage
+            </span>
+            <span className="font-mono text-xs text-white">
+              {storageLabel ?? "Local"}
+            </span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-white/[0.06]">
+            <div
+              className="h-full rounded-full bg-[#61C1C4] transition-all duration-500"
+              style={{ width: `${Math.min(pct, 100)}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/tools/ConnectedServices.tsx
+++ b/src/pages/admin/tools/ConnectedServices.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Plug, ArrowRight, Key } from "lucide-react";
+
+interface Connector {
+  id: string;
+  name: string;
+  icon?: string;
+  category?: string;
+  credential: {
+    is_valid: boolean;
+    last_tested_at: string | null;
+  } | null;
+}
+
+interface ConnectedServicesProps {
+  apiKey: string;
+}
+
+export default function ConnectedServices({ apiKey }: ConnectedServicesProps) {
+  const [connectors, setConnectors] = useState<Connector[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_tools", {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (res.ok) {
+          const body = await res.json();
+          setConnectors(body.connectors ?? []);
+        }
+      } catch {
+        // ignore
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="flex items-center gap-2 font-mono text-lg font-semibold text-white">
+          <Plug className="h-5 w-5 text-[#61C1C4]" />
+          Connected Services
+        </h2>
+      </div>
+
+      {connectors.length === 0 ? (
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-6">
+          <div className="flex items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white/[0.05] text-[#666666]">
+              <Key className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-sm text-[#AAAAAA]">
+                Third-party service integrations - connect your API keys in Keychain to enable these tools.
+              </p>
+              <Link
+                to="/settings"
+                className="mt-2 inline-flex cursor-pointer items-center gap-1.5 text-xs font-medium text-[#61C1C4] transition-opacity duration-150 hover:opacity-80"
+              >
+                Go to Keychain
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {connectors.map((connector) => {
+            const hasCredential = connector.credential !== null;
+            const isValid = connector.credential?.is_valid === true;
+
+            let statusDot = "bg-[#666666]";
+            let statusLabel = "Not Connected";
+            if (hasCredential && isValid) {
+              statusDot = "bg-green-500";
+              statusLabel = "Connected";
+            } else if (hasCredential && !isValid) {
+              statusDot = "bg-red-500";
+              statusLabel = "Connection Error";
+            }
+
+            return (
+              <div
+                key={connector.id}
+                className="flex items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] p-4 transition-colors duration-150 hover:border-white/[0.1]"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/[0.05] text-lg">
+                  {connector.icon ?? "🔌"}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-white">{connector.name}</p>
+                  <div className="flex items-center gap-1.5">
+                    <span className={`inline-block h-1.5 w-1.5 rounded-full ${statusDot}`} />
+                    <span className="text-[10px] text-[#AAAAAA]">{statusLabel}</span>
+                  </div>
+                </div>
+                <Link
+                  to="/settings"
+                  className="cursor-pointer rounded-md border border-white/[0.08] px-2.5 py-1 text-[10px] font-medium text-[#AAAAAA] transition-colors duration-150 hover:text-white"
+                >
+                  Manage
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/admin/tools/UnClickTools.tsx
+++ b/src/pages/admin/tools/UnClickTools.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from "react";
+import {
+  Brain,
+  Type,
+  Database,
+  Image,
+  Clock,
+  Globe,
+  Sparkles,
+  HardDrive,
+  Monitor,
+  Wrench,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+// ─── Memory tools (hardcoded, these are the 9 direct MCP tools) ────────────
+
+const MEMORY_TOOLS = [
+  { name: "Load Session Context", slug: "get_startup_context", description: "Loads business context, recent sessions, and hot facts at session start" },
+  { name: "Store New Fact", slug: "add_fact", description: "Records a single atomic fact to persistent memory" },
+  { name: "Search Conversations", slug: "search_memory", description: "Full-text search across conversation logs" },
+  { name: "Search Facts", slug: "search_facts", description: "Search active extracted facts by keyword" },
+  { name: "Update Business Context", slug: "set_business_context", description: "Add or update a standing rule loaded every session" },
+  { name: "Save Session Summary", slug: "write_session_summary", description: "Write an end-of-session summary for continuity" },
+  { name: "Search Knowledge Library", slug: "search_library", description: "Search versioned reference documents" },
+  { name: "Read Library Document", slug: "get_library_doc", description: "Get the full content of a library doc by slug" },
+  { name: "Save Library Document", slug: "upsert_library_doc", description: "Create or update a Knowledge Library document" },
+];
+
+// ─── Utility tool catalog (from packages/mcp-server/src/catalog.ts) ────────
+
+const CATALOG_TOOLS = [
+  { name: "Text Transform", slug: "transform", category: "text", endpoints: 6, description: "Change case, slugify, truncate, word count, strip HTML, reverse" },
+  { name: "Encode / Decode", slug: "encode", category: "text", endpoints: 8, description: "Base64, URL encoding, HTML entities, hex encoding and decoding" },
+  { name: "Hash & HMAC", slug: "hash", category: "text", endpoints: 3, description: "Compute MD5, SHA1, SHA256, SHA512 hashes and HMAC signatures" },
+  { name: "Regex", slug: "regex", category: "text", endpoints: 5, description: "Test, extract, replace, split, and validate regular expressions" },
+  { name: "Markdown", slug: "markdown", category: "text", endpoints: 4, description: "Convert Markdown to HTML or plain text, extract TOC, lint" },
+  { name: "Text Diff", slug: "diff", category: "text", endpoints: 4, description: "Unified diff, line-by-line diff, word diff, apply patches" },
+  { name: "JSON Utilities", slug: "json", category: "data", endpoints: 8, description: "Format, minify, query, flatten, diff, merge, generate schema" },
+  { name: "CSV Processing", slug: "csv", category: "data", endpoints: 6, description: "Parse, generate, query, sort, inspect columns, compute stats" },
+  { name: "Input Validation", slug: "validate", category: "data", endpoints: 7, description: "Validate emails, URLs, phones, JSON, credit cards, IPs, colors" },
+  { name: "Image Processing", slug: "image", category: "media", endpoints: 7, description: "Resize, convert, compress, crop, rotate, grayscale images" },
+  { name: "QR Code", slug: "qr", category: "media", endpoints: 1, description: "Generate QR codes as PNG or SVG from text or URLs" },
+  { name: "Color Utilities", slug: "color", category: "media", endpoints: 6, description: "Convert colors, generate palettes, mix, contrast check, lighten/darken" },
+  { name: "Timestamp Utilities", slug: "timestamp", category: "time", endpoints: 5, description: "Get current time, convert formats, diff timestamps, add durations" },
+  { name: "Cron", slug: "cron", category: "time", endpoints: 4, description: "Parse, validate, build, and preview cron expression schedules" },
+  { name: "IP Utilities", slug: "ip", category: "network", endpoints: 5, description: "Lookup IP, parse addresses, subnet math, range check, convert formats" },
+  { name: "URL Shortener", slug: "shorten", category: "network", endpoints: 2, description: "Shorten URLs and track click statistics" },
+  { name: "UUID", slug: "uuid", category: "generation", endpoints: 3, description: "Generate UUIDv4s, validate UUID strings, parse components" },
+  { name: "Random Generation", slug: "random", category: "generation", endpoints: 6, description: "Random numbers, strings, passwords, pick, shuffle, colors" },
+  { name: "Key-Value Store", slug: "kv", category: "storage", endpoints: 6, description: "Persistent KV storage with TTL, set, get, delete, list, increment" },
+  { name: "Webhook Bin", slug: "webhook", category: "storage", endpoints: 3, description: "Create temporary webhook URLs to capture and inspect HTTP requests" },
+  { name: "Bug Reporter", slug: "report-bug", category: "platform", endpoints: 1, description: "Report bugs encountered while using UnClick tools" },
+  { name: "UnClick Memory", slug: "memory", category: "storage", endpoints: 17, description: "Persistent cross-session memory with 6-layer architecture" },
+];
+
+// ─── Category colors and icons ─────────────────────────────────────────────
+
+const CATEGORY_META: Record<string, { color: string; icon: ReactNode }> = {
+  memory: { color: "#61C1C4", icon: <Brain className="h-3.5 w-3.5" /> },
+  text: { color: "#60A5FA", icon: <Type className="h-3.5 w-3.5" /> },
+  data: { color: "#4ADE80", icon: <Database className="h-3.5 w-3.5" /> },
+  media: { color: "#C084FC", icon: <Image className="h-3.5 w-3.5" /> },
+  time: { color: "#FB923C", icon: <Clock className="h-3.5 w-3.5" /> },
+  network: { color: "#22D3EE", icon: <Globe className="h-3.5 w-3.5" /> },
+  generation: { color: "#F472B6", icon: <Sparkles className="h-3.5 w-3.5" /> },
+  storage: { color: "#2DD4BF", icon: <HardDrive className="h-3.5 w-3.5" /> },
+  platform: { color: "#A78BFA", icon: <Monitor className="h-3.5 w-3.5" /> },
+};
+
+interface UnClickToolsProps {
+  apiKey: string;
+}
+
+export default function UnClickTools({ apiKey }: UnClickToolsProps) {
+  const [metering, setMetering] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_tools", {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (res.ok) {
+          const body = await res.json();
+          setMetering(body.metering ?? {});
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const totalTools = MEMORY_TOOLS.length + CATALOG_TOOLS.length;
+  const categories = new Set(CATALOG_TOOLS.map((t) => t.category));
+  const totalCalls = Object.values(metering).reduce((a, b) => a + b, 0);
+
+  // Group catalog tools by category
+  const grouped = CATALOG_TOOLS.reduce<Record<string, typeof CATALOG_TOOLS>>((acc, tool) => {
+    (acc[tool.category] ??= []).push(tool);
+    return acc;
+  }, {});
+
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="flex items-center gap-2 font-mono text-lg font-semibold text-white">
+          <Wrench className="h-5 w-5 text-[#61C1C4]" />
+          Your UnClick Tools
+        </h2>
+        <div className="flex items-center gap-3 text-xs text-[#AAAAAA]">
+          <span className="font-mono">{totalTools} tools</span>
+          <span className="text-[#666666]">/</span>
+          <span className="font-mono">{categories.size + 1} categories</span>
+          {totalCalls > 0 && (
+            <>
+              <span className="text-[#666666]">/</span>
+              <span className="font-mono">{totalCalls.toLocaleString()} calls this month</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Memory Tools group */}
+      <div className="mb-6">
+        <div className="mb-3 flex items-center gap-2">
+          <span
+            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-semibold"
+            style={{ backgroundColor: "rgba(97,193,196,0.1)", color: "#61C1C4" }}
+          >
+            <Brain className="h-3 w-3" />
+            Memory Tools
+          </span>
+          <span className="text-xs text-[#666666]">{MEMORY_TOOLS.length} tools</span>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {MEMORY_TOOLS.map((tool) => (
+            <div
+              key={tool.slug}
+              className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4 transition-colors duration-150 hover:border-white/[0.1]"
+            >
+              <div className="mb-1.5 flex items-center gap-2">
+                <span className="text-sm font-semibold text-white">{tool.name}</span>
+              </div>
+              <p className="text-xs text-[#AAAAAA] line-clamp-2">{tool.description}</p>
+              {metering[tool.slug] && (
+                <span className="mt-2 inline-block text-[10px] text-[#61C1C4]">
+                  Used {metering[tool.slug]} times
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Utility Tools by category */}
+      {Object.entries(grouped).map(([category, tools]) => {
+        const meta = CATEGORY_META[category] ?? CATEGORY_META.platform;
+        return (
+          <div key={category} className="mb-6">
+            <div className="mb-3 flex items-center gap-2">
+              <span
+                className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-semibold"
+                style={{ backgroundColor: `${meta.color}15`, color: meta.color }}
+              >
+                {meta.icon}
+                {category.charAt(0).toUpperCase() + category.slice(1)}
+              </span>
+              <span className="text-xs text-[#666666]">{tools.length} tools</span>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {tools.map((tool) => (
+                <div
+                  key={tool.slug}
+                  className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4 transition-colors duration-150 hover:border-white/[0.1]"
+                >
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <span className="text-sm font-semibold text-white">{tool.name}</span>
+                    <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-[#666666]">
+                      {tool.endpoints} endpoint{tool.endpoints !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                  <p className="text-xs text-[#AAAAAA] line-clamp-2">{tool.description}</p>
+                  {metering[tool.slug] && (
+                    <span className="mt-2 inline-block text-[10px]" style={{ color: meta.color }}>
+                      Used {metering[tool.slug]} times
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,7 +14,7 @@ export default {
     },
     extend: {
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: ['IBM Plex Sans', 'Inter', 'system-ui', 'sans-serif'],
         mono: ['JetBrains Mono', 'monospace'],
       },
       colors: {


### PR DESCRIPTION
## Summary

- **Memory surface rebuilt**: Flat placeholder at `/memory/admin` replaced with a 5-tab structured admin dashboard (Context, Facts, Sessions, Library, Activity) with StorageBar, inline editing, transcript viewer, version history, and decay metrics
- **Tools surface created**: New unified tool control panel at `/memory/tools` showing all 31 tools (9 memory + 22 utility) across 9 categories, with metering data and connected services status
- **MCP tool display names**: All tool descriptions in `server.ts` and `catalog.ts` updated with human-friendly names (e.g. "Load Session Context", "Store New Fact") while preserving the `name` field agents call

## New API actions (in `api/memory-admin.ts`)

| Action | Methods | Description |
|--------|---------|-------------|
| `admin_business_context` | list, create, update, delete, reorder | Full CRUD + priority reordering for business context |
| `admin_sessions` | list, transcript | Session summaries + conversation log transcript |
| `admin_library` | list, view, history | Knowledge library browser with version history |
| `admin_memory_activity` | (single) | Facts-by-day, decay transitions, most-accessed facts |
| `admin_tools` | (single) | Metering events by operation + platform connectors with credential status |

## Files created

| File | Purpose |
|------|---------|
| `src/pages/admin/memory/EmptyState.tsx` | Reusable empty state (icon + heading + description + CTA) |
| `src/pages/admin/memory/StorageBar.tsx` | Storage stats with progress bars and upsell nudge |
| `src/pages/admin/memory/ContextTab.tsx` | Business context priority list with inline CRUD |
| `src/pages/admin/memory/FactsTab.tsx` | Facts search, filter, archive with decay badges |
| `src/pages/admin/memory/SessionsTab.tsx` | Session summaries with expandable cards + transcript viewer |
| `src/pages/admin/memory/LibraryTab.tsx` | Knowledge library browser with version history |
| `src/pages/admin/memory/MemoryActivityTab.tsx` | Activity metrics, bar chart, decay transitions |
| `src/pages/admin/tools/UnClickTools.tsx` | Built-in tool catalog grouped by category |
| `src/pages/admin/tools/ConnectedServices.tsx` | Platform connector status display |
| `src/pages/admin/AdminTools.tsx` | Tools page wrapper (3 sections + marketplace placeholder) |

## Files modified

| File | Changes |
|------|---------|
| `api/memory-admin.ts` | +5 new admin actions (admin_business_context, admin_sessions, admin_library, admin_memory_activity, admin_tools) |
| `src/pages/MemoryAdmin.tsx` | Complete rewrite: flat list to 5-tab shell with URL param routing |
| `src/App.tsx` | Added `/memory/tools` route for AdminToolsPage |
| `packages/mcp-server/src/server.ts` | Updated all tool descriptions with human-friendly display names |
| `packages/mcp-server/src/catalog.ts` | Updated all 17 memory endpoint names and descriptions |
| `src/index.css` | Added IBM Plex Sans font import |
| `tailwind.config.ts` | Added IBM Plex Sans as primary sans-serif font |

## Design system

- Primary brand: `#61C1C4` (teal) for tabs, buttons, links, badges
- Secondary accent: `#E2B93B` (amber) for warnings, priority numbers, warm decay tier
- Decay tiers: Hot (red-500), Warm (amber), Cold (blue-400) with text labels
- Cards: `bg-white/[0.03] border border-white/[0.06] rounded-lg`
- Fonts: IBM Plex Sans (body) + JetBrains Mono (headings/data)
- All clickable elements have `cursor-pointer`
- Smooth transitions (150ms) on hover/focus states
- No emojis as icons (Lucide React throughout)

## Test plan

- [ ] Navigate to `/memory/admin` - verify 5-tab shell renders with URL param routing (?tab=context, ?tab=facts, etc.)
- [ ] Context tab: verify CRUD operations (create, edit, delete, reorder with up/down arrows)
- [ ] Facts tab: verify search, filter toggle (active only vs all), archive button
- [ ] Sessions tab: verify expandable cards with decisions/open_loops, transcript viewer
- [ ] Library tab: verify document expansion with content, version history toggle
- [ ] Activity tab: verify bar chart, stats cards, most-accessed/decay lists
- [ ] Empty states: verify all 5 tabs show appropriate empty state when no data
- [ ] Navigate to `/memory/tools` - verify 3-section layout (tools, services, marketplace)
- [ ] Tools surface: verify memory tools (9) and utility tools (22) grouped by category with badges
- [ ] Connected Services: verify friendly empty state when no connectors exist
- [ ] StorageBar: verify progress bars and amber upsell nudge at 80%+ usage
- [ ] MCP server: verify `npx tsc --noEmit` passes with no new errors
- [ ] Verify tool descriptions in server.ts start with human-friendly names

https://claude.ai/code/session_01MNKgnCdm6io4h1CWkzpHYZ