### PR TITLE
fix(credentials): add PG15+ requirement note to NULLS NOT DISTINCT migration

### DIFF
--- a/supabase/migrations/20260420040000_user_credentials_label.sql
+++ b/supabase/migrations/20260420040000_user_credentials_label.sql
@@ -1,3 +1,10 @@
+-- REQUIRES POSTGRES 15+ (uses NULLS NOT DISTINCT on the unique index below).
+-- Supabase production has been PG15+ since late 2023, so this is safe in
+-- prod and in any recent Supabase hosted project. Local developers running
+-- an older Supabase CLI against a PG14 or earlier instance will get a
+-- syntax error at the CREATE UNIQUE INDEX statement. Upgrade PG or update
+-- the CLI image.
+--
 -- Extend user_credentials with an optional `label` column so a single user
 -- can store multiple credentials for the same platform (e.g. two Anthropic
 -- keys: one for claude-code, one for bailey-plex-3).


### PR DESCRIPTION
Phase 2 fix for the Credentials vault cluster. Addresses the one concern from the Phase 1 findings posted on #47.

Phase 1 reference: https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/47#issuecomment-4285294820

## Changes

`supabase/migrations/20260420040000_user_credentials_label.sql`: adds a top-of-file note that the migration requires Postgres 15+ due to the `NULLS NOT DISTINCT` clause on the unique index. Existing body comment already mentioned PG15+ in passing on line 12, but it is buried inside the uniqueness explanation and easy to miss when a dev is debugging a `supabase db push` failure.

Prod is unaffected (Supabase hosted has been PG15+ since late 2023). Only impact is improved dev-environment clarity.

## Files changed

- `supabase/migrations/20260420040000_user_credentials_label.sql` -- 7 lines added (one header block, no logic change)

## Test plan

- [ ] Run `supabase db push` against the existing prod DB. Should be a no-op (migration already applied). No new behavior.
- [ ] Fresh local reset (`supabase db reset`) against a PG15+ instance. Migration applies cleanly.
- [ ] Optional: try on a PG14 instance. Confirm the error message now has a clear upgrade hint in the migration comments.

**Do NOT merge until Chris reviews.**