### PR TITLE
fix(auth): robust delete-account cascade with audit log and graceful error handling

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -3430,25 +3430,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       case "delete_account": {
         // Self-serve account deletion. The signed-in user is the ONLY
-        // user that can trigger this - there is no admin-impersonation
-        // path and no body / query param that targets another user.
+        // user that can trigger this - no admin-impersonation path,
+        // no body/query param targeting another user.
         //
         // Order of operations:
-        //
-        //   1. Audit the attempt to backstagepass_audit BEFORE any
-        //      delete fires, so partial failures still leave a record.
-        //   2. Delete rows keyed by api_key_hash across the mc_* /
-        //      keychain tables (no FK to auth.users, so these do NOT
-        //      cascade when the auth row is removed).
-        //   3. Call supabase.auth.admin.deleteUser() which removes the
-        //      auth.users row and cascades to any table with a FK to
-        //      it (profiles, customers, accounts, assets, jobs, etc.
-        //      all use ON DELETE CASCADE per their migrations).
-        //
-        // If step 3 fails the user still has their auth identity but
-        // their api_key_hash data is gone - better than the other way
-        // round. Step 2 failures are swallowed so we always reach step
-        // 3 and at least detach the auth identity.
+        //   1. Resolve user + api_key_hash (idempotency: return 200 if
+        //      already deleted).
+        //   2. Write to account_deletions_audit BEFORE any destructive
+        //      step so partial failures leave a trail.
+        //   3. Delete all api_key_hash-scoped rows in dependency order
+        //      (children before parents). Collect per-table row counts
+        //      and errors rather than silently swallowing.
+        //   4. Call auth.admin.deleteUser() to remove the auth.users row
+        //      and cascade to FK-linked tables (ON DELETE CASCADE).
+        //   5. Clean up the now-orphaned api_keys row (user_id FK is
+        //      ON DELETE SET NULL so it survives step 4).
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
         if (!user) return res.status(401).json({ error: "Unauthorized" });
@@ -3460,8 +3456,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .maybeSingle()).data as { key_hash?: string | null } | null;
         const apiKeyHash = keyRow?.key_hash ?? null;
 
-        // Audit BEFORE any destructive op so even a partial failure
-        // leaves a trail Chris can inspect.
+        // Idempotency: if a previous deletion removed the api_keys link
+        // already, return a benign response without re-attempting.
+        if (!keyRow && !apiKeyHash) {
+          const { error: idempotentAuthErr } = await supabase.auth.admin.deleteUser(user.id);
+          if (idempotentAuthErr && idempotentAuthErr.message?.toLowerCase().includes("not found")) {
+            return res.status(200).json({ success: true, already_deleted: true });
+          }
+        }
+
+        // Pre-deletion audit record (captured before any delete fires).
+        try {
+          await supabase.from("account_deletions_audit").insert({
+            api_key_hash:  apiKeyHash,
+            email:         user.email,
+            reason:        "user_self_delete",
+            tables_affected: [],
+            rows_deleted:  {},
+          });
+        } catch { /* audit failure must not block deletion */ }
+
+        // Also write to backstagepass_audit for backward compatibility.
         try {
           await supabase.from("backstagepass_audit").insert({
             api_key_hash: apiKeyHash,
@@ -3471,56 +3486,98 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             user_agent:   clientUa(req),
             metadata:     { user_id: user.id, email: user.email },
           });
-        } catch {
-          // Do not block the delete if audit write fails.
-        }
+        } catch { /* swallow */ }
 
-        // Delete api_key_hash-scoped rows. These tables do not carry a
-        // FK to auth.users so auth.admin.deleteUser cascade will not
-        // reach them. Swallow individual table errors so one bad drop
-        // does not leave the account half-alive.
-        if (apiKeyHash) {
-          const hashTables = [
-            "mc_business_context",
-            "mc_code_dumps",
-            "mc_conversation_log",
-            "mc_extracted_facts",
-            "mc_knowledge_library",
-            "mc_knowledge_library_history",
-            "mc_session_summaries",
-            "memory_configs",
-            "memory_devices",
-            "tenant_settings",
-            "tool_detections",
-            "tool_usage_events",
-            "user_credentials",
-            "platform_credentials",
-            "agent_trace",
-          ];
-          for (const table of hashTables) {
-            try {
-              await supabase.from(table).delete().eq("api_key_hash", apiKeyHash);
-            } catch { /* per-table swallow */ }
-          }
-          // metering_events uses the column name `key_hash`, not `api_key_hash`.
+        // Per-step tracking. Errors are collected, not thrown, so we
+        // always reach auth.admin.deleteUser regardless of table errors.
+        const rowsDeleted: Record<string, number> = {};
+        const stepErrors: Record<string, string>  = {};
+
+        async function delByHash(table: string, col = "api_key_hash") {
+          if (!apiKeyHash) return;
           try {
-            await supabase.from("metering_events").delete().eq("key_hash", apiKeyHash);
-          } catch { /* swallow */ }
+            const { count, error } = await supabase
+              .from(table)
+              .delete({ count: "exact" })
+              .eq(col, apiKeyHash);
+            rowsDeleted[table] = count ?? 0;
+            if (error) stepErrors[table] = error.message;
+          } catch (e) {
+            stepErrors[table] = String(e);
+            rowsDeleted[table] = 0;
+          }
         }
 
-        // Finally detach the auth identity. Supabase admin API cleans
-        // up auth.identities and any outstanding session tokens.
-        // Cascade FKs handle profiles / accounts / customers / jobs /
-        // etc. Any table added in the future with a user_id FK and
-        // ON DELETE CASCADE gets cleaned automatically.
+        if (apiKeyHash) {
+          // Delete children before parents to respect FK order.
+          // mc_run_messages -> mc_crew_runs -> mc_crews
+          await delByHash("mc_run_messages");
+          await delByHash("mc_crew_runs");
+          await delByHash("mc_crews");
+          // mc_facts_audit cascades from mc_extracted_facts (ON DELETE CASCADE),
+          // but delete explicitly for clear row accounting.
+          await delByHash("mc_facts_audit");
+          await delByHash("mc_extracted_facts");
+          await delByHash("mc_session_summaries");
+          await delByHash("mc_conversation_log");
+          await delByHash("mc_code_dumps");
+          await delByHash("mc_business_context");
+          await delByHash("mc_knowledge_library");
+          await delByHash("mc_knowledge_library_history");
+          await delByHash("mc_canonical_docs");
+          // User-specific agents only (is_system = false). System agents are
+          // shared across tenants and must not be deleted here.
+          try {
+            const { count, error } = await supabase
+              .from("mc_agents")
+              .delete({ count: "exact" })
+              .eq("api_key_hash", apiKeyHash)
+              .eq("is_system", false);
+            rowsDeleted["mc_agents"] = count ?? 0;
+            if (error) stepErrors["mc_agents"] = error.message;
+          } catch (e) {
+            stepErrors["mc_agents"] = String(e);
+            rowsDeleted["mc_agents"] = 0;
+          }
+          // Config / credential layer.
+          await delByHash("memory_configs");
+          await delByHash("memory_devices");
+          await delByHash("tenant_settings");
+          await delByHash("tool_detections");
+          await delByHash("tool_usage_events");
+          await delByHash("user_credentials");
+          await delByHash("platform_credentials");
+          await delByHash("agent_trace");
+          // metering_events uses "key_hash", not "api_key_hash".
+          await delByHash("metering_events", "key_hash");
+        }
+
+        // Remove the auth.users row. auth.admin.deleteUser requires the
+        // service_role key (SUPABASE_SERVICE_ROLE_KEY must be set).
         const { error: authErr } = await supabase.auth.admin.deleteUser(user.id);
         if (authErr) {
           return res.status(500).json({
-            error: `auth.users delete failed: ${authErr.message}. api_key_hash data was already purged.`,
+            error:        `auth.users delete failed: ${authErr.message}`,
+            step:         "auth_user",
+            step_errors:  stepErrors,
+            rows_deleted: rowsDeleted,
           });
         }
 
-        return res.status(200).json({ success: true });
+        // api_keys.user_id has ON DELETE SET NULL so the row survives
+        // auth deletion. Clean it up now that the cascade is done.
+        if (apiKeyHash) {
+          try {
+            await supabase.from("api_keys").delete().eq("key_hash", apiKeyHash);
+          } catch { /* best effort */ }
+        }
+
+        const hasPartialErrors = Object.keys(stepErrors).length > 0;
+        return res.status(200).json({
+          success:      true,
+          rows_deleted: rowsDeleted,
+          ...(hasPartialErrors && { partial: true, step_errors: stepErrors }),
+        });
       }
 
       case "admin_tools": {

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -125,6 +125,13 @@ export default function AdminSettings() {
   const [deleteTyped, setDeleteTyped] = useState("");
   const [deleting, setDeleting]       = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleteResult, setDeleteResult] = useState<{
+    success: boolean;
+    partial?: boolean;
+    step_errors?: Record<string, string>;
+    rows_deleted?: Record<string, number>;
+    step?: string;
+  } | null>(null);
 
   // TOTP MFA state
   const [mfaLoading, setMfaLoading]             = useState(true);
@@ -389,6 +396,7 @@ export default function AdminSettings() {
     if (!session) return;
     setDeleting(true);
     setDeleteError(null);
+    setDeleteResult(null);
     try {
       const res = await fetch("/api/memory-admin?action=delete_account", {
         method:  "POST",
@@ -397,10 +405,20 @@ export default function AdminSettings() {
           Authorization: `Bearer ${session.access_token}`,
         },
       });
+      const body = await res.json().catch(() => ({})) as {
+        success?: boolean;
+        error?: string;
+        step?: string;
+        partial?: boolean;
+        step_errors?: Record<string, string>;
+        rows_deleted?: Record<string, number>;
+        already_deleted?: boolean;
+      };
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error((body as { error?: string }).error ?? `Delete failed with ${res.status}`);
+        setDeleteResult({ success: false, step: body.step, step_errors: body.step_errors, rows_deleted: body.rows_deleted });
+        throw new Error(body.error ?? `Delete failed with ${res.status}`);
       }
+      setDeleteResult({ success: true, partial: body.partial, step_errors: body.step_errors, rows_deleted: body.rows_deleted });
       try { localStorage.removeItem("unclick_api_key"); } catch { /* ignore */ }
       await signOut();
       navigate("/", { replace: true });
@@ -832,30 +850,78 @@ export default function AdminSettings() {
             <p className="mt-3 text-xs text-[#BBB] leading-relaxed">
               This removes your auth identity plus every row keyed to your account: memory (facts,
               sessions, business context, conversation log, knowledge library, code dumps), stored
-              credentials, API keys, devices, and profile data. It is permanent.
+              credentials, API keys, crews, agents, devices, and profile data. It is permanent.
             </p>
-            <p className="mt-3 text-xs text-[#BBB]">
-              To confirm, type your email address:
-            </p>
-            <p className="mt-1 font-mono text-xs text-white">{session?.user?.email ?? ""}</p>
-            <input
-              type="email"
-              value={deleteTyped}
-              onChange={(e) => setDeleteTyped(e.target.value)}
-              placeholder="Type your email here"
-              autoFocus
-              disabled={deleting}
-              className="mt-3 w-full rounded-md border border-white/10 bg-black/50 px-3 py-2 font-mono text-xs text-white placeholder:text-[#555] focus:border-red-500/60 focus:outline-none"
-            />
-            {deleteError && (
-              <p className="mt-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
-                {deleteError}
-              </p>
+
+            {deleting && (
+              <div className="mt-4 space-y-1.5 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-3">
+                {[
+                  { label: "Deleting memory data..." },
+                  { label: "Deleting crews and agents..." },
+                  { label: "Deleting credentials and config..." },
+                  { label: "Removing your account..." },
+                ].map((s, i) => (
+                  <div key={i} className="flex items-center gap-2 text-xs text-white/60">
+                    <Loader2 className="h-3 w-3 animate-spin opacity-60" />
+                    {s.label}
+                  </div>
+                ))}
+              </div>
             )}
+
+            {deleteResult?.partial && deleteResult.step_errors && (
+              <div className="mt-3 rounded-md border border-yellow-500/20 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400">
+                Account deleted but some data cleanup had errors:
+                {Object.entries(deleteResult.step_errors).map(([table, err]) => (
+                  <div key={table} className="mt-1 font-mono text-[10px] text-yellow-300/70">
+                    {table}: {err}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {deleteError && (
+              <div className="mt-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+                <p>{deleteError}</p>
+                {deleteResult?.step && (
+                  <p className="mt-1 font-mono text-[10px] text-red-300/70">
+                    Failed at step: {deleteResult.step}
+                  </p>
+                )}
+                {deleteResult?.step_errors && Object.keys(deleteResult.step_errors).length > 0 && (
+                  <div className="mt-1">
+                    {Object.entries(deleteResult.step_errors).map(([table, err]) => (
+                      <p key={table} className="font-mono text-[10px] text-red-300/70">
+                        {table}: {err}
+                      </p>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {!deleting && (
+              <>
+                <p className="mt-3 text-xs text-[#BBB]">
+                  To confirm, type your email address:
+                </p>
+                <p className="mt-1 font-mono text-xs text-white">{session?.user?.email ?? ""}</p>
+                <input
+                  type="email"
+                  value={deleteTyped}
+                  onChange={(e) => setDeleteTyped(e.target.value)}
+                  placeholder="Type your email here"
+                  autoFocus
+                  disabled={deleting}
+                  className="mt-3 w-full rounded-md border border-white/10 bg-black/50 px-3 py-2 font-mono text-xs text-white placeholder:text-[#555] focus:border-red-500/60 focus:outline-none"
+                />
+              </>
+            )}
+
             <div className="mt-5 flex items-center justify-end gap-2">
               <button
                 type="button"
-                onClick={() => setDeleteOpen(false)}
+                onClick={() => { setDeleteOpen(false); setDeleteResult(null); setDeleteError(null); setDeleteTyped(""); }}
                 disabled={deleting}
                 className="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-xs font-medium text-[#BBB] transition-colors hover:bg-white/[0.06] disabled:opacity-40"
               >

--- a/supabase/migrations/20260423200000_account_deletions_audit.sql
+++ b/supabase/migrations/20260423200000_account_deletions_audit.sql
@@ -1,0 +1,34 @@
+-- Append-only audit table for self-serve account deletions.
+-- Written BEFORE any destructive steps so partial failures leave a trail.
+
+CREATE TABLE IF NOT EXISTS account_deletions_audit (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash      text,
+  email             text,
+  deleted_at        timestamptz NOT NULL DEFAULT now(),
+  reason            text,
+  tables_affected   text[]      NOT NULL DEFAULT '{}',
+  rows_deleted      jsonb       NOT NULL DEFAULT '{}',
+  partial_failure   boolean     NOT NULL DEFAULT false,
+  failure_detail    text
+);
+
+CREATE INDEX IF NOT EXISTS idx_ada_deleted_at ON account_deletions_audit(deleted_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ada_email       ON account_deletions_audit(email);
+
+ALTER TABLE account_deletions_audit ENABLE ROW LEVEL SECURITY;
+
+-- Service role has full access; no direct client access.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'account_deletions_audit'
+      AND policyname = 'account_deletions_audit_service_role'
+  ) THEN
+    CREATE POLICY account_deletions_audit_service_role
+      ON account_deletions_audit
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;


### PR DESCRIPTION
## Changes

Rewrites the `delete_account` handler in `api/memory-admin.ts` to cover the full tenant data surface, add a pre-deletion audit trail, and return structured errors the frontend can render step-by-step.

**Tables the cascade now covers** (in FK-safe order):

| Table | Column | Notes |
|-------|--------|-------|
| `mc_run_messages` | `api_key_hash` | child of mc_crew_runs |
| `mc_crew_runs` | `api_key_hash` | child of mc_crews |
| `mc_crews` | `api_key_hash` | |
| `mc_facts_audit` | `api_key_hash` | also cascades from mc_extracted_facts FK |
| `mc_extracted_facts` | `api_key_hash` | |
| `mc_session_summaries` | `api_key_hash` | |
| `mc_conversation_log` | `api_key_hash` | |
| `mc_code_dumps` | `api_key_hash` | |
| `mc_business_context` | `api_key_hash` | |
| `mc_knowledge_library` | `api_key_hash` | |
| `mc_knowledge_library_history` | `api_key_hash` | |
| `mc_canonical_docs` | `api_key_hash` | |
| `mc_agents` | `api_key_hash` | user agents only (`is_system = false`) |
| `memory_configs` | `api_key_hash` | |
| `memory_devices` | `api_key_hash` | |
| `tenant_settings` | `api_key_hash` | |
| `tool_detections` | `api_key_hash` | |
| `tool_usage_events` | `api_key_hash` | |
| `user_credentials` | `api_key_hash` | |
| `platform_credentials` | `api_key_hash` | |
| `agent_trace` | `api_key_hash` | |
| `metering_events` | `key_hash` | different column name |
| `api_keys` | `key_hash` | cleaned after auth.admin.deleteUser (FK is SET NULL, not CASCADE) |

Tables deleted via auth cascade (ON DELETE CASCADE from auth.users): `customers`, `testpass_packs`, `testpass_runs`, and any other `user_id`-keyed tables.

`install_tickets` stores the raw api_key (not hash) and expires within 24h - not deleted explicitly, expires naturally.

**What got hardened:**

- Structured error payload: failed step name + per-table errors + rows deleted so far
- Idempotency: second call returns `{ success: true, already_deleted: true }` instead of a new 500
- Pre-deletion audit record written to `account_deletions_audit` before any destructive step
- Frontend delete modal shows animated per-step progress while in flight; renders step-level error detail on failure rather than a generic message

**Root cause note on the unapplied migration:**

The `20260422005000_facts_git_linkage.sql` migration (unapplied in prod) adds `commit_sha` and `pr_number` to `mc_extracted_facts`. The `delete_account` handler itself does a simple `.delete().eq("api_key_hash", ...)` that does not reference those columns, so it would not directly 500 from the missing migration. However, `save_fact` (in `packages/mcp-server/src/memory/supabase.ts` lines 380-381) explicitly inserts those columns - that path WILL 500 until the migration is applied. **Apply the migration before merging** (see section below).

---

## WARNING: Migration required before merge

> **Apply `supabase/migrations/20260422005000_facts_git_linkage.sql` against the prod Supabase instance before merging this PR.**
>
> Go to https://supabase.com/dashboard/project/xmooqsylqlknuksiddca/sql/new and paste + run the SQL below. This unblocks `save_fact`, and any other code path inserting into `mc_extracted_facts` with the new columns.

```sql
-- Git-linkage columns for mc_extracted_facts
-- Adds optional commit_sha and pr_number so facts with categories
-- "built", "shipped", or "change" can be traced back to a code change.
-- These are pure audit-metadata columns; they do not touch bi-temporal
-- columns (valid_from, valid_to, system_from, system_to) which are
-- reserved for Chunk 2.

ALTER TABLE mc_extracted_facts
  ADD COLUMN IF NOT EXISTS commit_sha text,
  ADD COLUMN IF NOT EXISTS pr_number  integer;

COMMENT ON COLUMN mc_extracted_facts.commit_sha IS
  'Optional Git commit SHA linking this fact to a code change.';
COMMENT ON COLUMN mc_extracted_facts.pr_number IS
  'Optional PR number linking this fact to a code review.';

-- Index for GIT-LINK-001 audit queries
CREATE INDEX IF NOT EXISTS idx_mc_ef_git_link
  ON mc_extracted_facts(api_key_hash, category)
  WHERE commit_sha IS NOT NULL OR pr_number IS NOT NULL;
```

Also apply the new migration from this PR (`20260423200000_account_deletions_audit.sql`):

```sql
-- Append-only audit table for self-serve account deletions.
-- Written BEFORE any destructive steps so partial failures leave a trail.

CREATE TABLE IF NOT EXISTS account_deletions_audit (
  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
  api_key_hash      text,
  email             text,
  deleted_at        timestamptz NOT NULL DEFAULT now(),
  reason            text,
  tables_affected   text[]      NOT NULL DEFAULT '{}',
  rows_deleted      jsonb       NOT NULL DEFAULT '{}',
  partial_failure   boolean     NOT NULL DEFAULT false,
  failure_detail    text
);

CREATE INDEX IF NOT EXISTS idx_ada_deleted_at ON account_deletions_audit(deleted_at DESC);
CREATE INDEX IF NOT EXISTS idx_ada_email       ON account_deletions_audit(email);

ALTER TABLE account_deletions_audit ENABLE ROW LEVEL SECURITY;

DO $$ BEGIN
  IF NOT EXISTS (
    SELECT 1 FROM pg_policies
    WHERE tablename = 'account_deletions_audit'
      AND policyname = 'account_deletions_audit_service_role'
  ) THEN
    CREATE POLICY account_deletions_audit_service_role
      ON account_deletions_audit
      TO service_role
      USING (true)
      WITH CHECK (true);
  END IF;
END $$;
```

---

## Testing

- **Manual - golden path**: Sign in as a test user. Go to Settings -> Danger Zone. Type email to confirm. Click Delete. Verify all user-scoped tables show zero rows for that `api_key_hash` afterward (check `mc_extracted_facts`, `mc_session_summaries`, `mc_crews`, `mc_agents` where `is_system = false`).
- **Idempotency**: Call the endpoint a second time (re-sign-in if needed, or call directly with the same Bearer token while auth row still exists). Expect `{ success: true, already_deleted: true }` or a clean 200, not a 500.
- **Negative - wrong user**: The endpoint derives the user from the Bearer JWT. There is no `api_key_hash` param in the body - the only user that can be deleted is the one making the request.
- **Structured error surface**: Before running migrations, attempt a delete. The response should be a 500 with `{ error: "auth.users delete failed: ...", step: "auth_user", rows_deleted: {...} }` rather than an unformatted crash. The frontend should render the step name.
- **Frontend progress**: While delete is in flight, the modal should show four animated step rows. On success it navigates away. On error it shows the specific failed step and any per-table errors.

---

## UnClick Memory linkage

Fixes the delete-account 500 blocking `smartsandhurst@gmail.com` deletion. The cascade now covers crews, agents, and all mc_* tables added since the original handler was written.

---

**Do not auto-merge. Chris reviews before merging.**