### PR TITLE
feat(backstagepass): rotation reminders via last_rotated_at + overdue pill

### DIFF
--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -274,7 +274,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === "GET" && action === "list") {
     const url = `${supabaseUrl}/rest/v1/user_credentials`
       + `?api_key_hash=eq.${encodeURIComponent(tenant.apiKeyHash)}`
-      + `&select=id,platform_slug,label,is_valid,last_tested_at,last_used_at,expires_at,created_at,updated_at`
+      + `&select=id,platform_slug,label,is_valid,last_tested_at,last_used_at,last_rotated_at,expires_at,created_at,updated_at`
       + `&order=platform_slug.asc,label.asc.nullsfirst`;
     const { ok, data } = await supaFetch(url, "GET", supaHeaders(serviceRoleKey));
     if (!ok) return res.status(502).json({ error: "Vault lookup failed." });
@@ -462,9 +462,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       patch.encryption_iv   = enc.iv;
       patch.encryption_tag  = enc.authTag;
       patch.encryption_salt = salt.toString("hex");
-      // Fresh rotation → assume valid until re-tested.
+      // Fresh rotation → assume valid until re-tested. Stamp last_rotated_at
+      // so the admin UI can surface rotation age and flag overdue rows.
       patch.is_valid        = true;
       patch.last_tested_at  = null;
+      patch.last_rotated_at = new Date().toISOString();
       valuesRotated = true;
     }
 

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -46,21 +46,34 @@ import {
 // ─── Types ───────────────────────────────────────────────────────
 
 interface Credential {
-  id:              string;
-  platform:        string;
-  label:           string | null;
-  is_valid:        boolean;
-  last_tested_at:  string | null;
-  last_used_at:    string | null;
-  expires_at:      string | null;
-  created_at:      string;
-  updated_at:      string;
+  id:               string;
+  platform:         string;
+  label:            string | null;
+  is_valid:         boolean;
+  last_tested_at:   string | null;
+  last_used_at:     string | null;
+  last_rotated_at:  string | null;
+  expires_at:       string | null;
+  created_at:       string;
+  updated_at:       string;
   connector: {
     id:       string;
     name:     string;
     category: string;
     icon:     string | null;
   } | null;
+}
+
+// Rotation-reminder threshold. Credentials whose last_rotated_at is
+// older than this show an inline warning pill in the admin list. Kept
+// as a module constant so it is easy to find and tune.
+const ROTATION_WARNING_DAYS = 90;
+
+function daysSince(iso: string | null): number | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return null;
+  return Math.floor((Date.now() - t) / 86_400_000);
 }
 
 interface AuditEntry {
@@ -348,6 +361,19 @@ export default function AdminKeychain() {
                               <XCircle className="h-3 w-3" /> Invalid
                             </span>
                           )}
+
+                          {(() => {
+                            const age = daysSince(cred.last_rotated_at);
+                            if (age === null || age < ROTATION_WARNING_DAYS) return null;
+                            return (
+                              <span
+                                className="flex items-center gap-1 rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-400"
+                                title={`Last rotated ${age} days ago. Rotate to refresh the encrypted secret.`}
+                              >
+                                <AlertTriangle className="h-3 w-3" /> Rotate ({age}d)
+                              </span>
+                            );
+                          })()}
 
                           <button
                             onClick={() => (isOpen ? handleHide(cred) : void handleReveal(cred))}

--- a/supabase/migrations/20260421030000_user_credentials_last_rotated_at.sql
+++ b/supabase/migrations/20260421030000_user_credentials_last_rotated_at.sql
@@ -1,0 +1,31 @@
+-- Track when each BackstagePass credential was last rotated (values re-encrypted).
+--
+-- The admin surface uses this to surface overdue credentials with a
+-- visible warning so the user knows which ones need a rotation. The
+-- warning threshold is computed client-side (currently 90 days); the
+-- schema just stores the raw timestamp.
+--
+-- Distinction from existing columns:
+--   created_at       : row insert time, never changes.
+--   updated_at       : any field change (label, values, is_valid, ...).
+--   last_tested_at   : last time the testConnection action ran.
+--   last_used_at     : last time /api/backstagepass reveal decrypted this row.
+--   last_rotated_at  : last time the VALUES were re-encrypted (new secret).
+--
+-- Backfill for existing rows: start them at created_at so they do not
+-- all appear "just rotated" the moment this migration runs. New rows
+-- created after this migration land with DEFAULT NOW() via the second
+-- ALTER below.
+
+ALTER TABLE user_credentials
+  ADD COLUMN IF NOT EXISTS last_rotated_at TIMESTAMPTZ;
+
+UPDATE user_credentials
+  SET last_rotated_at = created_at
+  WHERE last_rotated_at IS NULL;
+
+ALTER TABLE user_credentials
+  ALTER COLUMN last_rotated_at SET DEFAULT NOW();
+
+COMMENT ON COLUMN user_credentials.last_rotated_at IS
+  'Timestamp of the last values-rotation (re-encryption) for this credential. Set to created_at on insert, updated by the BackstagePass update_values action. Drives the rotation-overdue warning in the admin UI.';


### PR DESCRIPTION
Surfaces BackstagePass credentials that are overdue for rotation in the admin list so users notice stale secrets.

Phase 1 reference: #46. Brief referenced `#39` but that issue does not exist; implementing per the overnight brief description. Issue-number mismatch cross-noted in #46.

## What it does

1. **New migration** `supabase/migrations/20260421030000_user_credentials_last_rotated_at.sql`
   - Adds `last_rotated_at TIMESTAMPTZ` column to `user_credentials`.
   - Backfills existing rows from `created_at` so nothing reads as "just rotated" the instant the migration runs.
   - `ALTER TABLE ... ALTER COLUMN last_rotated_at SET DEFAULT NOW()` so future inserts land with a sane default without touching every insert call site.
   - Adds a `COMMENT ON COLUMN` clarifying the distinction between `created_at`, `updated_at`, `last_tested_at`, `last_used_at`, and `last_rotated_at`.
2. **`api/backstagepass.ts`**
   - `list` select now includes `last_rotated_at`.
   - The `update_values` branch stamps `patch.last_rotated_at = new Date().toISOString()` on every re-encrypt. Label-only updates do NOT touch the column, so renaming a credential does not reset its rotation clock.
3. **`src/pages/admin/AdminKeychain.tsx`**
   - `Credential` interface gains `last_rotated_at: string | null`.
   - New module constant `ROTATION_WARNING_DAYS = 90`. Centralized so tuning the threshold is one line.
   - New `daysSince(iso)` helper returning floor-days since a timestamp.
   - Credential rows whose `last_rotated_at` is older than `ROTATION_WARNING_DAYS` render an amber "Rotate (Nd)" pill alongside the existing Active / Invalid pill. Uses the existing `AlertTriangle` icon that was already imported.

## Files changed

- `supabase/migrations/20260421030000_user_credentials_last_rotated_at.sql` -- new (31 lines)
- `api/backstagepass.ts` -- +4 / -2 (list select + patch field)
- `src/pages/admin/AdminKeychain.tsx` -- +35 / -9 (interface field, constant, helper, pill render)

Net: +70 lines, 3 files. Single-purpose.

## Design choice: threshold vs per-credential config

Shipped a single global threshold (90 days) rather than a per-credential `rotation_interval_days` column for MVP. Reasons:
- Most users will not bother configuring it per credential.
- A follow-up PR can add per-credential override by reading `cred.rotation_interval_days ?? ROTATION_WARNING_DAYS` if user demand shows up. Schema change is trivial.
- Keeps this PR tight and predictable.

## Test plan

- [ ] `supabase db push` to prod. Migration applies. New column appears on `user_credentials` with values equal to each row's `created_at`.
- [ ] Fresh `supabase db reset` on a local PG15+ instance. Migration applies without issue.
- [ ] On the admin list, credentials older than 90 days show an amber "Rotate (Nd)" pill. Younger ones do not.
- [ ] Rotate a credential via the Rotate action. Confirm the pill disappears immediately on the next list refresh and `last_rotated_at` in the DB is now the rotation moment.
- [ ] Rename (label-only) a credential via the Edit action. Confirm `last_rotated_at` is unchanged.

**Do NOT merge until Chris reviews.**