### PR TITLE
feat(admin): consolidate admin menus onto single OS shell

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import ArenaProblem from "./pages/arena/ArenaProblem.tsx";
 import ArenaLeaderboard from "./pages/arena/ArenaLeaderboard.tsx";
 import ArenaSubmitProblem from "./pages/arena/ArenaSubmitProblem.tsx";
 import FAQPage from "./pages/FAQPage.tsx";
-import SettingsPage from "./pages/Settings.tsx";
 import ConnectPage from "./pages/Connect.tsx";
 import DevelopersPage from "./pages/Developers.tsx";
 import DeveloperDocsPage from "./pages/DeveloperDocs.tsx";
@@ -74,7 +73,8 @@ const App = () => (
           <Route path="/developers/docs" element={<DeveloperDocsPage />} />
           <Route path="/developers/submit" element={<DeveloperSubmitPage />} />
           <Route path="/faq" element={<FAQPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
+          {/* Legacy /settings redirects into the admin shell */}
+          <Route path="/settings" element={<Navigate to="/admin/settings" replace />} />
           {/* Platform connector flow: /connect/:platform handles both connect + OAuth callback */}
           <Route path="/connect/:platform" element={<ConnectPage />} />
           <Route path="/developers/vibe-coding" element={<VibeCodingPage />} />
@@ -107,9 +107,8 @@ const App = () => (
             <Route path="tools" element={<AdminTools />} />
             <Route path="activity" element={<AdminActivity />} />
             <Route path="settings" element={<AdminSettings />} />
+            <Route path="agents" element={<AdminAgentsPage />} />
           </Route>
-          {/* AdminAgents ships its own shell wrapper, so register it at the top level */}
-          <Route path="/admin/agents" element={<AdminAgentsPage />} />
           {/* Phase 2 auth surface */}
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -50,7 +50,7 @@ export default function AdminShell({ title, subtitle, agentCount, children }: Ad
     },
     { label: "Memory", to: "/memory/admin", icon: Brain, matchPrefix: "/memory" },
     { label: "Tools", to: "/tools", icon: Wrench, matchPrefix: "/tools" },
-    { label: "Keychain", to: "/connect/github", icon: KeyRound, matchPrefix: "/connect" },
+    { label: "Keychain (BackstagePass)", to: "/admin/keychain", icon: KeyRound, matchPrefix: "/admin/keychain" },
     { label: "Activity", to: "/dispatch", icon: Activity, matchPrefix: "/dispatch" },
     { label: "Settings", to: "/settings", icon: SettingsIcon, matchPrefix: "/settings" },
   ];

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -30,7 +30,7 @@ import {
 const surfaces = [
   { path: "/admin/you", label: "You", icon: User },
   { path: "/admin/memory", label: "Memory", icon: Brain },
-  { path: "/admin/keychain", label: "Keychain", icon: KeyRound },
+  { path: "/admin/keychain", label: "Keychain (BackstagePass)", icon: KeyRound },
   { path: "/admin/tools", label: "Tools", icon: Wrench },
   { path: "/admin/activity", label: "Activity", icon: Activity },
   { path: "/admin/settings", label: "Settings", icon: Settings },
@@ -72,7 +72,7 @@ export default function AdminShell() {
 
   return (
     <div className="flex min-h-screen bg-[#0A0A0A] text-[#ccc]">
-      {/* ── Desktop sidebar (md+) ──────────────────────────────────── */}
+      {/* ── Desktop sidebar (md+) ──────────────────────────── */}
       <aside className="fixed inset-y-0 left-0 z-40 hidden w-56 flex-col border-r border-white/[0.06] bg-[#0A0A0A] md:flex">
         <div className="flex h-14 items-center px-5">
           <Link to="/">
@@ -122,7 +122,7 @@ export default function AdminShell() {
         </div>
       </aside>
 
-      {/* ── Desktop top bar (md+) with global search ───────────────── */}
+      {/* ── Desktop top bar (md+) with global search ───────────── */}
       <header className="fixed inset-x-0 top-0 z-30 hidden h-14 items-center border-b border-white/[0.06] bg-[#0A0A0A] md:flex md:pl-56">
         <div className="flex flex-1 items-center gap-3 px-4 lg:px-8">
           <div className="flex-1">
@@ -132,7 +132,7 @@ export default function AdminShell() {
         </div>
       </header>
 
-      {/* ── Mobile/tablet top bar (<md) ────────────────────────────── */}
+      {/* ── Mobile/tablet top bar (<md) ────────────────────── */}
       <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b border-white/[0.06] bg-[#0A0A0A] px-4 md:hidden">
         <Link to="/">
           <img
@@ -185,7 +185,7 @@ export default function AdminShell() {
         </div>
       )}
 
-      {/* ── Main content ───────────────────────────────────────────── */}
+      {/* ── Main content ────────────────────────────────── */}
       <main className="min-h-screen flex-1 pt-14 md:ml-56 md:pt-14">
         <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
           <Outlet />


### PR DESCRIPTION
## Summary

- Rename sidebar label "Keychain" → "Keychain (BackstagePass)" in both admin shells
- Fix broken Keychain link in the legacy shell: `/connect/github` → `/admin/keychain`
- Migrate `/admin/agents` onto the new OS-style AdminShell (nested route + Outlet) so it matches the rest of `/admin/*`
- Redirect legacy `/settings` → `/admin/settings` and drop the orphaned Settings page import

## Why

Chris spotted two different admin menu styles (old Navbar+Footer sidebar on `/admin/agents`, new OS-shell sidebar everywhere else). Consolidating onto the OS shell so every admin surface uses the same left sidebar, same search bar, same user pill.

## Test plan

- [ ] `/admin/you`, `/admin/memory`, `/admin/keychain`, `/admin/tools`, `/admin/activity`, `/admin/settings`, `/admin/agents` all render with the dark OS shell sidebar
- [ ] Sidebar label reads "Keychain (BackstagePass)" and navigates to `/admin/keychain`
- [ ] Hitting `/settings` redirects to `/admin/settings`
- [ ] `/admin/agents` list/create flow still works (no layout regressions from removing the old AdminShell wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)