### PR TITLE
feat(admin): recent signups widget for superadmins from archaeology batch 3

### DIFF
--- a/api/admin-users.ts
+++ b/api/admin-users.ts
@@ -1,0 +1,125 @@
+/**
+ * UnClick Admin Users - Vercel serverless function
+ *
+ * Route: GET /api/admin-users?action=<action>
+ *
+ * Superadmin-only actions gated on ADMIN_EMAILS env var (comma-separated
+ * list of email addresses). Non-admins get 403. Separate from
+ * memory-admin.ts because these actions query auth.users across all
+ * tenants rather than scoped to a single api_key_hash.
+ *
+ * Actions:
+ *   - admin_recent_signups: GET with Bearer <session_jwt>
+ *     Returns the latest 100 users from auth.users with
+ *     { id, email, provider, created_at, last_sign_in_at, confirmed }.
+ *
+ * Env:
+ *   SUPABASE_URL                - project URL
+ *   SUPABASE_SERVICE_ROLE_KEY   - service role (needed for auth.admin.listUsers)
+ *   ADMIN_EMAILS                - comma-separated superadmin allowlist
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+
+function bearerFrom(req: VercelRequest): string {
+  return (req.headers.authorization ?? "").replace(/^Bearer\s+/i, "").trim();
+}
+
+function adminEmailSet(): Set<string> {
+  const raw = process.env.ADMIN_EMAILS ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+async function resolveSessionUser(
+  token: string,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+): Promise<{ id: string; email: string | null } | null> {
+  if (!token) return null;
+  // api_keys (uc_* / agt_*) are never valid session JWTs — reject early.
+  if (token.startsWith("uc_") || token.startsWith("agt_")) return null;
+  try {
+    const scoped = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data, error } = await scoped.auth.getUser(token);
+    if (error || !data?.user) return null;
+    return { id: data.user.id, email: data.user.email ?? null };
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const action = (req.query.action as string) ?? "";
+  const supabaseUrl = process.env.SUPABASE_URL ?? "";
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(500).json({ error: "Server not configured" });
+  }
+
+  // All actions require a session JWT + admin email check.
+  const token = bearerFrom(req);
+  const caller = await resolveSessionUser(token, supabaseUrl, serviceRoleKey);
+  if (!caller) return res.status(401).json({ error: "Unauthorized" });
+
+  const allow = adminEmailSet();
+  const callerEmail = (caller.email ?? "").toLowerCase();
+  if (allow.size === 0 || !callerEmail || !allow.has(callerEmail)) {
+    // 403 is the signal the frontend uses to hide the widget entirely.
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  try {
+    switch (action) {
+      case "admin_recent_signups": {
+        if (req.method !== "GET") {
+          return res.status(405).json({ error: "GET required" });
+        }
+        // auth.admin.listUsers is service-role-only; paginates 50/page.
+        // We ask for 100 to see recent week+ of signups on a small tenant.
+        const { data, error } = await supabase.auth.admin.listUsers({
+          page: 1,
+          perPage: 100,
+        });
+        if (error) throw error;
+
+        const users = (data?.users ?? [])
+          .map((u) => ({
+            id: u.id,
+            email: u.email ?? null,
+            provider:
+              (u.app_metadata as { provider?: string } | undefined)?.provider ?? "email",
+            created_at: u.created_at,
+            last_sign_in_at: u.last_sign_in_at ?? null,
+            confirmed: Boolean(u.email_confirmed_at ?? u.phone_confirmed_at),
+          }))
+          .sort(
+            (a, b) =>
+              new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+          );
+
+        return res.status(200).json({ users });
+      }
+      default:
+        return res.status(400).json({ error: `Unknown action: ${action}` });
+    }
+  } catch (err: unknown) {
+    console.error(`Admin users error (${action}):`, (err as Error).message);
+    return res
+      .status(500)
+      .json({ error: `Failed to execute ${action}: ${(err as Error).message}` });
+  }
+}

--- a/src/pages/admin/AdminActivity.tsx
+++ b/src/pages/admin/AdminActivity.tsx
@@ -17,6 +17,9 @@ import {
   CheckCircle2,
   XCircle,
   Zap,
+  UserPlus,
+  ShieldCheck,
+  ShieldAlert,
 } from "lucide-react";
 
 interface MeteringEvent {
@@ -32,6 +35,15 @@ interface ConversationSession {
   session_id: string;
   message_count: number;
   last_message: string;
+}
+
+interface SignupUser {
+  id: string;
+  email: string | null;
+  provider: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+  confirmed: boolean;
 }
 
 function timeAgo(iso: string): string {
@@ -62,6 +74,10 @@ export default function AdminActivity() {
   const [events, setEvents] = useState<MeteringEvent[]>([]);
   const [sessions, setSessions] = useState<ConversationSession[]>([]);
   const [loading, setLoading] = useState(true);
+  // Admin-only recent signups. Hidden when the API returns 403 — non-admins
+  // never see the card exists, admins see a live list from auth.users.
+  const [signups, setSignups] = useState<SignupUser[] | null>(null);
+  const [signupsLoading, setSignupsLoading] = useState(true);
 
   useEffect(() => {
     if (!session) return;
@@ -79,6 +95,29 @@ export default function AdminActivity() {
         }
       } finally {
         if (!cancelled) setLoading(false);
+      }
+    })();
+
+    // Separately probe the superadmin-only recent signups endpoint. A 403
+    // means "not an admin" → hide the widget silently. Any other failure
+    // also hides it so we never leak half-rendered scaffolding.
+    (async () => {
+      try {
+        const res = await fetch("/api/admin-users?action=admin_recent_signups", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!cancelled) {
+          if (res.ok) {
+            const body = await res.json();
+            setSignups(body.users ?? []);
+          } else {
+            setSignups(null);
+          }
+        }
+      } catch {
+        if (!cancelled) setSignups(null);
+      } finally {
+        if (!cancelled) setSignupsLoading(false);
       }
     })();
 
@@ -262,6 +301,72 @@ export default function AdminActivity() {
               )}
             </div>
           </div>
+
+          {/* Admin-only: Recent signups. Hidden for non-admins (API
+              returns 403 → signups stays null). */}
+          {!signupsLoading && signups !== null && (
+            <div className="mt-8">
+              <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold text-white">
+                <UserPlus className="h-4 w-4 text-[#E2B93B]" />
+                Recent Signups
+                <span className="ml-1 rounded-full border border-white/[0.08] px-2 py-0.5 text-[10px] text-[#888]">
+                  admin only
+                </span>
+              </h2>
+
+              {signups.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-white/[0.08] bg-[#111111] p-6 text-center">
+                  <p className="text-xs text-[#666]">No signups yet</p>
+                </div>
+              ) : (
+                <div className="overflow-hidden rounded-xl border border-white/[0.06] bg-[#111111]">
+                  <table className="w-full text-left text-xs">
+                    <thead className="border-b border-white/[0.06] text-[10px] uppercase tracking-wider text-[#666]">
+                      <tr>
+                        <th className="px-3 py-2 font-medium">Email</th>
+                        <th className="px-3 py-2 font-medium">Provider</th>
+                        <th className="px-3 py-2 font-medium">Confirmed</th>
+                        <th className="px-3 py-2 font-medium">Signed up</th>
+                        <th className="px-3 py-2 font-medium">Last seen</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-white/[0.04]">
+                      {signups.slice(0, 50).map((u) => (
+                        <tr key={u.id} className="hover:bg-white/[0.02]">
+                          <td className="px-3 py-2 font-mono text-[11px] text-white">
+                            {u.email ?? "—"}
+                          </td>
+                          <td className="px-3 py-2 text-[#888]">{u.provider}</td>
+                          <td className="px-3 py-2">
+                            {u.confirmed ? (
+                              <span className="flex items-center gap-1 text-green-400">
+                                <ShieldCheck className="h-3 w-3" /> yes
+                              </span>
+                            ) : (
+                              <span className="flex items-center gap-1 text-amber-400">
+                                <ShieldAlert className="h-3 w-3" /> pending
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-[#888]">
+                            {timeAgo(u.created_at)}
+                          </td>
+                          <td className="px-3 py-2 text-[#666]">
+                            {u.last_sign_in_at ? timeAgo(u.last_sign_in_at) : "never"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {signups.length > 50 && (
+                    <p className="border-t border-white/[0.04] py-2 text-center text-[10px] text-[#555]">
+                      +{signups.length - 50} more
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

Cherry-picks `feat/admin-recent-signups` (1 commit, 2 files, 230 lines added).

- **New API** `api/admin-users.ts`: single `admin_recent_signups` action. Resolves the bearer JWT, checks caller email against the `ADMIN_EMAILS` env allowlist, then calls `supabase.auth.admin.listUsers` with the service role. Returns 403 for non-admins with no data leak.
- **Extended** `src/pages/admin/AdminActivity.tsx`: adds a third section below the existing activity grid. Probes `/api/admin-users` on mount; 403/error leaves the section unmounted (non-admins see nothing).

## Required env var

`ADMIN_EMAILS=creativelead@malamutemayhem.com` must be set in Vercel for the widget to appear (already needed for the Analytics gate).

## Test plan

- [ ] Admin user sees Recent Signups table on `/admin/activity`
- [ ] Non-admin user sees no signups section (403 silently unmounts widget)
- [ ] Build passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)