### PR TITLE
fix(admin): MemoryHealthPill goes green without API key

### DIFF
--- a/src/components/admin/MemoryHealthPill.tsx
+++ b/src/components/admin/MemoryHealthPill.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
+import { useSession } from "@/lib/auth";
 
 const API_KEY_STORAGE = "unclick_api_key";
 const REFRESH_MS = 60_000;
@@ -45,6 +46,7 @@ function shortTime(iso: string | null): string {
 
 export default function MemoryHealthPill() {
   const [data, setData] = useState<HealthData | null>(null);
+  const { session } = useSession();
   const apiKey = useMemo(() => {
     try {
       return localStorage.getItem(API_KEY_STORAGE) ?? "";
@@ -54,13 +56,21 @@ export default function MemoryHealthPill() {
   }, []);
 
   useEffect(() => {
-    if (!apiKey) return;
+    const token = session?.access_token;
+    if (!apiKey && !token) return;
     let cancelled = false;
     async function fetchOnce() {
       try {
-        const res = await fetch(
-          `/api/memory-admin?action=admin_check_connection&api_key=${encodeURIComponent(apiKey)}`
-        );
+        let res: Response;
+        if (apiKey) {
+          res = await fetch(
+            `/api/memory-admin?action=admin_check_connection&api_key=${encodeURIComponent(apiKey)}`
+          );
+        } else {
+          res = await fetch("/api/memory-admin?action=admin_check_connection", {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+        }
         if (!res.ok) return;
         const body = (await res.json()) as HealthData;
         if (!cancelled) setData(body);
@@ -74,7 +84,7 @@ export default function MemoryHealthPill() {
       cancelled = true;
       window.clearInterval(iv);
     };
-  }, [apiKey]);
+  }, [apiKey, session]);
 
   const tone = pickTone(data);
   const label =


### PR DESCRIPTION
## Summary

- `MemoryHealthPill` was unconditionally bailing out when `localStorage` had no `unclick_api_key`, leaving the pill permanently grey/\"Not connected\" for every admin user who signs in via Supabase (the normal path)
- `admin_check_connection` already supports a Supabase JWT Bearer auth path - this PR wires the pill up to it
- When `apiKey` is present it still uses the original query-param path; when absent it falls back to the session `access_token` as a `Bearer` header
- No API changes

## Test plan

- [ ] Sign into /admin without an API key set in localStorage - pill should go green (or \"No memory yet\" amber) rather than grey
- [ ] Sign into /admin with a valid API key stored - original query-param path still works
- [ ] With neither key nor session (logged out), pill stays grey

Auto-merge when CI green.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>