### PR TITLE
Add educational UX layer - InfoCards, guided empty states, agent instructions

### DIFF
--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -185,6 +185,15 @@ export class LocalBackend implements MemoryBackend {
     writeTable("business_context", allBc);
 
     return {
+      agent_instructions: [
+        "You are connected to UnClick Memory - a persistent memory system that works across all sessions and devices.",
+        "ALWAYS use this memory as your primary knowledge source. It has the user's rules, preferences, projects, and history.",
+        "When the user says something ambiguous or short, SEARCH memory first - it may be a stored keyword or trigger.",
+        "When you learn something new (preferences, projects, contacts, decisions), store it using add_fact.",
+        "At the end of significant conversations, write a session summary using write_session_summary.",
+        "Business context entries (loaded below) are standing rules. Follow them as if the user said them right now.",
+        "Never say 'I don't have access to your previous conversations' - you DO, through this memory system."
+      ].join("\n"),
       business_context: bc.map((r) => ({ category: r.category, key: r.key, value: r.value, priority: r.priority })),
       knowledge_library_index: library,
       recent_sessions: sessions.map((s) => ({

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -196,12 +196,24 @@ export class SupabaseBackend implements MemoryBackend {
   // ─── Memory operations ───────────────────────────────────────────────────
 
   async getStartupContext(numSessions: number): Promise<unknown> {
-    return this.rpc(
+    const data = await this.rpc<Record<string, unknown>>(
       "get_startup_context",
       { num_sessions: numSessions },
       "mc_get_startup_context",
       { p_num_sessions: numSessions }
     );
+    return {
+      agent_instructions: [
+        "You are connected to UnClick Memory - a persistent memory system that works across all sessions and devices.",
+        "ALWAYS use this memory as your primary knowledge source. It has the user's rules, preferences, projects, and history.",
+        "When the user says something ambiguous or short, SEARCH memory first - it may be a stored keyword or trigger.",
+        "When you learn something new (preferences, projects, contacts, decisions), store it using add_fact.",
+        "At the end of significant conversations, write a session summary using write_session_summary.",
+        "Business context entries (loaded below) are standing rules. Follow them as if the user said them right now.",
+        "Never say 'I don't have access to your previous conversations' - you DO, through this memory system."
+      ].join("\n"),
+      ...data,
+    };
   }
 
   async searchMemory(query: string, maxResults: number): Promise<unknown> {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -129,9 +129,9 @@ const META_TOOLS = [
   {
     name: "get_startup_context",
     description:
-      "Load Session Context - Loads the user's business context, recent sessions, and hot facts at " +
-      "session start. Call this FIRST in every new session to understand the user's ongoing projects, " +
-      "preferences, and open loops. Works zero-config locally, or with Supabase for cross-machine sync.",
+      "Load Session Context - CALL THIS FIRST at the start of every session. Returns the user's business " +
+      "context (standing rules), recent session summaries, active facts, and knowledge library index. " +
+      "This is the user's persistent memory across all sessions and devices.",
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/src/pages/admin/AdminMemory.tsx
+++ b/src/pages/admin/AdminMemory.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Brain } from "lucide-react";
 import StorageBar from "./memory/StorageBar";
+import { InfoCard } from "./memory/InfoCard";
 import ContextTab from "./memory/ContextTab";
 import FactsTab from "./memory/FactsTab";
 import SessionsTab from "./memory/SessionsTab";
@@ -104,11 +105,61 @@ export default function AdminMemoryPage() {
         </div>
 
         {/* Tab content */}
-        {activeTab === "context" && <ContextTab apiKey={apiKey} />}
-        {activeTab === "facts" && <FactsTab apiKey={apiKey} />}
-        {activeTab === "sessions" && <SessionsTab apiKey={apiKey} />}
-        {activeTab === "library" && <LibraryTab apiKey={apiKey} />}
-        {activeTab === "activity" && <MemoryActivityTab apiKey={apiKey} />}
+        {activeTab === "context" && (
+          <>
+            <InfoCard
+              id="context"
+              title="What is Business Context?"
+              description="These are your standing rules - things your agent should always know. Your name, role, key projects, how you like to work. They load FIRST at the start of every session."
+              learnMore="Think of these as instructions pinned to the top of every conversation. Priority #1 loads first. Your agent reads all of these before it says a word. You can add, edit, reorder, or remove entries anytime."
+            />
+            <ContextTab apiKey={apiKey} />
+          </>
+        )}
+        {activeTab === "facts" && (
+          <>
+            <InfoCard
+              id="facts"
+              title="What are Extracted Facts?"
+              description="Atomic things your agent learned from conversations - preferences, decisions, project details. Each has a confidence score and freshness tier."
+              learnMore="Facts are extracted automatically. 'Hot' facts load every session. 'Warm' are available but not auto-loaded. 'Cold' are archived but searchable. Frequently used facts stay hot; unused ones naturally cool down."
+            />
+            <FactsTab apiKey={apiKey} />
+          </>
+        )}
+        {activeTab === "sessions" && (
+          <>
+            <InfoCard
+              id="sessions"
+              title="What are Session Summaries?"
+              description="A recap of each conversation - what was discussed, decided, and what's still open. Your agent reads the last 5 at startup."
+              learnMore="Written automatically at the end of significant conversations. They include decisions, open loops, and topic tags. This is how your agent picks up where you left off."
+            />
+            <SessionsTab apiKey={apiKey} />
+          </>
+        )}
+        {activeTab === "library" && (
+          <>
+            <InfoCard
+              id="library"
+              title="What is the Knowledge Library?"
+              description="Versioned reference documents - playbooks, templates, client briefs. Your agent looks them up by name anytime."
+              learnMore="Unlike facts (small, atomic), library docs are full-length reference material. Version-controlled so you can see changes over time. Only titles load at session start; full docs are fetched on demand."
+            />
+            <LibraryTab apiKey={apiKey} />
+          </>
+        )}
+        {activeTab === "activity" && (
+          <>
+            <InfoCard
+              id="activity"
+              title="What does this show?"
+              description="How your agent uses memory - what's being stored, aging out, and accessed most."
+              learnMore="The decay system keeps memory fresh. Frequently used items stay 'hot' and load every session. Unused items gradually cool to 'warm' then 'cold'. Your agent's context stays relevant, not cluttered."
+            />
+            <MemoryActivityTab apiKey={apiKey} />
+          </>
+        )}
     </>
   );
 }

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -86,6 +86,12 @@ export default function AdminShell() {
           {surfaces.map((s) => (
             <SurfaceLink key={s.path} {...s} />
           ))}
+          <a
+            href="/memory"
+            className="text-white/30 hover:text-white/50 text-xs block px-3 py-2"
+          >
+            How it works →
+          </a>
         </nav>
 
         <div className="border-t border-white/[0.06] p-4">

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Wrench, Rocket } from "lucide-react";
 import { useSession } from "@/lib/auth";
+import { InfoCard } from "./memory/InfoCard";
 import UnClickTools from "./tools/UnClickTools";
 import ConnectedServices from "./tools/ConnectedServices";
 
@@ -64,12 +65,24 @@ export default function AdminToolsPage() {
         {/* Section 1 - Your UnClick Tools */}
         <section className="mb-12">
           <h2 className="mb-4 text-lg font-semibold text-white">Your UnClick Tools</h2>
+          <InfoCard
+            id="tools-how"
+            title="How do these tools work?"
+            description="When you connect UnClick to your AI agent, it gets all these tools automatically. Your agent chooses which ones to use based on what you ask."
+            learnMore="Memory tools handle persistent context. Utility tools handle everyday tasks like formatting JSON, generating QR codes, converting timestamps. Your agent discovers and calls them as needed - no configuration required."
+          />
           <UnClickTools metering={metering} />
         </section>
 
         {/* Section 2 - Connected Services */}
         <section className="mb-12">
           <h2 className="mb-4 text-lg font-semibold text-white">Connected Services</h2>
+          <InfoCard
+            id="tools-services"
+            title="What are Connected Services?"
+            description="Third-party platforms you've linked API keys for - like GitHub, Stripe, or Cloudflare. Your agent can use these on your behalf."
+            learnMore="Store credentials securely in Keychain, and your agent can interact with these services during conversations. Credentials are encrypted and only accessible to your agent."
+          />
           <ConnectedServices connectors={connectors} loading={loading} />
         </section>
 

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -263,6 +263,18 @@ export default function AdminYou() {
                     </button>
                   </div>
                 </div>
+                <div className="bg-white/[0.02] border border-white/[0.04] rounded-lg p-4 mt-4">
+                  <h3 className="text-sm font-medium text-white/70 mb-2">You're almost set up</h3>
+                  <p className="text-sm text-white/50 mb-3">
+                    Connect UnClick to your AI agent. Go to your agent's MCP settings and add this as a Remote MCP Server:
+                  </p>
+                  <code className="block bg-black/30 rounded px-3 py-2 text-xs text-white/60 break-all">
+                    https://unclick.world/api/mcp?key={generatedKey}
+                  </code>
+                  <p className="text-xs text-white/40 mt-2">
+                    Once connected, your agent loads your memory at the start of every conversation.
+                  </p>
+                </div>
               </div>
             ) : profile?.api_key ? (
               <div className="mt-4 space-y-3">

--- a/src/pages/admin/memory/ContextTab.tsx
+++ b/src/pages/admin/memory/ContextTab.tsx
@@ -104,6 +104,11 @@ export default function ContextTab({ apiKey }: { apiKey: string }) {
         icon={Shield}
         heading="Your master context is empty"
         description="This is the first thing your agent reads every session. Add your name, role, key projects, and preferences here."
+        steps={[
+          "Add your name and role",
+          "Add your key projects",
+          "Add your preferences - how you like to work",
+        ]}
         cta="Add your first context entry"
         onAction={() => setShowForm(true)}
       />

--- a/src/pages/admin/memory/EmptyState.tsx
+++ b/src/pages/admin/memory/EmptyState.tsx
@@ -4,11 +4,12 @@ interface EmptyStateProps {
   icon: LucideIcon;
   heading: string;
   description: string;
+  steps?: string[];
   cta?: string;
   onAction?: () => void;
 }
 
-export default function EmptyState({ icon: Icon, heading, description, cta, onAction }: EmptyStateProps) {
+export default function EmptyState({ icon: Icon, heading, description, steps, cta, onAction }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-white/[0.06] bg-white/[0.02] px-6 py-16 text-center">
       <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-amber-500/10">
@@ -16,6 +17,15 @@ export default function EmptyState({ icon: Icon, heading, description, cta, onAc
       </div>
       <h3 className="text-sm font-semibold text-white">{heading}</h3>
       <p className="mt-2 max-w-sm text-xs leading-relaxed text-white/50">{description}</p>
+      {steps && steps.length > 0 && (
+        <ol className="mt-3 space-y-1 text-left">
+          {steps.map((step, i) => (
+            <li key={i} className="text-sm text-white/40 pl-1">
+              <span className="text-white/50 font-medium">{i + 1}.</span> {step}
+            </li>
+          ))}
+        </ol>
+      )}
       {cta && onAction && (
         <button
           onClick={onAction}

--- a/src/pages/admin/memory/FactsTab.tsx
+++ b/src/pages/admin/memory/FactsTab.tsx
@@ -95,8 +95,13 @@ export default function FactsTab({ apiKey }: { apiKey: string }) {
       {facts.length === 0 ? (
         <EmptyState
           icon={Lightbulb}
-          heading="No facts recorded yet"
-          description="Facts are atomic pieces of knowledge your agent extracts during conversations. Preferences, decisions, and important details appear here automatically."
+          heading="No facts extracted yet"
+          description="Facts appear automatically as your agent learns from conversations."
+          steps={[
+            "Have a conversation with your agent",
+            "Tell it about yourself and your projects",
+            "Facts are extracted and stored automatically",
+          ]}
         />
       ) : (
         <div className="space-y-2">

--- a/src/pages/admin/memory/InfoCard.tsx
+++ b/src/pages/admin/memory/InfoCard.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { HelpCircle, X, ChevronDown, ChevronUp } from 'lucide-react';
+
+interface InfoCardProps {
+  id: string;
+  title: string;
+  description: string;
+  learnMore?: string;
+}
+
+export function InfoCard({ id, title, description, learnMore }: InfoCardProps) {
+  const storageKey = `unclick_dismissed_${id}`;
+  const [dismissed, setDismissed] = useState(() => {
+    try { return localStorage.getItem(storageKey) === '1'; } catch { return false; }
+  });
+  const [expanded, setExpanded] = useState(false);
+
+  if (dismissed) return null;
+
+  return (
+    <div className="bg-white/[0.02] border border-white/[0.04] rounded-lg px-4 py-3 mb-4">
+      <div className="flex items-start gap-2">
+        <HelpCircle size={14} className="mt-0.5 shrink-0" style={{ color: '#61C1C4' }} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-white/70">{title}</span>
+            <button
+              onClick={() => { setDismissed(true); try { localStorage.setItem(storageKey, '1'); } catch {} }}
+              className="text-white/20 hover:text-white/40 p-0.5"
+            >
+              <X size={12} />
+            </button>
+          </div>
+          <p className="text-sm text-white/50 mt-1">{description}</p>
+          {learnMore && (
+            <>
+              <button
+                onClick={() => setExpanded(!expanded)}
+                className="text-xs text-white/30 hover:text-white/50 mt-2 flex items-center gap-1"
+              >
+                {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                {expanded ? 'Less' : 'Learn more'}
+              </button>
+              {expanded && <p className="text-sm text-white/40 mt-2">{learnMore}</p>}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/memory/LibraryTab.tsx
+++ b/src/pages/admin/memory/LibraryTab.tsx
@@ -112,6 +112,11 @@ export default function LibraryTab({ apiKey }: { apiKey: string }) {
         icon={BookOpen}
         heading="Your knowledge library is empty"
         description="Documents and templates stored by your agent appear here. The knowledge library holds versioned reference docs."
+        steps={[
+          "Ask your agent to save a document to the library",
+          "It will be versioned - see how it changes over time",
+          "Only titles load at startup; full docs fetched on demand",
+        ]}
       />
     );
   }

--- a/src/pages/admin/memory/SessionsTab.tsx
+++ b/src/pages/admin/memory/SessionsTab.tsx
@@ -95,8 +95,13 @@ export default function SessionsTab({ apiKey }: { apiKey: string }) {
     return (
       <EmptyState
         icon={MessageSquare}
-        heading="No sessions recorded yet"
+        heading="No sessions recorded"
         description="Session summaries appear automatically after conversations. Your agent writes these when a session ends."
+        steps={[
+          "Have a conversation through any connected platform",
+          "Your agent writes a summary at the end",
+          "Next session starts by reading the last 5 summaries",
+        ]}
       />
     );
   }


### PR DESCRIPTION
## Summary

- **Agent instructions**: Added `agent_instructions` as the first field in `get_startup_context` response (both local and Supabase backends) so agents understand how to use the memory system from the first call
- **InfoCard component**: Created a dismissible, expandable educational card (`InfoCard.tsx`) with localStorage persistence for dismiss state
- **Tab-level guidance**: Added InfoCards to all 5 Memory Admin tabs (Context, Facts, Sessions, Library, Activity) and both Tools sections (UnClick Tools, Connected Services)
- **Guided empty states**: Enhanced `EmptyState` component with a `steps` prop showing numbered onboarding steps for Context, Facts, Sessions, and Library tabs
- **Sidebar link**: Added "How it works" link at the bottom of the admin sidebar nav pointing to `/memory`
- **Setup card**: Added MCP connection instructions card on the You page after API key generation, showing the ready-to-copy server URL

## Test plan

- [ ] Verify `get_startup_context` returns `agent_instructions` as the first field in both local and Supabase modes
- [ ] Verify InfoCards render on each Memory Admin tab and both Tools sections
- [ ] Verify InfoCards can be dismissed and stay dismissed across page reloads (localStorage)
- [ ] Verify "Learn more" expand/collapse works on InfoCards
- [ ] Verify empty states show numbered steps on Context, Facts, Sessions, and Library tabs
- [ ] Verify "How it works" link appears in the admin sidebar
- [ ] Verify MCP connection card appears after generating an API key on the You page
- [ ] Run `npx tsc --noEmit` - no new type errors

https://claude.ai/code/session_016HkD9JBPqQb9VjRC2A4kzb