### PR TITLE
feat(testpass): Anti-Stomp pack v0

### DIFF
--- a/packages/testpass/packs/anti-stomp-v0.yaml
+++ b/packages/testpass/packs/anti-stomp-v0.yaml
@@ -1,0 +1,206 @@
+id: anti-stomp-v0
+name: Anti-Stomp v0
+version: 0.1.0
+description: >
+  QC checks that detect when one agent's work silently undid another agent's.
+  Covers deleted files, removed routes/nav items, orphaned components,
+  stranded restructure branches, and PR archaeology hygiene.
+  Target: code repos with git history. Run with base and head refs set in GitContext.
+
+items:
+  # ─── Deletion audit ───────────────────────────────────────────────────────
+
+  - id: DELETE-001
+    title: Files deleted without rationale
+    category: deletion-audit
+    severity: high
+    check_type: deterministic
+    description: >
+      Run `git diff --name-only --diff-filter=D <base>..<head>` and filter for
+      files under src/pages/, src/components/, src/admin/, packages/*/src/, or api/.
+      Fail if any such file is not mentioned by name or filepath in the PR body.
+    expected:
+      verify:
+        type: shell
+        command: "git diff --name-only --diff-filter=D {base}..{head}"
+      monitored_paths:
+        - src/pages/
+        - src/components/
+        - src/admin/
+        - api/
+      monitored_glob: "packages/*/src/"
+    on_fail: >
+      Add a 'Deletions' section to the PR body listing each deleted file with
+      a one-line rationale.
+    tags: [deletion, pr-hygiene, anti-stomp]
+    profiles: [smoke, standard, deep]
+
+  - id: DELETE-002
+    title: Routes removed from router without rationale
+    category: deletion-audit
+    severity: high
+    check_type: deterministic
+    description: >
+      Locate the router config file (src/App.tsx or src/routes.tsx). Diff it
+      between base and head. Fail if any <Route path=...> element is removed
+      without explicit mention of the path value in the PR body.
+    expected:
+      verify:
+        type: shell
+        command: "git diff {base}..{head} -- src/App.tsx src/routes.tsx"
+      route_patterns:
+        - "<Route"
+        - "path="
+    on_fail: >
+      Confirm each removed route is intentional in PR body, or restore.
+    tags: [routing, deletion, pr-hygiene, anti-stomp]
+    profiles: [standard, deep]
+
+  # ─── Orphan audit ─────────────────────────────────────────────────────────
+
+  - id: ORPHAN-001
+    title: Stranded components with no imports
+    category: orphan-audit
+    severity: medium
+    check_type: deterministic
+    description: >
+      For each .tsx/.ts file under src/components/ and src/pages/ at HEAD,
+      grep the whole repo for references to the component name. Files with zero
+      references outside themselves are orphaned. Skip files marked
+      `// @entrypoint` or living under __tests__/.
+    expected:
+      verify:
+        type: shell
+        command: "git ls-tree -r --name-only {head} -- src/components/ src/pages/"
+      skip_patterns:
+        - __tests__/
+        - .test.
+        - .spec.
+      skip_comment: "// @entrypoint"
+    on_fail: >
+      Either delete, re-wire, or add `// @entrypoint` comment to each orphaned file.
+    tags: [orphan, cleanup, anti-stomp]
+    profiles: [standard, deep]
+
+  - id: ORPHAN-002
+    title: Abandoned restructure branches
+    category: orphan-audit
+    severity: medium
+    check_type: deterministic
+    description: >
+      Run `git branch -a --sort=-committerdate | head -30`. Filter for branches
+      containing "restructure", "refactor", "redesign", or "restore" that are
+      not merged into main. Flag each unmerged branch with its last commit date.
+    expected:
+      verify:
+        type: shell
+        command: "git branch -a --sort=-committerdate"
+      restructure_keywords:
+        - restructure
+        - refactor
+        - redesign
+        - restore
+      head_limit: 30
+    on_fail: >
+      Document in abandoned-branches.md, cherry-pick salvageable commits, or delete.
+    tags: [orphan, branches, anti-stomp]
+    profiles: [deep]
+
+  # ─── Surface audit ────────────────────────────────────────────────────────
+
+  - id: SURFACE-001
+    title: Per-surface design memory cross-check
+    category: surface-audit
+    severity: low
+    check_type: deterministic
+    description: >
+      Optional. For each file matching .auto-memory/project-*-ui.md, parse the
+      "Current structure" section and grep the code at HEAD for each listed
+      tab/section name. Skip entirely if no memory files exist.
+    expected:
+      verify:
+        type: shell
+        command: "git ls-tree -r --name-only {head} -- .auto-memory/"
+      section_header: "Current structure"
+      optional: true
+    on_fail: >
+      Either restore the missing item or update the memory file with rationale.
+    tags: [surface, design-memory, optional, anti-stomp]
+    profiles: [deep]
+
+  - id: SURFACE-002
+    title: Navigation tree diff
+    category: surface-audit
+    severity: medium
+    check_type: deterministic
+    description: >
+      Identify the nav config file by grepping for NavLink or SidebarNav in
+      src/pages/admin/AdminShell.tsx or src/components/Sidebar.tsx. Diff it
+      between base and head. Fail if any nav items were removed without explicit
+      mention in the PR body.
+    expected:
+      verify:
+        type: shell
+        command: "git diff {base}..{head} -- src/pages/admin/AdminShell.tsx src/components/Sidebar.tsx"
+      nav_patterns:
+        - NavLink
+        - SidebarNav
+        - sidebar-item
+    on_fail: >
+      Mention removed nav items in PR body with 1-line rationale each.
+    tags: [navigation, deletion, pr-hygiene, anti-stomp]
+    profiles: [standard, deep]
+
+  # ─── Import audit ─────────────────────────────────────────────────────────
+
+  - id: IMPORT-001
+    title: Component usage collapse
+    category: import-audit
+    severity: medium
+    check_type: deterministic
+    description: >
+      For each .tsx/.ts component file changed in the PR, compare the count of
+      files that reference the component name at base vs head. If the count goes
+      from N>0 to 0 and the file is not mentioned in the PR body as intentionally
+      retired, flag it.
+    expected:
+      verify:
+        type: shell
+        command: "git diff --name-only {base}..{head}"
+      component_dirs:
+        - src/components/
+        - src/pages/
+    on_fail: >
+      Confirm intentional retirement in PR body, or restore imports.
+    tags: [imports, orphan, anti-stomp]
+    profiles: [standard, deep]
+
+  # ─── PR hygiene ───────────────────────────────────────────────────────────
+
+  - id: AUDIT-001
+    title: Restore/reorg PRs must include archaeology
+    category: pr-hygiene
+    severity: high
+    check_type: deterministic
+    description: >
+      When the PR title contains "restore", "reorg", "refactor", "fix nav", or
+      "sidebar", check the PR body for a section titled "Archaeology" or
+      "Pre-restore audit". Fail if the section is missing.
+    expected:
+      verify:
+        type: pr_body
+      trigger_keywords:
+        - restore
+        - reorg
+        - refactor
+        - fix nav
+        - sidebar
+      required_sections:
+        - Archaeology
+        - "Pre-restore audit"
+    on_fail: >
+      Add an 'Archaeology' section to the PR body with output from:
+      `git log --all --diff-filter=D --name-only --pretty=format: -- '<target>/*' | sort -u`
+      and a short disposition per item (restore/archive/ignore).
+    tags: [pr-hygiene, archaeology, anti-stomp]
+    profiles: [smoke, standard, deep]

--- a/packages/testpass/src/__tests__/anti-stomp.test.ts
+++ b/packages/testpass/src/__tests__/anti-stomp.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Integration tests for the Anti-Stomp pack.
+ *
+ * Tests run check handlers directly against real temp git repos, so these
+ * are true integration tests of the check logic (not the DB layer).
+ *
+ * Note: runGitChecks DB-layer tests (updateItem / createEvidence) are
+ * blocked by the same ESM jest.mock hoisting issue affecting
+ * deterministic.test.ts. Address both at the same time when fixing that
+ * pre-existing issue.
+ */
+
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { GIT_HANDLERS, type GitContext } from "../runner/git.js";
+import { loadPackFromFile, loadPackFromYaml } from "../pack-loader.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ANTI_STOMP_PACK_PATH = path.resolve(__dirname, "../../packs/anti-stomp-v0.yaml");
+
+// ─── Git repo fixture helpers ─────────────────────────────────────────────────
+
+interface TempRepo {
+  dir: string;
+  cleanup: () => void;
+}
+
+function createTempRepo(): TempRepo {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "testpass-anti-stomp-"));
+  function git(args: string) {
+    execSync(`git ${args}`, { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
+  }
+  git("init");
+  git("config user.email testpass@example.com");
+  git("config user.name TestPass");
+  try { git("config advice.detachedHead false"); } catch { /* optional */ }
+  return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function writeAndCommit(
+  repoDir: string,
+  files: Record<string, string>,
+  message: string,
+): void {
+  for (const [relPath, content] of Object.entries(files)) {
+    const abs = path.join(repoDir, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, "utf-8");
+  }
+  execSync("git add -A", { cwd: repoDir, stdio: ["pipe", "pipe", "pipe"] });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: ["pipe", "pipe", "pipe"] });
+}
+
+function removeAndCommit(repoDir: string, filePaths: string[], message: string): void {
+  for (const relPath of filePaths) {
+    fs.rmSync(path.join(repoDir, relPath), { force: true });
+  }
+  execSync("git add -A", { cwd: repoDir, stdio: ["pipe", "pipe", "pipe"] });
+  execSync(`git commit -m "${message}"`, { cwd: repoDir, stdio: ["pipe", "pipe", "pipe"] });
+}
+
+// ─── Pack schema ──────────────────────────────────────────────────────────────
+
+describe("anti-stomp-v0.yaml - schema validation", () => {
+  it("loads and validates without errors", () => {
+    const pack = loadPackFromFile(ANTI_STOMP_PACK_PATH);
+    expect(pack.id).toBe("anti-stomp-v0");
+    expect(pack.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(pack.items.length).toBe(8);
+  });
+
+  it("contains all 8 check IDs", () => {
+    const pack = loadPackFromFile(ANTI_STOMP_PACK_PATH);
+    const ids = pack.items.map((i) => i.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "DELETE-001", "DELETE-002",
+        "ORPHAN-001", "ORPHAN-002",
+        "SURFACE-001", "SURFACE-002",
+        "IMPORT-001", "AUDIT-001",
+      ]),
+    );
+  });
+
+  it("all items are check_type deterministic", () => {
+    const pack = loadPackFromFile(ANTI_STOMP_PACK_PATH);
+    for (const item of pack.items) {
+      expect(item.check_type).toBe("deterministic");
+    }
+  });
+
+  it("RED - rejects pack with invalid semver", () => {
+    const bad = `
+id: anti-stomp-v0
+name: Anti-Stomp v0
+version: not-semver
+items:
+  - id: DELETE-001
+    title: Test
+    category: deletion-audit
+    severity: high
+    check_type: deterministic
+`;
+    expect(() => loadPackFromYaml(bad)).toThrow("schema validation failed");
+  });
+
+  it("RED - rejects pack with empty items array", () => {
+    const bad = `id: anti-stomp-v0\nname: Anti-Stomp\nversion: 0.1.0\nitems: []`;
+    expect(() => loadPackFromYaml(bad)).toThrow("schema validation failed");
+  });
+});
+
+// ─── DELETE-001: Files deleted without rationale ──────────────────────────────
+
+describe("DELETE-001 - Files deleted without rationale", () => {
+  let repo: TempRepo;
+
+  beforeEach(() => {
+    repo = createTempRepo();
+    writeAndCommit(
+      repo.dir,
+      {
+        "src/pages/Memory.tsx": "export default function Memory() { return null; }",
+        "src/pages/Tools.tsx": "export default function Tools() { return null; }",
+        "src/components/Widget.tsx": "export default function Widget() { return null; }",
+      },
+      "initial",
+    );
+  });
+
+  afterEach(() => repo.cleanup());
+
+  it("GREEN - passes when deleted file path is in PR body", async () => {
+    removeAndCommit(repo.dir, ["src/pages/Memory.tsx"], "remove Memory page");
+    const ctx: GitContext = {
+      repoPath: repo.dir,
+      base: "HEAD~1",
+      head: "HEAD",
+      prTitle: "Remove deprecated Memory page",
+      prBody: "## Deletions\n- src/pages/Memory.tsx: deprecated in sprint 14",
+    };
+    const result = await GIT_HANDLERS["DELETE-001"]!(ctx);
+    expect(result.verdict).toBe("check");
+  });
+
+  it("GREEN - passes when deleted file basename is in PR body", async () => {
+    removeAndCommit(repo.dir, ["src/pages/Memory.tsx"], "remove Memory page");
+    const ctx: GitContext = {
+      repoPath: repo.dir,
+      base: "HEAD~1",
+      head: "HEAD",
+      prTitle: "Remove deprecated Memory page",
+      prBody: "Removed Memory.tsx because the feature was retired.",
+    };
+    const result = await GIT_HANDLERS["DELETE-001"]!(ctx);
+    expect(result.verdict).toBe("check");
+  });
+
+  it("RED - fails when deleted file is not mentioned in PR body", async () => {
+    removeAndCommit(repo.dir, ["src/pages/Memory.tsx"], "silent stomp");
+    const ctx: GitContext = {
+      repoPath: repo.dir,
+      base: "HEAD~1",
+      head: "HEAD",
+      prTitle: "Refactor dashboard",
+      prBody: "Various improvements to dashboard layout and performance.",
+    };
+    const result = await GIT_HANDLERS["DELETE-001"]!(ctx);
+    expect(result.verdict).toBe("fail");
+    expect(result.note).toContain("Memory.tsx");
+  });
+
+  it("RED - fails when multiple files deleted and none mentioned", async () => {
+    removeAndCommit(
+      repo.dir,
+      ["src/pages/Memory.tsx", "src/components/Widget.tsx"],
+      "stomp two files",
+    );
+    const ctx: GitContext = {
+      repoPath: repo.dir,
+      base: "HEAD~1",
+      head: "HEAD",
+      prTitle: "Cleanup",
+      prBody: "Minor cleanup.",
+    };
+    const result = await GIT_HANDLERS["DELETE-001"]!(ctx);
+    expect(result.verdict).toBe("fail");
+  });
+
+  it("NA - when no relevant files are deleted", async () => {
+    writeAndCommit(repo.dir, { "docs/README.md": "# Docs" }, "add readme");
+    removeAndCommit(repo.dir, ["docs/README.md"], "remove readme");
+    const ctx: GitContext = {
+      repoPath: repo.dir,
+      base: "HEAD~1",
+      head: "HEAD",
+      prTitle: "Remove readme",
+      prBody: "Remove readme.",
+    };
+    const result = await GIT_HANDLERS["DELETE-001"]!(ctx);
+    expect(result.verdict).toBe("na");
+  });
+
+  it("includes a shell trace in evidence", async () => {
+    removeAndCommit(repo.dir, ["src/pages/Memory.tsx"], "stomp");
+    const ctx: GitContext = {
+      repoPath: repo.dir,
+      base: "HEAD~1",
+      head: "HEAD",
+      prTitle: "Refactor",
+      prBody: "Some changes.",
+    };
+    const result = await GIT_HANDLERS["DELETE-001"]!(ctx);
+    expect(result.traces.length).toBeGreaterThan(0);
+    expect(result.traces[0].command).toContain("diff");
+    expect(result.traces[0].output).toContain("Memory.tsx");
+  });
+
+  it("monitors packages/*/src/ paths", async () => {
+    writeAndCommit(
+      repo.dir,
+      { "packages/mcp-server/src/tool-wiring.ts": "export const x = 1;" },
+      "add package file",
+    );
+    removeAndCommit(repo.dir, ["packages/mcp-server/src/tool-wiring.ts"], "stomp package file");
+    const ctx: GitContext = {
+      repoPath: repo.dir,
+      base: "HEAD~1",
+      head: "HEAD",
+      prTitle: "Refactor",
+      prBody: "Nothing relevant.",
+    };
+    const result = await GIT_HANDLERS["DELETE-001"]!(ctx);
+    expect(result.verdict).toBe("fail");
+    expect(result.note).toContain("tool-wiring.ts");
+  });
+});
+
+// ─── AUDIT-001: Restore/reorg PRs must include archaeology ───────────────────
+
+describe("AUDIT-001 - Restore/reorg PRs must include archaeology", () => {
+  // AUDIT-001 only inspects prTitle + prBody - no git repo needed.
+  const fakeCtx = (prTitle: string, prBody: string): GitContext => ({
+    repoPath: os.tmpdir(),
+    base: "main",
+    head: "HEAD",
+    prTitle,
+    prBody,
+  });
+
+  it("GREEN - passes when title has 'restore' and body has Archaeology section", async () => {
+    const ctx = fakeCtx(
+      "restore Memory sub-nav",
+      [
+        "## Summary",
+        "Restores the 5-tab Memory sub-nav.",
+        "",
+        "## Archaeology",
+        "```",
+        "git log --all --diff-filter=D --name-only --pretty=format: -- 'src/pages/admin/memory/*' | sort -u",
+        "src/pages/admin/memory/MemoryTimeline.tsx  -> restore",
+        "src/pages/admin/memory/MemoryMap.tsx       -> archive",
+        "```",
+      ].join("\n"),
+    );
+    const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+    expect(result.verdict).toBe("check");
+  });
+
+  it("GREEN - passes with 'Pre-restore audit' section in body", async () => {
+    const ctx = fakeCtx(
+      "fix nav sidebar links",
+      "## Pre-restore audit\nChecked history - sidebar had 9 items before the reorg.",
+    );
+    const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+    expect(result.verdict).toBe("check");
+  });
+
+  it("GREEN - passes (NA) when no trigger keywords in title", async () => {
+    const ctx = fakeCtx("add dark mode toggle", "No archaeology needed for new features.");
+    const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+    expect(result.verdict).toBe("na");
+  });
+
+  it("RED - fails when title has 'restore' but no archaeology section", async () => {
+    const ctx = fakeCtx(
+      "restore Memory sub-nav",
+      "## Summary\nRestores the nav.\n\n## Test plan\n- [ ] Memory loads",
+    );
+    const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+    expect(result.verdict).toBe("fail");
+    expect(result.note).toContain("restore");
+  });
+
+  it("RED - fails when title has 'reorg' and body is empty", async () => {
+    const ctx = fakeCtx("admin reorg pass 2", "");
+    const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+    expect(result.verdict).toBe("fail");
+  });
+
+  it("RED - fails when title has 'sidebar' and body has no archaeology", async () => {
+    const ctx = fakeCtx(
+      "fix sidebar overlap on mobile",
+      "## Summary\nFixed CSS overflow on sidebar.",
+    );
+    const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+    expect(result.verdict).toBe("fail");
+  });
+
+  it("RED - all five trigger keywords independently fire the check", async () => {
+    const TRIGGERS = ["restore", "reorg", "refactor", "fix nav", "sidebar"];
+    for (const kw of TRIGGERS) {
+      const ctx = fakeCtx(`${kw} something`, "No archaeology section here.");
+      const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+      expect(result.verdict).toBe("fail");
+    }
+  });
+
+  it("RED - case-insensitive trigger match", async () => {
+    const ctx = fakeCtx("RESTORE Memory Tabs", "Summary only, no archaeology.");
+    const result = await GIT_HANDLERS["AUDIT-001"]!(ctx);
+    expect(result.verdict).toBe("fail");
+  });
+});
+
+// ─── Profile filtering ────────────────────────────────────────────────────────
+
+describe("profile filtering in pack definition", () => {
+  let pack: ReturnType<typeof loadPackFromFile>;
+
+  beforeAll(() => { pack = loadPackFromFile(ANTI_STOMP_PACK_PATH); });
+
+  it("DELETE-001 is in smoke profile", () => {
+    const item = pack.items.find((i) => i.id === "DELETE-001")!;
+    expect(item.profiles).toContain("smoke");
+  });
+
+  it("AUDIT-001 is in smoke profile", () => {
+    const item = pack.items.find((i) => i.id === "AUDIT-001")!;
+    expect(item.profiles).toContain("smoke");
+  });
+
+  it("ORPHAN-002 is deep-only", () => {
+    const item = pack.items.find((i) => i.id === "ORPHAN-002")!;
+    expect(item.profiles).toContain("deep");
+    expect(item.profiles).not.toContain("smoke");
+  });
+
+  it("SURFACE-001 is deep-only", () => {
+    const item = pack.items.find((i) => i.id === "SURFACE-001")!;
+    expect(item.profiles).toEqual(["deep"]);
+  });
+
+  it("DELETE-002 and IMPORT-001 are standard+deep only", () => {
+    for (const id of ["DELETE-002", "IMPORT-001"]) {
+      const item = pack.items.find((i) => i.id === id)!;
+      expect(item.profiles).not.toContain("smoke");
+      expect(item.profiles).toContain("standard");
+    }
+  });
+});
+
+// ─── GIT_HANDLERS export ──────────────────────────────────────────────────────
+
+describe("GIT_HANDLERS export", () => {
+  it("exports a handler for every check ID in the pack", () => {
+    const pack = loadPackFromFile(ANTI_STOMP_PACK_PATH);
+    for (const item of pack.items) {
+      expect(GIT_HANDLERS[item.id]).toBeDefined();
+    }
+  });
+});

--- a/packages/testpass/src/runner/git.ts
+++ b/packages/testpass/src/runner/git.ts
@@ -1,0 +1,489 @@
+/**
+ * Git-based check runner for the Anti-Stomp pack.
+ *
+ * Executes registered check handlers against a local git repo in a PR context
+ * (base ref, head ref, PR title, PR body). Writes verdicts and evidence to
+ * Supabase via run-manager, mirroring the pattern in deterministic.ts.
+ *
+ * Items without a registered handler are skipped (left as pending).
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Pack, RunProfile } from "../types.js";
+import type { RunManagerConfig } from "../run-manager.js";
+import { updateItem, createEvidence } from "../run-manager.js";
+
+// ─── Public context type ─────────────────────────────────────────────────────
+
+export interface GitContext {
+  repoPath: string; // absolute path to the local git repo
+  base: string;     // base ref (e.g. "main", "HEAD~1", commit SHA)
+  head: string;     // head ref (e.g. "HEAD", branch name, commit SHA)
+  prTitle: string;
+  prBody: string;
+}
+
+// ─── Internal types ──────────────────────────────────────────────────────────
+
+interface ShellTrace {
+  command: string;
+  output: string;
+}
+
+type CheckVerdict = "check" | "fail" | "na" | "other";
+
+interface CheckOutcome {
+  verdict: CheckVerdict;
+  note?: string;
+  traces: ShellTrace[];
+}
+
+type GitCheckHandler = (ctx: GitContext) => Promise<CheckOutcome>;
+
+// ─── git helper ──────────────────────────────────────────────────────────────
+
+function gitExec(repoPath: string, args: string): string {
+  try {
+    return execSync(`git ${args}`, {
+      cwd: repoPath,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Count files that mention `name` in the tree at `ref`.
+ * git grep output with a ref has lines like `ref:filepath`, so we split on ":"
+ * and exclude the file itself.
+ */
+function grepRefCount(repoPath: string, ref: string, name: string, excludeFile = ""): number {
+  try {
+    const out = execSync(`git grep -l "${name}" ${ref}`, {
+      cwd: repoPath,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (!out) return 0;
+    return out
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => (l.includes(":") ? l.split(":").slice(1).join(":") : l))
+      .filter((f) => f !== excludeFile).length;
+  } catch {
+    return 0; // grep exits 1 on no matches
+  }
+}
+
+// ─── Check handlers ──────────────────────────────────────────────────────────
+
+const MONITORED_RE = /^(src\/pages\/|src\/components\/|src\/admin\/|api\/|packages\/[^/]+\/src\/)/;
+
+const HANDLERS: Record<string, GitCheckHandler> = {
+
+  // DELETE-001: Files deleted without rationale
+  "DELETE-001": async (ctx) => {
+    const args = `diff --name-only --diff-filter=D ${ctx.base}..${ctx.head}`;
+    const output = gitExec(ctx.repoPath, args);
+    const deleted = output ? output.split("\n").filter(Boolean) : [];
+    const trace: ShellTrace = { command: `git ${args}`, output: output || "(none)" };
+
+    const relevant = deleted.filter((f) => MONITORED_RE.test(f));
+    if (relevant.length === 0) {
+      return { verdict: "na", note: "No relevant files deleted", traces: [trace] };
+    }
+
+    const unmentioned = relevant.filter((f) => {
+      const basename = path.basename(f);
+      return !ctx.prBody.includes(f) && !ctx.prBody.includes(basename);
+    });
+
+    if (unmentioned.length === 0) {
+      return {
+        verdict: "check",
+        note: `${relevant.length} deletion(s) all documented in PR body`,
+        traces: [trace],
+      };
+    }
+
+    return {
+      verdict: "fail",
+      note: `Undocumented deletion(s): ${unmentioned.join(", ")}`,
+      traces: [trace],
+    };
+  },
+
+  // DELETE-002: Routes removed from router without rationale
+  "DELETE-002": async (ctx) => {
+    const routerCandidates = ["src/App.tsx", "src/routes.tsx", "src/router.tsx"];
+    let routerFile = "";
+    for (const f of routerCandidates) {
+      if (gitExec(ctx.repoPath, `ls-files ${f}`)) { routerFile = f; break; }
+    }
+    if (!routerFile) return { verdict: "na", note: "No router file found", traces: [] };
+
+    const args = `diff ${ctx.base}..${ctx.head} -- ${routerFile}`;
+    const output = gitExec(ctx.repoPath, args);
+    const trace: ShellTrace = { command: `git ${args}`, output: output || "(no changes)" };
+
+    if (!output) return { verdict: "na", note: `No changes to ${routerFile}`, traces: [trace] };
+
+    const removedRoutes = output
+      .split("\n")
+      .filter((l) => l.startsWith("-") && !l.startsWith("---"))
+      .filter((l) => /<Route|path=["']/.test(l));
+
+    if (removedRoutes.length === 0) {
+      return { verdict: "check", note: "No <Route> elements removed", traces: [trace] };
+    }
+
+    const extractedPaths = removedRoutes
+      .map((l) => l.match(/path=["']([^"']+)["']/)?.[1])
+      .filter(Boolean) as string[];
+
+    const unmentioned = extractedPaths.filter((p) => !ctx.prBody.includes(p));
+    if (unmentioned.length === 0) {
+      return {
+        verdict: "check",
+        note: `${removedRoutes.length} removed route(s) all documented`,
+        traces: [trace],
+      };
+    }
+
+    return {
+      verdict: "fail",
+      note: `Undocumented route removal(s): ${unmentioned.join(", ")}`,
+      traces: [trace],
+    };
+  },
+
+  // ORPHAN-001: Stranded components with no imports
+  "ORPHAN-001": async (ctx) => {
+    const listArgs = `ls-tree -r --name-only ${ctx.head} -- src/components/ src/pages/`;
+    const listOutput = gitExec(ctx.repoPath, listArgs);
+    const files = listOutput
+      ? listOutput.split("\n").filter((f) => /\.(tsx|ts)$/.test(f))
+      : [];
+    const traces: ShellTrace[] = [
+      { command: `git ${listArgs}`, output: listOutput || "(none)" },
+    ];
+
+    const orphaned: string[] = [];
+
+    for (const file of files) {
+      if (/(__tests__|\.test\.|\.spec\.)/.test(file)) continue;
+
+      const content = gitExec(ctx.repoPath, `show ${ctx.head}:${file}`);
+      if (content.includes("// @entrypoint")) continue;
+
+      const name = path.basename(file).replace(/\.(tsx|ts)$/, "");
+      const importers = grepRefCount(ctx.repoPath, ctx.head, name, file);
+      if (importers === 0) orphaned.push(file);
+    }
+
+    if (orphaned.length === 0) {
+      return {
+        verdict: "check",
+        note: `All ${files.length} component(s) have at least one import reference`,
+        traces,
+      };
+    }
+
+    return {
+      verdict: "fail",
+      note: `${orphaned.length} orphaned component(s): ${orphaned.join(", ")}`,
+      traces,
+    };
+  },
+
+  // ORPHAN-002: Abandoned restructure branches
+  "ORPHAN-002": async (ctx) => {
+    const args = "branch -a --sort=-committerdate";
+    const output = gitExec(ctx.repoPath, args);
+    const trace: ShellTrace = { command: `git ${args}`, output: output || "(none)" };
+
+    if (!output) return { verdict: "na", note: "No branches found", traces: [trace] };
+
+    const KEYWORDS = /restructure|refactor|redesign|restore/i;
+    const branches = output
+      .split("\n")
+      .slice(0, 30)
+      .map((b) => b.trim().replace(/^\* /, "").replace(/^remotes\/[^/]+\//, ""))
+      .filter((b) => KEYWORDS.test(b) && b !== ctx.base && b !== ctx.head);
+
+    if (branches.length === 0) {
+      return { verdict: "na", note: "No restructure/refactor/redesign/restore branches found", traces: [trace] };
+    }
+
+    const mergedOutput = gitExec(ctx.repoPath, "branch --merged main");
+    const mergedBranches = mergedOutput.split("\n").map((b) => b.trim().replace(/^\* /, ""));
+
+    const unmerged = branches.filter((b) => !mergedBranches.includes(b));
+    if (unmerged.length === 0) {
+      return { verdict: "check", note: "All restructure branches are merged into main", traces: [trace] };
+    }
+
+    const details = unmerged.map((b) => {
+      const date = gitExec(ctx.repoPath, `log -1 --format="%ar" ${b}`);
+      return `${b} (${date || "unknown date"})`;
+    });
+
+    return {
+      verdict: "fail",
+      note: `Unmerged restructure branch(es): ${details.join("; ")}`,
+      traces: [trace],
+    };
+  },
+
+  // SURFACE-001: Per-surface design memory cross-check
+  "SURFACE-001": async (ctx) => {
+    const memArgs = `ls-tree -r --name-only ${ctx.head} -- .auto-memory/`;
+    const memOutput = gitExec(ctx.repoPath, memArgs);
+    const trace: ShellTrace = { command: `git ${memArgs}`, output: memOutput || "(none)" };
+
+    if (!memOutput) {
+      return { verdict: "na", note: "No .auto-memory/ files found (check skipped)", traces: [trace] };
+    }
+
+    const memFiles = memOutput.split("\n").filter((f) => /project-.*-ui\.md$/.test(f));
+    if (memFiles.length === 0) {
+      return { verdict: "na", note: "No project-*-ui.md memory files found", traces: [trace] };
+    }
+
+    const missing: string[] = [];
+    const traces: ShellTrace[] = [trace];
+
+    for (const memFile of memFiles) {
+      const content = gitExec(ctx.repoPath, `show ${ctx.head}:${memFile}`);
+      if (!content) continue;
+
+      const structureMatch = content.match(/## Current structure\n([\s\S]+?)(?=\n##|$)/);
+      if (!structureMatch) continue;
+
+      const items =
+        structureMatch[1]
+          .match(/^[-*]\s+(.+)$/gm)
+          ?.map((l) => l.replace(/^[-*]\s+/, "").trim()) ?? [];
+
+      for (const item of items) {
+        const found = grepRefCount(ctx.repoPath, ctx.head, item);
+        if (found === 0) missing.push(`${item} (from ${memFile})`);
+      }
+    }
+
+    if (missing.length === 0) {
+      return { verdict: "check", note: "All memory-listed items found in code", traces };
+    }
+
+    return {
+      verdict: "fail",
+      note: `Memory items missing from code: ${missing.join("; ")}`,
+      traces,
+    };
+  },
+
+  // SURFACE-002: Navigation tree diff
+  "SURFACE-002": async (ctx) => {
+    const navCandidates = [
+      "src/pages/admin/AdminShell.tsx",
+      "src/components/Sidebar.tsx",
+      "src/components/Nav.tsx",
+    ];
+    let navFile = "";
+    for (const f of navCandidates) {
+      if (gitExec(ctx.repoPath, `ls-files ${f}`)) { navFile = f; break; }
+    }
+
+    if (!navFile) {
+      const grepOut = gitExec(
+        ctx.repoPath,
+        `grep -rl "NavLink\\|SidebarNav\\|sidebar-item" -- *.tsx`,
+      );
+      if (grepOut) navFile = grepOut.split("\n")[0];
+    }
+
+    if (!navFile) return { verdict: "na", note: "No nav config file found", traces: [] };
+
+    const args = `diff ${ctx.base}..${ctx.head} -- ${navFile}`;
+    const output = gitExec(ctx.repoPath, args);
+    const trace: ShellTrace = { command: `git ${args}`, output: output || "(no changes)" };
+
+    if (!output) return { verdict: "na", note: `No changes to ${navFile}`, traces: [trace] };
+
+    const removedLines = output
+      .split("\n")
+      .filter((l) => l.startsWith("-") && !l.startsWith("---"))
+      .filter((l) => /NavLink|href=|to=|sidebar-item/.test(l));
+
+    if (removedLines.length === 0) {
+      return { verdict: "check", note: "No nav items removed", traces: [trace] };
+    }
+
+    const unmentioned = removedLines.filter((l) => {
+      const labelMatch = l.match(/["']([^"']{3,})["']/);
+      if (labelMatch) return !ctx.prBody.includes(labelMatch[1]);
+      return !ctx.prBody.toLowerCase().includes("nav");
+    });
+
+    if (unmentioned.length === 0) {
+      return {
+        verdict: "check",
+        note: `${removedLines.length} nav item removal(s) documented`,
+        traces: [trace],
+      };
+    }
+
+    return {
+      verdict: "fail",
+      note: `${unmentioned.length} undocumented nav removal(s): ${unmentioned
+        .slice(0, 3)
+        .map((l) => l.trim())
+        .join("; ")}`,
+      traces: [trace],
+    };
+  },
+
+  // IMPORT-001: Component usage collapse
+  "IMPORT-001": async (ctx) => {
+    const diffArgs = `diff --name-only ${ctx.base}..${ctx.head}`;
+    const changedOutput = gitExec(ctx.repoPath, diffArgs);
+    const changedFiles = changedOutput
+      ? changedOutput
+          .split("\n")
+          .filter((f) => /^src\/(components|pages)\/.*\.(tsx|ts)$/.test(f))
+      : [];
+    const trace: ShellTrace = { command: `git ${diffArgs}`, output: changedOutput || "(none)" };
+
+    if (changedFiles.length === 0) {
+      return { verdict: "na", note: "No component files changed", traces: [trace] };
+    }
+
+    const retired: Array<{ file: string; baseCount: number }> = [];
+
+    for (const file of changedFiles) {
+      const name = path.basename(file).replace(/\.(tsx|ts)$/, "");
+      const baseCount = grepRefCount(ctx.repoPath, ctx.base, name, file);
+      const headCount = grepRefCount(ctx.repoPath, ctx.head, name, file);
+      if (baseCount > 0 && headCount === 0) {
+        retired.push({ file, baseCount });
+      }
+    }
+
+    if (retired.length === 0) {
+      return { verdict: "check", note: "No component usage collapse detected", traces: [trace] };
+    }
+
+    const unmentioned = retired.filter(({ file }) => {
+      const basename = path.basename(file);
+      return !ctx.prBody.includes(file) && !ctx.prBody.includes(basename);
+    });
+
+    if (unmentioned.length === 0) {
+      return {
+        verdict: "check",
+        note: `${retired.length} component retirement(s) all documented`,
+        traces: [trace],
+      };
+    }
+
+    return {
+      verdict: "fail",
+      note: `Undocumented component retirement(s): ${unmentioned
+        .map((r) => `${r.file} (${r.baseCount} -> 0 imports)`)
+        .join(", ")}`,
+      traces: [trace],
+    };
+  },
+
+  // AUDIT-001: Restore/reorg PRs must include archaeology
+  "AUDIT-001": async (ctx) => {
+    const TRIGGERS = ["restore", "reorg", "refactor", "fix nav", "sidebar"];
+    const lowerTitle = ctx.prTitle.toLowerCase();
+    const matched = TRIGGERS.find((kw) => lowerTitle.includes(kw));
+
+    if (!matched) {
+      return { verdict: "na", note: "PR title does not trigger AUDIT-001", traces: [] };
+    }
+
+    const REQUIRED_SECTIONS = ["Archaeology", "Pre-restore audit"];
+    const hasSection = REQUIRED_SECTIONS.some((s) => ctx.prBody.includes(s));
+
+    if (hasSection) {
+      return { verdict: "check", note: "Archaeology section present in PR body", traces: [] };
+    }
+
+    return {
+      verdict: "fail",
+      note: `PR title matched "${matched}" but no 'Archaeology' or 'Pre-restore audit' section found in PR body`,
+      traces: [],
+    };
+  },
+};
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Run all registered git check handlers against the given repo + PR context.
+ * Items with no registered handler are skipped (left as pending).
+ * Checks run in parallel; each writes its own evidence + verdict row.
+ */
+export async function runGitChecks(
+  config: RunManagerConfig,
+  runId: string,
+  ctx: GitContext,
+  pack: Pack,
+  profile: RunProfile,
+): Promise<void> {
+  const items = pack.items.filter(
+    (i) => !i.profiles || i.profiles.includes(profile),
+  );
+
+  await Promise.all(
+    items.map(async (item) => {
+      const handler = HANDLERS[item.id];
+      if (!handler) return;
+
+      const checkStart = Date.now();
+      let outcome: CheckOutcome;
+      try {
+        outcome = await handler(ctx);
+      } catch (err) {
+        outcome = {
+          verdict: "other",
+          note: `Runner exception: ${(err as Error).message}`,
+          traces: [],
+        };
+      }
+      const time_ms = Date.now() - checkStart;
+
+      let evidenceRef: string | undefined;
+      if (outcome.traces.length > 0) {
+        try {
+          evidenceRef = await createEvidence(config, {
+            kind: "log",
+            payload: outcome.traces,
+          });
+        } catch {
+          // evidence write failure is non-fatal
+        }
+      }
+
+      await updateItem(config, runId, item.id, {
+        verdict: outcome.verdict,
+        on_fail_comment: outcome.note,
+        time_ms,
+        cost_usd: 0,
+        evidence_ref: evidenceRef,
+      });
+    }),
+  );
+}
+
+/**
+ * Export the handler map for direct use in tests.
+ */
+export { HANDLERS as GIT_HANDLERS };


### PR DESCRIPTION
## Summary

- Adds `packs/anti-stomp-v0.yaml` - 8-check QC pack that detects when one agent silently undoes another agent's work
- Adds `packages/testpass/src/runner/git.ts` - new git-based runner with handlers for all 8 checks
- Adds `packages/testpass/src/__tests__/anti-stomp.test.ts` - 26 integration tests (green + red paths)

No changes to existing TestPass Core files, pack schema, or MCP tools.

---

## Pack preview

| ID | Title | Severity | Profile |
|----|-------|----------|---------|
| DELETE-001 | Files deleted without rationale | high | smoke/standard/deep |
| DELETE-002 | Routes removed from router without rationale | high | standard/deep |
| ORPHAN-001 | Stranded components with no imports | medium | standard/deep |
| ORPHAN-002 | Abandoned restructure branches | medium | deep |
| SURFACE-001 | Per-surface design memory cross-check | low | deep |
| SURFACE-002 | Navigation tree diff | medium | standard/deep |
| IMPORT-001 | Component usage collapse | medium | standard/deep |
| AUDIT-001 | Restore/reorg PRs must include archaeology | high | smoke/standard/deep |

---

## Example evidence output — DELETE-001 on a staged stomp scenario

```
Scenario: agent B refactors dashboard, silently deletes src/pages/Memory.tsx
PR body: "Various improvements to dashboard layout and performance."

git diff --name-only --diff-filter=D HEAD~1..HEAD
→ src/pages/Memory.tsx

Monitored paths match: YES (src/pages/)
Mentioned in PR body: NO (neither path nor basename found)

verdict: fail
note:    "Undocumented deletion(s): src/pages/Memory.tsx"
trace:   { command: "git diff --name-only --diff-filter=D HEAD~1..HEAD", output: "src/pages/Memory.tsx" }
fix:     Add a 'Deletions' section to the PR body listing each deleted file with a one-line rationale.
```

---

## Archaeology

This pack was prompted by the Memory tabs incident: 5 tabs collapsed to 3 in one refactor, a 7-tab redesign was stranded on an unmerged branch, and a "restore Memory sub-nav" PR rebuilt only the 3-tab version without checking git history. Three rules from the UI design log (`.auto-memory/feedback-ui-design-log.md`) form the conceptual basis: per-surface memory files, mandatory pre-restore git archaeology, and an abandoned branch log.

---

## Pack-loader changes

None. The pack uses only existing schema fields (`check_type: deterministic`, `description`, `expected`, `on_fail`, `tags`, `profiles`). The `expected` field carries structured verify config for the runner since it is `z.unknown()`.

The git runner (`runner/git.ts`) is a new file, parallel to `runner/deterministic.ts`, with the same `updateItem`/`createEvidence` DB interface. No modifications to existing runner files.

---

## Test notes

The `jest.mock()` hoisting issue in ESM mode affects the pre-existing `deterministic.test.ts` too (same `jest is not defined` error). Anti-stomp tests avoid this by testing `GIT_HANDLERS` directly against real temp git repos - these are genuine integration tests of the check logic. The DB-layer pipeline tests (verifying `updateItem` call counts) can be added when the shared ESM mock issue is fixed.

---

## Acceptance criteria

- [ ] `node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --testPathPattern=anti-stomp` from `packages/testpass/` runs 26 tests, all green
- [ ] `loadPackFromFile("packs/anti-stomp-v0.yaml")` succeeds and returns 8 items
- [ ] Running the pack via `unclick_call` with `endpoint_id: "testpass.run"` and `pack_slug: "anti-stomp-v0"` against a repo with a staged stomp returns `verdict: fail` for DELETE-001
- [ ] Running the same pack against a PR that mentions all deletions returns `verdict: check` for DELETE-001
- [ ] AUDIT-001 fires on any PR with "restore", "reorg", "refactor", "fix nav", or "sidebar" in the title