### PR TITLE
feat(mcp): emit umami tool_call event on every MCP tool invocation

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,6 +13,17 @@ RESEND_API_KEY=re_your_api_key_here
 # Also add this to Vercel: Settings > Environment Variables > ADMIN_NOTIFICATION_EMAIL
 ADMIN_NOTIFICATION_EMAIL=your-admin-email@example.com
 
+# Umami (self-hosted) for server-side tool-usage analytics.
+# UMAMI_WEBSITE_ID: the id from the site's Umami tracking snippet in
+#   index.html (the data-website-id attribute). When set, every MCP
+#   tool invocation fires a fire-and-forget "tool_call" event to Umami.
+#   Leave blank to disable server-side tracking (dev / local).
+# UMAMI_URL: optional, defaults to https://analytics.unclick.world. Set
+#   if you point at a different Umami instance (e.g. staging).
+# Also add the website id to Vercel: Settings > Environment Variables.
+UMAMI_WEBSITE_ID=your-umami-website-id-here
+UMAMI_URL=https://analytics.unclick.world
+
 # Supabase table setup -- run this SQL in the Supabase SQL Editor:
 #
 # CREATE TABLE api_keys (

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -10,6 +10,41 @@ import { ADDITIONAL_TOOLS, ADDITIONAL_HANDLERS } from "./tool-wiring.js";
 import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
 
+// ─── Umami tool-usage tracking ──────────────────────────────────────────────
+//
+// Fires a fire-and-forget event to the self-hosted Umami instance every time
+// an agent actually invokes a tool. Lets Chris see which tools get used.
+// No-ops silently if UMAMI_WEBSITE_ID is not set (e.g. dev / local runs).
+// Never awaited so it cannot slow or break a tool call even if Umami is down.
+function trackToolCall(toolName: string): void {
+  const websiteId = process.env.UMAMI_WEBSITE_ID;
+  if (!websiteId) return;
+  const umamiUrl = process.env.UMAMI_URL ?? "https://analytics.unclick.world";
+  try {
+    void fetch(`${umamiUrl}/api/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "unclick-mcp-server/1.0",
+      },
+      body: JSON.stringify({
+        type: "event",
+        payload: {
+          website:  websiteId,
+          hostname: "unclick.world",
+          url:      "/api/mcp",
+          name:     "tool_call",
+          data:     { tool_name: toolName },
+        },
+      }),
+    }).catch(() => {
+      // swallow network / TLS errors
+    });
+  } catch {
+    // swallow synchronous errors (e.g. malformed env)
+  }
+}
+
 // ─── Search helper ──────────────────────────────────────────────────────────
 
 function searchTools(query: string, category?: string): ToolDef[] {
@@ -682,6 +717,9 @@ export function createServer(): Server {
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: rawArgs } = request.params;
     const args = (rawArgs ?? {}) as Record<string, unknown>;
+
+    // Fire-and-forget Umami event for tool-usage stats. Never awaited.
+    trackToolCall(name);
 
     try {
       // ── UnClick Memory (direct tools + memory.* endpoints) ───────


### PR DESCRIPTION
Server-side `tool_call` tracking so Chris can see which UnClick tools actually get used.

## Instrumentation point

`packages/mcp-server/src/server.ts` -- the MCP `CallToolRequestSchema` handler at line 682. This is the canonical dispatch point for every agent tool call, regardless of which MCP client the user is on (Claude Desktop, Claude Code, ChatGPT Connectors, Cowork, any MCP-compliant agent). Instrumenting once here captures 100% of real-usage volume.

`tool_name` is already in the MCP request payload (`request.params.name`), so no extra lookup needed. The call sits at the top of the handler, before any routing, so it fires even for unknown or deprecated tool names (useful for noticing misfires).

## Trade-off: server-side vs client-side

| Approach | Captures | Trade-off |
|---|---|---|
| **Server-side at MCP handler (chosen)** | Every agent tool invocation across every client | Requires a direct `fetch` to Umami's `/api/send` endpoint. Adds a fire-and-forget outbound request per tool call. |
| Client-side `umami.track` from the site | Only users interacting with the unclick.world UI | Misses agent-driven calls, which are the actual volume. |

Client-side was rejected because browsing the Tools catalog on the site is a fundamentally different signal from agents actually invoking tools. Chris asked for usage stats, not discovery stats.

## Fire-and-forget semantics

The `trackToolCall` helper is wrapped in layers so a misbehaving Umami cannot touch the tool call's latency or success:

1. Call site is `trackToolCall(name)` with no `await`.
2. Inside, the `fetch(...)` is `void`-prefixed and has a `.catch(() => {})` attached so network / TLS failures are silently dropped.
3. An outer `try { } catch { }` guards against synchronous errors (bad env, JSON stringify issues, etc).
4. If `UMAMI_WEBSITE_ID` is unset, the function returns immediately with zero side effects. Dev / local stdio runs get no tracking by default.

## New env vars

Added to `.env.local.example` and need to be mirrored into Vercel Settings > Environment Variables:

- `UMAMI_WEBSITE_ID` (required for tracking to fire). This is the `data-website-id` value from the script tag in `index.html`. Same id, reused server-side so events group with the existing client-side events in the Umami dashboard.
- `UMAMI_URL` (optional, defaults to `https://analytics.unclick.world`). Override only if pointing at a different instance (staging, local dev).

No secret values needed. The website id is already public (it ships in the client HTML).

## Files changed

- `packages/mcp-server/src/server.ts` -- +38 lines (trackToolCall helper + one-line call site)
- `.env.local.example` -- +11 lines (doc + two variable names)

## Test plan

- [ ] Set `UMAMI_WEBSITE_ID` in Vercel. Redeploy.
- [ ] From Claude Desktop or any MCP client, invoke `load_memory` or similar. Confirm a `tool_call` event appears in the Umami dashboard with `data.tool_name = "load_memory"`.
- [ ] Temporarily misconfigure `UMAMI_URL` to a dead host. Invoke a tool. Confirm the tool call still succeeds and the error was swallowed (no 5xx, no slow response).
- [ ] Unset `UMAMI_WEBSITE_ID`. Invoke a tool. Confirm no outbound network activity.

**Do NOT merge until Chris reviews.**