### PR TITLE
QC: UX polish -- contrast, homepage sections, admin stats, navbar admin link

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
-    <title>UnClick - The App Store for AI Agents</title>
+    <title>UnClick - The Operating System for AI Agents</title>
     <!-- Update counts from src/config/site-stats.ts -->
     <meta name="description" content="UnClick is the AI agent marketplace where your AI finds and uses tools. 172+ verified tools, one API key. Works with Claude, ChatGPT, OpenClaw, and any MCP-compatible agent. All free." />
     <meta name="keywords" content="AI agent marketplace, MCP tools, MCP marketplace, agent tools, AI tool store, AI app store, MCP server, agent-native API, AI tools for Claude, ChatGPT tools, OpenClaw tools, AI agent tools, tool marketplace for AI, MCP registry" />
@@ -17,7 +17,7 @@
     <!-- OpenGraph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="UnClick" />
-    <meta property="og:title" content="UnClick - The App Store for AI Agents" />
+    <meta property="og:title" content="UnClick - The Operating System for AI Agents" />
     <meta property="og:description" content="172+ verified tools for AI agents. One connection. Telegram, Slack, Shopify, Xero, games, security, science, and more. Works with Claude, ChatGPT, OpenClaw, and any MCP agent." />
     <meta property="og:url" content="https://unclick.world/" />
     <meta property="og:image" content="https://unclick.world/og-image.png" />
@@ -25,7 +25,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@unclickworld" />
-    <meta name="twitter:title" content="UnClick - The App Store for AI Agents" />
+    <meta name="twitter:title" content="UnClick - The Operating System for AI Agents" />
     <meta name="twitter:description" content="172+ verified tools for AI agents. One API key, instant access. Works with Claude, ChatGPT, OpenClaw, and any MCP-compatible agent." />
     <meta name="twitter:image" content="https://unclick.world/og-image.png" />
 
@@ -51,7 +51,7 @@
           "@type": "WebSite",
           "@id": "https://unclick.world/#website",
           "url": "https://unclick.world",
-          "name": "UnClick - The App Store for AI Agents",
+          "name": "UnClick - The Operating System for AI Agents",
           "publisher": { "@id": "https://unclick.world/#org" }
         },
         {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,13 +1,30 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { Wrench, Brain, Calendar, Users, Trophy, HelpCircle } from "lucide-react";
+import { Wrench, Brain, Calendar, Users, Trophy, HelpCircle, UserCircle2 } from "lucide-react";
 
 const Navbar = () => {
   const [open, setOpen] = useState(false);
+  const [hasSession, setHasSession] = useState(false);
   const { pathname } = useLocation();
   const isHome = pathname === "/";
   const installHref = isHome ? "#install" : "/#install";
+
+  // Reflect login state from localStorage. We check on every route change
+  // so the admin link appears immediately after a user claims their key
+  // on the Install section, without needing a full page reload.
+  useEffect(() => {
+    const check = () => {
+      try {
+        setHasSession(Boolean(localStorage.getItem("unclick_api_key")));
+      } catch {
+        setHasSession(false);
+      }
+    };
+    check();
+    window.addEventListener("storage", check);
+    return () => window.removeEventListener("storage", check);
+  }, [pathname]);
 
   const navLinks = [
     { label: "Tools", href: "/tools", icon: Wrench },
@@ -60,12 +77,23 @@ const Navbar = () => {
         </div>
 
         <div className="flex items-center gap-3">
-          <a
-            href={installHref}
-            className="hidden whitespace-nowrap rounded-md bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 sm:block"
-          >
-            Get Started Free
-          </a>
+          {hasSession ? (
+            <Link
+              to="/memory/admin"
+              className="hidden items-center gap-1.5 whitespace-nowrap rounded-md border border-border/60 bg-card/40 px-3 py-1.5 text-sm font-medium text-heading transition-colors hover:border-primary/30 hover:bg-card/70 sm:inline-flex"
+              aria-label="Admin"
+            >
+              <UserCircle2 className="h-4 w-4" />
+              Admin
+            </Link>
+          ) : (
+            <a
+              href={installHref}
+              className="hidden whitespace-nowrap rounded-md bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 sm:block"
+            >
+              Get Started Free
+            </a>
+          )}
 
           {/* Hamburger button */}
           <button
@@ -125,13 +153,24 @@ const Navbar = () => {
                   </Link>
                 )
               )}
-              <a
-                href={installHref}
-                onClick={() => setOpen(false)}
-                className="mt-2 rounded-md bg-primary px-4 py-2 text-center text-sm font-medium text-primary-foreground"
-              >
-                Get Started Free
-              </a>
+              {hasSession ? (
+                <Link
+                  to="/memory/admin"
+                  onClick={() => setOpen(false)}
+                  className="mt-2 inline-flex items-center justify-center gap-1.5 rounded-md border border-border/60 bg-card/40 px-4 py-2 text-center text-sm font-medium text-heading"
+                >
+                  <UserCircle2 className="h-4 w-4" />
+                  Admin
+                </Link>
+              ) : (
+                <a
+                  href={installHref}
+                  onClick={() => setOpen(false)}
+                  className="mt-2 rounded-md bg-primary px-4 py-2 text-center text-sm font-medium text-primary-foreground"
+                >
+                  Get Started Free
+                </a>
+              )}
             </div>
           </motion.div>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -36,9 +36,9 @@
 
     --radius: 0.5rem;
 
-    --body-text: 0 0% 53%;
+    --body-text: 0 0% 72%;
     --heading-text: 0 0% 91%;
-    --muted-text: 0 0% 33%;
+    --muted-text: 0 0% 55%;
 
     --sidebar-background: 0 0% 4%;
     --sidebar-foreground: 0 0% 91%;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,10 @@
 import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
+import Problem from "@/components/Problem";
 import InstallSection from "@/components/InstallSection";
+import Stats from "@/components/Stats";
+import TrustSignals from "@/components/TrustSignals";
+import FinalCTA from "@/components/FinalCTA";
 import FAQ from "@/components/FAQ";
 import Footer from "@/components/Footer";
 import { useCanonical } from "@/hooks/use-canonical";
@@ -12,7 +16,11 @@ const Index = () => {
     <div className="min-h-screen">
       <Navbar />
       <Hero />
+      <Problem />
       <InstallSection />
+      <Stats />
+      <TrustSignals />
+      <FinalCTA />
       <FAQ />
       <Footer />
     </div>

--- a/src/pages/MemoryAdmin.tsx
+++ b/src/pages/MemoryAdmin.tsx
@@ -35,7 +35,7 @@ import { Link } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import ClaimKeyBanner from "@/components/ClaimKeyBanner";
-import { Brain, Database, Monitor, CheckCircle2, ArrowRight } from "lucide-react";
+import { Brain, Database, Monitor, CheckCircle2, ArrowRight, Layers, FileText, Search, Code, Clock } from "lucide-react";
 
 interface MemoryConfigStatus {
   configured: boolean;
@@ -53,6 +53,15 @@ interface Device {
   last_seen: string;
 }
 
+interface MemoryStatus {
+  business_context?: number;
+  library?: number;
+  sessions?: number;
+  facts?: number;
+  conversations?: number;
+  code?: number;
+}
+
 function formatRelative(iso: string | null | undefined): string {
   if (!iso) return "never";
   const ts = new Date(iso).getTime();
@@ -66,9 +75,19 @@ function formatRelative(iso: string | null | undefined): string {
   return `${days}d ago`;
 }
 
+const STAT_CARDS: { key: keyof MemoryStatus; label: string; icon: typeof Layers }[] = [
+  { key: "facts", label: "Facts", icon: Search },
+  { key: "sessions", label: "Sessions", icon: Clock },
+  { key: "library", label: "Library docs", icon: Layers },
+  { key: "business_context", label: "Context entries", icon: FileText },
+  { key: "conversations", label: "Conversations", icon: Brain },
+  { key: "code", label: "Code dumps", icon: Code },
+];
+
 export default function MemoryAdminPage() {
   const [config, setConfig] = useState<MemoryConfigStatus | null>(null);
   const [devices, setDevices] = useState<Device[]>([]);
+  const [status, setStatus] = useState<MemoryStatus | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -81,9 +100,12 @@ export default function MemoryAdminPage() {
 
     (async () => {
       try {
-        const [cfgRes, devRes] = await Promise.all([
+        const [cfgRes, devRes, statusRes] = await Promise.all([
           fetch(`/api/memory-admin?action=setup_status&api_key=${encodeURIComponent(apiKey)}`),
           fetch("/api/memory-admin?action=list_devices", {
+            headers: { Authorization: `Bearer ${apiKey}` },
+          }),
+          fetch("/api/memory-admin?action=status", {
             headers: { Authorization: `Bearer ${apiKey}` },
           }),
         ]);
@@ -95,6 +117,11 @@ export default function MemoryAdminPage() {
           const body = (await devRes.json()) as { data: Device[] };
           setDevices(body.data ?? []);
         }
+        if (!cancelled && statusRes.ok) {
+          const body = (await statusRes.json()) as MemoryStatus & { data?: MemoryStatus };
+          // Endpoint may return raw counts or wrap them under `data`.
+          setStatus(body.data ?? body);
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -104,6 +131,9 @@ export default function MemoryAdminPage() {
       cancelled = true;
     };
   }, []);
+
+  const hasApiKey =
+    typeof window !== "undefined" && Boolean(localStorage.getItem("unclick_api_key"));
 
   const localCount = devices.filter((d) => d.storage_mode === "local").length;
   const cloudCount = devices.filter((d) => d.storage_mode === "cloud").length;
@@ -122,6 +152,29 @@ export default function MemoryAdminPage() {
             <h1 className="text-2xl font-semibold tracking-tight">Memory Admin</h1>
             <p className="text-sm text-body">View and manage your agent's persistent memory</p>
           </div>
+        </div>
+
+        {/* Stat cards: counts per memory layer from ?action=status */}
+        <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          {STAT_CARDS.map(({ key, label, icon: Icon }) => {
+            const value = status?.[key];
+            const display =
+              !hasApiKey ? "-" : loading ? "..." : typeof value === "number" ? value.toLocaleString() : "0";
+            return (
+              <div
+                key={key}
+                className="rounded-xl border border-border/40 bg-card/20 p-4"
+              >
+                <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                  <Icon className="h-3 w-3 text-primary/70" />
+                  {label}
+                </div>
+                <div className="mt-2 font-mono text-2xl font-semibold text-heading tabular-nums">
+                  {display}
+                </div>
+              </div>
+            );
+          })}
         </div>
 
         {/* Top-level nudge: user has 2+ devices on local storage but no cloud config */}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import { ArrowRight } from "lucide-react";
 
 type SettingsSection = "profile" | "api-keys" | "notifications" | "admin";
 
@@ -32,7 +34,22 @@ function ProfileSection() {
   );
 }
 
+function maskKey(key: string): string {
+  if (key.length <= 10) return "***";
+  return `${key.slice(0, 6)}${"*".repeat(Math.max(4, key.length - 10))}${key.slice(-4)}`;
+}
+
 function ApiKeysSection() {
+  const [apiKey, setApiKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      setApiKey(localStorage.getItem("unclick_api_key"));
+    } catch {
+      setApiKey(null);
+    }
+  }, []);
+
   return (
     <div className="space-y-4">
       <div className="rounded-xl border border-border/40 bg-card/20 p-8">
@@ -40,15 +57,31 @@ function ApiKeysSection() {
         <p className="mt-1 text-sm text-body">
           Use API keys to authenticate requests to the UnClick API.
         </p>
-        <div className="mt-6 rounded-lg border border-dashed border-border/50 bg-muted/5 p-6 text-center">
-          <span className="font-mono text-xs text-muted-foreground">
-            Key management coming soon. See{" "}
-            <a href="/docs" className="text-primary hover:underline">
-              /docs
-            </a>{" "}
-            to get started
-          </span>
-        </div>
+
+        {apiKey ? (
+          <div className="mt-6 rounded-lg border border-border/40 bg-muted/10 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <code className="font-mono text-xs text-heading">{maskKey(apiKey)}</code>
+              <span className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 font-mono text-[10px] text-primary">
+                Active
+              </span>
+            </div>
+            <p className="mt-3 text-xs text-body">
+              This key is stored locally in your browser. Revoke or rotate from the CLI.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-6 rounded-lg border border-dashed border-border/50 bg-muted/5 p-6 text-center">
+            <p className="text-sm text-body">You don't have an API key on this device yet.</p>
+            <Link
+              to="/memory/setup"
+              className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+            >
+              Get started
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Frontend-only QC and UX polish pass. Seven discrete commits, each addressing one issue.

- **Homepage empty gap** (`7bea902`): Index was rendering only Hero + InstallSection + FAQ, leaving a large visual void between the product cards and the FAQ. Restored the existing `Problem`, `Stats`, `TrustSignals`, and `FinalCTA` components so the page tells the full story (why -> install -> proof -> trust -> CTA -> FAQ).
- **Text contrast** (`e1b7e2e`): `--body-text` was 53% lightness on a 4% dark background, visually washed out on Memory, Pricing, Crews, etc. Raised to 72% (~9:1 ratio vs background) and bumped `--muted-text` from 33% (failing) to 55%.
- **Title tag mismatch** (`ad98885`): `<title>`, `og:title`, and `twitter:title` said "The App Store for AI Agents" while the hero headline reads "The Operating System for AI Agents". Standardised on the Operating System positioning.
- **Navbar admin link** (`65b1bb1`): Logged-in users had no surface to reach `/memory/admin`. When `localStorage.unclick_api_key` is set, the "Get Started Free" CTA swaps for a subtle "Admin" link (UserCircle icon) in both desktop and mobile menus. Reacts to storage events and route changes.
- **Memory Admin stat cards** (`954f9a7`): Page jumped straight to Cloud Sync / Devices with no at-a-glance memory sense. Added a 6-card row (facts, sessions, library docs, context entries, conversations, code dumps) fetching `/api/memory-admin?action=status` on mount. Handles logged-out (dashes) and loading (ellipsis) states.
- **Settings API Keys card** (`9e8f03e`): Closest match to the non-existent `AdminYou.tsx` referenced in the brief. Replaced the vague "coming soon / see /docs" placeholder with a real empty state: shows the active masked key if one is in `localStorage`, or a "Get started" CTA linking to `/memory/setup` if not.
- **Pricing** (no commit): Already has Free / Pro / Team + Enterprise tiers; the contrast fix covers the readability concern flagged in the brief.

No `api/*.ts` files were added or modified; Vercel function count unchanged. `api/memory-admin.ts` untouched.

## Test plan

- [ ] `/` renders all sections in order (Hero -> Problem -> Install -> Stats -> TrustSignals -> FinalCTA -> FAQ) with no large empty gaps
- [ ] Body copy on `/memory`, `/pricing`, `/crews` is clearly legible against the dark background
- [ ] `<title>` and social preview metadata read "The Operating System for AI Agents"
- [ ] Navbar shows "Get Started Free" when logged out, "Admin" (linking to `/memory/admin`) when `unclick_api_key` is present in localStorage (desktop + mobile)
- [ ] `/memory/admin` stat cards render: dashes when logged out, counts (or `...` while fetching) when logged in
- [ ] `/settings` -> API Keys shows the masked current key when present, or a "Get started" -> `/memory/setup` CTA when not
- [ ] `npx tsc --noEmit` introduces no new errors (only pre-existing `vitest/globals` warning)

Do not merge.