### PR TITLE
tweak(marketing): reduce Vanta waves zoom and height for full-viewport

### DIFF
--- a/src/components/VantaWavesBackground.tsx
+++ b/src/components/VantaWavesBackground.tsx
@@ -41,9 +41,9 @@ export default function VantaWavesBackground({ children }: Props) {
         scaleMobile: 1.00,
         color: 0x0a0a0a,
         shininess: 11.00,
-        waveHeight: 8.00,
+        waveHeight: 5.00,
         waveSpeed: 0.65,
-        zoom: 1.37,
+        zoom: 0.85,
         THREE,
       });
     });


### PR DESCRIPTION
At full viewport, the previous `zoom: 1.37` and `waveHeight: 8.00` looked too pronounced compared to the vantajs.com demo panel - waves felt aggressive and overpowering. Dialled back to `zoom: 0.85` and `waveHeight: 5.00` for a calmer, more restrained feel. No other config values changed.