### PR TITLE
feat(auth): brand remaining Supabase email templates (signup, invite, reset, MFA, notifications)

### DIFF
--- a/supabase/email-templates/confirm-email-change.html
+++ b/supabase/email-templates/confirm-email-change.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Confirm your new UnClick email</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    Confirm the email change on your UnClick account.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Confirm your new email
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                You asked to change the email on your UnClick account from <span style="color:#E8E8E8;">{{ .Email }}</span> to <span style="color:#E8E8E8;">{{ .NewEmail }}</span>.
+              </p>
+
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                Click the button below to confirm. Until you confirm, the existing email stays active on your account.
+              </p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center">
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                          <a href="{{ .ConfirmationURL }}"
+                             target="_blank"
+                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                            Confirm email change
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
+                If the button does not work, copy and paste this URL into your browser:
+              </p>
+              <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because someone requested an email change on this UnClick account. If that was not you, do not click the button and contact <a href="mailto:chris@unclick.world" style="color:#888888; text-decoration:underline;">chris@unclick.world</a> right away.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/confirm-reauthentication.html
+++ b/supabase/email-templates/confirm-reauthentication.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Confirm this is you</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    Your UnClick confirmation code. Enter it in the app to continue.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Confirm this is you
+              </h1>
+
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                UnClick asked for your confirmation before completing a sensitive action on your account. Enter this code in the app to continue.
+              </p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="background-color:#0A0A0A; border:2px solid #61C1C4; border-radius:12px; padding:24px 16px;">
+                    <div style="font-family:'Courier New', Courier, monospace; font-size:32px; font-weight:700; letter-spacing:8px; color:#61C1C4;">
+                      {{ .Token }}
+                    </div>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:24px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888; text-align:center;">
+                This code expires in 10 minutes and can only be used one time.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because UnClick asked for a re-authentication check on your account. If you did not trigger this, do not share the code and contact <a href="mailto:chris@unclick.world" style="color:#888888; text-decoration:underline;">chris@unclick.world</a> right away.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/confirm-signup.html
+++ b/supabase/email-templates/confirm-signup.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Confirm your UnClick account</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    Confirm your email to finish creating your UnClick account. The link expires in 24 hours.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Confirm your UnClick account
+              </h1>
+
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                Welcome to UnClick. Click the button below to confirm this email address and finish creating your account. This link expires in 24 hours.
+              </p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center">
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                          <a href="{{ .ConfirmationURL }}"
+                             target="_blank"
+                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                            Confirm email
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
+                If the button does not work, copy and paste this URL into your browser:
+              </p>
+              <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because someone created a new UnClick account with this email address. If that was not you, you can safely ignore this message.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/email-changed.html
+++ b/supabase/email-templates/email-changed.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Your UnClick email address was changed</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    The email address on your UnClick account was just changed.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Your email was changed
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                The email on your UnClick account changed from <span style="color:#E8E8E8;">{{ .OldEmail }}</span> to <span style="color:#E8E8E8;">{{ .Email }}</span>. Future sign-ins and account notifications will use the new address.
+              </p>
+
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                If you did not make this change, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can lock the account.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this at your previous email address because an email change was applied to your UnClick account.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/identity-linked.html
+++ b/supabase/email-templates/identity-linked.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>New sign-in identity linked to your UnClick account</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    A new sign-in identity was linked to your UnClick account.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                A new identity was linked
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                You linked <span style="color:#E8E8E8;">{{ .Provider }}</span> as a new sign-in option for the UnClick account on <span style="color:#E8E8E8;">{{ .Email }}</span>. You can now sign in with that provider.
+              </p>
+
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                If you did not link this identity, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can review your account.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because a sign-in identity was added to your UnClick account.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/identity-unlinked.html
+++ b/supabase/email-templates/identity-unlinked.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Sign-in identity unlinked from your UnClick account</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    A sign-in identity was removed from your UnClick account.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                An identity was unlinked
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                You removed <span style="color:#E8E8E8;">{{ .Provider }}</span> as a sign-in option for the UnClick account on <span style="color:#E8E8E8;">{{ .Email }}</span>. You can no longer sign in with that provider.
+              </p>
+
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                If you did not make this change, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can lock the account.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because a sign-in identity was removed from your UnClick account.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/invite-user.html
+++ b/supabase/email-templates/invite-user.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>You are invited to UnClick</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    You are invited to create an UnClick account. The invite link expires in 24 hours.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                You are invited to UnClick
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                Someone invited you to join UnClick, the agent-native toolbelt for Claude, ChatGPT, and any MCP-compatible AI.
+              </p>
+
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                Click the button below to accept the invitation and create your account. You can learn more at <a href="{{ .SiteURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .SiteURL }}</a>.
+              </p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center">
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                          <a href="{{ .ConfirmationURL }}"
+                             target="_blank"
+                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                            Accept invitation
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
+                If the button does not work, copy and paste this URL into your browser:
+              </p>
+              <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because someone invited you to UnClick with this email address. If you are not expecting this invitation, you can safely ignore this message.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/mfa-enrolled.html
+++ b/supabase/email-templates/mfa-enrolled.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Two-step verification turned on</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    A new two-step verification factor was added to your UnClick account.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Two-step verification turned on
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                You enrolled a new <span style="color:#E8E8E8;">{{ .FactorType }}</span> factor on the UnClick account for <span style="color:#E8E8E8;">{{ .Email }}</span>. Future sign-ins will require this second step.
+              </p>
+
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                If you did not enroll this factor, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> immediately so we can lock the account.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because two-step verification settings were changed on your UnClick account.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/mfa-unenrolled.html
+++ b/supabase/email-templates/mfa-unenrolled.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Two-step verification removed</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    A two-step verification factor was removed from your UnClick account.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Two-step verification removed
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                You removed the <span style="color:#E8E8E8;">{{ .FactorType }}</span> factor from the UnClick account on <span style="color:#E8E8E8;">{{ .Email }}</span>. Your account no longer requires a second step at sign-in.
+              </p>
+
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                If you did not remove this factor, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> immediately so we can lock the account.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because two-step verification settings were changed on your UnClick account.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/password-changed.html
+++ b/supabase/email-templates/password-changed.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Your UnClick password was changed</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    The password on your UnClick account was just changed.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Your password was changed
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                The password on the UnClick account for <span style="color:#E8E8E8;">{{ .Email }}</span> was just changed. No further action is required if this was you.
+              </p>
+
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                If this was not you, <a href="https://unclick.world/login" style="color:#61C1C4; text-decoration:underline;">reset your password</a> right away and contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a>.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because an account security event was triggered on your UnClick account.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/phone-changed.html
+++ b/supabase/email-templates/phone-changed.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Your UnClick phone number was changed</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    The phone number on your UnClick account was just changed.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Your phone number was changed
+              </h1>
+
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                The phone number on the UnClick account for <span style="color:#E8E8E8;">{{ .Email }}</span> changed from <span style="color:#E8E8E8;">{{ .OldPhone }}</span> to <span style="color:#E8E8E8;">{{ .Phone }}</span>.
+              </p>
+
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                If you did not make this change, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can lock the account.
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because an account security event was triggered on your UnClick account.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/email-templates/reset-password.html
+++ b/supabase/email-templates/reset-password.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>Reset your UnClick password</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
+    Reset the password on your UnClick account. The link expires in 15 minutes.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
+
+          <tr>
+            <td align="center" style="padding:0 0 32px 0;">
+              <a href="https://unclick.world" style="text-decoration:none;">
+                <img src="https://unclick.world/logo-wordmark.svg"
+                     alt="UnClick"
+                     width="200"
+                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+                Reset your password
+              </h1>
+
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+                Click the button below to reset the password on your UnClick account. The link expires in 15 minutes and can only be used one time. If you did not request this, you can safely ignore this email.
+              </p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center">
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                          <a href="{{ .ConfirmationURL }}"
+                             target="_blank"
+                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                            Reset password
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
+                If the button does not work, copy and paste this URL into your browser:
+              </p>
+              <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+              </p>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:32px 16px 0 16px;">
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
+                You are receiving this because someone requested a password reset for this email address at UnClick. If that was not you, no action is required and the link will expire on its own.
+              </p>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
+                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>


### PR DESCRIPTION
Version-controls the 12 remaining Supabase auth email templates in `supabase/email-templates/`. All share the visual shell shipped in #56 (magic-link.html).

## Shared shell

- Dark background `#0A0A0A`, card `#121212`, teal accent `#61C1C4`
- UnClick wordmark at top from `https://unclick.world/logo-wordmark.svg`
- Table-based layout, inline styles only, Arial / Helvetica stack
- Preheader text, footer with `unclick.world` link
- No `<style>` blocks, no flexbox / grid, Outlook / Gmail safe

## Three variants

**Action templates (teal button + `ConfirmationURL` fallback line):**
| File | Heading | Variables |
|---|---|---|
| `confirm-signup.html` | Confirm your UnClick account | `{{ .ConfirmationURL }}` |
| `invite-user.html` | You are invited to UnClick | `{{ .ConfirmationURL }}`, `{{ .SiteURL }}` |
| `confirm-email-change.html` | Confirm your new email | `{{ .Email }}`, `{{ .NewEmail }}`, `{{ .ConfirmationURL }}` |
| `reset-password.html` | Reset your password | `{{ .ConfirmationURL }}` |

**Token template (large monospace code box, no button):**
| File | Heading | Variables |
|---|---|---|
| `confirm-reauthentication.html` | Confirm this is you | `{{ .Token }}` in 32px letter-spaced mono, teal border |

**Notification templates (no button; "if this was not you, contact chris@unclick.world" line):**
| File | Heading | Variables |
|---|---|---|
| `password-changed.html` | Your password was changed | `{{ .Email }}` |
| `email-changed.html` | Your email was changed | `{{ .OldEmail }}`, `{{ .Email }}` |
| `phone-changed.html` | Your phone number was changed | `{{ .OldPhone }}`, `{{ .Phone }}`, `{{ .Email }}` |
| `identity-linked.html` | A new identity was linked | `{{ .Provider }}`, `{{ .Email }}` |
| `identity-unlinked.html` | An identity was unlinked | `{{ .Provider }}`, `{{ .Email }}` |
| `mfa-enrolled.html` | Two-step verification turned on | `{{ .FactorType }}`, `{{ .Email }}` |
| `mfa-unenrolled.html` | Two-step verification removed | `{{ .FactorType }}`, `{{ .Email }}` |

Support contact in every "if this was not you" line is `mailto:chris@unclick.world`, matching the structured-data Organization `contactPoint` in `index.html`.

## Install

Supabase Dashboard > Authentication > Email Templates. For each of the 12 slots:
1. Open the matching template in the dashboard (Supabase exposes one editor per template type).
2. Replace the HTML with the contents of the corresponding file in this PR.
3. Save.
4. Trigger a test event (signup, password reset, etc.) and verify the rendered email.

## Files changed

- 12 new files in `supabase/email-templates/` (942 lines total)
- No other changes, no backend or CLI install path

## Auto-merge eligibility

Yes. HTML-only; no functional code, no DB, no brand-copy on unclick.world public surfaces, no billing. Email copy follows the security / auth voice already established in `magic-link.html`.

Hard rules honored: em-dash-free across all 12 files (grep confirms), no secret values inlined, SHA verified before report.

## Out of scope

- Email verification flow screens on the website itself (would live in `src/pages/` not here).
- Automated E2E check that every Supabase template in the dashboard matches the file in this PR.
- Localization. All templates are English only for now.