### PR TITLE
feat(auth): add TOTP MFA via authenticator app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import InstallRecoverPage from "./pages/InstallRecover.tsx";
 import LoginPage from "./pages/Login.tsx";
 import SignupPage from "./pages/Signup.tsx";
 import AuthCallbackPage from "./pages/AuthCallback.tsx";
+import VerifyMfaPage from "./pages/VerifyMfa.tsx";
 import RequireAuth from "./components/RequireAuth.tsx";
 import BetaBanner from "./components/BetaBanner.tsx";
 import AdminShell from "./pages/admin/AdminShell.tsx";
@@ -115,6 +116,7 @@ const App = () => (
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
+          <Route path="/auth/verify-mfa" element={<VerifyMfaPage />} />
           <Route path="/organiser" element={<OrganiserPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />
           <Route path="/crews" element={<CrewsPage />} />

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -44,12 +44,14 @@ export default function AuthCallbackPage() {
         }
       }
       // Check if MFA is required before entering the admin shell
-      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aal?.nextLevel === "aal2" && aal.currentLevel !== "aal2") {
-        navigate("/auth/verify-mfa", { replace: true });
-      } else {
-        navigate("/admin", { replace: true });
-      }
+      void (async () => {
+        const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (aal?.nextLevel === "aal2" && aal.currentLevel !== "aal2") {
+          navigate("/auth/verify-mfa", { replace: true });
+        } else {
+          navigate("/admin", { replace: true });
+        }
+      })();
     }
   }, [loading, session, navigate]);
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -16,6 +16,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { useSession } from "@/lib/auth";
+import { supabase } from "@/lib/supabase";
 import { Loader2 } from "lucide-react";
 
 export default function AuthCallbackPage() {
@@ -42,7 +43,13 @@ export default function AuthCallbackPage() {
           track("returning_user_signin", { method });
         }
       }
-      navigate("/admin", { replace: true });
+      // Check if MFA is required before entering the admin shell
+      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (aal?.nextLevel === "aal2" && aal.currentLevel !== "aal2") {
+        navigate("/auth/verify-mfa", { replace: true });
+      } else {
+        navigate("/admin", { replace: true });
+      }
     }
   }, [loading, session, navigate]);
 

--- a/src/pages/VerifyMfa.tsx
+++ b/src/pages/VerifyMfa.tsx
@@ -1,0 +1,166 @@
+/**
+ * /auth/verify-mfa
+ *
+ * Second-factor challenge page. Reached automatically after magic-link or
+ * OAuth sign-in when the user has TOTP enrolled (aal2 required).
+ * Creates a challenge, accepts a 6-digit code, verifies it, then
+ * navigates to /admin.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+import { useSession } from "@/lib/auth";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Loader2 } from "lucide-react";
+
+export default function VerifyMfaPage() {
+  const navigate = useNavigate();
+  const { session, loading } = useSession();
+  const [factorId, setFactorId] = useState<string | null>(null);
+  const [challengeId, setChallengeId] = useState<string | null>(null);
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [initialising, setInitialising] = useState(true);
+  const codeRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!session) {
+      navigate("/login", { replace: true });
+      return;
+    }
+    (async () => {
+      // Check if we actually need MFA - if already aal2, go straight to admin
+      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (aal?.currentLevel === "aal2") {
+        navigate("/admin", { replace: true });
+        return;
+      }
+      // Find the enrolled TOTP factor
+      const { data: factors } = await supabase.auth.mfa.listFactors();
+      const totp = factors?.totp?.find((f) => f.status === "verified");
+      if (!totp) {
+        // No verified factor - session is fine as aal1, go to admin
+        navigate("/admin", { replace: true });
+        return;
+      }
+      setFactorId(totp.id);
+      // Create the challenge immediately so we're ready for user input
+      const { data: challenge, error: challengeErr } = await supabase.auth.mfa.challenge({
+        factorId: totp.id,
+      });
+      if (challengeErr || !challenge) {
+        setError(challengeErr?.message ?? "Could not start verification. Try signing in again.");
+        setInitialising(false);
+        return;
+      }
+      setChallengeId(challenge.id);
+      setInitialising(false);
+      setTimeout(() => codeRef.current?.focus(), 100);
+    })();
+  }, [loading, session, navigate]);
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault();
+    if (!factorId || !challengeId || code.length !== 6) return;
+    setVerifying(true);
+    setError(null);
+    const { error: verifyErr } = await supabase.auth.mfa.verify({
+      factorId,
+      challengeId,
+      code: code.trim(),
+    });
+    if (verifyErr) {
+      setError(verifyErr.message);
+      setCode("");
+      setVerifying(false);
+      codeRef.current?.focus();
+      // Create a fresh challenge - old one is consumed on verify attempt
+      if (factorId) {
+        const { data: fresh } = await supabase.auth.mfa.challenge({ factorId });
+        if (fresh) setChallengeId(fresh.id);
+      }
+      return;
+    }
+    navigate("/admin", { replace: true });
+  }
+
+  const isReady = !initialising && challengeId;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navbar />
+      <main className="mx-auto w-full max-w-md px-4 py-24">
+        <div className="rounded-2xl border border-border/60 bg-card/40 p-8 text-center shadow-lg">
+          {initialising ? (
+            <>
+              <Loader2 className="mx-auto h-6 w-6 animate-spin text-primary" />
+              <p className="mt-4 text-sm text-muted-foreground">Setting up verification...</p>
+            </>
+          ) : !isReady ? (
+            <>
+              <h1 className="text-xl font-semibold text-heading">Verification failed</h1>
+              <p className="mt-2 text-sm text-muted-foreground">{error ?? "Could not start verification."}</p>
+              <button
+                onClick={() => navigate("/login", { replace: true })}
+                className="mt-5 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-black hover:opacity-90"
+              >
+                Back to sign in
+              </button>
+            </>
+          ) : (
+            <>
+              <h1 className="text-xl font-semibold text-heading">Two-step verification</h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Enter the 6-digit code from your authenticator app.
+              </p>
+              <form onSubmit={(e) => void handleVerify(e)} className="mt-6">
+                <input
+                  ref={codeRef}
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]{6}"
+                  maxLength={6}
+                  value={code}
+                  onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                  placeholder="000000"
+                  disabled={verifying}
+                  className="w-full rounded-md border border-border bg-background px-4 py-3 text-center font-mono text-2xl tracking-[0.5em] text-heading placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none disabled:opacity-60"
+                />
+                {error && (
+                  <p className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                    {error}
+                  </p>
+                )}
+                <button
+                  type="submit"
+                  disabled={verifying || code.length !== 6}
+                  className="mt-4 w-full rounded-md bg-primary py-2.5 text-sm font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {verifying ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Verifying...
+                    </span>
+                  ) : (
+                    "Verify"
+                  )}
+                </button>
+              </form>
+              <button
+                onClick={() => navigate("/login", { replace: true })}
+                className="mt-4 text-xs text-muted-foreground hover:text-heading"
+              >
+                Sign in with a different account
+              </button>
+            </>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -45,7 +45,9 @@ import {
   ChevronUp,
   FileText,
   Loader2,
+  ShieldCheck,
 } from "lucide-react";
+import { supabase } from "@/lib/supabase";
 
 const API_KEY_STORAGE = "unclick_api_key";
 const PLATFORM_STORAGE = "unclick_platform";
@@ -124,6 +126,18 @@ export default function AdminSettings() {
   const [deleting, setDeleting]       = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
+  // TOTP MFA state
+  const [mfaLoading, setMfaLoading]             = useState(true);
+  const [enrolledFactorId, setEnrolledFactorId] = useState<string | null>(null);
+  const [enrolling, setEnrolling]               = useState(false);
+  const [mfaQr, setMfaQr]                       = useState<string | null>(null);
+  const [mfaSecret, setMfaSecret]               = useState<string | null>(null);
+  const [mfaFactorId, setMfaFactorId]           = useState<string | null>(null);
+  const [mfaCode, setMfaCode]                   = useState("");
+  const [mfaVerifying, setMfaVerifying]         = useState(false);
+  const [mfaError, setMfaError]                 = useState<string | null>(null);
+  const [unenrolling, setUnenrolling]           = useState(false);
+
   useEffect(() => {
     try {
       localStorage.setItem(PLATFORM_STORAGE, platform);
@@ -131,6 +145,15 @@ export default function AdminSettings() {
       /* ignore */
     }
   }, [platform]);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.mfa.listFactors();
+      const verified = data?.totp?.find((f) => f.status === "verified");
+      setEnrolledFactorId(verified?.id ?? null);
+      setMfaLoading(false);
+    })();
+  }, []);
 
   useEffect(() => {
     const effectiveToken = apiKey || session?.access_token || "";
@@ -290,6 +313,77 @@ export default function AdminSettings() {
     if (!apiKey) return;
     window.open(`/api/memory-admin?action=business_context`, "_blank");
   };
+
+  async function handleStartEnroll() {
+    setEnrolling(true);
+    setMfaError(null);
+    const { data, error } = await supabase.auth.mfa.enroll({ factorType: "totp", issuer: "UnClick" });
+    if (error || !data) {
+      setMfaError(error?.message ?? "Could not start enrollment.");
+      setEnrolling(false);
+      return;
+    }
+    setMfaQr(data.totp.qr_code);
+    setMfaSecret(data.totp.secret);
+    setMfaFactorId(data.id);
+    setEnrolling(false);
+  }
+
+  async function handleConfirmEnroll(e: React.FormEvent) {
+    e.preventDefault();
+    if (!mfaFactorId || mfaCode.length !== 6) return;
+    setMfaVerifying(true);
+    setMfaError(null);
+    const { data: challenge, error: challengeErr } = await supabase.auth.mfa.challenge({ factorId: mfaFactorId });
+    if (challengeErr || !challenge) {
+      setMfaError(challengeErr?.message ?? "Challenge failed.");
+      setMfaVerifying(false);
+      return;
+    }
+    const { error: verifyErr } = await supabase.auth.mfa.verify({
+      factorId: mfaFactorId,
+      challengeId: challenge.id,
+      code: mfaCode.trim(),
+    });
+    if (verifyErr) {
+      setMfaError(verifyErr.message);
+      setMfaCode("");
+      setMfaVerifying(false);
+      return;
+    }
+    setEnrolledFactorId(mfaFactorId);
+    setMfaQr(null);
+    setMfaSecret(null);
+    setMfaFactorId(null);
+    setMfaCode("");
+    setMfaVerifying(false);
+    toast({ title: "Authenticator app enabled", description: "Two-step verification is now active on your account." });
+  }
+
+  function handleCancelEnroll() {
+    if (mfaFactorId) {
+      void supabase.auth.mfa.unenroll({ factorId: mfaFactorId });
+    }
+    setMfaQr(null);
+    setMfaSecret(null);
+    setMfaFactorId(null);
+    setMfaCode("");
+    setMfaError(null);
+  }
+
+  async function handleUnenroll() {
+    if (!enrolledFactorId) return;
+    setUnenrolling(true);
+    const { error } = await supabase.auth.mfa.unenroll({ factorId: enrolledFactorId });
+    if (error) {
+      toast({ title: "Could not disable", description: error.message, variant: "destructive" });
+      setUnenrolling(false);
+      return;
+    }
+    setEnrolledFactorId(null);
+    setUnenrolling(false);
+    toast({ title: "Authenticator app removed", description: "Two-step verification has been disabled." });
+  }
 
   async function handleDeleteAccount() {
     if (!session) return;
@@ -559,6 +653,107 @@ export default function AdminSettings() {
                 Servers.
               </li>
             </ul>
+          )}
+        </section>
+
+        {/* TWO-STEP VERIFICATION */}
+        <section className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+            <ShieldCheck className="h-4 w-4 text-[#61C1C4]" />
+            Two-step verification
+          </h2>
+          <p className="mt-1 text-xs text-white/60">
+            Add an authenticator app (Google Authenticator, Authy, 1Password) as a second factor
+            when you sign in with your email link.
+          </p>
+
+          {mfaLoading ? (
+            <div className="mt-4 flex items-center gap-2 text-xs text-white/40">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Checking status...
+            </div>
+          ) : enrolledFactorId && !mfaQr ? (
+            <div className="mt-4 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm text-white">
+                <CheckCircle2 className="h-4 w-4 text-[#61C1C4]" />
+                Authenticator app enabled
+              </div>
+              <button
+                onClick={() => void handleUnenroll()}
+                disabled={unenrolling}
+                className="rounded-md border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-white/60 transition-colors hover:border-white/20 hover:text-white/90 disabled:opacity-40"
+              >
+                {unenrolling ? "Removing..." : "Disable"}
+              </button>
+            </div>
+          ) : mfaQr ? (
+            <div className="mt-4 space-y-4">
+              <p className="text-xs text-white/70">
+                Scan this QR code with your authenticator app, then enter the 6-digit code to confirm.
+              </p>
+              <div className="flex justify-center rounded-lg border border-white/[0.06] bg-white p-4">
+                <img src={mfaQr} alt="TOTP QR code" className="h-40 w-40" />
+              </div>
+              {mfaSecret && (
+                <p className="text-center text-[11px] text-white/40">
+                  Manual key:{" "}
+                  <code className="font-mono text-white/60">{mfaSecret}</code>
+                </p>
+              )}
+              <form onSubmit={(e) => void handleConfirmEnroll(e)} className="space-y-3">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]{6}"
+                  maxLength={6}
+                  value={mfaCode}
+                  onChange={(e) => setMfaCode(e.target.value.replace(/\D/g, ""))}
+                  placeholder="6-digit code"
+                  disabled={mfaVerifying}
+                  className="w-full rounded-md border border-white/10 bg-black/40 px-3 py-2.5 text-center font-mono text-xl tracking-[0.4em] text-white placeholder:text-white/20 focus:border-[#61C1C4]/60 focus:outline-none disabled:opacity-50"
+                />
+                {mfaError && (
+                  <p className="rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+                    {mfaError}
+                  </p>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleCancelEnroll}
+                    disabled={mfaVerifying}
+                    className="flex-1 rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-xs font-medium text-white/60 transition-colors hover:text-white/90 disabled:opacity-40"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={mfaVerifying || mfaCode.length !== 6}
+                    className="flex flex-1 items-center justify-center gap-2 rounded-md bg-[#61C1C4] px-3 py-2 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    {mfaVerifying ? (
+                      <><Loader2 className="h-3.5 w-3.5 animate-spin" />Verifying...</>
+                    ) : (
+                      "Enable"
+                    )}
+                  </button>
+                </div>
+              </form>
+            </div>
+          ) : (
+            <div className="mt-4">
+              <button
+                onClick={() => void handleStartEnroll()}
+                disabled={enrolling}
+                className="flex items-center gap-2 rounded-md border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-4 py-2 text-xs font-semibold text-[#61C1C4] transition-colors hover:bg-[#61C1C4]/20 disabled:opacity-40"
+              >
+                {enrolling ? (
+                  <><Loader2 className="h-3.5 w-3.5 animate-spin" />Setting up...</>
+                ) : (
+                  "Set up authenticator app"
+                )}
+              </button>
+            </div>
           )}
         </section>
 


### PR DESCRIPTION
## Summary
- New `/auth/verify-mfa` page for 6-digit TOTP code entry after sign-in
- `AuthCallback` checks AAL post-session and redirects to verify-mfa when aal2 is required
- `AdminSettings` gets a Two-step verification section: QR code enrollment, verify to activate, disable to remove

## Test plan
- [ ] Sign in with magic link, check redirect to /auth/verify-mfa when TOTP factor enrolled
- [ ] Verify correct 6-digit code navigates to /admin
- [ ] Verify wrong code shows error and refreshes challenge
- [ ] Settings > Two-step verification: scan QR with authenticator app, enter code, see Enabled state
- [ ] Disable removes factor, next sign-in goes directly to /admin

Generated with [Claude Code](https://claude.com/claude-code)