### PR TITLE
feat(keychain): expand connector catalog + add vault seed script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.local.json
 *.tsbuildinfo
 
 # Editor directories and files

--- a/scripts/seed-vault-from-plan.mjs
+++ b/scripts/seed-vault-from-plan.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Seed BackstagePass (Keychain) vault from a local plan file.
+ *
+ * Usage:
+ *   node scripts/seed-vault-from-plan.mjs [plan-file.json]
+ *
+ * The plan file is a JSON document with this shape:
+ *   {
+ *     "api_key":     "uc_...",           // the owner's UnClick API key
+ *     "api_base":    "https://unclick.world", // optional, defaults to production
+ *     "credentials": [
+ *       {
+ *         "platform":    "github",        // must match platform_connectors.id
+ *         "label":       "personal",      // optional, defaults to "default"
+ *         "values":      { "api_key": "ghp_..." }
+ *       },
+ *       {
+ *         "platform":    "google-workspace",
+ *         "values": {
+ *           "client_id":     "...apps.googleusercontent.com",
+ *           "client_secret": "GOCSPX-...",
+ *           "refresh_token": "..."
+ *         }
+ *       }
+ *     ]
+ *   }
+ *
+ * The script POSTs each entry to /api/credentials, which handles encryption
+ * server-side (AES-256-GCM with a random per-credential salt).
+ *
+ * Never commit a real plan file. Name it *.local.json so .gitignore skips it.
+ */
+
+import { readFile } from "node:fs/promises";
+import { argv, exit } from "node:process";
+
+const DEFAULT_API_BASE = "https://unclick.world";
+
+function usage(msg) {
+  if (msg) console.error(`Error: ${msg}\n`);
+  console.error("Usage: node scripts/seed-vault-from-plan.mjs <plan-file.json>");
+  exit(msg ? 1 : 0);
+}
+
+async function main() {
+  const planPath = argv[2];
+  if (!planPath) usage("missing plan file path");
+
+  let plan;
+  try {
+    const raw = await readFile(planPath, "utf8");
+    plan = JSON.parse(raw);
+  } catch (err) {
+    usage(`failed to read plan file: ${err.message}`);
+  }
+
+  const apiKey  = plan.api_key;
+  const apiBase = (plan.api_base || DEFAULT_API_BASE).replace(/\/$/, "");
+  const entries = Array.isArray(plan.credentials) ? plan.credentials : [];
+
+  if (!apiKey || !/^uc_|^agt_/.test(apiKey)) {
+    usage("plan.api_key must be a UnClick API key starting with uc_ or agt_");
+  }
+  if (entries.length === 0) usage("plan.credentials must be a non-empty array");
+
+  console.log(`Seeding ${entries.length} credential entr${entries.length === 1 ? "y" : "ies"} into ${apiBase}\n`);
+
+  let ok = 0, failed = 0;
+  for (const entry of entries) {
+    const { platform, values, label } = entry;
+    if (!platform || !values || typeof values !== "object") {
+      console.error(`  ✗ invalid entry: ${JSON.stringify(entry)}`);
+      failed++;
+      continue;
+    }
+
+    const body = {
+      platform,
+      credentials: label ? { ...values, __label: label } : values,
+      api_key:     apiKey,
+    };
+
+    try {
+      const res = await fetch(`${apiBase}/api/credentials`, {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify(body),
+      });
+
+      if (res.ok) {
+        console.log(`  ✓ ${platform}${label ? ` [${label}]` : ""}`);
+        ok++;
+      } else {
+        const text = await res.text().catch(() => "");
+        console.error(`  ✗ ${platform}: ${res.status} ${text.slice(0, 160)}`);
+        failed++;
+      }
+    } catch (err) {
+      console.error(`  ✗ ${platform}: ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log(`\nDone: ${ok} ok, ${failed} failed`);
+  exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  exit(1);
+});

--- a/scripts/seed-vault-plan.example.json
+++ b/scripts/seed-vault-plan.example.json
@@ -1,0 +1,51 @@
+{
+  "_comment": "Copy this file to seed-vault-plan.local.json and fill in real values. The .local.json suffix is gitignored.",
+  "api_key": "uc_REPLACE_ME",
+  "api_base": "https://unclick.world",
+  "credentials": [
+    {
+      "platform": "github",
+      "label":    "default",
+      "values":   { "api_key": "ghp_REPLACE" }
+    },
+    {
+      "platform": "anthropic",
+      "label":    "claude-code",
+      "values":   { "api_key": "sk-ant-api03-REPLACE" }
+    },
+    {
+      "platform": "google-gemini",
+      "values":   { "api_key": "AIzaSy_REPLACE" }
+    },
+    {
+      "platform": "google-workspace",
+      "values": {
+        "client_id":     "REPLACE.apps.googleusercontent.com",
+        "client_secret": "GOCSPX-REPLACE",
+        "refresh_token": "REPLACE"
+      }
+    },
+    {
+      "platform": "microsoft-graph",
+      "values": {
+        "tenant_id":     "REPLACE",
+        "client_id":     "REPLACE",
+        "client_secret": "REPLACE"
+      }
+    },
+    {
+      "platform": "npm",
+      "label":    "publish",
+      "values":   { "api_key": "npm_REPLACE" }
+    },
+    {
+      "platform": "supabase",
+      "values": {
+        "access_token":      "sbp_REPLACE",
+        "publishable_key":   "sb_publishable_REPLACE",
+        "secret_key":        "sb_secret_REPLACE",
+        "service_role_key":  "eyJREPLACE"
+      }
+    }
+  ]
+}

--- a/supabase/migrations/20260420020000_keychain_expand_connectors.sql
+++ b/supabase/migrations/20260420020000_keychain_expand_connectors.sql
@@ -1,0 +1,32 @@
+-- Expand BackstagePass (Keychain) connector catalog.
+-- Adds connectors that match Chris's real stack + fill obvious gaps in
+-- AI/ML, Productivity, and Developer Tools categories. All entries are
+-- idempotent via ON CONFLICT DO UPDATE so the migration is safe to re-run.
+--
+-- Sort order starts at 100 to sit cleanly after batch-o (ended at 94).
+
+INSERT INTO platform_connectors (id, name, category, auth_type, description, setup_url, test_endpoint, sort_order) VALUES
+  ('google-gemini',     'Google Gemini',     'AI/ML',            'api_key', 'Google Generative AI (Gemini) models: chat, vision, embeddings', 'https://aistudio.google.com/api-keys',                 'https://generativelanguage.googleapis.com/v1beta/models', 100),
+  ('google-workspace',  'Google Workspace',  'Productivity',     'oauth',   'Gmail, Calendar, Drive, Docs, Sheets via Google OAuth',           'https://console.cloud.google.com/apis/credentials',    'https://www.googleapis.com/oauth2/v1/tokeninfo',          101),
+  ('microsoft-graph',   'Microsoft 365',     'Productivity',     'oauth',   'Outlook, Teams, Excel, OneDrive, SharePoint via Microsoft Graph', 'https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade', 'https://graph.microsoft.com/v1.0/me',                    102),
+  ('npm',               'npm',               'Developer Tools',  'api_key', 'Publish and manage npm packages; read download stats',            'https://www.npmjs.com/settings/~/tokens',              'https://registry.npmjs.org/-/whoami',                     103),
+  ('huggingface',       'Hugging Face',      'AI/ML',            'api_key', 'Model hub, inference endpoints, datasets, and spaces',            'https://huggingface.co/settings/tokens',               'https://huggingface.co/api/whoami-v2',                    104),
+  ('openrouter',        'OpenRouter',        'AI/ML',            'api_key', 'Unified API for 100+ LLMs: chat, completions, routing',           'https://openrouter.ai/keys',                            'https://openrouter.ai/api/v1/auth/key',                   105),
+  ('replicate',         'Replicate',         'AI/ML',            'api_key', 'Run open-source models via API: image, video, audio, LLMs',       'https://replicate.com/account/api-tokens',              'https://api.replicate.com/v1/account',                    106),
+  ('elevenlabs',        'ElevenLabs',        'AI/ML',            'api_key', 'Realistic AI voice generation, cloning, and dubbing',             'https://elevenlabs.io/app/settings/api-keys',           'https://api.elevenlabs.io/v1/user',                       107),
+  ('deepgram',          'Deepgram',          'AI/ML',            'api_key', 'Speech-to-text, TTS, and real-time audio transcription',          'https://console.deepgram.com/project/default/api-keys', 'https://api.deepgram.com/v1/projects',                    108),
+  ('hubspot',           'HubSpot',           'Business',         'api_key', 'CRM: contacts, companies, deals, tickets, and marketing',         'https://app.hubspot.com/settings/account/api',          'https://api.hubapi.com/account-info/v3/details',          109),
+  ('clerk',             'Clerk',             'Developer Tools',  'api_key', 'User auth: session management, user lists, magic links',          'https://dashboard.clerk.com/last-active?path=api-keys', 'https://api.clerk.com/v1/users?limit=1',                  110),
+  ('auth0',             'Auth0',             'Developer Tools',  'api_key', 'Identity platform: users, roles, rules, and log streams',         'https://manage.auth0.com/dashboard',                    'https://{tenant}.auth0.com/api/v2/users?per_page=1',      111),
+  ('asana',             'Asana',             'Productivity',     'api_key', 'Projects, tasks, workspaces, and teams in Asana',                 'https://app.asana.com/0/my-apps',                       'https://app.asana.com/api/1.0/users/me',                  112),
+  ('trello',            'Trello',            'Productivity',     'api_key', 'Boards, lists, cards, and members in Trello',                      'https://trello.com/app-key',                            'https://api.trello.com/1/members/me',                     113),
+  ('intercom',          'Intercom',          'Business',         'api_key', 'Customer messaging: conversations, contacts, and articles',       'https://app.intercom.com/a/apps/_/settings/developers', 'https://api.intercom.io/me',                              114),
+  ('planetscale',       'PlanetScale',       'Developer Tools',  'api_key', 'Serverless MySQL: databases, branches, deploy requests',          'https://app.planetscale.com/user/settings/tokens',      'https://api.planetscale.com/v1/organizations',            115)
+ON CONFLICT (id) DO UPDATE SET
+  name          = EXCLUDED.name,
+  category      = EXCLUDED.category,
+  auth_type     = EXCLUDED.auth_type,
+  description   = EXCLUDED.description,
+  setup_url     = EXCLUDED.setup_url,
+  test_endpoint = EXCLUDED.test_endpoint,
+  sort_order    = EXCLUDED.sort_order;


### PR DESCRIPTION
## Summary

- Adds **16 new connectors** to the BackstagePass catalog: `google-gemini`, `google-workspace`, `microsoft-graph`, `npm`, `huggingface`, `openrouter`, `replicate`, `elevenlabs`, `deepgram`, `hubspot`, `clerk`, `auth0`, `asana`, `trello`, `intercom`, `planetscale`
- Catalog migration is idempotent (`ON CONFLICT DO UPDATE`), safe to re-run
- New `scripts/seed-vault-from-plan.mjs` — Node script that bulk-POSTs credentials to `/api/credentials` from a local plan file, so you don't have to click through `/connect/*` pages one by one
- `.gitignore` now also excludes `*.local.json` so real plan files never hit git
- `scripts/seed-vault-plan.example.json` committed as the template

## Why

Two parts:
1. **Catalog** — Chris's real stack (Google Gemini, Google Workspace OAuth, Microsoft Graph, npm publishing) wasn't in the connector registry, so those credentials had nowhere to live.
2. **Seed script** — populating a vault via UI is one-credential-at-a-time. The script turns it into `node scripts/seed-vault-from-plan.mjs my-plan.local.json`.

## Test plan

- [ ] `/admin/keychain` lists the 16 new connectors after the migration runs
- [ ] `node scripts/seed-vault-from-plan.mjs scripts/seed-vault-plan.example.json` fails cleanly with "uc_REPLACE_ME" validation message
- [ ] With a real local plan file, script POSTs succeed (HTTP 200) and `/admin/keychain` shows stored credentials for each platform
- [ ] `git check-ignore scripts/foo.local.json` returns exit 0 (gitignore works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)