### PR TITLE
feat: add umami.track() calls for customer stats

### DIFF
--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -28,6 +28,20 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     if (!loading && session) {
+      const user = session.user;
+      const provider = user.app_metadata?.provider ?? "unknown";
+      const method = provider === "email" ? "magic_link" : provider;
+      const createdAt = user.created_at ? new Date(user.created_at).getTime() : 0;
+      const isNewUser = createdAt > 0 && Date.now() - createdAt < 60_000;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const track = (window as any).umami?.track;
+      if (track) {
+        if (isNewUser) {
+          track("new_user_signup", { method, email: user.email });
+        } else {
+          track("returning_user_signin", { method });
+        }
+      }
       navigate("/admin", { replace: true });
     }
   }, [loading, session, navigate]);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -47,6 +47,8 @@ export default function LoginPage() {
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).umami?.track("signin", { method: "magic_link" });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong. Try again.");
     } finally {
@@ -57,6 +59,8 @@ export default function LoginPage() {
   async function handleOAuth(provider: "google" | "azure") {
     setError("");
     setBusy(provider);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).umami?.track("signin", { method: provider });
     try {
       await signInWithOAuth(provider);
       // Redirect happens via Supabase. Nothing else to do here.

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -51,6 +51,8 @@ export default function SignupPage() {
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).umami?.track("signup", { method: "magic_link" });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong. Try again.");
     } finally {
@@ -61,6 +63,8 @@ export default function SignupPage() {
   async function handleOAuth(provider: "google" | "azure") {
     setError("");
     setBusy(provider);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).umami?.track("signup", { method: provider });
     try {
       await signInWithOAuth(provider);
     } catch (err) {


### PR DESCRIPTION
Closes #48 (partial -- see scope notes below).

## What this does

Adds `umami.track()` calls at the two main conversion points in the auth flow so the Umami Cohorts, Segments, and Attribution panels start receiving data.

Umami is already loaded globally in `index.html` via `analytics.unclick.world/script.js`. No script tag changes needed.

## Events instrumented

| Event | Where | Trigger |
|-------|-------|---------|
| `signup` `{ method: "magic_link" }` | `Signup.tsx` | Magic link request accepted by Supabase |
| `signup` `{ method: "google" \| "azure" }` | `Signup.tsx` | OAuth flow initiated from /signup |
| `signin` `{ method: "magic_link" }` | `Login.tsx` | Magic link request accepted by Supabase |
| `signin` `{ method: "google" \| "azure" }` | `Login.tsx` | OAuth flow initiated from /login |

## Files changed

- `src/pages/Signup.tsx` -- 4 lines added (2 events)
- `src/pages/Login.tsx` -- 4 lines added (2 events)

## Scope decisions for Chris to confirm

**signup vs signin distinction:** Supabase magic links do not distinguish new users from returning users at the form submission layer -- both end up at `/auth/callback` where a session is created. Tracking fires from the page the user was on (`/signup` fires `signup`, `/login` fires `signin`). This is intent-based, not guaranteed-new-user. Discuss: should we detect new users in `AuthCallback.tsx` using `session.user.created_at` vs `last_sign_in_at`? Happy to add that in a follow-up if useful.

**plan_upgrade event:** No frontend upgrade flow exists yet (Pricing page CTAs go to `#install`, Settings plan section is "Coming soon"). This event has no place to live. Will add when the Stripe checkout or upgrade modal is built.

**tool_call event:** The Arena pages are problem-submission surfaces, not tool-API-call surfaces. Instrumenting actual tool calls would require auditing `src/pages/tools/` and the MCP/arena invocation path. Not straightforward -- left out of scope per the original brief.

## Implementation note

Uses `(window as any).umami?.track(...)` with optional chaining so it is a no-op if the script has not loaded (e.g. ad-blocked). The `eslint-disable` comments suppress the explicit-any lint rule inline.

## Test plan

- [ ] Visit `/signup`, submit a valid email. Confirm `signup` event appears in Umami dashboard under Events.
- [ ] Visit `/signup`, click Continue with Google. Confirm `signup` event fires before redirect.
- [ ] Visit `/login`, submit a valid email. Confirm `signin` event appears.
- [ ] Visit `/login`, click Continue with Google. Confirm `signin` event fires before redirect.
- [ ] Block analytics.unclick.world in browser devtools. Confirm no JS errors thrown.

**Do NOT merge until Chris reviews.**

---

## Update 2026-04-21: new-user detection added

Added commit `102ab06` on top of `6054797` to address the "intent-based vs guaranteed-new-user" scope note above. Now `AuthCallback.tsx` also emits a second layer of events based on `session.user.created_at`:

| Event | When |
|-------|------|
| `new_user_signup` `{ method, email }` | `created_at` within last 60s (new user on first callback) |
| `returning_user_signin` `{ method }` | `created_at` older than 60s |

`method` is derived from `session.user.app_metadata.provider` ("email" is mapped to "magic_link"; "google"/"azure" pass through). The existing page-intent events (`signup`/`signin` from /signup and /login) remain in place; these are a different telemetry layer that reflect the actual auth outcome rather than the page the user started from.
