### PR TITLE
feat(testpass): Chunk 3 - deterministic runner for RPC + MCP lifecycle checks

### DIFF
--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -22,6 +22,7 @@ import {
   updateRunStatus,
   computeVerdictSummary,
 } from "../packages/testpass/src/run-manager.js";
+import { runDeterministicChecks } from "../packages/testpass/src/runner/deterministic.js";
 import { loadPackFromFile } from "../packages/testpass/src/pack-loader.js";
 import * as path from "node:path";
 import * as url from "node:url";
@@ -160,10 +161,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     await seedPendingItems(config, runId, pack, profile, evidenceRef);
 
-    return json(res, 201, { run_id: runId, evidence_ref: evidenceRef ?? null });
+    // Run deterministic checks inline. Agent checks (check_type: agent)
+    // with no registered handler are left pending for a future runner.
+    if (body.target.url) {
+      try {
+        await runDeterministicChecks(config, runId, body.target.url, pack, profile);
+      } catch (err) {
+        console.error(`TestPass deterministic run failed for ${runId}:`, (err as Error).message);
+      }
+    }
+
+    // Finalize: any item still pending means we're waiting on the agent runner.
+    const summary = await computeVerdictSummary(config, runId);
+    const isDone  = summary.pending === 0;
+    await updateRunStatus(
+      config,
+      runId,
+      isDone ? (summary.fail > 0 ? "failed" : "complete") : "running",
+      summary,
+    );
+
+    return json(res, 201, { run_id: runId, evidence_ref: evidenceRef ?? null, summary });
   }
 
-  // Complete a specific run (called by the deterministic runner in Chunk 3)
+  // Complete a specific run (called when agent checks land after Chunk 4+)
   if (req.method === "POST" && action === "complete_run") {
     const body = req.body as { run_id?: string };
     if (!body.run_id) return json(res, 400, { error: "run_id required" });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2958,6 +2958,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -3019,6 +3029,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -3033,6 +3053,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -6154,6 +6198,230 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@types/js-yaml": {
@@ -19571,6 +19839,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "jest": "^29.0.0",

--- a/packages/testpass/package.json
+++ b/packages/testpass/package.json
@@ -17,6 +17,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "jest": "^29.0.0",
@@ -26,12 +27,19 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "extensionsToTreatAsEsm": [".ts"],
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
     },
     "transform": {
-      "^.+\\.tsx?$": ["ts-jest", { "useESM": true }]
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "useESM": true
+        }
+      ]
     }
   }
 }

--- a/packages/testpass/src/__tests__/deterministic.test.ts
+++ b/packages/testpass/src/__tests__/deterministic.test.ts
@@ -1,0 +1,272 @@
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { runDeterministicChecks } from "../runner/deterministic.js";
+import * as runManager from "../run-manager.js";
+import { loadPackFromYaml } from "../pack-loader.js";
+
+// ─── Mock the DB layer ────────────────────────────────────────────────────
+jest.mock("../run-manager.js", () => ({
+  updateItem:     jest.fn().mockResolvedValue(undefined),
+  createEvidence: jest.fn().mockResolvedValue("evidence-id-stub"),
+}));
+
+const mockUpdateItem     = runManager.updateItem     as jest.Mock;
+const mockCreateEvidence = runManager.createEvidence as jest.Mock;
+
+// ─── Mock MCP server ──────────────────────────────────────────────────────
+
+function makeMockMcpServer(): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let raw = "";
+      req.on("data", (c: Buffer) => (raw += c.toString()));
+      req.on("end", () => {
+        // Batch request
+        if (raw.trimStart().startsWith("[")) {
+          const batch = JSON.parse(raw) as Array<{ id?: number; method: string }>;
+          const responses = batch
+            .filter((r) => r.id !== undefined)
+            .map((r) => ({ jsonrpc: "2.0", id: r.id, result: mockResult(r.method) }));
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(responses));
+          return;
+        }
+
+        const rpc = JSON.parse(raw) as { id?: number; method: string; params?: unknown };
+
+        // Notification: no id
+        if (rpc.id === undefined) {
+          res.writeHead(204).end();
+          return;
+        }
+
+        const result = mockResult(rpc.method);
+        if (result === "__ERROR__") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            jsonrpc: "2.0",
+            id:      rpc.id,
+            error:   { code: -32601, message: "Method not found" },
+          }));
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() });
+    });
+  });
+}
+
+function mockResult(method: string): unknown {
+  if (method === "initialize") {
+    return {
+      protocolVersion: "2024-11-05",
+      serverInfo:      { name: "test-mcp", version: "1.0.0" },
+      capabilities:    { tools: {} },
+      instructions:    "Test MCP server for TestPass",
+    };
+  }
+  if (method === "ping") return {};
+  return "__ERROR__";
+}
+
+// ─── Minimal pack fixture ─────────────────────────────────────────────────
+
+const PACK_YAML = `
+id: testpass-core
+name: TestPass Core v0
+version: 0.1.0
+items:
+  - id: RPC-001
+    title: jsonrpc field
+    category: json-rpc
+    severity: critical
+    check_type: deterministic
+  - id: RPC-002
+    title: id echo
+    category: json-rpc
+    severity: high
+    check_type: deterministic
+  - id: RPC-003
+    title: error shape
+    category: json-rpc
+    severity: high
+    check_type: deterministic
+  - id: RPC-004
+    title: method not found code
+    category: json-rpc
+    severity: high
+    check_type: deterministic
+  - id: RPC-005
+    title: batch support
+    category: json-rpc
+    severity: medium
+    check_type: deterministic
+  - id: RPC-006
+    title: notification no response
+    category: json-rpc
+    severity: medium
+    check_type: deterministic
+  - id: MCP-001
+    title: initialize result
+    category: mcp-lifecycle
+    severity: critical
+    check_type: agent
+  - id: MCP-002
+    title: instructions
+    category: mcp-lifecycle
+    severity: medium
+    check_type: agent
+  - id: MCP-003
+    title: capabilities
+    category: mcp-lifecycle
+    severity: high
+    check_type: agent
+  - id: MCP-004
+    title: initialized notification
+    category: mcp-lifecycle
+    severity: high
+    check_type: agent
+  - id: MCP-005
+    title: ping
+    category: mcp-lifecycle
+    severity: medium
+    check_type: agent
+  - id: MCP-006
+    title: unknown method
+    category: mcp-lifecycle
+    severity: high
+    check_type: agent
+`;
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("runDeterministicChecks", () => {
+  let srv: { url: string; close: () => void };
+  const config = { supabaseUrl: "http://unused", serviceRoleKey: "unused" };
+  const pack   = loadPackFromYaml(PACK_YAML);
+
+  beforeAll(async () => { srv = await makeMockMcpServer(); });
+  afterAll(() => srv.close());
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it("calls updateItem for all 12 items", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    expect(mockUpdateItem).toHaveBeenCalledTimes(12);
+  });
+
+  it("passes RPC-001 (jsonrpc field)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "RPC-001");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes RPC-002 (id echo)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "RPC-002");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes RPC-003 (error shape)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "RPC-003");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes RPC-004 (method not found = -32601)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "RPC-004");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes or marks na RPC-005 (batch)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "RPC-005");
+    expect(["check", "na"]).toContain(call?.[3].verdict);
+  });
+
+  it("passes RPC-006 (notification no response)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "RPC-006");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes MCP-001 (initialize result shape)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-001");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes MCP-002 (instructions non-empty)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-002");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes MCP-003 (capabilities declared)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-003");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes MCP-004 (initialized notification accepted)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-004");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes MCP-005 (ping returns empty result)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-005");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("passes MCP-006 (unknown method = -32601)", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    const call = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-006");
+    expect(call?.[3].verdict).toBe("check");
+  });
+
+  it("records evidence for every check", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    expect(mockCreateEvidence).toHaveBeenCalledTimes(12);
+    expect(mockCreateEvidence.mock.calls[0][1].kind).toBe("http_trace");
+  });
+
+  it("records time_ms and zero cost_usd on each item", async () => {
+    await runDeterministicChecks(config, "run-1", srv.url, pack, "standard");
+    for (const call of mockUpdateItem.mock.calls) {
+      expect(typeof call[3].time_ms).toBe("number");
+      expect(call[3].cost_usd).toBe(0);
+    }
+  });
+
+  it("marks verdict other on unreachable server", async () => {
+    await runDeterministicChecks(config, "run-bad", "http://127.0.0.1:1", pack, "standard");
+    for (const call of mockUpdateItem.mock.calls) {
+      expect(["other", "fail"]).toContain(call[3].verdict);
+    }
+  });
+
+  it("skips smoke-only items when running with deep profile", async () => {
+    const smokeOnlyYaml = `
+id: test
+name: Test
+version: 0.1.0
+items:
+  - id: RPC-001
+    title: rpc
+    category: json-rpc
+    severity: critical
+    check_type: deterministic
+    profiles: [smoke]
+`;
+    const smokePack = loadPackFromYaml(smokeOnlyYaml);
+    await runDeterministicChecks(config, "run-2", srv.url, smokePack, "deep");
+    expect(mockUpdateItem).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/testpass/src/index.ts
+++ b/packages/testpass/src/index.ts
@@ -2,4 +2,5 @@ export * from "./pack-schema.js";
 export * from "./pack-loader.js";
 export * from "./probe.js";
 export * from "./run-manager.js";
+export * from "./runner/deterministic.js";
 export type * from "./types.js";

--- a/packages/testpass/src/pack-schema.ts
+++ b/packages/testpass/src/pack-schema.ts
@@ -24,7 +24,7 @@ export const PackSchema = z.object({
   extends: z.string().optional(),
   include: z.array(z.string()).optional(),
   exclude: z.array(z.string()).optional(),
-  overrides: z.record(z.string(), z.partial(PackItemSchema.omit({ id: true }))).optional(),
+  overrides: z.record(z.string(), PackItemSchema.omit({ id: true }).partial()).optional(),
   items: z.array(PackItemSchema).min(1),
 });
 

--- a/packages/testpass/src/run-manager.ts
+++ b/packages/testpass/src/run-manager.ts
@@ -118,6 +118,7 @@ export async function updateItem(
     on_fail_comment?: string;
     time_ms?: number;
     cost_usd?: number;
+    evidence_ref?: string;
   }
 ): Promise<void> {
   await supaFetch(

--- a/packages/testpass/src/runner/deterministic.ts
+++ b/packages/testpass/src/runner/deterministic.ts
@@ -1,0 +1,328 @@
+/**
+ * Deterministic runner for TestPass Core.
+ *
+ * Executes all registered check handlers against a target MCP server
+ * via HTTP JSON-RPC, writes per-check verdicts and evidence to Supabase,
+ * and returns when all handlers have settled.
+ *
+ * Items without a registered handler are left as "pending" so a future
+ * agent runner (Chunk 4) can pick them up.
+ */
+
+import type { Pack, RunProfile } from "../types.js";
+import type { RunManagerConfig } from "../run-manager.js";
+import { updateItem, createEvidence } from "../run-manager.js";
+
+// ─── Internal types ────────────────────────────────────────────────
+
+interface HttpTrace {
+  request:  { url: string; body: unknown };
+  response: { status: number; body: unknown; latency_ms: number };
+}
+
+type CheckVerdict = "check" | "fail" | "na" | "other";
+
+interface CheckOutcome {
+  verdict: CheckVerdict;
+  note?:   string;
+  traces:  HttpTrace[];
+}
+
+// ─── Low-level send ─────────────────────────────────────────────────
+// Always reads the full response body regardless of whether it is a
+// notification. This differs from probe.ts which shortcuts for
+// notifications - the runner needs to assert on response content.
+
+async function send(
+  url:       string,
+  reqBody:   unknown,
+  timeoutMs  = 10_000,
+): Promise<{ status: number; body: unknown; latency_ms: number }> {
+  const start      = Date.now();
+  const controller = new AbortController();
+  const tid        = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method:  "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body:    JSON.stringify(reqBody),
+      signal:  controller.signal,
+    });
+    let body: unknown = null;
+    const text = await res.text();
+    if (text) {
+      try { body = JSON.parse(text); } catch { body = text; }
+    }
+    return { status: res.status, body, latency_ms: Date.now() - start };
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+function rpcReq(method: string, params: unknown, id?: number): unknown {
+  const r: Record<string, unknown> = { jsonrpc: "2.0", method, params };
+  if (id !== undefined) r.id = id;
+  return r;
+}
+
+// ─── Check handlers ────────────────────────────────────────────────
+
+type CheckHandler = (targetUrl: string) => Promise<CheckOutcome>;
+
+const HANDLERS: Record<string, CheckHandler> = {
+
+  // RPC-001: Every response must carry jsonrpc: "2.0".
+  "RPC-001": async (url) => {
+    const req = rpcReq("initialize", {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: "testpass-runner", version: "0.1.0" },
+      capabilities: {},
+    }, 1);
+    const r = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body = r.body as Record<string, unknown> | null;
+    if (body?.jsonrpc === "2.0") return { verdict: "check", traces: [trace] };
+    return { verdict: "fail", note: `Expected jsonrpc "2.0", got ${JSON.stringify(body?.jsonrpc)}`, traces: [trace] };
+  },
+
+  // RPC-002: Response id must echo the request id.
+  "RPC-002": async (url) => {
+    const ID  = 42;
+    const req = rpcReq("initialize", {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: "testpass-runner", version: "0.1.0" },
+      capabilities: {},
+    }, ID);
+    const r = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body = r.body as Record<string, unknown> | null;
+    if (body?.id === ID) return { verdict: "check", traces: [trace] };
+    return { verdict: "fail", note: `Expected id ${ID}, got ${JSON.stringify(body?.id)}`, traces: [trace] };
+  },
+
+  // RPC-003: Error object must have integer code and string message.
+  "RPC-003": async (url) => {
+    const req = rpcReq("__testpass_nonexistent__", {}, 99);
+    const r   = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body = r.body as Record<string, unknown> | null;
+    const err  = body?.error as Record<string, unknown> | undefined;
+    if (err && typeof err.code === "number" && typeof err.message === "string") {
+      return { verdict: "check", traces: [trace] };
+    }
+    return { verdict: "fail", note: `Error must have integer code and string message, got ${JSON.stringify(err)}`, traces: [trace] };
+  },
+
+  // RPC-004: Unknown method must return error.code === -32601.
+  "RPC-004": async (url) => {
+    const req = rpcReq("__testpass_nonexistent__", {}, 100);
+    const r   = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body = r.body as Record<string, unknown> | null;
+    const err  = body?.error as Record<string, unknown> | undefined;
+    if (err?.code === -32601) return { verdict: "check", traces: [trace] };
+    return { verdict: "fail", note: `Expected error.code -32601, got ${JSON.stringify(err?.code)}`, traces: [trace] };
+  },
+
+  // RPC-005: Batch request must return an array (or a graceful non-crash).
+  "RPC-005": async (url) => {
+    const batchBody = [
+      rpcReq("initialize", { protocolVersion: "2024-11-05", clientInfo: { name: "testpass-runner", version: "0.1.0" }, capabilities: {} }, 201),
+      rpcReq("initialize", { protocolVersion: "2024-11-05", clientInfo: { name: "testpass-runner", version: "0.1.0" }, capabilities: {} }, 202),
+    ];
+    const r     = await send(url, batchBody);
+    const trace: HttpTrace = { request: { url, body: batchBody }, response: r };
+    if (r.status === 204 || r.body === null) {
+      return { verdict: "na", note: "Server returned no content for batch - batch not supported (acceptable)", traces: [trace] };
+    }
+    if (Array.isArray(r.body)) return { verdict: "check", traces: [trace] };
+    const b = r.body as Record<string, unknown> | null;
+    if (b && "error" in (b as object)) {
+      return { verdict: "na", note: "Server returned single error for batch - batch not supported but server did not crash", traces: [trace] };
+    }
+    return { verdict: "fail", note: `Expected array or graceful error for batch, got ${JSON.stringify(r.body)}`, traces: [trace] };
+  },
+
+  // RPC-006: Notification (no id) must not return a JSON-RPC response object.
+  "RPC-006": async (url) => {
+    const req = { jsonrpc: "2.0", method: "notifications/initialized", params: {} };
+    const r   = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    if (r.status === 204 || r.body === null || r.body === "") {
+      return { verdict: "check", traces: [trace] };
+    }
+    const body = r.body;
+    if (body && typeof body === "object") {
+      if (Object.keys(body as object).length === 0) return { verdict: "check", traces: [trace] };
+      if ("result" in (body as object) || ("error" in (body as object) && (body as Record<string, unknown>).id !== undefined)) {
+        return { verdict: "fail", note: `Server returned JSON-RPC response to notification: ${JSON.stringify(body)}`, traces: [trace] };
+      }
+    }
+    return { verdict: "check", traces: [trace] };
+  },
+
+  // MCP-001: initialize must return serverInfo, protocolVersion, and capabilities.
+  "MCP-001": async (url) => {
+    const req = rpcReq("initialize", {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: "testpass-runner", version: "0.1.0" },
+      capabilities: {},
+    }, 300);
+    const r = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body   = r.body as Record<string, unknown> | null;
+    const result = body?.result as Record<string, unknown> | undefined;
+    if (result && result.serverInfo && result.protocolVersion && result.capabilities !== undefined) {
+      return { verdict: "check", traces: [trace] };
+    }
+    return { verdict: "fail", note: `InitializeResult missing serverInfo/protocolVersion/capabilities: ${JSON.stringify(result)}`, traces: [trace] };
+  },
+
+  // MCP-002: instructions must be a non-empty string.
+  "MCP-002": async (url) => {
+    const req = rpcReq("initialize", {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: "testpass-runner", version: "0.1.0" },
+      capabilities: {},
+    }, 301);
+    const r = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body   = r.body as Record<string, unknown> | null;
+    const result = body?.result as Record<string, unknown> | undefined;
+    if (result && typeof result.instructions === "string" && result.instructions.trim().length > 0) {
+      return { verdict: "check", traces: [trace] };
+    }
+    return { verdict: "fail", note: `instructions missing or empty: ${JSON.stringify(result?.instructions)}`, traces: [trace] };
+  },
+
+  // MCP-003: capabilities must declare at least tools, resources, or prompts.
+  "MCP-003": async (url) => {
+    const req = rpcReq("initialize", {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: "testpass-runner", version: "0.1.0" },
+      capabilities: {},
+    }, 302);
+    const r = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body   = r.body as Record<string, unknown> | null;
+    const result = body?.result as Record<string, unknown> | undefined;
+    const caps   = result?.capabilities as Record<string, unknown> | undefined;
+    if (caps && (caps.tools !== undefined || caps.resources !== undefined || caps.prompts !== undefined)) {
+      return { verdict: "check", traces: [trace] };
+    }
+    return { verdict: "fail", note: `capabilities must declare tools/resources/prompts: ${JSON.stringify(caps)}`, traces: [trace] };
+  },
+
+  // MCP-004: initialized notification must not return an error.
+  "MCP-004": async (url) => {
+    const initReq  = rpcReq("initialize", {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: "testpass-runner", version: "0.1.0" },
+      capabilities: {},
+    }, 303);
+    const notifReq = { jsonrpc: "2.0", method: "notifications/initialized", params: {} };
+    const initR  = await send(url, initReq);
+    const notifR = await send(url, notifReq);
+    const traces: HttpTrace[] = [
+      { request: { url, body: initReq }, response: initR },
+      { request: { url, body: notifReq }, response: notifR },
+    ];
+    const initBody  = initR.body as Record<string, unknown> | null;
+    const notifBody = notifR.body as Record<string, unknown> | null;
+    if (!initBody?.result) {
+      return { verdict: "fail", note: `initialize failed: ${JSON.stringify(initBody)}`, traces };
+    }
+    const notifErr = notifBody && "error" in notifBody && (notifBody.error as Record<string, unknown>)?.code !== undefined;
+    if (!notifErr) return { verdict: "check", traces };
+    return { verdict: "fail", note: `initialized notification returned error: ${JSON.stringify(notifBody)}`, traces };
+  },
+
+  // MCP-005: ping must return an empty result within 5 seconds.
+  "MCP-005": async (url) => {
+    const req   = rpcReq("ping", {}, 304);
+    const start = Date.now();
+    const r     = await send(url, req, 5_500);
+    const latency = Date.now() - start;
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    if (latency > 5_000) {
+      return { verdict: "fail", note: `ping took ${latency}ms (exceeds 5000ms limit)`, traces: [trace] };
+    }
+    const body   = r.body as Record<string, unknown> | null;
+    const result = body?.result;
+    if (result === undefined || result === null || (typeof result === "object" && Object.keys(result as object).length === 0)) {
+      return { verdict: "check", traces: [trace] };
+    }
+    return { verdict: "fail", note: `ping must return empty result, got ${JSON.stringify(result)}`, traces: [trace] };
+  },
+
+  // MCP-006: Unknown method must return error.code -32601 without crashing.
+  "MCP-006": async (url) => {
+    const req = rpcReq("__testpass_unknown_mcp__", {}, 305);
+    const r   = await send(url, req);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+    const body = r.body as Record<string, unknown> | null;
+    const err  = body?.error as Record<string, unknown> | undefined;
+    if (err?.code === -32601) return { verdict: "check", traces: [trace] };
+    if (err) return { verdict: "fail", note: `Expected error.code -32601, got ${JSON.stringify(err.code)}`, traces: [trace] };
+    return { verdict: "fail", note: `Unknown method must return error, got ${JSON.stringify(body)}`, traces: [trace] };
+  },
+};
+
+// ─── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Run all registered deterministic check handlers against `targetUrl`.
+ * Items with no registered handler are skipped (left as pending).
+ * Checks run in parallel; each writes its own evidence + verdict row.
+ */
+export async function runDeterministicChecks(
+  config:    RunManagerConfig,
+  runId:     string,
+  targetUrl: string,
+  pack:      Pack,
+  profile:   RunProfile,
+): Promise<void> {
+  const items = pack.items.filter(
+    (i) => !i.profiles || i.profiles.includes(profile),
+  );
+
+  await Promise.all(
+    items.map(async (item) => {
+      const handler = HANDLERS[item.id];
+      if (!handler) return;
+
+      const checkStart = Date.now();
+      let outcome: CheckOutcome;
+      try {
+        outcome = await handler(targetUrl);
+      } catch (err) {
+        outcome = {
+          verdict: "other",
+          note:    `Runner exception: ${(err as Error).message}`,
+          traces:  [],
+        };
+      }
+      const time_ms = Date.now() - checkStart;
+
+      let evidenceRef: string | undefined;
+      if (outcome.traces.length > 0) {
+        try {
+          evidenceRef = await createEvidence(config, {
+            kind:    "http_trace",
+            payload: outcome.traces.length === 1 ? outcome.traces[0] : outcome.traces,
+          });
+        } catch {
+          // evidence write failure is non-fatal
+        }
+      }
+
+      await updateItem(config, runId, item.id, {
+        verdict:          outcome.verdict,
+        on_fail_comment:  outcome.note,
+        time_ms,
+        cost_usd:         0,
+        evidence_ref:     evidenceRef,
+      });
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

- Implements all 12 checks from TestPass Core v0 deterministically via HTTP JSON-RPC assertions
- Checks run in parallel after `seedPendingItems`; run is finalized (complete/failed) before `start_run` returns
- Each check writes its own evidence row (`kind: http_trace`) and updates the item verdict + `time_ms` + `cost_usd: 0`
- Items with no registered handler (future agent checks) are left pending for Chunk 4
- Pack-schema bugfix: `z.partial(schema)` -> `schema.partial()` (was a pre-existing compile error caught by the new test)

## What runs

| ID | Title | Strategy |
|----|-------|----------|
| RPC-001 | jsonrpc field = "2.0" | assert response.jsonrpc |
| RPC-002 | id echo | assert response.id === request.id |
| RPC-003 | error shape (code + message) | call unknown method, inspect error |
| RPC-004 | -32601 for unknown method | exact code check |
| RPC-005 | batch returns array | batch two requests, accept array or na |
| RPC-006 | notification has no response | 204 / empty body = pass |
| MCP-001 | InitializeResult shape | serverInfo + protocolVersion + capabilities |
| MCP-002 | instructions non-empty | string, non-blank |
| MCP-003 | capabilities declared | tools or resources or prompts |
| MCP-004 | initialized notification accepted | no error back |
| MCP-005 | ping returns {} within 5s | timing + empty result |
| MCP-006 | unknown method = -32601 | same as RPC-004 via MCP method name |

## Test plan

- [ ] 17/17 unit tests pass (mock MCP server)
- [ ] `POST /api/testpass?action=start_run` against `https://unclick.world/api/mcp` returns `>=10/12` pass items in summary
- [ ] Evidence rows appear in `testpass_evidence` with `kind: http_trace`

Auto-merge when CI green.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>