### PR TITLE
fix(backstagepass): timing-safe proof-of-possession + per-credential auto-clear timer

### DIFF
--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -21,9 +21,11 @@
  * that decrypts or re-encrypts. List and metadata-only update (label
  * change) only need factor 1.
  *
- * Every action writes a row to `backstagepass_audit` — success or
- * failure. Failed reveals are especially worth logging because they
- * are the primary signal of a compromised session.
+ * The mutating actions (reveal, update, delete) write a row to
+ * `backstagepass_audit` on success or failure. The read-only actions
+ * (list, audit) do not write audit rows to avoid log spam. Failed
+ * reveals are especially worth logging because they are the primary
+ * signal of a compromised session.
  *
  * CORS is strict — unclick.world only. Admin surface should never
  * talk to this from a preview/3p origin.
@@ -67,6 +69,18 @@ const SALT_BYTES        = 32;
 
 function sha256hex(input: string): string {
   return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+// Constant-time comparison of two equal-length hex-encoded hashes.
+// Used for proof-of-possession checks so callers cannot learn the
+// stored hash via response timing.
+function hashesEqual(aHex: string, bHex: string): boolean {
+  if (aHex.length !== bHex.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(aHex, "hex"), Buffer.from(bHex, "hex"));
+  } catch {
+    return false;
+  }
 }
 
 function deriveKey(apiKey: string, salt: Buffer): Buffer {
@@ -351,7 +365,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Proof-of-possession: the submitted api_key must hash to the same
     // value stored for this user. Prevents a session hijack from
     // converting directly into a plaintext credential dump.
-    if (sha256hex(apiKey) !== tenant.apiKeyHash) {
+    if (!hashesEqual(sha256hex(apiKey), tenant.apiKeyHash)) {
       await writeAudit({
         supabaseUrl, serviceRoleKey, tenant, req,
         action: "reveal", credentialId: id, success: false,
@@ -446,7 +460,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (!apiKey) {
         return res.status(400).json({ error: "api_key is required to change credential values." });
       }
-      if (sha256hex(apiKey) !== tenant.apiKeyHash) {
+      if (!hashesEqual(sha256hex(apiKey), tenant.apiKeyHash)) {
         await writeAudit({
           supabaseUrl, serviceRoleKey, tenant, req,
           action: "update_values", credentialId: id, success: false,

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -23,7 +23,7 @@
  * Backend: /api/backstagepass?action={list,reveal,update,delete,audit}
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "@/lib/auth";
 import {
   AlertTriangle,
@@ -117,6 +117,13 @@ export default function AdminKeychain() {
   // we keep plaintext here until they hide it or the auto-clear timer
   // fires. Never persisted anywhere.
   const [revealed, setRevealed]       = useState<Record<string, Record<string, string>>>({});
+  // Per-credential reveal timestamp (ms since epoch). Used by the single
+  // interval below to auto-clear an entry exactly 60s after it was
+  // revealed, independent of any other reveal or hide happening in
+  // between.
+  const [revealedAt, setRevealedAt]   = useState<Record<string, number>>({});
+  const revealedAtRef                 = useRef<Record<string, number>>({});
+  revealedAtRef.current               = revealedAt;
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [revealError, setRevealError] = useState<Record<string, string>>({});
   const [revealing, setRevealing]     = useState<Record<string, boolean>>({});
@@ -157,21 +164,32 @@ export default function AdminKeychain() {
 
   useEffect(() => { void fetchList(); }, [fetchList]);
 
-  // Auto-clear revealed plaintext after 60s per row. We track a set of
-  // scheduled timeouts so hiding a row manually cancels its timer.
+  // Auto-clear revealed plaintext 60s after each individual reveal.
+  // A single interval reads the latest revealedAt map via ref and
+  // evicts entries whose absolute timestamp has aged past 60s. This
+  // avoids the previous bug where revealing a second credential would
+  // reset the timer for an already-revealed one.
   useEffect(() => {
-    const timers: number[] = [];
-    for (const id of Object.keys(revealed)) {
-      const t = window.setTimeout(() => {
-        setRevealed((prev) => {
-          const { [id]: _gone, ...rest } = prev;
-          return rest;
-        });
-      }, 60_000);
-      timers.push(t);
-    }
-    return () => { for (const t of timers) window.clearTimeout(t); };
-  }, [revealed]);
+    const intervalId = window.setInterval(() => {
+      const now = Date.now();
+      const expired: string[] = [];
+      for (const [id, at] of Object.entries(revealedAtRef.current)) {
+        if (now - at >= 60_000) expired.push(id);
+      }
+      if (expired.length === 0) return;
+      setRevealed((prev) => {
+        const next = { ...prev };
+        for (const id of expired) delete next[id];
+        return next;
+      });
+      setRevealedAt((prev) => {
+        const next = { ...prev };
+        for (const id of expired) delete next[id];
+        return next;
+      });
+    }, 5_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
 
   async function handleReveal(cred: Credential) {
     const apiKey = readLocalApiKey();
@@ -193,6 +211,7 @@ export default function AdminKeychain() {
       const body = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(body.error ?? `Reveal failed with ${res.status}`);
       setRevealed((p) => ({ ...p, [cred.id]: body.values ?? {} }));
+      setRevealedAt((p) => ({ ...p, [cred.id]: Date.now() }));
     } catch (err) {
       setRevealError((p) => ({
         ...p,
@@ -205,6 +224,10 @@ export default function AdminKeychain() {
 
   function handleHide(cred: Credential) {
     setRevealed((p) => {
+      const { [cred.id]: _gone, ...rest } = p;
+      return rest;
+    });
+    setRevealedAt((p) => {
       const { [cred.id]: _gone, ...rest } = p;
       return rest;
     });


### PR DESCRIPTION
Phase 2 fixes for the BackstagePass cluster. Addresses three concerns from the Phase 1 findings posted on #46.

Phase 1 reference: https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/46#issuecomment-4285294094

## Changes

### 1. `api/backstagepass.ts`: timing-safe proof-of-possession

Both the `reveal` path (previously ~line 265) and the `update_values` path (~line 335) compared `sha256hex(apiKey) !== tenant.apiKeyHash` with plain JS `!==`. String inequality short-circuits on the first differing byte. Replaced with a new `hashesEqual` helper that wraps `crypto.timingSafeEqual` after hex-decoding both sides:

```typescript
function hashesEqual(aHex: string, bHex: string): boolean {
  if (aHex.length !== bHex.length) return false;
  try {
    return crypto.timingSafeEqual(Buffer.from(aHex, "hex"), Buffer.from(bHex, "hex"));
  } catch {
    return false;
  }
}
```

Practical exploitability was low (both sides are SHA-256 hashes, comparison happens server-side under network jitter) but this removes the bad practice before the endpoint handles higher-value credentials.

### 2. `src/pages/admin/AdminKeychain.tsx`: per-credential auto-clear timer

The previous `useEffect` depended on the entire `revealed` map, so React re-ran it on every reveal or hide. In the cleanup phase it cleared all timers, then in the body it scheduled fresh 60-second timers for every currently-revealed credential. Net effect: revealing a second credential reset the clear deadline of the first one.

New approach: store an absolute `revealedAt[id]` timestamp at reveal time. A single `setInterval` (5s tick) reads the latest map via a ref and evicts any entry whose `Date.now() - revealedAt[id] >= 60_000`. The worst-case over-reveal is 65s (reveal right before a tick), which is well within acceptable security bounds and fixes the original unbounded-slide bug.

### 3. `api/backstagepass.ts` header comment

The file header claimed "Every action writes a row to `backstagepass_audit`" which was inaccurate. `list` and `audit` GETs do not call `writeAudit` by design (spam avoidance). Updated the header to explicitly list reveal/update/delete as audited and list/audit as not.

## Files changed

- `api/backstagepass.ts` -- 24 lines net (timing-safe helper, two call site changes, header comment)
- `src/pages/admin/AdminKeychain.tsx` -- 53 lines net (ref + state + interval + handleReveal/handleHide updates)

## Out of scope for this PR

The `api/memory-admin.ts` any-casts item from the Phase 1 findings is intentionally excluded. Per the directive on #47 that item needs its own written plan posted as a comment before any code changes.

## Test plan

- [ ] Reveal credential A. Wait 30s. Reveal credential B. Confirm A disappears ~30s later (not 60s later).
- [ ] Reveal credential A. Hide it manually. Confirm it disappears immediately and no stale timer fires.
- [ ] Submit a wrong `api_key` to `reveal` from a local client. Confirm 403 returned with same timing regardless of which byte of the hash differs (tighter invariant than before; not directly measurable but the code path is now timing-safe).
- [ ] CI `Website (root package)` stays green.

**Do NOT merge until Chris reviews.**