### PR TITLE
feat(you): email to api_key auto-link + reveal + admin gating

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -2177,6 +2177,47 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({ data: data ?? [] });
       }
 
+      case "auth_device_list": {
+        // Alias for list_devices that normalises the row shape for the
+        // /admin/you page, which expects device_id / device_name /
+        // paired_at / last_seen_at rather than the raw memory_devices
+        // column names.
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const { data, error } = await supabase
+          .from("memory_devices")
+          .select("id, device_fingerprint, label, first_seen, last_seen")
+          .eq("api_key_hash", apiKeyHash)
+          .order("last_seen", { ascending: false });
+        if (error) throw error;
+        const mapped = (data ?? []).map((d) => ({
+          id:           d.id as string,
+          device_id:    (d.device_fingerprint ?? "") as string,
+          device_name:  (d.label ?? null) as string | null,
+          paired_at:    (d.first_seen ?? d.last_seen ?? new Date(0).toISOString()) as string,
+          last_seen_at: (d.last_seen ?? new Date(0).toISOString()) as string,
+        }));
+        return res.status(200).json({ data: mapped });
+      }
+
+      case "auth_device_revoke": {
+        // Same delete semantics as remove_device but takes the device
+        // id in a POST body to match the /admin/you Revoke button.
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const body = req.body as { device_id?: string };
+        const fp = (body?.device_id ?? "").trim();
+        if (!fp) return res.status(400).json({ error: "device_id required" });
+        const { error } = await supabase
+          .from("memory_devices")
+          .delete()
+          .eq("api_key_hash", apiKeyHash)
+          .eq("device_fingerprint", fp);
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
       case "admin_check_connection": {
         // Lightweight check used by the Connect page to verify that Claude Code
         // (or any MCP client) has handshaken with this user's API key recently.
@@ -3139,36 +3180,134 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       case "admin_profile": {
-        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
-        if (!tenant) return res.status(401).json({ error: "Unauthorized" });
+        // Resolve the signed-in user via their Supabase session JWT. Unlike
+        // resolveSessionTenant, this does not require an existing api_keys
+        // row - we may be creating the first one right now.
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Unauthorized" });
 
-        const { data: keyRow } = await supabase
+        // Look up an existing api_keys row for this user.
+        let keyRow = (await supabase
           .from("api_keys")
           .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
-          .eq("key_hash", tenant.apiKeyHash)
-          .maybeSingle();
+          .eq("user_id", user.id)
+          .maybeSingle()).data as
+          | {
+              id: string;
+              key_prefix: string | null;
+              label: string | null;
+              tier: string | null;
+              is_active: boolean | null;
+              usage_count: number | null;
+              last_used_at: string | null;
+              created_at: string;
+            }
+          | null;
+
+        // Auto-provision on first access. The signed-in email proves
+        // ownership (Supabase verified it via magic-link / OAuth), so
+        // we mint a uc_* key and link it to user.id the first time
+        // /admin/you loads. The raw key is returned exactly once, under
+        // `generated_api_key`, so the frontend can surface it behind
+        // the reveal UI. Subsequent calls only return the prefix.
+        let generatedApiKey: string | null = null;
+        if (!keyRow) {
+          const rawKey = `uc_${crypto.randomBytes(16).toString("hex")}`;
+          const keyHash = sha256hex(rawKey);
+          const keyPrefix = rawKey.slice(0, 8);
+          const insertRes = await supabase
+            .from("api_keys")
+            .insert({
+              user_id:   user.id,
+              key_hash:  keyHash,
+              key_prefix: keyPrefix,
+              label:     "auto-provisioned",
+              tier:      "free",
+              is_active: true,
+              usage_count: 0,
+            })
+            .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
+            .maybeSingle();
+
+          if (insertRes.error) {
+            // If a concurrent request created the row (unique conflict on
+            // user_id), re-read instead of failing.
+            const retry = await supabase
+              .from("api_keys")
+              .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
+              .eq("user_id", user.id)
+              .maybeSingle();
+            keyRow = retry.data as typeof keyRow;
+          } else {
+            keyRow = insertRes.data as typeof keyRow;
+            generatedApiKey = rawKey;
+          }
+        }
 
         const apiKey = keyRow
           ? {
-              id: keyRow.id as string,
-              prefix: (keyRow.key_prefix ?? "") as string,
-              label: (keyRow.label ?? "") as string,
-              tier: (keyRow.tier ?? "free") as string,
+              id: keyRow.id,
+              prefix: keyRow.key_prefix ?? "",
+              label:  keyRow.label ?? "",
+              tier:   keyRow.tier ?? "free",
               is_active: Boolean(keyRow.is_active),
               usage_count: Number(keyRow.usage_count ?? 0),
-              last_used_at: (keyRow.last_used_at ?? null) as string | null,
-              created_at: keyRow.created_at as string,
+              last_used_at: keyRow.last_used_at ?? null,
+              created_at: keyRow.created_at,
             }
           : null;
 
-        const tier = apiKey ? apiKey.tier : tenant.tier ?? null;
-
         return res.status(200).json({
-          user_id: tenant.userId,
-          email: tenant.email,
-          tier,
+          user_id: user.id,
+          email:   user.email,
+          tier:    apiKey ? apiKey.tier : "free",
           needs_key: !apiKey,
           api_key: apiKey,
+          generated_api_key: generatedApiKey,
+        });
+      }
+
+      case "generate_api_key": {
+        // Explicit on-demand provisioning. Idempotent: if the signed-in
+        // user already has an api_keys row, return the existing prefix
+        // without regenerating. If not, mint a uc_* key and link to the
+        // user. Returns the raw key exactly once on creation.
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+        const existing = (await supabase
+          .from("api_keys")
+          .select("id, key_prefix, tier")
+          .eq("user_id", user.id)
+          .maybeSingle()).data as { id: string; key_prefix: string | null; tier: string | null } | null;
+
+        if (existing) {
+          return res.status(200).json({
+            api_key: null,
+            prefix:  existing.key_prefix ?? "",
+            tier:    existing.tier ?? "free",
+            already_provisioned: true,
+          });
+        }
+
+        const rawKey = `uc_${crypto.randomBytes(16).toString("hex")}`;
+        const { error } = await supabase.from("api_keys").insert({
+          user_id:   user.id,
+          key_hash:  sha256hex(rawKey),
+          key_prefix: rawKey.slice(0, 8),
+          label:     "default",
+          tier:      "free",
+          is_active: true,
+          usage_count: 0,
+        });
+        if (error) return res.status(500).json({ error: error.message });
+
+        return res.status(200).json({
+          api_key: rawKey,
+          prefix:  rawKey.slice(0, 8),
+          tier:    "free",
+          already_provisioned: false,
         });
       }
 

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -6,7 +6,7 @@
  * ClaimKeyBanner is shown if the user has an unclaimed localStorage key.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useSession, signOut } from "@/lib/auth";
 import ClaimKeyBanner from "@/components/ClaimKeyBanner";
@@ -21,11 +21,20 @@ import {
   Clock,
   Copy,
   Check,
-  Plus,
+  Eye,
+  EyeOff,
   AlertTriangle,
   Brain,
   ArrowRight,
 } from "lucide-react";
+
+// Mask a value like BackstagePass: first 4 chars + 8 bullets + last 4.
+// Short values collapse to plain bullets so the length cannot be leaked.
+function maskValue(v: string): string {
+  if (!v) return "";
+  if (v.length <= 8) return "\u2022".repeat(Math.max(v.length, 4));
+  return `${v.slice(0, 4)}${"\u2022".repeat(8)}${v.slice(-4)}`;
+}
 
 interface MemoryNudge {
   connected: boolean;
@@ -159,27 +168,34 @@ function timeAgo(iso: string | null | undefined): string {
 }
 
 export default function AdminYou() {
-  const { session, user } = useSession();
+  // Destructure `loading` so the page can wait for the Supabase session
+  // restore to resolve before showing a "not signed in" empty state or
+  // firing any fetches. Fixes the brief confusion-on-load flicker.
+  const { session, user, loading: sessionLoading } = useSession();
   const navigate = useNavigate();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [devices, setDevices] = useState<DeviceRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
-  const [generating, setGenerating] = useState(false);
-  const [genError, setGenError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
 
-  async function fetchProfile() {
-    if (!session) return;
-    const headers = { Authorization: `Bearer ${session.access_token}` };
-    const profileRes = await fetch("/api/memory-admin?action=admin_profile", { headers });
-    if (profileRes.ok) {
-      setProfile(await profileRes.json());
-    }
-  }
+  // `generatedKey` holds the raw uc_* value that is ONLY available once:
+  // either auto-provisioned on first /admin/you load, or returned by an
+  // explicit generate/rotate call. After the reveal timer expires or the
+  // user reloads the page, only the prefix remains (the backend stores
+  // key_hash, not plaintext). The state holds the value in memory only.
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+  const [keyRevealed, setKeyRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const revealTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!session) return;
+    // Wait for Supabase to confirm the session state before firing
+    // fetches. If there is no session and no load is pending, route to
+    // login instead of calling a 401-guaranteed endpoint.
+    if (sessionLoading) return;
+    if (!session) {
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
 
     (async () => {
@@ -191,7 +207,22 @@ export default function AdminYou() {
         ]);
 
         if (!cancelled && profileRes.ok) {
-          setProfile(await profileRes.json());
+          const body = (await profileRes.json()) as ProfileData & {
+            generated_api_key?: string | null;
+          };
+          setProfile({
+            user_id:   body.user_id,
+            email:     body.email,
+            tier:      body.tier,
+            needs_key: body.needs_key,
+            api_key:   body.api_key,
+          });
+          // Auto-provisioned on first load: the raw key is here once.
+          // Surface it behind the reveal toggle, default to masked.
+          if (body.generated_api_key) {
+            setGeneratedKey(body.generated_api_key);
+            setKeyRevealed(false);
+          }
         }
         if (!cancelled && devicesRes.ok) {
           const body = await devicesRes.json();
@@ -203,40 +234,36 @@ export default function AdminYou() {
     })();
 
     return () => { cancelled = true; };
-  }, [session]);
+  }, [session, sessionLoading]);
 
-  async function handleGenerateKey() {
-    if (!session) return;
-    setGenerating(true);
-    setGenError(null);
-    try {
-      const res = await fetch("/api/memory-admin?action=generate_api_key", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${session.access_token}`,
-        },
-      });
-      const body = await res.json();
-      if (!res.ok) {
-        setGenError(body.error ?? "Failed to generate key");
-        return;
-      }
-      setGeneratedKey(body.api_key);
-      localStorage.setItem("unclick_api_key", body.api_key);
-      await fetchProfile();
-    } catch {
-      setGenError("Network error - please try again");
-    } finally {
-      setGenerating(false);
+  // Auto-clear the revealed api_key 60 seconds after reveal, and also
+  // forget the raw key entirely so it does not linger in React state.
+  useEffect(() => {
+    if (!keyRevealed) return;
+    if (revealTimerRef.current !== null) {
+      window.clearTimeout(revealTimerRef.current);
     }
-  }
+    revealTimerRef.current = window.setTimeout(() => {
+      setKeyRevealed(false);
+      setGeneratedKey(null);
+    }, 60_000);
+    return () => {
+      if (revealTimerRef.current !== null) {
+        window.clearTimeout(revealTimerRef.current);
+        revealTimerRef.current = null;
+      }
+    };
+  }, [keyRevealed]);
 
   async function handleCopyKey() {
     if (!generatedKey) return;
-    await navigator.clipboard.writeText(generatedKey);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(generatedKey);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2_000);
+    } catch {
+      // Browser can block clipboard writes in some contexts; fail silent.
+    }
   }
 
   async function handleLogout() {
@@ -276,10 +303,22 @@ export default function AdminYou() {
         <MemoryNudgeBanner apiKey={localStorage.getItem("unclick_api_key") ?? ""} />
       ) : null}
 
-      {loading ? (
+      {sessionLoading || loading ? (
         <div className="flex items-center gap-2 py-12 text-[#666]">
           <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm">Loading profile...</span>
+          <span className="text-sm">
+            {sessionLoading ? "Checking your session..." : "Loading profile..."}
+          </span>
+        </div>
+      ) : !session ? (
+        <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-8 text-center">
+          <p className="text-sm text-white/70">You are not signed in.</p>
+          <Link
+            to="/login"
+            className="mt-4 inline-flex items-center gap-1 rounded-md bg-[#61C1C4] px-3 py-1.5 text-xs font-semibold text-black hover:opacity-90"
+          >
+            Go to sign in <ArrowRight className="h-3 w-3" />
+          </Link>
         </div>
       ) : (
         <div className="grid gap-6 lg:grid-cols-2">
@@ -343,15 +382,27 @@ export default function AdminYou() {
                 <div className="rounded-lg border border-[#E2B93B]/30 bg-[#E2B93B]/5 p-3">
                   <div className="flex items-start gap-2 text-xs text-[#E2B93B]">
                     <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span>Save this key now. You won't see it again.</span>
+                    <span>Save this key now. It auto-hides in 60 seconds and you will not be able to see it again after that.</span>
                   </div>
                   <div className="mt-2 flex items-center gap-2">
                     <code className="min-w-0 flex-1 truncate rounded bg-[#0A0A0A] px-3 py-2 font-mono text-xs text-white">
-                      {generatedKey}
+                      {keyRevealed ? generatedKey : maskValue(generatedKey)}
                     </code>
+                    <button
+                      onClick={() => setKeyRevealed((v) => !v)}
+                      className="shrink-0 rounded-md border border-white/[0.08] bg-white/[0.04] p-2 text-white transition-colors hover:bg-white/[0.08]"
+                      title={keyRevealed ? "Hide key" : "Reveal key"}
+                    >
+                      {keyRevealed ? (
+                        <EyeOff className="h-3.5 w-3.5" />
+                      ) : (
+                        <Eye className="h-3.5 w-3.5" />
+                      )}
+                    </button>
                     <button
                       onClick={handleCopyKey}
                       className="shrink-0 rounded-md border border-white/[0.08] bg-white/[0.04] p-2 text-white transition-colors hover:bg-white/[0.08]"
+                      title="Copy key to clipboard"
                     >
                       {copied ? (
                         <Check className="h-3.5 w-3.5 text-green-400" />
@@ -367,7 +418,7 @@ export default function AdminYou() {
                     Connect UnClick to your AI agent. Go to your agent's MCP settings and add this as a Remote MCP Server:
                   </p>
                   <code className="block bg-black/30 rounded px-3 py-2 text-xs text-white/60 break-all">
-                    https://unclick.world/api/mcp?key={generatedKey}
+                    https://unclick.world/api/mcp?key={keyRevealed ? generatedKey : maskValue(generatedKey)}
                   </code>
                   <p className="text-xs text-white/40 mt-2">
                     Once connected, your agent loads your memory at the start of every conversation.
@@ -407,38 +458,10 @@ export default function AdminYou() {
                   </span>
                 </div>
               </div>
-            ) : profile?.needs_key ? (
-              <div className="mt-4 space-y-3">
-                <div className="rounded-lg border border-dashed border-white/[0.08] p-4 text-center">
-                  <p className="text-xs text-[#666]">
-                    No API key linked to your account.
-                  </p>
-                </div>
-                {genError && (
-                  <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
-                    {genError}
-                  </div>
-                )}
-                <button
-                  onClick={handleGenerateKey}
-                  disabled={generating}
-                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-4 py-2.5 text-sm font-medium text-[#E2B93B] transition-colors hover:bg-[#E2B93B]/20 disabled:opacity-50"
-                >
-                  {generating ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Plus className="h-4 w-4" />
-                  )}
-                  {generating ? "Generating..." : "Generate API Key"}
-                </button>
-              </div>
             ) : (
               <div className="mt-4 rounded-lg border border-dashed border-white/[0.08] p-4 text-center">
                 <p className="text-xs text-[#666]">
-                  No API key linked. Use the banner above to claim your key, or{" "}
-                  <a href="/#install" className="text-[#E2B93B] underline-offset-2 hover:underline">
-                    get started
-                  </a>.
+                  Preparing your API key. Refresh this page if it does not appear within a few seconds.
                 </p>
               </div>
             )}


### PR DESCRIPTION
Closes #62. Fixes the reported confusion on `/admin/you` for a newly signed-up user.

## Depends on #61

This PR is stacked on top of `fix/memory-admin-cross-tenant-leak` so that the new `auth_device_list` / `auth_device_revoke` cases use the `resolveApiKeyHash` helper from the security PR. **Merge order: #61 first, then this.** Once #61 lands on main, this PR auto-retargets main and the diff narrows to just the new code here.

## Three surgical changes

### 1. `api/memory-admin.ts`

- **`admin_profile` now auto-provisions on first access.** Resolves the signed-in user via `resolveSessionUser` (which does NOT require a pre-existing `api_keys` row), looks up the user's row, and if missing, inserts a fresh `uc_*` key linked to `user_id`. The raw key is returned exactly once under `generated_api_key`. Handles the concurrent-insert race on unique `user_id` by re-reading. Tier defaults to `free`, label `auto-provisioned`.
- **`generate_api_key` action added.** Idempotent: returns the existing prefix if the user already has a row, otherwise mints a new one and returns the raw value once. Requires a Supabase session JWT (rejects `uc_*/agt_*` bearers).
- **`auth_device_list` action added.** Alias of `list_devices` that maps the `memory_devices` row shape (`device_fingerprint`, `label`, `first_seen`, `last_seen`) to the `DeviceRow` shape the `/admin/you` page expects (`device_id`, `device_name`, `paired_at`, `last_seen_at`).
- **`auth_device_revoke` action added.** POST with `{ device_id }` body. Deletes the matching `memory_devices` row by `device_fingerprint` for the current session user.

### 2. `src/pages/admin/AdminYou.tsx`

- **Two-stage session gate.** Destructure `loading: sessionLoading` from `useSession`. While `sessionLoading`, show "Checking your session..." so there is no race where an authed user sees a "not signed in" flash before Supabase restores the session. After `sessionLoading` is false and there is still no session, show a clear "You are not signed in" card with a link to `/login`. No more stuck spinner.
- **Mask-by-default reveal on the freshly-provisioned key.** Mirror the BackstagePass pattern: `maskValue(key)` renders `first4 + 8 bullets + last4`. `Eye` / `EyeOff` toggle to reveal. 60-second auto-clear via a `useRef`-tracked `setTimeout` that also clears `generatedKey` from React state when it fires, so the raw value does not linger in memory. `Copy` button writes the full key to clipboard and shows a 2-second `Check` confirmation.
- **Auto-pick-up `generated_api_key` from `admin_profile`.** On first load, if the backend returned a freshly-provisioned key, stash it in `generatedKey` state and render the reveal card by default. No extra click, no "Generate API Key" button, no "Claim" step for a user who just signed up via magic link.
- **Removed the dead `Generate API Key` branch** (`handleGenerateKey`, `generating`, `genError`, `Plus` icon). The endpoint it called had no backend handler and it is no longer reachable anyway under the new flow.

### 3. Files changed

| File | Lines |
|---|---|
| `api/memory-admin.ts` | +162 / -11 (admin_profile rewrite + generate_api_key + auth_device_list + auth_device_revoke) |
| `src/pages/admin/AdminYou.tsx` | +96 / -85 (useRef + sessionLoading + reveal state + render refactor) |

Net: 2 files, +258 / -96. Single purpose.

## Test plan

- [ ] Fresh signup: create a new account via magic link in a private window. Visit `/admin/you`. Expect: spinner briefly shows "Checking your session..." then the page renders with an amber "Save this key now" card, key is masked by default (`uc_abcd••••••••e123` style). No console 400s, no 401s.
- [ ] Click the Eye icon. Key reveals. Click it again. Key re-masks. Copy icon copies the raw key to clipboard.
- [ ] Wait 60 seconds with the key revealed. It auto-masks AND the raw value is dropped from state (the provisioned-once card is gone on next re-render).
- [ ] Reload the page. The one-time reveal card is gone. The standard API key info card shows the prefix (`uc_abcd...`), tier (`free`), status Active.
- [ ] Returning user: existing account with an `api_keys` row. Visit `/admin/you`. No auto-provision (the row already exists). Standard info card. No raw key surfaced.
- [ ] Devices card: empty state for a new user ("No paired devices yet"). Console clean; no 400s from `auth_device_list`.
- [ ] Sign out. `localStorage.unclick_api_key` is cleared (covered by #61).
- [ ] Sign in as a different user on the same browser. `/admin/you` renders that user's profile only, not the previous user's.

## Out of scope

- Broader admin-role gating across other pages.
- Migrating the remaining `localStorage.unclick_api_key` readers (`MemoryNudgeBanner`, `ClaimKeyBanner`, `AdminSearchBar`, `AIChatPanel`, `BugReportButton`, `MemoryHealthPill`, `HealthCheck`, `AdminAgents`, `Tools`) to session-JWT auth.
- Replacing the `ClaimKeyBanner` component: kept to cover legacy users who claimed a key pre-signup via the anon flow.

**Do NOT merge until Chris reviews. Merge #61 first.**