### PR TITLE
feat(marketing): add dismissible Beta banner with signup CTA and bug report link

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,11 @@
 # Copy this file to .env.local and fill in your credentials.
 # Supabase: Dashboard > Project Settings > API
 
+# Beta banner - shown on all pages during public beta.
+# Set to "false" in Vercel env vars to hide it when you exit beta.
+# Omitting the var keeps the banner visible (safe default).
+VITE_BETA_BANNER_ENABLED=true
+
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-public-key-here
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import LoginPage from "./pages/Login.tsx";
 import SignupPage from "./pages/Signup.tsx";
 import AuthCallbackPage from "./pages/AuthCallback.tsx";
 import RequireAuth from "./components/RequireAuth.tsx";
+import BetaBanner from "./components/BetaBanner.tsx";
 import AdminShell from "./pages/admin/AdminShell.tsx";
 import AdminYou from "./pages/admin/AdminYou.tsx";
 import AdminMemory from "./pages/admin/AdminMemory.tsx";
@@ -58,6 +59,7 @@ const App = () => (
       <Sonner />
       <Analytics />
       <BrowserRouter>
+        <BetaBanner />
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/docs" element={<DocsPage />} />

--- a/src/components/BetaBanner.tsx
+++ b/src/components/BetaBanner.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { X } from "lucide-react";
+import { useSession } from "@/lib/auth";
+
+const STORAGE_KEY = "unclick_beta_banner_dismissed";
+const BANNER_H = 36;
+const BANNER_H_PX = `${BANNER_H}px`;
+
+function isDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export default function BetaBanner() {
+  const enabled = import.meta.env.VITE_BETA_BANNER_ENABLED !== "false";
+  const { session } = useSession();
+  const [visible, setVisible] = useState(enabled && !isDismissed());
+
+  useEffect(() => {
+    document.documentElement.style.setProperty("--bbn-h", visible ? BANNER_H_PX : "0px");
+    return () => {
+      document.documentElement.style.setProperty("--bbn-h", "0px");
+    };
+  }, [visible]);
+
+  function dismiss() {
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  const ctaHref = session ? "/admin/you" : "/signup";
+  const ctaLabel = session ? "go to your dashboard" : "try it free";
+
+  return (
+    <div
+      className="fixed inset-x-0 top-0 z-[70] flex items-center justify-center gap-2 border-b border-[#61C1C4]/20 bg-[#0D1A1A] px-4"
+      style={{ height: BANNER_H_PX }}
+    >
+      <span className="text-[11px] leading-none text-[#888]" aria-hidden>
+        &#9888;
+      </span>
+      <p className="text-[12px] leading-none text-[#999]">
+        <span className="font-medium text-[#ccc]">UnClick is in beta</span>
+        {" - "}
+        <Link to={ctaHref} className="text-[#61C1C4] transition-colors hover:text-[#7dd4d7]">
+          {ctaLabel}
+        </Link>
+        {" - "}
+        <a
+          href="mailto:bugs@unclick.world?subject=UnClick%20Beta%20Bug%20Report"
+          className="text-[#61C1C4] transition-colors hover:text-[#7dd4d7]"
+        >
+          report a bug
+        </a>
+      </p>
+
+      <button
+        onClick={dismiss}
+        aria-label="Dismiss beta banner"
+        className="absolute right-3 rounded p-1 text-[#555] transition-colors hover:text-[#999]"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,7 +24,7 @@ const Navbar = () => {
   ];
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-md">
+    <nav className="fixed left-0 right-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-md" style={{ top: "var(--bbn-h, 0px)" }}>
       <div className="container mx-auto flex h-14 max-w-6xl items-center justify-between gap-4 px-6">
         <Link to="/" className="shrink-0">
           <img src="/logo-wordmark.svg" alt="UnClick" style={{ height: "3.3rem" }} className="w-auto pt-2 pb-[3px]" />

--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,7 @@
     --sidebar-accent-foreground: 0 0% 91%;
     --sidebar-border: 0 0% 15%;
     --sidebar-ring: 182 46% 57%;
+    --bbn-h: 0px;
   }
 }
 

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -73,7 +73,7 @@ export default function AdminShell() {
   return (
     <div className="flex min-h-screen bg-[#0A0A0A] text-[#ccc]">
       {/* ── Desktop sidebar (md+) ──────────────────────────── */}
-      <aside className="fixed inset-y-0 left-0 z-40 hidden w-56 flex-col border-r border-white/[0.06] bg-[#0A0A0A] md:flex">
+      <aside className="fixed left-0 z-40 hidden w-56 flex-col border-r border-white/[0.06] bg-[#0A0A0A] md:flex" style={{ top: "var(--bbn-h, 0px)", bottom: 0 }}>
         <div className="flex h-14 items-center px-5">
           <Link to="/">
             <img
@@ -123,7 +123,7 @@ export default function AdminShell() {
       </aside>
 
       {/* ── Desktop top bar (md+) with global search ───────────── */}
-      <header className="fixed inset-x-0 top-0 z-30 hidden h-14 items-center border-b border-white/[0.06] bg-[#0A0A0A] md:flex md:pl-56">
+      <header className="fixed inset-x-0 z-30 hidden h-14 items-center border-b border-white/[0.06] bg-[#0A0A0A] md:flex md:pl-56" style={{ top: "var(--bbn-h, 0px)" }}>
         <div className="flex flex-1 items-center gap-3 px-4 lg:px-8">
           <div className="flex-1">
             <AdminSearchBar />
@@ -133,7 +133,7 @@ export default function AdminShell() {
       </header>
 
       {/* ── Mobile/tablet top bar (<md) ────────────────────── */}
-      <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b border-white/[0.06] bg-[#0A0A0A] px-4 md:hidden">
+      <header className="fixed inset-x-0 z-40 flex h-14 items-center justify-between border-b border-white/[0.06] bg-[#0A0A0A] px-4 md:hidden" style={{ top: "var(--bbn-h, 0px)" }}>
         <Link to="/">
           <img
             src="/logo-wordmark.svg"
@@ -161,7 +161,7 @@ export default function AdminShell() {
 
       {/* Mobile nav drawer */}
       {mobileNavOpen && (
-        <div className="fixed inset-x-0 top-14 z-30 border-b border-white/[0.06] bg-[#0A0A0A] p-3 md:hidden">
+        <div className="fixed inset-x-0 z-30 border-b border-white/[0.06] bg-[#0A0A0A] p-3 md:hidden" style={{ top: "calc(var(--bbn-h, 0px) + 56px)" }}>
           <div className="mb-3">
             <AdminSearchBar />
           </div>
@@ -186,7 +186,7 @@ export default function AdminShell() {
       )}
 
       {/* ── Main content ────────────────────────────────── */}
-      <main className="min-h-screen flex-1 pt-14 md:ml-56 md:pt-14">
+      <main className="min-h-screen flex-1 md:ml-56" style={{ paddingTop: "calc(var(--bbn-h, 0px) + 56px)" }}>
         <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
           <Outlet />
         </div>


### PR DESCRIPTION
## What

Thin 36px fixed banner at the top of every page signaling beta status.

## Details

- **BetaBanner.tsx** (new): fixed at `top-0 z-70`, teal-on-dark palette matching the UnClick design system
- **Copy**: "UnClick is in beta - try it free - report a bug" where:
  - "try it free" links to `/signup` (signed-out) or `/admin/you` (signed-in)
  - "report a bug" is `mailto:bugs@unclick.world?subject=UnClick%20Beta%20Bug%20Report`
- **Dismissible**: X button stores `unclick_beta_banner_dismissed=1` in localStorage; banner gone for the session
- **Feature flag**: `VITE_BETA_BANNER_ENABLED` - omitting or setting `true` shows banner; set `false` in Vercel to kill it when beta ends
- **CSS custom property** (`--bbn-h`): BetaBanner sets it to `36px` on mount, `0px` on dismiss. Navbar and all AdminShell fixed headers read it via `style={{ top: "var(--bbn-h, 0px)" }}` so nothing overlaps regardless of state

## Files changed

- `src/components/BetaBanner.tsx` - new component
- `src/App.tsx` - render BetaBanner inside BrowserRouter
- `src/index.css` - initialize `--bbn-h: 0px` on `:root`
- `src/components/Navbar.tsx` - top offset via CSS var
- `src/pages/admin/AdminShell.tsx` - all 3 fixed headers + main padding via CSS var
- `.env.local.example` - document the new flag

## Action required from Chris

Set up email forwarding: `bugs@unclick.world` -> `creativelead@malamutemayhem.com`

Do this in Namecheap (or wherever unclick.world DNS/email lives): add a redirect/forward for the `bugs` mailbox to your personal address. If using Office 365 or another hosted email, add the alias there instead.