### PR TITLE
fix(admin): hide Analytics sidebar link from non-admin users

### DIFF
--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -23,6 +23,7 @@ import {
   computeVerdictSummary,
 } from "../packages/testpass/src/run-manager.js";
 import { runDeterministicChecks } from "../packages/testpass/src/runner/deterministic.js";
+import { runAgentChecks } from "../packages/testpass/src/runner/agent.js";
 import { loadPackFromFile } from "../packages/testpass/src/pack-loader.js";
 import * as path from "node:path";
 import * as url from "node:url";
@@ -171,7 +172,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    // Finalize: any item still pending means we're waiting on the agent runner.
+    // Run agent checks for any items still pending after the deterministic pass.
+    try {
+      await runAgentChecks(config, runId, body.target.url, pack, profile, evidenceRef);
+    } catch (err) {
+      console.error(`TestPass agent run failed for ${runId}:`, (err as Error).message);
+    }
+
+    // Finalize: any item still pending means agent checks are not configured.
     const summary = await computeVerdictSummary(config, runId);
     const isDone  = summary.pending === 0;
     await updateRunStatus(

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ai-sdk/google": "^3.0.64",
         "@ai-sdk/openai": "^3.0.53",
         "@ai-sdk/react": "^3.0.170",
+        "@anthropic-ai/sdk": "^0.90.0",
         "@hookform/resolvers": "^3.10.0",
         "@modelcontextprotocol/sdk": "^1.15.1",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -386,6 +387,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@asteasolutions/zod-to-openapi": {
@@ -6462,6 +6496,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/nodemailer": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
@@ -7281,6 +7325,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -7387,6 +7443,18 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ai": {
@@ -7637,7 +7705,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -8397,7 +8464,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8880,7 +8946,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -9694,7 +9759,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10370,6 +10434,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -10800,7 +10873,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -10811,6 +10883,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -11293,7 +11384,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -11466,6 +11556,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iceberg-js": {
@@ -14674,7 +14773,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -14684,7 +14782,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -14878,11 +14975,30 @@
         "react-dom": "^16.8 || ^17 || ^18"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
       "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -14903,21 +15019,18 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -17732,6 +17845,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -19086,6 +19205,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
@@ -19835,6 +19963,7 @@
       "name": "@unclick/testpass",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.36.0",
         "js-yaml": "^4.1.0",
         "zod": "^3.22.4"
       },
@@ -19846,6 +19975,36 @@
         "ts-jest": "^29.0.0",
         "typescript": "^5.4.0"
       }
+    },
+    "packages/testpass/node_modules/@anthropic-ai/sdk": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.36.3.tgz",
+      "integrity": "sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "packages/testpass/node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/testpass/node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "packages/testpass/node_modules/@types/node": {
       "version": "20.19.39",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@ai-sdk/google": "^3.0.64",
     "@ai-sdk/openai": "^3.0.53",
     "@ai-sdk/react": "^3.0.170",
+    "@anthropic-ai/sdk": "^0.90.0",
     "@hookform/resolvers": "^3.10.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
     "@radix-ui/react-accordion": "^1.2.11",

--- a/packages/testpass/package.json
+++ b/packages/testpass/package.json
@@ -13,6 +13,7 @@
     "test": "node --experimental-vm-modules node_modules/.bin/jest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.36.0",
     "js-yaml": "^4.1.0",
     "zod": "^3.22.4"
   },

--- a/packages/testpass/src/index.ts
+++ b/packages/testpass/src/index.ts
@@ -3,4 +3,5 @@ export * from "./pack-loader.js";
 export * from "./probe.js";
 export * from "./run-manager.js";
 export * from "./runner/deterministic.js";
+export * from "./runner/agent.js";
 export type * from "./types.js";

--- a/packages/testpass/src/runner/agent.ts
+++ b/packages/testpass/src/runner/agent.ts
@@ -1,0 +1,186 @@
+/**
+ * Agent runner for TestPass.
+ *
+ * Picks up items left pending by the deterministic runner and evaluates
+ * them using Claude Haiku. Designed for checks that require judgment
+ * rather than binary pass/fail assertions (check_type: agent | hybrid).
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { Pack, RunProfile } from "../types.js";
+import type { RunManagerConfig } from "../run-manager.js";
+import { updateItem, createEvidence } from "../run-manager.js";
+
+type AgentVerdict = "check" | "fail" | "na" | "other";
+
+interface AgentOutcome {
+  verdict: AgentVerdict;
+  note?: string;
+  reasoning: string;
+}
+
+async function fetchPendingCheckIds(
+  config: RunManagerConfig,
+  runId: string,
+): Promise<string[]> {
+  const url = `${config.supabaseUrl}/rest/v1/testpass_items?run_id=eq.${runId}&verdict=eq.pending&select=check_id`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+    },
+  });
+  if (!res.ok) return [];
+  const rows = (await res.json()) as Array<{ check_id: string }>;
+  return rows.map((r) => r.check_id);
+}
+
+async function fetchProbePayload(
+  config: RunManagerConfig,
+  evidenceRef: string,
+): Promise<unknown> {
+  const url = `${config.supabaseUrl}/rest/v1/testpass_evidence?id=eq.${evidenceRef}&select=payload&limit=1`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+    },
+  });
+  if (!res.ok) return null;
+  const rows = (await res.json()) as Array<{ payload: unknown }>;
+  return rows[0]?.payload ?? null;
+}
+
+const SYSTEM_PROMPT = `You are a QA evaluator for MCP (Model Context Protocol) servers. You are given a check specification and probe data collected from a live server. Determine if the server passes or fails the check.
+
+Respond with valid JSON only, no other text:
+{"verdict":"check","reasoning":"one sentence"}
+
+Verdict meanings:
+- "check": server passes this requirement
+- "fail": server clearly fails this requirement
+- "na": check cannot be evaluated from the available data
+- "other": ambiguous result requiring human review`;
+
+async function evaluateCheck(
+  client: Anthropic,
+  checkId: string,
+  title: string,
+  description: string | undefined,
+  expected: unknown,
+  onFail: string | undefined,
+  targetUrl: string,
+  probeData: unknown,
+): Promise<AgentOutcome> {
+  const parts = [
+    `Check ID: ${checkId}`,
+    `Title: ${title}`,
+    description ? `Description: ${description}` : null,
+    expected ? `Expected: ${JSON.stringify(expected)}` : null,
+    onFail ? `On fail guidance: ${onFail}` : null,
+    `Target URL: ${targetUrl}`,
+    probeData
+      ? `Probe data:\n${JSON.stringify(probeData, null, 2)}`
+      : "No probe data available.",
+  ].filter(Boolean) as string[];
+
+  const msg = await client.messages.create({
+    model: "claude-haiku-4-5",
+    max_tokens: 256,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: parts.join("\n") }],
+  });
+
+  const text = (msg.content as Array<{ type: string; text?: string }>)
+    .find((b) => b.type === "text")?.text ?? "";
+  try {
+    const parsed = JSON.parse(text.trim()) as { verdict?: string; reasoning?: string };
+    const validVerdicts: AgentVerdict[] = ["check", "fail", "na", "other"];
+    const verdict: AgentVerdict = validVerdicts.includes(parsed.verdict as AgentVerdict)
+      ? (parsed.verdict as AgentVerdict)
+      : "other";
+    return { verdict, reasoning: parsed.reasoning ?? text };
+  } catch {
+    return { verdict: "other", note: "Failed to parse LLM response", reasoning: text };
+  }
+}
+
+/**
+ * Run LLM-assisted checks for all pending items in a run.
+ * Items with no matching pack spec are silently skipped.
+ * Each check runs independently via Promise.allSettled.
+ */
+export async function runAgentChecks(
+  config: RunManagerConfig,
+  runId: string,
+  targetUrl: string,
+  pack: Pack,
+  _profile: RunProfile,
+  probeEvidenceRef?: string,
+): Promise<void> {
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (!anthropicKey) return;
+
+  const pendingCheckIds = await fetchPendingCheckIds(config, runId);
+  if (pendingCheckIds.length === 0) return;
+
+  let probeData: unknown = null;
+  if (probeEvidenceRef) {
+    probeData = await fetchProbePayload(config, probeEvidenceRef);
+  }
+
+  const client = new Anthropic({ apiKey: anthropicKey });
+  const packItemMap = new Map(pack.items.map((i) => [i.id, i]));
+
+  await Promise.allSettled(
+    pendingCheckIds.map(async (checkId) => {
+      const spec = packItemMap.get(checkId);
+      if (!spec) return;
+
+      const checkStart = Date.now();
+      let outcome: AgentOutcome;
+      try {
+        outcome = await evaluateCheck(
+          client,
+          checkId,
+          spec.title,
+          spec.description,
+          spec.expected,
+          spec.on_fail,
+          targetUrl,
+          probeData,
+        );
+      } catch (err) {
+        outcome = {
+          verdict: "other",
+          note: `Agent runner exception: ${(err as Error).message}`,
+          reasoning: "",
+        };
+      }
+
+      const time_ms = Date.now() - checkStart;
+
+      let evidenceRef: string | undefined;
+      try {
+        evidenceRef = await createEvidence(config, {
+          kind: "agent_verdict",
+          payload: {
+            reasoning: outcome.reasoning,
+            model: "claude-haiku-4-5",
+            check_id: checkId,
+          },
+        });
+      } catch {
+        // non-fatal
+      }
+
+      await updateItem(config, runId, checkId, {
+        verdict: outcome.verdict,
+        on_fail_comment: outcome.note,
+        time_ms,
+        cost_usd: 0,
+        evidence_ref: evidenceRef,
+      });
+    }),
+  );
+}

--- a/packages/testpass/src/types.ts
+++ b/packages/testpass/src/types.ts
@@ -8,7 +8,7 @@ export type Severity = PackItem["severity"];
 export type Verdict = "check" | "na" | "fail" | "other" | "pending";
 export type RunProfile = "smoke" | "standard" | "deep";
 export type RunStatus = "running" | "complete" | "failed" | "budget_exceeded";
-export type EvidenceKind = "tool_list" | "snapshot" | "screenshot" | "http_trace" | "log";
+export type EvidenceKind = "tool_list" | "snapshot" | "screenshot" | "http_trace" | "log" | "agent_verdict";
 
 export interface RunTarget {
   type: "mcp" | "url" | "git";

--- a/src/pages/admin/AdminMemory.tsx
+++ b/src/pages/admin/AdminMemory.tsx
@@ -3,14 +3,20 @@ import { useSearchParams } from "react-router-dom";
 import { Brain } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import StorageBar from "./memory/StorageBar";
+import BrainMap from "./BrainMap";
 import ContextTab from "./memory/ContextTab";
 import FactsTab from "./memory/FactsTab";
 import SessionsTab from "./memory/SessionsTab";
+import LibraryTab from "./memory/LibraryTab";
+import MemoryActivityTab from "./memory/MemoryActivityTab";
 
 const TABS = [
-  { id: "facts", label: "Facts" },
-  { id: "sessions", label: "Sessions" },
-  { id: "identity", label: "Identity" },
+  { id: "brain-map", label: "Brain Map" },
+  { id: "facts",     label: "Facts"     },
+  { id: "sessions",  label: "Sessions"  },
+  { id: "library",   label: "Library"   },
+  { id: "activity",  label: "Activity"  },
+  { id: "identity",  label: "Identity"  },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
@@ -18,8 +24,9 @@ type TabId = (typeof TABS)[number]["id"];
 // Back-compat for existing deep links that used ?tab=context
 function resolveTab(param: string | null): TabId {
   if (param === "context") return "identity";
-  if (param === "facts" || param === "sessions" || param === "identity") return param;
-  return "facts";
+  const valid: TabId[] = ["brain-map", "facts", "sessions", "library", "activity", "identity"];
+  if (valid.includes(param as TabId)) return param as TabId;
+  return "brain-map";
 }
 
 export default function AdminMemoryPage() {
@@ -181,6 +188,7 @@ export default function AdminMemoryPage() {
         </div>
 
         {/* Tab content */}
+        {activeTab === "brain-map" && <BrainMap />}
         {activeTab === "facts" && (
           <div>
             <p className="mb-4 text-sm text-white/60">
@@ -197,6 +205,24 @@ export default function AdminMemoryPage() {
               New sessions read the most recent ones so your agent picks up where you left off.
             </p>
             <SessionsTab apiKey={accessToken} />
+          </div>
+        )}
+        {activeTab === "library" && (
+          <div>
+            <p className="mb-4 text-sm text-white/60">
+              Knowledge documents stored by your agent. Reference material, guides, and notes
+              that get loaded on demand via search.
+            </p>
+            <LibraryTab apiKey={accessToken} />
+          </div>
+        )}
+        {activeTab === "activity" && (
+          <div>
+            <p className="mb-4 text-sm text-white/60">
+              Memory activity over time. Fact growth, storage breakdown, decay signals,
+              and most-accessed items.
+            </p>
+            <MemoryActivityTab apiKey={accessToken} />
           </div>
         )}
         {activeTab === "identity" && (

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -32,6 +32,8 @@ import {
   FileText,
   Clock,
   Fingerprint,
+  Sparkles,
+  BookOpen,
 } from "lucide-react";
 
 function SurfaceLink({ path, label, icon: Icon, onClick }: {
@@ -59,15 +61,18 @@ function SurfaceLink({ path, label, icon: Icon, onClick }: {
 }
 
 const MEMORY_TABS = [
-  { id: "facts",    label: "Facts",    icon: FileText   },
-  { id: "sessions", label: "Sessions", icon: Clock      },
-  { id: "identity", label: "Identity", icon: Fingerprint },
+  { id: "brain-map", label: "Brain Map", icon: Sparkles   },
+  { id: "facts",     label: "Facts",     icon: FileText   },
+  { id: "sessions",  label: "Sessions",  icon: Clock      },
+  { id: "library",   label: "Library",   icon: BookOpen   },
+  { id: "activity",  label: "Activity",  icon: Activity   },
+  { id: "identity",  label: "Identity",  icon: Fingerprint },
 ] as const;
 
 function MemoryNavItem({ onClick }: { onClick?: () => void }) {
   const location = useLocation();
   const isMemory = location.pathname === "/admin/memory";
-  const activeTab = new URLSearchParams(location.search).get("tab") ?? "facts";
+  const activeTab = new URLSearchParams(location.search).get("tab") ?? "brain-map";
 
   return (
     <div>

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -9,7 +9,7 @@
  * Each surface is extractable as a native app later.
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, NavLink, Outlet, useNavigate, useLocation } from "react-router-dom";
 import { useSession, signOut } from "@/lib/auth";
 import AdminSearchBar from "@/components/admin/AdminSearchBar";
@@ -117,9 +117,25 @@ function MemoryNavItem({ onClick }: { onClick?: () => void }) {
 }
 
 export default function AdminShell() {
-  const { user } = useSession();
+  const { user, session } = useSession();
   const navigate = useNavigate();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    const token = session?.access_token;
+    if (!token) return;
+    let cancelled = false;
+    fetch("/api/memory-admin?action=admin_profile", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body) => {
+        if (!cancelled && body) setIsAdmin(Boolean(body.is_admin));
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [session?.access_token]);
 
   async function handleLogout() {
     await signOut();
@@ -135,7 +151,7 @@ export default function AdminShell() {
         <SurfaceLink path="/admin/tools"    label="Tools"                    icon={Wrench}   onClick={onLinkClick} />
         <SurfaceLink path="/admin/activity" label="Activity"                 icon={Activity} onClick={onLinkClick} />
         <SurfaceLink path="/admin/agents"    label="Agents"                   icon={Bot}       onClick={onLinkClick} />
-        <SurfaceLink path="/admin/analytics" label="Analytics"               icon={BarChart3} onClick={onLinkClick} />
+        {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"               icon={BarChart3} onClick={onLinkClick} />}
         <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />
       </>
     );

--- a/src/pages/admin/BrainMap.tsx
+++ b/src/pages/admin/BrainMap.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useSession } from "@/lib/auth";
+import {
+  Zap, Heart, Clock, CheckCircle2, Circle, Monitor, Plug, Bot,
+  Fingerprint, FolderKanban, Code, Lightbulb, Wrench, MessageSquare, Save,
+} from "lucide-react";
+
+type BootSummary = {
+  last_boot_at: string | null;
+  facts_loaded: number;
+  context_items_loaded: number;
+  sessions_loaded: number;
+  project_items_loaded: number;
+};
+
+type ContextRow = { category: string };
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return "never";
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+async function tryFetch(url: string, token: string) {
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json();
+}
+
+export default function BrainMap() {
+  const { session } = useSession();
+  const [bootSummary, setBootSummary] = useState<BootSummary | null>(null);
+  const [contextRows, setContextRows] = useState<ContextRow[]>([]);
+  const [factCount, setFactCount] = useState(0);
+  const [sessionCount, setSessionCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const jwt = session?.access_token ?? "";
+    const apiKey = localStorage.getItem("unclick_api_key") ?? "";
+    const token = jwt || apiKey;
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+
+    (async () => {
+      // Use allSettled so a missing admin_boot_summary doesn't block the rest
+      const [bootRes, ctxRes, factsRes, sessRes] = await Promise.allSettled([
+        tryFetch("/api/memory-admin?action=admin_boot_summary", token),
+        tryFetch("/api/memory-admin?action=business_context", token),
+        tryFetch("/api/memory-admin?action=facts", token),
+        tryFetch("/api/memory-admin?action=sessions&limit=1", token),
+      ]);
+      if (bootRes.status === "fulfilled")
+        setBootSummary(bootRes.value.data ?? bootRes.value ?? null);
+      if (ctxRes.status === "fulfilled")
+        setContextRows(ctxRes.value.data ?? []);
+      if (factsRes.status === "fulfilled")
+        setFactCount((factsRes.value.data ?? []).length);
+      if (sessRes.status === "fulfilled")
+        setSessionCount((sessRes.value.data ?? []).length);
+      setLoading(false);
+    })();
+  }, [session]);
+
+  const identityCount = useMemo(
+    () =>
+      contextRows.filter(
+        (r) =>
+          r.category === "identity" ||
+          r.category === "preference" ||
+          r.category === "standing_rule"
+      ).length,
+    [contextRows]
+  );
+  const repoCount = useMemo(
+    () => contextRows.filter((r) => r.category === "repository").length,
+    [contextRows]
+  );
+  const hasIdentity     = contextRows.some((r) => r.category === "identity");
+  const hasPreference   = contextRows.some((r) => r.category === "preference");
+  const hasStandingRule = contextRows.some((r) => r.category === "standing_rule");
+  const hasRepo         = repoCount > 0;
+  const hasFiveFacts    = factCount >= 5;
+  const hasSession      = sessionCount >= 1;
+
+  const checklist = [
+    { ok: hasIdentity,     label: "Identity set",        link: "/admin/memory?tab=identity" },
+    { ok: hasPreference,   label: "Preferences set",     link: "/admin/memory?tab=identity" },
+    { ok: hasFiveFacts,    label: "At least 5 facts",    link: "/admin/memory?tab=facts"    },
+    { ok: hasSession,      label: "A saved session",     link: "/admin/memory?tab=sessions" },
+    { ok: hasStandingRule, label: "Standing rules",      link: "/admin/memory?tab=identity" },
+    { ok: hasRepo,         label: "Repository context",  link: undefined                    },
+  ];
+  const healthPct = Math.round(
+    (checklist.filter((c) => c.ok).length / checklist.length) * 100
+  );
+
+  const bootLine = bootSummary
+    ? `Last load: ${bootSummary.facts_loaded} facts, ${bootSummary.context_items_loaded} context, ${bootSummary.sessions_loaded} sessions`
+    : "No load recorded yet";
+
+  const stages = [
+    { num: "0",  title: "Agent's Local Context", sub: "Before UnClick",     desc: "Your AI reads CLAUDE.md, .cursor/rules, or other config files from your machine before connecting.", color: "#888",     icon: Monitor  },
+    { num: "1",  title: "MCP Connection",         sub: "Handshake",          desc: "Your AI connects to UnClick via MCP. API key authenticates and identifies your account.",              color: "#61C1C4", icon: Plug     },
+    { num: "2",  title: "Agent Profile",           sub: "Who am I?",          desc: "UnClick loads the agent's persona, system prompt, and which memory layers are enabled.",              color: "#a78bfa", icon: Bot      },
+    { num: "3",  title: "Identity",                sub: "Who are you?",       desc: `Your brand, preferences, and standing rules. ${identityCount} items stored.`,                         color: "#E2B93B", icon: Fingerprint, link: "/admin/memory?tab=identity" },
+    { num: "4",  title: "Project Scope",           sub: "What are we working on?", desc: "If a project is active, project-scoped memory loads alongside global. Project wins on conflicts.", color: "#61C1C4", icon: FolderKanban },
+    { num: "5",  title: "Codebase",               sub: "How is the code shaped?",  desc: `Tech stack, deploy process, constraints, gotchas. ${repoCount} items stored.`,                  color: "#4ade80", icon: Code     },
+    { num: "6",  title: "Knowledge",              sub: "What do I know?",     desc: `Facts extracted from conversations. ${factCount} items stored.`,                                      color: "#f472b6", icon: Lightbulb, link: "/admin/memory?tab=facts" },
+    { num: "7",  title: "Sessions",               sub: "What happened recently?", desc: "Summaries of past conversations. Last 5 load at startup.",                                       color: "#fb923c", icon: Clock,   link: "/admin/memory?tab=sessions" },
+    { num: "8",  title: "Tool Guidance",           sub: "What can I use?",    desc: "Connected tools are classified: compatible, conflicting, or replaceable.",                            color: "#61C1C4", icon: Wrench   },
+    { num: "9",  title: "Brain Loaded",            sub: "Ready",              desc: bootLine,                                                                                               color: "#E2B93B", icon: Zap      },
+    { num: "10", title: "Live Session",            sub: "Working together",   desc: "Your AI searches memory on demand and saves new knowledge as it learns -- not just at session end.", color: "#4ade80", icon: MessageSquare },
+    { num: "11", title: "Session End",             sub: "Learning saved",     desc: "Summary written, new facts persisted, old facts decayed. Next session starts smarter.",              color: "#a78bfa", icon: Save     },
+  ];
+
+  const phaseLabels: Record<string, { text: string; color: string }> = {
+    "0":  { text: "PRE-BOOT",      color: "text-[#888]"     },
+    "1":  { text: "BOOT SEQUENCE", color: "text-[#61C1C4]"  },
+    "9":  { text: "READY",         color: "text-[#E2B93B]"  },
+    "10": { text: "LIVE SESSION",  color: "text-[#4ade80]"  },
+    "11": { text: "POST-SESSION",  color: "text-[#a78bfa]"  },
+  };
+
+  return (
+    <div>
+      <div className="mb-6 grid gap-4 lg:grid-cols-2">
+        {/* What Loaded */}
+        <div className="rounded-xl border border-[#61C1C4]/40 bg-[#111] p-5">
+          <div className="mb-1 flex items-center gap-2">
+            <Zap className="h-4 w-4 text-[#61C1C4]" />
+            <h2 className="text-sm font-semibold text-white">What Loaded</h2>
+          </div>
+          <p className="mb-4 text-xs text-[#888]">
+            What your AI loaded at the most recent session start
+          </p>
+          <div className="mb-3 grid grid-cols-3 gap-3">
+            {(
+              [
+                ["Facts",   bootSummary?.facts_loaded],
+                ["Context", bootSummary?.context_items_loaded],
+                ["Sessions",bootSummary?.sessions_loaded],
+              ] as const
+            ).map(([label, val]) => (
+              <div key={label} className="rounded-lg bg-white/[0.03] p-3">
+                <div className="text-lg font-semibold text-white">{loading ? "--" : (val ?? 0)}</div>
+                <div className="text-[10px] uppercase tracking-wide text-[#888]">{label}</div>
+              </div>
+            ))}
+          </div>
+          {!loading && (bootSummary?.project_items_loaded ?? 0) > 0 && (
+            <p className="mb-2 text-xs text-[#888]">
+              Project items: {bootSummary?.project_items_loaded}
+            </p>
+          )}
+          <p className="text-xs text-[#666]">
+            Loaded {loading ? "--" : timeAgo(bootSummary?.last_boot_at ?? null)}
+          </p>
+        </div>
+
+        {/* Memory Health */}
+        <div className="rounded-xl border border-[#E2B93B]/40 bg-[#111] p-5">
+          <div className="mb-1 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Heart className="h-4 w-4 text-[#E2B93B]" />
+              <h2 className="text-sm font-semibold text-white">Memory Health</h2>
+            </div>
+            <span className="text-sm font-semibold text-[#E2B93B]">
+              {loading ? "--" : `${healthPct}%`}
+            </span>
+          </div>
+          <div className="mb-4 h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
+            <div
+              className="h-full bg-[#E2B93B] transition-all"
+              style={{ width: `${loading ? 0 : healthPct}%` }}
+            />
+          </div>
+          <ul className="space-y-2">
+            {checklist.map((item) => (
+              <li key={item.label} className="flex items-center justify-between text-xs">
+                <span className="flex items-center gap-2">
+                  {item.ok ? (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-[#4ade80]" />
+                  ) : (
+                    <Circle className="h-3.5 w-3.5 text-[#444]" />
+                  )}
+                  <span className={item.ok ? "text-[#ccc]" : "text-[#888]"}>{item.label}</span>
+                </span>
+                {!item.ok && item.link && (
+                  <Link to={item.link} className="text-[#61C1C4] hover:underline">
+                    add
+                  </Link>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* Timeline */}
+      <div className="mb-4">
+        <h2 className="text-lg font-semibold text-white">Memory Flow</h2>
+        <p className="text-xs text-[#888]">
+          How your AI builds its understanding, step by step.
+        </p>
+      </div>
+
+      <div className="relative">
+        {stages.map((stage, idx) => {
+          const phase = phaseLabels[stage.num];
+          const Icon  = stage.icon;
+          const isLast = idx === stages.length - 1;
+          return (
+            <div key={stage.num}>
+              {phase && (
+                <div className={`mb-2 ml-12 text-[10px] font-bold uppercase tracking-widest ${phase.color}`}>
+                  {phase.text}
+                </div>
+              )}
+              <div className="relative flex gap-4">
+                <div className="flex flex-col items-center">
+                  <div
+                    className="flex h-8 w-8 items-center justify-center rounded-full border-2 text-xs font-semibold"
+                    style={{ borderColor: stage.color, color: stage.color }}
+                  >
+                    {stage.num}
+                  </div>
+                  {!isLast && (
+                    <div className="w-0.5 flex-1 bg-gradient-to-b from-white/20 to-white/[0.04]" />
+                  )}
+                </div>
+                <div className="mb-2 flex-1 rounded-xl border border-white/[0.06] bg-[#111] p-4">
+                  <div className="flex items-center">
+                    <Icon className="mr-2 h-4 w-4" style={{ color: stage.color }} />
+                    {"link" in stage && stage.link ? (
+                      <Link
+                        to={stage.link}
+                        className="text-sm font-semibold text-[#61C1C4] hover:underline"
+                      >
+                        {stage.title}
+                      </Link>
+                    ) : (
+                      <h3 className="text-sm font-semibold text-white">{stage.title}</h3>
+                    )}
+                    <span className="ml-2 text-xs text-[#888]">{stage.sub}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-[#666]">{stage.desc}</p>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `isAdmin` state to `AdminShell` - fetches `admin_profile` once when session loads
- Conditionally renders the Analytics sidebar link only for admin users
- All other sidebar links (You, Memory, Keychain, Tools, Activity, Agents, Settings) remain visible to all signed-in users - they are user-scoped, not admin-only

## Audit results

| Surface | Admin-only? | Sidebar gated? |
|---------|------------|----------------|
| Analytics | Yes (page redirects non-admins) | Now yes |
| Memory | Has own page-level admin gate | Not hidden (shows friendly "not available" message) |
| Activity | No - user-scoped | No change |
| Agents | No - user-scoped per api_key_hash | No change |
| Settings | No - user-scoped | No change |

## Acceptance

- Admin user sees all links including Analytics
- Non-admin signed-in user does NOT see Analytics link
- Direct navigation to `/admin/analytics` still redirects (server-side gate unchanged)
- No visual flash: `isAdmin` starts `false` so Analytics link never renders before the check resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)