### PR TITLE
feat(admin): seed vault button + relocate danger zone to settings

### DIFF
--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -24,6 +24,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { useSession } from "@/lib/auth";
 import {
   AlertTriangle,
@@ -35,6 +36,7 @@ import {
   KeyRound,
   Loader2,
   Pencil,
+  Plus,
   RefreshCw,
   RotateCw,
   Shield,
@@ -149,6 +151,7 @@ export default function AdminKeychain() {
   const [rotateTarget, setRotateTarget] = useState<Credential | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Credential | null>(null);
   const [auditOpen, setAuditOpen]       = useState(false);
+  const [starterOpen, setStarterOpen]   = useState(false);
 
   // Audit log (only fetched when drawer opens)
   const [auditEntries, setAuditEntries] = useState<AuditEntry[] | null>(null);
@@ -389,12 +392,15 @@ export default function AdminKeychain() {
           <KeyRound className="mx-auto h-8 w-8 text-[#333]" />
           <p className="mt-3 text-sm text-[#666]">No credentials stored</p>
           <p className="mt-1 text-xs text-[#444]">
-            Connect a platform via{" "}
-            <a href="/backstagepass" className="text-[#E2B93B] underline-offset-2 hover:underline">
-              BackstagePass
-            </a>{" "}
-            or the MCP server to see it here
+            Connect a platform via the MCP server, or add one manually below.
           </p>
+          <button
+            onClick={() => setStarterOpen(true)}
+            className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-3 py-2 text-xs font-semibold text-[#E2B93B] transition-colors hover:bg-[#E2B93B]/20"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add starter credentials
+          </button>
         </div>
       ) : (
         <div className="space-y-6">
@@ -601,6 +607,61 @@ export default function AdminKeychain() {
           loading={auditLoading}
           onClose={() => setAuditOpen(false)}
         />
+      )}
+
+      {/* Starter credentials picker */}
+      {starterOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setStarterOpen(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-xl border border-white/[0.08] bg-[#111111] p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-white">Add a credential</h3>
+              <button
+                onClick={() => setStarterOpen(false)}
+                className="rounded-md p-1 text-[#888] transition-colors hover:bg-white/[0.04] hover:text-white"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <p className="mb-4 text-xs text-[#666]">
+              Choose a platform to connect. You can also add any platform via the MCP server.
+            </p>
+            <div className="space-y-1.5">
+              {([
+                { slug: "slack",    name: "Slack",    desc: "Messages and channels" },
+                { slug: "shopify",  name: "Shopify",  desc: "Store and orders" },
+                { slug: "xero",     name: "Xero",     desc: "Accounting and invoices" },
+                { slug: "discord",  name: "Discord",  desc: "Servers and messages" },
+                { slug: "telegram", name: "Telegram", desc: "Bots and channels" },
+                { slug: "reddit",   name: "Reddit",   desc: "Posts and comments" },
+              ] as const).map(({ slug, name, desc }) => (
+                <Link
+                  key={slug}
+                  to={`/connect/${slug}`}
+                  onClick={() => setStarterOpen(false)}
+                  className="flex items-center justify-between rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2.5 transition-colors hover:border-[#E2B93B]/30 hover:bg-[#E2B93B]/5"
+                >
+                  <div>
+                    <p className="text-xs font-medium text-white">{name}</p>
+                    <p className="text-[11px] text-[#555]">{desc}</p>
+                  </div>
+                  <Plus className="h-3.5 w-3.5 shrink-0 text-[#555]" />
+                </Link>
+              ))}
+            </div>
+            <p className="mt-4 text-center text-[11px] text-[#444]">
+              More platforms available via{" "}
+              <Link to="/backstagepass" className="text-[#E2B93B] hover:underline" onClick={() => setStarterOpen(false)}>
+                BackstagePass
+              </Link>
+            </p>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -19,9 +19,9 @@
  */
 
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
-import { useSession } from "@/lib/auth";
+import { useSession, signOut } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -100,6 +100,7 @@ function formatRelative(iso: string | null): string {
 export default function AdminSettings() {
   const { toast } = useToast();
   const { session } = useSession();
+  const navigate = useNavigate();
   const [apiKey] = useState<string>(getApiKey);
   const [platform, setPlatform] = useState<Platform>(getStoredPlatform);
 
@@ -117,6 +118,11 @@ export default function AdminSettings() {
   const [generating, setGenerating] = useState(false);
 
   const [howToCheckOpen, setHowToCheckOpen] = useState(false);
+
+  const [deleteOpen, setDeleteOpen]   = useState(false);
+  const [deleteTyped, setDeleteTyped] = useState("");
+  const [deleting, setDeleting]       = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     try {
@@ -284,6 +290,31 @@ export default function AdminSettings() {
     if (!apiKey) return;
     window.open(`/api/memory-admin?action=business_context`, "_blank");
   };
+
+  async function handleDeleteAccount() {
+    if (!session) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=delete_account", {
+        method:  "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? `Delete failed with ${res.status}`);
+      }
+      try { localStorage.removeItem("unclick_api_key"); } catch { /* ignore */ }
+      await signOut();
+      navigate("/", { replace: true });
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Delete failed");
+      setDeleting(false);
+    }
+  }
 
   return (
     <div>
@@ -548,6 +579,18 @@ export default function AdminSettings() {
               Export everything
             </Button>
           </div>
+          <div className="mt-6 border-t border-[#E2B93B]/10 pt-5">
+            <p className="text-xs font-medium text-white/80">Delete account</p>
+            <p className="mt-1 text-xs text-white/50">
+              Permanently removes your memory, credentials, API keys, and profile. Cannot be undone.
+            </p>
+            <button
+              onClick={() => { setDeleteTyped(""); setDeleteError(null); setDeleteOpen(true); }}
+              className="mt-3 rounded-md border border-red-500/40 bg-red-500/10 px-4 py-2 text-xs font-semibold text-red-400 transition-colors hover:bg-red-500/20"
+            >
+              Delete account
+            </button>
+          </div>
         </section>
 
         {/* SUPPORT */}
@@ -577,6 +620,75 @@ export default function AdminSettings() {
           </div>
         </section>
       </div>
+
+      {deleteOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={() => { if (!deleting) setDeleteOpen(false); }}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-red-500/30 bg-[#0A0A0A] p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-red-400" />
+              <h3 className="text-base font-semibold text-white">Delete your account</h3>
+            </div>
+            <p className="mt-3 text-xs text-[#BBB] leading-relaxed">
+              This removes your auth identity plus every row keyed to your account: memory (facts,
+              sessions, business context, conversation log, knowledge library, code dumps), stored
+              credentials, API keys, devices, and profile data. It is permanent.
+            </p>
+            <p className="mt-3 text-xs text-[#BBB]">
+              To confirm, type your email address:
+            </p>
+            <p className="mt-1 font-mono text-xs text-white">{session?.user?.email ?? ""}</p>
+            <input
+              type="email"
+              value={deleteTyped}
+              onChange={(e) => setDeleteTyped(e.target.value)}
+              placeholder="Type your email here"
+              autoFocus
+              disabled={deleting}
+              className="mt-3 w-full rounded-md border border-white/10 bg-black/50 px-3 py-2 font-mono text-xs text-white placeholder:text-[#555] focus:border-red-500/60 focus:outline-none"
+            />
+            {deleteError && (
+              <p className="mt-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+                {deleteError}
+              </p>
+            )}
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setDeleteOpen(false)}
+                disabled={deleting}
+                className="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-xs font-medium text-[#BBB] transition-colors hover:bg-white/[0.06] disabled:opacity-40"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleDeleteAccount()}
+                disabled={
+                  deleting ||
+                  deleteTyped.trim().toLowerCase() !== (session?.user?.email ?? "").trim().toLowerCase() ||
+                  !(session?.user?.email ?? "")
+                }
+                className="flex items-center gap-2 rounded-md border border-red-500/50 bg-red-500/20 px-3 py-2 text-xs font-semibold text-red-300 transition-colors hover:bg-red-500/30 disabled:cursor-not-allowed disabled:opacity-30"
+              >
+                {deleting ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  "Delete account permanently"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -187,11 +187,6 @@ export default function AdminYou() {
   const [copied, setCopied] = useState(false);
   const revealTimerRef = useRef<number | null>(null);
 
-  // Danger Zone: self-serve account deletion.
-  const [deleteOpen, setDeleteOpen]     = useState(false);
-  const [deleteTyped, setDeleteTyped]   = useState("");
-  const [deleting, setDeleting]         = useState(false);
-  const [deleteError, setDeleteError]   = useState<string | null>(null);
 
   useEffect(() => {
     // Wait for Supabase to confirm the session state before firing
@@ -308,34 +303,6 @@ export default function AdminYou() {
   async function handleLogout() {
     await signOut();
     navigate("/login", { replace: true });
-  }
-
-  async function handleDeleteAccount() {
-    if (!session) return;
-    setDeleting(true);
-    setDeleteError(null);
-    try {
-      const res = await fetch("/api/memory-admin?action=delete_account", {
-        method:  "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${session.access_token}`,
-        },
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? `Delete failed with ${res.status}`);
-      }
-      // Hard-clear local caches before signOut so a rapid redirect
-      // cannot leave the previous identity's api_key in localStorage
-      // for a microsecond.
-      try { localStorage.removeItem("unclick_api_key"); } catch { /* ignore */ }
-      await signOut();
-      navigate("/", { replace: true });
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : "Delete failed");
-      setDeleting(false);
-    }
   }
 
   async function revokeDevice(deviceId: string) {
@@ -574,100 +541,9 @@ export default function AdminYou() {
             )}
           </div>
 
-          {/* Danger Zone (full width) */}
-          <div className="rounded-xl border border-red-500/30 bg-red-950/20 p-6 lg:col-span-2">
-            <h2 className="flex items-center gap-2 text-sm font-semibold text-red-400">
-              <AlertTriangle className="h-4 w-4" />
-              Danger Zone
-            </h2>
-            <p className="mt-2 text-xs text-red-300/80">
-              Deleting your account permanently removes your UnClick memory,
-              stored credentials, API keys, and profile information. This cannot
-              be undone. Active MCP clients using your api_key will stop working.
-            </p>
-            <button
-              onClick={() => {
-                setDeleteTyped("");
-                setDeleteError(null);
-                setDeleteOpen(true);
-              }}
-              className="mt-4 rounded-md border border-red-500/40 bg-red-500/10 px-4 py-2 text-xs font-semibold text-red-400 transition-colors hover:bg-red-500/20"
-            >
-              Delete account
-            </button>
-          </div>
         </div>
       )}
 
-      {deleteOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-          onClick={() => { if (!deleting) setDeleteOpen(false); }}
-        >
-          <div
-            className="w-full max-w-md rounded-2xl border border-red-500/30 bg-[#0A0A0A] p-6 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-red-400" />
-              <h3 className="text-base font-semibold text-white">Delete your account</h3>
-            </div>
-            <p className="mt-3 text-xs text-[#BBB] leading-relaxed">
-              This removes your auth identity plus every row keyed to your
-              account: memory (facts, sessions, business context, conversation
-              log, knowledge library, code dumps), stored credentials, API
-              keys, devices, and profile data. It is permanent.
-            </p>
-            <p className="mt-3 text-xs text-[#BBB]">
-              To confirm, type your email address:
-            </p>
-            <p className="mt-1 font-mono text-xs text-white">{user?.email ?? ""}</p>
-            <input
-              type="email"
-              value={deleteTyped}
-              onChange={(e) => setDeleteTyped(e.target.value)}
-              placeholder="Type your email here"
-              autoFocus
-              disabled={deleting}
-              className="mt-3 w-full rounded-md border border-white/10 bg-black/50 px-3 py-2 font-mono text-xs text-white placeholder:text-[#555] focus:border-red-500/60 focus:outline-none"
-            />
-            {deleteError && (
-              <p className="mt-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
-                {deleteError}
-              </p>
-            )}
-            <div className="mt-5 flex items-center justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => setDeleteOpen(false)}
-                disabled={deleting}
-                className="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-xs font-medium text-[#BBB] transition-colors hover:bg-white/[0.06] disabled:opacity-40"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleDeleteAccount()}
-                disabled={
-                  deleting ||
-                  deleteTyped.trim().toLowerCase() !== (user?.email ?? "").trim().toLowerCase() ||
-                  !(user?.email ?? "")
-                }
-                className="flex items-center gap-2 rounded-md border border-red-500/50 bg-red-500/20 px-3 py-2 text-xs font-semibold text-red-300 transition-colors hover:bg-red-500/30 disabled:cursor-not-allowed disabled:opacity-30"
-              >
-                {deleting ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    Deleting...
-                  </>
-                ) : (
-                  "Delete account permanently"
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

- **AdminKeychain empty state**: Add "Add starter credentials" button that opens a platform picker modal (Slack, Shopify, Xero, Discord, Telegram, Reddit) with direct links to `/connect/:platform`
- **Danger Zone relocation**: Move account-deletion section from `/admin/you` to `/admin/settings`, keeping the existing muted-yellow styling and adding a red Delete Account sub-section with email-confirmation modal
- **Key reveal / copy verified**: Eye-toggle and clipboard copy on AdminKeychain were confirmed working as-is - no changes needed

## Resend SMTP

Could not check domain verification - RESEND_API_KEY is in Vercel env only. Needs manual check or Vercel CLI access.

## Files changed

- `src/pages/admin/AdminKeychain.tsx` - empty state button + starter modal
- `src/pages/admin/AdminSettings.tsx` - delete account state, handler, button, modal
- `src/pages/admin/AdminYou.tsx` - remove relocated danger zone