### PR TITLE
feat(email): bulletproof template rewrite - all 13 Supabase auth emails

### DIFF
--- a/supabase/email-templates/confirm-email-change.html
+++ b/supabase/email-templates/confirm-email-change.html
@@ -4,92 +4,76 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
   <title>Confirm your new UnClick email</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
     Confirm the email change on your UnClick account.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
                 Confirm your new email
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                You asked to change the email on your UnClick account from <span style="color:#E8E8E8;">{{ .Email }}</span> to <span style="color:#E8E8E8;">{{ .NewEmail }}</span>.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                You requested to change your UnClick email from <span style="color:#1A1A1A; font-weight:600;">{{ .Email }}</span> to <span style="color:#1A1A1A; font-weight:600;">{{ .NewEmail }}</span>.
               </p>
-
-              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                Click the button below to confirm. Until you confirm, the existing email stays active on your account.
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                Click the button below to confirm. Your existing email stays active until you do.
               </p>
-
               <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                <tr>
-                  <td align="center">
-                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
-                          <a href="{{ .ConfirmationURL }}"
-                             target="_blank"
-                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
-                            Confirm email change
-                          </a>
-                        </td>
-                      </tr>
-                    </table>
-                  </td>
-                </tr>
+                <tr><td align="center">
+                  <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                      <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                        <a href="{{ .ConfirmationURL }}" target="_blank"
+                           style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                          Confirm email change
+                        </a>
+                      </td>
+                    </tr>
+                  </table>
+                </td></tr>
               </table>
-
               <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
                 If the button does not work, copy and paste this URL into your browser:
               </p>
               <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
                 <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because someone requested an email change on this UnClick account. If that was not you, do not click the button and contact <a href="mailto:chris@unclick.world" style="color:#888888; text-decoration:underline;">chris@unclick.world</a> right away.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                If you did not request this change, contact us at <a href="https://unclick.world" style="color:#AAAAAA;">unclick.world</a>.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/confirm-reauthentication.html
+++ b/supabase/email-templates/confirm-reauthentication.html
@@ -4,77 +4,73 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>Confirm this is you</title>
+  <title>Confirm your identity - UnClick</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    Your UnClick confirmation code. Enter it in the app to continue.
+    Confirm your identity to continue on UnClick.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                Confirm this is you
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Confirm your identity
               </h1>
-
-              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                UnClick asked for your confirmation before completing a sensitive action on your account. Enter this code in the app to continue.
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                To complete this action on your UnClick account, we need to verify your identity. Click below to confirm. This link expires in 15 minutes.
               </p>
-
               <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                <tr>
-                  <td align="center" style="background-color:#0A0A0A; border:2px solid #61C1C4; border-radius:12px; padding:24px 16px;">
-                    <div style="font-family:'Courier New', Courier, monospace; font-size:32px; font-weight:700; letter-spacing:8px; color:#61C1C4;">
-                      {{ .Token }}
-                    </div>
-                  </td>
-                </tr>
+                <tr><td align="center">
+                  <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                      <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                        <a href="{{ .ConfirmationURL }}" target="_blank"
+                           style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                          Confirm identity
+                        </a>
+                      </td>
+                    </tr>
+                  </table>
+                </td></tr>
               </table>
-
-              <p style="margin:24px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888; text-align:center;">
-                This code expires in 10 minutes and can only be used one time.
+              <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
+                If the button does not work, copy and paste this URL into your browser:
               </p>
-
+              <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+              </p>
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because UnClick asked for a re-authentication check on your account. If you did not trigger this, do not share the code and contact <a href="mailto:chris@unclick.world" style="color:#888888; text-decoration:underline;">chris@unclick.world</a> right away.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                If you did not initiate this request, contact us immediately at <a href="https://unclick.world" style="color:#AAAAAA;">unclick.world</a>.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/confirm-signup.html
+++ b/supabase/email-templates/confirm-signup.html
@@ -4,88 +4,73 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
   <title>Confirm your UnClick account</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    Confirm your email to finish creating your UnClick account. The link expires in 24 hours.
+    One click to confirm your new UnClick account.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                Confirm your UnClick account
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Confirm your account
               </h1>
-
-              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                Welcome to UnClick. Click the button below to confirm this email address and finish creating your account. This link expires in 24 hours.
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                Welcome to UnClick. Click below to confirm your email address and activate your account.
               </p>
-
               <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                <tr>
-                  <td align="center">
-                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
-                          <a href="{{ .ConfirmationURL }}"
-                             target="_blank"
-                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
-                            Confirm email
-                          </a>
-                        </td>
-                      </tr>
-                    </table>
-                  </td>
-                </tr>
+                <tr><td align="center">
+                  <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                      <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                        <a href="{{ .ConfirmationURL }}" target="_blank"
+                           style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                          Confirm account
+                        </a>
+                      </td>
+                    </tr>
+                  </table>
+                </td></tr>
               </table>
-
               <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
                 If the button does not work, copy and paste this URL into your browser:
               </p>
               <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
                 <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because someone created a new UnClick account with this email address. If that was not you, you can safely ignore this message.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                If you did not create an UnClick account, you can safely ignore this email.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/email-changed.html
+++ b/supabase/email-templates/email-changed.html
@@ -4,67 +4,56 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>Your UnClick email address was changed</title>
+  <title>Your UnClick email has been changed</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    The email address on your UnClick account was just changed.
+    Your UnClick email address has been updated.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                Your email was changed
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Email address updated
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                The email on your UnClick account changed from <span style="color:#E8E8E8;">{{ .OldEmail }}</span> to <span style="color:#E8E8E8;">{{ .Email }}</span>. Future sign-ins and account notifications will use the new address.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                The email address on your UnClick account has been successfully changed.
               </p>
-
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                If you did not make this change, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can lock the account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                If you did not make this change, contact us immediately at <a href="https://unclick.world" style="color:#61C1C4;">unclick.world</a>.
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this at your previous email address because an email change was applied to your UnClick account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                This is a security notification from UnClick.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/identity-linked.html
+++ b/supabase/email-templates/identity-linked.html
@@ -4,67 +4,56 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>New sign-in identity linked to your UnClick account</title>
+  <title>Sign-in method added - UnClick</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    A new sign-in identity was linked to your UnClick account.
+    A new sign-in method has been linked to your UnClick account.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                A new identity was linked
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Sign-in method added
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                You linked <span style="color:#E8E8E8;">{{ .Provider }}</span> as a new sign-in option for the UnClick account on <span style="color:#E8E8E8;">{{ .Email }}</span>. You can now sign in with that provider.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                A new sign-in method has been linked to your UnClick account.
               </p>
-
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                If you did not link this identity, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can review your account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                If you did not make this change, contact us immediately at <a href="https://unclick.world" style="color:#61C1C4;">unclick.world</a>.
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because a sign-in identity was added to your UnClick account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                This is a security notification from UnClick.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/identity-unlinked.html
+++ b/supabase/email-templates/identity-unlinked.html
@@ -4,67 +4,56 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>Sign-in identity unlinked from your UnClick account</title>
+  <title>Sign-in method removed - UnClick</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    A sign-in identity was removed from your UnClick account.
+    A sign-in method has been removed from your UnClick account.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                An identity was unlinked
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Sign-in method removed
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                You removed <span style="color:#E8E8E8;">{{ .Provider }}</span> as a sign-in option for the UnClick account on <span style="color:#E8E8E8;">{{ .Email }}</span>. You can no longer sign in with that provider.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                A sign-in method has been removed from your UnClick account.
               </p>
-
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                If you did not make this change, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can lock the account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                If you did not make this change, contact us immediately at <a href="https://unclick.world" style="color:#61C1C4;">unclick.world</a>.
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because a sign-in identity was removed from your UnClick account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                This is a security notification from UnClick.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/invite-user.html
+++ b/supabase/email-templates/invite-user.html
@@ -4,92 +4,73 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>You are invited to UnClick</title>
+  <title>You have been invited to UnClick</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    You are invited to create an UnClick account. The invite link expires in 24 hours.
+    You have been invited to join UnClick.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                You are invited to UnClick
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                You have been invited
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                Someone invited you to join UnClick, the agent-native toolbelt for Claude, ChatGPT, and any MCP-compatible AI.
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                You have been invited to join UnClick, the AI agent operating system. Click the button below to accept your invitation and set up your account.
               </p>
-
-              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                Click the button below to accept the invitation and create your account. You can learn more at <a href="{{ .SiteURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .SiteURL }}</a>.
-              </p>
-
               <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                <tr>
-                  <td align="center">
-                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
-                          <a href="{{ .ConfirmationURL }}"
-                             target="_blank"
-                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
-                            Accept invitation
-                          </a>
-                        </td>
-                      </tr>
-                    </table>
-                  </td>
-                </tr>
+                <tr><td align="center">
+                  <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                      <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                        <a href="{{ .ConfirmationURL }}" target="_blank"
+                           style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                          Accept invitation
+                        </a>
+                      </td>
+                    </tr>
+                  </table>
+                </td></tr>
               </table>
-
               <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
                 If the button does not work, copy and paste this URL into your browser:
               </p>
               <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
                 <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because someone invited you to UnClick with this email address. If you are not expecting this invitation, you can safely ignore this message.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                If you did not expect this invitation, you can safely ignore this email.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/magic-link.html
+++ b/supabase/email-templates/magic-link.html
@@ -4,41 +4,39 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
   <title>Sign in to UnClick</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
     Your one-time sign-in link for UnClick. Expires in 15 minutes.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
 
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg"
                      alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+                     width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
 
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
                 Sign in to UnClick
               </h1>
 
-              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
                 Click the button below to sign in to your UnClick account. The link expires in 15 minutes and can only be used one time.
               </p>
 
@@ -72,17 +70,16 @@
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because someone requested a sign-in link for this email address at UnClick. If that was not you, you can safely ignore this message.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                You received this because someone requested a sign-in link for this email at UnClick. If that was not you, ignore this message.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>

--- a/supabase/email-templates/mfa-enrolled.html
+++ b/supabase/email-templates/mfa-enrolled.html
@@ -4,67 +4,56 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>Two-step verification turned on</title>
+  <title>Two-factor authentication enabled - UnClick</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    A new two-step verification factor was added to your UnClick account.
+    Two-factor authentication has been enabled on your UnClick account.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                Two-step verification turned on
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Two-factor authentication enabled
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                You enrolled a new <span style="color:#E8E8E8;">{{ .FactorType }}</span> factor on the UnClick account for <span style="color:#E8E8E8;">{{ .Email }}</span>. Future sign-ins will require this second step.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                Two-factor authentication (2FA) has been enabled on your UnClick account. Your account is now more secure.
               </p>
-
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                If you did not enroll this factor, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> immediately so we can lock the account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                If you did not enable 2FA, contact us immediately at <a href="https://unclick.world" style="color:#61C1C4;">unclick.world</a>.
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because two-step verification settings were changed on your UnClick account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                This is a security notification from UnClick.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/mfa-unenrolled.html
+++ b/supabase/email-templates/mfa-unenrolled.html
@@ -4,67 +4,56 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>Two-step verification removed</title>
+  <title>Two-factor authentication removed - UnClick</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    A two-step verification factor was removed from your UnClick account.
+    Two-factor authentication has been removed from your UnClick account.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                Two-step verification removed
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Two-factor authentication removed
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                You removed the <span style="color:#E8E8E8;">{{ .FactorType }}</span> factor from the UnClick account on <span style="color:#E8E8E8;">{{ .Email }}</span>. Your account no longer requires a second step at sign-in.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                Two-factor authentication (2FA) has been removed from your UnClick account.
               </p>
-
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                If you did not remove this factor, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> immediately so we can lock the account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                If you did not make this change, contact us immediately at <a href="https://unclick.world" style="color:#61C1C4;">unclick.world</a>.
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because two-step verification settings were changed on your UnClick account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                This is a security notification from UnClick.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/password-changed.html
+++ b/supabase/email-templates/password-changed.html
@@ -4,67 +4,56 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>Your UnClick password was changed</title>
+  <title>Your UnClick password has been changed</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    The password on your UnClick account was just changed.
+    Your UnClick password has been updated.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                Your password was changed
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Password updated
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                The password on the UnClick account for <span style="color:#E8E8E8;">{{ .Email }}</span> was just changed. No further action is required if this was you.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                The password on your UnClick account has been successfully changed.
               </p>
-
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                If this was not you, <a href="https://unclick.world/login" style="color:#61C1C4; text-decoration:underline;">reset your password</a> right away and contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a>.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                If you did not make this change, contact us immediately at <a href="https://unclick.world" style="color:#61C1C4;">unclick.world</a>.
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because an account security event was triggered on your UnClick account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                This is a security notification from UnClick.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/phone-changed.html
+++ b/supabase/email-templates/phone-changed.html
@@ -4,67 +4,56 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
-  <title>Your UnClick phone number was changed</title>
+  <title>Your UnClick phone number has been changed</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    The phone number on your UnClick account was just changed.
+    Your UnClick phone number has been updated.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
-                Your phone number was changed
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
+                Phone number updated
               </h1>
-
-              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                The phone number on the UnClick account for <span style="color:#E8E8E8;">{{ .Email }}</span> changed from <span style="color:#E8E8E8;">{{ .OldPhone }}</span> to <span style="color:#E8E8E8;">{{ .Phone }}</span>.
+              <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                The phone number on your UnClick account has been successfully changed.
               </p>
-
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                If you did not make this change, contact <a href="mailto:chris@unclick.world" style="color:#61C1C4; text-decoration:underline;">chris@unclick.world</a> right away so we can lock the account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                If you did not make this change, contact us immediately at <a href="https://unclick.world" style="color:#61C1C4;">unclick.world</a>.
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because an account security event was triggered on your UnClick account.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                This is a security notification from UnClick.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>

--- a/supabase/email-templates/reset-password.html
+++ b/supabase/email-templates/reset-password.html
@@ -4,88 +4,73 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark light">
-  <meta name="supported-color-schemes" content="dark light">
   <title>Reset your UnClick password</title>
 </head>
-<body style="margin:0; padding:0; background-color:#0A0A0A; color:#E8E8E8; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
+<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    Reset the password on your UnClick account. The link expires in 15 minutes.
+    Reset your UnClick password. Link expires in 15 minutes.
   </div>
 
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0A0A0A;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
     <tr>
       <td align="center" style="padding:40px 16px;">
-
         <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; width:100%;">
 
           <tr>
-            <td align="center" style="padding:0 0 32px 0;">
-              <a href="https://unclick.world" style="text-decoration:none;">
-                <img src="https://unclick.world/logo-wordmark.svg"
-                     alt="UnClick"
-                     width="200"
-                     style="display:block; border:0; outline:none; max-width:200px; width:200px; height:auto;">
+            <td style="padding:0;">
+              <a href="https://unclick.world" style="text-decoration:none; display:block;">
+                <img src="https://unclick.world/email-header.jpg" alt="UnClick" width="600"
+                     style="display:block; width:100%; max-width:600px; border:0; outline:none; height:auto; border-radius:12px 12px 0 0;">
               </a>
             </td>
           </tr>
 
           <tr>
-            <td style="background-color:#121212; border:1px solid #1F1F1F; border-radius:12px; padding:40px 32px;">
-
-              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#E8E8E8;">
+            <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
+              <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
                 Reset your password
               </h1>
-
-              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#B8B8B8;">
-                Click the button below to reset the password on your UnClick account. The link expires in 15 minutes and can only be used one time. If you did not request this, you can safely ignore this email.
+              <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
+                Click the button below to reset your UnClick password. This link expires in 15 minutes and can only be used once.
               </p>
-
               <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                <tr>
-                  <td align="center">
-                    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
-                          <a href="{{ .ConfirmationURL }}"
-                             target="_blank"
-                             style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
-                            Reset password
-                          </a>
-                        </td>
-                      </tr>
-                    </table>
-                  </td>
-                </tr>
+                <tr><td align="center">
+                  <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                      <td bgcolor="#61C1C4" style="border-radius:8px; mso-padding-alt:14px 36px;">
+                        <a href="{{ .ConfirmationURL }}" target="_blank"
+                           style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
+                          Reset password
+                        </a>
+                      </td>
+                    </tr>
+                  </table>
+                </td></tr>
               </table>
-
               <p style="margin:32px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; color:#888888;">
                 If the button does not work, copy and paste this URL into your browser:
               </p>
               <p style="margin:8px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:1.6; word-break:break-all;">
                 <a href="{{ .ConfirmationURL }}" style="color:#61C1C4; text-decoration:underline;">{{ .ConfirmationURL }}</a>
               </p>
-
             </td>
           </tr>
 
           <tr>
             <td align="center" style="padding:32px 16px 0 16px;">
-              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#666666;">
-                You are receiving this because someone requested a password reset for this email address at UnClick. If that was not you, no action is required and the link will expire on its own.
+              <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:1.6; color:#999999;">
+                If you did not request a password reset, ignore this email. Your password will not change.
               </p>
-              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#666666;">
-                <a href="https://unclick.world" style="color:#888888; text-decoration:none;">unclick.world</a>
+              <p style="margin:16px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#BBBBBB;">
+                <a href="https://unclick.world" style="color:#AAAAAA; text-decoration:none;">unclick.world</a>
               </p>
             </td>
           </tr>
 
         </table>
-
       </td>
     </tr>
   </table>
-
 </body>
 </html>


### PR DESCRIPTION
Rewrites all 13 Supabase auth email templates to the bulletproof pattern.

**Pattern:** Branded JPG header (`https://unclick.world/email-header.jpg`) + light background (#F5F5F5) + white card + dark text + teal CTA buttons (#61C1C4).

**Action templates (CTA button):** magic-link, confirm-signup, confirm-email-change, invite-user, reset-password, confirm-reauthentication.

**Notification templates (no button):** email-changed, identity-linked, identity-unlinked, mfa-enrolled, mfa-unenrolled, password-changed, phone-changed.

Note: header JPG at `public/email-header.jpg` is being dropped in by Chris separately and is not committed here.