### PR TITLE
feat(backstagepass): encrypted bulk export of all credentials

### DIFF
--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -762,5 +762,94 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(201).json({ id: row.id, platform, label: label || null, added: true });
   }
 
+  if (action === "bulk_export") {
+    const apiKey   = typeof body.api_key  === "string" ? body.api_key  : "";
+    const password = typeof body.password === "string" ? body.password : "";
+    if (!apiKey)   return res.status(400).json({ error: "api_key is required." });
+    if (!password) return res.status(400).json({ error: "password is required." });
+
+    if (!hashesEqual(sha256hex(apiKey), tenant.apiKeyHash)) {
+      await writeAudit({
+        supabaseUrl, serviceRoleKey, tenant, req,
+        action: "bulk_export", success: false,
+        metadata: { reason: "api_key_mismatch" },
+      });
+      return res.status(403).json({ error: "UnClick API key does not match the signed-in user." });
+    }
+
+    const listUrl = `${supabaseUrl}/rest/v1/user_credentials`
+      + `?api_key_hash=eq.${encodeURIComponent(tenant.apiKeyHash)}`
+      + `&select=id,platform_slug,label,encrypted_data,encryption_iv,encryption_tag,encryption_salt`;
+    const { ok: listOk, data: listData } = await supaFetch(listUrl, "GET", supaHeaders(serviceRoleKey));
+    if (!listOk) {
+      await writeAudit({
+        supabaseUrl, serviceRoleKey, tenant, req,
+        action: "bulk_export", success: false,
+        metadata: { reason: "list_failed" },
+      });
+      return res.status(502).json({ error: "Vault lookup failed." });
+    }
+
+    const rows = (listData as Array<Record<string, unknown>>) ?? [];
+    const exportedCredentials: Array<{ platform: string; label: string | null; values: Record<string, string> }> = [];
+
+    for (const row of rows) {
+      let values: Record<string, string>;
+      try {
+        const salt = Buffer.from(row.encryption_salt as string, "hex");
+        const key  = deriveKey(apiKey, salt);
+        const pt   = decrypt(
+          row.encryption_iv  as string,
+          row.encryption_tag as string,
+          row.encrypted_data as string,
+          key,
+        );
+        values = JSON.parse(pt) as Record<string, string>;
+      } catch {
+        await writeAudit({
+          supabaseUrl, serviceRoleKey, tenant, req,
+          action: "bulk_export", success: false,
+          metadata: { reason: "decrypt_failed", credential_id: row.id },
+        });
+        return res.status(500).json({ error: "Failed to decrypt one or more credentials." });
+      }
+      exportedCredentials.push({
+        platform: row.platform_slug as string,
+        label:    (row.label as string | null) ?? null,
+        values,
+      });
+    }
+
+    const vault = {
+      version:     1,
+      exported_at: new Date().toISOString(),
+      credentials: exportedCredentials,
+    };
+
+    const vaultJson = JSON.stringify(vault);
+    const exportSalt = crypto.randomBytes(SALT_BYTES);
+    const exportKey  = deriveKey(password, exportSalt);
+    const enc        = encrypt(vaultJson, exportKey);
+
+    // Binary format: [4-byte magic "UNV1"] + [32-byte salt] + [12-byte IV] + [ciphertext+authTag]
+    const magic      = Buffer.from("UNV1", "utf8");
+    const ivBuf      = Buffer.from(enc.iv, "hex");
+    const authTagBuf = Buffer.from(enc.authTag, "hex");
+    const cipherBuf  = Buffer.from(enc.ciphertext, "hex");
+    const blob       = Buffer.concat([magic, exportSalt, ivBuf, cipherBuf, authTagBuf]);
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+
+    await writeAudit({
+      supabaseUrl, serviceRoleKey, tenant, req,
+      action: "bulk_export", success: true,
+      metadata: { credential_count: exportedCredentials.length },
+    });
+
+    res.setHeader("Content-Type", "application/octet-stream");
+    res.setHeader("Content-Disposition", `attachment; filename="unclick-vault-${timestamp}.enc"`);
+    return res.status(200).send(blob);
+  }
+
   return res.status(400).json({ error: `Unknown action: ${action || "(empty)"}` });
 }

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -214,6 +214,13 @@ export default function AdminKeychain() {
   const [auditEntries, setAuditEntries] = useState<AuditEntry[] | null>(null);
   const [auditLoading, setAuditLoading] = useState(false);
 
+  // Bulk export modal
+  const [exportOpen, setExportOpen]         = useState(false);
+  const [exportPassword, setExportPassword] = useState("");
+  const [exportConfirm, setExportConfirm]   = useState("");
+  const [exporting, setExporting]           = useState(false);
+  const [exportError, setExportError]       = useState<string | null>(null);
+
   const authHeader = useMemo(
     () => (session ? { Authorization: `Bearer ${session.access_token}` } : {}),
     [session],
@@ -429,6 +436,63 @@ export default function AdminKeychain() {
     }
   }
 
+  async function handleBulkExport() {
+    const apiKey = readLocalApiKey();
+    if (!apiKey) {
+      setExportError("No UnClick API key in this browser. Visit /admin/you to claim or regenerate.");
+      return;
+    }
+    if (exportPassword.length < 12) {
+      setExportError("Password must be at least 12 characters.");
+      return;
+    }
+    if (exportPassword !== exportConfirm) {
+      setExportError("Passwords do not match.");
+      return;
+    }
+    setExporting(true);
+    setExportError(null);
+    try {
+      const res = await fetch("/api/backstagepass?action=bulk_export", {
+        method:  "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body:    JSON.stringify({ api_key: apiKey, password: exportPassword }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? `Export failed with ${res.status}`);
+      }
+      const blob     = await res.blob();
+      const url      = URL.createObjectURL(blob);
+      const anchor   = document.createElement("a");
+      const filename = res.headers.get("Content-Disposition")?.match(/filename="([^"]+)"/)?.[1]
+        ?? `unclick-vault-${new Date().toISOString().slice(0, 10)}.enc`;
+      anchor.href     = url;
+      anchor.download = filename;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      setExportOpen(false);
+      setExportPassword("");
+      setExportConfirm("");
+    } catch (e) {
+      setExportError(e instanceof Error ? e.message : "Export failed.");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  function exportPasswordStrength(pw: string): { label: string; color: string } {
+    if (pw.length < 12) return { label: "Weak",   color: "bg-red-500" };
+    const hasUpper  = /[A-Z]/.test(pw);
+    const hasLower  = /[a-z]/.test(pw);
+    const hasDigit  = /[0-9]/.test(pw);
+    const hasSymbol = /[^A-Za-z0-9]/.test(pw);
+    const variety   = [hasUpper, hasLower, hasDigit, hasSymbol].filter(Boolean).length;
+    if (pw.length >= 16 && variety >= 3) return { label: "Strong", color: "bg-green-500" };
+    if (pw.length >= 12 && variety >= 2) return { label: "Good",   color: "bg-[#E2B93B]" };
+    return { label: "Weak", color: "bg-red-500" };
+  }
+
   const grouped = credentials.reduce<Record<string, Credential[]>>((acc, cred) => {
     const cat = cred.connector?.category ?? "Other";
     if (!acc[cat]) acc[cat] = [];
@@ -446,6 +510,12 @@ export default function AdminKeychain() {
           </p>
         </div>
         <div className="flex gap-2">
+          <button
+            onClick={() => { setExportOpen(true); setExportPassword(""); setExportConfirm(""); setExportError(null); }}
+            className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] transition-colors hover:border-[#E2B93B]/20 hover:text-[#E2B93B]"
+          >
+            Export all credentials
+          </button>
           <button
             onClick={openAudit}
             className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] transition-colors hover:border-[#E2B93B]/20 hover:text-[#E2B93B]"
@@ -708,6 +778,76 @@ export default function AdminKeychain() {
           onClose={() => setAuditOpen(false)}
         />
       )}
+
+      {/* Export vault modal */}
+      {exportOpen && (() => {
+        const pw       = exportPassword;
+        const strength = exportPasswordStrength(pw);
+        const canDownload = pw.length >= 12 && pw === exportConfirm;
+        return (
+          <ModalShell title="Export vault" onClose={() => { setExportOpen(false); setExportPassword(""); setExportConfirm(""); setExportError(null); }}>
+            <p className="mb-4 text-xs text-[#888]">
+              Download an encrypted backup of all your credentials. Set a password to protect the file.
+            </p>
+            <div className="space-y-3">
+              <div>
+                <label className="mb-1 block text-[11px] text-[#888]">Vault password</label>
+                <input
+                  type="password"
+                  value={exportPassword}
+                  onChange={(e) => setExportPassword(e.target.value)}
+                  minLength={12}
+                  placeholder="Min 12 characters"
+                  className="w-full rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 text-sm text-white placeholder:text-[#444] focus:border-[#E2B93B]/40 focus:outline-none"
+                  autoFocus
+                />
+                {pw.length > 0 && (
+                  <div className="mt-1.5 flex items-center gap-2">
+                    <div className="h-1 flex-1 rounded-full bg-white/[0.08]">
+                      <div
+                        className={`h-1 rounded-full transition-all ${strength.color} ${
+                          strength.label === "Strong" ? "w-full" : strength.label === "Good" ? "w-2/3" : "w-1/3"
+                        }`}
+                      />
+                    </div>
+                    <span className={`text-[10px] font-medium ${
+                      strength.label === "Strong" ? "text-green-400" : strength.label === "Good" ? "text-[#E2B93B]" : "text-red-400"
+                    }`}>
+                      {strength.label}
+                    </span>
+                  </div>
+                )}
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] text-[#888]">Confirm password</label>
+                <input
+                  type="password"
+                  value={exportConfirm}
+                  onChange={(e) => setExportConfirm(e.target.value)}
+                  placeholder="Re-enter password"
+                  className="w-full rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 text-sm text-white placeholder:text-[#444] focus:border-[#E2B93B]/40 focus:outline-none"
+                />
+              </div>
+            </div>
+            {exportError && <p className="mt-2 text-[11px] text-red-400">{exportError}</p>}
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => { setExportOpen(false); setExportPassword(""); setExportConfirm(""); setExportError(null); }}
+                className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] hover:text-white"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => void handleBulkExport()}
+                disabled={!canDownload || exporting}
+                className="rounded-lg bg-[#E2B93B] px-3 py-2 text-xs font-medium text-black hover:bg-[#E2B93B]/90 disabled:opacity-50"
+              >
+                {exporting ? "Downloading..." : "Download"}
+              </button>
+            </div>
+          </ModalShell>
+        );
+      })()}
 
       {/* Add credential modal */}
       {starterOpen && (


### PR DESCRIPTION
## Summary

- Adds `POST /api/backstagepass?action=bulk_export` endpoint that decrypts all user credentials, re-encrypts them with a user-supplied password (AES-256-GCM + PBKDF2, 100k iterations, fresh salt), and returns a binary `.enc` file with a `UNV1` magic header
- Authentication follows the same two-factor pattern (Supabase JWT + proof-of-possession api_key hash check) as the existing `reveal` action
- Frontend adds "Export all credentials" button on `/admin/keychain` that opens an "Export vault" modal with password + confirm fields, a strength indicator (Weak/Good/Strong), and triggers a browser download on success

## Test plan

- [ ] Click "Export all credentials" button on the keychain page - modal should open
- [ ] Enter mismatched passwords - Download button should stay disabled
- [ ] Enter password under 12 chars - Download button should stay disabled and strength shows "Weak"
- [ ] Enter a valid password (>=12 chars, matching) - Download button enables
- [ ] Submit - should download a `.enc` binary file
- [ ] Verify audit log shows a `bulk_export` entry after download
- [ ] With wrong api_key (test by clearing localStorage) - should show toast error

🤖 Generated with [Claude Code](https://claude.com/claude-code)