### PR TITLE
feat(marketing): Vanta WAVES animated background on homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,8 @@
         "stripe": "^17.7.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.134.0",
+        "vanta": "^0.5.24",
         "vaul": "^0.9.9",
         "zod": "^3.25.76"
       },
@@ -17621,6 +17623,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.134.0.tgz",
+      "integrity": "sha512-LbBerg7GaSPjYtTOnu41AMp7tV6efUNR3p4Wk5NzkSsNTBuA5mDGOfwwZL1jhhVMLx9V20HolIUo0+U3AXehbg==",
+      "license": "MIT"
+    },
     "node_modules/throttleit": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
@@ -18919,6 +18927,12 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/vanta": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/vanta/-/vanta-0.5.24.tgz",
+      "integrity": "sha512-fvieEbHy1ZS23zrcX+topzqAgA4Uct1enngOEWLFBgs9TtOf6RDFOYatH7KSVdrABzQDMCQ5myQy+nTSZZwLzg==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "stripe": "^17.7.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.134.0",
+    "vanta": "^0.5.24",
     "vaul": "^0.9.9",
     "zod": "^3.25.76"
   },

--- a/src/components/VantaWavesBackground.tsx
+++ b/src/components/VantaWavesBackground.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, ReactNode } from 'react';
+
+interface Props {
+  children?: ReactNode;
+}
+
+const STATIC_BG = 'bg-[#0a0a0a]';
+
+export default function VantaWavesBackground({ children }: Props) {
+  const vantaRef = useRef<HTMLDivElement>(null);
+  const vantaEffect = useRef<any>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const lowPower =
+      (navigator.hardwareConcurrency !== undefined && navigator.hardwareConcurrency < 4) ||
+      window.innerWidth < 768;
+
+    if (reducedMotion || lowPower) return;
+
+    let cancelled = false;
+
+    Promise.all([
+      import('three'),
+      import('vanta/dist/vanta.waves.min'),
+    ]).then(([THREE, VANTA_MOD]) => {
+      if (cancelled || !vantaRef.current) return;
+      const VANTA = (VANTA_MOD as any).default ?? VANTA_MOD;
+      // @ts-ignore
+      window.THREE = THREE;
+      vantaEffect.current = VANTA({
+        el: vantaRef.current,
+        mouseControls: true,
+        touchControls: true,
+        gyroControls: false,
+        minHeight: 200.00,
+        minWidth: 200.00,
+        scale: 1.00,
+        scaleMobile: 1.00,
+        color: 0x0a0a0a,
+        shininess: 11.00,
+        waveHeight: 8.00,
+        waveSpeed: 0.65,
+        zoom: 1.37,
+        THREE,
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      if (vantaEffect.current) {
+        vantaEffect.current.destroy();
+        vantaEffect.current = null;
+      }
+    };
+  }, []);
+
+  return (
+    <div ref={vantaRef} className={`relative min-h-screen ${STATIC_BG}`}>
+      <div className="relative z-10">{children}</div>
+    </div>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import FAQ from "@/components/FAQ";
 import Footer from "@/components/Footer";
 import { useCanonical } from "@/hooks/use-canonical";
 import { useMetaTags } from "@/hooks/useMetaTags";
+import VantaWavesBackground from "@/components/VantaWavesBackground";
 
 const Index = () => {
   useCanonical("/");
@@ -21,7 +22,7 @@ const Index = () => {
   });
 
   return (
-    <div className="min-h-screen">
+    <VantaWavesBackground>
       <Navbar />
       <Hero />
       <Problem />
@@ -31,7 +32,7 @@ const Index = () => {
       <FinalCTA />
       <FAQ />
       <Footer />
-    </div>
+    </VantaWavesBackground>
   );
 };
 


### PR DESCRIPTION
## Summary

- Adds Vanta.js WAVES WebGL effect to the marketing homepage only
- New reusable component: `src/components/VantaWavesBackground.tsx`

## Dependencies added

- `three@0.134` (Vanta requires r134 specifically)
- `vanta` (latest)

## Accessibility & performance

- Respects `prefers-reduced-motion`: falls back to static `#0a0a0a` bg
- Mobile/low-power fallback: disables effect when `innerWidth < 768` or `hardwareConcurrency < 4`, renders static dark bg
- WebGL runs only on the marketing homepage; admin/auth pages are unaffected

## Scope

Marketing homepage only. Admin surfaces excluded intentionally -- Vanta is WebGL and not cheap.

## Preview

<!-- Vercel preview URL will appear here once CI runs -->

## Test plan

- [ ] Desktop: waves animate, hero copy readable, color matches brand (#0A0A0A)
- [ ] Mobile: static fallback renders, layout intact
- [ ] Reduced-motion OS setting: static bg, no animation
- [ ] Vercel build: green
- [ ] Admin pages: unaffected

---
**DO NOT auto-merge** -- Chris will review the Vercel preview first.