### PR TITLE
chore: archaeology batch 2 - analytics and email branches

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,37 @@
+/**
+ * Analytics helper — thin wrapper around Umami's window.umami.track().
+ *
+ * The Umami snippet is loaded async in index.html with data-website-id
+ * 724975a0-999c-4006-b238-19ee7182c25b, pointed at
+ * https://analytics.unclick.world. It attaches window.umami with a
+ * .track(eventName, eventData?) function once it finishes loading.
+ *
+ * This helper is safe to call before the script has loaded, in dev
+ * environments without the script, and in tests — it no-ops instead
+ * of throwing. Every failure mode is swallowed so analytics can never
+ * break the app.
+ *
+ * Usage:
+ *   track("signup_started", { method: "magic" });
+ *   track("auth_success",   { new_user: true, provider: "google" });
+ */
+
+type EventData = Record<string, string | number | boolean | null | undefined>;
+
+interface UmamiWindow {
+  umami?: {
+    track?: (event: string, data?: EventData) => void;
+  };
+}
+
+export function track(event: string, data?: EventData): void {
+  if (typeof window === "undefined") return;
+  try {
+    const umami = (window as unknown as UmamiWindow).umami;
+    if (umami && typeof umami.track === "function") {
+      umami.track(event, data);
+    }
+  } catch {
+    // Never let analytics break the app.
+  }
+}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -11,13 +11,14 @@
  * sends ?error=...&error_description=... which we surface inline.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { useSession } from "@/lib/auth";
 import { supabase } from "@/lib/supabase";
 import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/analytics";
 import { Loader2 } from "lucide-react";
 
 export default function AuthCallbackPage() {
@@ -27,6 +28,7 @@ export default function AuthCallbackPage() {
 
   const urlError = params.get("error_description") || params.get("error");
   const [timedOut, setTimedOut] = useState(false);
+  const tracked = useRef(false);
 
   useEffect(() => {
     if (!loading && session) {
@@ -35,20 +37,29 @@ export default function AuthCallbackPage() {
       const method = provider === "email" ? "magic_link" : provider;
       const createdAt = user.created_at ? new Date(user.created_at).getTime() : 0;
       const isNewUser = createdAt > 0 && Date.now() - createdAt < 60_000;
+      // Fire auth_success via analytics wrapper exactly once per callback landing.
+      if (!tracked.current) {
+        tracked.current = true;
+        const created = user?.created_at ? Date.parse(user.created_at) : 0;
+        const lastSignIn = user?.last_sign_in_at ? Date.parse(user.last_sign_in_at) : 0;
+        const newUser =
+          created > 0 && lastSignIn > 0 && Math.abs(lastSignIn - created) < 10_000;
+        track("auth_success", { new_user: newUser, provider });
+      }
       posthog.identify(user.id, {
         email: user.email,
         provider,
         created_at: user.created_at,
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const track = (window as any).umami?.track;
+      const umamiTrack = (window as any).umami?.track;
       if (isNewUser) {
         // TODO(posthog-migration): remove umami call once PostHog validated
-        track?.("new_user_signup", { method, email: user.email });
+        umamiTrack?.("new_user_signup", { method, email: user.email });
         posthog.capture("signup_completed", { method, email: user.email });
       } else {
         // TODO(posthog-migration): remove umami call once PostHog validated
-        track?.("returning_user_signin", { method });
+        umamiTrack?.("returning_user_signin", { method });
         posthog.capture("signin_completed", { method });
       }
       // Check if MFA is required before entering the admin shell

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label";
 import { Loader2, Mail, Check } from "lucide-react";
 import { signInWithMagicLink, signInWithOAuth, useSession } from "@/lib/auth";
 import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/analytics";
 import { useEffect } from "react";
 
 export default function LoginPage() {
@@ -45,6 +46,7 @@ export default function LoginPage() {
       return;
     }
     setBusy("magic");
+    track("login_started", { method: "magic" });
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
@@ -62,6 +64,7 @@ export default function LoginPage() {
   async function handleOAuth(provider: "google" | "azure") {
     setError("");
     setBusy(provider);
+    track("login_started", { method: provider });
     // TODO(posthog-migration): remove umami call once PostHog validated
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).umami?.track("signin", { method: provider });

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -23,6 +23,7 @@ import { Label } from "@/components/ui/label";
 import { Loader2, Mail, Check } from "lucide-react";
 import { signInWithMagicLink, signInWithOAuth, useSession } from "@/lib/auth";
 import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/analytics";
 
 export default function SignupPage() {
   useCanonical("https://unclick.world/signup");
@@ -49,6 +50,7 @@ export default function SignupPage() {
       return;
     }
     setBusy("magic");
+    track("signup_started", { method: "magic" });
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
@@ -66,6 +68,7 @@ export default function SignupPage() {
   async function handleOAuth(provider: "google" | "azure") {
     setError("");
     setBusy(provider);
+    track("signup_started", { method: provider });
     // TODO(posthog-migration): remove umami call once PostHog validated
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).umami?.track("signup", { method: provider });


### PR DESCRIPTION
## Summary

Pre-check and selective cherry-pick of 7 stale branches from the analytics/email group.

## Branch decisions

### INCLUDED (1 of 7)

**feat/analytics-events** (commit 4a8ff53)
- Adds `src/lib/analytics.ts` - a null-safe Umami `track()` wrapper that no-ops in dev/tests and never throws
- Wires `login_started`, `signup_started`, and `auth_success` events in Login, Signup, and AuthCallback
- This file did not exist on main; cherry-pick conflicted with existing PostHog code, resolved by keeping BOTH tracking systems running in parallel
- Event naming is more descriptive than the existing inline `window.umami?.track("signin", ...)` calls

### SKIPPED (6 of 7)

**feat/posthog-integration** (commits df94694, 0ba7098)
- `src/lib/posthog.ts` and `api/lib/posthog.ts` already exist on main (landed via PR #79)
- The `defaults` flag and env var docs were the only additions; env vars already documented on main
- No new value

**feat/umami-customer-tracking**
- Zero unique commits vs main (fully merged, already covered by PR #51)

**feat/umami-tool-tracking**
- Zero unique commits vs main (fully merged, already covered by PR #57)

**feat/email-bulletproof-v2**
- Zero diff vs main on all 13 email templates - the bulletproof-v2 rewrite already landed on main
- Nothing to add

**feat/supabase-magic-link-branding**
- Zero unique commits vs main

**feat/brand-all-supabase-emails** (commit cc86d1e)
- Implements a dark-theme redesign (#0A0A0A body, SVG wordmark) across all 12 email templates
- Main already has the canonical light bulletproof-v2 format (JPEG header, white body, Outlook-safe)
- The dark theme is a different design direction and would overwrite the existing email format
- Skipped to preserve the already-landed bulletproof-v2 standard

## New env vars

None. The PostHog env vars (VITE_POSTHOG_KEY, POSTHOG_API_KEY, etc.) were part of the skipped posthog-integration branch and are already documented on main.

## Build

`npm run build` passes cleanly - no TypeScript errors.