### PR TITLE
feat(analytics): Umami event tracking for signup, login, auth_success

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,37 @@
+/**
+ * Analytics helper — thin wrapper around Umami's window.umami.track().
+ *
+ * The Umami snippet is loaded async in index.html with data-website-id
+ * 724975a0-999c-4006-b238-19ee7182c25b, pointed at
+ * https://analytics.unclick.world. It attaches window.umami with a
+ * .track(eventName, eventData?) function once it finishes loading.
+ *
+ * This helper is safe to call before the script has loaded, in dev
+ * environments without the script, and in tests — it no-ops instead
+ * of throwing. Every failure mode is swallowed so analytics can never
+ * break the app.
+ *
+ * Usage:
+ *   track("signup_started", { method: "magic" });
+ *   track("auth_success",   { new_user: true, provider: "google" });
+ */
+
+type EventData = Record<string, string | number | boolean | null | undefined>;
+
+interface UmamiWindow {
+  umami?: {
+    track?: (event: string, data?: EventData) => void;
+  };
+}
+
+export function track(event: string, data?: EventData): void {
+  if (typeof window === "undefined") return;
+  try {
+    const umami = (window as unknown as UmamiWindow).umami;
+    if (umami && typeof umami.track === "function") {
+      umami.track(event, data);
+    }
+  } catch {
+    // Never let analytics break the app.
+  }
+}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -11,11 +11,12 @@
  * sends ?error=...&error_description=... which we surface inline.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { useSession } from "@/lib/auth";
+import { track } from "@/lib/analytics";
 import { Loader2 } from "lucide-react";
 
 export default function AuthCallbackPage() {
@@ -25,9 +26,25 @@ export default function AuthCallbackPage() {
 
   const urlError = params.get("error_description") || params.get("error");
   const [timedOut, setTimedOut] = useState(false);
+  const tracked = useRef(false);
 
   useEffect(() => {
     if (!loading && session) {
+      // Fire auth_success to Umami exactly once per callback landing.
+      // new_user inferred by comparing created_at with last_sign_in_at:
+      // if they're within 10s of each other, this is a first-time
+      // signup; otherwise it's a returning login.
+      if (!tracked.current) {
+        tracked.current = true;
+        const user = session.user;
+        const created = user?.created_at ? Date.parse(user.created_at) : 0;
+        const lastSignIn = user?.last_sign_in_at ? Date.parse(user.last_sign_in_at) : 0;
+        const newUser =
+          created > 0 && lastSignIn > 0 && Math.abs(lastSignIn - created) < 10_000;
+        const provider =
+          (user?.app_metadata as { provider?: string } | undefined)?.provider ?? "unknown";
+        track("auth_success", { new_user: newUser, provider });
+      }
       navigate("/admin", { replace: true });
     }
   }, [loading, session, navigate]);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2, Mail, Check } from "lucide-react";
 import { signInWithMagicLink, signInWithOAuth, useSession } from "@/lib/auth";
+import { track } from "@/lib/analytics";
 import { useEffect } from "react";
 
 export default function LoginPage() {
@@ -44,6 +45,7 @@ export default function LoginPage() {
       return;
     }
     setBusy("magic");
+    track("login_started", { method: "magic" });
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
@@ -57,6 +59,7 @@ export default function LoginPage() {
   async function handleOAuth(provider: "google" | "azure") {
     setError("");
     setBusy(provider);
+    track("login_started", { method: provider });
     try {
       await signInWithOAuth(provider);
       // Redirect happens via Supabase. Nothing else to do here.

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -22,6 +22,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2, Mail, Check } from "lucide-react";
 import { signInWithMagicLink, signInWithOAuth, useSession } from "@/lib/auth";
+import { track } from "@/lib/analytics";
 
 export default function SignupPage() {
   useCanonical("https://unclick.world/signup");
@@ -48,6 +49,7 @@ export default function SignupPage() {
       return;
     }
     setBusy("magic");
+    track("signup_started", { method: "magic" });
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
@@ -61,6 +63,7 @@ export default function SignupPage() {
   async function handleOAuth(provider: "google" | "azure") {
     setError("");
     setBusy(provider);
+    track("signup_started", { method: provider });
     try {
       await signInWithOAuth(provider);
     } catch (err) {


### PR DESCRIPTION
## Summary

Pageviews were already firing via the Umami snippet in `index.html`. This PR adds the first custom events so we can split traffic into signups vs logins vs returning sessions, and see which auth method people actually pick.

- Adds `src/lib/analytics.ts` — a safe `window.umami.track()` wrapper that no-ops if the snippet hasn't loaded. All failures swallowed; analytics can never break the app.
- `Signup.tsx` → `signup_started { method: "magic" | "google" | "azure" }`
- `Login.tsx` → `login_started { method: "magic" | "google" | "azure" }`
- `AuthCallback.tsx` → `auth_success { new_user, provider }`

`new_user` is inferred by comparing `session.user.created_at` with `last_sign_in_at` — if they're within 10s of each other, it's a first-time signup; otherwise it's a returning login. `auth_success` fires exactly once per callback landing, guarded by a `useRef` latch.

## Context

Companion to yesterday's Umami revival (analytics.unclick.world was down during the pooler-region debug). The analytics window during that outage is permanently lost — Umami is client-side and drops events when the server is 500'ing. From deploy onward, all three events will flow normally.

## Test plan

- [ ] Deploy preview, open /signup, click Google — confirm `signup_started {method: google}` lands in Umami
- [ ] Same with magic-link form submit — `signup_started {method: magic}`
- [ ] Magic-link round-trip on a new email — confirm `auth_success {new_user: true}`
- [ ] Sign out, sign back in with same email — confirm `auth_success {new_user: false}`
- [ ] Block `analytics.unclick.world` in DevTools network tab, repeat any flow — confirm page still works (analytics helper must no-op silently)

## What's next

Follow-ups worth tracking once these land:
- Install CTA click (funnel top)
- API key created (activation moment)
- OAuth connector connected (first productive use)
- Server-side `auth_signup` via Supabase Auth Hook (more reliable than client-inferred `new_user`, but needs paid plan or custom webhook)