### PR TITLE
feat(testpass): Chunk 2 - MCP probe, run manager, and API endpoint

### DIFF
--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -1,0 +1,177 @@
+/**
+ * TestPass API - Vercel serverless function
+ *
+ * Actions:
+ *   GET  ?action=get_run&run_id=<uuid>              - fetch run + items
+ *   POST ?action=start_run                          - create run, probe target, seed items
+ *
+ * Authentication: Supabase JWT Bearer token (session user = actor).
+ * Service role key used server-side for DB writes (bypasses RLS which
+ * checks actor_user_id = auth.uid() - that match happens at read time).
+ *
+ * Body shape for start_run:
+ *   { pack_slug: string, target: RunTarget, profile?: RunProfile }
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { probeServer } from "../packages/testpass/src/probe.js";
+import {
+  createRun,
+  createEvidence,
+  seedPendingItems,
+  updateRunStatus,
+  computeVerdictSummary,
+} from "../packages/testpass/src/run-manager.js";
+import { loadPackFromFile } from "../packages/testpass/src/pack-loader.js";
+import * as path from "node:path";
+import * as url from "node:url";
+import type { RunTarget, RunProfile } from "../packages/testpass/src/types.js";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const CORS = {
+  "Access-Control-Allow-Origin": "https://unclick.world",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization,Content-Type",
+};
+
+function json(res: VercelResponse, status: number, body: unknown) {
+  res.status(status).setHeader("Content-Type", "application/json");
+  Object.entries(CORS).forEach(([k, v]) => res.setHeader(k, v));
+  res.end(JSON.stringify(body));
+}
+
+async function getActorUserId(
+  supabaseUrl: string,
+  token: string
+): Promise<string | null> {
+  const r = await fetch(`${supabaseUrl}/auth/v1/user`, {
+    headers: { apikey: process.env.SUPABASE_SERVICE_ROLE_KEY ?? "", Authorization: `Bearer ${token}` },
+  });
+  if (!r.ok) return null;
+  const u = (await r.json()) as { id?: string };
+  return u.id ?? null;
+}
+
+async function getPackIdBySlug(
+  supabaseUrl: string,
+  serviceKey: string,
+  slug: string
+): Promise<string | null> {
+  const r = await fetch(
+    `${supabaseUrl}/rest/v1/testpass_packs?slug=eq.${encodeURIComponent(slug)}&select=id&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
+  );
+  if (!r.ok) return null;
+  const rows = (await r.json()) as Array<{ id: string }>;
+  return rows[0]?.id ?? null;
+}
+
+async function getRunWithItems(
+  supabaseUrl: string,
+  serviceKey: string,
+  runId: string,
+  actorUserId: string
+) {
+  const [runRes, itemsRes] = await Promise.all([
+    fetch(
+      `${supabaseUrl}/rest/v1/testpass_runs?id=eq.${runId}&actor_user_id=eq.${actorUserId}&select=*&limit=1`,
+      { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
+    ),
+    fetch(
+      `${supabaseUrl}/rest/v1/testpass_items?run_id=eq.${runId}&select=*&order=created_at.asc`,
+      { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
+    ),
+  ]);
+  const run = ((await runRes.json()) as unknown[])[0] ?? null;
+  const items = (await itemsRes.json()) as unknown[];
+  return { run, items };
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === "OPTIONS") return json(res, 204, {});
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    return json(res, 500, { error: "Server misconfigured: missing Supabase env vars" });
+  }
+
+  const token = (req.headers.authorization ?? "").replace(/^Bearer\s+/i, "");
+  if (!token) return json(res, 401, { error: "Missing Bearer token" });
+
+  const actorUserId = await getActorUserId(supabaseUrl, token);
+  if (!actorUserId) return json(res, 401, { error: "Invalid session" });
+
+  const action = req.query.action as string;
+  const config = { supabaseUrl, serviceRoleKey: serviceKey };
+
+  if (req.method === "GET" && action === "get_run") {
+    const runId = req.query.run_id as string;
+    if (!runId) return json(res, 400, { error: "run_id required" });
+    const data = await getRunWithItems(supabaseUrl, serviceKey, runId, actorUserId);
+    if (!data.run) return json(res, 404, { error: "Run not found" });
+    return json(res, 200, data);
+  }
+
+  if (req.method === "POST" && action === "start_run") {
+    const body = req.body as {
+      pack_slug?: string;
+      target?: RunTarget;
+      profile?: RunProfile;
+    };
+    if (!body.pack_slug || !body.target?.url) {
+      return json(res, 400, { error: "pack_slug and target.url required" });
+    }
+    const profile: RunProfile = body.profile ?? "standard";
+
+    // Resolve pack from DB (built-ins have null owner)
+    const packId = await getPackIdBySlug(supabaseUrl, serviceKey, body.pack_slug);
+    if (!packId) return json(res, 404, { error: `Pack '${body.pack_slug}' not found` });
+
+    // Load pack definition from bundled YAML (built-in packs only for now)
+    const packPath = path.resolve(__dirname, `../packages/testpass/packs/${body.pack_slug}.yaml`);
+    let pack;
+    try {
+      pack = loadPackFromFile(packPath);
+    } catch {
+      return json(res, 422, { error: `Pack YAML not found on server for '${body.pack_slug}'` });
+    }
+
+    const runId = await createRun(config, {
+      packId,
+      target: body.target,
+      profile,
+      actorUserId,
+    });
+
+    // Probe the target MCP server and store evidence (non-blocking on failures)
+    let evidenceRef: string | undefined;
+    try {
+      const probeResult = await probeServer(body.target.url, { timeoutMs: 12_000 });
+      evidenceRef = await createEvidence(config, {
+        kind: "tool_list",
+        payload: probeResult,
+      });
+    } catch (err) {
+      // Probe failed - run continues with pending items, no evidence ref
+      console.error(`TestPass probe failed for run ${runId}:`, (err as Error).message);
+    }
+
+    await seedPendingItems(config, runId, pack, profile, evidenceRef);
+
+    return json(res, 201, { run_id: runId, evidence_ref: evidenceRef ?? null });
+  }
+
+  // Complete a specific run (called by the deterministic runner in Chunk 3)
+  if (req.method === "POST" && action === "complete_run") {
+    const body = req.body as { run_id?: string };
+    if (!body.run_id) return json(res, 400, { error: "run_id required" });
+    const summary = await computeVerdictSummary(config, body.run_id);
+    const hasFailures = summary.fail > 0 || summary.pending > 0;
+    await updateRunStatus(config, body.run_id, hasFailures ? "failed" : "complete", summary);
+    return json(res, 200, { summary });
+  }
+
+  return json(res, 404, { error: "Unknown action" });
+}

--- a/packages/testpass/src/__tests__/probe.test.ts
+++ b/packages/testpass/src/__tests__/probe.test.ts
@@ -1,0 +1,71 @@
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { probeServer } from "../probe.js";
+
+function makeJsonRpcServer(
+  handler: (method: string, params: unknown) => unknown | null
+): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let body = "";
+      req.on("data", (c: Buffer) => (body += c.toString()));
+      req.on("end", () => {
+        const rpc = JSON.parse(body) as { id?: number; method: string; params: unknown };
+        const result = handler(rpc.method, rpc.params);
+        if (rpc.id === undefined) {
+          res.writeHead(204).end();
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() });
+    });
+  });
+}
+
+describe("probeServer", () => {
+  let srv: { url: string; close: () => void };
+
+  beforeAll(async () => {
+    srv = await makeJsonRpcServer((method) => {
+      if (method === "initialize") {
+        return {
+          protocolVersion: "2024-11-05",
+          serverInfo: { name: "test-server", version: "1.0.0" },
+          capabilities: { tools: {} },
+          instructions: "Test MCP server",
+        };
+      }
+      if (method === "tools/list") {
+        return { tools: [{ name: "echo", description: "Echoes input" }] };
+      }
+      return null;
+    });
+  });
+
+  afterAll(() => srv.close());
+
+  it("returns protocolVersion and serverInfo", async () => {
+    const result = await probeServer(srv.url);
+    expect(result.protocolVersion).toBe("2024-11-05");
+    expect(result.serverInfo.name).toBe("test-server");
+  });
+
+  it("returns tool list from tools/list", async () => {
+    const result = await probeServer(srv.url);
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe("echo");
+  });
+
+  it("records latencyMs", async () => {
+    const result = await probeServer(srv.url);
+    expect(result.latencyMs).toBeGreaterThan(0);
+  });
+
+  it("throws on unreachable server", async () => {
+    await expect(probeServer("http://127.0.0.1:1", { timeoutMs: 500 })).rejects.toThrow();
+  });
+});

--- a/packages/testpass/src/index.ts
+++ b/packages/testpass/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./pack-schema.js";
 export * from "./pack-loader.js";
+export * from "./probe.js";
+export * from "./run-manager.js";
 export type * from "./types.js";

--- a/packages/testpass/src/probe.ts
+++ b/packages/testpass/src/probe.ts
@@ -1,0 +1,118 @@
+/**
+ * MCP probe - connects to an MCP server over HTTP and reads its tool list.
+ *
+ * Transport: HTTP POST to a single endpoint (simple JSON-RPC over HTTP).
+ * SSE transport is out of scope for Chunk 2.
+ */
+
+export interface ProbeResult {
+  protocolVersion: string;
+  serverInfo: { name: string; version: string };
+  capabilities: Record<string, unknown>;
+  tools: ToolEntry[];
+  instructions?: string;
+  latencyMs: number;
+}
+
+export interface ToolEntry {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+export interface ProbeOptions {
+  timeoutMs?: number;
+  clientName?: string;
+  clientVersion?: string;
+}
+
+class JsonRpcError extends Error {
+  code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "JsonRpcError";
+  }
+}
+
+async function rpc(
+  url: string,
+  method: string,
+  params: unknown,
+  id: number | null,
+  timeoutMs: number
+): Promise<unknown> {
+  const body: Record<string, unknown> = { jsonrpc: "2.0", method, params };
+  if (id !== null) body.id = id;
+
+  const controller = new AbortController();
+  const tid = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} from MCP server`);
+    }
+    if (id === null) return null; // notification - no response expected
+    const data = (await res.json()) as {
+      result?: unknown;
+      error?: { code: number; message: string };
+    };
+    if (data.error) throw new JsonRpcError(data.error.code, data.error.message);
+    return data.result;
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+/**
+ * Probe an MCP server: initialize, list tools, return structured evidence.
+ */
+export async function probeServer(url: string, opts: ProbeOptions = {}): Promise<ProbeResult> {
+  const { timeoutMs = 10_000, clientName = "testpass-probe", clientVersion = "0.1.0" } = opts;
+  const start = Date.now();
+
+  const initResult = (await rpc(
+    url,
+    "initialize",
+    {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: clientName, version: clientVersion },
+      capabilities: {},
+    },
+    1,
+    timeoutMs
+  )) as {
+    protocolVersion: string;
+    serverInfo?: { name: string; version: string };
+    capabilities?: Record<string, unknown>;
+    instructions?: string;
+  };
+
+  // Send initialized notification (no id = notification, no response expected)
+  await rpc(url, "notifications/initialized", {}, null, timeoutMs).catch(() => {
+    // Servers that don't accept POSTs for notifications return errors; ignore.
+  });
+
+  // List tools if capability declared
+  let tools: ToolEntry[] = [];
+  if (initResult.capabilities?.tools !== undefined) {
+    const listResult = (await rpc(url, "tools/list", {}, 2, timeoutMs)) as {
+      tools?: ToolEntry[];
+    };
+    tools = listResult?.tools ?? [];
+  }
+
+  return {
+    protocolVersion: initResult.protocolVersion,
+    serverInfo: initResult.serverInfo ?? { name: "unknown", version: "unknown" },
+    capabilities: initResult.capabilities ?? {},
+    tools,
+    instructions: initResult.instructions,
+    latencyMs: Date.now() - start,
+  };
+}

--- a/packages/testpass/src/run-manager.ts
+++ b/packages/testpass/src/run-manager.ts
@@ -1,0 +1,155 @@
+/**
+ * run-manager - Supabase REST API wrapper for TestPass run lifecycle.
+ *
+ * Creates/updates runs, items, and evidence rows without pulling in the
+ * Supabase SDK (keeps the package edge-compatible and dependency-light).
+ */
+
+import type { Pack } from "./types.js";
+import type { RunTarget, RunProfile, RunStatus, VerdictSummary } from "./types.js";
+
+export interface RunManagerConfig {
+  supabaseUrl: string;
+  serviceRoleKey: string;
+}
+
+async function supaFetch(
+  config: RunManagerConfig,
+  path: string,
+  method: string,
+  body?: unknown,
+  extra?: Record<string, string>
+): Promise<unknown> {
+  const res = await fetch(`${config.supabaseUrl}/rest/v1/${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+      Prefer: "return=representation",
+      ...extra,
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`Supabase ${method} ${path} → ${res.status}: ${text}`);
+  return text ? JSON.parse(text) : null;
+}
+
+export async function createRun(
+  config: RunManagerConfig,
+  params: {
+    packId: string;
+    target: RunTarget;
+    profile: RunProfile;
+    actorUserId: string;
+  }
+): Promise<string> {
+  const rows = (await supaFetch(config, "testpass_runs", "POST", {
+    pack_id: params.packId,
+    target: params.target,
+    profile: params.profile,
+    actor_user_id: params.actorUserId,
+    status: "running",
+    verdict_summary: { total: 0, check: 0, na: 0, fail: 0, other: 0, pending: 0, pass_rate: 0 },
+  })) as Array<{ id: string }>;
+  return rows[0].id;
+}
+
+export async function updateRunStatus(
+  config: RunManagerConfig,
+  runId: string,
+  status: RunStatus,
+  summary?: VerdictSummary
+): Promise<void> {
+  const patch: Record<string, unknown> = { status };
+  if (status !== "running") patch.completed_at = new Date().toISOString();
+  if (summary) patch.verdict_summary = summary;
+  await supaFetch(config, `testpass_runs?id=eq.${runId}`, "PATCH", patch);
+}
+
+export async function createEvidence(
+  config: RunManagerConfig,
+  params: {
+    kind: string;
+    payload: unknown;
+  }
+): Promise<string> {
+  const rows = (await supaFetch(config, "testpass_evidence", "POST", {
+    kind: params.kind,
+    payload: params.payload,
+  })) as Array<{ id: string }>;
+  return rows[0].id;
+}
+
+export async function seedPendingItems(
+  config: RunManagerConfig,
+  runId: string,
+  pack: Pack,
+  profile: RunProfile,
+  evidenceRef?: string
+): Promise<void> {
+  const items = pack.items.filter(
+    (i) => !i.profiles || i.profiles.includes(profile)
+  );
+  if (items.length === 0) return;
+  await supaFetch(
+    config,
+    "testpass_items",
+    "POST",
+    items.map((i) => ({
+      run_id: runId,
+      check_id: i.id,
+      title: i.title,
+      category: i.category,
+      severity: i.severity,
+      verdict: "pending",
+      evidence_ref: evidenceRef ?? null,
+    }))
+  );
+}
+
+export async function updateItem(
+  config: RunManagerConfig,
+  runId: string,
+  checkId: string,
+  update: {
+    verdict: string;
+    on_fail_comment?: string;
+    time_ms?: number;
+    cost_usd?: number;
+  }
+): Promise<void> {
+  await supaFetch(
+    config,
+    `testpass_items?run_id=eq.${runId}&check_id=eq.${encodeURIComponent(checkId)}`,
+    "PATCH",
+    update
+  );
+}
+
+export async function computeVerdictSummary(
+  config: RunManagerConfig,
+  runId: string
+): Promise<VerdictSummary> {
+  const items = (await supaFetch(
+    config,
+    `testpass_items?run_id=eq.${runId}&select=verdict`,
+    "GET"
+  )) as Array<{ verdict: string }>;
+
+  const summary: VerdictSummary = {
+    total: items.length,
+    check: 0, na: 0, fail: 0, other: 0, pending: 0,
+    pass_rate: 0,
+  };
+  for (const item of items) {
+    const v = item.verdict as keyof VerdictSummary;
+    if (v in summary && v !== "total" && v !== "pass_rate") {
+      (summary[v] as number)++;
+    }
+  }
+  const decided = summary.check + summary.na + summary.fail + summary.other;
+  summary.pass_rate = decided > 0 ? summary.check / decided : 0;
+  return summary;
+}


### PR DESCRIPTION
## Summary
- \`probe.ts\`: HTTP JSON-RPC client that initializes + lists tools from any MCP server, returns structured evidence with latency
- \`run-manager.ts\`: Supabase REST wrapper for run lifecycle (create, seed items, store evidence, compute verdict summary, finalize)
- \`api/testpass.ts\`: Vercel function with \`start_run\` (probe + seed pending items), \`get_run\` (fetch status + items), \`complete_run\` (finalize verdicts)
- \`probe.test.ts\`: in-process mock HTTP server tests for happy path, tool list, latency, and unreachable-server error

## Test plan
- [ ] \`npm test\` in \`packages/testpass\` passes probe suite
- [ ] POST \`/api/testpass?action=start_run\` with a live MCP server URL creates a run + evidence row
- [ ] GET \`/api/testpass?action=get_run&run_id=...\` returns run + seeded pending items
- [ ] Probe against unreachable server leaves run in \`running\` status with no evidence_ref (graceful)

Generated with [Claude Code](https://claude.com/claude-code)