### PR TITLE
feat(admin): Backend Admin submenu with super-admin gating

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import SignupPage from "./pages/Signup.tsx";
 import AuthCallbackPage from "./pages/AuthCallback.tsx";
 import VerifyMfaPage from "./pages/VerifyMfa.tsx";
 import RequireAuth from "./components/RequireAuth.tsx";
+import RequireAdmin from "./components/RequireAdmin.tsx";
 import BetaBanner from "./components/BetaBanner.tsx";
 import AdminShell from "./pages/admin/AdminShell.tsx";
 import AdminYou from "./pages/admin/AdminYou.tsx";
@@ -61,6 +62,10 @@ import CrewComposer from "./pages/admin/crews/CrewComposer.tsx";
 import CrewsRuns from "./pages/admin/crews/CrewsRuns.tsx";
 import CrewsSettings from "./pages/admin/crews/CrewsSettings.tsx";
 import CrewRun from "./pages/admin/crews/CrewRun.tsx";
+import AdminUsers from "./pages/admin/AdminUsers.tsx";
+import AdminSystemHealth from "./pages/admin/AdminSystemHealth.tsx";
+import AdminModeration from "./pages/admin/AdminModeration.tsx";
+import AdminAuditLog from "./pages/admin/AdminAuditLog.tsx";
 import BuildDeskPage from "./pages/BuildDesk.tsx";
 import { initPostHog } from "./lib/posthog.ts";
 
@@ -126,9 +131,6 @@ const App = () => (
             <Route path="activity" element={<AdminActivity />} />
             <Route path="settings" element={<AdminSettings />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
-            <Route path="analytics"      element={<AdminAnalytics />} />
-            <Route path="codebase"       element={<AdminCodebase />} />
-            <Route path="orchestrator"   element={<AdminOrchestratorPage />} />
             <Route path="testpass"              element={<TestPassCatalog />} />
             <Route path="testpass/new"          element={<NewRunWizard />} />
             <Route path="testpass/runs/:id"     element={<RunDetail />} />
@@ -139,6 +141,14 @@ const App = () => (
             <Route path="crews/runs"          element={<CrewsRuns />} />
             <Route path="crews/runs/:runId"  element={<CrewRun />} />
             <Route path="crews/settings"      element={<CrewsSettings />} />
+            {/* Admin-only surfaces (wrapped in RequireAdmin; also hidden from non-admin sidebar) */}
+            <Route path="analytics"      element={<RequireAdmin><AdminAnalytics /></RequireAdmin>} />
+            <Route path="codebase"       element={<RequireAdmin><AdminCodebase /></RequireAdmin>} />
+            <Route path="orchestrator"   element={<RequireAdmin><AdminOrchestratorPage /></RequireAdmin>} />
+            <Route path="users"          element={<RequireAdmin><AdminUsers /></RequireAdmin>} />
+            <Route path="system-health"  element={<RequireAdmin><AdminSystemHealth /></RequireAdmin>} />
+            <Route path="moderation"     element={<RequireAdmin><AdminModeration /></RequireAdmin>} />
+            <Route path="audit-log"      element={<RequireAdmin><AdminAuditLog /></RequireAdmin>} />
           </Route>
           {/* Phase 2 auth surface */}
           <Route path="/login" element={<LoginPage />} />

--- a/src/components/RequireAdmin.tsx
+++ b/src/components/RequireAdmin.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { useSession } from "@/lib/auth";
+import { Loader2 } from "lucide-react";
+
+export default function RequireAdmin({ children }: { children: React.ReactNode }) {
+  const { session, loading } = useSession();
+  const [status, setStatus] = useState<"checking" | "admin" | "denied">("checking");
+
+  useEffect(() => {
+    const token = session?.access_token;
+    if (!token) return;
+    let cancelled = false;
+    fetch("/api/memory-admin?action=admin_profile", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body) => {
+        if (cancelled) return;
+        setStatus(body && (body as { is_admin?: boolean }).is_admin ? "admin" : "denied");
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("denied");
+      });
+    return () => { cancelled = true; };
+  }, [session?.access_token]);
+
+  if (loading || status === "checking") {
+    return (
+      <div className="flex items-center gap-2 py-12 text-[#666]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span className="text-sm">Verifying access...</span>
+      </div>
+    );
+  }
+
+  if (status === "denied") {
+    return <Navigate to="/admin/you" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/pages/admin/AdminAuditLog.tsx
+++ b/src/pages/admin/AdminAuditLog.tsx
@@ -1,0 +1,22 @@
+import { ScrollText } from "lucide-react";
+
+export default function AdminAuditLog() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center gap-3">
+        <ScrollText className="h-6 w-6 text-[#E2B93B]" />
+        <h1 className="text-2xl font-semibold text-white">Audit Log</h1>
+        <span className="rounded-full border border-[#E2B93B]/40 bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#E2B93B]">
+          Coming soon
+        </span>
+      </div>
+
+      <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+        <p className="text-sm leading-relaxed text-[#ccc]">
+          A record of every admin action taken inside UnClick. Helps answer the question "who
+          changed what and when" and keeps things transparent for GDPR and compliance reviews.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminModeration.tsx
+++ b/src/pages/admin/AdminModeration.tsx
@@ -1,0 +1,22 @@
+import { ShieldCheck } from "lucide-react";
+
+export default function AdminModeration() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center gap-3">
+        <ShieldCheck className="h-6 w-6 text-[#E2B93B]" />
+        <h1 className="text-2xl font-semibold text-white">Marketplace Moderation</h1>
+        <span className="rounded-full border border-[#E2B93B]/40 bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#E2B93B]">
+          Coming soon
+        </span>
+      </div>
+
+      <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+        <p className="text-sm leading-relaxed text-[#ccc]">
+          A review queue for tools submitted by outside developers. Approve what looks good,
+          reject what does not, and keep the marketplace safe for everyone using it.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -37,7 +37,11 @@ import {
   Sparkles,
   BookOpen,
   FlaskConical,
-  Users,
+  ShieldAlert,
+  Users as UsersIcon,
+  HeartPulse,
+  ShieldCheck,
+  ScrollText,
 } from "lucide-react";
 
 function SurfaceLink({ path, label, icon: Icon, onClick }: {
@@ -61,6 +65,61 @@ function SurfaceLink({ path, label, icon: Icon, onClick }: {
       <Icon className="h-4 w-4 shrink-0" />
       <span>{label}</span>
     </NavLink>
+  );
+}
+
+const ADMIN_SUBMENU = [
+  { path: "/admin/analytics",     label: "Analytics",             icon: BarChart3   },
+  { path: "/admin/codebase",      label: "Codebase",              icon: Code2       },
+  { path: "/admin/orchestrator",  label: "Orchestrator",          icon: Terminal    },
+  { path: "/admin/users",         label: "User Management",       icon: UsersIcon   },
+  { path: "/admin/system-health", label: "System Health",         icon: HeartPulse  },
+  { path: "/admin/moderation",    label: "Marketplace Moderation", icon: ShieldCheck },
+  { path: "/admin/audit-log",     label: "Audit Log",             icon: ScrollText  },
+] as const;
+
+function AdminSubmenu({ onLinkClick }: { onLinkClick?: () => void }) {
+  const location = useLocation();
+  const [open, setOpen] = useState(() =>
+    ADMIN_SUBMENU.some((item) => location.pathname.startsWith(item.path)),
+  );
+
+  return (
+    <div className="mt-1 rounded-lg border border-[#E2B93B]/25 bg-[#E2B93B]/[0.04] p-1">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="Internal tools for super-admins. You see this because your email is on the admin list."
+        className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-sm font-semibold text-[#E2B93B] transition-colors hover:bg-[#E2B93B]/10"
+      >
+        <ShieldAlert className="h-4 w-4 shrink-0" />
+        <span className="flex-1 text-left">Admin</span>
+        {open
+          ? <ChevronDown className="h-3 w-3 shrink-0" />
+          : <ChevronRight className="h-3 w-3 shrink-0" />}
+      </button>
+      {open && (
+        <div className="mt-1 flex flex-col gap-0.5 border-l-2 border-[#E2B93B]/40 pl-2">
+          {ADMIN_SUBMENU.map(({ path, label, icon: Icon }) => (
+            <NavLink
+              key={path}
+              to={path}
+              onClick={onLinkClick}
+              className={({ isActive }) =>
+                `flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium transition-colors ${
+                  isActive
+                    ? "bg-[#E2B93B]/15 text-[#E2B93B]"
+                    : "text-[#a68a30] hover:bg-[#E2B93B]/10 hover:text-[#E2B93B]"
+                }`
+              }
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              <span>{label}</span>
+            </NavLink>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -154,13 +213,11 @@ export default function AdminShell() {
         <SurfaceLink path="/admin/keychain" label="Keychain (BackstagePass)" icon={KeyRound} onClick={onLinkClick} />
         <SurfaceLink path="/admin/tools"    label="Tools"                    icon={Wrench}   onClick={onLinkClick} />
         <SurfaceLink path="/admin/activity" label="Activity"                 icon={Activity} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/agents"       label="Agents"        icon={Bot}       onClick={onLinkClick} />
-        <SurfaceLink path="/admin/crews"        label="Crews"         icon={Users}     onClick={onLinkClick} />
-        <SurfaceLink path="/admin/codebase"    label="Codebase"      icon={Code2}     onClick={onLinkClick} />
-        <SurfaceLink path="/admin/orchestrator" label="Orchestrator"  icon={Terminal}  onClick={onLinkClick} />
+        <SurfaceLink path="/admin/agents"       label="Agents"        icon={Bot}          onClick={onLinkClick} />
+        <SurfaceLink path="/admin/crews"        label="Crews"         icon={UsersIcon}    onClick={onLinkClick} />
         <SurfaceLink path="/admin/testpass"     label="TestPass"      icon={FlaskConical} onClick={onLinkClick} />
-        {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}
         <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />
+        {isAdmin && <AdminSubmenu onLinkClick={onLinkClick} />}
       </>
     );
   }

--- a/src/pages/admin/AdminSystemHealth.tsx
+++ b/src/pages/admin/AdminSystemHealth.tsx
@@ -1,0 +1,22 @@
+import { HeartPulse } from "lucide-react";
+
+export default function AdminSystemHealth() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center gap-3">
+        <HeartPulse className="h-6 w-6 text-[#E2B93B]" />
+        <h1 className="text-2xl font-semibold text-white">System Health</h1>
+        <span className="rounded-full border border-[#E2B93B]/40 bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#E2B93B]">
+          Coming soon
+        </span>
+      </div>
+
+      <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+        <p className="text-sm leading-relaxed text-[#ccc]">
+          A single place to see if the site is healthy: recent deploys, database stats, and a
+          live feed of errors so you can catch problems the moment they happen.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -1,0 +1,22 @@
+import { Users } from "lucide-react";
+
+export default function AdminUsers() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center gap-3">
+        <Users className="h-6 w-6 text-[#E2B93B]" />
+        <h1 className="text-2xl font-semibold text-white">User Management</h1>
+        <span className="rounded-full border border-[#E2B93B]/40 bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#E2B93B]">
+          Coming soon
+        </span>
+      </div>
+
+      <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+        <p className="text-sm leading-relaxed text-[#ccc]">
+          See every person who has signed up for UnClick. From here you will be able to step
+          into a user's account to help them, or revoke their keys if something goes wrong.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

### Moved under yellow Admin submenu
- Analytics (was already gated, now visually grouped)
- Codebase
- Orchestrator

### New stub routes under Admin
- /admin/users (User Management)
- /admin/system-health (System Health)
- /admin/moderation (Marketplace Moderation)
- /admin/audit-log (Audit Log)

### Gating pattern
Frontend: entire Admin button + submenu wrapped in {isAdmin && (...)} - non-admins see zero DOM. Routes wrapped in RequireAdmin or component-level redirect.

### Visual
Yellow #E2B93B accent on submenu items. Hover tooltip on Admin button.

### Deferred
Server-side requireAdmin() stubs noted in code for future API endpoints.

> DO NOT AUTO-MERGE. Chris reviews.