### PR TITLE
fix(admin): gate admin endpoint calls behind role check to eliminate 401 console noise

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -3257,6 +3257,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             }
           : null;
 
+        // Derive is_admin from the ADMIN_EMAILS env var. Comma-separated
+        // list, case-insensitive trim-equal. Fixes the 401 console noise
+        // on /admin/memory for non-admin signers by giving the frontend
+        // a clean role flag to gate admin-only surfaces behind.
+        const adminEmailsRaw = process.env.ADMIN_EMAILS ?? "";
+        const adminEmails = adminEmailsRaw
+          .split(",")
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean);
+        const isAdmin = user.email
+          ? adminEmails.includes(user.email.toLowerCase())
+          : false;
+
         return res.status(200).json({
           user_id: user.id,
           email:   user.email,
@@ -3264,6 +3277,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           needs_key: !apiKey,
           api_key: apiKey,
           generated_api_key: generatedApiKey,
+          is_admin: isAdmin,
         });
       }
 

--- a/src/pages/admin/AdminMemory.tsx
+++ b/src/pages/admin/AdminMemory.tsx
@@ -45,24 +45,57 @@ export default function AdminMemoryPage() {
   const { session, loading: sessionLoading } = useSession();
   const accessToken = session?.access_token ?? "";
 
+  // Admin gate: only admin emails (ADMIN_EMAILS env on the backend) can
+  // load the memory surface. Everyone else sees a friendly "admin-only"
+  // card instead of firing memory fetches that would 401 in the console.
+  // `null` = not yet determined (still loading the admin_profile call).
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+
   useEffect(() => {
     if (!accessToken) {
       setStorageLoading(false);
+      setIsAdmin(null);
       return;
     }
+    let cancelled = false;
     (async () => {
+      // Resolve the admin flag FIRST. admin_profile is also the
+      // endpoint that auto-provisions an api_keys row if one is missing
+      // (see #63), so by the time we fire admin_memory_activity below
+      // the tenant hash exists.
+      let admin = false;
+      try {
+        const profileRes = await fetch("/api/memory-admin?action=admin_profile", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (profileRes.ok) {
+          const profile = (await profileRes.json()) as { is_admin?: boolean };
+          admin = Boolean(profile.is_admin);
+        }
+      } catch {
+        admin = false;
+      }
+      if (cancelled) return;
+      setIsAdmin(admin);
+
+      if (!admin) {
+        setStorageLoading(false);
+        return;
+      }
+
       try {
         const res = await fetch("/api/memory-admin?action=admin_memory_activity", {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
         if (res.ok) {
           const body = await res.json();
-          setStorage(body.storage ?? null);
+          if (!cancelled) setStorage(body.storage ?? null);
         }
       } finally {
-        setStorageLoading(false);
+        if (!cancelled) setStorageLoading(false);
       }
     })();
+    return () => { cancelled = true; };
   }, [accessToken]);
 
   const setTab = (tab: TabId) => {
@@ -83,6 +116,29 @@ export default function AdminMemoryPage() {
         <p className="text-sm text-white/70">Sign in to see what UnClick remembers about you.</p>
         <p className="mt-2 text-xs text-white/50">
           Memory is scoped to your account; sign in from <a href="/login" className="text-[#61C1C4] underline">/login</a> to continue.
+        </p>
+      </div>
+    );
+  }
+
+  // Still resolving the admin flag. Brief spinner instead of a flash
+  // of admin-only content before the gate settles.
+  if (isAdmin === null) {
+    return (
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-8 text-center">
+        <p className="text-sm text-white/70">Loading your memory workspace...</p>
+      </div>
+    );
+  }
+
+  // Non-admin: no memory fetches fire, no 401 console noise, friendly
+  // message on the page.
+  if (!isAdmin) {
+    return (
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-8 text-center">
+        <p className="text-sm text-white/70">Memory is not available on this account yet.</p>
+        <p className="mt-2 text-xs text-white/50">
+          Your account settings and API key are on <a href="/admin/you" className="text-[#61C1C4] underline">/admin/you</a>.
         </p>
       </div>
     );

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -207,11 +207,12 @@ export default function AdminYou() {
     (async () => {
       try {
         const headers = { Authorization: `Bearer ${session.access_token}` };
-        const [profileRes, devicesRes] = await Promise.all([
-          fetch("/api/memory-admin?action=admin_profile", { headers }),
-          fetch("/api/memory-admin?action=auth_device_list", { headers }),
-        ]);
-
+        // Serialize admin_profile BEFORE auth_device_list. admin_profile
+        // is the endpoint that auto-provisions an api_keys row on first
+        // visit; auth_device_list needs that row to exist or it 401s.
+        // Racing them via Promise.all caused auth_device_list to lose
+        // the race for brand-new signups and fire a 401 in the console.
+        const profileRes = await fetch("/api/memory-admin?action=admin_profile", { headers });
         if (!cancelled && profileRes.ok) {
           const body = (await profileRes.json()) as ProfileData & {
             generated_api_key?: string | null;
@@ -252,9 +253,18 @@ export default function AdminYou() {
             } catch { /* ignore */ }
           }
         }
-        if (!cancelled && devicesRes.ok) {
-          const body = await devicesRes.json();
-          setDevices(body.data ?? []);
+        // Only fire auth_device_list after admin_profile has returned, so
+        // the auto-provisioned api_keys row definitely exists.
+        if (!cancelled) {
+          try {
+            const devicesRes = await fetch("/api/memory-admin?action=auth_device_list", { headers });
+            if (!cancelled && devicesRes.ok) {
+              const body = await devicesRes.json();
+              setDevices(body.data ?? []);
+            }
+          } catch {
+            // Network errors are non-fatal for the devices card.
+          }
         }
       } finally {
         if (!cancelled) setLoading(false);


### PR DESCRIPTION
Closes the 401 console noise that non-admin users (smartsandhurst, byrneck) saw on `/admin/memory` and `/admin/you` after the security fix landed. Follow-up to #63; the scope was explicitly deferred from that PR.

## Observed

Signed in as a non-admin, the console lit up with:

- `/api/memory-admin?action=admin_memory_activity` -> 401
- `/api/memory-admin?action=facts&show_all=true` -> 401 (x2, once per FactsTab mount)
- `/api/memory-admin?action=admin_sessions&method=list` -> 401
- `/api/memory-admin?action=admin_business_context&method=list` -> 401
- `/api/memory-admin?action=auth_device_list` -> 401 (x2, a race on first-visit /admin/you)

The backend was correct. These endpoints are user-scoped via the `resolveApiKeyHash` pattern from #61; they 401 when the signed-in user either has no `api_keys` row yet OR is not intended to see admin surfaces. The fix is to gate the frontend calls behind a role check so the backend never sees the request in the first place.

## Three surgical changes

### 1. Backend: `api/memory-admin.ts::admin_profile` returns `is_admin`

Reads `ADMIN_EMAILS` from the env (already configured in Vercel per the earlier env audit). Comma-separated, case-insensitive trim-equal check against `session.user.email`. Default `false` when the env is missing or the email does not match.

14 lines. No changes to any other handler.

### 2. Frontend: `src/pages/admin/AdminMemory.tsx` gates behind `is_admin`

- On mount, fetch `admin_profile` first and read `is_admin`.
- Serialize: by the time `admin_memory_activity` fires, the `api_keys` row is already auto-provisioned (side-effect of `admin_profile` per #63), so no chicken-and-egg.
- If `is_admin` is false: render a friendly "Memory is not available on this account yet" card pointing the user to `/admin/you`, and SKIP the `admin_memory_activity` fetch entirely. Child tabs (`FactsTab`, `SessionsTab`, `ContextTab`) are not mounted, so their `facts` / `admin_sessions` / `admin_business_context` fetches do not fire either. No 401 chain, no console noise.
- While `is_admin` is still null (admin_profile in flight): render a brief "Loading your memory workspace..." card to avoid a flash of admin content before the gate settles.

60 lines of diff.

### 3. Frontend: `src/pages/admin/AdminYou.tsx` serializes admin_profile before auth_device_list

Replaces `Promise.all([admin_profile, auth_device_list])` with a strict sequence. `admin_profile` is the endpoint that inserts the first-visit `api_keys` row; `auth_device_list` needs that row. The old parallel fetch lost the race on brand-new signups and emitted a spurious 401 on first visit. Now there is no race.

26 lines of diff.

## Files changed

- `api/memory-admin.ts` -- +14 / -0
- `src/pages/admin/AdminMemory.tsx` -- +57 / -3
- `src/pages/admin/AdminYou.tsx` -- +17 / -9

Total: 3 files, +90 / -10. Single-purpose, under the cap.

## Important scope note

`/admin/you` is NOT gated behind `is_admin`. Every signed-in user still gets their per-user profile card, API key reveal card, and Danger Zone. The `is_admin` gate is specifically for `/admin/memory` which is an admin-only surface.

## Test plan

- [ ] Sign in as creativelead (admin per ADMIN_EMAILS). Visit `/admin/memory`. Expected: content renders, memory_activity + facts + admin_sessions + admin_business_context all return 200. Zero 401s in console.
- [ ] Visit `/admin/you` as creativelead. Devices fetch runs after admin_profile. Zero 401s.
- [ ] Sign in as smartsandhurst / byrneck (NOT in ADMIN_EMAILS). Visit `/admin/memory`. Expected: brief loading card, then "Memory is not available on this account yet" card with a link to /admin/you. Zero red 401s in console. Zero fetches to admin_memory_activity, facts, admin_sessions, or admin_business_context.
- [ ] Visit `/admin/you` as smartsandhurst. Profile card, API key card, Danger Zone all render normally. Devices card either empty-state or actual devices. Zero 401s.

## Auto-merge eligibility

Yes. No money, no brand, no destructive DB, no legal surface. CI-green autoload.

Hard rules honored: em-dash-free, no secret values inlined, SHA verified before report.