### PR TITLE
fix(webhook): move handler to /api/webhook to match production stripe config

### DIFF
--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -1,7 +1,11 @@
 /**
  * UnClick Stripe webhook handler
  *
- * Vercel serverless function at POST /api/stripe/webhook.
+ * Vercel serverless function at POST /api/webhook. This is the
+ * canonical path Stripe is configured to hit (webhook endpoint
+ * we_1TOY4YPSP3ulIuLuhdsRipRw, name unclick-world-prod, subscribed
+ * to 93 events). Keep this path stable; Stripe's webhook config is
+ * managed out-of-band.
  *
  * Scope (scaffold only):
  *   1. Verify the Stripe-Signature header using the shared whsec_ secret.


### PR DESCRIPTION
Path-only fix. Chris's production Stripe webhook (`we_1TOY4YPSP3ulIuLuhdsRipRw`, name `unclick-world-prod`, subscribed to 93 events) points at `https://unclick.world/api/webhook`, but the scaffold handler from #55 was at `/api/stripe/webhook`. Every live event would have 404'd.

## Change

- `git mv api/stripe/webhook.ts api/webhook.ts`
- Removed the now-empty `api/stripe/` directory.
- Updated the file header comment so the next reader sees the live webhook URL and the Stripe endpoint id / 93-event subscription it corresponds to.

Handler logic is unchanged. It verifies the `Stripe-Signature` header and acks every event type with 200, which already matches any subscription shape.

## Files changed

- `api/webhook.ts` -- renamed from `api/stripe/webhook.ts`, +5 / -1 (doc comment only)

## Function count

Still one Vercel function; just at a different path. Pro 100-function ceiling well clear.

## Env vars (unchanged)

`STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET` already documented in `.env.local.example`. Only the deploy path moved; no env var names changed. The whsec value does need to be the one for the new `unclick-world-prod` webhook endpoint, which Chris is handling out-of-band.

## Test plan

- [ ] After deploy, `curl -I https://unclick.world/api/webhook` returns 405 with `Allow: POST` header (the handler's method guard).
- [ ] Stripe dashboard > Webhooks > `we_1TOY4YPSP3ulIuLuhdsRipRw` > "Send test event". Stripe shows 200 response. Vercel runtime log for `/api/webhook` shows the logged event type + id.
- [ ] Tamper with the signature header via `curl`. Endpoint returns 400 "Signature verification failed".

## Auto-merge eligibility

Yes. This is a path rename. No billing logic, no brand copy, no destructive DB, no legal surface. The webhook endpoint is already live at Stripe's side waiting for the path to exist; this just connects them.

Hard rules honored: em-dash-free, no secret values inlined, SHA verified before report.