### PR TITLE
feat(crews): Phase C execution engine for Council template

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -93,6 +93,7 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { runCouncilEngine } from "../src/lib/crews/engine";
 import { streamText, tool, stepCountIs, convertToModelMessages, type UIMessage, type ModelMessage } from "ai";
 import { google } from "@ai-sdk/google";
 import { z } from "zod";
@@ -4941,6 +4942,99 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (deleteErr) throw deleteErr;
         if (!count) return res.status(404).json({ error: "Crew not found or not owned by you" });
         return res.status(200).json({ success: true });
+      }
+
+      // ─── Phase C: Crew run actions ─────────────────────────────────────────
+
+      case "start_crew_run": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        if (!process.env.ANTHROPIC_API_KEY) {
+          return res.status(500).json({ error: "ANTHROPIC_API_KEY not configured in Vercel env." });
+        }
+        const { crew_id, task_prompt, token_budget } = (req.body ?? {}) as {
+          crew_id?: string;
+          task_prompt?: string;
+          token_budget?: number;
+        };
+        if (!crew_id || !task_prompt?.trim()) {
+          return res.status(400).json({ error: "crew_id and task_prompt required" });
+        }
+        const { data: runRow, error: runErr } = await supabase
+          .from("mc_crew_runs")
+          .insert({
+            api_key_hash: apiKeyHash,
+            crew_id,
+            task_prompt: task_prompt.trim(),
+            token_budget: token_budget ?? 150000,
+            status: "pending",
+          })
+          .select()
+          .single();
+        if (runErr) throw runErr;
+        // Respond immediately - engine runs after response, Vercel keeps function alive
+        res.status(202).json({ run_id: runRow.id });
+        await runCouncilEngine({
+          runId: runRow.id,
+          crewId: crew_id,
+          apiKeyHash,
+          taskPrompt: task_prompt.trim(),
+          tokenBudget: token_budget ?? 150000,
+          supabaseUrl,
+          serviceRoleKey: supabaseKey,
+        }).catch((e: Error) => console.error("Council engine error:", e.message));
+        return;
+      }
+
+      case "get_run": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const runId = String(
+          req.query.run_id ?? (req.body as { run_id?: string })?.run_id ?? ""
+        ).trim();
+        if (!runId) return res.status(400).json({ error: "run_id required" });
+        const [runRes, msgsRes] = await Promise.all([
+          supabase
+            .from("mc_crew_runs")
+            .select("*")
+            .eq("id", runId)
+            .eq("api_key_hash", apiKeyHash)
+            .maybeSingle(),
+          supabase
+            .from("mc_run_messages")
+            .select("*")
+            .eq("run_id", runId)
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at"),
+        ]);
+        if (runRes.error) throw runRes.error;
+        if (!runRes.data) return res.status(404).json({ error: "Run not found" });
+        return res.status(200).json({ run: runRes.data, messages: msgsRes.data ?? [] });
+      }
+
+      case "list_runs": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const crewId =
+          String(req.query.crew_id ?? (req.body as { crew_id?: string })?.crew_id ?? "").trim() ||
+          null;
+        const limit = Math.min(
+          Number(req.query.limit ?? (req.body as { limit?: number })?.limit ?? 50),
+          100
+        );
+        let q = supabase
+          .from("mc_crew_runs")
+          .select(
+            "id,crew_id,task_prompt,status,tokens_used,result_artifact,started_at,completed_at,created_at"
+          )
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+        if (crewId) q = q.eq("crew_id", crewId);
+        const { data, error } = await q;
+        if (error) throw error;
+        return res.status(200).json({ data: data ?? [] });
       }
 
       default:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import CrewsCatalog from "./pages/admin/crews/CrewsCatalog.tsx";
 import CrewComposer from "./pages/admin/crews/CrewComposer.tsx";
 import CrewsRuns from "./pages/admin/crews/CrewsRuns.tsx";
 import CrewsSettings from "./pages/admin/crews/CrewsSettings.tsx";
+import CrewRun from "./pages/admin/crews/CrewRun.tsx";
 import BuildDeskPage from "./pages/BuildDesk.tsx";
 import { initPostHog } from "./lib/posthog.ts";
 
@@ -129,8 +130,9 @@ const App = () => (
             <Route path="crews"          element={<CrewsCatalog />} />
             <Route path="crews/new"      element={<CrewComposer />} />
             <Route path="crews/:id/edit" element={<CrewComposer />} />
-            <Route path="crews/runs"     element={<CrewsRuns />} />
-            <Route path="crews/settings" element={<CrewsSettings />} />
+            <Route path="crews/runs"          element={<CrewsRuns />} />
+            <Route path="crews/runs/:runId"  element={<CrewRun />} />
+            <Route path="crews/settings"      element={<CrewsSettings />} />
           </Route>
           {/* Phase 2 auth surface */}
           <Route path="/login" element={<LoginPage />} />

--- a/src/lib/crews/engine.ts
+++ b/src/lib/crews/engine.ts
@@ -1,0 +1,203 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { createClient } from "@supabase/supabase-js";
+
+const MODEL = "claude-sonnet-4-6";
+const MAX_PER_CALL = 2048;
+const LABELS = "ABCDEFGHIJKLMNOP".split("");
+
+export interface EngineCtx {
+  runId: string;
+  crewId: string;
+  apiKeyHash: string;
+  taskPrompt: string;
+  tokenBudget: number;
+  supabaseUrl: string;
+  serviceRoleKey: string;
+}
+
+interface AgentRow {
+  id: string;
+  slug: string;
+  name: string;
+  category: string;
+  seed_prompt: string | null;
+}
+
+interface StageResult {
+  agentId: string;
+  label: string;
+  name: string;
+  content: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
+  const { runId, crewId, apiKeyHash, taskPrompt, tokenBudget } = ctx;
+  const sb = createClient(ctx.supabaseUrl, ctx.serviceRoleKey);
+  const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  let tokensUsed = 0;
+
+  async function updateRun(patch: Record<string, unknown>) {
+    await sb
+      .from("mc_crew_runs")
+      .update(patch)
+      .eq("id", runId)
+      .eq("api_key_hash", apiKeyHash);
+  }
+
+  async function writeMsg(
+    agentId: string | null,
+    role: string,
+    stage: string,
+    content: string,
+    tokensIn: number,
+    tokensOut: number,
+  ) {
+    tokensUsed += tokensIn + tokensOut;
+    await sb.from("mc_run_messages").insert({
+      api_key_hash: apiKeyHash,
+      run_id: runId,
+      agent_id: agentId,
+      role,
+      stage,
+      content,
+      tokens_in: tokensIn,
+      tokens_out: tokensOut,
+    });
+  }
+
+  async function callClaude(system: string, user: string) {
+    if (tokensUsed >= tokenBudget) {
+      throw Object.assign(new Error("token_budget_exceeded"), { isBudget: true });
+    }
+    const msg = await anthropic.messages.create({
+      model: MODEL,
+      max_tokens: MAX_PER_CALL,
+      system,
+      messages: [{ role: "user", content: user }],
+    });
+    const content = msg.content
+      .filter((b) => b.type === "text")
+      .map((b) => (b as Anthropic.TextBlock).text)
+      .join("");
+    return { content, tokensIn: msg.usage.input_tokens, tokensOut: msg.usage.output_tokens };
+  }
+
+  try {
+    await updateRun({ status: "running", started_at: new Date().toISOString() });
+
+    // Load crew (api_key_hash filter is mandatory - service_role bypasses RLS)
+    const { data: crew } = await sb
+      .from("mc_crews")
+      .select("agent_ids")
+      .eq("id", crewId)
+      .eq("api_key_hash", apiKeyHash)
+      .single();
+    if (!crew) throw new Error("Crew not found");
+
+    const agentIds: string[] = (crew as { agent_ids: string[] }).agent_ids ?? [];
+    const { data: rawAgents } = await sb
+      .from("mc_agents")
+      .select("id,slug,name,category,seed_prompt")
+      .in("id", agentIds);
+    const agents: AgentRow[] = (rawAgents ?? []) as AgentRow[];
+
+    const advisors = agents.filter((a) => a.category !== "meta");
+    let chairman: AgentRow | null = agents.find((a) => a.slug === "chairman") ?? null;
+
+    // Auto-add system chairman if not in crew
+    if (!chairman) {
+      const { data: sys } = await sb
+        .from("mc_agents")
+        .select("id,slug,name,category,seed_prompt")
+        .eq("slug", "chairman")
+        .eq("is_system", true)
+        .maybeSingle();
+      chairman = (sys as AgentRow | null) ?? null;
+    }
+
+    // Pre-run: load relevant facts from UnClick Memory (search_memory equivalent)
+    const { data: factRows } = await sb
+      .from("mc_extracted_facts")
+      .select("fact")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("status", "active")
+      .order("created_at", { ascending: false })
+      .limit(100);
+
+    const words = taskPrompt.toLowerCase().split(/\W+/).filter((w) => w.length > 4);
+    const matched = ((factRows ?? []) as { fact: string }[])
+      .filter((f) => words.some((w) => f.fact.toLowerCase().includes(w)))
+      .slice(0, 5);
+
+    const memCtx = matched.length > 0
+      ? `Relevant context from your memory:\n${matched.map((f) => `- ${f.fact}`).join("\n")}\n\n`
+      : "";
+
+    // Stage 1: Fan-out - each advisor gives their opinion in parallel
+    const stage1: StageResult[] = await Promise.all(
+      advisors.map(async (agent, i) => {
+        const system = `${agent.seed_prompt ?? `You are ${agent.name}.`}\n\nProvide your honest, specific opinion on the task. 150 to 250 words. Be direct and substantive.`;
+        const user = `${memCtx}Task: ${taskPrompt}`;
+        const { content, tokensIn, tokensOut } = await callClaude(system, user);
+        return {
+          agentId: agent.id,
+          label: `Opinion ${LABELS[i] ?? String(i + 1)}`,
+          name: agent.name,
+          content,
+          tokensIn,
+          tokensOut,
+        };
+      })
+    );
+
+    for (const r of stage1) {
+      await writeMsg(r.agentId, "advisor", "opinion", r.content, r.tokensIn, r.tokensOut);
+    }
+    await updateRun({ tokens_used: tokensUsed });
+
+    // Stage 2: Peer review - each advisor ranks the others' opinions in parallel
+    await Promise.all(
+      stage1.map(async (reviewer) => {
+        const others = stage1.filter((o) => o.agentId !== reviewer.agentId);
+        const othersText = others.map((o) => `${o.label}:\n${o.content}`).join("\n\n---\n\n");
+        const agent = advisors.find((a) => a.id === reviewer.agentId)!;
+        const system = `${agent.seed_prompt ?? `You are ${agent.name}.`}\n\nRank each opinion below from 1 (most compelling) to ${others.length} (least). One-line rationale per ranking. Be honest and concise.`;
+        const user = `Task: ${taskPrompt}\n\nOpinions to rank:\n\n${othersText}`;
+        const { content, tokensIn, tokensOut } = await callClaude(system, user);
+        await writeMsg(reviewer.agentId, "advisor", "peer_review", content, tokensIn, tokensOut);
+      })
+    );
+    await updateRun({ tokens_used: tokensUsed });
+
+    // Stage 3: Chairman synthesises all opinions into a final answer
+    if (chairman) {
+      const opinionsText = stage1
+        .map((o) => `${o.label} (${o.name}):\n${o.content}`)
+        .join("\n\n---\n\n");
+      const system = `You are the Chairman. Synthesise all advisor opinions into one clear, final answer.\n\nFormat your response exactly as:\n\nFINAL ANSWER:\n[Your conclusion, 200 to 350 words]\n\nWHAT DIDN'T MAKE THE CONSENSUS:\n[Minority views not incorporated, 1 to 3 bullet points starting with -. If full consensus, write: No significant dissents.]`;
+      const user = `Task: ${taskPrompt}\n\nAdvisor opinions:\n\n${opinionsText}`;
+      const { content, tokensIn, tokensOut } = await callClaude(system, user);
+      await writeMsg(chairman.id, "chairman", "synthesis", content, tokensIn, tokensOut);
+    }
+
+    await updateRun({
+      status: "complete",
+      completed_at: new Date().toISOString(),
+      tokens_used: tokensUsed,
+    });
+  } catch (err: unknown) {
+    const isBudget = (err as { isBudget?: boolean }).isBudget === true;
+    await updateRun({
+      status: "failed",
+      completed_at: new Date().toISOString(),
+      tokens_used: tokensUsed,
+      result_artifact: {
+        error: isBudget
+          ? "token_budget_exceeded"
+          : ((err as Error).message ?? "Engine error"),
+      },
+    }).catch(() => null);
+  }
+}

--- a/src/pages/admin/crews/CrewComposer.tsx
+++ b/src/pages/admin/crews/CrewComposer.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate, useParams } from "react-router-dom";
 import CrewsNav from "@/components/crews/CrewsNav";
 import AgentPickerTile from "@/components/crews/AgentPickerTile";
 import { AGENT_CATEGORIES } from "@/data/mockAgents";
 import { CREW_TEMPLATES } from "@/data/mockCrewTemplates";
 import type { Agent } from "@/types/crews";
 import { useSession } from "@/lib/auth";
-import { Search, Save, Users } from "lucide-react";
+import { Search, Save, Users, Play } from "lucide-react";
 
 const MAX_HATS = 9;
 const MIN_HATS = 3;
@@ -14,6 +14,7 @@ const MIN_HATS = 3;
 export default function CrewComposer() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { id: editCrewId } = useParams<{ id?: string }>();
   const { session } = useSession();
   const initialTemplate = searchParams.get("template") ?? CREW_TEMPLATES[0].slug;
 
@@ -22,9 +23,12 @@ export default function CrewComposer() {
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [query, setQuery] = useState("");
   const [crewName, setCrewName] = useState("");
+  const [taskPrompt, setTaskPrompt] = useState("");
   const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [savedCrewId, setSavedCrewId] = useState<string | null>(editCrewId ?? null);
   const [cloning, setCloning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -91,8 +95,8 @@ export default function CrewComposer() {
     }
   }
 
-  async function handleSave() {
-    if (!authHeader || selected.length < MIN_HATS || !crewName.trim()) return;
+  async function saveCrew(): Promise<string | null> {
+    if (!authHeader || selected.length < MIN_HATS || !crewName.trim()) return null;
     setSaving(true);
     setError(null);
     try {
@@ -105,16 +109,52 @@ export default function CrewComposer() {
           agent_ids: selected.map((a) => a.id),
         }),
       });
-      const body = await res.json() as { data?: { id: string }; error?: string };
+      const body = (await res.json()) as { data?: { id: string }; error?: string };
       if (body.data?.id) {
-        navigate(`/admin/crews/${body.data.id}`);
-      } else {
-        setError(body.error ?? "Save failed.");
+        setSavedCrewId(body.data.id);
+        return body.data.id;
       }
+      setError(body.error ?? "Save failed.");
+      return null;
     } catch {
       setError("Save failed.");
+      return null;
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleSave() {
+    const id = await saveCrew();
+    if (id) navigate(`/admin/crews/${id}`);
+  }
+
+  async function handleRun() {
+    if (!authHeader) return;
+    if (!taskPrompt.trim()) {
+      setError("Enter a task prompt before running.");
+      return;
+    }
+    const crewId = savedCrewId ?? editCrewId ?? (await saveCrew());
+    if (!crewId) return;
+    setRunning(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=start_crew_run", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ crew_id: crewId, task_prompt: taskPrompt.trim() }),
+      });
+      const body = (await res.json()) as { run_id?: string; error?: string };
+      if (body.run_id) {
+        navigate(`/admin/crews/runs/${body.run_id}`);
+      } else {
+        setError(body.error ?? "Failed to start run.");
+      }
+    } catch {
+      setError("Failed to start run.");
+    } finally {
+      setRunning(false);
     }
   }
 
@@ -262,18 +302,37 @@ export default function CrewComposer() {
             </div>
           )}
 
-          <div className="mt-4 border-t border-white/[0.06] pt-4">
+          <div className="mt-4 border-t border-white/[0.06] pt-4 space-y-3">
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-[#aaa]">Task prompt</span>
+              <textarea
+                value={taskPrompt}
+                onChange={(e) => setTaskPrompt(e.target.value)}
+                placeholder="What do you want the crew to decide or analyse?"
+                rows={3}
+                className="w-full resize-none rounded-lg border border-white/[0.07] bg-white/[0.03] px-3 py-2 text-xs text-[#eee] placeholder-[#444] focus:border-[#61C1C4]/40 focus:outline-none"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => void handleRun()}
+              disabled={!canSave || running || saving}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-[#61C1C4] py-2.5 text-sm font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Play className="h-4 w-4" />
+              {running ? "Starting..." : "Run this crew"}
+            </button>
             <button
               type="button"
               onClick={() => void handleSave()}
-              disabled={!canSave || saving}
-              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-[#61C1C4] py-2.5 text-sm font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!canSave || saving || running}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/[0.07] bg-white/[0.03] py-2 text-sm font-semibold text-[#ccc] transition-colors hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-40"
             >
               <Save className="h-4 w-4" />
               {saving ? "Saving..." : "Save crew"}
             </button>
             {!canSave && selected.length > 0 && (
-              <p className="mt-1.5 text-center text-[10px] text-[#555]">
+              <p className="text-center text-[10px] text-[#555]">
                 {!crewName.trim()
                   ? "Enter a crew name to save."
                   : selected.length < MIN_HATS

--- a/src/pages/admin/crews/CrewRun.tsx
+++ b/src/pages/admin/crews/CrewRun.tsx
@@ -1,0 +1,243 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useSession } from "@/lib/auth";
+import CrewsNav from "@/components/crews/CrewsNav";
+import { Copy, Check, ChevronLeft, Loader2 } from "lucide-react";
+
+type RunStatus = "pending" | "running" | "complete" | "failed";
+
+interface RunRow {
+  id: string;
+  crew_id: string;
+  task_prompt: string;
+  status: RunStatus;
+  tokens_used: number | null;
+  result_artifact: { error?: string } | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+}
+
+interface RunMessage {
+  id: string;
+  agent_id: string | null;
+  role: string;
+  stage: string;
+  content: string;
+  tokens_in: number;
+  tokens_out: number;
+  created_at: string;
+}
+
+const STATUS_MAP: Record<RunStatus, [string, string]> = {
+  pending: ["Pending", "bg-amber-500/10 text-amber-400"],
+  running: ["Running", "bg-blue-500/10 text-blue-400"],
+  complete: ["Complete", "bg-emerald-500/10 text-emerald-400"],
+  failed: ["Failed", "bg-rose-500/10 text-rose-400"],
+};
+
+function StatusPill({ status }: { status: RunStatus }) {
+  const [label, cls] = STATUS_MAP[status] ?? ["Unknown", "bg-white/10 text-white/50"];
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${cls}`}>{label}</span>
+  );
+}
+
+function parseSynthesis(content: string): { main: string; dissents: string } {
+  const dissentsMarker = "WHAT DIDN'T MAKE THE CONSENSUS:";
+  const idx = content.indexOf(dissentsMarker);
+  const raw = idx === -1 ? content : content.slice(0, idx);
+  const main = raw.replace(/^FINAL ANSWER:\n?/, "").trim();
+  const dissents = idx === -1 ? "" : content.slice(idx + dissentsMarker.length).trim();
+  return { main, dissents };
+}
+
+export default function CrewRun() {
+  const { runId } = useParams<{ runId: string }>();
+  const { session } = useSession();
+  const [run, setRun] = useState<RunRow | null>(null);
+  const [messages, setMessages] = useState<RunMessage[]>([]);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const authHeader = session
+    ? { Authorization: `Bearer ${session.access_token}` }
+    : null;
+
+  const fetchRun = useCallback(async () => {
+    if (!authHeader || !runId) return;
+    try {
+      const res = await fetch(
+        `/api/memory-admin?action=get_run&run_id=${runId}`,
+        { headers: authHeader }
+      );
+      const body = (await res.json()) as {
+        run?: RunRow;
+        messages?: RunMessage[];
+        error?: string;
+      };
+      if (body.run) {
+        setRun(body.run);
+        setMessages(body.messages ?? []);
+      } else if (body.error) {
+        setFetchError(body.error);
+      }
+    } catch {
+      setFetchError("Failed to load run.");
+    }
+  }, [runId, session?.access_token]);
+
+  useEffect(() => {
+    void fetchRun();
+  }, [fetchRun]);
+
+  useEffect(() => {
+    const active = run?.status === "pending" || run?.status === "running";
+    if (active && !intervalRef.current) {
+      intervalRef.current = setInterval(() => void fetchRun(), 3000);
+    } else if (!active && intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [run?.status, fetchRun]);
+
+  const opinions = messages.filter((m) => m.stage === "opinion");
+  const synthesis = messages.find((m) => m.stage === "synthesis");
+  const { main: synthMain, dissents: synthDissents } = synthesis
+    ? parseSynthesis(synthesis.content)
+    : { main: "", dissents: "" };
+
+  const runError = run?.result_artifact?.error;
+  const budgetExceeded = runError === "token_budget_exceeded";
+  const apiMissing = runError === "ANTHROPIC_API_KEY not configured in Vercel env.";
+
+  function copyToClipboard() {
+    void navigator.clipboard.writeText(synthMain).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  const isActive = run?.status === "pending" || run?.status === "running";
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <Link
+          to="/admin/crews/runs"
+          className="flex items-center gap-1 text-xs text-[#555] transition-colors hover:text-[#aaa]"
+        >
+          <ChevronLeft className="h-3 w-3" /> All runs
+        </Link>
+        {run && <StatusPill status={run.status} />}
+      </div>
+      <h1 className="mb-1 text-2xl font-semibold tracking-tight text-[#eee]">Run</h1>
+      <CrewsNav />
+
+      {fetchError && (
+        <p className="mb-4 rounded-lg bg-rose-500/10 px-3 py-2 text-xs text-rose-400">
+          {fetchError}
+        </p>
+      )}
+
+      {!run ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-6 w-6 animate-spin text-[#444]" />
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <div className="rounded-xl border border-white/[0.07] bg-white/[0.02] p-4">
+            <p className="mb-1 text-xs font-medium text-[#666]">Task</p>
+            <p className="text-sm text-[#ccc]">{run.task_prompt}</p>
+          </div>
+
+          {run.status === "failed" && (
+            <div className="rounded-xl border border-rose-500/20 bg-rose-500/5 p-4 text-sm text-rose-400">
+              {budgetExceeded
+                ? "This run used more words than the budget allows. Try a shorter task, or bump the budget in Settings."
+                : apiMissing
+                ? "Claude API not configured. Ask Bailey or check Vercel env vars."
+                : (runError ?? "Run failed.")}
+            </div>
+          )}
+
+          {opinions.length > 0 && (
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-[#555]">
+                Advisor opinions
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {opinions.map((msg, i) => (
+                  <div
+                    key={msg.id}
+                    className="rounded-xl border border-white/[0.07] bg-white/[0.02] p-4"
+                  >
+                    <p className="mb-2 text-[10px] font-semibold text-[#61C1C4]">
+                      Opinion {String.fromCharCode(65 + i)}
+                    </p>
+                    <p className="text-xs leading-relaxed text-[#bbb]">{msg.content}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {isActive && (
+            <div className="flex items-center gap-2 text-xs text-[#555]">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              <span>
+                {run.status === "pending"
+                  ? "Preparing crew..."
+                  : opinions.length > 0
+                  ? "Synthesising responses..."
+                  : "Advisors thinking..."}
+              </span>
+            </div>
+          )}
+
+          {synthesis && (
+            <div className="rounded-xl border border-[#61C1C4]/20 bg-[#61C1C4]/5 p-5">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-xs font-semibold uppercase tracking-wider text-[#61C1C4]">
+                  Council verdict
+                </p>
+                <button
+                  type="button"
+                  onClick={copyToClipboard}
+                  className="flex items-center gap-1 rounded-lg border border-white/[0.07] bg-white/[0.03] px-2.5 py-1 text-xs text-[#888] transition-colors hover:text-[#ccc]"
+                >
+                  {copied ? (
+                    <Check className="h-3 w-3" />
+                  ) : (
+                    <Copy className="h-3 w-3" />
+                  )}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+              <p className="whitespace-pre-wrap text-sm leading-relaxed text-[#ddd]">
+                {synthMain}
+              </p>
+              {synthDissents && synthDissents !== "No significant dissents." && (
+                <div className="mt-4 border-t border-white/[0.06] pt-4">
+                  <p className="mb-2 text-xs font-medium text-[#555]">
+                    What didn't make the consensus.
+                  </p>
+                  <p className="whitespace-pre-wrap text-xs leading-relaxed text-[#666]">
+                    {synthDissents}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/crews/CrewsRuns.tsx
+++ b/src/pages/admin/crews/CrewsRuns.tsx
@@ -1,7 +1,60 @@
+import { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSession } from "@/lib/auth";
 import CrewsNav from "@/components/crews/CrewsNav";
-import { History } from "lucide-react";
+import { History, Loader2 } from "lucide-react";
+
+type RunStatus = "pending" | "running" | "complete" | "failed";
+
+interface RunRow {
+  id: string;
+  crew_id: string | null;
+  task_prompt: string;
+  status: RunStatus;
+  tokens_used: number | null;
+  created_at: string;
+}
+
+const STATUS_LABELS: Record<RunStatus, [string, string]> = {
+  pending: ["Pending", "bg-amber-500/10 text-amber-400"],
+  running: ["Running", "bg-blue-500/10 text-blue-400"],
+  complete: ["Complete", "bg-emerald-500/10 text-emerald-400"],
+  failed: ["Failed", "bg-rose-500/10 text-rose-400"],
+};
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
 
 export default function CrewsRuns() {
+  const { session } = useSession();
+  const navigate = useNavigate();
+  const [runs, setRuns] = useState<RunRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const authHeader = useMemo(
+    () => (session ? { Authorization: `Bearer ${session.access_token}` } : null),
+    [session]
+  );
+
+  useEffect(() => {
+    if (!authHeader) return;
+    setLoading(true);
+    fetch("/api/memory-admin?action=list_runs", { headers: authHeader })
+      .then((r) => r.json() as Promise<{ data?: RunRow[]; error?: string }>)
+      .then((body) => {
+        if (body.data) setRuns(body.data);
+        else if (body.error) setError(body.error);
+      })
+      .catch(() => setError("Failed to load runs."))
+      .finally(() => setLoading(false));
+  }, [authHeader]);
+
   return (
     <div>
       <h1 className="mb-1 text-2xl font-semibold tracking-tight text-[#eee]">Runs</h1>
@@ -9,14 +62,55 @@ export default function CrewsRuns() {
         Every crew run you start will appear here with its status and result.
       </p>
       <CrewsNav />
-      <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-white/[0.08] py-20 text-center">
-        <History className="mb-3 h-8 w-8 text-[#444]" />
-        <p className="text-sm font-medium text-[#777]">No crews have run yet.</p>
-        <p className="mt-1 max-w-xs text-xs text-[#555]">
-          Pick a starter crew on the Templates page, type your question, and press Go. Your run
-          history will appear here.
-        </p>
-      </div>
+
+      {error && (
+        <p className="mb-4 rounded-lg bg-rose-500/10 px-3 py-2 text-xs text-rose-400">{error}</p>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-6 w-6 animate-spin text-[#444]" />
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-white/[0.08] py-20 text-center">
+          <History className="mb-3 h-8 w-8 text-[#444]" />
+          <p className="text-sm font-medium text-[#777]">Nothing here yet.</p>
+          <p className="mt-1 max-w-xs text-xs text-[#555]">
+            Pick a crew, type your question, press Run. Your run history will appear here.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {runs.map((run) => {
+            const [label, cls] = STATUS_LABELS[run.status] ?? [
+              "Unknown",
+              "bg-white/10 text-white/50",
+            ];
+            return (
+              <button
+                key={run.id}
+                type="button"
+                onClick={() => navigate(`/admin/crews/runs/${run.id}`)}
+                className="flex w-full items-center gap-3 rounded-xl border border-white/[0.07] bg-white/[0.02] px-4 py-3 text-left transition-colors hover:bg-white/[0.04]"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="mb-0.5 truncate text-sm text-[#ccc]">
+                    {run.task_prompt.length > 80
+                      ? `${run.task_prompt.slice(0, 80)}...`
+                      : run.task_prompt}
+                  </p>
+                  <p className="text-xs text-[#555]">{fmtDate(run.created_at)}</p>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold ${cls}`}
+                >
+                  {label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/supabase/migrations/20260423100000_crews_phase_c.sql
+++ b/supabase/migrations/20260423100000_crews_phase_c.sql
@@ -1,0 +1,45 @@
+-- Phase C: Crew run transcript table
+-- Idempotent: CREATE TABLE IF NOT EXISTS + conditional policy blocks
+
+create table if not exists mc_run_messages (
+  id           uuid primary key default gen_random_uuid(),
+  api_key_hash text not null,
+  run_id       uuid not null references mc_crew_runs(id) on delete cascade,
+  agent_id     uuid references mc_agents(id) on delete set null,
+  role         text not null check (role in ('advisor','chairman','user','system')),
+  stage        text not null check (stage in ('opinion','peer_review','synthesis')),
+  content      text not null default '',
+  tokens_in    integer not null default 0,
+  tokens_out   integer not null default 0,
+  created_at   timestamptz not null default now()
+);
+
+create index if not exists mc_run_messages_run_id on mc_run_messages(run_id);
+
+alter table mc_run_messages enable row level security;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'mc_run_messages' and policyname = 'mc_run_messages_service_role'
+  ) then
+    create policy mc_run_messages_service_role on mc_run_messages
+      to service_role using (true) with check (true);
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'mc_run_messages' and policyname = 'mc_run_messages_own_rows'
+  ) then
+    create policy mc_run_messages_own_rows on mc_run_messages
+      for all to authenticated
+      using (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      )
+      with check (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      );
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

- **Migration** `supabase/migrations/20260423100000_crews_phase_c.sql` - `mc_run_messages` table (run transcript, idempotent, RLS)
- **Engine** `src/lib/crews/engine.ts` - 3-stage Council flow: Stage 1 advisor fan-out (parallel), Stage 2 peer review (parallel), Stage 3 chairman synthesis. Pre-loads top-5 matching facts from UnClick Memory before fan-out. Token budget enforced, status tracked on `mc_crew_runs`
- **API** Three new actions on `api/memory-admin.ts`: `start_crew_run`, `get_run`, `list_runs`
- **Frontend** `CrewRun.tsx` (live-polling run view at `/admin/crews/runs/:runId`), `CrewsRuns.tsx` (real list with status pills), `CrewComposer.tsx` (task prompt textarea + Run button)

## Changes

- `supabase/migrations/20260423100000_crews_phase_c.sql` (new) - mc_run_messages table only; no parallel memory tables (see architecture note below)
- `src/lib/crews/engine.ts` (new) - Council execution engine, server-only
- `src/pages/admin/crews/CrewRun.tsx` (new) - run detail page with 3-second polling
- `api/memory-admin.ts` - import + 3 new action cases
- `src/pages/admin/crews/CrewComposer.tsx` - task prompt field, saveCrew() refactor, Run button
- `src/pages/admin/crews/CrewsRuns.tsx` - replaced stub with real list
- `src/App.tsx` - added `crews/runs/:runId` route

## Deletions

None. Pure addition.

## Archaeology

N/A. Pure addition on top of Phase B schema (mc_agents, mc_crews, mc_crew_runs).

## Testing

Before this is usable, Chris must set `ANTHROPIC_API_KEY` in Vercel env vars (see flag below).

Manual test path once env var is set:
1. Navigate to /admin/crews/new, pick 3+ agents, enter crew name + task prompt, click "Run this crew"
2. Confirm navigation to /admin/crews/runs/:id
3. Watch status pill cycle Pending -> Running -> Complete
4. Verify advisor opinions appear, then Council verdict with copy button and dissents section
5. Check /admin/crews/runs for the run entry with status pill and task prompt preview

## UnClick Memory linkage

- Migration: `supabase/migrations/20260423100000_crews_phase_c.sql`
- Endpoint actions: `start_crew_run`, `get_run`, `list_runs`
- Frontend routes: `/admin/crews/runs`, `/admin/crews/runs/:runId`

## Architecture note: memory tables dropped (per Phase C amendment)

`mc_run_memory_shared` and `mc_run_memory_private` were removed from the migration. Memory architecture is:

- **Private working memory** = ephemeral JavaScript variables during the run. Not persisted.
- **Shared facts** = read from UnClick Memory (`mc_extracted_facts`) before fan-out (top-5 relevant facts injected into each advisor's context). Write path deferred to Phase D.

## IMPORTANT: ANTHROPIC_API_KEY required before Phase C is usable

Set `ANTHROPIC_API_KEY` in Vercel project env vars. The endpoint returns a clear 500 error if it is missing: "ANTHROPIC_API_KEY not configured in Vercel env."

## Follow-ups (not fixed here)

- Other templates (Six Modes, Pre-Mortem, Red/Blue, Editorial Desk, Debate Circle) still show as "Coming soon." Phase D wires them through the same engine.
- Phase D will add approval-gated fact extraction from Crew run transcripts via UnClick Memory's `save_fact` flow. Agents' useful observations during a run will surface as pending facts for user approval, matching the auto-extraction pattern from `project-memory-update-plan.md` chunk 4. Phase C intentionally does not persist run outputs to long-term memory.
- Free-tier rate limit (3 runs/month) not enforced yet. Phase F or a separate billing chunk.
- Cross-model chairman (Gemini Flash or similar) deferred. Phase E explicitly adds this.
- Live Activity View fancy animations (memory flow dots, hub-and-spoke layout) -> Phase D.

## No auto-merge

Chris reviews.