### PR TITLE
feat(crews): chunk A — seed 14-template roster with icons + categories

### DIFF
--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -20,7 +20,13 @@ import {
   X,
   Check,
 } from "lucide-react";
-import { AGENT_TEMPLATES, MEMORY_LAYERS, type MemoryLayerKey } from "./agentTemplates";
+import {
+  AGENT_TEMPLATES,
+  CREW_CATEGORIES,
+  MEMORY_LAYERS,
+  type AgentTemplate,
+  type MemoryLayerKey,
+} from "./agentTemplates";
 
 interface Agent {
   id: string;
@@ -56,11 +62,26 @@ interface AgentDetail {
 const ROLE_OPTIONS = [
   { value: "researcher", label: "Researcher" },
   { value: "developer", label: "Developer" },
+  { value: "architect", label: "Architect" },
+  { value: "qa_engineer", label: "QA Engineer" },
+  { value: "security_officer", label: "Security Officer" },
+  { value: "designer", label: "Designer" },
+  { value: "ceo", label: "CEO" },
+  { value: "cto", label: "CTO" },
   { value: "writer", label: "Writer" },
+  { value: "finance_lead", label: "Finance Lead" },
+  { value: "legal_advisor", label: "Legal Advisor" },
   { value: "organiser", label: "Organiser" },
+  { value: "customer_advocate", label: "Customer Advocate" },
+  { value: "devils_advocate", label: "Devil's Advocate" },
   { value: "general", label: "General" },
   { value: "custom", label: "Custom" },
 ];
+
+// Role slug -> Lucide icon, used to render an agent's icon when no avatar URL is set.
+const ROLE_ICON_MAP = new Map(
+  AGENT_TEMPLATES.map((t) => [t.role, t.icon] as const),
+);
 
 function getApiKey(): string {
   if (typeof window === "undefined") return "";
@@ -122,7 +143,7 @@ export default function AdminAgentsPage() {
   const defaultAgent = useMemo(() => agents.find((a) => a.is_default), [agents]);
   const noDefaultWarning = agents.length > 0 && !defaultAgent;
 
-  const handleCreate = async (template: (typeof AGENT_TEMPLATES)[number] | null) => {
+  const handleCreate = async (template: AgentTemplate | null) => {
     setShowTemplates(false);
     try {
       const body = template
@@ -295,102 +316,107 @@ export default function AdminAgentsPage() {
         <p className="text-xs text-muted-foreground">Loading agents...</p>
       ) : (
         <ul className="space-y-3">
-          {agents.map((agent) => (
-            <li
-              key={agent.id}
-              className="rounded-xl border border-border/40 bg-card/20 p-5 transition-colors hover:border-border/60"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex items-start gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                    {agent.avatar_url ? (
-                      <img
-                        src={agent.avatar_url}
-                        alt={agent.name}
-                        className="h-10 w-10 rounded-xl object-cover"
-                      />
-                    ) : (
-                      <Bot className="h-5 w-5" />
-                    )}
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <h3 className="text-sm font-semibold text-heading">{agent.name}</h3>
-                      {agent.is_default && (
-                        <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 font-mono text-[10px] text-amber-400">
-                          <Star className="h-3 w-3" /> default
-                        </span>
+          {agents.map((agent) => {
+            const RoleIcon = ROLE_ICON_MAP.get(agent.role);
+            return (
+              <li
+                key={agent.id}
+                className="rounded-xl border border-border/40 bg-card/20 p-5 transition-colors hover:border-border/60"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                      {agent.avatar_url ? (
+                        <img
+                          src={agent.avatar_url}
+                          alt={agent.name}
+                          className="h-10 w-10 rounded-xl object-cover"
+                        />
+                      ) : RoleIcon ? (
+                        <RoleIcon className="h-5 w-5" />
+                      ) : (
+                        <Bot className="h-5 w-5" />
                       )}
-                      <span
-                        className={`inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px] ${
-                          agent.is_active
-                            ? "border-primary/30 bg-primary/10 text-primary"
-                            : "border-border/50 bg-card/40 text-muted-foreground"
-                        }`}
-                      >
-                        {agent.is_active ? "active" : "inactive"}
-                      </span>
                     </div>
-                    <p className="mt-0.5 text-xs text-body">
-                      {agent.description ?? "No description"}
-                    </p>
-                    <p className="mt-1 text-[10px] text-muted-foreground">
-                      Tools: {agent.tool_count === 0 ? "all" : agent.tool_count} ·
-                      Memory:{" "}
-                      {agent.memory_layer_count === 0
-                        ? "all layers"
-                        : `${agent.memory_layer_count} of ${MEMORY_LAYERS.length}`}{" "}
-                      · Role: {agent.role}
-                    </p>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-sm font-semibold text-heading">{agent.name}</h3>
+                        {agent.is_default && (
+                          <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 font-mono text-[10px] text-amber-400">
+                            <Star className="h-3 w-3" /> default
+                          </span>
+                        )}
+                        <span
+                          className={`inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px] ${
+                            agent.is_active
+                              ? "border-primary/30 bg-primary/10 text-primary"
+                              : "border-border/50 bg-card/40 text-muted-foreground"
+                          }`}
+                        >
+                          {agent.is_active ? "active" : "inactive"}
+                        </span>
+                      </div>
+                      <p className="mt-0.5 text-xs text-body">
+                        {agent.description ?? "No description"}
+                      </p>
+                      <p className="mt-1 text-[10px] text-muted-foreground">
+                        Tools: {agent.tool_count === 0 ? "all" : agent.tool_count} ·
+                        Memory:{" "}
+                        {agent.memory_layer_count === 0
+                          ? "all layers"
+                          : `${agent.memory_layer_count} of ${MEMORY_LAYERS.length}`}{" "}
+                        · Role: {agent.role}
+                      </p>
+                    </div>
                   </div>
-                </div>
-                <div className="flex shrink-0 items-center gap-1">
-                  {!agent.is_default && (
+                  <div className="flex shrink-0 items-center gap-1">
+                    {!agent.is_default && (
+                      <button
+                        type="button"
+                        onClick={() => handleSetDefault(agent.id)}
+                        title="Make default"
+                        className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-amber-400"
+                      >
+                        <Star className="h-3.5 w-3.5" />
+                      </button>
+                    )}
                     <button
                       type="button"
-                      onClick={() => handleSetDefault(agent.id)}
-                      title="Make default"
-                      className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-amber-400"
+                      onClick={() => openEditor(agent.id)}
+                      title="Edit"
+                      className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-primary"
                     >
-                      <Star className="h-3.5 w-3.5" />
+                      <Pencil className="h-3.5 w-3.5" />
                     </button>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => openEditor(agent.id)}
-                    title="Edit"
-                    className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-primary"
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleDuplicate(agent.id)}
-                    title="Duplicate"
-                    className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-primary"
-                  >
-                    <Copy className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleToggleActive(agent)}
-                    title={agent.is_active ? "Disable" : "Enable"}
-                    className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-primary"
-                  >
-                    <Power className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(agent.id)}
-                    title="Delete"
-                    className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-rose-400"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDuplicate(agent.id)}
+                      title="Duplicate"
+                      className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-primary"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleToggleActive(agent)}
+                      title={agent.is_active ? "Disable" : "Enable"}
+                      className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-primary"
+                    >
+                      <Power className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(agent.id)}
+                      title="Delete"
+                      className="rounded-md border border-border/40 bg-card/40 p-1.5 text-muted-foreground transition-colors hover:text-rose-400"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
                 </div>
-              </div>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       )}
 
@@ -418,7 +444,7 @@ function TemplatePicker({
   onPick,
   onClose,
 }: {
-  onPick: (template: (typeof AGENT_TEMPLATES)[number] | null) => void;
+  onPick: (template: AgentTemplate | null) => void;
   onClose: () => void;
 }) {
   return (
@@ -427,10 +453,10 @@ function TemplatePicker({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-3xl rounded-xl border border-border/40 bg-card p-6 shadow-2xl"
+        className="flex max-h-[90vh] w-full max-w-3xl flex-col rounded-xl border border-border/40 bg-card shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-4 flex items-start justify-between">
+        <div className="flex items-start justify-between border-b border-border/40 p-6">
           <div>
             <h2 className="text-lg font-semibold text-heading">Start from a template</h2>
             <p className="mt-1 text-xs text-body">
@@ -447,36 +473,68 @@ function TemplatePicker({
           </button>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          {AGENT_TEMPLATES.map((tpl) => (
-            <button
-              key={tpl.role}
-              type="button"
-              onClick={() => onPick(tpl)}
-              className="rounded-lg border border-border/40 bg-card/40 p-4 text-left transition-colors hover:border-primary/40 hover:bg-primary/5"
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-semibold text-heading">{tpl.name}</span>
-                <span className="rounded-full border border-border/40 bg-card/40 px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
-                  {tpl.role}
-                </span>
-              </div>
-              <p className="mt-1 text-xs text-body">{tpl.description}</p>
-            </button>
-          ))}
-          <button
-            type="button"
-            onClick={() => onPick(null)}
-            className="rounded-lg border border-dashed border-border/50 bg-card/20 p-4 text-left transition-colors hover:border-primary/40 hover:bg-primary/5"
-          >
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-semibold text-heading">Custom</span>
-              <span className="rounded-full border border-border/40 bg-card/40 px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
-                blank
-              </span>
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="space-y-5">
+            {CREW_CATEGORIES.map((cat) => {
+              const members = AGENT_TEMPLATES.filter((t) => t.category === cat.key);
+              if (members.length === 0) return null;
+              return (
+                <div key={cat.key}>
+                  <div className="mb-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {cat.label}
+                    </p>
+                    <p className="text-[11px] text-muted-foreground/70">{cat.hint}</p>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {members.map((tpl) => {
+                      const Icon = tpl.icon;
+                      return (
+                        <button
+                          key={tpl.role}
+                          type="button"
+                          onClick={() => onPick(tpl)}
+                          className="rounded-lg border border-border/40 bg-card/40 p-4 text-left transition-colors hover:border-primary/40 hover:bg-primary/5"
+                        >
+                          <div className="flex items-center gap-2">
+                            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                              <Icon className="h-4 w-4" />
+                            </div>
+                            <span className="text-sm font-semibold text-heading">{tpl.name}</span>
+                            <span className="rounded-full border border-border/40 bg-card/40 px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+                              {tpl.role}
+                            </span>
+                          </div>
+                          <p className="mt-1.5 text-xs text-body">{tpl.description}</p>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Start blank
+              </p>
+              <button
+                type="button"
+                onClick={() => onPick(null)}
+                className="w-full rounded-lg border border-dashed border-border/50 bg-card/20 p-4 text-left transition-colors hover:border-primary/40 hover:bg-primary/5"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-heading">Custom</span>
+                  <span className="rounded-full border border-border/40 bg-card/40 px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+                    blank
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-body">
+                  Start from scratch and define everything yourself.
+                </p>
+              </button>
             </div>
-            <p className="mt-1 text-xs text-body">Start from scratch and define everything yourself.</p>
-          </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/admin/agentTemplates.ts
+++ b/src/pages/admin/agentTemplates.ts
@@ -1,9 +1,31 @@
 /**
- * Starter agent templates and the canonical list of memory layers.
+ * Starter agent templates, the canonical list of memory layers, and the
+ * Crew category taxonomy.
  *
  * tool_slugs map to platform_connectors.id values. Connectors that don't exist
  * in the catalogue are silently skipped at create time.
+ *
+ * Each template carries a Lucide icon and a category so the TemplatePicker
+ * can group the roster visually.
  */
+
+import type { LucideIcon } from "lucide-react";
+import {
+  Search,
+  Code,
+  PenSquare,
+  ListTodo,
+  Building2,
+  Bug,
+  Shield,
+  Palette,
+  Briefcase,
+  Cpu,
+  DollarSign,
+  Scale,
+  Heart,
+  Swords,
+} from "lucide-react";
 
 export type MemoryLayerKey =
   | "business_context"
@@ -46,55 +68,126 @@ export const MEMORY_LAYERS: { key: MemoryLayerKey; label: string; hint: string }
   },
 ];
 
-interface AgentTemplate {
+export type CrewCategory = "build" | "business" | "user" | "pushback";
+
+export const CREW_CATEGORIES: { key: CrewCategory; label: string; hint: string }[] = [
+  { key: "build", label: "Build the product", hint: "Ships the software." },
+  { key: "business", label: "Run the business", hint: "Keeps the lights on." },
+  { key: "user", label: "Serve the user", hint: "Speaks for the person using it." },
+  { key: "pushback", label: "Pushback", hint: "Built-in friction. Keeps the crew honest." },
+];
+
+export interface AgentTemplate {
   name: string;
   role: string;
   description: string;
   system_prompt: string;
   tool_slugs: string[];
   memory_layers: MemoryLayerKey[];
+  category: CrewCategory;
+  icon: LucideIcon;
 }
 
+const ALL_LAYERS: MemoryLayerKey[] = [
+  "business_context",
+  "extracted_facts",
+  "session_summaries",
+  "knowledge_library",
+  "conversation_log",
+  "code_dumps",
+];
+
 export const AGENT_TEMPLATES: AgentTemplate[] = [
+  // --- Build the product ---
   {
     name: "Researcher",
     role: "researcher",
     description: "Finds info, summarises, cites sources.",
     system_prompt:
       "You are a research assistant. Find accurate information, summarise clearly, and always cite sources. Ask clarifying questions before starting a search. Prefer recent sources over old ones.",
-    tool_slugs: [
-      "google",
-      "guardian",
-      "newsapi",
-      "wikipedia",
-      "reddit",
-      "arxiv",
-      "pubmed",
-    ],
-    memory_layers: [
-      "business_context",
-      "extracted_facts",
-      "session_summaries",
-      "knowledge_library",
-      "conversation_log",
-      "code_dumps",
-    ],
+    tool_slugs: ["google", "guardian", "newsapi", "wikipedia", "reddit", "arxiv", "pubmed"],
+    memory_layers: ALL_LAYERS,
+    category: "build",
+    icon: Search,
   },
   {
     name: "Developer",
     role: "developer",
-    description: "Reviews code, suggests fixes, runs tests.",
+    description: "Ships code. Clean, tested, well-commented.",
     system_prompt:
-      "You are a code assistant. Write clean, well-commented code. Follow the project's existing style. Run tests before saying you're done. Explain your changes clearly.",
+      "You are a code assistant. Write clean, well-commented code. Follow the project's existing style. Run tests before saying you're done. Explain every change in plain language.",
     tool_slugs: ["github", "vercel", "supabase", "cloudflare", "circleci", "datadog"],
-    memory_layers: [
-      "business_context",
-      "extracted_facts",
-      "session_summaries",
-      "knowledge_library",
-      "conversation_log",
-      "code_dumps",
-    ],
+    memory_layers: ALL_LAYERS,
+    category: "build",
+    icon: Code,
+  },
+  {
+    name: "Architect",
+    role: "architect",
+    description: "Owns system design and long-term direction.",
+    system_prompt:
+      "You own system design and long-term technical direction. Challenge scope creep and call out when a one-line fix is the wrong answer. Think in trade-offs: latency, cost, maintainability, team fit. Produce short architecture notes, not long docs.",
+    tool_slugs: ["github", "vercel", "supabase", "cloudflare"],
+    memory_layers: ALL_LAYERS,
+    category: "build",
+    icon: Building2,
+  },
+  {
+    name: "QA Engineer",
+    role: "qa_engineer",
+    description: "Breaks things on purpose. Writes tests.",
+    system_prompt:
+      "You break things on purpose. Write test plans, edge cases, regression suites. Ask 'what happens at the seams' before every ship. Assume users will do the dumbest possible thing and plan for it.",
+    tool_slugs: ["github", "circleci", "datadog"],
+    memory_layers: ALL_LAYERS,
+    category: "build",
+    icon: Bug,
+  },
+  {
+    name: "Security Officer",
+    role: "security_officer",
+    description: "Thinks adversarially. Reviews auth and secrets.",
+    system_prompt:
+      "You think adversarially. Review auth flows, token handling, input validation, secret management, row-level security, and supply chain. Block a ship over a real vulnerability. Link each concern to a named attack pattern.",
+    tool_slugs: ["github", "supabase", "cloudflare", "datadog"],
+    memory_layers: ALL_LAYERS,
+    category: "build",
+    icon: Shield,
+  },
+  {
+    name: "Designer",
+    role: "designer",
+    description: "Owns UI, UX, and visual craft.",
+    system_prompt:
+      "You own UI, UX, and visual craft. Brand-aware, accessible by default, mobile first. Work in systems and tokens, not one-off screens. Push back on interfaces that ask users to think when they shouldn't have to.",
+    tool_slugs: ["figma", "canva", "anthropic"],
+    memory_layers: ALL_LAYERS,
+    category: "build",
+    icon: Palette,
+  },
+
+  // --- Run the business ---
+  {
+    name: "CEO",
+    role: "ceo",
+    description: "Names the single most important thing this week.",
+    system_prompt:
+      "You zoom out. Name the single most important thing this week and make everything else wait. Read every draft with one question: does this move the core metric. Kill good ideas that distract from the main one.",
+    tool_slugs: ["anthropic", "notion", "slack"],
+    memory_layers: ALL_LAYERS,
+    category: "business",
+    icon: Briefcase,
+  },
+  {
+    name: "CTO",
+    role: "cto",
+    description: "Sets the technical bar. Picks vendors, stack, deploy story.",
+    system_prompt:
+      "You set the technical bar. Pick the vendors, the stack, the deploy story. Balance speed with debt. Own on-call, incident response, and the question of when to hire versus when to ship.",
+    tool_slugs: ["github", "vercel", "supabase", "cloudflare", "datadog"],
+    memory_layers: ALL_LAYERS,
+    category: "business",
+    icon: Cpu,
   },
   {
     name: "Writer",
@@ -103,37 +196,67 @@ export const AGENT_TEMPLATES: AgentTemplate[] = [
     system_prompt:
       "You are a writing assistant. Match the user's voice and tone. Keep things clear and concise. No jargon unless the audience expects it. Always proofread before delivering.",
     tool_slugs: ["guardian", "newsapi", "wikipedia", "convertkit", "anthropic", "cohere"],
-    memory_layers: [
-      "business_context",
-      "extracted_facts",
-      "session_summaries",
-      "knowledge_library",
-      "conversation_log",
-      "code_dumps",
-    ],
+    memory_layers: ALL_LAYERS,
+    category: "business",
+    icon: PenSquare,
   },
+  {
+    name: "Finance Lead",
+    role: "finance_lead",
+    description: "Runway, unit economics, burn, pricing.",
+    system_prompt:
+      "You track runway, unit economics, burn, and pricing. Build models that explain, not just calculate. Ask 'what does this cost at 10x volume' before signing anything off.",
+    tool_slugs: ["stripe"],
+    memory_layers: ALL_LAYERS,
+    category: "business",
+    icon: DollarSign,
+  },
+  {
+    name: "Legal Advisor",
+    role: "legal_advisor",
+    description: "Flags privacy, IP, ToS, and data risks.",
+    system_prompt:
+      "You flag privacy, IP, consumer law, data residency, and ToS risks. Draft plain-language summaries, not legalese. You are not a substitute for a real lawyer on material issues, and you say so.",
+    tool_slugs: ["anthropic"],
+    memory_layers: ALL_LAYERS,
+    category: "business",
+    icon: Scale,
+  },
+
+  // --- Serve the user ---
   {
     name: "Organiser",
     role: "organiser",
-    description: "Tracks tasks, deadlines, status.",
+    description: "Tracks tasks, deadlines, and status.",
     system_prompt:
       "You are a task organiser. Help prioritise work, track deadlines, and keep projects moving. Summarise status clearly. Flag blockers early.",
-    tool_slugs: [
-      "calendly",
-      "clickup",
-      "asana",
-      "clockify",
-      "discord",
-      "slack",
-      "telegram",
-    ],
-    memory_layers: [
-      "business_context",
-      "extracted_facts",
-      "session_summaries",
-      "knowledge_library",
-      "conversation_log",
-      "code_dumps",
-    ],
+    tool_slugs: ["calendly", "clickup", "asana", "clockify", "discord", "slack", "telegram"],
+    memory_layers: ALL_LAYERS,
+    category: "user",
+    icon: ListTodo,
+  },
+  {
+    name: "Customer Advocate",
+    role: "customer_advocate",
+    description: "Speaks for the end user. Kills assumed knowledge.",
+    system_prompt:
+      "You speak for the person actually using the thing. Read every draft asking 'would I understand this, trust this, finish this'. Kill assumed knowledge. Demand real examples.",
+    tool_slugs: ["slack", "discord", "telegram"],
+    memory_layers: ALL_LAYERS,
+    category: "user",
+    icon: Heart,
+  },
+
+  // --- Pushback ---
+  {
+    name: "Devil's Advocate",
+    role: "devils_advocate",
+    description: "Built-in friction. Punches holes in everything.",
+    system_prompt:
+      "You are built-in friction. Your job is to punch holes. Name the strongest counter-argument, the hidden assumption, the failure mode. Never polite when the stakes are real. Keep the crew honest and the ideas sharp.",
+    tool_slugs: [],
+    memory_layers: ALL_LAYERS,
+    category: "pushback",
+    icon: Swords,
   },
 ];


### PR DESCRIPTION
First installment of the Crews feature from the approved deep-dive plan.

## What changes

### `agentTemplates.ts`
- Expanded from 4 to 14 templates. New members: Architect, QA Engineer, Security Officer, Designer, CEO, CTO, Finance Lead, Legal Advisor, Customer Advocate, Devil's Advocate.
- Added a `category` field (`build` / `business` / `user` / `pushback`) and a Lucide `icon` per template.
- Exported `CREW_CATEGORIES` as the canonical taxonomy for the picker UI.

### `AdminAgents.tsx`
- TemplatePicker now groups templates under their crew category with a short description, and renders each template's Lucide icon.
- Agent list tiles render the role-matched icon when no `avatar_url` is set (falls back to the generic Bot icon if the role is unknown).
- `ROLE_OPTIONS` expanded to cover every new role slug so the editor dropdown stays in sync.

## What doesn't change
- No schema migrations.
- No orchestration, no Captain, no Council — those land in chunks B and C.
- No build-pipeline behaviour.
- Existing agents keep working as-is.

## Follow-ups (tracked as separate chunks)
- **Chunk A2**: master Crews toggle in `/admin/agents` settings strip (requires small schema addition).
- **Chunk B**: Council execution engine (fans out to N members, aggregates).
- **Chunk C**: Captain + Devil's Advocate auto-inclusion rules.
- **Chunk D**: Automate-skill integration (pre-ship Council gate).

## Test plan
- [ ] Visit `/admin/agents`, click New Agent, confirm picker shows four category sections.
- [ ] Pick one of the new templates (e.g. Devil's Advocate) and confirm it creates with the right role slug, system prompt, and icon in the agent list.
- [ ] Edit an existing agent and confirm the role dropdown includes every new role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)