### PR TITLE
fix(admin): restore admin_profile action handler

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -3098,6 +3098,40 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
 
+      case "admin_profile": {
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Unauthorized" });
+
+        const { data: keyRow } = await supabase
+          .from("api_keys")
+          .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
+          .eq("key_hash", tenant.apiKeyHash)
+          .maybeSingle();
+
+        const apiKey = keyRow
+          ? {
+              id: keyRow.id as string,
+              prefix: (keyRow.key_prefix ?? "") as string,
+              label: (keyRow.label ?? "") as string,
+              tier: (keyRow.tier ?? "free") as string,
+              is_active: Boolean(keyRow.is_active),
+              usage_count: Number(keyRow.usage_count ?? 0),
+              last_used_at: (keyRow.last_used_at ?? null) as string | null,
+              created_at: keyRow.created_at as string,
+            }
+          : null;
+
+        const tier = apiKey ? apiKey.tier : tenant.tier ?? null;
+
+        return res.status(200).json({
+          user_id: tenant.userId,
+          email: tenant.email,
+          tier,
+          needs_key: !apiKey,
+          api_key: apiKey,
+        });
+      }
+
       case "admin_tools": {
         const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
         if (!tenant) return res.status(401).json({ error: "Not signed in" });


### PR DESCRIPTION
## Bug

`/admin/you` shows "No API key linked. Use the banner above to claim your key, or get started." for users who DO have a linked API key.

## Root cause

`src/pages/admin/AdminYou.tsx` calls `/api/memory-admin?action=admin_profile`, but no `case "admin_profile":` handler exists in `api/memory-admin.ts`. The request hits the default fallthrough and returns `400 { error: "Unknown action: admin_profile" }`. The frontend sees `!profileRes.ok`, never calls `setProfile`, `profile` stays null, and the UI falls through to the catch-all message.

## Fix

Restores the `admin_profile` case next to the other session-JWT handlers (right before `admin_tools`). Auth uses the existing `resolveSessionTenant` helper. 401s when no tenant can be resolved, otherwise fetches the matching `api_keys` row and returns the profile.

## Shape returned

Exactly what `AdminYou.tsx`'s `ProfileData` interface expects:

```ts
{
  user_id: string;
  email: string | null;
  tier: string | null;
  needs_key: boolean;
  api_key: {
    id: string;
    prefix: string;        // sourced from api_keys.key_prefix
    label: string;
    tier: string;
    is_active: boolean;
    usage_count: number;
    last_used_at: string | null;
    created_at: string;
  } | null;
}
```

`needs_key` is `true` when the tenant is resolved but no `api_keys` row is found; `false` otherwise.

## Test plan

- [ ] Sign in as a user with a linked API key and load `/admin/you` - identity card renders key prefix, label, tier, usage, last used
- [ ] Sign in as a user without a linked API key - banner/CTA surfaces correctly (needs_key: true branch)
- [ ] Unauthenticated request returns 401
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)