### PR TITLE
fix(you): add Re-issue API Key button + reset_api_key endpoint

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -3354,6 +3354,40 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
 
+      case "reset_api_key": {
+        // Re-issue a new uc_* key for the signed-in user. Invalidates
+        // the old key immediately (hash replaced). BackstagePass
+        // encrypted credentials become unreadable until re-saved.
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+        const existing = (await supabase
+          .from("api_keys")
+          .select("id, tier")
+          .eq("user_id", user.id)
+          .maybeSingle()).data as { id: string; tier: string | null } | null;
+
+        if (!existing) return res.status(404).json({ error: "No API key to reset" });
+
+        const rawKey = `uc_${crypto.randomBytes(16).toString("hex")}`;
+        const { error: updateError } = await supabase
+          .from("api_keys")
+          .update({
+            key_hash:    sha256hex(rawKey),
+            key_prefix:  rawKey.slice(0, 8),
+            usage_count: 0,
+          })
+          .eq("id", existing.id);
+        if (updateError) return res.status(500).json({ error: updateError.message });
+
+        return res.status(200).json({
+          api_key: rawKey,
+          prefix:  rawKey.slice(0, 8),
+          tier:    existing.tier ?? "free",
+        });
+      }
+
       case "delete_account": {
         // Self-serve account deletion. The signed-in user is the ONLY
         // user that can trigger this - there is no admin-impersonation

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -186,6 +186,8 @@ export default function AdminYou() {
   const [keyRevealed, setKeyRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
   const revealTimerRef = useRef<number | null>(null);
+  const [reissuing, setReissuing] = useState(false);
+  const [reissueError, setReissueError] = useState<string | null>(null);
 
 
   useEffect(() => {
@@ -297,6 +299,31 @@ export default function AdminYou() {
       window.setTimeout(() => setCopied(false), 2_000);
     } catch {
       // Browser can block clipboard writes in some contexts; fail silent.
+    }
+  }
+
+  async function handleReissueKey() {
+    if (!session) return;
+    setReissuing(true);
+    setReissueError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=reset_api_key", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) {
+        const body = await res.json() as { error?: string };
+        setReissueError(body.error ?? "Failed to re-issue key");
+        return;
+      }
+      const body = await res.json() as { api_key: string };
+      try { localStorage.setItem("unclick_api_key", body.api_key); } catch { /* ignore */ }
+      setGeneratedKey(body.api_key);
+      setKeyRevealed(false);
+    } catch (e) {
+      setReissueError((e as Error).message);
+    } finally {
+      setReissuing(false);
     }
   }
 
@@ -490,6 +517,21 @@ export default function AdminYou() {
                   <span className="text-xs text-white">
                     {timeAgo(profile.api_key.last_used_at)}
                   </span>
+                </div>
+                <div className="border-t border-white/[0.06] pt-3">
+                  <p className="mb-2 text-[11px] text-[#666]">
+                    Key not visible? Your browser may have cleared it. Re-issuing generates a new key and invalidates the old one - any BackstagePass encrypted credentials will need to be re-saved.
+                  </p>
+                  {reissueError && (
+                    <p className="mb-2 text-[11px] text-red-400">{reissueError}</p>
+                  )}
+                  <button
+                    onClick={handleReissueKey}
+                    disabled={reissuing}
+                    className="w-full rounded-md border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-xs text-white transition-colors hover:bg-white/[0.08] disabled:opacity-50"
+                  >
+                    {reissuing ? "Re-issuing..." : "Re-issue API Key"}
+                  </button>
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
## Summary
- Adds `reset_api_key` POST action to `api/memory-admin.ts`: resolves user from session JWT, generates a new `uc_*` key, replaces `key_hash` + `key_prefix` in `api_keys`, returns plaintext once
- Adds `reissuing` / `reissueError` state and `handleReissueKey` handler to `AdminYou.tsx`
- The `profile?.api_key` branch now shows a warning + "Re-issue API Key" button below the existing key metadata rows
- On success, sets `generatedKey` state and persists to `localStorage`, transitioning to the existing eye/copy reveal card

## Test plan
- [ ] Sign in, clear localStorage, reload `/admin/you` - should see key prefix + "Re-issue API Key" button
- [ ] Click "Re-issue API Key" - button shows "Re-issuing..." during request
- [ ] After success, eye/copy card appears with new key revealed
- [ ] Old `uc_*` key no longer works against `/api/mcp`
- [ ] Network error shows inline error message below the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)