### PR TITLE
chore: add Claude Code workflow for @claude mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,35 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Wires up the Claude GitHub App so that `@claude` mentions in issues and PR comments automatically spawn a Cloud Code session, create a branch, and open a PR.

Adds a single file: `.github/workflows/claude.yml` (35 lines).

## Required before merging

Add a repo secret named `ANTHROPIC_API_KEY` at:
`Settings -> Secrets and variables -> Actions -> New repository secret`

Recommended: use the `BaileyPlexPing` key so GitHub Action usage doesn't drain the main `ClaudeCode` key quota.

## Why

Currently `@claude` mentions do nothing because there is no workflow listening for them. The Claude GitHub App is installed but has no handler. This workflow is the handler.

## Test plan

- [ ] Merge this PR
- [ ] Add `ANTHROPIC_API_KEY` secret
- [ ] Open a test issue with `@claude` in a comment
- [ ] Confirm bot reacts and opens a PR within a few minutes

## No-laptop flow unlocked

After this, any future build brief can be:
1. Open an issue (Bailey does this via GitHub MCP)
2. Comment `@claude do the task`
3. PR appears, no local machine required