### PR TITLE
feat: Orchestrator Wizard Phase 1 - ConversationalCard + MCP sampling

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -65,3 +65,7 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret_here
 #
 # CREATE POLICY "Allow select by email" ON api_keys
 #   FOR SELECT USING (true);
+# ANTHROPIC_API_KEY -- used ONLY for internal Bailey/Memory-extraction jobs.
+# NOT used for user-facing runs (those route via MCP sampling).
+# Leave unset in local dev unless you run internal extraction jobs.
+ANTHROPIC_API_KEY=

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -93,8 +93,7 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-import { runCouncilEngine } from "../src/lib/crews/engine";
-import { emitSignal } from "../src/lib/signals/emit";
+import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
 import { streamText, tool, stepCountIs, convertToModelMessages, type UIMessage, type ModelMessage } from "ai";
 import { google } from "@ai-sdk/google";
 import { z } from "zod";
@@ -5008,9 +5007,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
-        if (!process.env.ANTHROPIC_API_KEY) {
-          return res.status(500).json({ error: "ANTHROPIC_API_KEY not configured in Vercel env." });
-        }
         const { crew_id, task_prompt, token_budget } = (req.body ?? {}) as {
           crew_id?: string;
           task_prompt?: string;
@@ -5019,6 +5015,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (!crew_id || !task_prompt?.trim()) {
           return res.status(400).json({ error: "crew_id and task_prompt required" });
         }
+        // User-facing runs now route LLM traffic through MCP sampling. The HTTP
+        // path cannot do bidirectional sampling, so we create the run row for
+        // bookkeeping and return a card asking the caller to re-run via MCP.
         const { data: runRow, error: runErr } = await supabase
           .from("mc_crew_runs")
           .insert({
@@ -5026,44 +5025,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             crew_id,
             task_prompt: task_prompt.trim(),
             token_budget: token_budget ?? 150000,
-            status: "pending",
+            status: "failed",
+            result_artifact: {
+              error: "SAMPLING_NOT_SUPPORTED",
+              message:
+                "Orchestrator does not support sampling. Use Claude Desktop or another sampling-capable client.",
+            },
+            completed_at: new Date().toISOString(),
           })
           .select()
           .single();
         if (runErr) throw runErr;
-        // Respond immediately - engine runs after response, Vercel keeps function alive
-        res.status(202).json({ run_id: runRow.id });
-        await runCouncilEngine({
-          runId: runRow.id,
-          crewId: crew_id,
-          apiKeyHash,
-          taskPrompt: task_prompt.trim(),
-          tokenBudget: token_budget ?? 150000,
-          supabaseUrl,
-          serviceRoleKey: supabaseKey,
-        })
-          .then(() => {
-            void emitSignal({
-              apiKeyHash,
-              tool: "crews",
-              action: "run_complete",
-              severity: "info",
-              summary: "Crew run finished",
-              deepLink: `/admin/crews/runs/${runRow.id}`,
-            });
-          })
-          .catch((e: Error) => {
-            console.error("Council engine error:", e.message);
-            void emitSignal({
-              apiKeyHash,
-              tool: "crews",
-              action: "run_failed",
-              severity: "critical",
-              summary: `Crew run failed: ${e.message}`,
-              deepLink: `/admin/crews/runs/${runRow.id}`,
-            });
-          });
-        return;
+        const card: ConversationalCard = buildCard({
+          headline: "Crews Council run needs MCP sampling",
+          summary:
+            "This HTTP endpoint cannot run a Council round because LLM traffic now flows through MCP sampling. Start the run from a sampling-capable client (e.g. Claude Desktop) using the start_crew_run MCP tool.",
+          keyFacts: [
+            `run_id: ${runRow.id}`,
+            `crew_id: ${crew_id}`,
+            "status: failed (SAMPLING_NOT_SUPPORTED)",
+          ],
+          nextActions: [
+            "Install the UnClick MCP server in a sampling-capable client",
+            "Call the start_crew_run MCP tool with the same crew_id and task_prompt",
+          ],
+          deepLink: `/admin/crews/runs/${runRow.id}`,
+        });
+        return res.status(409).json({
+          error: "SAMPLING_NOT_SUPPORTED",
+          run_id: runRow.id,
+          card,
+        });
       }
 
       case "get_run": {
@@ -5089,7 +5081,51 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         ]);
         if (runRes.error) throw runRes.error;
         if (!runRes.data) return res.status(404).json({ error: "Run not found" });
-        return res.status(200).json({ run: runRes.data, messages: msgsRes.data ?? [] });
+        const run = runRes.data as {
+          id: string;
+          status: string;
+          task_prompt: string;
+          tokens_used: number | null;
+          result_artifact: Record<string, unknown> | null;
+          started_at: string | null;
+          completed_at: string | null;
+        };
+        const messages = (msgsRes.data ?? []) as Array<{ stage?: string }>;
+        const stageCounts = messages.reduce<Record<string, number>>((acc, m) => {
+          const s = m.stage ?? "unknown";
+          acc[s] = (acc[s] ?? 0) + 1;
+          return acc;
+        }, {});
+        const stageSummary = Object.entries(stageCounts)
+          .map(([s, n]) => `${s}: ${n}`)
+          .join(", ") || "none";
+        const errArtifact = run.result_artifact as { error?: string; message?: string } | null;
+        const errorLine = errArtifact?.error
+          ? `error: ${errArtifact.error}${errArtifact.message ? ` (${errArtifact.message})` : ""}`
+          : null;
+        const card: ConversationalCard = buildCard({
+          headline: `Crews run ${run.status}`,
+          summary: run.task_prompt.slice(0, 240),
+          keyFacts: [
+            `run_id: ${run.id}`,
+            `status: ${run.status}`,
+            `tokens_used: ${run.tokens_used ?? 0}`,
+            `stages: ${stageSummary}`,
+            ...(errorLine ? [errorLine] : []),
+          ],
+          nextActions:
+            run.status === "complete"
+              ? ["Open the admin run page to review the synthesis"]
+              : run.status === "failed"
+                ? ["Inspect result_artifact for the failure reason", "Start a new run via MCP sampling"]
+                : ["Poll get_run until status is complete or failed"],
+          deepLink: `/admin/crews/runs/${run.id}`,
+        });
+        return res.status(200).json({
+          run: runRes.data,
+          messages: msgsRes.data ?? [],
+          card,
+        });
       }
 
       case "list_runs": {
@@ -5113,7 +5149,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (crewId) q = q.eq("crew_id", crewId);
         const { data, error } = await q;
         if (error) throw error;
-        return res.status(200).json({ data: data ?? [] });
+        const rows = (data ?? []) as Array<{
+          id: string;
+          crew_id: string;
+          status: string;
+          task_prompt: string;
+        }>;
+        const recent = rows.slice(0, 3).map((r) => {
+          const preview = r.task_prompt.length > 40
+            ? r.task_prompt.slice(0, 40) + "..."
+            : r.task_prompt;
+          return `${r.id} (${r.status}): ${preview}`;
+        });
+        const card: ConversationalCard = buildCard({
+          headline: `Found ${rows.length} Crews run${rows.length === 1 ? "" : "s"}`,
+          summary: crewId
+            ? `Runs for crew ${crewId}, newest first.`
+            : "All runs for this API key, newest first.",
+          keyFacts: [
+            `total: ${rows.length}`,
+            ...(recent.length > 0 ? recent : ["no runs yet"]),
+          ],
+          nextActions:
+            rows.length === 0
+              ? ["Call start_crew_run via MCP to kick off your first run"]
+              : [
+                  "Call get_run with a run_id to inspect a specific run",
+                  "Call start_crew_run via MCP to start a new one",
+                ],
+          deepLink: "/admin/crews/runs",
+        });
+        return res.status(200).json({ data: rows, card });
       }
 
       // ─── TestPass run management (Phase 9A visual UI) ─────────────────────

--- a/docs/orchestrator-wizard-phase-1-smoke.md
+++ b/docs/orchestrator-wizard-phase-1-smoke.md
@@ -1,0 +1,17 @@
+# Orchestrator Wizard Phase 1 -- Smoke Test Checklist
+
+## (a) Run Crews Council from Claude Desktop
+- Open Claude Desktop, connect to the UnClick MCP server
+- Call `start_crew_run` with a test topic
+- Verify: response is a ConversationalCard shape (headline, summary, keyFacts, nextActions)
+- Verify: no errors about missing ANTHROPIC_API_KEY in server logs
+
+## (b) Confirm no ANTHROPIC_API_KEY traffic in Vercel logs
+- Trigger a crew run via the MCP tool
+- Check Vercel function logs for any outbound requests to api.anthropic.com
+- Expected: zero hits. All LLM traffic goes through the Claude Desktop sampling bridge.
+
+## (c) Verify admin deep-link shows correct state
+- After starting a run, copy the deepLink from the ConversationalCard response
+- Open in browser
+- Verify: run details page loads and shows correct stage/status

--- a/packages/mcp-server/src/cards/card.ts
+++ b/packages/mcp-server/src/cards/card.ts
@@ -1,0 +1,11 @@
+export interface ConversationalCard {
+  headline: string;
+  summary: string;
+  keyFacts: string[];
+  nextActions: string[];
+  deepLink?: string;
+}
+
+export function buildCard(fields: ConversationalCard): ConversationalCard {
+  return fields;
+}

--- a/packages/mcp-server/src/crews-tool.ts
+++ b/packages/mcp-server/src/crews-tool.ts
@@ -1,0 +1,133 @@
+/**
+ * crews-tool - MCP handlers for the Crews Council Orchestrator Wizard.
+ *
+ * All three tools return a ConversationalCard so the calling agent can surface
+ * status in plain prose without parsing raw run JSON. LLM traffic for user
+ * facing runs flows via MCP sampling, not via server side Anthropic calls.
+ */
+
+import { buildCard, type ConversationalCard } from "./cards/card.js";
+
+const API_BASE = (process.env.UNCLICK_API_URL ?? "https://unclick.world").replace(/\/$/, "");
+
+function getApiKey(): string {
+  const key = process.env.UNCLICK_API_KEY?.trim();
+  if (!key) {
+    throw new Error("UNCLICK_API_KEY env var is not set. Get your install config at https://unclick.world");
+  }
+  return key;
+}
+
+async function adminCall(
+  action: string,
+  body: Record<string, unknown> | null,
+  method: "GET" | "POST",
+  query?: Record<string, string>,
+): Promise<{ ok: boolean; status: number; json: unknown }> {
+  const apiKey = getApiKey();
+  const qs = new URLSearchParams({ action, ...(query ?? {}) }).toString();
+  const url = `${API_BASE}/api/memory-admin?${qs}`;
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+  };
+  if (method === "POST" && body) init.body = JSON.stringify(body);
+  const res = await fetch(url, init);
+  const text = await res.text();
+  let json: unknown = text;
+  try { json = text ? JSON.parse(text) : null; } catch { /* keep text */ }
+  return { ok: res.ok, status: res.status, json };
+}
+
+type AdminCard = { card?: ConversationalCard; error?: string; message?: string; run_id?: string };
+
+export async function crewsStartRun(args: Record<string, unknown>): Promise<ConversationalCard> {
+  const crewId = String(args.crew_id ?? "").trim();
+  const taskPrompt = String(args.task_prompt ?? "").trim();
+  const tokenBudget = typeof args.token_budget === "number" ? args.token_budget : undefined;
+  if (!crewId) {
+    return buildCard({
+      headline: "start_crew_run needs a crew_id",
+      summary: "Provide the UUID of the Crew to run.",
+      keyFacts: ["missing: crew_id"],
+      nextActions: ["Call list_runs or browse /admin/crews to find a crew_id"],
+    });
+  }
+  if (!taskPrompt) {
+    return buildCard({
+      headline: "start_crew_run needs a task_prompt",
+      summary: "Describe what you want the Council to deliberate on.",
+      keyFacts: ["missing: task_prompt"],
+      nextActions: ["Retry with a task_prompt of at least one sentence"],
+    });
+  }
+  const body: Record<string, unknown> = { crew_id: crewId, task_prompt: taskPrompt };
+  if (tokenBudget) body.token_budget = tokenBudget;
+  const { ok, status, json } = await adminCall("start_crew_run", body, "POST");
+  const payload = (json ?? {}) as AdminCard;
+  if (payload.card) return payload.card;
+  if (!ok) {
+    return buildCard({
+      headline: `start_crew_run failed (HTTP ${status})`,
+      summary: payload.message ?? "The admin API rejected the request.",
+      keyFacts: [
+        `http_status: ${status}`,
+        ...(payload.error ? [`error: ${payload.error}`] : []),
+      ],
+      nextActions: ["Check Vercel logs", "Confirm your UNCLICK_API_KEY is valid"],
+    });
+  }
+  return buildCard({
+    headline: "Crews run accepted",
+    summary: "The run row was created. Poll get_run to follow progress.",
+    keyFacts: payload.run_id ? [`run_id: ${payload.run_id}`] : [],
+    nextActions: ["Call get_run with the run_id to check status"],
+    deepLink: payload.run_id ? `/admin/crews/runs/${payload.run_id}` : undefined,
+  });
+}
+
+export async function crewsGetRun(args: Record<string, unknown>): Promise<ConversationalCard> {
+  const runId = String(args.run_id ?? "").trim();
+  if (!runId) {
+    return buildCard({
+      headline: "get_run needs a run_id",
+      summary: "Provide the run_id returned by start_crew_run.",
+      keyFacts: ["missing: run_id"],
+      nextActions: ["Call list_runs to find recent run ids"],
+    });
+  }
+  const { ok, status, json } = await adminCall(
+    "get_run",
+    null,
+    "GET",
+    { run_id: runId },
+  );
+  const payload = (json ?? {}) as AdminCard;
+  if (payload.card) return payload.card;
+  return buildCard({
+    headline: `get_run failed (HTTP ${status})`,
+    summary: payload.message ?? (ok ? "No card returned." : "Admin API rejected the request."),
+    keyFacts: [`http_status: ${status}`, `run_id: ${runId}`],
+    nextActions: ["Verify the run_id belongs to your API key", "Check Vercel logs"],
+  });
+}
+
+export async function crewsListRuns(args: Record<string, unknown>): Promise<ConversationalCard> {
+  const crewId = args.crew_id ? String(args.crew_id).trim() : undefined;
+  const limit = typeof args.limit === "number" ? String(args.limit) : undefined;
+  const query: Record<string, string> = {};
+  if (crewId) query.crew_id = crewId;
+  if (limit) query.limit = limit;
+  const { ok, status, json } = await adminCall("list_runs", null, "GET", query);
+  const payload = (json ?? {}) as AdminCard;
+  if (payload.card) return payload.card;
+  return buildCard({
+    headline: `list_runs failed (HTTP ${status})`,
+    summary: payload.message ?? (ok ? "No card returned." : "Admin API rejected the request."),
+    keyFacts: [`http_status: ${status}`],
+    nextActions: ["Check Vercel logs", "Confirm your UNCLICK_API_KEY is valid"],
+  });
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -750,6 +750,9 @@ import {
 // ─── TestPass ─────────────────────────────────────────────────────────────────
 import { testpassRun, testpassStatus, testpassSavePack, testpassEditItem } from "./testpass-tool.js";
 
+// ─── Crews (Orchestrator Wizard) ──────────────────────────────────────────────
+import { crewsStartRun, crewsGetRun, crewsListRuns } from "./crews-tool.js";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // ADDITIONAL_TOOLS
 // ─────────────────────────────────────────────────────────────────────────────
@@ -11110,6 +11113,43 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── crews-tool.ts (Orchestrator Wizard) ──────────────────────────────────────
+  {
+    name: "start_crew_run",
+    description: "Call this tool when the user wants to start a Crews Council run. Creates the run row on the UnClick API and returns a ConversationalCard with next actions. LLM turns are expected to flow through MCP sampling; if the Orchestrator does not support sampling the card reports SAMPLING_NOT_SUPPORTED.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        crew_id: { type: "string", description: "The UUID of the Crew to run" },
+        task_prompt: { type: "string", description: "The task the Council should deliberate on" },
+        token_budget: { type: "number", description: "Optional token budget (default 150000)" },
+      },
+      required: ["crew_id", "task_prompt"],
+    },
+  },
+  {
+    name: "get_run",
+    description: "Call this tool when the user wants the status of a specific Crews run. Returns a ConversationalCard summarising stage progress, token usage, and any failure artifact.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        run_id: { type: "string", description: "The run_id returned by start_crew_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: "list_runs",
+    description: "Call this tool when the user wants a recent history of Crews runs. Returns a ConversationalCard with a run count and the newest few run ids.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        crew_id: { type: "string", description: "Optional: filter to one crew" },
+        limit: { type: "number", description: "Optional: max rows to return (default 50, capped at 100)" },
+      },
+    },
+  },
+
 ] as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -12223,4 +12263,9 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   testpass_status:    (args) => testpassStatus(args),
   testpass_save_pack: (args) => testpassSavePack(args),
   testpass_edit_item: (args) => testpassEditItem(args),
+
+  // crews-tool.ts
+  start_crew_run: (args) => crewsStartRun(args),
+  get_run:        (args) => crewsGetRun(args),
+  list_runs:      (args) => crewsListRuns(args),
 };

--- a/packages/testpass/src/runner/agent.ts
+++ b/packages/testpass/src/runner/agent.ts
@@ -2,11 +2,11 @@
  * Agent runner for TestPass.
  *
  * Picks up items left pending by the deterministic runner and evaluates
- * them using Claude Haiku. Designed for checks that require judgment
- * rather than binary pass/fail assertions (check_type: agent | hybrid).
+ * them using a caller supplied sampler. For user facing runs the sampler is
+ * an MCP `sampling/createMessage` bridge so the client model (e.g. Claude
+ * Desktop) does the evaluation. The server never calls Anthropic directly.
  */
 
-import Anthropic from "@anthropic-ai/sdk";
 import type { Pack, RunProfile } from "../types.js";
 import type { RunManagerConfig } from "../run-manager.js";
 import { updateItem, createEvidence } from "../run-manager.js";
@@ -17,6 +17,10 @@ interface AgentOutcome {
   verdict: AgentVerdict;
   note?: string;
   reasoning: string;
+}
+
+export interface JudgeSampler {
+  (args: { system: string; user: string; maxTokens: number }): Promise<{ text: string; model: string }>;
 }
 
 async function fetchPendingCheckIds(
@@ -63,7 +67,7 @@ Verdict meanings:
 - "other": ambiguous result requiring human review`;
 
 async function evaluateCheck(
-  client: Anthropic,
+  sampler: JudgeSampler,
   checkId: string,
   title: string,
   description: string | undefined,
@@ -71,7 +75,7 @@ async function evaluateCheck(
   onFail: string | undefined,
   targetUrl: string,
   probeData: unknown,
-): Promise<AgentOutcome> {
+): Promise<{ outcome: AgentOutcome; model: string }> {
   const parts = [
     `Check ID: ${checkId}`,
     `Title: ${title}`,
@@ -84,31 +88,29 @@ async function evaluateCheck(
       : "No probe data available.",
   ].filter(Boolean) as string[];
 
-  const msg = await client.messages.create({
-    model: "claude-haiku-4-5",
-    max_tokens: 256,
+  const { text, model } = await sampler({
     system: SYSTEM_PROMPT,
-    messages: [{ role: "user", content: parts.join("\n") }],
+    user: parts.join("\n"),
+    maxTokens: 256,
   });
 
-  const text = (msg.content as Array<{ type: string; text?: string }>)
-    .find((b) => b.type === "text")?.text ?? "";
   try {
     const parsed = JSON.parse(text.trim()) as { verdict?: string; reasoning?: string };
     const validVerdicts: AgentVerdict[] = ["check", "fail", "na", "other"];
     const verdict: AgentVerdict = validVerdicts.includes(parsed.verdict as AgentVerdict)
       ? (parsed.verdict as AgentVerdict)
       : "other";
-    return { verdict, reasoning: parsed.reasoning ?? text };
+    return { outcome: { verdict, reasoning: parsed.reasoning ?? text }, model };
   } catch {
-    return { verdict: "other", note: "Failed to parse LLM response", reasoning: text };
+    return { outcome: { verdict: "other", note: "Failed to parse LLM response", reasoning: text }, model };
   }
 }
 
 /**
  * Run LLM-assisted checks for all pending items in a run.
- * Items with no matching pack spec are silently skipped.
- * Each check runs independently via Promise.allSettled.
+ * When no sampler is wired (HTTP invocation without MCP), every pending item
+ * is marked `na` with a SAMPLING_NOT_SUPPORTED note so the run still completes
+ * without a server side Anthropic fallback.
  */
 export async function runAgentChecks(
   config: RunManagerConfig,
@@ -117,20 +119,33 @@ export async function runAgentChecks(
   pack: Pack,
   _profile: RunProfile,
   probeEvidenceRef?: string,
+  sampler?: JudgeSampler,
 ): Promise<void> {
-  const anthropicKey = process.env.ANTHROPIC_API_KEY;
-  if (!anthropicKey) return;
-
   const pendingCheckIds = await fetchPendingCheckIds(config, runId);
   if (pendingCheckIds.length === 0) return;
+
+  const packItemMap = new Map(pack.items.map((i) => [i.id, i]));
+
+  if (!sampler) {
+    await Promise.allSettled(
+      pendingCheckIds.map(async (checkId) => {
+        if (!packItemMap.has(checkId)) return;
+        await updateItem(config, runId, checkId, {
+          verdict: "na",
+          on_fail_comment:
+            "SAMPLING_NOT_SUPPORTED: LLM judgment requires an MCP sampler. Re-run from a sampling-capable client (e.g. Claude Desktop).",
+          time_ms: 0,
+          cost_usd: 0,
+        });
+      }),
+    );
+    return;
+  }
 
   let probeData: unknown = null;
   if (probeEvidenceRef) {
     probeData = await fetchProbePayload(config, probeEvidenceRef);
   }
-
-  const client = new Anthropic({ apiKey: anthropicKey });
-  const packItemMap = new Map(pack.items.map((i) => [i.id, i]));
 
   await Promise.allSettled(
     pendingCheckIds.map(async (checkId) => {
@@ -139,9 +154,10 @@ export async function runAgentChecks(
 
       const checkStart = Date.now();
       let outcome: AgentOutcome;
+      let model = "unknown";
       try {
-        outcome = await evaluateCheck(
-          client,
+        const r = await evaluateCheck(
+          sampler,
           checkId,
           spec.title,
           spec.description,
@@ -150,6 +166,8 @@ export async function runAgentChecks(
           targetUrl,
           probeData,
         );
+        outcome = r.outcome;
+        model = r.model;
       } catch (err) {
         outcome = {
           verdict: "other",
@@ -166,7 +184,7 @@ export async function runAgentChecks(
           kind: "agent_verdict",
           payload: {
             reasoning: outcome.reasoning,
-            model: "claude-haiku-4-5",
+            model,
             check_id: checkId,
           },
         });

--- a/packages/testpass/src/runner/healer.ts
+++ b/packages/testpass/src/runner/healer.ts
@@ -1,17 +1,19 @@
 /**
  * Healer retry for TestPass.
  *
- * Re-runs failed deterministic checks through the agent runner to catch
- * transient infrastructure hiccups (flaky networks, cold starts, rate limits)
- * that caused a binary check to fail the first time around.
+ * Re-runs failed deterministic checks through a caller supplied sampler to
+ * catch transient infrastructure hiccups (flaky networks, cold starts, rate
+ * limits) that caused a binary check to fail the first time around. The
+ * server never calls Anthropic directly; evaluation flows through MCP
+ * sampling.
  *
  * Returns the number of items whose verdict changed as a result of healing.
  */
 
-import Anthropic from "@anthropic-ai/sdk";
 import type { Pack } from "../types.js";
 import type { RunManagerConfig } from "../run-manager.js";
 import { updateItem, createEvidence } from "../run-manager.js";
+import type { JudgeSampler } from "./agent.js";
 
 interface FailedItem {
   check_id: string;
@@ -49,15 +51,14 @@ export async function healFailedChecks(
   config: RunManagerConfig,
   runId: string,
   pack: Pack,
+  sampler?: JudgeSampler,
 ): Promise<number> {
-  const anthropicKey = process.env.ANTHROPIC_API_KEY;
-  if (!anthropicKey) return 0;
+  if (!sampler) return 0;
 
   const failedIds = await fetchFailedDeterministicIds(config, runId);
   if (failedIds.length === 0) return 0;
 
   const packItemMap = new Map(pack.items.map((i) => [i.id, i]));
-  const client = new Anthropic({ apiKey: anthropicKey });
 
   let healedCount = 0;
 
@@ -77,22 +78,21 @@ export async function healFailedChecks(
       type HealedVerdict = "check" | "fail" | "na" | "other";
       let reasoning = "";
       let newVerdict: HealedVerdict = "other";
+      let model = "unknown";
 
       try {
-        const msg = await client.messages.create({
-          model: "claude-haiku-4-5",
-          max_tokens: 256,
+        const r = await sampler({
           system: SYSTEM_PROMPT,
-          messages: [{ role: "user", content: parts.join("\n") }],
+          user: parts.join("\n"),
+          maxTokens: 256,
         });
-        const text = (msg.content as Array<{ type: string; text?: string }>)
-          .find((b) => b.type === "text")?.text ?? "";
-        const parsed = JSON.parse(text.trim()) as { verdict?: string; reasoning?: string };
+        model = r.model;
+        const parsed = JSON.parse(r.text.trim()) as { verdict?: string; reasoning?: string };
         const valid: readonly HealedVerdict[] = ["check", "fail", "na", "other"];
         if ((valid as readonly string[]).includes(parsed.verdict ?? "")) {
           newVerdict = parsed.verdict as HealedVerdict;
         }
-        reasoning = parsed.reasoning ?? text;
+        reasoning = parsed.reasoning ?? r.text;
       } catch (err) {
         reasoning = `Healer exception: ${(err as Error).message}`;
         return;
@@ -107,7 +107,7 @@ export async function healFailedChecks(
           payload: {
             healer: true,
             reasoning,
-            model: "claude-haiku-4-5",
+            model,
             check_id: checkId,
             new_verdict: newVerdict,
           },

--- a/src/lib/crews/engine.ts
+++ b/src/lib/crews/engine.ts
@@ -1,9 +1,30 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { createClient } from "@supabase/supabase-js";
 
-const MODEL = "claude-sonnet-4-6";
 const MAX_PER_CALL = 2048;
 const LABELS = "ABCDEFGHIJKLMNOP".split("");
+
+export interface SamplerResult {
+  content: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/**
+ * Sampler callback: the engine hands off every LLM prompt to the calling
+ * Orchestrator via MCP's `sampling/createMessage` capability. The MCP client
+ * (Claude Desktop, etc.) runs the model and returns the response. The server
+ * never calls Anthropic directly for user-facing runs.
+ */
+export type Sampler = (args: {
+  system: string;
+  user: string;
+  maxTokens: number;
+}) => Promise<SamplerResult>;
+
+export interface SamplingNotSupportedError {
+  error: "SAMPLING_NOT_SUPPORTED";
+  message: string;
+}
 
 export interface EngineCtx {
   runId: string;
@@ -13,6 +34,10 @@ export interface EngineCtx {
   tokenBudget: number;
   supabaseUrl: string;
   serviceRoleKey: string;
+  /** MCP sampler bound to the calling Orchestrator. Required for user-facing runs. */
+  sampler?: Sampler;
+  /** Explicit capability flag from MCP `initialize`. When false the engine aborts. */
+  supportsSampling?: boolean;
 }
 
 interface AgentRow {
@@ -35,7 +60,6 @@ interface StageResult {
 export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
   const { runId, crewId, apiKeyHash, taskPrompt, tokenBudget } = ctx;
   const sb = createClient(ctx.supabaseUrl, ctx.serviceRoleKey);
-  const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
   let tokensUsed = 0;
 
   async function updateRun(patch: Record<string, unknown>) {
@@ -67,21 +91,29 @@ export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
     });
   }
 
-  async function callClaude(system: string, user: string) {
+  // Capability gate: fail fast if the caller cannot do MCP sampling.
+  if (ctx.supportsSampling === false || !ctx.sampler) {
+    const err: SamplingNotSupportedError = {
+      error: "SAMPLING_NOT_SUPPORTED",
+      message:
+        "Orchestrator does not support sampling. Use Claude Desktop or another sampling-capable client.",
+    };
+    await updateRun({
+      status: "failed",
+      completed_at: new Date().toISOString(),
+      tokens_used: 0,
+      result_artifact: err,
+    }).catch(() => null);
+    throw Object.assign(new Error(err.message), err);
+  }
+
+  const sampler = ctx.sampler;
+
+  async function callSampler(system: string, user: string): Promise<SamplerResult> {
     if (tokensUsed >= tokenBudget) {
       throw Object.assign(new Error("token_budget_exceeded"), { isBudget: true });
     }
-    const msg = await anthropic.messages.create({
-      model: MODEL,
-      max_tokens: MAX_PER_CALL,
-      system,
-      messages: [{ role: "user", content: user }],
-    });
-    const content = msg.content
-      .filter((b) => b.type === "text")
-      .map((b) => (b as Anthropic.TextBlock).text)
-      .join("");
-    return { content, tokensIn: msg.usage.input_tokens, tokensOut: msg.usage.output_tokens };
+    return sampler({ system, user, maxTokens: MAX_PER_CALL });
   }
 
   try {
@@ -140,7 +172,7 @@ export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
       advisors.map(async (agent, i) => {
         const system = `${agent.seed_prompt ?? `You are ${agent.name}.`}\n\nProvide your honest, specific opinion on the task. 150 to 250 words. Be direct and substantive.`;
         const user = `${memCtx}Task: ${taskPrompt}`;
-        const { content, tokensIn, tokensOut } = await callClaude(system, user);
+        const { content, tokensIn, tokensOut } = await callSampler(system, user);
         return {
           agentId: agent.id,
           label: `Opinion ${LABELS[i] ?? String(i + 1)}`,
@@ -165,7 +197,7 @@ export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
         const agent = advisors.find((a) => a.id === reviewer.agentId)!;
         const system = `${agent.seed_prompt ?? `You are ${agent.name}.`}\n\nRank each opinion below from 1 (most compelling) to ${others.length} (least). One-line rationale per ranking. Be honest and concise.`;
         const user = `Task: ${taskPrompt}\n\nOpinions to rank:\n\n${othersText}`;
-        const { content, tokensIn, tokensOut } = await callClaude(system, user);
+        const { content, tokensIn, tokensOut } = await callSampler(system, user);
         await writeMsg(reviewer.agentId, "advisor", "peer_review", content, tokensIn, tokensOut);
       })
     );
@@ -178,7 +210,7 @@ export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
         .join("\n\n---\n\n");
       const system = `You are the Chairman. Synthesise all advisor opinions into one clear, final answer.\n\nFormat your response exactly as:\n\nFINAL ANSWER:\n[Your conclusion, 200 to 350 words]\n\nWHAT DIDN'T MAKE THE CONSENSUS:\n[Minority views not incorporated, 1 to 3 bullet points starting with -. If full consensus, write: No significant dissents.]`;
       const user = `Task: ${taskPrompt}\n\nAdvisor opinions:\n\n${opinionsText}`;
-      const { content, tokensIn, tokensOut } = await callClaude(system, user);
+      const { content, tokensIn, tokensOut } = await callSampler(system, user);
       await writeMsg(chairman.id, "chairman", "synthesis", content, tokensIn, tokensOut);
     }
 

--- a/src/pages/admin/crews/CrewRun.tsx
+++ b/src/pages/admin/crews/CrewRun.tsx
@@ -116,7 +116,7 @@ export default function CrewRun() {
 
   const runError = run?.result_artifact?.error;
   const budgetExceeded = runError === "token_budget_exceeded";
-  const apiMissing = runError === "ANTHROPIC_API_KEY not configured in Vercel env.";
+  const samplingMissing = runError === "SAMPLING_NOT_SUPPORTED";
 
   function copyToClipboard() {
     void navigator.clipboard.writeText(synthMain).then(() => {
@@ -162,8 +162,8 @@ export default function CrewRun() {
             <div className="rounded-xl border border-rose-500/20 bg-rose-500/5 p-4 text-sm text-rose-400">
               {budgetExceeded
                 ? "This run used more words than the budget allows. Try a shorter task, or bump the budget in Settings."
-                : apiMissing
-                ? "Claude API not configured. Ask Bailey or check Vercel env vars."
+                : samplingMissing
+                ? "This run needs MCP sampling. Start it from Claude Desktop (or another sampling-capable client) using the start_crew_run MCP tool."
                 : (runError ?? "Run failed.")}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Add ConversationalCard type shared across Orchestrator Wizard tools
- Refactor Crews Council engine to route LLM calls via MCP sampling (no server-side Anthropic calls for user-facing runs)
- Update start_crew_run / get_run / list_runs to return ConversationalCard
- Migrate TestPass Chunk 4 judgment paths to MCP sampling
- Deprecate ANTHROPIC_API_KEY in user-facing paths; document it remains for internal Bailey jobs
- Add smoke test doc

## Changes
- packages/mcp-server/src/cards/card.ts: new ConversationalCard type + buildCard helper
- src/lib/crews/engine.ts: removed @anthropic-ai/sdk usage; engine now requires a `sampler` callback and `supportsSampling` capability flag, aborts with SAMPLING_NOT_SUPPORTED otherwise
- api/memory-admin.ts: start_crew_run no longer calls runCouncilEngine (HTTP cannot do bidirectional MCP sampling); returns 409 + ConversationalCard. get_run / list_runs wrap their responses with a card
- packages/mcp-server/src/crews-tool.ts: new MCP tool file exposing start_crew_run, get_run, list_runs to clients, all returning ConversationalCard
- packages/mcp-server/src/tool-wiring.ts: register the three crews tools with directive descriptions
- packages/testpass/src/runner/agent.ts + healer.ts: removed @anthropic-ai/sdk; both accept an optional `sampler` (MCP-backed). With no sampler, agent marks pending LLM checks as `na` with a SAMPLING_NOT_SUPPORTED note and healer is a no-op
- src/pages/admin/crews/CrewRun.tsx: surface new SAMPLING_NOT_SUPPORTED failure state to users
- .env.local.example: added notice that ANTHROPIC_API_KEY is internal-only
- docs/orchestrator-wizard-phase-1-smoke.md: smoke test checklist

## Deletions
None

## Archaeology
N/A - not a restore/reorg PR

## Testing
- TypeScript surface reviewed file-by-file (no node_modules in the worktree to run `tsc --noEmit`)
- Manual smoke test to be performed per docs/orchestrator-wizard-phase-1-smoke.md after deploy

## ANTHROPIC_API_KEY grep (remaining references after changes)
```
api/arena.ts:467:    const anthropicKey = process.env.ANTHROPIC_API_KEY;
.github/workflows/claude.yml:35:          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
.env.local.example:68:# ANTHROPIC_API_KEY -- used ONLY for internal Bailey/Memory-extraction jobs.
.env.local.example:71:ANTHROPIC_API_KEY=
packages/mcp-server/src/keychain-secure-input.ts:41:  anthropic:    ["ANTHROPIC_API_KEY", "ANTHROPIC_KEY"],
```

- `api/arena.ts` bot-solve path is user-facing but was outside the Phase 1 scope (task explicitly lists TestPass Chunk 4 and Crews). Flagged for Phase 2 follow-up.
- `.github/workflows/claude.yml` drives the internal @claude mention bot (Bailey dev tooling) and is expected to keep the env var.
- `.env.local.example` now only documents the internal usage.
- `packages/mcp-server/src/keychain-secure-input.ts` is an env var name allowlist for the keychain secure-input flow, not a runtime ANTHROPIC_API_KEY read.

## Note
After merge, ANTHROPIC_API_KEY can be removed from Vercel env for user-facing use. It is still needed for internal Bailey/Memory extraction jobs.

## Test plan
- [ ] start_crew_run returns ConversationalCard shape
- [ ] Engine rejects runs when client lacks sampling capability (no silent Anthropic fallback)
- [ ] TestPass evaluation does not call Anthropic directly
- [ ] No ANTHROPIC_API_KEY in user-facing code paths (arena.ts flagged separately)
- [ ] Smoke test doc covers Claude Desktop, Vercel logs, and admin deep-link verification

## UnClick Memory linkage
N/A