### PR TITLE
fix(devices): filter 169.254.x.x link-local IPs from paired device list

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -2125,6 +2125,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         };
         const fp = (body?.device_fingerprint ?? "").trim();
         if (!fp) return res.status(400).json({ error: "device_fingerprint required" });
+        if (/^169\.254\./.test(fp)) return res.status(400).json({ error: "link-local addresses cannot be paired" });
         const mode = body?.storage_mode === "cloud" ? "cloud" : "local";
 
         const { error: upErr } = await supabase
@@ -2189,13 +2190,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("api_key_hash", apiKeyHash)
           .order("last_seen", { ascending: false });
         if (error) throw error;
-        const mapped = (data ?? []).map((d) => ({
-          id:           d.id as string,
-          device_id:    (d.device_fingerprint ?? "") as string,
-          device_name:  (d.label ?? null) as string | null,
-          paired_at:    (d.first_seen ?? d.last_seen ?? new Date(0).toISOString()) as string,
-          last_seen_at: (d.last_seen ?? new Date(0).toISOString()) as string,
-        }));
+        const LINK_LOCAL_RE = /^169\.254\./;
+        const mapped = (data ?? [])
+          .filter((d) => !LINK_LOCAL_RE.test((d.device_fingerprint ?? "") as string))
+          .map((d) => ({
+            id:           d.id as string,
+            device_id:    (d.device_fingerprint ?? "") as string,
+            device_name:  (d.label ?? null) as string | null,
+            paired_at:    (d.first_seen ?? d.last_seen ?? new Date(0).toISOString()) as string,
+            last_seen_at: (d.last_seen ?? new Date(0).toISOString()) as string,
+          }));
         return res.status(200).json({ data: mapped });
       }
 


### PR DESCRIPTION
## Summary

- Vercel internal network was generating APIPA (169.254.x.x) link-local IP addresses on every admin API call and storing them as device pairings, producing 38+ phantom devices on /admin/you
- Two-pronged fix so the leak stops and existing junk disappears:
  1. `pair_device` now rejects fingerprints matching `169.254.*` with a 400 - nothing new gets written
  2. `auth_device_list` filters out any existing rows with link-local fingerprints before mapping - the 38 phantom entries vanish from the UI immediately without a DB migration

## Test plan

- [ ] /admin/you device list drops from 38 down to the real paired devices after deploy
- [ ] Subsequent page loads don't re-add link-local entries
- [ ] Pairing a real device still works normally

Auto-merge when CI green.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>