### PR TITLE
feat(testpass): Phase 9A visual run UI and report page

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5037,6 +5037,115 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({ data: data ?? [] });
       }
 
+      // ─── TestPass run management (Phase 9A visual UI) ─────────────────────
+
+      case "list_testpass_runs": {
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Authorization header required" });
+        const limit = Math.min(Number(req.query.limit ?? req.body?.limit ?? 50), 100);
+        const targetFilter = (req.query.target ?? req.body?.target ?? "") as string;
+        let q = supabase
+          .from("testpass_runs")
+          .select("id, pack_id, pack_name, target, profile, started_at, completed_at, status, verdict_summary")
+          .eq("actor_user_id", user.id)
+          .order("started_at", { ascending: false })
+          .limit(limit);
+        if (targetFilter) q = q.ilike("target->>url", `%${targetFilter}%`);
+        const { data, error } = await q;
+        if (error) throw error;
+        return res.status(200).json({ runs: data ?? [] });
+      }
+
+      case "list_testpass_packs": {
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Authorization header required" });
+        const { data, error } = await supabase
+          .from("testpass_packs")
+          .select("id, slug, name, version, description, yaml")
+          .or(`owner_user_id.is.null,owner_user_id.eq.${user.id}`)
+          .order("created_at", { ascending: true });
+        if (error) throw error;
+        const packs = (data ?? []).map((p) => {
+          const yamlData = (p.yaml ?? {}) as Record<string, unknown>;
+          const items = Array.isArray(yamlData.items) ? yamlData.items : [];
+          const category = (yamlData.category as string | undefined) ?? "general";
+          return {
+            id: p.id,
+            slug: p.slug,
+            name: p.name,
+            description: p.description,
+            check_count: items.length,
+            category,
+            is_system: !p.yaml || Object.keys(p.yaml as object).length === 0,
+          };
+        });
+        return res.status(200).json({ packs });
+      }
+
+      case "get_testpass_run": {
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Authorization header required" });
+        const runId = (req.query.run_id ?? req.body?.run_id ?? "") as string;
+        if (!runId) return res.status(400).json({ error: "run_id required" });
+        const [runRes, itemsRes] = await Promise.all([
+          supabase
+            .from("testpass_runs")
+            .select("*")
+            .eq("id", runId)
+            .eq("actor_user_id", user.id)
+            .maybeSingle(),
+          supabase
+            .from("testpass_items")
+            .select("*")
+            .eq("run_id", runId)
+            .order("created_at", { ascending: true }),
+        ]);
+        if (runRes.error) throw runRes.error;
+        if (!runRes.data) return res.status(404).json({ error: "Run not found" });
+        if (itemsRes.error) throw itemsRes.error;
+        return res.status(200).json({ run: runRes.data, items: itemsRes.data ?? [] });
+      }
+
+      case "start_testpass_run": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Authorization header required" });
+        const { pack_id, target, depth } = (req.body ?? {}) as {
+          pack_id?: string;
+          target?: string;
+          depth?: string;
+        };
+        if (!pack_id) return res.status(400).json({ error: "pack_id required" });
+        if (!target) return res.status(400).json({ error: "target required" });
+        const profile = (["smoke", "standard", "deep"].includes(depth ?? "") ? depth : "standard") as string;
+        const { data: pack } = await supabase
+          .from("testpass_packs")
+          .select("slug, name")
+          .eq("id", pack_id)
+          .maybeSingle();
+        if (!pack) return res.status(404).json({ error: "Pack not found" });
+        const host = req.headers.host ?? "localhost:3000";
+        const proto = host.includes("localhost") ? "http" : "https";
+        const engineRes = await fetch(`${proto}://${host}/api/testpass`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: req.headers.authorization ?? "",
+          },
+          body: JSON.stringify({
+            action: "run",
+            target_url: target,
+            profile,
+            pack_slug: pack.slug,
+            pack_id,
+            pack_name: pack.name,
+          }),
+        });
+        const engineBody = (await engineRes.json().catch(() => ({}))) as Record<string, unknown>;
+        if (!engineRes.ok) return res.status(engineRes.status).json(engineBody);
+        return res.status(200).json({ run_id: engineBody.run_id });
+      }
+
       default:
         return res.status(400).json({ error: `Unknown action: ${action}` });
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,9 @@ import AdminAnalytics from "./pages/admin/AdminAnalytics.tsx";
 import AdminCodebase from "./pages/admin/AdminCodebase.tsx";
 import AdminOrchestratorPage from "./pages/admin/AdminOrchestrator.tsx";
 import AdminTestPass from "./pages/admin/AdminTestPass.tsx";
+import TestPassCatalog from "./pages/admin/testpass/TestPassCatalog.tsx";
+import NewRunWizard from "./pages/admin/testpass/NewRunWizard.tsx";
+import RunDetail from "./pages/admin/testpass/RunDetail.tsx";
 import CrewsCatalog from "./pages/admin/crews/CrewsCatalog.tsx";
 import CrewComposer from "./pages/admin/crews/CrewComposer.tsx";
 import CrewsRuns from "./pages/admin/crews/CrewsRuns.tsx";
@@ -126,7 +129,10 @@ const App = () => (
             <Route path="analytics"      element={<AdminAnalytics />} />
             <Route path="codebase"       element={<AdminCodebase />} />
             <Route path="orchestrator"   element={<AdminOrchestratorPage />} />
-            <Route path="testpass"       element={<AdminTestPass />} />
+            <Route path="testpass"              element={<TestPassCatalog />} />
+            <Route path="testpass/new"          element={<NewRunWizard />} />
+            <Route path="testpass/runs/:id"     element={<RunDetail />} />
+            <Route path="testpass/packs/:id/edit" element={<AdminTestPass />} />
             <Route path="crews"          element={<CrewsCatalog />} />
             <Route path="crews/new"      element={<CrewComposer />} />
             <Route path="crews/:id/edit" element={<CrewComposer />} />

--- a/src/pages/admin/testpass/NewRunWizard.tsx
+++ b/src/pages/admin/testpass/NewRunWizard.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { ArrowLeft, ChevronRight, Loader2, Play } from "lucide-react";
+import { useSession } from "@/lib/auth";
+import { CATEGORY_BADGE } from "./testpass-ui";
+
+interface PackCard { id: string; name: string; description: string; check_count: number; category: string; }
+type Depth = "smoke" | "standard" | "deep";
+
+const DEPTH_OPTIONS: { value: Depth; label: string; detail: string; subtitle: string }[] = [
+  { value: "smoke",    label: "Smoke",    detail: "1 pass, fastest",          subtitle: "Use when you want a quick sanity check." },
+  { value: "standard", label: "Standard", detail: "2 passes, balanced",        subtitle: "Use before every release." },
+  { value: "deep",     label: "Deep",     detail: "3 passes + Healer retry",   subtitle: "Use before a major launch or security review." },
+];
+
+export default function NewRunWizard() {
+  const { session } = useSession();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = session?.access_token;
+  const authHeader = useMemo(() => (token ? { Authorization: `Bearer ${token}` } : {}), [token]);
+
+  const [step, setStep] = useState(1);
+  const [packs, setPacks] = useState<PackCard[]>([]);
+  const [loadingPacks, setLoadingPacks] = useState(false);
+  const [selectedPackId, setSelectedPackId] = useState<string>(searchParams.get("pack_id") ?? "");
+  const [targetUrl, setTargetUrl] = useState("https://your-mcp-server.example.com/mcp");
+  const [depth, setDepth] = useState<Depth>("standard");
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPacks = useCallback(async () => {
+    if (!token) return;
+    setLoadingPacks(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=list_testpass_packs", { headers: authHeader });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok) setPacks(body.packs ?? []);
+    } finally { setLoadingPacks(false); }
+  }, [token, authHeader]);
+
+  useEffect(() => { void fetchPacks(); }, [fetchPacks]);
+  useEffect(() => {
+    const pre = searchParams.get("pack_id");
+    if (pre) { setSelectedPackId(pre); setStep(2); }
+  }, [searchParams]);
+
+  async function handleRun() {
+    if (!selectedPackId || !targetUrl || targetUrl === "https://your-mcp-server.example.com/mcp") {
+      setError("Enter your MCP server URL before running."); return;
+    }
+    setRunning(true); setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=start_testpass_run", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ pack_id: selectedPackId, target: targetUrl, depth }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? `Run failed (${res.status})`);
+      navigate(`/admin/testpass/runs/${body.run_id as string}`);
+    } catch (e) { setError(e instanceof Error ? e.message : "Run failed"); }
+    finally { setRunning(false); }
+  }
+
+  const selectedPack = packs.find((p) => p.id === selectedPackId);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="mb-6 flex items-center gap-3">
+        <button onClick={() => navigate("/admin/testpass")} className="flex items-center gap-1.5 text-sm text-[#888] hover:text-white">
+          <ArrowLeft className="h-4 w-4" /> Back
+        </button>
+        <h1 className="text-xl font-semibold text-white">New TestPass run</h1>
+      </div>
+
+      <div className="mb-8 flex items-center gap-2 text-xs text-[#666]">
+        {["Pick pack", "Pick target", "Pick depth"].map((label, i) => (
+          <div key={label} className="flex items-center gap-2">
+            <span className={`flex h-5 w-5 items-center justify-center rounded-full border text-[10px] font-bold ${step === i+1 ? "border-[#61C1C4] bg-[#61C1C4]/15 text-[#61C1C4]" : step > i+1 ? "border-[#61C1C4]/40 bg-[#61C1C4]/10 text-[#61C1C4]" : "border-white/[0.12] text-[#555]"}`}>{i + 1}</span>
+            <span className={step === i + 1 ? "text-white" : ""}>{label}</span>
+            {i < 2 && <ChevronRight className="h-3 w-3" />}
+          </div>
+        ))}
+      </div>
+
+      {step === 1 && (
+        <div>
+          <p className="mb-4 text-sm text-[#888]">Choose a conformance pack. Each pack is a named set of checks.</p>
+          {loadingPacks ? (
+            <div className="flex items-center gap-2 text-[#888] py-8 justify-center"><Loader2 className="h-4 w-4 animate-spin" /> Loading packs...</div>
+          ) : packs.length === 0 ? (
+            <p className="py-8 text-center text-sm text-[#888]">No packs available. Create one from the Packs tab first.</p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {packs.map((p) => (
+                <button key={p.id} onClick={() => { setSelectedPackId(p.id); setStep(2); }}
+                  className={`rounded-xl border p-4 text-left transition-colors ${selectedPackId === p.id ? "border-[#61C1C4]/50 bg-[#61C1C4]/10" : "border-white/[0.06] bg-[#111] hover:border-white/[0.12]"}`}>
+                  <div className="flex items-center gap-2 flex-wrap mb-1">
+                    <span className="text-sm font-semibold text-white">{p.name}</span>
+                    <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${CATEGORY_BADGE[p.category] ?? CATEGORY_BADGE.general}`}>{p.category}</span>
+                  </div>
+                  <p className="text-xs text-[#888] line-clamp-2">{p.description || "Use when you need to verify MCP conformance."}</p>
+                  <p className="mt-2 text-[11px] text-[#666]">{p.check_count} checks</p>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {step === 2 && (
+        <div>
+          <p className="mb-1 text-sm text-[#888]">Enter the URL of the MCP server you want to test.{selectedPack && <span className="text-white ml-1">Pack: {selectedPack.name}</span>}</p>
+          <p className="mb-4 text-xs text-[#666]">Use when: testing a staging deployment, validating a new integration, or checking conformance before release.</p>
+          <label className="block text-xs font-medium text-[#ccc] mb-2">MCP server URL</label>
+          <input type="url" value={targetUrl} onChange={(e) => setTargetUrl(e.target.value)}
+            className="w-full rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2.5 text-sm text-white focus:border-[#61C1C4]/40 focus:outline-none"
+            placeholder="https://your-mcp-server.example.com/mcp" />
+          <p className="mt-2 text-xs text-[#666]">Replace the example URL with your actual server. The URL should respond to JSON-RPC 2.0 requests.</p>
+          <div className="mt-6 flex gap-2">
+            <button onClick={() => setStep(1)} className="rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] hover:text-white">Back</button>
+            <button onClick={() => setStep(3)} disabled={!targetUrl}
+              className="flex-1 rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-4 py-2 text-sm font-medium text-[#61C1C4] hover:bg-[#61C1C4]/20 disabled:opacity-50">
+              Next: Pick depth
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div>
+          <p className="mb-4 text-sm text-[#888]">How thorough should the run be?</p>
+          <div className="grid gap-3">
+            {DEPTH_OPTIONS.map((opt) => (
+              <button key={opt.value} onClick={() => setDepth(opt.value)}
+                className={`rounded-xl border p-4 text-left transition-colors ${depth === opt.value ? "border-[#61C1C4]/50 bg-[#61C1C4]/10" : "border-white/[0.06] bg-[#111] hover:border-white/[0.12]"}`}>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">{opt.label}</span>
+                  <span className="text-xs text-[#666]">{opt.detail}</span>
+                </div>
+                <p className="mt-1 text-xs text-[#888]">{opt.subtitle}</p>
+              </button>
+            ))}
+          </div>
+          {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
+          <div className="mt-6 flex gap-2">
+            <button onClick={() => setStep(2)} className="rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] hover:text-white">Back</button>
+            <button onClick={() => void handleRun()} disabled={running}
+              className="flex-1 flex items-center justify-center gap-2 rounded-lg border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-4 py-2 text-sm font-semibold text-[#E2B93B] hover:bg-[#E2B93B]/20 disabled:opacity-50">
+              {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+              {running ? "Starting run..." : "Run TestPass"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/testpass/RunDetail.tsx
+++ b/src/pages/admin/testpass/RunDetail.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Check, ClipboardCopy, Download, Loader2, MessageSquare, X } from "lucide-react";
+import { useSession } from "@/lib/auth";
+import { SEVERITY_BADGE, STATUS_LABEL, STATUS_PILL, VERDICT_ICON, elapsedLabel, fmtDate } from "./testpass-ui";
+
+type VS = { check?: number; fail?: number; na?: number; other?: number; pending?: number };
+interface RunData { id: string; pack_name: string; target: { url?: string }; profile: string; started_at: string; completed_at?: string; status: string; verdict_summary: VS; }
+interface CheckItem { id: string; check_id: string; title: string; category: string; severity: "critical"|"high"|"medium"|"low"; verdict: "check"|"na"|"fail"|"other"|"pending"; on_fail_comment?: string|null; fix_recipe?: string[]|null; }
+
+export default function RunDetail() {
+  const { id: runId } = useParams<{ id: string }>();
+  const { session } = useSession();
+  const navigate = useNavigate();
+  const token = session?.access_token;
+  const authHeader = useMemo(() => (token ? { Authorization: `Bearer ${token}` } : {}), [token]);
+
+  const [run, setRun] = useState<RunData | null>(null);
+  const [items, setItems] = useState<CheckItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false); const [showModal, setShowModal] = useState(false); const [copiedStep, setCopiedStep] = useState<number | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchRun = useCallback(async () => {
+    if (!runId || !token) return null;
+    try {
+      const res = await fetch(`/api/memory-admin?action=get_testpass_run&run_id=${encodeURIComponent(runId)}`, { headers: authHeader });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(body.error ?? "Failed to load run"); return null; }
+      setRun(body.run as RunData);
+      setItems(body.items as CheckItem[]);
+      if ((body.items as CheckItem[])?.length > 0 && !selectedId) setSelectedId((body.items as CheckItem[])[0].id);
+      return (body.run as RunData).status;
+    } catch (e) { setError(e instanceof Error ? e.message : "Failed to load run"); return null; }
+    finally { setLoading(false); }
+  }, [runId, token, authHeader, selectedId]);
+
+  useEffect(() => {
+    void fetchRun().then((status) => {
+      if (status === "running" || status === "pending") {
+        pollRef.current = setInterval(() => {
+          void fetchRun().then((s) => {
+            if (s && s !== "running" && s !== "pending" && pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+          });
+        }, 3000);
+      }
+    });
+    return () => { if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; } };
+  }, [fetchRun]);
+
+  const selected = items.find((i) => i.id === selectedId) ?? null;
+  const failItems = items.filter((i) => i.verdict === "fail");
+  const vs = run?.verdict_summary ?? {};
+
+  async function copyFixList() {
+    const text = failItems.map((i) => `## ${i.check_id}: ${i.title}\n${i.on_fail_comment ?? ""}\n${(i.fix_recipe ?? []).map((s, n) => `  ${n+1}. ${s}`).join("\n")}`).join("\n\n");
+    await navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 3000);
+  }
+  const agentPrompt = failItems.length > 0
+    ? `I ran TestPass against ${run?.target?.url ?? "my MCP server"} and got ${failItems.length} failing check${failItems.length === 1 ? "" : "s"}:\n\n` + failItems.map((i) => `- ${i.check_id}: ${i.title}\n  ${i.on_fail_comment ?? ""}`).join("\n") + "\n\nCan you help me fix these?"
+    : `TestPass completed with no failures for ${run?.target?.url ?? "my MCP server"}.`;
+
+  if (loading) return <div className="flex items-center justify-center py-24 gap-2 text-[#888]"><Loader2 className="h-5 w-5 animate-spin" /> Loading run...</div>;
+  if (error || !run) return <div className="py-24 text-center"><p className="text-red-400 text-sm mb-4">{error ?? "Run not found."}</p><button onClick={() => navigate("/admin/testpass")} className="text-sm text-[#888] hover:text-white">Back to TestPass</button></div>;
+
+  return (
+    <div className="flex flex-col gap-0">
+      <button onClick={() => navigate("/admin/testpass")} className="mb-4 flex items-center gap-1.5 text-sm text-[#888] hover:text-white w-fit"><ArrowLeft className="h-4 w-4" /> All runs</button>
+
+      <div className="mb-6 rounded-xl border border-white/[0.06] bg-[#111] p-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${STATUS_PILL[run.status] ?? STATUS_PILL.pending}`}>{STATUS_LABEL[run.status] ?? run.status}{(run.status === "running" || run.status === "pending") && <Loader2 className="ml-1.5 inline-block h-3 w-3 animate-spin" />}</span>
+              <span className="text-xs text-[#666]">{run.profile} depth</span>
+            </div>
+            <p className="font-mono text-sm text-[#aaa]">{run.target?.url ?? "(no URL)"}</p>
+            <p className="text-xs text-[#666]">Pack: <span className="text-[#ccc]">{run.pack_name}</span><span className="mx-2 text-[#444]">|</span>Started: <span className="text-[#ccc]">{fmtDate(run.started_at)}</span><span className="mx-2 text-[#444]">|</span>Elapsed: <span className="text-[#ccc]">{elapsedLabel(run.started_at, run.completed_at)}</span></p>
+          </div>
+          <div className="flex flex-wrap gap-3 text-xs">
+            {[["Pass", vs.check, "text-[#61C1C4]"], ["Fail", vs.fail, "text-red-400"], ["N/A", vs.na, "text-gray-400"], ["Other", vs.other, "text-[#E2B93B]"], ["Pending", vs.pending, "text-blue-300"]].filter(([,v]) => (v as number ?? 0) > 0).map(([label, val, color]) => (
+              <div key={label as string} className="flex flex-col items-center">
+                <span className={`text-lg font-bold ${color}`}>{val as number}</span>
+                <span className="text-[#666]">{label as string}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-4 min-h-[500px]">
+        <div className="w-72 shrink-0 rounded-xl border border-white/[0.06] bg-[#111] overflow-auto">
+          {items.length === 0 ? <p className="p-4 text-xs text-[#666]">No checks yet. The run is still starting.</p> : (
+            <ul className="divide-y divide-white/[0.04]">
+              {items.map((item) => (
+                <li key={item.id}>
+                  <button onClick={() => setSelectedId(item.id)} className={`w-full px-4 py-3 text-left transition-colors ${selectedId === item.id ? "bg-white/[0.05]" : "hover:bg-white/[0.02]"}`}>
+                    <div className="flex items-start gap-2">
+                      <span className="text-sm mt-0.5 shrink-0">{VERDICT_ICON[item.verdict] ?? "❓"}</span>
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-[#ccc] truncate">{item.title}</p>
+                        <div className="mt-1 flex items-center gap-1.5">
+                          <span className="font-mono text-[10px] text-[#555]">{item.check_id}</span>
+                          <span className={`rounded border px-1.5 py-0.5 text-[9px] ${SEVERITY_BADGE[item.severity] ?? ""}`}>{item.severity}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex-1 rounded-xl border border-white/[0.06] bg-[#111] p-5 overflow-auto">
+          {!selected ? <p className="text-sm text-[#666]">Select a check on the left to see details.</p> : (
+            <div className="flex flex-col gap-4">
+              <div>
+                <div className="flex items-center gap-2 flex-wrap mb-1">
+                  <span className="text-lg">{VERDICT_ICON[selected.verdict]}</span>
+                  <span className={`rounded border px-2 py-0.5 text-xs ${SEVERITY_BADGE[selected.severity] ?? ""}`}>{selected.severity}</span>
+                  <span className="font-mono text-xs text-[#555]">{selected.check_id}</span>
+                </div>
+                <h2 className="text-sm font-semibold text-white">{selected.title}</h2>
+                <p className="text-xs text-[#666] mt-0.5">Category: {selected.category}</p>
+              </div>
+              {selected.on_fail_comment && (
+                <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+                  <p className="text-xs font-medium text-red-400 mb-1">Finding</p>
+                  <p className="text-xs text-[#ccc]">{selected.on_fail_comment}</p>
+                </div>
+              )}
+              {selected.fix_recipe && selected.fix_recipe.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-[#888] mb-2">Fix steps</p>
+                  <ol className="flex flex-col gap-2">
+                    {selected.fix_recipe.map((step, idx) => (
+                      <li key={idx} className="flex items-start gap-2 rounded-lg border border-white/[0.06] bg-black/20 p-2.5">
+                        <span className="shrink-0 flex h-5 w-5 items-center justify-center rounded-full bg-white/[0.06] text-[10px] font-bold text-[#888]">{idx + 1}</span>
+                        <span className="text-xs text-[#ccc] flex-1">{step}</span>
+                        <button onClick={async () => { await navigator.clipboard.writeText(step); setCopiedStep(idx); setTimeout(() => setCopiedStep(null), 2000); }} className="shrink-0 text-[#555] hover:text-[#888]" title="Copy this step">
+                          {copiedStep === idx ? <Check className="h-3.5 w-3.5 text-[#61C1C4]" /> : <ClipboardCopy className="h-3.5 w-3.5" />}
+                        </button>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )}
+              {!selected.on_fail_comment && !(selected.fix_recipe?.length) && (
+                <p className="text-xs text-[#666]">{selected.verdict === "check" ? "This check passed." : selected.verdict === "na" ? "Not applicable." : "No additional details recorded."}</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-xl border border-white/[0.06] bg-[#111] px-5 py-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          {failItems.length > 0 && (
+            <button onClick={() => void copyFixList()} className="flex items-center gap-1.5 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-1.5 text-xs text-red-400 hover:bg-red-500/20">
+              {copied ? <Check className="h-3.5 w-3.5" /> : <ClipboardCopy className="h-3.5 w-3.5" />} {copied ? "Copied" : "Copy fix list"}
+            </button>
+          )}
+          <button onClick={() => setShowModal(true)} className="flex items-center gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.03] px-3 py-1.5 text-xs text-[#888] hover:text-white">
+            <MessageSquare className="h-3.5 w-3.5" /> Ask your AI agent
+          </button>
+        </div>
+        <button onClick={() => { const b = new Blob([JSON.stringify({ run, items }, null, 2)], { type: "application/json" }); const u = URL.createObjectURL(b); const a = document.createElement("a"); a.href = u; a.download = `testpass-${runId?.slice(0,8)}.json`; a.click(); URL.revokeObjectURL(u); }}
+          className="flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-3 py-1.5 text-xs text-[#888] hover:text-white">
+          <Download className="h-3.5 w-3.5" /> Export JSON
+        </button>
+      </div>
+
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-lg rounded-xl border border-white/[0.08] bg-[#111] p-6 shadow-2xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-white">Ask your AI agent</h3>
+              <button onClick={() => setShowModal(false)} className="text-[#666] hover:text-white"><X className="h-4 w-4" /></button>
+            </div>
+            <p className="mb-3 text-xs text-[#888]">Copy this prompt into your AI chat (Claude, ChatGPT, or any agent) to get help with these checks.</p>
+            <pre className="rounded-lg border border-white/[0.06] bg-black/40 p-3 text-[11px] text-[#ccc] whitespace-pre-wrap max-h-56 overflow-auto">{agentPrompt}</pre>
+            <button onClick={async () => { await navigator.clipboard.writeText(agentPrompt); setCopied(true); setTimeout(() => setCopied(false), 3000); }}
+              className="mt-3 flex items-center gap-1.5 rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-2 text-xs text-[#61C1C4] hover:bg-[#61C1C4]/20">
+              {copied ? <Check className="h-3.5 w-3.5" /> : <ClipboardCopy className="h-3.5 w-3.5" />} {copied ? "Copied" : "Copy prompt"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/testpass/TestPassCatalog.tsx
+++ b/src/pages/admin/testpass/TestPassCatalog.tsx
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { FlaskConical, Loader2, Play, Settings2 } from "lucide-react";
+import { useSession } from "@/lib/auth";
+import { CATEGORY_BADGE, STATUS_LABEL, STATUS_PILL, fmtDate } from "./testpass-ui";
+
+interface RunRow {
+  id: string; pack_id: string; pack_name: string;
+  target: { url?: string }; profile: string; started_at: string;
+  status: string; verdict_summary: { check?: number; fail?: number };
+}
+
+interface PackCard {
+  id: string; slug: string; name: string; description: string;
+  check_count: number; category: string;
+}
+
+export default function TestPassCatalog() {
+  const { session } = useSession();
+  const navigate = useNavigate();
+  const token = session?.access_token;
+  const authHeader = useMemo(() => (token ? { Authorization: `Bearer ${token}` } : {}), [token]);
+
+  const [tab, setTab] = useState<"runs" | "packs">("runs");
+  const [runs, setRuns] = useState<RunRow[]>([]);
+  const [packs, setPacks] = useState<PackCard[]>([]);
+  const [loadingRuns, setLoadingRuns] = useState(false);
+  const [loadingPacks, setLoadingPacks] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRuns = useCallback(async () => {
+    if (!token) return;
+    setLoadingRuns(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=list_testpass_runs&limit=50", { headers: authHeader });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Failed to load runs");
+      setRuns(body.runs ?? []);
+    } catch (e) { setError(e instanceof Error ? e.message : "Failed to load runs"); }
+    finally { setLoadingRuns(false); }
+  }, [token, authHeader]);
+
+  const fetchPacks = useCallback(async () => {
+    if (!token) return;
+    setLoadingPacks(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=list_testpass_packs", { headers: authHeader });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Failed to load packs");
+      setPacks(body.packs ?? []);
+    } catch (e) { setError(e instanceof Error ? e.message : "Failed to load packs"); }
+    finally { setLoadingPacks(false); }
+  }, [token, authHeader]);
+
+  useEffect(() => { void fetchRuns(); }, [fetchRuns]);
+  useEffect(() => { if (tab === "packs") void fetchPacks(); }, [tab, fetchPacks]);
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <FlaskConical className="h-6 w-6 text-[#61C1C4]" />
+          <div>
+            <h1 className="text-2xl font-semibold text-white">TestPass</h1>
+            <p className="mt-0.5 text-sm text-[#888]">MCP conformance checker. Run a pack, review the report, ship with confidence.</p>
+          </div>
+        </div>
+        <button onClick={() => navigate("/admin/testpass/new")}
+          className="flex items-center gap-2 rounded-lg border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-4 py-2 text-sm font-semibold text-[#E2B93B] hover:bg-[#E2B93B]/20">
+          <Play className="h-4 w-4" /> Start new run
+        </button>
+      </div>
+
+      <div className="mb-6 flex gap-1 rounded-lg border border-white/[0.06] bg-[#111] p-1 w-fit">
+        {(["runs", "packs"] as const).map((t) => (
+          <button key={t} onClick={() => setTab(t)}
+            className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors capitalize ${tab === t ? "bg-white/[0.08] text-white" : "text-[#888] hover:text-white"}`}>
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="mb-4 text-sm text-red-400">{error}</p>}
+
+      {tab === "runs" && (
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] overflow-hidden">
+          {loadingRuns ? (
+            <div className="flex items-center justify-center py-16 gap-2 text-[#888]"><Loader2 className="h-4 w-4 animate-spin" /> Loading runs...</div>
+          ) : runs.length === 0 ? (
+            <div className="py-16 text-center">
+              <p className="text-[#888] text-sm">No runs yet. Start your first run to see results here.</p>
+              <button onClick={() => navigate("/admin/testpass/new")}
+                className="mt-4 rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-4 py-2 text-sm text-[#61C1C4] hover:bg-[#61C1C4]/20">
+                Start first run
+              </button>
+            </div>
+          ) : (
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b border-white/[0.06] text-left text-xs text-[#666]">
+                  {["Target", "Pack", "Status", "Started", "Pass / Fail"].map((h) => (
+                    <th key={h} className="px-4 py-3 font-medium">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r) => (
+                  <tr key={r.id} onClick={() => navigate(`/admin/testpass/runs/${r.id}`)}
+                    className="cursor-pointer border-b border-white/[0.04] hover:bg-white/[0.02]">
+                    <td className="px-4 py-3 font-mono text-xs text-[#aaa] max-w-[200px] truncate">{r.target?.url ?? "(no URL)"}</td>
+                    <td className="px-4 py-3 text-[#ccc] text-xs">{r.pack_name || r.pack_id?.slice(0, 8)}</td>
+                    <td className="px-4 py-3">
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${STATUS_PILL[r.status] ?? STATUS_PILL.pending}`}>
+                        {STATUS_LABEL[r.status] ?? r.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-xs text-[#888]">{fmtDate(r.started_at)}</td>
+                    <td className="px-4 py-3 text-xs">
+                      <span className="text-[#61C1C4]">{r.verdict_summary?.check ?? 0} pass</span>
+                      <span className="text-[#666] mx-1">/</span>
+                      <span className="text-red-400">{r.verdict_summary?.fail ?? 0} fail</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      )}
+
+      {tab === "packs" && (
+        <div>
+          {loadingPacks ? (
+            <div className="flex items-center justify-center py-16 gap-2 text-[#888]"><Loader2 className="h-4 w-4 animate-spin" /> Loading packs...</div>
+          ) : packs.length === 0 ? (
+            <p className="py-16 text-center text-sm text-[#888]">No packs available. Create one in the YAML editor.</p>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {packs.map((p) => (
+                <div key={p.id} className="rounded-xl border border-white/[0.06] bg-[#111] p-5 flex flex-col gap-3">
+                  <div>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h3 className="text-sm font-semibold text-white">{p.name}</h3>
+                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${CATEGORY_BADGE[p.category] ?? CATEGORY_BADGE.general}`}>{p.category}</span>
+                    </div>
+                    <p className="mt-1 text-xs text-[#888] line-clamp-2">{p.description || "Use when you need to verify MCP conformance."}</p>
+                    <p className="mt-1 text-[11px] text-[#666]">{p.check_count} checks</p>
+                  </div>
+                  <div className="flex gap-2 mt-auto">
+                    <button onClick={() => navigate(`/admin/testpass/new?pack_id=${p.id}`)}
+                      className="flex-1 flex items-center justify-center gap-1.5 rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-3 py-2 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/20">
+                      <Play className="h-3 w-3" /> Start run
+                    </button>
+                    <button onClick={() => navigate(`/admin/testpass/packs/${p.id}/edit`)}
+                      className="flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-black/30 px-3 py-2 text-xs text-[#888] hover:text-white">
+                      <Settings2 className="h-3 w-3" /> Edit YAML
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/testpass/testpass-ui.ts
+++ b/src/pages/admin/testpass/testpass-ui.ts
@@ -1,0 +1,41 @@
+export const STATUS_PILL: Record<string, string> = {
+  running:         "bg-blue-500/15 text-blue-300 border-blue-500/30",
+  complete:        "bg-[#61C1C4]/15 text-[#61C1C4] border-[#61C1C4]/30",
+  failed:          "bg-red-500/15 text-red-400 border-red-500/30",
+  budget_exceeded: "bg-orange-500/15 text-orange-400 border-orange-500/30",
+  pending:         "bg-gray-500/15 text-gray-400 border-gray-500/30",
+};
+
+export const STATUS_LABEL: Record<string, string> = {
+  running: "Running", complete: "Complete", failed: "Failed",
+  budget_exceeded: "Failed", pending: "Pending",
+};
+
+export const VERDICT_ICON: Record<string, string> = {
+  check: "✅", fail: "❌", na: "⏭️", other: "❓", pending: "⏳",
+};
+
+export const SEVERITY_BADGE: Record<string, string> = {
+  critical: "bg-red-600/10 text-red-400 border-red-600/30",
+  high:     "bg-orange-500/10 text-orange-400 border-orange-500/30",
+  medium:   "bg-[#E2B93B]/10 text-[#E2B93B] border-[#E2B93B]/30",
+  low:      "bg-gray-500/10 text-gray-400 border-gray-500/30",
+};
+
+export const CATEGORY_BADGE: Record<string, string> = {
+  "json-rpc": "bg-purple-500/15 text-purple-300",
+  "mcp":      "bg-[#61C1C4]/15 text-[#61C1C4]",
+  "general":  "bg-gray-500/15 text-gray-300",
+};
+
+export function fmtDate(iso?: string) {
+  if (!iso) return "";
+  try { return new Date(iso).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" }); }
+  catch { return iso; }
+}
+
+export function elapsedLabel(startIso: string, endIso?: string) {
+  const secs = Math.round((Date.now() - new Date(startIso).getTime()) / 1000);
+  const end = endIso ? Math.round((new Date(endIso).getTime() - new Date(startIso).getTime()) / 1000) : secs;
+  return end < 60 ? `${end}s` : `${Math.floor(end / 60)}m ${end % 60}s`;
+}

--- a/supabase/migrations/20260423200000_testpass_run_ui_fields.sql
+++ b/supabase/migrations/20260423200000_testpass_run_ui_fields.sql
@@ -1,0 +1,9 @@
+-- Phase 9A: add fields needed by the visual run UI
+
+-- Fix recipe: ordered list of remediation steps per check (jsonb array of strings)
+alter table testpass_items
+  add column if not exists fix_recipe jsonb not null default '[]';
+
+-- Pack name snapshot so the runs list can display it without a join
+alter table testpass_runs
+  add column if not exists pack_name text not null default '';


### PR DESCRIPTION
## Summary

- Replaces the raw YAML editor at `/admin/testpass` with a visual, conversational run management UI
- Adds 3 new pages (Catalog, NewRunWizard, RunDetail) and 4 new API actions
- The YAML editor moves to `/admin/testpass/packs/:id/edit` (accessible via "Edit YAML" on pack cards)
- All agent-related copy is provider-agnostic ("Ask your AI agent", not any specific product name)

## Changes

**New pages:**
- `src/pages/admin/testpass/TestPassCatalog.tsx` -- primary page at `/admin/testpass`. Runs tab (table with status pills, pass/fail counts, clickable rows) + Packs tab (card grid with "Start run" and "Edit YAML" per card)
- `src/pages/admin/testpass/NewRunWizard.tsx` -- 3-step wizard at `/admin/testpass/new` (pick pack, enter target URL, pick depth: Smoke/Standard/Deep)
- `src/pages/admin/testpass/RunDetail.tsx` -- live run view at `/admin/testpass/runs/:id`. Two-column layout: check list (verdict icons) + selected check detail (finding, fix steps with copy-to-clipboard per step). Polls every 3s while status is pending/running. Footer: "Copy fix list", "Ask your AI agent" modal, "Export JSON"
- `src/pages/admin/testpass/testpass-ui.ts` -- shared constants and helpers (STATUS_PILL, VERDICT_ICON, SEVERITY_BADGE, fmtDate, elapsedLabel)

**New API actions (api/memory-admin.ts):**
- `list_testpass_runs` -- recent runs scoped to session user (actor_user_id)
- `list_testpass_packs` -- available packs as cards-ready data (owner + system packs)
- `get_testpass_run` -- run metadata + all items, scoped by actor_user_id
- `start_testpass_run` -- validates user, looks up pack, proxies to /api/testpass engine, returns `{ run_id }`

**Migration:** `20260423200000_testpass_run_ui_fields.sql`
- Adds `fix_recipe jsonb` to `testpass_items` (ordered remediation steps)
- Adds `pack_name text` to `testpass_runs` (denormalized for fast list display)

**Routes updated:** `src/App.tsx`

## Deletions

None. `AdminTestPass.tsx` (YAML editor) is preserved and re-routed to `testpass/packs/:id/edit`.

## Archaeology

None.

## Testing

Click through:
1. `/admin/testpass` -- should show Runs tab (empty state on fresh DB) and Packs tab with pack cards
2. `/admin/testpass/new` -- walk through the 3 steps, observe pre-filled URL placeholder, depth radio cards
3. `/admin/testpass/new?pack_id=<id>` -- should skip to step 2 with pack pre-selected
4. Start a run -- should navigate to `/admin/testpass/runs/:id` and poll for status updates
5. Click a failing check -- right column should show finding + fix steps with copy buttons
6. Footer "Ask your AI agent" button -- opens modal with ready-to-paste prompt (no Bailey mentions, no billing copy)
7. Footer "Export JSON" -- downloads run + items as JSON
8. Click "Edit YAML" on a pack card -- should open the existing YAML editor at the new route

## UnClick Memory linkage

**New routes:**
- `GET /admin/testpass` -- TestPassCatalog (Runs + Packs tabs)
- `GET /admin/testpass/new` -- NewRunWizard
- `GET /admin/testpass/runs/:id` -- RunDetail (with 3s polling)
- `GET /admin/testpass/packs/:id/edit` -- AdminTestPass (YAML editor, moved)

**New API actions:**
- `list_testpass_runs`, `list_testpass_packs`, `get_testpass_run`, `start_testpass_run`

## Known limitation

**Known limitation:** The current LLM agent runner (Chunk 4) uses `ANTHROPIC_API_KEY` server-side. Per the platform philosophy locked 2026-04-23 (see `feedback-platform-philosophy.md` in Bailey's memory), UnClick will not ship API-credit billing to end users. Phase 9C will re-architect LLM-judgment checks to route back to the caller's chat agent via MCP tool calls, so the user's own subscription (Claude Pro, ChatGPT Plus, etc.) covers the LLM work. The server-side `ANTHROPIC_API_KEY` will be retired for user-facing runs once 9C lands. Deterministic checks in this PR are unaffected.

## Follow-ups (not in this PR)

- **Phase 9B:** Report loop (same target + pack reuses the same report across runs, iterative fix tracking)
- **Phase 9C:** Agent bridge polish (`run_testpass` MCP tool, conversational narration, `accept_fix` flow) -- also retires server-side LLM calls for user-facing runs
- Admin dashboard tile showing open report count (9B dependency)
- Per-tool "Last tested" badge on marketplace (9C dependency)

---
DO NOT AUTO-MERGE. Chris reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)