### PR TITLE
feat(memory): pushy descriptions + preamble + SKILL + onboarding

### DIFF
--- a/.claude/skills/unclick-memory/SKILL.md
+++ b/.claude/skills/unclick-memory/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: unclick-memory
+description: Load UnClick persistent memory at session start and apply the full session protocol. TRIGGER at the very start of every session, every new task, and every conversation -- even before the user says anything substantive. Also trigger whenever the user says "remember", "recall", "last time", "context", "preferences", "facts about me", "who am I", "pick up where we left off", "what have I told you", or references any past work. If the user seems to lack context about their own history, trigger immediately. Do NOT skip for trivial opening messages -- personal facts change how almost every answer should be framed.
+---
+
+# UnClick memory session protocol
+
+You have access to the UnClick MCP server, which provides persistent cross-session memory.
+Follow this four-step protocol every session, every time.
+
+## Step 1 -- LOAD (mandatory, always first)
+
+Call `load_memory` **before your first response** to the user, even if the message looks trivial.
+This loads the user's identity, standing rules, preferences, recent sessions, and active facts.
+
+```
+load_memory({ num_sessions: 5 })
+```
+
+Treat the output as authoritative context. If `load_memory` is unavailable, note this and continue
+without fabricating prior context.
+
+## Step 2 -- SEARCH (on demand, throughout the session)
+
+Call `search_memory` whenever the user references anything that might be stored:
+- "remember", "recall", "do you know", "what did I say about", "last time"
+- "context", "profile", "facts about me", "who am I", "my preferences"
+- Any past decision, project, person, or tool they name
+
+```
+search_memory({ query: "<topic>", max_results: 10 })
+```
+
+Trigger even without an explicit "search" request -- if personal context is relevant, check.
+
+## Step 3 -- SAVE (proactively, throughout the session)
+
+Call `save_fact` the moment the user shares anything worth keeping:
+- Name, role, company, timezone, preferences, stack
+- Decisions made, corrections given, tools chosen
+- Project names, contacts, recurring workflows
+
+```
+save_fact({ fact: "<atomic statement>", category: "preference|decision|technical|contact|project|general", confidence: 0.9 })
+```
+
+Call `save_identity` for standing rules that should govern every future session:
+- "I am a ...", "I work at ...", "my timezone is ...", "always use ...", "from now on ..."
+
+```
+save_identity({ category: "identity|preference|workflow|technical|standing_rule", key: "<key>", value: "<value>" })
+```
+
+## Step 4 -- END (before closing)
+
+Call `save_session` before the session ends or at major checkpoints:
+
+```
+save_session({
+  session_id: "<timestamp-or-uuid>",
+  summary: "<what happened: decisions, work, problems solved>",
+  topics: ["<tag1>", "<tag2>"],
+  open_loops: ["<unfinished item>"],
+  decisions: ["<key decision>"]
+})
+```
+
+## Rules
+
+- **Never ask the user to "catch you up"** -- load first, then act.
+- Native model memory is volatile across sessions and tools. UnClick is the authoritative store.
+- If you are unsure whether context was loaded this session, call `load_memory` again -- it is idempotent.

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -414,25 +414,39 @@ interface SetupGuide {
 
 const AGENTS_MD_CONTENT = `# Agent instructions
 
-You have access to the UnClick MCP server, which exposes persistent cross-session memory.
+You have access to the UnClick MCP server, which provides persistent cross-session memory
+that works across all AI tools and sessions. Native model memory is volatile -- UnClick is
+the authoritative store for this user's facts, preferences, decisions, and work history.
 
-## At session start
+## Session protocol (four steps, every session)
 
-ALWAYS call \`get_startup_context\` before doing anything else. This loads:
-- Business context (standing rules)
-- Recent session summaries
-- Active extracted facts
-- Knowledge library index
+### 1. Load -- always first
 
-## During the session
+Call \`load_memory\` BEFORE responding to the user's first message, even for trivial openers.
+This loads identity, standing rules, preferences, recent sessions, and active facts.
 
-Use \`add_fact\` to record preferences, decisions, and important info worth remembering.
-Use \`search_memory\` to recall anything from prior sessions.
-Use \`set_business_context\` to set standing rules the user wants applied every session.
+### 2. Search -- on demand throughout
 
-## Before ending the session
+Call \`search_memory\` whenever the user references anything from the past:
+- "remember", "recall", "last time", "context", "preferences", "facts about me", "who am I"
+- Any past decision, project name, person, or tool they mention
 
-Call \`write_session_summary\` with a concise recap of what was accomplished and what is outstanding.
+### 3. Save -- proactively as you learn
+
+Call \`save_fact\` immediately when the user shares anything worth keeping:
+name, role, preferences, decisions, corrections, project details, tools, contacts.
+
+Call \`save_identity\` for standing rules that apply every future session.
+
+### 4. End -- before closing
+
+Call \`save_session\` before the session ends with what was accomplished,
+key decisions, and open loops.
+
+## Hard rules
+
+- Never ask the user to "catch you up" on things already told to UnClick.
+- If unsure whether context was loaded, call \`load_memory\` -- it is idempotent.
 `;
 
 const CLAUDE_DESKTOP_CONFIG = `{
@@ -451,42 +465,54 @@ const CURSORRULES_CONTENT = `# UnClick memory protocol
 
 The UnClick MCP server provides persistent cross-session memory.
 
-At the start of every session, call the \`get_startup_context\` tool before doing anything else. It returns business context, recent session summaries, and active facts.
+At the start of every session, call \`load_memory\` before doing anything else.
+It returns standing rules, recent session summaries, and active facts.
 
-Record durable preferences, decisions, or facts with \`add_fact\`. Recall with \`search_memory\`. Before ending a session, call \`write_session_summary\`.
+Record durable preferences, decisions, or facts with \`save_fact\`.
+Recall anything from prior sessions with \`search_memory\`.
+Set standing rules that apply every session with \`save_identity\`.
+Before ending a session, call \`save_session\`.
+Never ask the user to catch you up -- load first, then act.
 `;
 
 const WINDSURFRULES_CONTENT = `# UnClick memory protocol
 
 The UnClick MCP server provides persistent cross-session memory.
 
-At the start of every session, call the \`get_startup_context\` tool before doing anything else. It returns business context, recent session summaries, and active facts.
+At the start of every session, call \`load_memory\` before doing anything else.
+It returns standing rules, recent session summaries, and active facts.
 
-Record durable preferences, decisions, or facts with \`add_fact\`. Recall with \`search_memory\`. Before ending a session, call \`write_session_summary\`.
+Record durable preferences, decisions, or facts with \`save_fact\`.
+Recall anything from prior sessions with \`search_memory\`.
+Set standing rules that apply every session with \`save_identity\`.
+Before ending a session, call \`save_session\`.
+Never ask the user to catch you up -- load first, then act.
 `;
 
 const COWORK_SKILL_CONFIG = `---
 name: session-bootstrap
-description: Loads UnClick persistent memory at session start. Always invoke before other work.
+description: Loads UnClick persistent memory at session start and applies the full session protocol. TRIGGER at the very start of every session and every new conversation -- even before the user says anything substantive. Also trigger whenever the user says "remember", "recall", "context", "preferences", "facts about me", "who am I", or references past work.
 ---
 
 # Session bootstrap
 
-Call the UnClick MCP tool \`get_startup_context\` immediately. Treat its output as authoritative context for this session.
+Call the UnClick MCP tool \`load_memory\` immediately. Treat its output as authoritative context for this session.
 
 If the tool is unavailable, note this and continue. Do not fabricate prior context.
+
+During the session: call \`save_fact\` for anything worth keeping, \`search_memory\` to recall past context.
+Before closing: call \`save_session\` to record what was done and what is open.
 `;
 
 const CUSTOM_CLIENT_SNIPPET = `// Pseudo-code for a custom MCP client.
-// On session start, call get_startup_context before any user-triggered work.
+// On session start, call load_memory before any user-triggered work.
 
 async function onSessionStart(mcpClient) {
   // 1. If your client honours the MCP \`instructions\` field, the UnClick
-  //    server will tell you to call get_startup_context automatically.
-  //    Enable the "auto-load" setting in the UnClick admin to turn this on.
+  //    server will tell the agent to call load_memory automatically.
 
   // 2. Otherwise, call the tool directly:
-  const ctx = await mcpClient.callTool("get_startup_context", {});
+  const ctx = await mcpClient.callTool("load_memory", {});
   systemPrompt.push(ctx.content);
 
   // 3. Optional: subscribe to resources for background updates.
@@ -513,14 +539,21 @@ const SETUP_GUIDES: Record<string, SetupGuide> = {
         code_snippet: AGENTS_MD_CONTENT,
       },
       {
-        title: "Verify get_startup_context is in the tool list",
+        title: "Verify load_memory is in the tool list",
         description:
-          "Run /mcp inside Claude Code. You should see the UnClick server and the 5 direct memory tools, including get_startup_context.",
+          "Run /mcp inside Claude Code. You should see the UnClick server and the 5 direct memory tools: load_memory, save_fact, search_memory, save_identity, and save_session.",
+      },
+      {
+        title: "Optional: pause Claude's native memory",
+        description:
+          "For best results, go to Claude Settings > Capabilities > Memory and pause native Claude memory for this project. " +
+          "Native memory and UnClick can coexist, but pausing native memory ensures UnClick is the sole authoritative store -- " +
+          "preventing conflicts where Claude summarises outdated native context instead of loading from UnClick.",
       },
       {
         title: "Test by starting a fresh session",
         description:
-          "Start a new Claude Code session in the repo. The first turn should call get_startup_context and show context loaded before doing other work.",
+          "Start a new Claude Code session in the repo. The first turn should call load_memory and show context loaded before doing other work.",
       },
     ],
     config_file: { filename: "AGENTS.md", content: AGENTS_MD_CONTENT },
@@ -533,7 +566,7 @@ const SETUP_GUIDES: Record<string, SetupGuide> = {
     auto_load_method: "MCP instructions field plus resources subscription",
     reliability: "Medium-High",
     reliability_notes:
-      "Claude Desktop honours the MCP instructions field in most recent versions, which is enough to auto-call get_startup_context. Subscribing to memory://context/full as a resource is a belt-and-braces backup.",
+      "Claude Desktop honours the MCP instructions field in most recent versions, which is enough to auto-call load_memory. Subscribing to memory://context/full as a resource is a belt-and-braces backup.",
     setup_steps: [
       {
         title: "Add UnClick to claude_desktop_config.json",
@@ -544,7 +577,13 @@ const SETUP_GUIDES: Record<string, SetupGuide> = {
       {
         title: "Enable auto-load in the UnClick admin",
         description:
-          "Turn on auto-load so the server sends its instructions field. Claude Desktop will then call get_startup_context on session start.",
+          "Turn on auto-load so the server sends its instructions field. Claude Desktop will then call load_memory on session start.",
+      },
+      {
+        title: "Optional: pause Claude's native memory",
+        description:
+          "Go to Claude Settings > Capabilities > Memory and pause native Claude memory. " +
+          "This ensures UnClick is the sole authoritative store and prevents conflicts with Claude's own memory summaries.",
       },
       {
         title: "Optional: subscribe to the memory context resource",
@@ -562,7 +601,7 @@ const SETUP_GUIDES: Record<string, SetupGuide> = {
     auto_load_method: ".cursorrules file plus tool description reminders",
     reliability: "Medium",
     reliability_notes:
-      "Cursor supports MCP tools but not prompts or resources. Auto-load relies on .cursorrules text telling the agent to call get_startup_context. Some sessions may skip the call if the rules file is terse.",
+      "Cursor supports MCP tools but not prompts or resources. Auto-load relies on .cursorrules text telling the agent to call load_memory. Some sessions may skip the call if the rules file is terse.",
     setup_steps: [
       {
         title: "Add the UnClick MCP server to Cursor",
@@ -573,13 +612,13 @@ const SETUP_GUIDES: Record<string, SetupGuide> = {
       {
         title: "Create .cursorrules at the project root",
         description:
-          "Cursor reads .cursorrules on every session. This is the main hook that persuades the agent to call get_startup_context.",
+          "Cursor reads .cursorrules on every session. This is the main hook that persuades the agent to call load_memory.",
         code_snippet: CURSORRULES_CONTENT,
       },
       {
-        title: "Verify the tool appears in Cursor's MCP panel",
+        title: "Verify the tools appear in Cursor's MCP panel",
         description:
-          "Open the MCP panel and confirm get_startup_context, add_fact, search_memory, write_session_summary, and set_business_context are listed.",
+          "Open the MCP panel and confirm load_memory, save_fact, search_memory, save_identity, and save_session are listed.",
       },
     ],
     config_file: { filename: ".cursorrules", content: CURSORRULES_CONTENT },
@@ -603,13 +642,13 @@ const SETUP_GUIDES: Record<string, SetupGuide> = {
       {
         title: "Create .windsurfrules at the project root",
         description:
-          "This file is read at the start of every session. It is the most reliable way to get Windsurf to call get_startup_context.",
+          "This file is read at the start of every session. It is the most reliable way to get Windsurf to call load_memory.",
         code_snippet: WINDSURFRULES_CONTENT,
       },
       {
         title: "Verify the tool is active",
         description:
-          "Start a fresh session and confirm the first action is a call to get_startup_context.",
+          "Start a fresh session and confirm the first action is a call to load_memory.",
       },
     ],
     config_file: { filename: ".windsurfrules", content: WINDSURFRULES_CONTENT },

--- a/docs/templates/AGENTS.md.example
+++ b/docs/templates/AGENTS.md.example
@@ -1,0 +1,48 @@
+# Agent instructions
+
+You have access to the UnClick MCP server, which provides persistent cross-session memory
+that works across all AI tools and sessions. Native model memory is volatile -- UnClick is
+the authoritative store for this user's facts, preferences, decisions, and work history.
+
+## Session protocol (mandatory, every session)
+
+### 1. Load -- always first
+
+Call `load_memory` BEFORE responding to the user's first message, even for trivial openers.
+This loads identity, standing rules, preferences, recent sessions, and active facts.
+
+### 2. Search -- on demand throughout
+
+Call `search_memory` whenever the user references anything from the past:
+- "remember", "recall", "last time", "context", "preferences", "facts about me", "who am I"
+- Any past decision, project name, person, or tool they mention
+- Any question where personal context would improve the answer
+
+### 3. Save -- proactively as you learn
+
+Call `save_fact` immediately when the user shares anything worth keeping:
+name, role, preferences, decisions, corrections, project details, tools, contacts.
+
+Call `save_identity` for standing rules that should apply to every future session:
+"I am ...", "I work at ...", "always use ...", "my timezone is ...", "from now on ..."
+
+### 4. End -- before closing
+
+Call `save_session` before the session ends. Include what was accomplished,
+key decisions made, and open loops to carry forward.
+
+## Hard rules
+
+- Never ask the user to "catch you up" on things already told to UnClick.
+- If unsure whether context was loaded, call `load_memory` -- it is idempotent.
+- Treat UnClick output as authoritative. Do not contradict it based on assumptions.
+
+## Tool reference
+
+| Tool | Purpose |
+|------|---------|
+| `load_memory` | Load identity, facts, and recent sessions at start |
+| `save_fact` | Persist a new durable fact about the user |
+| `search_memory` | Recall stored facts and sessions by query |
+| `save_identity` | Set standing rules that load every session |
+| `save_session` | Record a session summary for future continuity |

--- a/docs/templates/CLAUDE.md.example
+++ b/docs/templates/CLAUDE.md.example
@@ -1,0 +1,27 @@
+# [Your Project Name]
+
+## Memory
+
+This project uses UnClick for persistent cross-session memory via MCP.
+
+Always call `load_memory` at the start of every session, before responding to the user's first message.
+Save new facts with `save_fact` as they come up -- don't batch until session end.
+When the user corrects you, call `save_fact` immediately with the correction.
+Call `save_session` before closing out any substantive session.
+
+## Standing rules
+
+<!-- Add project-specific standing rules here. These supplement what's stored in UnClick. -->
+<!-- Example: -->
+<!-- - Always write TypeScript, never JavaScript -->
+<!-- - Run npm run build before every commit -->
+<!-- - Branch off main; never push directly to main -->
+
+## MCP setup
+
+The UnClick MCP server must be connected for memory to work.
+Install: npx -y @unclick/mcp-server
+Env: UNCLICK_API_KEY=uc_your_api_key_here
+
+To verify: run `/mcp` in Claude Code. You should see `load_memory`, `save_fact`,
+`search_memory`, `save_identity`, and `save_session` in the tool list.

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -170,10 +170,13 @@ const VISIBLE_TOOLS = [
     name: "load_memory",
     title: "Load memory",
     description:
-      "Loads the user's identity, preferences, facts, and recent session history. " +
-      "Call this FIRST at the start of every session, before responding to the user " +
-      "or calling any other tool. Skipping this means you won't know who the user is " +
-      "or what they care about.",
+      "Loads the user's identity, preferences, facts, and recent session history from persistent cross-session storage. " +
+      "Use IMMEDIATELY at the start of every session -- before responding to the user's first message, before calling any other tool. " +
+      "Trigger even when the opening message looks trivial: keywords like 'remember', 'recall', 'context', 'profile', " +
+      "'facts about me', 'who am I', 'last time', 'preferences', 'pick up where we left off' all signal stored context exists. " +
+      "Also trigger after any context reset or tool reconnect, or any time you are unsure whether context was loaded this session. " +
+      "Do NOT skip because the first message is simple -- personal facts change how almost every answer should be framed. " +
+      "Do NOT trigger for pure factual lookups (capitals, math, definitions) that require no personal context.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -189,9 +192,14 @@ const VISIBLE_TOOLS = [
     name: "save_fact",
     title: "Remember a fact",
     description:
-      "Saves a new fact about the user for future sessions. Use this whenever the user " +
-      "shares something worth remembering -- preferences, decisions, contact details, " +
-      "technical choices. Facts persist across all sessions and AI tools.",
+      "Saves a new persistent fact about the user that will be available in all future sessions across every AI tool. " +
+      "Use whenever the user shares anything worth keeping -- even if they don't explicitly ask: 'capture', 'noted', " +
+      "'remember this', 'log', 'store', 'don't forget', or any preference, decision, correction, contact, project detail, " +
+      "technical choice, or personal detail the user mentions. " +
+      "Also trigger proactively when the user corrects you (save the correction immediately), " +
+      "reveals a preference by rejecting something, or names a person/tool/project for the first time. " +
+      "Do NOT trigger for transient values (today's weather, one-off calculations, temporary state that won't matter next session). " +
+      "Do NOT trigger for facts already confirmed stored earlier in this session.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -211,10 +219,14 @@ const VISIBLE_TOOLS = [
     name: "search_memory",
     title: "Search memory",
     description:
-      "Searches the user's stored facts and session history. Use this when the user " +
-      "asks about something from a previous session, references a past decision, or " +
-      "when you need context about a specific topic. Returns matching facts and session " +
-      "summaries.",
+      "Searches the user's stored facts and session history using hybrid semantic + keyword retrieval. " +
+      "Use whenever the user asks about anything that might be stored: 'remember', 'recall', 'do you know', " +
+      "'what did I say about', 'last time', 'context', 'profile', 'facts about me', 'who am I', 'my preferences', " +
+      "'what have I told you', or when you need background on a topic before answering. " +
+      "Trigger even when the user doesn't explicitly say 'search' -- if the question involves past decisions, " +
+      "preferences, project details, or named people and tools, check memory first. " +
+      "Do NOT trigger for one-shot math, translations, definitions, or questions with no plausible stored context. " +
+      "Do NOT trigger if load_memory was just called and already returned the relevant context.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -228,9 +240,13 @@ const VISIBLE_TOOLS = [
     name: "save_identity",
     title: "Save my identity",
     description:
-      "Saves or updates the user's identity information -- business name, role, standing " +
-      "rules, preferences. This information loads at the start of every session. Use this " +
-      "when the user wants to change how every future session behaves.",
+      "Saves or updates a standing rule or identity entry that loads at the start of every future session. " +
+      "Use whenever the user states or updates something about themselves or how they want every session to behave: " +
+      "'my name', 'my role', 'I am', 'I work at', 'my preferences', 'I always', 'from now on', 'always remember', " +
+      "'my timezone', 'my stack', 'my workflow', 'call me', or any other standing rule or identity anchor. " +
+      "Unlike save_fact (session-scoped context), save_identity is for rules and identity that should govern every future session. " +
+      "Do NOT trigger for one-time facts about a specific task or project (use save_fact instead). " +
+      "Do NOT trigger for information the user explicitly says is temporary.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -249,9 +265,14 @@ const VISIBLE_TOOLS = [
     name: "save_session",
     title: "Save this session",
     description:
-      "Saves a summary of the current session including decisions made, tasks completed, " +
-      "and open items. Call this at the end of a session or when significant work is " +
-      "completed. The summary will be available in future sessions.",
+      "Saves a structured summary of the current session so the next session can resume without re-asking. " +
+      "Use at the end of every meaningful session -- even if the user doesn't ask: 'summary', 'wrap-up', " +
+      "'end of session', 'recap', 'we're done', 'see you next time', 'close out', or whenever significant " +
+      "work was completed, decisions were made, or open loops exist that need carrying forward. " +
+      "Also trigger at natural checkpoints mid-session when a major phase completes. " +
+      "Include: what was accomplished, key decisions made, open loops or next steps. " +
+      "Do NOT trigger after trivial exchanges (single Q&A, quick lookups) with nothing worth carrying forward. " +
+      "Do NOT trigger if the session has already been saved with no new work done since.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -685,27 +706,26 @@ export function createServer(): Server {
       // "load the user's memory before you answer." Without this, `load_memory`
       // is just another tool in a list and the agent rarely calls it first.
       instructions: [
-        "UnClick is this user's cross-session memory and agent toolbelt.",
+        "UnClick is this user's persistent memory and toolbelt -- durable across",
+        "every AI session, tool, and device. Native model memory is volatile;",
+        "this MCP is the authoritative store.",
         "",
-        "ASSUME INTERRUPTION. Your context may reset between messages or sessions.",
-        "This MCP is the authoritative store for the user's durable facts,",
-        "preferences, decisions, and work-in-progress. Treat native model memory",
-        "as a volatile supplement only.",
+        "MANDATORY SESSION PROTOCOL (four steps, every session):",
+        "  1. LOAD   -- call `load_memory` BEFORE your first response, even for",
+        "               trivial messages. Personal facts change how you should",
+        "               answer almost every question.",
+        "  2. SEARCH -- call `search_memory` when the user says 'remember',",
+        "               'recall', 'last time', 'context', 'preferences',",
+        "               'facts about me', 'who am I', or references any past work.",
+        "  3. SAVE   -- call `save_fact` the moment the user shares anything",
+        "               worth keeping: name, preferences, decisions, corrections.",
+        "               Use `save_identity` for standing rules that apply every",
+        "               session (role, timezone, stack, workflow).",
+        "  4. END    -- call `save_session` before closing. Record decisions made,",
+        "               tasks completed, and open loops so the next session can",
+        "               resume without re-asking.",
         "",
-        "ALWAYS call `load_memory` before responding to the user's first message",
-        "in any new session or after any apparent context reset. Do this even if",
-        "the user's first message looks trivial — personal facts (name, timezone,",
-        "projects, preferences, open loops) change how you should answer almost",
-        "every question.",
-        "",
-        "AS YOU WORK: use `save_fact` to persist new durable facts the user shares",
-        "(identity, preferences, tools, family, business, decisions). Use",
-        "`save_session` at natural checkpoints to record what you did, what's open,",
-        "and what the next step is — so the next agent (or next-you) can resume",
-        "without re-asking.",
-        "",
-        "Never ask the user to 'catch you up' on things they've already told",
-        "UnClick. Load first, then act.",
+        "Never ask the user to 'catch you up' -- load first, then act.",
       ].join("\n"),
     }
   );

--- a/src/lib/context-file-generator.ts
+++ b/src/lib/context-file-generator.ts
@@ -53,9 +53,16 @@ function buildClaudeMd(input: ContextFileInput): string {
   }
 
   lines.push("## Memory");
-  lines.push("- Always call load_memory at session start");
+  lines.push("- Always call load_memory at session start, before responding to the first message");
+  lines.push("- Call search_memory when the user references anything from the past");
   lines.push("- Save facts and preferences as you learn them -- don't wait until session end");
-  lines.push("- When I correct you, save the correction immediately");
+  lines.push("- When I correct you, call save_fact immediately with the correction");
+  lines.push("- Call save_session before closing any substantive session");
+  lines.push("- Never ask me to catch you up on things I've already told UnClick");
+  lines.push("");
+  lines.push("## Skills");
+  lines.push("- Use the `unclick-memory` skill (in .claude/skills/unclick-memory/SKILL.md) for");
+  lines.push("  the full session protocol including load, search, save, and end steps");
   lines.push("");
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary

- Rewrite `serverInfo.instructions` preamble with explicit 4-step session protocol (LOAD/SEARCH/SAVE/END)
- Rewrite all 5 tool descriptions in Anthropic pushy style: one-sentence purpose + positive triggers (BM25 keywords) + exclusions block
- Create `.claude/skills/unclick-memory/SKILL.md` with full protocol + Claude Code triggers
- Create `docs/templates/CLAUDE.md.example` and `docs/templates/AGENTS.md.example` as drop-in user templates
- Add "pause native Claude memory" nudge to setup guide for Claude Code + Claude Desktop
- Fix all old tool names in `api/memory-admin.ts` (AGENTS_MD, cursorrules, windsurfrules, cowork skill, custom client snippet)
- Wire skill reference into `src/lib/context-file-generator.ts` generated CLAUDE.md

## Preamble before

```
UnClick is this user's cross-session memory and agent toolbelt.

ASSUME INTERRUPTION. Your context may reset between messages or sessions.
This MCP is the authoritative store for the user's durable facts,
preferences, decisions, and work-in-progress. Treat native model memory
as a volatile supplement only.

ALWAYS call `load_memory` before responding to the user's first message
in any new session or after any apparent context reset. Do this even if
the user's first message looks trivial — personal facts (name, timezone,
projects, preferences, open loops) change how you should answer almost
every question.

AS YOU WORK: use `save_fact` to persist new durable facts the user shares
(identity, preferences, tools, family, business, decisions). Use
`save_session` at natural checkpoints to record what you did, what's open,
and what the next step is — so the next agent (or next-you) can resume
without re-asking.

Never ask the user to 'catch you up' on things they've already told
UnClick. Load first, then act.
```

## Preamble after

```
UnClick is this user's persistent memory and toolbelt -- durable across
every AI session, tool, and device. Native model memory is volatile;
this MCP is the authoritative store.

MANDATORY SESSION PROTOCOL (four steps, every session):
  1. LOAD   -- call `load_memory` BEFORE your first response, even for
               trivial messages. Personal facts change how you should
               answer almost every question.
  2. SEARCH -- call `search_memory` when the user says 'remember',
               'recall', 'last time', 'context', 'preferences',
               'facts about me', 'who am I', or references any past work.
  3. SAVE   -- call `save_fact` the moment the user shares anything
               worth keeping: name, preferences, decisions, corrections.
               Use `save_identity` for standing rules that apply every
               session (role, timezone, stack, workflow).
  4. END    -- call `save_session` before closing. Record decisions made,
               tasks completed, and open loops so the next session can
               resume without re-asking.

Never ask the user to 'catch you up' -- load first, then act.
```
(~1100 chars, well under 1.8KB limit)

## Tool description changes

| Tool | Key change |
|------|-----------|
| `load_memory` | Added explicit BM25 trigger keywords (remember, recall, context, profile, facts about me, who am I, last time, preferences) + exclusions for pure factual lookups |
| `save_fact` | Added proactive triggers (corrections, implicit preferences, first-named entities) + exclusions for transient/already-stored values |
| `search_memory` | Added semantic trigger keywords + "even without explicit search request" framing + exclusions for math/definitions |
| `save_identity` | Clarified standing-rules vs session-facts split + trigger keywords (my name, my role, I am, I work at, from now on) + exclusions for temporary info |
| `save_session` | Added natural-language triggers (summary, wrap-up, end of session, recap, see you next time) + checkpoint trigger + exclusions for trivial exchanges |

## File paths

- SKILL.md: `.claude/skills/unclick-memory/SKILL.md`
- CLAUDE.md example: `docs/templates/CLAUDE.md.example`
- AGENTS.md example: `docs/templates/AGENTS.md.example`

## Onboarding nudge placement

Added as a step in `api/memory-admin.ts` `SETUP_GUIDES["claude-code"]` and `SETUP_GUIDES["claude-desktop"]`:
> "Optional: pause Claude's native memory -- go to Claude Settings > Capabilities > Memory and pause native Claude memory. This ensures UnClick is the sole authoritative store and prevents conflicts with Claude's own memory summaries."

## No schema changes

Zero changes to retrieval logic, database schema, or MCP handlers. All changes are text/descriptions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)