### PR TITLE
feat(backstagepass): add testConnection action + Test button in AdminKeychain

### DIFF
--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -102,6 +102,44 @@ function decrypt(
   ]).toString("utf8");
 }
 
+// ─── Connection probes ───────────────────────────────────────────────────
+//
+// Lightweight authenticated GET per platform. The action=testConnection
+// handler decrypts the stored credential, looks up the probe by platform
+// slug, and makes one outbound request with a short timeout. Only a small
+// curated set is supported initially. Platforms not in the map return an
+// "untestable" response (ok=null) rather than throwing.
+//
+// To add a new platform: identify a cheap authenticated read endpoint on
+// that provider (typically /me, /user, /models, /whoami) and add an entry
+// here. Keep the request boring: GET, minimal headers, no body.
+const PLATFORM_PROBES: Record<string, {
+  url:           string;
+  buildHeaders: (values: Record<string, string>) => Record<string, string>;
+}> = {
+  github: {
+    url: "https://api.github.com/user",
+    buildHeaders: (v) => ({
+      Authorization: `Bearer ${v.api_key ?? v.token ?? ""}`,
+      Accept:        "application/vnd.github+json",
+      "User-Agent":  "unclick-backstagepass",
+    }),
+  },
+  anthropic: {
+    url: "https://api.anthropic.com/v1/models",
+    buildHeaders: (v) => ({
+      "x-api-key":         v.api_key ?? "",
+      "anthropic-version": "2023-06-01",
+    }),
+  },
+  openai: {
+    url: "https://api.openai.com/v1/models",
+    buildHeaders: (v) => ({
+      Authorization: `Bearer ${v.api_key ?? ""}`,
+    }),
+  },
+};
+
 // ─── Supabase REST helper ────────────────────────────────────────
 
 function supaHeaders(serviceRoleKey: string): Record<string, string> {
@@ -416,6 +454,109 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       label:    (row.label as string) ?? null,
       values,
     });
+  }
+
+  if (action === "testConnection") {
+    const id     = typeof body.id === "string" ? body.id : "";
+    const apiKey = typeof body.api_key === "string" ? body.api_key : "";
+    if (!id)     return res.status(400).json({ error: "id is required." });
+    if (!apiKey) return res.status(400).json({ error: "api_key is required." });
+
+    if (sha256hex(apiKey) !== tenant.apiKeyHash) {
+      await writeAudit({
+        supabaseUrl, serviceRoleKey, tenant, req,
+        action: "test_connection", credentialId: id, success: false,
+        metadata: { reason: "api_key_mismatch" },
+      });
+      return res.status(403).json({ error: "UnClick API key does not match the signed-in user." });
+    }
+
+    const row = await fetchOwnedRow(id);
+    if (!row) {
+      await writeAudit({
+        supabaseUrl, serviceRoleKey, tenant, req,
+        action: "test_connection", credentialId: id, success: false,
+        metadata: { reason: "not_found" },
+      });
+      return res.status(404).json({ error: "Credential not found." });
+    }
+
+    const platform = row.platform_slug as string;
+    const probe = PLATFORM_PROBES[platform];
+    if (!probe) {
+      await writeAudit({
+        supabaseUrl, serviceRoleKey, tenant, req,
+        action: "test_connection", credentialId: id,
+        platformSlug: platform, label: (row.label as string) ?? null,
+        success: false, metadata: { reason: "platform_untestable" },
+      });
+      return res.status(200).json({
+        ok:         null,
+        platform,
+        tested_at:  new Date().toISOString(),
+        message:    `Connection testing is not yet supported for ${platform}.`,
+      });
+    }
+
+    let values: Record<string, string>;
+    try {
+      const salt = Buffer.from(row.encryption_salt as string, "hex");
+      const key  = deriveKey(apiKey, salt);
+      const pt   = decrypt(
+        row.encryption_iv  as string,
+        row.encryption_tag as string,
+        row.encrypted_data as string,
+        key,
+      );
+      values = JSON.parse(pt) as Record<string, string>;
+    } catch {
+      await writeAudit({
+        supabaseUrl, serviceRoleKey, tenant, req,
+        action: "test_connection", credentialId: id,
+        platformSlug: platform, label: (row.label as string) ?? null,
+        success: false, metadata: { reason: "decrypt_failed" },
+      });
+      return res.status(500).json({ error: "Failed to decrypt credential." });
+    }
+
+    const testedAt = new Date().toISOString();
+    let ok = false;
+    let status = 0;
+    let message = "";
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 5_000);
+      const probeRes = await fetch(probe.url, {
+        method:  "GET",
+        headers: probe.buildHeaders(values),
+        signal:  controller.signal,
+      });
+      clearTimeout(timer);
+      status  = probeRes.status;
+      ok      = probeRes.ok;
+      message = ok ? "Authenticated request succeeded." : `Platform returned ${probeRes.status}.`;
+    } catch (err) {
+      message = err instanceof Error && err.name === "AbortError"
+        ? "Probe timed out after 5s."
+        : `Probe failed: ${err instanceof Error ? err.message : "unknown error"}`;
+    }
+
+    // Touch last_tested_at so the list view can surface test freshness.
+    supaFetch(
+      `${supabaseUrl}/rest/v1/user_credentials?id=eq.${encodeURIComponent(id)}`,
+      "PATCH",
+      supaHeaders(serviceRoleKey),
+      { is_valid: ok, last_tested_at: testedAt },
+    ).catch(() => { /* ignore */ });
+
+    await writeAudit({
+      supabaseUrl, serviceRoleKey, tenant, req,
+      action: "test_connection", credentialId: id,
+      platformSlug: platform, label: (row.label as string) ?? null,
+      success: ok, metadata: { status },
+    });
+
+    return res.status(200).json({ ok, status, platform, tested_at: testedAt, message });
   }
 
   if (action === "update") {

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -41,6 +41,7 @@ import {
   Trash2,
   X,
   XCircle,
+  Zap,
 } from "lucide-react";
 
 // ─── Types ───────────────────────────────────────────────────────
@@ -120,6 +121,8 @@ export default function AdminKeychain() {
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [revealError, setRevealError] = useState<Record<string, string>>({});
   const [revealing, setRevealing]     = useState<Record<string, boolean>>({});
+  const [testing, setTesting]         = useState<Record<string, boolean>>({});
+  const [testResult, setTestResult]   = useState<Record<string, { ok: boolean | null; message: string; testedAt: string }>>({});
 
   // Modals
   const [editTarget, setEditTarget]     = useState<Credential | null>(null);
@@ -208,6 +211,60 @@ export default function AdminKeychain() {
       const { [cred.id]: _gone, ...rest } = p;
       return rest;
     });
+  }
+
+  async function handleTestConnection(cred: Credential) {
+    const apiKey = readLocalApiKey();
+    if (!apiKey) {
+      setTestResult((p) => ({
+        ...p,
+        [cred.id]: {
+          ok:       false,
+          message:  "No UnClick API key in this browser. Visit /admin/you to claim or regenerate.",
+          testedAt: new Date().toISOString(),
+        },
+      }));
+      return;
+    }
+    setTesting((p) => ({ ...p, [cred.id]: true }));
+    try {
+      const res = await fetch("/api/backstagepass?action=testConnection", {
+        method:  "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body:    JSON.stringify({ id: cred.id, api_key: apiKey }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setTestResult((p) => ({
+          ...p,
+          [cred.id]: {
+            ok:       false,
+            message:  body.error ?? `Test failed with ${res.status}`,
+            testedAt: new Date().toISOString(),
+          },
+        }));
+      } else {
+        setTestResult((p) => ({
+          ...p,
+          [cred.id]: {
+            ok:       body.ok ?? null,
+            message:  body.message ?? "",
+            testedAt: body.tested_at ?? new Date().toISOString(),
+          },
+        }));
+      }
+    } catch (err) {
+      setTestResult((p) => ({
+        ...p,
+        [cred.id]: {
+          ok:       false,
+          message:  err instanceof Error ? err.message : "Test failed",
+          testedAt: new Date().toISOString(),
+        },
+      }));
+    } finally {
+      setTesting((p) => ({ ...p, [cred.id]: false }));
+    }
   }
 
   async function copyToClipboard(field: string, value: string) {
@@ -371,6 +428,18 @@ export default function AdminKeychain() {
                             <Pencil className="h-3.5 w-3.5" />
                           </button>
                           <button
+                            onClick={() => void handleTestConnection(cred)}
+                            disabled={testing[cred.id]}
+                            className="rounded-md p-1.5 text-[#888] transition-colors hover:bg-white/[0.04] hover:text-white disabled:opacity-40"
+                            title="Test connection"
+                          >
+                            {testing[cred.id] ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <Zap className="h-3.5 w-3.5" />
+                            )}
+                          </button>
+                          <button
                             onClick={() => setRotateTarget(cred)}
                             className="rounded-md p-1.5 text-[#888] transition-colors hover:bg-white/[0.04] hover:text-white"
                             title="Rotate values"
@@ -389,6 +458,21 @@ export default function AdminKeychain() {
 
                       {errMsg && (
                         <p className="mt-3 text-[11px] text-red-400">{errMsg}</p>
+                      )}
+
+                      {testResult[cred.id] && (
+                        <p
+                          className={`mt-3 text-[11px] ${
+                            testResult[cred.id].ok === true
+                              ? "text-green-400"
+                              : testResult[cred.id].ok === false
+                                ? "text-red-400"
+                                : "text-[#888]"
+                          }`}
+                        >
+                          {testResult[cred.id].ok === true ? "Connection OK. " : testResult[cred.id].ok === false ? "Connection failed. " : ""}
+                          {testResult[cred.id].message}
+                        </p>
                       )}
 
                       {isOpen && plaintext && (


### PR DESCRIPTION
Adds a "Test" affordance to BackstagePass so users can verify a stored credential still works without revealing plaintext.

Phase 1 reference: #46. Brief referenced `#38` but that issue does not exist; implementing per the overnight brief description.

## What it does

1. **New `PLATFORM_PROBES` map** (`api/backstagepass.ts`). Curated map of platform slug to `{ url, buildHeaders(values) }` for a lightweight authenticated GET. Shipping today:
   - `github` -- `GET https://api.github.com/user` with `Authorization: Bearer <api_key>`
   - `anthropic` -- `GET https://api.anthropic.com/v1/models` with `x-api-key`
   - `openai` -- `GET https://api.openai.com/v1/models` with `Authorization: Bearer`
   Platforms not in the map return `ok=null` and an audit reason `platform_untestable` instead of throwing. Adding new platforms is one entry each.
2. **New `action=testConnection` handler**. Mirrors the `reveal` auth path exactly (Supabase JWT + proof-of-possession `api_key`), decrypts the credential, runs one outbound probe with a 5-second `AbortController` timeout, and returns only `{ ok, status, platform, tested_at, message }`. Plaintext is never in the response.
3. **Row metadata update**. Patches `is_valid` (from the probe's `ok`) and `last_tested_at` on the `user_credentials` row after the test. The columns already exist from `supabase/migrations/20260420110000_user_credentials_status.sql` so no new migration needed.
4. **Audit row**. Writes a `test_connection` event to `backstagepass_audit` with the probe status code in metadata. Failed reveals, missing rows, decrypt failures, and platform-not-supported all get audited too.
5. **UI: Test button**. New `Zap` icon button next to Rename / Rotate / Delete in `src/pages/admin/AdminKeychain.tsx`. Shows a spinner during test, then renders an inline green "Connection OK" / red "Connection failed" / grey "not-supported" message under the row. Result persists until the next test on that credential.

## Files changed

- `api/backstagepass.ts` -- +141 lines (PLATFORM_PROBES map + new action handler)
- `src/pages/admin/AdminKeychain.tsx` -- +84 lines (Zap import + state + handleTestConnection + button + result render)

Net: +225 lines, 2 files. Well under the 300-line / 5-file cap.

## Test plan

- [ ] Reveal a GitHub credential stored with `values.api_key = ghp_...`, click Test. Confirm green "Connection OK".
- [ ] Swap the GitHub values to a bogus token via Rotate, click Test. Confirm red "Connection failed. Platform returned 401." and `is_valid` flips to false in the list.
- [ ] Click Test on a `google-workspace` credential. Confirm grey "Connection testing is not yet supported for google-workspace." with no probe attempted.
- [ ] Submit an action=testConnection call with a wrong `api_key`. Confirm 403, matching the reveal behavior.
- [ ] Watch the audit drawer after each test. Confirm one `test_connection` row per click with the expected `success` flag.

## Out of scope for this PR

- Per-platform alternative auth shapes (e.g. OAuth refresh-flow platforms like `google-workspace`, `xero`). Those need the full grant dance and are their own follow-up.
- Batch testing ("test all credentials"). Single-credential only for now.
- Timing-safe comparison on the `sha256hex(apiKey) !== tenant.apiKeyHash` check. Kept as `!==` here to match the main-branch style. PR #52 (the BackstagePass Phase 2 cluster) already introduces `hashesEqual`; once that lands we can follow up and unify the two call sites plus this one.

**Do NOT merge until Chris reviews.**