### PR TITLE
feat(stripe): minimal webhook handler scaffold + SDK install

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -24,6 +24,15 @@ ADMIN_NOTIFICATION_EMAIL=your-admin-email@example.com
 UMAMI_WEBSITE_ID=your-umami-website-id-here
 UMAMI_URL=https://analytics.unclick.world
 
+# Stripe (test mode for now).
+# Dashboard > Developers > API keys for the sk_/pk_ pair.
+# Dashboard > Developers > Webhooks for the whsec_ signing secret.
+# Also add all three to Vercel: Settings > Environment Variables.
+# Never commit the values, only the variable names.
+STRIPE_SECRET_KEY=sk_test_your_secret_key_here
+STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret_here
+
 # Supabase table setup -- run this SQL in the Supabase SQL Editor:
 #
 # CREATE TABLE api_keys (

--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -1,0 +1,91 @@
+/**
+ * UnClick Stripe webhook handler
+ *
+ * Vercel serverless function at POST /api/stripe/webhook.
+ *
+ * Scope (scaffold only):
+ *   1. Verify the Stripe-Signature header using the shared whsec_ secret.
+ *   2. Log the verified event type and id.
+ *   3. Return 200 so Stripe does not retry.
+ *
+ * Out of scope (follow-up work):
+ *   - Writing subscription / invoice / payment events to Supabase.
+ *   - Idempotency store keyed by Stripe event id.
+ *   - Customer portal, Checkout, Connect onboarding.
+ *
+ * Required env vars (set in Vercel: Settings > Environment Variables):
+ *   STRIPE_SECRET_KEY       - sk_test_... or sk_live_...
+ *   STRIPE_WEBHOOK_SECRET   - whsec_... from the dashboard webhook config
+ *
+ * Note on bodyParser: Stripe signature verification requires the raw
+ * request body. Vercel's default JSON body parser would mutate the
+ * bytes, so we disable it here and read the stream ourselves.
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import Stripe from "stripe";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function readRawBody(req: VercelRequest): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+  }
+  return Buffer.concat(chunks);
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const stripeKey     = process.env.STRIPE_SECRET_KEY;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!stripeKey || !webhookSecret) {
+    console.error("[stripe-webhook] missing STRIPE_SECRET_KEY or STRIPE_WEBHOOK_SECRET");
+    res.status(500).json({ error: "Server not configured" });
+    return;
+  }
+
+  const sig = req.headers["stripe-signature"];
+  if (typeof sig !== "string") {
+    res.status(400).json({ error: "Missing stripe-signature header" });
+    return;
+  }
+
+  let raw: Buffer;
+  try {
+    raw = await readRawBody(req);
+  } catch (err) {
+    console.error("[stripe-webhook] failed to read request body:", err);
+    res.status(400).json({ error: "Failed to read request body" });
+    return;
+  }
+
+  const stripe = new Stripe(stripeKey);
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(raw, sig, webhookSecret);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    console.error("[stripe-webhook] signature verification failed:", message);
+    res.status(400).json({ error: "Signature verification failed" });
+    return;
+  }
+
+  // Scaffold: log the verified event and ack. Handlers for specific event
+  // types (subscription lifecycle, invoices, checkout completion) land in
+  // follow-up PRs once the Supabase tables for billing state exist.
+  console.log(`[stripe-webhook] received ${event.type} (id=${event.id})`);
+  res.status(200).json({ received: true, type: event.type, id: event.id });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "recharts": "^2.15.4",
         "remark-gfm": "^4.0.1",
         "sonner": "^1.7.4",
+        "stripe": "^17.7.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.9",
@@ -13440,6 +13441,19 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
     },
     "node_modules/strnum": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "recharts": "^2.15.4",
     "remark-gfm": "^4.0.1",
     "sonner": "^1.7.4",
+    "stripe": "^17.7.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",


### PR DESCRIPTION
Scaffolds the Stripe integration surface for UnClick billing in test mode. Zero product logic, just the plumbing.

## What this builds

1. **`api/stripe/webhook.ts`** -- Vercel serverless handler at `POST /api/stripe/webhook`. Disables the default JSON body parser so the raw bytes survive for signature verification, then calls `stripe.webhooks.constructEvent(raw, sig, secret)` with the `STRIPE_WEBHOOK_SECRET`. On a valid signature it logs `event.type` and `event.id` and returns 200. On a bad signature or missing env it returns 4xx / 500.
2. **`stripe@^17`** added to `package.json` dependencies. Latest stable major.
3. **`package-lock.json`** regenerated via `npm install --package-lock-only` so GitHub Actions `npm ci` and Vercel installs stay in sync. This follows the lesson from the `@vercel/node` lockfile incident earlier today -- never edit `package.json` via raw file write without regenerating the lockfile.
4. **`.env.local.example`** updated with three new variable NAMES only: `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`. No values in source control.

## What this does NOT do

- No event-type handlers. The webhook just logs and acks today. Subscription lifecycle, invoice events, and checkout completion get dedicated follow-up PRs once the Supabase billing tables exist.
- No idempotency. Stripe guarantees at-least-once delivery; we need an events-seen table keyed by `event.id` before we start mutating state.
- No Stripe Connect. Connect onboarding has compliance implications (KYC, payouts, 1099s) that are worth discussing before wiring. Left entirely for a separate conversation.
- No Checkout, no customer portal, no tax, no products beyond the scaffold one.
- No frontend integration. The `pk_test_` publishable key isn't used yet.

## Stripe test-mode objects created out-of-band

Objects live in the `acct_1TOTRWANilNNkc6j` (Malamute Mayhem sandbox) test ledger. IDs only, no secret values:

| Kind | ID | Notes |
|------|-----|------|
| Product | `prod_UNE9qlCyTNi87t` | "UnClick API Usage" |
| Price | `price_1TOThMANilNNkc6jelEGGUma` | Flat $1.00 USD/mo recurring. Scaffold only. Metered pricing now requires the new Stripe Meters API; deferred to a billing-design follow-up. |
| Webhook | `we_1TOThQANilNNkc6jQk3VgnPK` | Points at `https://unclick.world/api/stripe/webhook`, subscribed to 8 events (payment_intent succeeded/failed, subscription created/updated/deleted, invoice paid/payment_failed, checkout.session.completed). |

## Files changed

- `api/stripe/webhook.ts` -- new (91 lines)
- `package.json` -- +1 line (stripe dep)
- `package-lock.json` -- regenerated (+1601 net, auto-generated)
- `.env.local.example` -- +9 lines (three variable names + docs)

## Function count check

Adds one new Vercel function (`api/stripe/webhook.ts`). Repo will be at 15 out of the Pro plan's 100-function ceiling. Safe headroom.

## Test plan

- [ ] Confirm CI `npm ci` passes now that the lockfile is in sync with `package.json`.
- [ ] Once env vars are set in Vercel (see follow-up comment), trigger a test event from the Stripe dashboard (Developers > Webhooks > the webhook > Send test event). Should see 200 response and the event logged in Vercel runtime logs.
- [ ] Send a test event with a tampered signature. Should see 400.

**Do NOT merge until Chris reviews.**