### PR TITLE
Phase 5: Build Desk Foundation -- memory reliability + orchestration scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# UnClick
+
+AI agent operating system. One npm install gives agents access to 450+ callable endpoints across 60+ integrations AND persistent cross-session memory, all via the MCP protocol.
+
+## Monorepo structure
+
+```
+packages/mcp-server/            # THE npm package (@unclick/mcp-server) - published to npm
+packages/mcp-server/src/memory/ # Built-in memory module (6-layer architecture)
+packages/memory-mcp/            # DEPRECATED standalone package (kept for reference)
+src/                            # React website (Vite + TypeScript)
+api/                            # Vercel serverless functions (REST API endpoints)
+```
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers meta-tools + 5 direct memory tools |
+| `packages/mcp-server/src/tool-wiring.ts` | Maps tool names to API calls |
+| `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (all 17 ops) |
+| `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
+| `src/pages/tools/Tools.tsx` | Website tools grid, one tile per integration |
+
+## Architecture
+
+**4 meta-tools** let agents discover and call anything dynamically:
+
+- `unclick_search` - find tools by keyword
+- `unclick_browse` - list all tools, optionally by category
+- `unclick_tool_info` - get endpoints and params for a specific tool
+- `unclick_call` - execute any endpoint with parameters (including `memory.*`)
+
+**5 direct memory tools** expose the session protocol agents should follow:
+
+- `get_startup_context` - call FIRST in every session
+- `write_session_summary` - call BEFORE session ends
+- `add_fact` - record preferences, decisions, important info
+- `search_memory` - recall anything from prior sessions
+- `set_business_context` - set standing rules (always loaded)
+
+The other 12 memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
+
+## Adding a new tool
+
+1. Create `api/*-tool.ts` with the Vercel handler and endpoint logic
+2. Wire it in `packages/mcp-server/src/tool-wiring.ts` (add name, description, category, and endpoint mapping)
+3. Add a tile in `src/pages/tools/Tools.tsx`
+
+## Style rules
+
+- No em dashes anywhere in code or content (use a regular dash or restructure the sentence)
+- No per-tool MCP registrations EXCEPT the 5 direct memory tools (everything else goes through the 4 meta-tools)

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -33,6 +33,12 @@
  *   - admin_build_tasks: method=list|get|create|update_status|soft_delete
  *   - admin_build_workers: method=list|register|update|delete|health_check
  *   - admin_build_dispatch: POST with task_id + worker_id (same tenant)
+ *
+ * Memory reliability instrumentation (Bearer <api_key>):
+ *   - log_tool_event: POST from MCP server; inserts memory_load_events row,
+ *                     sets was_first_call_in_session via 30-minute window
+ *   - admin_memory_load_metrics: 7-day totals, get_startup_context compliance,
+ *                                breakdown by client_type
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
@@ -1154,6 +1160,98 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             "Nightly extraction (LLM fact distillation from conversation_log) " +
             "is not yet implemented. See docs/sessions for the open question " +
             "to Chris about model selection.",
+        });
+      }
+
+      // ── Memory reliability instrumentation ───────────────────────────
+      case "log_tool_event": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const apiKeyHash = sha256hex(apiKey);
+
+        const toolName = String(req.body?.tool_name ?? "").trim();
+        if (!toolName) return res.status(400).json({ error: "tool_name required" });
+        const sessionIdentifier = req.body?.session_identifier
+          ? String(req.body.session_identifier)
+          : null;
+        const clientType = req.body?.client_type ? String(req.body.client_type) : null;
+
+        // 30-minute window governs session detection. Scope by session_identifier
+        // when present, else by tenant alone.
+        const windowStart = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+        let probe = supabase
+          .from("memory_load_events")
+          .select("id", { count: "exact", head: true })
+          .eq("api_key_hash", apiKeyHash)
+          .gte("created_at", windowStart);
+        if (sessionIdentifier) {
+          probe = probe.eq("session_identifier", sessionIdentifier);
+        }
+        const probeRes = await probe;
+        if (probeRes.error) throw probeRes.error;
+        const wasFirst = (probeRes.count ?? 0) === 0;
+
+        const { data, error } = await supabase
+          .from("memory_load_events")
+          .insert({
+            api_key_hash: apiKeyHash,
+            tool_name: toolName,
+            session_identifier: sessionIdentifier,
+            client_type: clientType,
+            was_first_call_in_session: wasFirst,
+          })
+          .select()
+          .single();
+        if (error) throw error;
+        return res.status(200).json({ data });
+      }
+
+      case "admin_memory_load_metrics": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const apiKeyHash = sha256hex(apiKey);
+
+        const windowStart = new Date(
+          Date.now() - 7 * 24 * 60 * 60 * 1000
+        ).toISOString();
+        const { data, error } = await supabase
+          .from("memory_load_events")
+          .select("tool_name, client_type, was_first_call_in_session")
+          .eq("api_key_hash", apiKeyHash)
+          .gte("created_at", windowStart);
+        if (error) throw error;
+
+        const rows = (data ?? []) as Array<{
+          tool_name: string;
+          client_type: string | null;
+          was_first_call_in_session: boolean;
+        }>;
+
+        const totalEvents = rows.length;
+        const firstCalls = rows.filter((r) => r.was_first_call_in_session);
+        const totalSessions = firstCalls.length;
+        const compliantSessions = firstCalls.filter(
+          (r) => r.tool_name === "get_startup_context"
+        ).length;
+        const compliancePct =
+          totalSessions === 0
+            ? 0
+            : Math.round((compliantSessions / totalSessions) * 1000) / 10;
+
+        const byClientType: Record<string, number> = {};
+        for (const r of rows) {
+          const key = r.client_type ?? "unknown";
+          byClientType[key] = (byClientType[key] ?? 0) + 1;
+        }
+
+        return res.status(200).json({
+          window: "7d",
+          total_events: totalEvents,
+          total_sessions: totalSessions,
+          compliant_sessions: compliantSessions,
+          get_startup_context_compliance_pct: compliancePct,
+          by_client_type: byClientType,
         });
       }
 

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -28,6 +28,11 @@
  *                   + nudge signal
  *   - list_devices: GET with Bearer <api_key>
  *   - remove_device: DELETE ?fingerprint=... with Bearer (or ?dismiss=1)
+ *
+ * Build Desk admin actions (Bearer <api_key>, tenant-scoped by sha256hex):
+ *   - admin_build_tasks: method=list|get|create|update_status|soft_delete
+ *   - admin_build_workers: method=list|register|update|delete|health_check
+ *   - admin_build_dispatch: POST with task_id + worker_id (same tenant)
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
@@ -1150,6 +1155,281 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             "is not yet implemented. See docs/sessions for the open question " +
             "to Chris about model selection.",
         });
+      }
+
+      // ── Build Desk admin actions ─────────────────────────────────────
+      case "admin_build_tasks": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const apiKeyHash = sha256hex(apiKey);
+        const method = String(req.query.method ?? req.body?.method ?? "list").trim();
+
+        switch (method) {
+          case "list": {
+            const { data, error } = await supabase
+              .from("build_tasks")
+              .select("*")
+              .eq("api_key_hash", apiKeyHash)
+              .order("created_at", { ascending: false });
+            if (error) throw error;
+            return res.status(200).json({ data: data ?? [] });
+          }
+          case "get": {
+            const taskId = String(req.query.task_id ?? req.body?.task_id ?? "").trim();
+            if (!taskId) return res.status(400).json({ error: "task_id required" });
+            const { data, error } = await supabase
+              .from("build_tasks")
+              .select("*")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", taskId)
+              .maybeSingle();
+            if (error) throw error;
+            if (!data) return res.status(404).json({ error: "Task not found" });
+            return res.status(200).json({ data });
+          }
+          case "create": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const {
+              title,
+              description,
+              status,
+              plan_json,
+              acceptance_criteria_json,
+              assigned_worker_id,
+              parent_task_id,
+            } = req.body ?? {};
+            if (!title) return res.status(400).json({ error: "title required" });
+
+            if (assigned_worker_id) {
+              const { data: w, error: wErr } = await supabase
+                .from("build_workers")
+                .select("id")
+                .eq("api_key_hash", apiKeyHash)
+                .eq("id", assigned_worker_id)
+                .maybeSingle();
+              if (wErr) throw wErr;
+              if (!w) return res.status(400).json({ error: "assigned_worker_id not found" });
+            }
+            if (parent_task_id) {
+              const { data: p, error: pErr } = await supabase
+                .from("build_tasks")
+                .select("id")
+                .eq("api_key_hash", apiKeyHash)
+                .eq("id", parent_task_id)
+                .maybeSingle();
+              if (pErr) throw pErr;
+              if (!p) return res.status(400).json({ error: "parent_task_id not found" });
+            }
+
+            const { data, error } = await supabase
+              .from("build_tasks")
+              .insert({
+                api_key_hash: apiKeyHash,
+                title,
+                description: description ?? null,
+                status: status ?? "draft",
+                plan_json: plan_json ?? null,
+                acceptance_criteria_json: acceptance_criteria_json ?? null,
+                assigned_worker_id: assigned_worker_id ?? null,
+                parent_task_id: parent_task_id ?? null,
+              })
+              .select()
+              .single();
+            if (error) throw error;
+            return res.status(200).json({ data });
+          }
+          case "update_status": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const { task_id, status } = req.body ?? {};
+            if (!task_id || !status) {
+              return res.status(400).json({ error: "task_id and status required" });
+            }
+            const { data, error } = await supabase
+              .from("build_tasks")
+              .update({ status, updated_at: new Date().toISOString() })
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", task_id)
+              .select()
+              .maybeSingle();
+            if (error) throw error;
+            if (!data) return res.status(404).json({ error: "Task not found" });
+            return res.status(200).json({ data });
+          }
+          case "soft_delete": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const { task_id } = req.body ?? {};
+            if (!task_id) return res.status(400).json({ error: "task_id required" });
+            const { data, error } = await supabase
+              .from("build_tasks")
+              .update({ status: "failed", updated_at: new Date().toISOString() })
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", task_id)
+              .select()
+              .maybeSingle();
+            if (error) throw error;
+            if (!data) return res.status(404).json({ error: "Task not found" });
+            return res.status(200).json({ success: true });
+          }
+          default:
+            return res.status(400).json({ error: `Unknown method: ${method}` });
+        }
+      }
+
+      case "admin_build_workers": {
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const apiKeyHash = sha256hex(apiKey);
+        const method = String(req.query.method ?? req.body?.method ?? "list").trim();
+
+        switch (method) {
+          case "list": {
+            const { data, error } = await supabase
+              .from("build_workers")
+              .select("*")
+              .eq("api_key_hash", apiKeyHash)
+              .order("created_at", { ascending: false });
+            if (error) throw error;
+            return res.status(200).json({ data: data ?? [] });
+          }
+          case "register": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const { name, worker_type, connection_config_json, status } = req.body ?? {};
+            if (!name || !worker_type) {
+              return res.status(400).json({ error: "name and worker_type required" });
+            }
+            const { data, error } = await supabase
+              .from("build_workers")
+              .insert({
+                api_key_hash: apiKeyHash,
+                name,
+                worker_type,
+                connection_config_json: connection_config_json ?? null,
+                status: status ?? "offline",
+              })
+              .select()
+              .single();
+            if (error) throw error;
+            return res.status(200).json({ data });
+          }
+          case "update": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const { worker_id, name, worker_type, connection_config_json, status } = req.body ?? {};
+            if (!worker_id) return res.status(400).json({ error: "worker_id required" });
+            const updates: Record<string, unknown> = {};
+            if (name !== undefined) updates.name = name;
+            if (worker_type !== undefined) updates.worker_type = worker_type;
+            if (connection_config_json !== undefined) {
+              updates.connection_config_json = connection_config_json;
+            }
+            if (status !== undefined) updates.status = status;
+            if (Object.keys(updates).length === 0) {
+              return res.status(400).json({ error: "No fields to update" });
+            }
+            const { data, error } = await supabase
+              .from("build_workers")
+              .update(updates)
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", worker_id)
+              .select()
+              .maybeSingle();
+            if (error) throw error;
+            if (!data) return res.status(404).json({ error: "Worker not found" });
+            return res.status(200).json({ data });
+          }
+          case "delete": {
+            if (req.method !== "POST" && req.method !== "DELETE") {
+              return res.status(405).json({ error: "POST or DELETE required" });
+            }
+            const workerId = String(
+              req.body?.worker_id ?? req.query.worker_id ?? ""
+            ).trim();
+            if (!workerId) return res.status(400).json({ error: "worker_id required" });
+            const { error } = await supabase
+              .from("build_workers")
+              .delete()
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", workerId);
+            if (error) throw error;
+            return res.status(200).json({ success: true });
+          }
+          case "health_check": {
+            if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+            const { worker_id, status } = req.body ?? {};
+            if (!worker_id) return res.status(400).json({ error: "worker_id required" });
+            const updates: Record<string, unknown> = {
+              last_health_check_at: new Date().toISOString(),
+            };
+            if (status !== undefined) updates.status = status;
+            const { data, error } = await supabase
+              .from("build_workers")
+              .update(updates)
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", worker_id)
+              .select()
+              .maybeSingle();
+            if (error) throw error;
+            if (!data) return res.status(404).json({ error: "Worker not found" });
+            return res.status(200).json({ data });
+          }
+          default:
+            return res.status(400).json({ error: `Unknown method: ${method}` });
+        }
+      }
+
+      case "admin_build_dispatch": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKey = bearerFrom(req);
+        if (!apiKey) return res.status(401).json({ error: "Authorization header required" });
+        const apiKeyHash = sha256hex(apiKey);
+        const { task_id, worker_id, payload_json } = req.body ?? {};
+        if (!task_id || !worker_id) {
+          return res.status(400).json({ error: "task_id and worker_id required" });
+        }
+
+        const [taskRes, workerRes] = await Promise.all([
+          supabase
+            .from("build_tasks")
+            .select("id")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", task_id)
+            .maybeSingle(),
+          supabase
+            .from("build_workers")
+            .select("id")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", worker_id)
+            .maybeSingle(),
+        ]);
+        if (taskRes.error) throw taskRes.error;
+        if (workerRes.error) throw workerRes.error;
+        if (!taskRes.data) return res.status(404).json({ error: "task_id not found" });
+        if (!workerRes.data) return res.status(404).json({ error: "worker_id not found" });
+
+        const { data: eventData, error: eventErr } = await supabase
+          .from("build_dispatch_events")
+          .insert({
+            api_key_hash: apiKeyHash,
+            task_id,
+            worker_id,
+            event_type: "dispatched",
+            payload_json: payload_json ?? null,
+          })
+          .select()
+          .single();
+        if (eventErr) throw eventErr;
+
+        const { error: updErr } = await supabase
+          .from("build_tasks")
+          .update({
+            status: "dispatched",
+            assigned_worker_id: worker_id,
+            updated_at: new Date().toISOString(),
+          })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", task_id);
+        if (updErr) throw updErr;
+
+        return res.status(200).json({ data: eventData });
       }
 
       default:

--- a/docs/sessions/2026-04-17-phase-5-build-desk-foundation.md
+++ b/docs/sessions/2026-04-17-phase-5-build-desk-foundation.md
@@ -1,0 +1,92 @@
+# Session: 2026-04-17 - Phase 5 Build Desk Foundation
+
+## Summary
+
+Phase 5 lays the groundwork for AI agent orchestration. Four areas landed: a sibling `AGENTS.md` for
+session-start memory loading, reliability instrumentation that makes `get_startup_context` compliance
+measurable, a Build Desk admin page at `/build` for dispatching coding work, and the underlying
+database schema + API actions for tasks, workers, and dispatch events.
+
+## What shipped
+
+### 1. AGENTS.md for session-start memory loading
+
+- Added `AGENTS.md` at repo root with identical content to `CLAUDE.md`
+- Gives non-Claude agents (Codex, Cursor, Gemini CLI, custom MCP clients) the same session-start
+  protocol and project context
+
+### 2. Memory reliability instrumentation
+
+- Rewrote the `get_startup_context` tool description to be directive: "MUST be called before any
+  other UnClick tool in this session... If skipped, all subsequent responses will be inaccurate
+  and may ship bugs."
+- Appended a reminder suffix to every other tool description in
+  `packages/mcp-server/src/server.ts`: "If get_startup_context has not been called this session,
+  call it first." (via `GSC_REMINDER` constant, applied to 28 tools across META_TOOLS and
+  DIRECT_TOOLS)
+- New table `memory_load_events` (migration `20260417010000_memory_load_events.sql`):
+  id, created_at, api_key_hash, tool_name, session_identifier, client_type,
+  was_first_call_in_session, with index on (api_key_hash, created_at DESC)
+- New module `packages/mcp-server/src/memory/load-events.ts` exposes `logToolCall(toolName)` as
+  a fire-and-forget POST to the control plane. Wired into the `CallToolRequestSchema` handler so
+  every tool dispatch emits an event
+- New API action `log_tool_event` (POST, Bearer auth): inserts a row, sets
+  `was_first_call_in_session` by probing the 30-minute window scoped to tenant + session_identifier
+- New API action `admin_memory_load_metrics` (Bearer auth): 7-day totals, first-in-session session
+  count, `get_startup_context` compliance percentage, breakdown by `client_type`
+
+### 3. Build Desk admin scaffold at /build
+
+- New page `src/pages/BuildDesk.tsx` with three inline tabs (Tasks, Workers, History) using the
+  shadcn `Tabs` component
+- Registered at `/build` in `src/App.tsx`
+- Matches the `MemoryAdmin` page shell: `<Navbar />` + `max-w-6xl` main + icon header + `<Footer />`
+- Placeholder content per tab explaining what each area will do, plus an empty-state card
+
+### 4. Build Desk schema + API actions
+
+- New migration `20260417000000_build_desk.sql` introduces three tables:
+  - `build_tasks` (status CHECK for draft/planned/dispatched/in_progress/review/done/failed,
+    self-referencing `parent_task_id`, JSONB plan and acceptance criteria)
+  - `build_workers` (worker_type CHECK for claude_code/codex/cursor_cli/gemini_cli/custom_mcp,
+    status CHECK for available/busy/offline, last_health_check_at)
+  - `build_dispatch_events` (event_type CHECK for dispatched/accepted/progress/completed/failed,
+    FK to tasks and workers with ON DELETE CASCADE)
+- Indexes on every `api_key_hash` column plus composite `(api_key_hash, status)` indexes
+- Three new API actions added to `api/memory-admin.ts`:
+  - `admin_build_tasks` with methods list, get, create, update_status, soft_delete
+  - `admin_build_workers` with methods list, register, update, delete, health_check
+  - `admin_build_dispatch` validates that `task_id` and `worker_id` both belong to the tenant,
+    inserts a `dispatched` event, updates the task's `status` and `assigned_worker_id`
+
+## Architectural decisions
+
+- **Build Desk tables use direct `api_key_hash` isolation, not an `mc_` prefix.** The tables
+  live in the UnClick control-plane Supabase (same place as `memory_configs`, `memory_devices`),
+  and every row is scoped by `sha256hex(api_key)`. No shared key prefix convention since the
+  tables are never queried from the per-tenant BYOD schema.
+- **`memory_load_events` uses a 30-minute window for session detection.** When logging a tool
+  call, the server probes for any prior event within 30 minutes scoped by tenant + `session_identifier`
+  (or tenant only if no identifier is provided). No prior row means this is the first call of a new
+  session, which is the denominator for compliance calculations.
+- **All admin actions fold into `api/memory-admin.ts`** rather than spawning new API files. Vercel's
+  Hobby plan caps serverless functions at 12; we sit at 11 with these additions. Dispatching on
+  `?action=` + optional `method=` keeps the surface extensible without another file.
+- **shadcn `Tabs` is used for Build Desk UI.** The component already exists at
+  `src/components/ui/tabs.tsx` (Radix-based) but was previously unused across pages. Build Desk
+  is the first consumer; `MemoryAdmin` remains tabless for now.
+
+## Follow-up sessions
+
+- **Session 6: Build Desk Task composition UI** - replace placeholder tabs with real CRUD: create
+  task forms, plan decomposition, acceptance-criteria editor
+- **Session 7: Claude Code worker integration** - first concrete worker backend; end-to-end dispatch
+  from `/build` to a running Claude Code instance and back
+- **Session 8: Multi-backend support** - register Codex CLI, Cursor, Gemini CLI, custom MCP workers;
+  routing rules and worker selection
+- **Session 9: Crew roles** - connect Build Desk to `/crews` so a task can be assigned to a persona
+  (developer, researcher, writer, organiser) instead of a specific worker
+- **Session 10: Action-triggered memory retrieval hooks** - auto-load relevant facts / library
+  docs when a task transitions between statuses, closing the loop between memory and orchestration
+- **Session 11: Memory algorithm v2** - act on the compliance metrics from this phase: adaptive
+  decay tuning, smarter fact extraction, automated pruning based on observed access patterns

--- a/packages/mcp-server/src/memory/load-events.ts
+++ b/packages/mcp-server/src/memory/load-events.ts
@@ -1,0 +1,49 @@
+/**
+ * Tool-call event logger for UnClick Memory reliability metrics.
+ *
+ * Fire-and-forget POST to /api/memory-admin?action=log_tool_event whenever
+ * the MCP server dispatches a tool. The control plane uses these rows to
+ * compute get_startup_context compliance across sessions and clients.
+ *
+ * Never blocks or throws into the tool-call path: a logging failure must
+ * not break the actual tool invocation.
+ */
+
+import * as crypto from "crypto";
+
+const MEMORY_API_BASE =
+  process.env.UNCLICK_MEMORY_BASE_URL ||
+  process.env.UNCLICK_SITE_URL ||
+  "https://unclick.world";
+
+// Stable for the lifetime of this MCP server process.
+// A fresh server boot counts as a new session for compliance metrics.
+const SESSION_IDENTIFIER = crypto.randomUUID();
+
+function clientType(): string {
+  return (
+    process.env.UNCLICK_CLIENT_TYPE ||
+    process.env.MCP_CLIENT_NAME ||
+    "unknown"
+  );
+}
+
+export function logToolCall(toolName: string): void {
+  const apiKey = process.env.UNCLICK_API_KEY;
+  if (!apiKey) return;
+
+  fetch(`${MEMORY_API_BASE}/api/memory-admin?action=log_tool_event`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      tool_name: toolName,
+      session_identifier: SESSION_IDENTIFIER,
+      client_type: clientType(),
+    }),
+  }).catch(() => {
+    // Swallow: reliability metrics must never break tool dispatch.
+  });
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -9,6 +9,12 @@ import { createClient, type UnClickClient } from "./client.js";
 import { ADDITIONAL_TOOLS, ADDITIONAL_HANDLERS } from "./tool-wiring.js";
 import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
+import { logToolCall } from "./memory/load-events.js";
+
+// Appended to every tool description except get_startup_context itself, so the
+// agent sees the session-start protocol reminder every time it lists tools.
+const GSC_REMINDER =
+  " If get_startup_context has not been called this session, call it first.";
 
 // ─── Search helper ──────────────────────────────────────────────────────────
 
@@ -48,7 +54,8 @@ const META_TOOLS = [
     description:
       "Search Available Tools - Search the UnClick tool marketplace by keyword or description. " +
       "Use this to discover which tools are available for a task. " +
-      "Example: 'I need to resize an image' returns the image tool with its endpoints.",
+      "Example: 'I need to resize an image' returns the image tool with its endpoints." +
+      GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -69,7 +76,7 @@ const META_TOOLS = [
     name: "unclick_browse",
     description:
       "Browse Tool Catalog - Browse all available UnClick tools, optionally filtered by category. " +
-      "Returns a list of tools with their slugs and descriptions.",
+      "Returns a list of tools with their slugs and descriptions." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -86,7 +93,7 @@ const META_TOOLS = [
     description:
       "Get Tool Details - Get detailed information about a specific UnClick tool including all its endpoints, " +
       "required parameters, and response shapes. Use this after unclick_search to understand " +
-      "exactly how to call a tool.",
+      "exactly how to call a tool." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -105,7 +112,8 @@ const META_TOOLS = [
     description:
       "Execute Tool - Call any UnClick tool endpoint. Specify the endpoint ID and parameters. " +
       "Use unclick_search or unclick_tool_info to discover endpoint IDs and required params. " +
-      "Example: endpoint_id='image.resize', params={image: '<base64>', width: 800, height: 600}",
+      "Example: endpoint_id='image.resize', params={image: '<base64>', width: 800, height: 600}" +
+      GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -129,9 +137,10 @@ const META_TOOLS = [
   {
     name: "get_startup_context",
     description:
-      "Load Session Context - CALL THIS FIRST at the start of every session. Returns the user's business " +
-      "context (standing rules), recent session summaries, active facts, and knowledge library index. " +
-      "This is the user's persistent memory across all sessions and devices.",
+      "Load Session Context - MUST be called FIRST at the start of every session, before any other " +
+      "UnClick tool. Returns the user's business context (standing rules), recent session summaries, " +
+      "active facts, known scars, and knowledge library index. This is the user's persistent memory " +
+      "across all sessions and devices. If skipped, subsequent responses will be inaccurate.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -148,7 +157,8 @@ const META_TOOLS = [
     description:
       "Save Session Summary - Write a session summary at the end of a session. Critical for " +
       "cross-session continuity. Call this BEFORE the session ends (when the user says goodbye, or " +
-      "context is running low). Include key decisions, open loops, and topics discussed.",
+      "context is running low). Include key decisions, open loops, and topics discussed." +
+      GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -168,7 +178,8 @@ const META_TOOLS = [
     description:
       "Store New Fact - Add a new atomic fact to UnClick Memory. One fact = one statement. " +
       "Use when the user states a preference, makes a decision, or shares important info. " +
-      "Good: 'Team prefers Tailwind over CSS modules'. Bad: 'We talked about styling'.",
+      "Good: 'Team prefers Tailwind over CSS modules'. Bad: 'We talked about styling'." +
+      GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -188,7 +199,7 @@ const META_TOOLS = [
     name: "search_memory",
     description:
       "Search Conversations - Full-text search across UnClick Memory conversation logs. Use when " +
-      "you need to recall something specific from a previous session.",
+      "you need to recall something specific from a previous session." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -203,7 +214,7 @@ const META_TOOLS = [
     description:
       "Update Business Context - Add or update a standing rule in UnClick Memory (Layer 1). Business " +
       "context is ALWAYS loaded at session start. Use for standing rules, client info, and preferences " +
-      "that are always relevant.",
+      "that are always relevant." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -223,7 +234,7 @@ const META_TOOLS = [
 const DIRECT_TOOLS = [
   {
     name: "unclick_shorten_url",
-    description: "Shorten a URL using UnClick. Returns a short URL and its code.",
+    description: "Shorten a URL using UnClick. Returns a short URL and its code." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -234,7 +245,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_generate_qr",
-    description: "Generate a QR code from text or a URL. Returns base64-encoded PNG or SVG.",
+    description: "Generate a QR code from text or a URL. Returns base64-encoded PNG or SVG." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -247,7 +258,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_hash",
-    description: "Compute a cryptographic hash (MD5, SHA1, SHA256, SHA512) of text.",
+    description: "Compute a cryptographic hash (MD5, SHA1, SHA256, SHA512) of text." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -264,7 +275,8 @@ const DIRECT_TOOLS = [
   {
     name: "unclick_transform_text",
     description:
-      "Transform text case: upper, lower, title, sentence, camelCase, snake_case, kebab-case, PascalCase.",
+      "Transform text case: upper, lower, title, sentence, camelCase, snake_case, kebab-case, PascalCase." +
+      GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -279,7 +291,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_validate_email",
-    description: "Validate an email address format.",
+    description: "Validate an email address format." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -290,7 +302,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_validate_url",
-    description: "Validate a URL format, optionally check if it's reachable.",
+    description: "Validate a URL format, optionally check if it's reachable." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -302,7 +314,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_resize_image",
-    description: "Resize an image (provided as base64) to specified dimensions.",
+    description: "Resize an image (provided as base64) to specified dimensions." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -320,7 +332,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_parse_csv",
-    description: "Parse a CSV string into a JSON array of rows.",
+    description: "Parse a CSV string into a JSON array of rows." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -333,7 +345,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_json_format",
-    description: "Format / pretty-print a JSON string.",
+    description: "Format / pretty-print a JSON string." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -345,7 +357,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_encode",
-    description: "Encode or decode text. Supports base64, URL, HTML, and hex.",
+    description: "Encode or decode text. Supports base64, URL, HTML, and hex." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -365,7 +377,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_generate_uuid",
-    description: "Generate one or more random UUIDs (v4).",
+    description: "Generate one or more random UUIDs (v4)." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -375,7 +387,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_random_password",
-    description: "Generate a secure random password.",
+    description: "Generate a secure random password." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -389,7 +401,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_cron_parse",
-    description: "Convert a cron expression to a human-readable description and get next occurrences.",
+    description: "Convert a cron expression to a human-readable description and get next occurrences." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -401,7 +413,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_ip_parse",
-    description: "Parse an IP address — get decimal, binary, hex, and type (private/loopback/multicast).",
+    description: "Parse an IP address - get decimal, binary, hex, and type (private/loopback/multicast)." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -412,7 +424,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_color_convert",
-    description: "Convert a color between hex, RGB, HSL, and HSV formats.",
+    description: "Convert a color between hex, RGB, HSL, and HSV formats." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -425,7 +437,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_regex_test",
-    description: "Test a regex pattern against text and get all matches with groups.",
+    description: "Test a regex pattern against text and get all matches with groups." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -438,7 +450,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_timestamp_convert",
-    description: "Convert a timestamp (ISO, Unix seconds, or Unix ms) to all common formats.",
+    description: "Convert a timestamp (ISO, Unix seconds, or Unix ms) to all common formats." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -451,7 +463,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_diff_text",
-    description: "Compare two strings and return a unified diff showing what changed.",
+    description: "Compare two strings and return a unified diff showing what changed." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -463,7 +475,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_kv_set",
-    description: "Store a value in the UnClick key-value store with optional TTL.",
+    description: "Store a value in the UnClick key-value store with optional TTL." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -476,7 +488,7 @@ const DIRECT_TOOLS = [
   },
   {
     name: "unclick_kv_get",
-    description: "Retrieve a value from the UnClick key-value store.",
+    description: "Retrieve a value from the UnClick key-value store." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -491,7 +503,7 @@ const DIRECT_TOOLS = [
       "Report a bug or unexpected behavior encountered while using an UnClick tool. " +
       "Call this whenever a tool returns an error, behaves unexpectedly, or fails silently. " +
       "Severity is auto-classified from the error message: 500/fatal → critical, " +
-      "timeout/503 → high, 4xx/invalid → low, everything else → medium.",
+      "timeout/503 → high, 4xx/invalid → low, everything else → medium." + GSC_REMINDER,
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -634,6 +646,9 @@ export function createServer(): Server {
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: rawArgs } = request.params;
     const args = (rawArgs ?? {}) as Record<string, unknown>;
+
+    // Fire-and-forget reliability instrumentation (see memory/load-events.ts).
+    logToolCall(name);
 
     try {
       // ── UnClick Memory (direct tools + memory.* endpoints) ───────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import AdminMemory from "./pages/admin/AdminMemory.tsx";
 import AdminKeychain from "./pages/admin/AdminKeychain.tsx";
 import AdminTools from "./pages/admin/AdminTools.tsx";
 import AdminActivity from "./pages/admin/AdminActivity.tsx";
+import BuildDeskPage from "./pages/BuildDesk.tsx";
 
 const queryClient = new QueryClient();
 
@@ -105,6 +106,7 @@ const App = () => (
           <Route path="/organiser" element={<OrganiserPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />
           <Route path="/crews" element={<CrewsPage />} />
+          <Route path="/build" element={<BuildDeskPage />} />
           <Route path="/new-to-ai" element={<NewToAIPage />} />
           <Route path="/smarthome" element={<SmartHomePage />} />
           <Route path="/pricing" element={<PricingPage />} />

--- a/src/pages/BuildDesk.tsx
+++ b/src/pages/BuildDesk.tsx
@@ -1,0 +1,122 @@
+/**
+ * Build Desk - admin scaffold
+ *
+ * Plan, decompose, and dispatch structured coding work to AI workers
+ * (Claude Code, Codex CLI, Cursor, custom MCP workers). Tracks task
+ * dispatch history and results.
+ *
+ * Tabs:
+ *   1. Tasks   - structured work items with acceptance criteria
+ *   2. Workers - registered AI coding backends
+ *   3. History - dispatch log, status, and results
+ */
+
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Hammer, ListChecks, Bot, History } from "lucide-react";
+
+function BuildTasksTab() {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-border/40 bg-card/20 p-6">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-heading">
+          <ListChecks className="h-4 w-4 text-primary" />
+          Build Tasks
+        </h2>
+        <p className="mt-3 text-xs text-body leading-relaxed">
+          Build Tasks are structured work items you can plan, decompose, and dispatch to AI coding
+          workers. Create tasks with acceptance criteria, assign them to workers like Claude Code
+          or Codex, and track progress here.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-dashed border-border/50 bg-muted/5 p-12 text-center">
+        <span className="font-mono text-xs text-muted-foreground">No build tasks yet</span>
+      </div>
+    </div>
+  );
+}
+
+function BuildWorkersTab() {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-border/40 bg-card/20 p-6">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-heading">
+          <Bot className="h-4 w-4 text-primary" />
+          Workers
+        </h2>
+        <p className="mt-3 text-xs text-body leading-relaxed">
+          Workers are AI coding backends that execute your build tasks. Register Claude Code, Codex
+          CLI, Cursor, or custom MCP workers here. UnClick dispatches tasks to the right worker and
+          brings results back.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-dashed border-border/50 bg-muted/5 p-12 text-center">
+        <span className="font-mono text-xs text-muted-foreground">No workers registered</span>
+      </div>
+    </div>
+  );
+}
+
+function BuildHistoryTab() {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-border/40 bg-card/20 p-6">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-heading">
+          <History className="h-4 w-4 text-primary" />
+          Build History
+        </h2>
+        <p className="mt-3 text-xs text-body leading-relaxed">
+          Build History shows every task dispatch, its status, and results. Use this to track what
+          your AI workers have done and review their output.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-dashed border-border/50 bg-muted/5 p-12 text-center">
+        <span className="font-mono text-xs text-muted-foreground">No dispatch history</span>
+      </div>
+    </div>
+  );
+}
+
+export default function BuildDeskPage() {
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <main className="mx-auto max-w-6xl px-6 pb-32 pt-28">
+        <div className="mb-8 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Hammer className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Build Desk</h1>
+            <p className="text-sm text-body">
+              Plan, dispatch, and track coding work across your AI workers
+            </p>
+          </div>
+        </div>
+
+        <Tabs defaultValue="tasks" className="w-full">
+          <TabsList className="mb-6">
+            <TabsTrigger value="tasks">Tasks</TabsTrigger>
+            <TabsTrigger value="workers">Workers</TabsTrigger>
+            <TabsTrigger value="history">History</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="tasks">
+            <BuildTasksTab />
+          </TabsContent>
+          <TabsContent value="workers">
+            <BuildWorkersTab />
+          </TabsContent>
+          <TabsContent value="history">
+            <BuildHistoryTab />
+          </TabsContent>
+        </Tabs>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/supabase/migrations/20260417000000_build_desk.sql
+++ b/supabase/migrations/20260417000000_build_desk.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- UnClick Build Desk
+-- Structured coding work items, AI worker registry, and dispatch
+-- event log. All rows tenant-scoped by api_key_hash (SHA-256 of
+-- the UnClick API key, mirroring the memory BYOD pattern).
+-- ============================================================
+
+-- Structured work items with plans + acceptance criteria
+CREATE TABLE IF NOT EXISTS build_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  api_key_hash TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN (
+    'draft', 'planned', 'dispatched', 'in_progress', 'review', 'done', 'failed'
+  )),
+  plan_json JSONB,
+  acceptance_criteria_json JSONB,
+  assigned_worker_id UUID,
+  parent_task_id UUID REFERENCES build_tasks(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_build_tasks_hash ON build_tasks(api_key_hash);
+CREATE INDEX IF NOT EXISTS idx_build_tasks_status ON build_tasks(api_key_hash, status);
+CREATE INDEX IF NOT EXISTS idx_build_tasks_parent ON build_tasks(parent_task_id);
+
+-- AI coding backends (Claude Code, Codex CLI, Cursor, Gemini CLI, custom MCP)
+CREATE TABLE IF NOT EXISTS build_workers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  api_key_hash TEXT NOT NULL,
+  name TEXT NOT NULL,
+  worker_type TEXT NOT NULL CHECK (worker_type IN (
+    'claude_code', 'codex', 'cursor_cli', 'gemini_cli', 'custom_mcp'
+  )),
+  connection_config_json JSONB,
+  status TEXT NOT NULL DEFAULT 'offline' CHECK (status IN (
+    'available', 'busy', 'offline'
+  )),
+  last_health_check_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_build_workers_hash ON build_workers(api_key_hash);
+CREATE INDEX IF NOT EXISTS idx_build_workers_status ON build_workers(api_key_hash, status);
+
+-- Append-only log of every dispatch, progress update, and result
+CREATE TABLE IF NOT EXISTS build_dispatch_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  api_key_hash TEXT NOT NULL,
+  task_id UUID NOT NULL REFERENCES build_tasks(id) ON DELETE CASCADE,
+  worker_id UUID NOT NULL REFERENCES build_workers(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL CHECK (event_type IN (
+    'dispatched', 'accepted', 'progress', 'completed', 'failed'
+  )),
+  payload_json JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_build_dispatch_hash ON build_dispatch_events(api_key_hash);
+CREATE INDEX IF NOT EXISTS idx_build_dispatch_task ON build_dispatch_events(task_id);
+CREATE INDEX IF NOT EXISTS idx_build_dispatch_worker ON build_dispatch_events(worker_id);

--- a/supabase/migrations/20260417010000_memory_load_events.sql
+++ b/supabase/migrations/20260417010000_memory_load_events.sql
@@ -1,0 +1,19 @@
+-- ============================================================
+-- UnClick Memory load events
+-- Instrumentation for memory reliability: every tool call is
+-- logged so we can compute get_startup_context compliance and
+-- spot sessions that skipped the session-start protocol.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS memory_load_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  api_key_hash TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  session_identifier TEXT,
+  client_type TEXT,
+  was_first_call_in_session BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_load_events_hash_created
+  ON memory_load_events (api_key_hash, created_at DESC);


### PR DESCRIPTION
## Summary

Phase 5 lays the groundwork for AI agent orchestration. Four distinct areas of work landed across three commits on this branch.

## 1. AGENTS.md for session-start memory loading

- New `AGENTS.md` at repo root, identical content to `CLAUDE.md`
- Gives non-Claude agents (Codex, Cursor, Gemini CLI, custom MCP clients) the same session-start protocol and project context

## 2. Memory reliability instrumentation

Makes `get_startup_context` compliance measurable, and pushes every listed tool to remind the agent of the session-start protocol.

- **Directive tool descriptions** in `packages/mcp-server/src/server.ts`:
  - `get_startup_context` description rewritten: "MUST be called before any other UnClick tool in this session... If skipped, all subsequent responses will be inaccurate and may ship bugs."
  - All 28 other tool descriptions (META_TOOLS + DIRECT_TOOLS) now carry a `GSC_REMINDER` suffix: "If get_startup_context has not been called this session, call it first."
- **New table `memory_load_events`** (`supabase/migrations/20260417010000_memory_load_events.sql`): id, created_at, api_key_hash, tool_name, session_identifier, client_type, was_first_call_in_session, with `idx_memory_load_events_hash_created` on `(api_key_hash, created_at DESC)`
- **Server-side logger** `packages/mcp-server/src/memory/load-events.ts`: fire-and-forget `logToolCall(toolName)`, per-process UUID as `session_identifier`, wired into the `CallToolRequestSchema` handler
- **`log_tool_event` action** (POST, Bearer auth): inserts a row, sets `was_first_call_in_session` by probing the 30-minute window scoped to tenant + session
- **`admin_memory_load_metrics` action** (Bearer auth): 7-day totals, `get_startup_context` compliance percentage, breakdown by `client_type`

## 3. Build Desk admin scaffold at /build

- New page `src/pages/BuildDesk.tsx` with three inline tabs (Tasks / Workers / History) using the shadcn `Tabs` component
- Registered at `/build` in `src/App.tsx`, matching the `MemoryAdmin` page shell
- Placeholder content per tab explaining what each area will do, plus an empty-state card

## 4. Build Desk schema + API actions

- **New migration `20260417000000_build_desk.sql`**:
  - `build_tasks` (status CHECK for draft/planned/dispatched/in_progress/review/done/failed, self-referencing `parent_task_id`, JSONB plan and acceptance criteria)
  - `build_workers` (worker_type CHECK for claude_code/codex/cursor_cli/gemini_cli/custom_mcp, status CHECK for available/busy/offline)
  - `build_dispatch_events` (event_type CHECK for dispatched/accepted/progress/completed/failed, FK to tasks and workers with ON DELETE CASCADE)
  - Indexes on every `api_key_hash` column plus composite `(api_key_hash, status)` indexes
- **Three new actions in `api/memory-admin.ts`**:
  - `admin_build_tasks` with methods list / get / create / update_status / soft_delete
  - `admin_build_workers` with methods list / register / update / delete / health_check
  - `admin_build_dispatch` validates that `task_id` and `worker_id` both belong to the tenant, inserts a `dispatched` event, updates the task status

## Architectural decisions

- **Direct `api_key_hash` isolation, no `mc_` prefix** - Build Desk tables live in the UnClick control-plane Supabase alongside `memory_configs` and `memory_devices`; every row is scoped by `sha256hex(api_key)`
- **30-minute window for session detection** in `memory_load_events` - denominator for compliance metrics
- **All actions folded into `memory-admin.ts`** - stays under Vercel's 12-function cap (currently 11 files in `api/`)
- **shadcn Tabs component** used for Build Desk UI - first consumer of the previously-unused `src/components/ui/tabs.tsx`

## Follow-up sessions

- **Session 6** - Build Desk Task composition UI (real CRUD, plan decomposition, acceptance-criteria editor)
- **Session 7** - Claude Code worker integration (first concrete worker backend, end-to-end dispatch)
- **Session 8** - Multi-backend support (Codex CLI, Cursor, Gemini CLI, custom MCP workers)
- **Session 9** - Crew roles (connect Build Desk to `/crews` for persona-based task assignment)
- **Session 10** - Action-triggered memory retrieval hooks (auto-load relevant facts on status transitions)
- **Session 11** - Memory algorithm v2 (act on compliance metrics from this phase)

## Test plan

- [ ] Apply migrations `20260417000000_build_desk.sql` and `20260417010000_memory_load_events.sql` on a staging Supabase
- [ ] Visit `/build` and confirm the Tasks / Workers / History tabs render with placeholder content
- [ ] Register a worker via `POST /api/memory-admin?action=admin_build_workers&method=register`
- [ ] Create a task, then dispatch it with `admin_build_dispatch`, confirm the task transitions to `dispatched` and an event row exists
- [ ] Run an MCP tool call from a development session, then query `admin_memory_load_metrics` and confirm the row count and compliance percentage update
- [ ] Verify `AGENTS.md` is picked up by non-Claude agents (Codex, Cursor) as expected

https://claude.ai/code/session_017zqLqpG4J8wPogQDLFZbz9