### PR TITLE
Add projects hierarchy, repo memory, and memory visibility

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -1147,6 +1147,30 @@ function slugify(input: string): string {
     .slice(0, 60);
 }
 
+/**
+ * Resolve either a browser session JWT or a raw UnClick API key down to
+ * an api_key_hash. Browser admin pages send a supabase session token,
+ * while MCP or CLI callers send an api_key as Bearer. Returns null if
+ * neither resolves.
+ */
+async function resolveTenantAny(
+  req: VercelRequest,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  sb: SupabaseClient,
+): Promise<{ apiKeyHash: string } | null> {
+  const token = bearerFrom(req);
+  if (token && (token.startsWith("uc_") || token.startsWith("agt_"))) {
+    return { apiKeyHash: sha256hex(token) };
+  }
+  const tenant = await resolveSessionTenant(req, supabaseUrl, serviceRoleKey, sb);
+  if (tenant) return { apiKeyHash: tenant.apiKeyHash };
+  if (token) return { apiKeyHash: sha256hex(token) };
+  return null;
+}
+
+const PROJECT_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -4298,6 +4322,252 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         results.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
 
         return res.status(200).json({ data: results.slice(0, limit * 2) });
+      }
+
+      // ── Projects CRUD ────────────────────────────────────────────────
+      case "project_list": {
+        const tenant = await resolveTenantAny(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not authenticated" });
+        const { data, error } = await supabase
+          .from("mc_projects")
+          .select("*")
+          .eq("api_key_hash", tenant.apiKeyHash)
+          .order("is_default", { ascending: false })
+          .order("name", { ascending: true });
+        if (error) throw error;
+        return res.status(200).json({ data: data ?? [] });
+      }
+
+      case "project_create": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveTenantAny(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not authenticated" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const name = String(body.name ?? "").trim();
+        const slug = String(body.slug ?? "").trim().toLowerCase();
+        const description = typeof body.description === "string" ? body.description.trim() : null;
+        const repoUrl = typeof body.repo_url === "string" ? body.repo_url.trim() : null;
+
+        if (!name) return res.status(400).json({ error: "name required" });
+        if (!slug || slug.length < 2 || slug.length > 40 || !PROJECT_SLUG_RE.test(slug)) {
+          return res.status(400).json({
+            error: "slug must be 2-40 chars, lowercase alphanumeric with hyphens only",
+          });
+        }
+
+        const { count } = await supabase
+          .from("mc_projects")
+          .select("id", { count: "exact", head: true })
+          .eq("api_key_hash", tenant.apiKeyHash);
+        const isFirst = !count || count === 0;
+
+        const { data, error } = await supabase
+          .from("mc_projects")
+          .insert({
+            api_key_hash: tenant.apiKeyHash,
+            name,
+            slug,
+            description,
+            repo_url: repoUrl,
+            is_default: isFirst,
+          })
+          .select()
+          .single();
+        if (error) {
+          if (String(error.message).toLowerCase().includes("duplicate")) {
+            return res.status(409).json({ error: "slug already exists" });
+          }
+          throw error;
+        }
+        return res.status(200).json({ success: true, data });
+      }
+
+      case "project_update": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveTenantAny(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not authenticated" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const id = String(body.id ?? "").trim();
+        if (!id) return res.status(400).json({ error: "id required" });
+
+        const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+        if (typeof body.name === "string" && body.name.trim()) updates.name = body.name.trim();
+        if (typeof body.description === "string") updates.description = body.description.trim() || null;
+        if (typeof body.repo_url === "string") updates.repo_url = body.repo_url.trim() || null;
+
+        const { error } = await supabase
+          .from("mc_projects")
+          .update(updates)
+          .eq("id", id)
+          .eq("api_key_hash", tenant.apiKeyHash);
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
+      case "project_delete": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveTenantAny(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not authenticated" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const id = String(body.id ?? "").trim();
+        if (!id) return res.status(400).json({ error: "id required" });
+
+        const { error } = await supabase
+          .from("mc_projects")
+          .delete()
+          .eq("id", id)
+          .eq("api_key_hash", tenant.apiKeyHash);
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
+      case "project_set_default": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveTenantAny(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not authenticated" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const id = String(body.id ?? "").trim();
+        if (!id) return res.status(400).json({ error: "id required" });
+
+        const clearRes = await supabase
+          .from("mc_projects")
+          .update({ is_default: false })
+          .eq("api_key_hash", tenant.apiKeyHash);
+        if (clearRes.error) throw clearRes.error;
+
+        const setRes = await supabase
+          .from("mc_projects")
+          .update({ is_default: true, updated_at: new Date().toISOString() })
+          .eq("id", id)
+          .eq("api_key_hash", tenant.apiKeyHash);
+        if (setRes.error) throw setRes.error;
+
+        return res.status(200).json({ success: true });
+      }
+
+      // ── Memory visibility: most recent load_memory snapshot ─────────
+      case "admin_boot_summary": {
+        const tenant = await resolveTenantAny(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not authenticated" });
+
+        let lastBootAt: string | null = null;
+        try {
+          const { data: evt } = await supabase
+            .from("mc_memory_load_events")
+            .select("created_at")
+            .eq("api_key_hash", tenant.apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(1)
+            .maybeSingle();
+          if (evt?.created_at) lastBootAt = String(evt.created_at);
+        } catch {
+          // table may not exist; fall through to counts-only response
+        }
+
+        const [factsRes, contextRes, sessionsRes, projectsRes] = await Promise.all([
+          supabase
+            .from("mc_extracted_facts")
+            .select("id", { count: "exact", head: true })
+            .eq("api_key_hash", tenant.apiKeyHash)
+            .eq("status", "active"),
+          supabase
+            .from("mc_business_context")
+            .select("id", { count: "exact", head: true })
+            .eq("api_key_hash", tenant.apiKeyHash),
+          supabase
+            .from("mc_session_summaries")
+            .select("id, session_id, summary, created_at")
+            .eq("api_key_hash", tenant.apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(5),
+          supabase
+            .from("mc_extracted_facts")
+            .select("project_id")
+            .eq("api_key_hash", tenant.apiKeyHash)
+            .eq("status", "active")
+            .not("project_id", "is", null),
+        ]);
+
+        const projectItems = (projectsRes.data ?? []).length;
+
+        return res.status(200).json({
+          last_boot_at: lastBootAt,
+          facts_loaded: factsRes.count ?? 0,
+          context_items_loaded: contextRes.count ?? 0,
+          sessions_loaded: sessionsRes.data?.length ?? 0,
+          project_items_loaded: projectItems,
+          recent_sessions: sessionsRes.data ?? [],
+        });
+      }
+
+      // ── Memory visibility: timeline of recent memory changes ────────
+      case "admin_memory_timeline": {
+        const tenant = await resolveTenantAny(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not authenticated" });
+
+        const [factsRes, contextRes, sessionsRes] = await Promise.all([
+          supabase
+            .from("mc_extracted_facts")
+            .select("id, fact, category, created_at")
+            .eq("api_key_hash", tenant.apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(20),
+          supabase
+            .from("mc_business_context")
+            .select("id, category, key, updated_at")
+            .eq("api_key_hash", tenant.apiKeyHash)
+            .order("updated_at", { ascending: false })
+            .limit(10),
+          supabase
+            .from("mc_session_summaries")
+            .select("id, session_id, summary, created_at")
+            .eq("api_key_hash", tenant.apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(10),
+        ]);
+
+        type TimelineItem = {
+          event_type: "fact_created" | "context_updated" | "session_saved";
+          id: string;
+          created_at: string;
+          summary: string;
+          category?: string;
+        };
+
+        const items: TimelineItem[] = [];
+        for (const row of factsRes.data ?? []) {
+          items.push({
+            event_type: "fact_created",
+            id: String(row.id),
+            created_at: String(row.created_at ?? ""),
+            summary: String(row.fact ?? ""),
+            category: typeof row.category === "string" ? row.category : undefined,
+          });
+        }
+        for (const row of contextRes.data ?? []) {
+          items.push({
+            event_type: "context_updated",
+            id: String(row.id),
+            created_at: String(row.updated_at ?? ""),
+            summary: `${row.category}.${row.key}`,
+            category: typeof row.category === "string" ? row.category : undefined,
+          });
+        }
+        for (const row of sessionsRes.data ?? []) {
+          items.push({
+            event_type: "session_saved",
+            id: String(row.id),
+            created_at: String(row.created_at ?? ""),
+            summary: String(row.summary ?? row.session_id ?? ""),
+          });
+        }
+
+        items.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+        return res.status(200).json({ timeline: items.slice(0, 30) });
       }
 
       // ── Bug reports visible to the submitting api_key_hash ──────────

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -32,16 +32,55 @@ function bool(v: unknown, fallback = false): boolean {
   return typeof v === "boolean" ? v : fallback;
 }
 
+/**
+ * Format any business_context entries with category="repository" as a clear
+ * Repository Context block so the agent reads them as first-class project
+ * knowledge rather than opaque JSON.
+ */
+function formatRepositoryContext(baseContext: unknown): string | null {
+  if (!baseContext || typeof baseContext !== "object") return null;
+  const bc = (baseContext as Record<string, unknown>).business_context;
+  if (!Array.isArray(bc)) return null;
+  const repoRows = bc.filter(
+    (row): row is Record<string, unknown> =>
+      typeof row === "object" && row !== null && (row as Record<string, unknown>).category === "repository",
+  );
+  if (repoRows.length === 0) return null;
+
+  const lines = ["## Repository Context"];
+  for (const row of repoRows) {
+    const key = String(row.key ?? "");
+    const raw = row.value;
+    const value = typeof raw === "string" ? raw : JSON.stringify(raw);
+    lines.push(`- ${key}: ${value}`);
+  }
+  return lines.join("\n");
+}
+
+const REPO_MAP_KEYS = [
+  "stack",
+  "deploy_branch",
+  "deploy_process",
+  "file_structure",
+  "constraints",
+  "gotchas",
+  "conventions",
+  "testing",
+] as const;
+
 export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> = {
   async get_startup_context(args) {
     const db = await getBackend();
     const slug = typeof args.agent_slug === "string" ? args.agent_slug : undefined;
     const id = typeof args.agent_id === "string" ? args.agent_id : undefined;
+    const projectSlug = str(args.project) || undefined;
 
     const [baseContext, resolved] = await Promise.all([
-      db.getStartupContext(num(args.num_sessions, 5)),
+      db.getStartupContext(num(args.num_sessions, 5), projectSlug),
       resolveAgent({ agent_slug: slug, agent_id: id }),
     ]);
+
+    const repoBlock = formatRepositoryContext(baseContext);
 
     // Optional: if the client passed the list of other tools in this session,
     // classify them and attach tool_guidance so the agent can nudge the user.
@@ -57,8 +96,10 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
     }
 
     if (!resolved) {
-      if (tool_guidance === undefined) return baseContext;
-      return { ...(baseContext as Record<string, unknown>), tool_guidance };
+      const out: Record<string, unknown> = { ...(baseContext as Record<string, unknown>) };
+      if (repoBlock) out.repository_context = repoBlock;
+      if (tool_guidance !== undefined) out.tool_guidance = tool_guidance;
+      return out;
     }
 
     const scoped = filterContextByLayers(baseContext, resolved.enabled_memory_layers);
@@ -77,6 +118,7 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       memory:
         scoped && typeof scoped === "object" ? scoped : { _raw: baseContext },
     };
+    if (repoBlock) result.repository_context = repoBlock;
     if (tool_guidance !== undefined) result.tool_guidance = tool_guidance;
     return result;
   },
@@ -116,6 +158,7 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       decisions: arr(args.decisions),
       platform: str(args.platform, "claude-code"),
       duration_minutes: typeof args.duration_minutes === "number" ? args.duration_minutes : undefined,
+      project: str(args.project) || undefined,
     });
   },
 
@@ -126,6 +169,7 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       category: str(args.category, "general"),
       confidence: num(args.confidence, 0.9),
       source_session_id: typeof args.source_session_id === "string" ? args.source_session_id : undefined,
+      project: str(args.project) || undefined,
     });
   },
 
@@ -179,8 +223,22 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       str(args.key),
       args.value,
       typeof args.priority === "number" ? args.priority : undefined,
+      str(args.project) || undefined,
     );
     return { set: true, category: str(args.category), key: str(args.key) };
+  },
+
+  async save_repo_map(args) {
+    const db = await getBackend();
+    const projectSlug = str(args.project) || undefined;
+    const written: string[] = [];
+    for (const key of REPO_MAP_KEYS) {
+      const raw = args[key];
+      if (typeof raw !== "string" || raw.trim().length === 0) continue;
+      await db.setBusinessContext("repository", key, raw, undefined, projectSlug);
+      written.push(key);
+    }
+    return { written, project: projectSlug ?? null };
   },
 
   async upsert_library_doc(args) {

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -155,7 +155,7 @@ export class LocalBackend implements MemoryBackend {
     console.error(`UnClick Memory: local mode (data at ${DATA_DIR})`);
   }
 
-  async getStartupContext(numSessions: number): Promise<unknown> {
+  async getStartupContext(numSessions: number, _projectSlug?: string): Promise<unknown> {
     const bc = readTable<BusinessContextRow>("business_context")
       .filter((r) => r.decay_tier === "hot" || r.decay_tier === "warm")
       .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
@@ -363,7 +363,7 @@ export class LocalBackend implements MemoryBackend {
       .sort((a, b) => a.category.localeCompare(b.category) || a.key.localeCompare(b.key));
   }
 
-  async setBusinessContext(category: string, key: string, value: unknown, priority?: number): Promise<void> {
+  async setBusinessContext(category: string, key: string, value: unknown, priority?: number, _projectSlug?: string): Promise<void> {
     const rows = readTable<BusinessContextRow>("business_context");
     const existing = rows.find((r) => r.category === category && r.key === key);
     if (existing) {

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -127,6 +127,21 @@ export class SupabaseBackend implements MemoryBackend {
   }
 
   /**
+   * Resolve a project slug to its UUID. Managed-cloud only; BYOD ignores
+   * (no mc_projects table). Returns null when slug is empty or unknown
+   * so callers can fall through to org-global (project_id = NULL).
+   */
+  private async resolveProjectId(slug?: string): Promise<string | null> {
+    if (!slug || this.tenancy.mode !== "managed") return null;
+    const { data, error } = await this.client.rpc("mc_resolve_project", {
+      p_api_key_hash: this.tenancy.apiKeyHash,
+      p_slug: slug,
+    });
+    if (error) return null;
+    return typeof data === "string" ? data : null;
+  }
+
+  /**
    * Enforce free-tier caps on writes. Only runs in managed cloud mode.
    * BYOD users own their database, so caps don't apply. Pro tier (or any
    * non-free tier) skips the check.
@@ -195,13 +210,49 @@ export class SupabaseBackend implements MemoryBackend {
 
   // ─── Memory operations ───────────────────────────────────────────────────
 
-  async getStartupContext(numSessions: number): Promise<unknown> {
+  async getStartupContext(numSessions: number, projectSlug?: string): Promise<unknown> {
     const data = await this.rpc<Record<string, unknown>>(
       "get_startup_context",
       { num_sessions: numSessions },
       "mc_get_startup_context",
       { p_num_sessions: numSessions }
     );
+
+    let project_scope: Record<string, unknown> | undefined;
+    if (projectSlug && this.tenancy.mode === "managed") {
+      const projectId = await this.resolveProjectId(projectSlug);
+      if (projectId) {
+        const [ctxRes, factsRes, projRow] = await Promise.all([
+          this.client
+            .from(this.tables.business_context)
+            .select("category, key, value, priority")
+            .eq("api_key_hash", this.tenancy.apiKeyHash)
+            .eq("project_id", projectId)
+            .order("category")
+            .order("key"),
+          this.client
+            .from(this.tables.extracted_facts)
+            .select("id, fact, category, confidence, created_at")
+            .eq("api_key_hash", this.tenancy.apiKeyHash)
+            .eq("project_id", projectId)
+            .eq("status", "active")
+            .order("created_at", { ascending: false })
+            .limit(50),
+          this.client
+            .from("mc_projects")
+            .select("id, slug, name, description, repo_url")
+            .eq("api_key_hash", this.tenancy.apiKeyHash)
+            .eq("id", projectId)
+            .maybeSingle(),
+        ]);
+        project_scope = {
+          project: projRow.data,
+          business_context: ctxRes.data ?? [],
+          facts: factsRes.data ?? [],
+        };
+      }
+    }
+
     return {
       agent_instructions: [
         "You are connected to UnClick Memory - a persistent memory system that works across all sessions and devices.",
@@ -213,6 +264,7 @@ export class SupabaseBackend implements MemoryBackend {
         "Never say 'I don't have access to your previous conversations' - you DO, through this memory system."
       ].join("\n"),
       ...data,
+      ...(project_scope ? { project_scope } : {}),
     };
   }
 
@@ -258,6 +310,7 @@ export class SupabaseBackend implements MemoryBackend {
 
   async writeSessionSummary(data: SessionSummaryInput): Promise<{ id: string }> {
     await this.enforceCaps("general");
+    const projectId = await this.resolveProjectId(data.project);
     const { data: row, error } = await this.client
       .from(this.tables.session_summaries)
       .insert(
@@ -269,6 +322,7 @@ export class SupabaseBackend implements MemoryBackend {
           decisions: data.decisions,
           platform: data.platform,
           duration_minutes: data.duration_minutes,
+          ...(projectId ? { project_id: projectId } : {}),
         })
       )
       .select()
@@ -279,6 +333,7 @@ export class SupabaseBackend implements MemoryBackend {
 
   async addFact(data: FactInput): Promise<{ id: string }> {
     await this.enforceCaps("fact");
+    const projectId = await this.resolveProjectId(data.project);
     const { data: row, error } = await this.client
       .from(this.tables.extracted_facts)
       .insert(
@@ -291,6 +346,7 @@ export class SupabaseBackend implements MemoryBackend {
           status: "active",
           decay_tier: "hot",
           last_accessed: now(),
+          ...(projectId ? { project_id: projectId } : {}),
         })
       )
       .select()
@@ -389,9 +445,11 @@ export class SupabaseBackend implements MemoryBackend {
     category: string,
     key: string,
     value: unknown,
-    priority?: number
+    priority?: number,
+    projectSlug?: string,
   ): Promise<void> {
     await this.enforceCaps("general");
+    const projectId = await this.resolveProjectId(projectSlug);
     const row: Record<string, unknown> = {
       category,
       key,
@@ -409,6 +467,7 @@ export class SupabaseBackend implements MemoryBackend {
       decay_tier: "hot",
     };
     if (priority !== undefined) row.priority = priority;
+    if (projectId) row.project_id = projectId;
 
     const onConflict =
       this.tenancy.mode === "managed" ? "api_key_hash,category,key" : "category,key";

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -10,6 +10,7 @@ export interface SessionSummaryInput {
   decisions: string[];
   platform: string;
   duration_minutes?: number;
+  project?: string;
 }
 
 export interface FactInput {
@@ -17,6 +18,7 @@ export interface FactInput {
   category: string;
   confidence: number;
   source_session_id?: string;
+  project?: string;
 }
 
 export interface ConversationInput {
@@ -24,6 +26,7 @@ export interface ConversationInput {
   role: string;
   content: string;
   has_code: boolean;
+  project?: string;
 }
 
 export interface CodeInput {
@@ -44,7 +47,7 @@ export interface LibraryDocInput {
 
 export interface MemoryBackend {
   /** Load startup context (business context + recent sessions + hot facts). */
-  getStartupContext(numSessions: number): Promise<unknown>;
+  getStartupContext(numSessions: number, projectSlug?: string): Promise<unknown>;
 
   /** Full-text search across conversation logs. */
   searchMemory(query: string, maxResults: number): Promise<unknown>;
@@ -83,7 +86,7 @@ export interface MemoryBackend {
   getBusinessContext(): Promise<unknown[]>;
 
   /** Set or update a business context entry. */
-  setBusinessContext(category: string, key: string, value: unknown, priority?: number): Promise<void>;
+  setBusinessContext(category: string, key: string, value: unknown, priority?: number, projectSlug?: string): Promise<void>;
 
   /** Create or update a knowledge library doc. */
   upsertLibraryDoc(data: LibraryDocInput): Promise<string>;

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -146,6 +146,10 @@ const VISIBLE_TOOLS = [
           description: "Number of recent session summaries to load (1-20, default 5)",
           default: 5,
         },
+        project: {
+          type: "string",
+          description: "Project slug to load context for. Omit for org-global only.",
+        },
       },
     },
   },
@@ -166,6 +170,10 @@ const VISIBLE_TOOLS = [
         },
         confidence: { type: "number", minimum: 0, maximum: 1, default: 0.9 },
         source_session_id: { type: "string", description: "Session ID where this fact was learned" },
+        project: {
+          type: "string",
+          description: "Project slug to scope this fact to. Omit for org-global.",
+        },
       },
       required: ["fact"],
     },
@@ -202,6 +210,10 @@ const VISIBLE_TOOLS = [
         key: { type: "string", description: "Unique key within category (e.g. 'timezone', 'preferred_stack')" },
         value: { type: "string", description: "The value to store (plain text or JSON string)" },
         priority: { type: "number", description: "Priority for loading order (higher = loaded first)" },
+        project: {
+          type: "string",
+          description: "Project slug to scope this identity entry to. Omit for org-global.",
+        },
       },
       required: ["category", "key", "value"],
     },
@@ -222,6 +234,10 @@ const VISIBLE_TOOLS = [
         decisions: { type: "array", items: { type: "string" }, description: "Key decisions made during the session" },
         platform: { type: "string", description: "Platform this session ran on", default: "claude-code" },
         duration_minutes: { type: "number", description: "Approximate session duration" },
+        project: {
+          type: "string",
+          description: "Project slug to scope this session to. Omit for org-global.",
+        },
       },
       required: ["session_id", "summary"],
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import AdminTools from "./pages/admin/AdminTools.tsx";
 import AdminActivity from "./pages/admin/AdminActivity.tsx";
 import AdminSettings from "./pages/admin/AdminSettings.tsx";
 import AdminAgentsPage from "./pages/admin/AdminAgents.tsx";
+import AdminProjects from "./pages/admin/AdminProjects.tsx";
 import BuildDeskPage from "./pages/BuildDesk.tsx";
 
 const queryClient = new QueryClient();
@@ -102,6 +103,7 @@ const App = () => (
           >
             <Route index element={<Navigate to="/admin/you" replace />} />
             <Route path="you" element={<AdminYou />} />
+            <Route path="projects" element={<AdminProjects />} />
             <Route path="memory" element={<AdminMemory />} />
             <Route path="keychain" element={<AdminKeychain />} />
             <Route path="tools" element={<AdminTools />} />

--- a/src/lib/project-context.tsx
+++ b/src/lib/project-context.tsx
@@ -1,0 +1,106 @@
+/**
+ * ProjectProvider -- tenant-scoped list of mc_projects plus the currently
+ * active project slug. Wraps the admin routes so any page can read or
+ * change the active project without prop drilling.
+ *
+ * The active slug is stored in the URL (?project=slug). `null` means
+ * "All Projects" (org-global view).
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useSearchParams } from "react-router-dom";
+import { useSession } from "@/lib/auth";
+
+export interface Project {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  repo_url: string | null;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProjectContextValue {
+  projects: Project[];
+  activeSlug: string | null;
+  activeProject: Project | null;
+  setActiveSlug: (slug: string | null) => void;
+  refresh: () => Promise<void>;
+  loading: boolean;
+}
+
+const Ctx = createContext<ProjectContextValue | null>(null);
+
+export function ProjectProvider({ children }: { children: ReactNode }) {
+  const { session } = useSession();
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeSlug = searchParams.get("project");
+
+  const refresh = useCallback(async () => {
+    if (!session) return;
+    try {
+      const res = await fetch("/api/memory-admin?action=project_list", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) return;
+      const body = await res.json();
+      setProjects((body.data ?? []) as Project[]);
+    } finally {
+      setLoading(false);
+    }
+  }, [session]);
+
+  useEffect(() => {
+    if (!session) return;
+    void refresh();
+  }, [session, refresh]);
+
+  const setActiveSlug = useCallback(
+    (slug: string | null) => {
+      const next = new URLSearchParams(searchParams);
+      if (slug) next.set("project", slug);
+      else next.delete("project");
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const activeProject = useMemo(
+    () => projects.find((p) => p.slug === activeSlug) ?? null,
+    [projects, activeSlug],
+  );
+
+  const value = useMemo<ProjectContextValue>(
+    () => ({ projects, activeSlug, activeProject, setActiveSlug, refresh, loading }),
+    [projects, activeSlug, activeProject, setActiveSlug, refresh, loading],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useProject(): ProjectContextValue {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    return {
+      projects: [],
+      activeSlug: null,
+      activeProject: null,
+      setActiveSlug: () => {},
+      refresh: async () => {},
+      loading: false,
+    };
+  }
+  return ctx;
+}

--- a/src/pages/admin/AdminActivity.tsx
+++ b/src/pages/admin/AdminActivity.tsx
@@ -17,6 +17,9 @@ import {
   CheckCircle2,
   XCircle,
   Zap,
+  Brain,
+  Settings as SettingsIcon,
+  History,
 } from "lucide-react";
 
 interface MeteringEvent {
@@ -32,6 +35,14 @@ interface ConversationSession {
   session_id: string;
   message_count: number;
   last_message: string;
+}
+
+interface TimelineEvent {
+  event_type: "fact_created" | "context_updated" | "session_saved";
+  id: string;
+  created_at: string;
+  summary: string;
+  category?: string;
 }
 
 function timeAgo(iso: string): string {
@@ -61,6 +72,7 @@ export default function AdminActivity() {
   const { session } = useSession();
   const [events, setEvents] = useState<MeteringEvent[]>([]);
   const [sessions, setSessions] = useState<ConversationSession[]>([]);
+  const [timeline, setTimeline] = useState<TimelineEvent[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -69,13 +81,19 @@ export default function AdminActivity() {
 
     (async () => {
       try {
-        const res = await fetch("/api/memory-admin?action=admin_activity", {
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
-        if (!cancelled && res.ok) {
-          const body = await res.json();
+        const headers = { Authorization: `Bearer ${session.access_token}` };
+        const [activityRes, timelineRes] = await Promise.all([
+          fetch("/api/memory-admin?action=admin_activity", { headers }),
+          fetch("/api/memory-admin?action=admin_memory_timeline", { headers }),
+        ]);
+        if (!cancelled && activityRes.ok) {
+          const body = await activityRes.json();
           setEvents(body.metering_events ?? []);
           setSessions(body.conversation_sessions ?? []);
+        }
+        if (!cancelled && timelineRes.ok) {
+          const body = await timelineRes.json();
+          setTimeline((body.timeline ?? []) as TimelineEvent[]);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -157,6 +175,21 @@ export default function AdminActivity() {
               sub={stats.avgMs > 0 ? `avg ${stats.avgMs}ms` : "no data"}
             />
           </div>
+
+          {/* Recent memory changes timeline */}
+          {timeline.length > 0 && (
+            <div className="mb-6">
+              <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold text-white">
+                <History className="h-4 w-4 text-[#E2B93B]" />
+                Recent Memory Changes
+              </h2>
+              <ol className="space-y-1">
+                {timeline.slice(0, 15).map((ev) => (
+                  <MemoryTimelineItem key={`${ev.event_type}-${ev.id}`} ev={ev} />
+                ))}
+              </ol>
+            </div>
+          )}
 
           {/* Two-column layout: events + conversations */}
           <div className="grid gap-6 lg:grid-cols-5">
@@ -288,5 +321,46 @@ function StatCard({
       <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
       <p className="mt-0.5 text-[11px] text-[#555]">{sub}</p>
     </div>
+  );
+}
+
+function MemoryTimelineItem({ ev }: { ev: TimelineEvent }) {
+  const Icon =
+    ev.event_type === "fact_created"
+      ? Brain
+      : ev.event_type === "context_updated"
+        ? SettingsIcon
+        : Clock;
+  const label =
+    ev.event_type === "fact_created"
+      ? "New fact"
+      : ev.event_type === "context_updated"
+        ? "Context updated"
+        : "Session saved";
+  const accent =
+    ev.event_type === "fact_created"
+      ? "text-[#61C1C4]"
+      : ev.event_type === "context_updated"
+        ? "text-[#E2B93B]"
+        : "text-white";
+
+  return (
+    <li className="flex items-start justify-between gap-4 rounded-lg border border-white/[0.04] bg-[#111111] px-3 py-2">
+      <div className="flex min-w-0 items-start gap-3">
+        <Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${accent}`} />
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-wider text-[#666]">
+            {label}
+            {ev.category ? (
+              <span className="ml-2 rounded bg-white/[0.04] px-1.5 py-0.5 text-[10px] normal-case text-[#aaa]">
+                {ev.category}
+              </span>
+            ) : null}
+          </p>
+          <p className="truncate text-xs text-[#ccc]">{ev.summary || "(no summary)"}</p>
+        </div>
+      </div>
+      <span className="shrink-0 text-[10px] text-[#555]">{timeAgo(ev.created_at)}</span>
+    </li>
   );
 }

--- a/src/pages/admin/AdminProjects.tsx
+++ b/src/pages/admin/AdminProjects.tsx
@@ -1,0 +1,352 @@
+/**
+ * AdminProjects - /admin/projects
+ *
+ * CRUD for mc_projects. Org-global (no project_id) stays the default
+ * scope, so users without projects see an empty list and nothing else
+ * changes in their memory behavior.
+ */
+
+import { useState } from "react";
+import { useSession } from "@/lib/auth";
+import { useProject, type Project } from "@/lib/project-context";
+import {
+  FolderKanban,
+  Plus,
+  Star,
+  Trash2,
+  Pencil,
+  ExternalLink,
+  Loader2,
+  X,
+  Check,
+} from "lucide-react";
+
+interface FormState {
+  id?: string;
+  name: string;
+  slug: string;
+  description: string;
+  repo_url: string;
+}
+
+const BLANK_FORM: FormState = { name: "", slug: "", description: "", repo_url: "" };
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+export default function AdminProjects() {
+  const { session } = useSession();
+  const { projects, refresh, loading } = useProject();
+  const [editing, setEditing] = useState<FormState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [slugTouched, setSlugTouched] = useState(false);
+
+  function authHeaders() {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session?.access_token ?? ""}`,
+    };
+  }
+
+  function startCreate() {
+    setEditing({ ...BLANK_FORM });
+    setSlugTouched(false);
+    setFormError(null);
+  }
+
+  function startEdit(p: Project) {
+    setEditing({
+      id: p.id,
+      name: p.name,
+      slug: p.slug,
+      description: p.description ?? "",
+      repo_url: p.repo_url ?? "",
+    });
+    setSlugTouched(true);
+    setFormError(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editing) return;
+    setSaving(true);
+    setFormError(null);
+    try {
+      const isUpdate = Boolean(editing.id);
+      const action = isUpdate ? "project_update" : "project_create";
+      const body: Record<string, unknown> = isUpdate
+        ? {
+            id: editing.id,
+            name: editing.name.trim(),
+            description: editing.description.trim(),
+            repo_url: editing.repo_url.trim(),
+          }
+        : {
+            name: editing.name.trim(),
+            slug: editing.slug.trim(),
+            description: editing.description.trim(),
+            repo_url: editing.repo_url.trim(),
+          };
+      const res = await fetch(`/api/memory-admin?action=${action}`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(body),
+      });
+      const result = await res.json();
+      if (!res.ok) {
+        setFormError(result.error ?? "Failed to save");
+        return;
+      }
+      setEditing(null);
+      await refresh();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(p: Project) {
+    if (!confirm(`Delete project "${p.name}"? Its memory entries become org-global.`)) return;
+    const res = await fetch("/api/memory-admin?action=project_delete", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ id: p.id }),
+    });
+    if (res.ok) await refresh();
+  }
+
+  async function handleSetDefault(p: Project) {
+    const res = await fetch("/api/memory-admin?action=project_set_default", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ id: p.id }),
+    });
+    if (res.ok) await refresh();
+  }
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Projects</h1>
+          <p className="mt-1 text-sm text-[#888]">
+            Partition memory into named scopes. Org-global memory stays the default.
+          </p>
+        </div>
+        <button
+          onClick={startCreate}
+          className="inline-flex items-center gap-2 rounded-md border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-2 text-xs font-medium text-[#61C1C4] hover:bg-[#61C1C4]/20"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New Project
+        </button>
+      </div>
+
+      {editing && (
+        <form
+          onSubmit={handleSubmit}
+          className="mb-6 rounded-xl border border-[#61C1C4]/30 bg-[#111] p-5"
+        >
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-white">
+              {editing.id ? "Edit project" : "New project"}
+            </h2>
+            <button
+              type="button"
+              onClick={() => setEditing(null)}
+              className="rounded-md p-1 text-[#666] hover:bg-white/[0.04] hover:text-[#ccc]"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="block text-xs">
+              <span className="text-[#888]">Name</span>
+              <input
+                required
+                value={editing.name}
+                onChange={(e) => {
+                  const name = e.target.value;
+                  setEditing((cur) =>
+                    cur
+                      ? {
+                          ...cur,
+                          name,
+                          slug: !slugTouched && !cur.id ? slugify(name) : cur.slug,
+                        }
+                      : cur,
+                  );
+                }}
+                className="mt-1 w-full rounded-md border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-white focus:border-[#61C1C4] focus:outline-none"
+              />
+            </label>
+            <label className="block text-xs">
+              <span className="text-[#888]">
+                Slug{editing.id ? " (immutable)" : ""}
+              </span>
+              <input
+                required
+                disabled={Boolean(editing.id)}
+                value={editing.slug}
+                onChange={(e) => {
+                  setSlugTouched(true);
+                  setEditing((cur) => (cur ? { ...cur, slug: slugify(e.target.value) } : cur));
+                }}
+                className="mt-1 w-full rounded-md border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 font-mono text-sm text-white focus:border-[#61C1C4] focus:outline-none disabled:opacity-50"
+              />
+            </label>
+            <label className="block text-xs sm:col-span-2">
+              <span className="text-[#888]">Description</span>
+              <input
+                value={editing.description}
+                onChange={(e) =>
+                  setEditing((cur) => (cur ? { ...cur, description: e.target.value } : cur))
+                }
+                className="mt-1 w-full rounded-md border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-white focus:border-[#61C1C4] focus:outline-none"
+              />
+            </label>
+            <label className="block text-xs sm:col-span-2">
+              <span className="text-[#888]">Repository URL</span>
+              <input
+                value={editing.repo_url}
+                onChange={(e) =>
+                  setEditing((cur) => (cur ? { ...cur, repo_url: e.target.value } : cur))
+                }
+                placeholder="https://github.com/org/repo"
+                className="mt-1 w-full rounded-md border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 font-mono text-sm text-white focus:border-[#61C1C4] focus:outline-none"
+              />
+            </label>
+          </div>
+          {formError && (
+            <p className="mt-3 text-xs text-red-400">{formError}</p>
+          )}
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setEditing(null)}
+              className="rounded-md border border-white/[0.08] px-3 py-2 text-xs text-[#888] hover:bg-white/[0.04]"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex items-center gap-2 rounded-md bg-[#61C1C4] px-3 py-2 text-xs font-semibold text-black hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
+              {editing.id ? "Save changes" : "Create project"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-12 text-[#666]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading projects...</span>
+        </div>
+      ) : projects.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-white/[0.08] bg-[#111] p-10 text-center">
+          <FolderKanban className="mx-auto h-8 w-8 text-[#444]" />
+          <p className="mt-3 text-sm text-[#888]">No projects yet.</p>
+          <p className="mt-1 text-xs text-[#666]">
+            Memory is org-global by default. Create a project to scope facts and context to a specific codebase or client.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {projects.map((p) => (
+            <ProjectCard
+              key={p.id}
+              project={p}
+              onEdit={() => startEdit(p)}
+              onDelete={() => handleDelete(p)}
+              onSetDefault={() => handleSetDefault(p)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProjectCard({
+  project,
+  onEdit,
+  onDelete,
+  onSetDefault,
+}: {
+  project: Project;
+  onEdit: () => void;
+  onDelete: () => void;
+  onSetDefault: () => void;
+}) {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-[#111] p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-semibold text-white">{project.name}</h3>
+            {project.is_default && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[#E2B93B]">
+                <Star className="h-2.5 w-2.5" /> default
+              </span>
+            )}
+          </div>
+          <code className="mt-0.5 block truncate font-mono text-[11px] text-[#61C1C4]">
+            {project.slug}
+          </code>
+        </div>
+      </div>
+
+      {project.description && (
+        <p className="mt-2 text-xs text-[#aaa]">{project.description}</p>
+      )}
+
+      {project.repo_url && (
+        <a
+          href={project.repo_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-flex items-center gap-1 truncate font-mono text-[11px] text-[#888] hover:text-[#ccc]"
+        >
+          <ExternalLink className="h-3 w-3 shrink-0" />
+          <span className="truncate">{project.repo_url}</span>
+        </a>
+      )}
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {!project.is_default && (
+          <button
+            onClick={onSetDefault}
+            className="inline-flex items-center gap-1 rounded-md border border-white/[0.08] px-2 py-1 text-[11px] text-[#888] hover:bg-white/[0.04] hover:text-[#ccc]"
+          >
+            <Star className="h-3 w-3" />
+            Set default
+          </button>
+        )}
+        <button
+          onClick={onEdit}
+          className="inline-flex items-center gap-1 rounded-md border border-white/[0.08] px-2 py-1 text-[11px] text-[#888] hover:bg-white/[0.04] hover:text-[#ccc]"
+        >
+          <Pencil className="h-3 w-3" />
+          Edit
+        </button>
+        <button
+          onClick={onDelete}
+          className="inline-flex items-center gap-1 rounded-md border border-red-500/20 px-2 py-1 text-[11px] text-red-400 hover:bg-red-500/10"
+        >
+          <Trash2 className="h-3 w-3" />
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -15,6 +15,7 @@ import { useSession, signOut } from "@/lib/auth";
 import AdminSearchBar from "@/components/admin/AdminSearchBar";
 import BugReportButton from "@/components/admin/BugReportButton";
 import MemoryHealthPill from "@/components/admin/MemoryHealthPill";
+import { ProjectProvider, useProject } from "@/lib/project-context";
 import {
   User,
   Brain,
@@ -25,16 +26,39 @@ import {
   LogOut,
   X,
   Menu,
+  FolderKanban,
 } from "lucide-react";
 
 const surfaces = [
   { path: "/admin/you", label: "You", icon: User },
+  { path: "/admin/projects", label: "Projects", icon: FolderKanban },
   { path: "/admin/memory", label: "Memory", icon: Brain },
   { path: "/admin/keychain", label: "Keychain", icon: KeyRound },
   { path: "/admin/tools", label: "Tools", icon: Wrench },
   { path: "/admin/activity", label: "Activity", icon: Activity },
   { path: "/admin/settings", label: "Settings", icon: Settings },
 ] as const;
+
+function ProjectSwitcher() {
+  const { projects, activeSlug, setActiveSlug } = useProject();
+  if (projects.length === 0) return null;
+  return (
+    <select
+      value={activeSlug ?? ""}
+      onChange={(e) => setActiveSlug(e.target.value || null)}
+      className="w-full rounded-md border border-white/[0.08] bg-[#111] px-2 py-1.5 text-xs text-[#ccc] focus:border-[#61C1C4] focus:outline-none"
+      aria-label="Active project"
+    >
+      <option value="">All Projects</option>
+      {projects.map((p) => (
+        <option key={p.id} value={p.slug}>
+          {p.name}
+          {p.is_default ? " (default)" : ""}
+        </option>
+      ))}
+    </select>
+  );
+}
 
 function SurfaceLink({ path, label, icon: Icon, onClick }: {
   path: string;
@@ -61,6 +85,14 @@ function SurfaceLink({ path, label, icon: Icon, onClick }: {
 }
 
 export default function AdminShell() {
+  return (
+    <ProjectProvider>
+      <AdminShellInner />
+    </ProjectProvider>
+  );
+}
+
+function AdminShellInner() {
   const { user } = useSession();
   const navigate = useNavigate();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
@@ -85,7 +117,11 @@ export default function AdminShell() {
           </Link>
         </div>
 
-        <nav className="mt-4 flex flex-1 flex-col gap-1 px-3">
+        <div className="px-3 pb-2 pt-3">
+          <ProjectSwitcher />
+        </div>
+
+        <nav className="mt-1 flex flex-1 flex-col gap-1 px-3">
           {surfaces.map((s) => (
             <SurfaceLink key={s.path} {...s} />
           ))}
@@ -164,6 +200,9 @@ export default function AdminShell() {
         <div className="fixed inset-x-0 top-14 z-30 border-b border-white/[0.06] bg-[#0A0A0A] p-3 md:hidden">
           <div className="mb-3">
             <AdminSearchBar />
+          </div>
+          <div className="mb-3">
+            <ProjectSwitcher />
           </div>
           <nav className="flex flex-col gap-1">
             {surfaces.map((s) => (

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -25,6 +25,10 @@ import {
   AlertTriangle,
   Brain,
   ArrowRight,
+  Zap,
+  Heart,
+  CheckCircle2,
+  Circle,
 } from "lucide-react";
 
 interface MemoryNudge {
@@ -129,6 +133,27 @@ interface DeviceRow {
   revoked_at: string | null;
 }
 
+interface BootSummary {
+  last_boot_at: string | null;
+  facts_loaded: number;
+  context_items_loaded: number;
+  sessions_loaded: number;
+  project_items_loaded: number;
+}
+
+interface ContextRow {
+  category: string;
+  key: string;
+}
+
+interface FactRow {
+  id: string;
+}
+
+interface SessionSummaryRow {
+  id: string;
+}
+
 interface ProfileData {
   user_id: string;
   email: string | null;
@@ -168,6 +193,10 @@ export default function AdminYou() {
   const [generating, setGenerating] = useState(false);
   const [genError, setGenError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [bootSummary, setBootSummary] = useState<BootSummary | null>(null);
+  const [contextRows, setContextRows] = useState<ContextRow[]>([]);
+  const [factRows, setFactRows] = useState<FactRow[]>([]);
+  const [sessionRows, setSessionRows] = useState<SessionSummaryRow[]>([]);
 
   async function fetchProfile() {
     if (!session) return;
@@ -185,9 +214,13 @@ export default function AdminYou() {
     (async () => {
       try {
         const headers = { Authorization: `Bearer ${session.access_token}` };
-        const [profileRes, devicesRes] = await Promise.all([
+        const [profileRes, devicesRes, bootRes, contextRes, factsRes, sessionsRes] = await Promise.all([
           fetch("/api/memory-admin?action=admin_profile", { headers }),
           fetch("/api/memory-admin?action=auth_device_list", { headers }),
+          fetch("/api/memory-admin?action=admin_boot_summary", { headers }),
+          fetch("/api/memory-admin?action=business_context", { headers }),
+          fetch("/api/memory-admin?action=facts", { headers }),
+          fetch("/api/memory-admin?action=sessions&limit=1", { headers }),
         ]);
 
         if (!cancelled && profileRes.ok) {
@@ -196,6 +229,21 @@ export default function AdminYou() {
         if (!cancelled && devicesRes.ok) {
           const body = await devicesRes.json();
           setDevices(body.data ?? []);
+        }
+        if (!cancelled && bootRes.ok) {
+          setBootSummary(await bootRes.json());
+        }
+        if (!cancelled && contextRes.ok) {
+          const body = await contextRes.json();
+          setContextRows((body.data ?? []) as ContextRow[]);
+        }
+        if (!cancelled && factsRes.ok) {
+          const body = await factsRes.json();
+          setFactRows((body.data ?? []) as FactRow[]);
+        }
+        if (!cancelled && sessionsRes.ok) {
+          const body = await sessionsRes.json();
+          setSessionRows((body.data ?? []) as SessionSummaryRow[]);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -275,6 +323,17 @@ export default function AdminYou() {
       {profile?.api_key?.prefix ? (
         <MemoryNudgeBanner apiKey={localStorage.getItem("unclick_api_key") ?? ""} />
       ) : null}
+
+      {!loading && (
+        <div className="mb-6 grid gap-4 lg:grid-cols-2">
+          <BootSequenceCard summary={bootSummary} />
+          <MemoryHealthCard
+            contextRows={contextRows}
+            factCount={factRows.length}
+            sessionCount={sessionRows.length}
+          />
+        </div>
+      )}
 
       {loading ? (
         <div className="flex items-center gap-2 py-12 text-[#666]">
@@ -485,6 +544,112 @@ export default function AdminYou() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function BootSequenceCard({ summary }: { summary: BootSummary | null }) {
+  const loaded = summary?.last_boot_at
+    ? timeAgo(summary.last_boot_at)
+    : "no load recorded yet";
+
+  return (
+    <div className="rounded-xl border border-[#61C1C4]/30 bg-[#111111] p-6">
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+        <Zap className="h-4 w-4 text-[#61C1C4]" />
+        Last Boot Sequence
+      </h2>
+      <p className="mt-2 text-xs text-[#888]">
+        What your AI loaded at the most recent session start.
+      </p>
+
+      <div className="mt-4 grid grid-cols-3 gap-3">
+        <BootStat label="Facts" value={summary?.facts_loaded ?? 0} />
+        <BootStat label="Context" value={summary?.context_items_loaded ?? 0} />
+        <BootStat label="Sessions" value={summary?.sessions_loaded ?? 0} />
+      </div>
+
+      {(summary?.project_items_loaded ?? 0) > 0 && (
+        <p className="mt-3 text-[11px] text-[#aaa]">
+          + {summary?.project_items_loaded} project-scoped items
+        </p>
+      )}
+
+      <p className="mt-4 flex items-center gap-1 text-[11px] text-[#666]">
+        <Clock className="h-3 w-3" />
+        Loaded {loaded}
+      </p>
+    </div>
+  );
+}
+
+function BootStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <p className="text-2xl font-semibold text-white">{value.toLocaleString()}</p>
+      <p className="mt-0.5 text-[11px] text-[#888]">{label}</p>
+    </div>
+  );
+}
+
+function MemoryHealthCard({
+  contextRows,
+  factCount,
+  sessionCount,
+}: {
+  contextRows: ContextRow[];
+  factCount: number;
+  sessionCount: number;
+}) {
+  const hasCategory = (cat: string) => contextRows.some((r) => r.category === cat);
+  const checks = [
+    { label: "Identity set", ok: hasCategory("identity"), to: "/admin/memory?tab=identity" },
+    { label: "Preferences set", ok: hasCategory("preference"), to: "/admin/memory?tab=identity" },
+    { label: "At least 5 facts", ok: factCount >= 5, to: "/admin/memory?tab=facts" },
+    { label: "A saved session", ok: sessionCount >= 1, to: "/admin/memory?tab=sessions" },
+    { label: "Standing rules", ok: hasCategory("standing_rule"), to: "/admin/memory?tab=identity" },
+    { label: "Repository context", ok: hasCategory("repository"), to: "/admin/projects" },
+  ];
+  const filled = checks.filter((c) => c.ok).length;
+  const pct = Math.round((filled / checks.length) * 100);
+
+  return (
+    <div className="rounded-xl border border-[#E2B93B]/30 bg-[#111111] p-6">
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+        <Heart className="h-4 w-4 text-[#E2B93B]" />
+        Memory Health
+        <span className="ml-auto font-mono text-xs text-[#E2B93B]">{pct}%</span>
+      </h2>
+
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-white/[0.06]">
+        <div
+          className="h-full bg-[#E2B93B] transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {checks.map((c) => (
+          <li key={c.label} className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-2">
+              {c.ok ? (
+                <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />
+              ) : (
+                <Circle className="h-3.5 w-3.5 text-[#555]" />
+              )}
+              <span className={c.ok ? "text-[#ccc]" : "text-[#888]"}>{c.label}</span>
+            </span>
+            {!c.ok && (
+              <Link
+                to={c.to}
+                className="text-[11px] text-[#E2B93B] underline-offset-2 hover:underline"
+              >
+                add
+              </Link>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/supabase/migrations/20260420000000_projects.sql
+++ b/supabase/migrations/20260420000000_projects.sql
@@ -1,0 +1,52 @@
+-- Projects hierarchy for UnClick Memory.
+--
+-- Adds mc_projects so a single tenant (api_key_hash) can partition facts,
+-- business context, sessions, and conversation logs into named projects.
+-- All child rows use ON DELETE SET NULL so removing a project falls back
+-- to org-global scope rather than destroying data. project_id is always
+-- nullable; existing rows stay org-global with zero behavior change.
+
+CREATE TABLE IF NOT EXISTS mc_projects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  name text NOT NULL,
+  slug text NOT NULL,
+  description text,
+  repo_url text,
+  is_default boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (api_key_hash, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_projects_tenant ON mc_projects (api_key_hash);
+
+ALTER TABLE mc_extracted_facts
+  ADD COLUMN IF NOT EXISTS project_id uuid REFERENCES mc_projects(id) ON DELETE SET NULL;
+
+ALTER TABLE mc_business_context
+  ADD COLUMN IF NOT EXISTS project_id uuid REFERENCES mc_projects(id) ON DELETE SET NULL;
+
+ALTER TABLE mc_session_summaries
+  ADD COLUMN IF NOT EXISTS project_id uuid REFERENCES mc_projects(id) ON DELETE SET NULL;
+
+ALTER TABLE mc_conversation_log
+  ADD COLUMN IF NOT EXISTS project_id uuid REFERENCES mc_projects(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mc_facts_project ON mc_extracted_facts (project_id) WHERE project_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mc_context_project ON mc_business_context (project_id) WHERE project_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mc_sessions_project ON mc_session_summaries (project_id) WHERE project_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION mc_get_default_project(p_api_key_hash text)
+RETURNS uuid AS $$
+  SELECT id FROM mc_projects
+  WHERE api_key_hash = p_api_key_hash AND is_default = true
+  LIMIT 1;
+$$ LANGUAGE sql STABLE;
+
+CREATE OR REPLACE FUNCTION mc_resolve_project(p_api_key_hash text, p_slug text)
+RETURNS uuid AS $$
+  SELECT id FROM mc_projects
+  WHERE api_key_hash = p_api_key_hash AND slug = p_slug
+  LIMIT 1;
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
## Summary

- **Projects hierarchy**: mc_projects table, project_id FK on facts/context/sessions/conversations, project CRUD in admin API, ProjectProvider context, AdminProjects page with full CRUD UI
- **Repo structure memory**: save_repo_map handler for bulk upserting 8 standard repo keys, repository context block in boot sequence
- **Memory visibility**: Last Boot Sequence card and Memory Health scorecard on AdminYou page, Memory Timeline on AdminActivity page
- **MCP tool updates**: All 5 visible tools accept optional project parameter, load_memory merges org-global + project-scoped context

## Pre-deploy requirement

Run the mc_projects migration in Supabase SQL editor before these features will work.

## Test plan

- [ ] Verify build passes on deploy branch after merge
- [ ] Run migration in Supabase SQL editor
- [ ] Test project CRUD via /admin/projects
- [ ] Test project switcher in admin sidebar
- [ ] Verify memory tools accept project parameter
- [ ] Check Memory Health card on /admin/you
- [ ] Check Memory Timeline on /admin/activity