### PR TITLE
fix: restore missing on: trigger for publish-mcp-server workflow

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -1,5 +1,11 @@
 name: Publish MCP server
 
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
 # Auto-publishes @unclick/mcp-server to npm whenever files under
 # packages/mcp-server/ change on main. Bumps the patch version, pushes the
 # version bump commit back, then publishes. Skips if the last commit is


### PR DESCRIPTION
## Summary

- `.github/workflows/publish-mcp-server.yml` was missing its `on:` block entirely, so the workflow never ran and `@unclick/mcp-server` could not be published to npm automatically.
- Added the standard tag-push trigger (`v*`) plus `workflow_dispatch` for manual runs.

## Changes

- Added `on: push: tags: ['v*']` and `workflow_dispatch` to `publish-mcp-server.yml`.

## Deletions

None.

## Archaeology

n/a - pre-existing bug, not introduced in any recent PR.

## Testing

Verify that pushing a tag matching `v*` now triggers the workflow. Can also confirm via `workflow_dispatch` from the Actions tab without creating a real release.

## UnClick Memory Linkage

Unblocks npm publishing of `@unclick/mcp-server`. Without this trigger, the publish job never fired regardless of commits.