### PR TITLE
TestPass Chunk 5: MCP tools, multi-pass controller, healer

### DIFF
--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -3,7 +3,10 @@
  *
  * Actions:
  *   GET  ?action=get_run&run_id=<uuid>              - fetch run + items
+ *   GET  ?action=status&run_id=<uuid>               - fetch run status + verdict summary
  *   POST ?action=start_run                          - create run, probe target, seed items
+ *   POST ?action=complete_run                       - finalise summary for an in-progress run
+ *   POST ?action=heal&run_id=<uuid>                 - agent-retry any deterministic failures
  *
  * Authentication: Supabase JWT Bearer token (session user = actor).
  * Service role key used server-side for DB writes (bypasses RLS which
@@ -24,6 +27,8 @@ import {
 } from "../packages/testpass/src/run-manager.js";
 import { runDeterministicChecks } from "../packages/testpass/src/runner/deterministic.js";
 import { runAgentChecks } from "../packages/testpass/src/runner/agent.js";
+import { runMultiPass } from "../packages/testpass/src/runner/controller.js";
+import { healFailedChecks } from "../packages/testpass/src/runner/healer.js";
 import { loadPackFromFile } from "../packages/testpass/src/pack-loader.js";
 import * as path from "node:path";
 import * as url from "node:url";
@@ -90,6 +95,48 @@ async function getRunWithItems(
   return { run, items };
 }
 
+async function getRunStatus(
+  supabaseUrl: string,
+  serviceKey: string,
+  runId: string,
+  actorUserId: string
+): Promise<{ status: string; verdict_summary: Record<string, unknown>; fail_count: number } | null> {
+  const r = await fetch(
+    `${supabaseUrl}/rest/v1/testpass_runs?id=eq.${runId}&actor_user_id=eq.${actorUserId}&select=status,verdict_summary&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
+  );
+  if (!r.ok) return null;
+  const rows = (await r.json()) as Array<{ status: string; verdict_summary: Record<string, unknown> | null }>;
+  const row = rows[0];
+  if (!row) return null;
+  const summary = row.verdict_summary ?? {};
+  const failCount = typeof summary.fail === "number" ? summary.fail : 0;
+  return { status: row.status, verdict_summary: summary, fail_count: failCount };
+}
+
+async function getRunPackSlug(
+  supabaseUrl: string,
+  serviceKey: string,
+  runId: string,
+  actorUserId: string
+): Promise<string | null> {
+  const r = await fetch(
+    `${supabaseUrl}/rest/v1/testpass_runs?id=eq.${runId}&actor_user_id=eq.${actorUserId}&select=pack_id&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
+  );
+  if (!r.ok) return null;
+  const rows = (await r.json()) as Array<{ pack_id: string }>;
+  const packId = rows[0]?.pack_id;
+  if (!packId) return null;
+  const p = await fetch(
+    `${supabaseUrl}/rest/v1/testpass_packs?id=eq.${packId}&select=slug&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
+  );
+  if (!p.ok) return null;
+  const packRows = (await p.json()) as Array<{ slug: string }>;
+  return packRows[0]?.slug ?? null;
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === "OPTIONS") return json(res, 204, {});
 
@@ -113,6 +160,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!runId) return json(res, 400, { error: "run_id required" });
     const data = await getRunWithItems(supabaseUrl, serviceKey, runId, actorUserId);
     if (!data.run) return json(res, 404, { error: "Run not found" });
+    return json(res, 200, data);
+  }
+  if (req.method === "GET" && action === "status") {
+    const runId = req.query.run_id as string;
+    if (!runId) return json(res, 400, { error: "run_id required" });
+    const data = await getRunStatus(supabaseUrl, serviceKey, runId, actorUserId);
+    if (!data) return json(res, 404, { error: "Run not found" });
     return json(res, 200, data);
   }
 
@@ -162,32 +216,52 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     await seedPendingItems(config, runId, pack, profile, evidenceRef);
 
-    // Run deterministic checks inline. Agent checks (check_type: agent)
-    // with no registered handler are left pending for a future runner.
-    if (body.target.url) {
+    if (profile === "deep") {
       try {
-        await runDeterministicChecks(config, runId, body.target.url, pack, profile);
+        await runMultiPass(config, runId, body.target.url, pack, profile);
       } catch (err) {
-        console.error(`TestPass deterministic run failed for ${runId}:`, (err as Error).message);
+        console.error(`TestPass multi-pass run failed for ${runId}:`, (err as Error).message);
+      }
+    } else {
+      // Run deterministic checks inline. Agent checks (check_type: agent)
+      // with no registered handler are left pending for a future runner.
+      if (body.target.url) {
+        try {
+          await runDeterministicChecks(config, runId, body.target.url, pack, profile);
+        } catch (err) {
+          console.error(`TestPass deterministic run failed for ${runId}:`, (err as Error).message);
+        }
+      }
+
+      // Run agent checks for any items still pending after the deterministic pass.
+      try {
+        await runAgentChecks(config, runId, body.target.url, pack, profile, evidenceRef);
+      } catch (err) {
+        console.error(`TestPass agent run failed for ${runId}:`, (err as Error).message);
       }
     }
 
-    // Run agent checks for any items still pending after the deterministic pass.
-    try {
-      await runAgentChecks(config, runId, body.target.url, pack, profile, evidenceRef);
-    } catch (err) {
-      console.error(`TestPass agent run failed for ${runId}:`, (err as Error).message);
-    }
-
     // Finalize: any item still pending means agent checks are not configured.
+    // Skip finalization if the controller already flipped the run to
+    // budget_exceeded; that status is terminal.
     const summary = await computeVerdictSummary(config, runId);
-    const isDone  = summary.pending === 0;
-    await updateRunStatus(
-      config,
-      runId,
-      isDone ? (summary.fail > 0 ? "failed" : "complete") : "running",
-      summary,
+    const runStatusRes = await fetch(
+      `${supabaseUrl}/rest/v1/testpass_runs?id=eq.${runId}&select=status&limit=1`,
+      { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
     );
+    const statusRows = runStatusRes.ok
+      ? ((await runStatusRes.json()) as Array<{ status: string }>)
+      : [];
+    const currentStatus = statusRows[0]?.status;
+    if (currentStatus !== "budget_exceeded") {
+      const isDone = summary.pending === 0;
+      await updateRunStatus(
+        config,
+        runId,
+        isDone ? (summary.fail > 0 ? "failed" : "complete") : "running",
+        summary,
+      );
+    }
 
     return json(res, 201, { run_id: runId, evidence_ref: evidenceRef ?? null, summary });
   }
@@ -200,6 +274,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const hasFailures = summary.fail > 0 || summary.pending > 0;
     await updateRunStatus(config, body.run_id, hasFailures ? "failed" : "complete", summary);
     return json(res, 200, { summary });
+  }
+
+  // Healer: re-run deterministic failures through the agent model.
+  if (req.method === "POST" && action === "heal") {
+    const runId = (req.query.run_id as string) || ((req.body as { run_id?: string })?.run_id ?? "");
+    if (!runId) return json(res, 400, { error: "run_id required" });
+
+    const packSlug = await getRunPackSlug(supabaseUrl, serviceKey, runId, actorUserId);
+    if (!packSlug) return json(res, 404, { error: "Run not found" });
+
+    const packPath = path.resolve(__dirname, `../packages/testpass/packs/${packSlug}.yaml`);
+    let pack;
+    try {
+      pack = loadPackFromFile(packPath);
+    } catch {
+      return json(res, 422, { error: `Pack YAML not found on server for ${packSlug}` });
+    }
+
+    let healed = 0;
+    try {
+      healed = await healFailedChecks(config, runId, pack);
+    } catch (err) {
+      console.error(`TestPass healer failed for ${runId}:`, (err as Error).message);
+    }
+
+    // Recompute summary after healing so callers can re-read an up-to-date run.
+    const summary = await computeVerdictSummary(config, runId);
+    const hasFailures = summary.fail > 0 || summary.pending > 0;
+    await updateRunStatus(config, runId, hasFailures ? "failed" : "complete", summary);
+
+    return json(res, 200, { healed, summary });
   }
 
   return json(res, 404, { error: "Unknown action" });

--- a/packages/mcp-server/src/testpass-tool.ts
+++ b/packages/mcp-server/src/testpass-tool.ts
@@ -1,0 +1,75 @@
+/**
+ * TestPass MCP tools.
+ *
+ * Thin wrappers over the UnClick /api/testpass serverless endpoint. The user's
+ * UNCLICK_API_KEY is forwarded as the Bearer token so the endpoint can resolve
+ * the calling tenant and scope DB writes to their account.
+ */
+
+const SITE_URL =
+  process.env.UNCLICK_SITE_URL ||
+  process.env.UNCLICK_MEMORY_BASE_URL ||
+  "https://unclick.world";
+
+type Profile = "smoke" | "standard" | "deep";
+
+interface RunArgs {
+  target_url?: string;
+  pack_id?: string;
+  profile?: Profile;
+}
+
+interface StatusArgs {
+  run_id?: string;
+}
+
+function authHeader(): { Authorization: string } | { error: string } {
+  const apiKey = process.env.UNCLICK_API_KEY;
+  if (!apiKey) {
+    return { error: "UNCLICK_API_KEY env var is not set. Get one at https://unclick.world" };
+  }
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+export async function testpassRun(args: RunArgs): Promise<unknown> {
+  if (!args.target_url) return { error: "target_url is required" };
+  const auth = authHeader();
+  if ("error" in auth) return auth;
+
+  const body = {
+    pack_slug: args.pack_id ?? "testpass-core",
+    target: { type: "mcp", url: args.target_url },
+    profile: args.profile ?? "smoke",
+  };
+
+  const res = await fetch(`${SITE_URL}/api/testpass?action=start_run`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...auth },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) return { error: `TestPass API HTTP ${res.status}: ${text}` };
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+export async function testpassStatus(args: StatusArgs): Promise<unknown> {
+  if (!args.run_id) return { error: "run_id is required" };
+  const auth = authHeader();
+  if ("error" in auth) return auth;
+
+  const res = await fetch(
+    `${SITE_URL}/api/testpass?action=status&run_id=${encodeURIComponent(args.run_id)}`,
+    { headers: auth },
+  );
+  const text = await res.text();
+  if (!res.ok) return { error: `TestPass API HTTP ${res.status}: ${text}` };
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -747,6 +747,9 @@ import {
   ckListSequences, ckListTags, ckTagSubscriber,
 } from "./convertkit-tool.js";
 
+// ─── TestPass ─────────────────────────────────────────────────────────────────
+import { testpassRun, testpassStatus } from "./testpass-tool.js";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // ADDITIONAL_TOOLS
 // ─────────────────────────────────────────────────────────────────────────────
@@ -11055,6 +11058,32 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── testpass-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "testpass_run",
+    description: "Trigger a TestPass QC run against a target MCP server. Validates protocol compliance, handshake, and runtime behaviour.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        target_url: { type: "string", description: "URL of the MCP server to test (e.g. https://example.com/mcp)." },
+        pack_id: { type: "string", description: "Pack slug to run. Default: testpass-core." },
+        profile: { type: "string", enum: ["smoke", "standard", "deep"], description: "Depth of the run. Default: smoke." },
+      },
+      required: ["target_url"],
+    },
+  },
+  {
+    name: "testpass_status",
+    description: "Get the current status of a TestPass run, including verdict summary and fail count.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        run_id: { type: "string", description: "UUID of the TestPass run." },
+      },
+      required: ["run_id"],
+    },
+  },
+
 ] as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -12162,4 +12191,8 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   togetherai_completion:      (args) => togetherai_completion(args),
   togetherai_create_embedding:(args) => togetherai_create_embedding(args),
   togetherai_list_models:     (args) => togetherai_list_models(args),
+
+  // testpass-tool.ts
+  testpass_run:         (args) => testpassRun(args),
+  testpass_status:      (args) => testpassStatus(args),
 };

--- a/packages/testpass/src/index.ts
+++ b/packages/testpass/src/index.ts
@@ -4,4 +4,6 @@ export * from "./probe.js";
 export * from "./run-manager.js";
 export * from "./runner/deterministic.js";
 export * from "./runner/agent.js";
+export * from "./runner/controller.js";
+export * from "./runner/healer.js";
 export type * from "./types.js";

--- a/packages/testpass/src/runner/controller.ts
+++ b/packages/testpass/src/runner/controller.ts
@@ -1,0 +1,115 @@
+/**
+ * Multi-pass controller for TestPass.
+ *
+ * Runs the smoke -> standard -> deep profiles in sequence against a single
+ * run, short-circuiting when a pass is clean enough to skip deeper work and
+ * aborting when the cumulative LLM spend trips the configured budget cap.
+ *
+ * Called by api/testpass.ts when a caller requests profile "deep". Lower
+ * profiles still run directly; the controller is only worth the extra
+ * round-trips when the caller actually wants the full escalation.
+ */
+
+import type { Pack, RunProfile, Severity } from "../types.js";
+import type { RunManagerConfig } from "../run-manager.js";
+import { updateRunStatus } from "../run-manager.js";
+import { runDeterministicChecks } from "./deterministic.js";
+import { runAgentChecks } from "./agent.js";
+
+const PROFILE_ORDER: RunProfile[] = ["smoke", "standard", "deep"];
+const DEFAULT_MAX_COST_USD = 0.5;
+const EARLY_STOP_PASS_RATE = 0.95;
+
+function profilesUpTo(maxProfile: RunProfile): RunProfile[] {
+  const idx = PROFILE_ORDER.indexOf(maxProfile);
+  return PROFILE_ORDER.slice(0, idx + 1);
+}
+
+interface ItemSnapshot {
+  check_id: string;
+  verdict: string;
+  severity: Severity;
+  cost_usd: number | null;
+}
+
+async function fetchItems(
+  config: RunManagerConfig,
+  runId: string,
+): Promise<ItemSnapshot[]> {
+  const url = `${config.supabaseUrl}/rest/v1/testpass_items?run_id=eq.${runId}&select=check_id,verdict,severity,cost_usd`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+    },
+  });
+  if (!res.ok) return [];
+  return (await res.json()) as ItemSnapshot[];
+}
+
+function passRate(items: ItemSnapshot[]): number {
+  let decided = 0;
+  let passed = 0;
+  for (const i of items) {
+    if (i.verdict === "pending") continue;
+    decided++;
+    if (i.verdict === "check") passed++;
+  }
+  return decided > 0 ? passed / decided : 0;
+}
+
+function hasCriticalFailure(items: ItemSnapshot[]): boolean {
+  return items.some((i) => i.verdict === "fail" && i.severity === "critical");
+}
+
+function totalCostUsd(items: ItemSnapshot[]): number {
+  let sum = 0;
+  for (const i of items) sum += typeof i.cost_usd === "number" ? i.cost_usd : 0;
+  return sum;
+}
+
+/**
+ * Run smoke -> standard -> deep in order, honouring budget cap and
+ * early-stop heuristics. Each pass executes deterministic then agent
+ * checks for items scoped to that profile. Callers are expected to
+ * compute and persist the final verdict summary after this returns.
+ */
+export async function runMultiPass(
+  config: RunManagerConfig,
+  runId: string,
+  targetUrl: string,
+  pack: Pack,
+  maxProfile: RunProfile,
+  maxCostUsd: number = DEFAULT_MAX_COST_USD,
+): Promise<void> {
+  const profiles = profilesUpTo(maxProfile);
+
+  for (let i = 0; i < profiles.length; i++) {
+    const profile = profiles[i];
+
+    try {
+      await runDeterministicChecks(config, runId, targetUrl, pack, profile);
+    } catch (err) {
+      console.error(`Multi-pass deterministic (${profile}) failed for ${runId}:`, (err as Error).message);
+    }
+
+    try {
+      await runAgentChecks(config, runId, targetUrl, pack, profile);
+    } catch (err) {
+      console.error(`Multi-pass agent (${profile}) failed for ${runId}:`, (err as Error).message);
+    }
+
+    const items = await fetchItems(config, runId);
+
+    if (totalCostUsd(items) >= maxCostUsd) {
+      await updateRunStatus(config, runId, "budget_exceeded");
+      return;
+    }
+
+    const isLast = i === profiles.length - 1;
+    if (isLast) break;
+
+    if (profile === "smoke" && passRate(items) >= EARLY_STOP_PASS_RATE) return;
+    if (profile === "standard" && hasCriticalFailure(items)) return;
+  }
+}

--- a/packages/testpass/src/runner/healer.ts
+++ b/packages/testpass/src/runner/healer.ts
@@ -1,0 +1,170 @@
+/**
+ * Healer retry for TestPass.
+ *
+ * Picks up deterministic-check failures from a completed run and asks the
+ * agent runner to take a second look. This catches cases where a target
+ * server is correct per the spec but the deterministic assertion was
+ * overly strict, or where a transient error tripped the first pass.
+ *
+ * Only deterministic check_type items are eligible; agent and hybrid
+ * items already got their judgment call on the first pass.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { Pack } from "../types.js";
+import type { RunManagerConfig } from "../run-manager.js";
+import { updateItem, createEvidence } from "../run-manager.js";
+
+type AgentVerdict = "check" | "fail" | "na" | "other";
+
+interface FailingItem {
+  check_id: string;
+  evidence_ref: string | null;
+}
+
+const SYSTEM_PROMPT = `You are a QA healer for MCP (Model Context Protocol) servers. A deterministic check already flagged this target as failing. Review the check spec and any recorded evidence to decide whether the fail is genuine or whether the first pass was too strict or hit a transient error.
+
+Respond with valid JSON only, no other text:
+{"verdict":"check","reasoning":"one sentence"}
+
+Verdict meanings:
+- "check": on review the target actually passes this requirement
+- "fail": the failure stands
+- "na": the check cannot be evaluated from the available data
+- "other": ambiguous, flag for human review`;
+
+async function fetchFailedItems(
+  config: RunManagerConfig,
+  runId: string,
+): Promise<FailingItem[]> {
+  const url = `${config.supabaseUrl}/rest/v1/testpass_items?run_id=eq.${runId}&verdict=eq.fail&select=check_id,evidence_ref`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+    },
+  });
+  if (!res.ok) return [];
+  return (await res.json()) as FailingItem[];
+}
+
+async function fetchEvidencePayload(
+  config: RunManagerConfig,
+  evidenceRef: string,
+): Promise<unknown> {
+  const url = `${config.supabaseUrl}/rest/v1/testpass_evidence?id=eq.${evidenceRef}&select=payload&limit=1`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+    },
+  });
+  if (!res.ok) return null;
+  const rows = (await res.json()) as Array<{ payload: unknown }>;
+  return rows[0]?.payload ?? null;
+}
+
+function parseVerdict(text: string): { verdict: AgentVerdict; reasoning: string } {
+  const valid: AgentVerdict[] = ["check", "fail", "na", "other"];
+  try {
+    const parsed = JSON.parse(text.trim()) as { verdict?: string; reasoning?: string };
+    const verdict: AgentVerdict = valid.includes(parsed.verdict as AgentVerdict)
+      ? (parsed.verdict as AgentVerdict)
+      : "other";
+    return { verdict, reasoning: parsed.reasoning ?? text };
+  } catch {
+    return { verdict: "other", reasoning: text };
+  }
+}
+
+/**
+ * Re-evaluate every deterministic failure in this run using the agent model.
+ * Returns the count of items whose verdict changed away from "fail".
+ */
+export async function healFailedChecks(
+  config: RunManagerConfig,
+  runId: string,
+  pack: Pack,
+): Promise<number> {
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (!anthropicKey) return 0;
+
+  const failing = await fetchFailedItems(config, runId);
+  if (failing.length === 0) return 0;
+
+  const packItemMap = new Map(pack.items.map((i) => [i.id, i]));
+  const client = new Anthropic({ apiKey: anthropicKey });
+
+  let healed = 0;
+
+  await Promise.allSettled(
+    failing.map(async (item) => {
+      const spec = packItemMap.get(item.check_id);
+      if (!spec || spec.check_type !== "deterministic") return;
+
+      const evidence = item.evidence_ref
+        ? await fetchEvidencePayload(config, item.evidence_ref)
+        : null;
+
+      const parts = [
+        `Check ID: ${item.check_id}`,
+        `Title: ${spec.title}`,
+        spec.description ? `Description: ${spec.description}` : null,
+        spec.expected ? `Expected: ${JSON.stringify(spec.expected)}` : null,
+        spec.on_fail ? `On fail guidance: ${spec.on_fail}` : null,
+        evidence
+          ? `Recorded evidence from the failing deterministic run:\n${JSON.stringify(evidence, null, 2)}`
+          : "No evidence was captured on the original run.",
+      ].filter(Boolean) as string[];
+
+      const start = Date.now();
+      let verdict: AgentVerdict = "fail";
+      let reasoning = "";
+      try {
+        const msg = await client.messages.create({
+          model: "claude-haiku-4-5",
+          max_tokens: 256,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: "user", content: parts.join("\n") }],
+        });
+        const text = (msg.content as Array<{ type: string; text?: string }>)
+          .find((b) => b.type === "text")?.text ?? "";
+        const parsed = parseVerdict(text);
+        verdict = parsed.verdict;
+        reasoning = parsed.reasoning;
+      } catch (err) {
+        reasoning = `Healer exception: ${(err as Error).message}`;
+        return;
+      }
+
+      if (verdict === "fail") return;
+
+      let evidenceRef: string | undefined;
+      try {
+        evidenceRef = await createEvidence(config, {
+          kind: "agent_verdict",
+          payload: {
+            reasoning,
+            model: "claude-haiku-4-5",
+            check_id: item.check_id,
+            healer: true,
+          },
+        });
+      } catch {
+        // non-fatal
+      }
+
+      await updateItem(config, runId, item.check_id, {
+        verdict,
+        on_fail_comment: `healed: ${reasoning}`,
+        time_ms: Date.now() - start,
+        cost_usd: 0,
+        evidence_ref: evidenceRef,
+      });
+
+      healed++;
+    }),
+  );
+
+  return healed;
+}


### PR DESCRIPTION
## Summary

Adds `testpass_run` and `testpass_status` MCP tools, a multi-pass smoke -> standard -> deep controller with a budget cap, and a deterministic healer retry.

- `packages/mcp-server/src/testpass-tool.ts` + wiring exposes the two new tools over the UnClick MCP server.
- `packages/testpass/src/runner/controller.ts` sequences profiles, short-circuits on clean smoke / critical-fail standard, and flips runs to `budget_exceeded` once cumulative cost crosses the cap (default $0.50).
- `packages/testpass/src/runner/healer.ts` re-evaluates deterministic failures via Claude Haiku and rewrites verdicts where the agent disagrees.
- `api/testpass.ts` gains `GET ?action=status&run_id=...` (returns `{status, verdict_summary, fail_count}`) and `POST ?action=heal&run_id=...` (returns `{healed, summary}`), and invokes the multi-pass controller for `profile === "deep"`.
- `packages/testpass/src/index.ts` exports the new modules.

Closes Chunk 5 of the TestPass product plan.

## Test plan

- [ ] `npm run build` at repo root (Vite web build) succeeds.
- [ ] `npm --workspace packages/testpass run build` succeeds (tsc clean).
- [ ] `npm --workspace packages/mcp-server run build` succeeds (tsc clean).
- [ ] `GET /api/testpass?action=status&run_id=<uuid>` returns the run status + verdict summary for the calling user.
- [ ] `POST /api/testpass?action=heal&run_id=<uuid>` flips at least one deterministic fail to a non-fail verdict when Haiku re-judges.
- [ ] `POST /api/testpass?action=start_run` with `profile: "deep"` runs smoke -> standard -> deep, short-circuits when appropriate, and leaves the run in `budget_exceeded` once cumulative cost >= cap.