### PR TITLE
feat(signals): Phase 2 - Telegram, browser push, webhook, batching, quiet hours, per-event routing

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5315,10 +5315,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           "phone_push_enabled",
           "telegram_enabled",
           "telegram_chat_id",
+          "browser_push_enabled",
+          "push_subscription",
+          "webhook_url",
+          "webhook_secret",
           "quiet_hours_start",
           "quiet_hours_end",
           "min_severity",
           "per_tool_overrides",
+          "routing_rules",
         ];
         const patch: Record<string, unknown> = {
           api_key_hash: apiKeyHash,

--- a/api/signals-dispatch.ts
+++ b/api/signals-dispatch.ts
@@ -1,5 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
+import crypto from "crypto";
+import webpush from "web-push";
 
 interface SignalRow {
   id: string;
@@ -11,6 +13,12 @@ interface SignalRow {
   deep_link: string | null;
   payload: Record<string, unknown> | null;
   created_at: string;
+  held_until: string | null;
+}
+
+interface PushSubscription {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
 }
 
 interface PreferencesRow {
@@ -20,10 +28,21 @@ interface PreferencesRow {
   phone_push_enabled: boolean;
   telegram_enabled: boolean;
   telegram_chat_id: string | null;
+  browser_push_enabled: boolean;
+  push_subscription: PushSubscription | null;
+  webhook_url: string | null;
+  webhook_secret: string | null;
   quiet_hours_start: string | null;
   quiet_hours_end: string | null;
   min_severity: "info" | "action_needed" | "critical";
   per_tool_overrides: Record<string, unknown> | null;
+  routing_rules: Record<string, string[]> | null;
+}
+
+interface BatchGroup {
+  signals: SignalRow[];
+  representative: SignalRow;
+  count: number;
 }
 
 const SEVERITY_RANK: Record<"info" | "action_needed" | "critical", number> = {
@@ -32,23 +51,72 @@ const SEVERITY_RANK: Record<"info" | "action_needed" | "critical", number> = {
   critical: 2,
 };
 
-async function sendEmail(params: {
-  to: string;
-  subject: string;
-  text: string;
-}): Promise<boolean> {
-  const apiKey = process.env.RESEND_API_KEY;
-  if (!apiKey) {
-    console.warn("[signals-dispatch] RESEND_API_KEY not set, skipping email");
-    return false;
+function isInQuietHours(start: string | null, end: string | null): boolean {
+  if (!start || !end) return false;
+  const [sh, sm] = start.split(":").map(Number);
+  const [eh, em] = end.split(":").map(Number);
+  const now = new Date();
+  const nowMin = now.getUTCHours() * 60 + now.getUTCMinutes();
+  const startMin = sh * 60 + sm;
+  const endMin = eh * 60 + em;
+  if (startMin <= endMin) return nowMin >= startMin && nowMin < endMin;
+  return nowMin >= startMin || nowMin < endMin;
+}
+
+function quietHoursEndAt(end: string): string {
+  const [eh, em] = end.split(":").map(Number);
+  const d = new Date();
+  d.setUTCHours(eh, em, 0, 0);
+  if (d.getTime() <= Date.now()) d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString();
+}
+
+function resolveChannels(prefs: PreferencesRow, tool: string, action: string): string[] {
+  const rule = prefs.routing_rules?.[`${tool}:${action}`];
+  if (rule) return rule;
+  const all: string[] = [];
+  if (prefs.email_enabled && prefs.email_address) all.push("email");
+  if (prefs.telegram_enabled && prefs.telegram_chat_id) all.push("telegram");
+  if (prefs.browser_push_enabled && prefs.push_subscription) all.push("browser_push");
+  if (prefs.webhook_url) all.push("webhook");
+  return all;
+}
+
+function buildBatchGroups(signals: SignalRow[]): BatchGroup[] {
+  const byKey = new Map<string, SignalRow[]>();
+  for (const s of signals) {
+    const key = `${s.api_key_hash}:${s.tool}:${s.action}`;
+    const arr = byKey.get(key) ?? [];
+    arr.push(s);
+    byKey.set(key, arr);
   }
+  const groups: BatchGroup[] = [];
+  for (const sigs of byKey.values()) {
+    sigs.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    const first = new Date(sigs[0].created_at).getTime();
+    const last = new Date(sigs[sigs.length - 1].created_at).getTime();
+    if (last - first <= 60_000) {
+      groups.push({ signals: sigs, representative: sigs[sigs.length - 1], count: sigs.length });
+    } else {
+      for (const s of sigs) groups.push({ signals: [s], representative: s, count: 1 });
+    }
+  }
+  return groups;
+}
+
+function formatBatchSummary(group: BatchGroup): string {
+  const { representative: r, count } = group;
+  if (count === 1) return r.summary;
+  return `${r.tool} ran ${count} times. Latest: ${r.summary}`;
+}
+
+async function sendEmail(params: { to: string; subject: string; text: string }): Promise<boolean> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return false;
   try {
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
       body: JSON.stringify({
         from: "UnClick Signals <signals@unclick.world>",
         to: [params.to],
@@ -57,13 +125,77 @@ async function sendEmail(params: {
       }),
     });
     if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      console.error("[signals-dispatch] Resend error:", res.status, body);
+      console.error("[signals-dispatch] Resend error:", res.status, await res.text().catch(() => ""));
       return false;
     }
     return true;
   } catch (err) {
-    console.error("[signals-dispatch] network error:", err);
+    console.error("[signals-dispatch] email error:", err);
+    return false;
+  }
+}
+
+async function sendTelegram(chatId: string, text: string): Promise<boolean> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.warn("[signals-dispatch] TELEGRAM_BOT_TOKEN not set");
+    return false;
+  }
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text, parse_mode: "Markdown" }),
+    });
+    if (!res.ok) {
+      console.error("[signals-dispatch] Telegram error:", res.status, await res.text().catch(() => ""));
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("[signals-dispatch] Telegram network error:", err);
+    return false;
+  }
+}
+
+async function sendWebhook(
+  url: string,
+  secret: string | null,
+  payload: Record<string, unknown>
+): Promise<boolean> {
+  const body = JSON.stringify(payload);
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (secret) {
+    const sig = crypto.createHmac("sha256", secret).update(body).digest("hex");
+    headers["X-UnClick-Signature"] = `sha256=${sig}`;
+  }
+  try {
+    const res = await fetch(url, { method: "POST", headers, body });
+    if (!res.ok) {
+      console.error("[signals-dispatch] webhook error:", res.status, url);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("[signals-dispatch] webhook network error:", err);
+    return false;
+  }
+}
+
+async function sendBrowserPush(sub: PushSubscription, title: string, body: string, url: string): Promise<boolean> {
+  const vapidPublic = process.env.VAPID_PUBLIC_KEY;
+  const vapidPrivate = process.env.VAPID_PRIVATE_KEY;
+  const vapidSubject = process.env.VAPID_SUBJECT ?? "mailto:signals@unclick.world";
+  if (!vapidPublic || !vapidPrivate) {
+    console.warn("[signals-dispatch] VAPID keys not set");
+    return false;
+  }
+  webpush.setVapidDetails(vapidSubject, vapidPublic, vapidPrivate);
+  try {
+    await webpush.sendNotification(sub, JSON.stringify({ title, body, url }));
+    return true;
+  } catch (err) {
+    console.error("[signals-dispatch] browser push error:", err);
     return false;
   }
 }
@@ -83,12 +215,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const supabase = createClient(supabaseUrl, supabaseKey);
 
+  const now = new Date().toISOString();
   const cutoff = new Date(Date.now() - 35_000).toISOString();
   const { data: signals, error } = await supabase
     .from("mc_signals")
-    .select("id, api_key_hash, tool, action, severity, summary, deep_link, payload, created_at")
+    .select("id, api_key_hash, tool, action, severity, summary, deep_link, payload, created_at, held_until")
     .is("read_at", null)
     .lt("created_at", cutoff)
+    .or(`held_until.is.null,held_until.lte.${now}`)
     .order("created_at", { ascending: true })
     .limit(200);
 
@@ -99,13 +233,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const rows = (signals ?? []) as SignalRow[];
   const pending = rows.filter((s) => {
-    const dispatched = (s.payload ?? {}) as Record<string, unknown>;
-    return !dispatched.dispatched_at;
+    const p = (s.payload ?? {}) as Record<string, unknown>;
+    return !p.dispatched_at;
   });
 
-  if (pending.length === 0) {
-    return res.status(200).json({ dispatched: 0, skipped: 0 });
-  }
+  if (pending.length === 0) return res.status(200).json({ dispatched: 0, skipped: 0 });
 
   const apiKeyHashes = Array.from(new Set(pending.map((s) => s.api_key_hash)));
   const { data: prefsRows } = await supabase
@@ -121,66 +253,113 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let dispatched = 0;
   let skipped = 0;
 
+  // Filter by min_severity first, then check quiet hours per user
+  const toDispatch: SignalRow[] = [];
   for (const signal of pending) {
     const prefs = prefsByHash.get(signal.api_key_hash);
-    if (!prefs) {
-      skipped++;
-      continue;
-    }
+    if (!prefs) { skipped++; continue; }
 
     const minRank = SEVERITY_RANK[prefs.min_severity ?? "info"];
-    const sigRank = SEVERITY_RANK[signal.severity] ?? 0;
-    if (sigRank < minRank) {
+    if ((SEVERITY_RANK[signal.severity] ?? 0) < minRank) { skipped++; continue; }
+
+    if (isInQuietHours(prefs.quiet_hours_start, prefs.quiet_hours_end)) {
+      const heldUntil = quietHoursEndAt(prefs.quiet_hours_end!);
+      await supabase.from("mc_signals").update({ held_until: heldUntil }).eq("id", signal.id);
       skipped++;
       continue;
     }
 
-    let sent = false;
+    toDispatch.push(signal);
+  }
 
-    if (prefs.email_enabled && prefs.email_address) {
-      const subjectPrefix = signal.severity === "critical" ? "Action needed" : "Update";
-      const subject = `[UnClick] ${subjectPrefix}: ${signal.summary}`;
-      const textBody = [
-        signal.summary,
+  // Build batch groups per user
+  const groups = buildBatchGroups(toDispatch);
+
+  for (const group of groups) {
+    const prefs = prefsByHash.get(group.representative.api_key_hash)!;
+    const r = group.representative;
+    const summary = formatBatchSummary(group);
+    const channels = resolveChannels(prefs, r.tool, r.action);
+
+    if (channels.includes("in_admin") || channels.length === 0) {
+      // Visible in admin UI already; no external notification needed
+      for (const s of group.signals) {
+        await supabase.from("mc_signals").update({
+          payload: { ...(s.payload ?? {}), dispatched_at: new Date().toISOString(), dispatched_channels: ["in_admin"] },
+        }).eq("id", s.id);
+      }
+      skipped += group.count;
+      continue;
+    }
+
+    const sent: string[] = [];
+
+    if (channels.includes("email") && prefs.email_address) {
+      const prefix = r.severity === "critical" ? "Action needed" : "Update";
+      const subject = `[UnClick] ${prefix}: ${summary}`;
+      const lines = [
+        summary,
         "",
-        `Tool: ${signal.tool}`,
-        `Action: ${signal.action}`,
-        `Severity: ${signal.severity}`,
-        `When: ${signal.created_at}`,
-        signal.deep_link ? `Open: https://unclick.world${signal.deep_link}` : "",
+        `Tool: ${r.tool}`,
+        `Action: ${r.action}`,
+        `Severity: ${r.severity}`,
+        `When: ${r.created_at}`,
+        group.count > 1 ? `Batched: ${group.count} events` : "",
+        r.deep_link ? `Open: https://unclick.world${r.deep_link}` : "",
         "",
-        "Manage signal preferences: https://unclick.world/admin/signals/settings",
+        "Manage preferences: https://unclick.world/admin/signals/settings",
       ].filter(Boolean).join("\n");
-      const ok = await sendEmail({
-        to: prefs.email_address,
-        subject,
-        text: textBody,
-      });
-      sent = sent || ok;
+      if (await sendEmail({ to: prefs.email_address, subject, text: lines })) sent.push("email");
     }
 
-    if (prefs.phone_push_enabled) {
-      console.log("[signals-dispatch] cowork push pending integration");
+    if (channels.includes("telegram") && prefs.telegram_chat_id) {
+      const icon = r.severity === "critical" ? "red_circle" : r.severity === "action_needed" ? "large_yellow_circle" : "large_blue_circle";
+      const msg = [
+        `:${icon}: *${r.tool}* (${r.action})`,
+        "",
+        summary,
+        group.count > 1 ? `_${group.count} events batched_` : "",
+        r.deep_link ? `[Open in UnClick](https://unclick.world${r.deep_link})` : "",
+      ].filter(Boolean).join("\n");
+      if (await sendTelegram(prefs.telegram_chat_id, msg)) sent.push("telegram");
     }
 
-    if (prefs.telegram_enabled) {
-      console.log("[signals-dispatch] telegram pending Phase 2");
+    if (channels.includes("browser_push") && prefs.push_subscription) {
+      const pushUrl = r.deep_link ? `https://unclick.world${r.deep_link}` : "https://unclick.world/admin/signals";
+      if (await sendBrowserPush(prefs.push_subscription, `UnClick: ${r.tool}`, summary, pushUrl)) {
+        sent.push("browser_push");
+      }
     }
 
-    const newPayload = {
-      ...(signal.payload ?? {}),
-      dispatched_at: new Date().toISOString(),
-      dispatched_channels: [
-        sent ? "email" : null,
-      ].filter(Boolean),
-    };
-    await supabase
-      .from("mc_signals")
-      .update({ payload: newPayload })
-      .eq("id", signal.id);
+    if (channels.includes("webhook") && prefs.webhook_url) {
+      const webhookPayload = {
+        tool: r.tool,
+        action: r.action,
+        severity: r.severity,
+        summary,
+        deep_link: r.deep_link,
+        created_at: r.created_at,
+        batched_count: group.count,
+        signal_ids: group.signals.map((s) => s.id),
+      };
+      if (await sendWebhook(prefs.webhook_url, prefs.webhook_secret ?? null, webhookPayload)) {
+        sent.push("webhook");
+      }
+    }
 
-    if (sent) dispatched++;
-    else skipped++;
+    const didSend = sent.length > 0;
+    for (const s of group.signals) {
+      await supabase.from("mc_signals").update({
+        payload: {
+          ...(s.payload ?? {}),
+          dispatched_at: new Date().toISOString(),
+          dispatched_channels: sent,
+        },
+      }).eq("id", s.id);
+    }
+
+    if (didSend) dispatched += group.count;
+    else skipped += group.count;
   }
 
   return res.status(200).json({ dispatched, skipped });

--- a/api/signals-test-webhook.ts
+++ b/api/signals-test-webhook.ts
@@ -1,0 +1,58 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+import crypto from "crypto";
+
+async function resolveApiKeyHash(req: VercelRequest, supabaseUrl: string, supabaseKey: string): Promise<string | null> {
+  const token = (req.headers.authorization ?? "").replace(/^Bearer\s+/i, "");
+  if (!token) return null;
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data } = await supabase.auth.getUser(token);
+  if (!data.user) return null;
+  const userId = data.user.id;
+  const hash = crypto.createHash("sha256").update(userId).digest("hex");
+  return hash;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) return res.status(500).json({ error: "Database service unavailable" });
+
+  const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+  if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data: prefs } = await supabase
+    .from("mc_signal_preferences")
+    .select("webhook_url, webhook_secret")
+    .eq("api_key_hash", apiKeyHash)
+    .maybeSingle();
+
+  if (!prefs?.webhook_url) return res.status(400).json({ error: "No webhook URL configured" });
+
+  const payload = {
+    tool: "UnClick",
+    action: "test",
+    severity: "info",
+    summary: "This is a test signal from UnClick.",
+    deep_link: "/admin/signals",
+    created_at: new Date().toISOString(),
+    batched_count: 1,
+    signal_ids: ["test"],
+  };
+  const body = JSON.stringify(payload);
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (prefs.webhook_secret) {
+    const sig = crypto.createHmac("sha256", prefs.webhook_secret).update(body).digest("hex");
+    headers["X-UnClick-Signature"] = `sha256=${sig}`;
+  }
+
+  try {
+    const r = await fetch(prefs.webhook_url, { method: "POST", headers, body });
+    return res.status(200).json({ ok: r.ok, status: r.status });
+  } catch (err) {
+    return res.status(502).json({ error: String(err) });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "three": "^0.134.0",
         "vanta": "^0.5.24",
         "vaul": "^0.9.9",
+        "web-push": "^3.6.7",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -93,6 +94,7 @@
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
+        "@types/web-push": "^3.6.4",
         "@vercel/node": "^3.2.29",
         "@vitejs/plugin-react-swc": "^3.11.0",
         "autoprefixer": "^10.4.21",
@@ -6971,6 +6973,16 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -8069,6 +8081,18 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -8304,6 +8328,12 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -8422,6 +8452,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -9959,6 +9995,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/edge-runtime": {
       "version": "2.5.9",
@@ -11960,6 +12005,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -13618,6 +13672,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -14808,6 +14883,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -14825,7 +14906,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -16717,7 +16797,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19202,6 +19281,47 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "three": "^0.134.0",
     "vanta": "^0.5.24",
     "vaul": "^0.9.9",
+    "web-push": "^3.6.7",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -100,6 +101,7 @@
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
+    "@types/web-push": "^3.6.4",
     "@vercel/node": "^3.2.29",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.21",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,16 @@
+self.addEventListener("push", (e) => {
+  const data = e.data?.json() ?? {};
+  e.waitUntil(
+    self.registration.showNotification(data.title ?? "UnClick Signal", {
+      body: data.body ?? "",
+      icon: "/favicon-192.png",
+      badge: "/favicon-192.png",
+      data: { url: data.url ?? "/admin/signals" },
+    })
+  );
+});
+
+self.addEventListener("notificationclick", (e) => {
+  e.notification.close();
+  e.waitUntil(clients.openWindow(e.notification.data.url));
+});

--- a/src/pages/admin/signals/SignalsSettings.tsx
+++ b/src/pages/admin/signals/SignalsSettings.tsx
@@ -1,9 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { ArrowLeft, Loader2, Save } from "lucide-react";
+import { ArrowLeft, Bell, Loader2, Plus, Save, Trash2 } from "lucide-react";
 import { useSession } from "@/lib/auth";
 
 type MinSeverity = "info" | "action_needed" | "critical";
+type Channel = "email" | "telegram" | "browser_push" | "webhook" | "in_admin";
+
+const ALL_CHANNELS: { id: Channel; label: string }[] = [
+  { id: "email", label: "Email" },
+  { id: "telegram", label: "Telegram" },
+  { id: "browser_push", label: "Browser push" },
+  { id: "webhook", label: "Webhook" },
+  { id: "in_admin", label: "In-admin only" },
+];
 
 interface Preferences {
   email_enabled: boolean;
@@ -11,9 +20,14 @@ interface Preferences {
   phone_push_enabled: boolean;
   telegram_enabled: boolean;
   telegram_chat_id: string | null;
+  browser_push_enabled: boolean;
+  push_subscription: PushSubscriptionJSON | null;
+  webhook_url: string | null;
+  webhook_secret: string | null;
   quiet_hours_start: string | null;
   quiet_hours_end: string | null;
   min_severity: MinSeverity;
+  routing_rules: Record<string, Channel[]>;
 }
 
 const DEFAULTS: Preferences = {
@@ -22,10 +36,20 @@ const DEFAULTS: Preferences = {
   phone_push_enabled: true,
   telegram_enabled: false,
   telegram_chat_id: "",
+  browser_push_enabled: false,
+  push_subscription: null,
+  webhook_url: "",
+  webhook_secret: "",
   quiet_hours_start: "",
   quiet_hours_end: "",
   min_severity: "info",
+  routing_rules: {},
 };
+
+function urlsafeBase64(buf: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
 
 export default function SignalsSettings() {
   const { session } = useSession();
@@ -37,6 +61,11 @@ export default function SignalsSettings() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [pushStatus, setPushStatus] = useState<"idle" | "busy" | "ok" | "err">("idle");
+  const [testWebhookStatus, setTestWebhookStatus] = useState<"idle" | "busy" | "ok" | "err">("idle");
+  const [newRuleKey, setNewRuleKey] = useState("");
+  const [newRuleChannels, setNewRuleChannels] = useState<Channel[]>([]);
+  const [showAddRule, setShowAddRule] = useState(false);
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -53,9 +82,14 @@ export default function SignalsSettings() {
         phone_push_enabled: p.phone_push_enabled ?? true,
         telegram_enabled: p.telegram_enabled ?? false,
         telegram_chat_id: p.telegram_chat_id ?? "",
+        browser_push_enabled: p.browser_push_enabled ?? false,
+        push_subscription: p.push_subscription ?? null,
+        webhook_url: p.webhook_url ?? "",
+        webhook_secret: p.webhook_secret ?? "",
         quiet_hours_start: p.quiet_hours_start ?? "",
         quiet_hours_end: p.quiet_hours_end ?? "",
         min_severity: p.min_severity ?? "info",
+        routing_rules: p.routing_rules ?? {},
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load preferences");
@@ -81,9 +115,14 @@ export default function SignalsSettings() {
           phone_push_enabled: prefs.phone_push_enabled,
           telegram_enabled: prefs.telegram_enabled,
           telegram_chat_id: prefs.telegram_chat_id || null,
+          browser_push_enabled: prefs.browser_push_enabled,
+          push_subscription: prefs.push_subscription,
+          webhook_url: prefs.webhook_url || null,
+          webhook_secret: prefs.webhook_secret || null,
           quiet_hours_start: prefs.quiet_hours_start || null,
           quiet_hours_end: prefs.quiet_hours_end || null,
           min_severity: prefs.min_severity,
+          routing_rules: prefs.routing_rules,
         }),
       });
       const body = await res.json().catch(() => ({}));
@@ -99,6 +138,84 @@ export default function SignalsSettings() {
 
   function update<K extends keyof Preferences>(key: K, value: Preferences[K]) {
     setPrefs((p) => ({ ...p, [key]: value }));
+  }
+
+  async function enableBrowserPush() {
+    setPushStatus("busy");
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setPushStatus("err");
+        setError("Browser permission denied. Allow notifications in your browser settings.");
+        return;
+      }
+      const reg = await navigator.serviceWorker.register("/sw.js");
+      await navigator.serviceWorker.ready;
+      const vapidKey = import.meta.env.VITE_VAPID_PUBLIC_KEY as string | undefined;
+      if (!vapidKey) throw new Error("VITE_VAPID_PUBLIC_KEY not configured");
+      const keyBytes = Uint8Array.from(atob(vapidKey.replace(/-/g, "+").replace(/_/g, "/")), (c) => c.charCodeAt(0));
+      const sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: keyBytes });
+      const subJson = sub.toJSON() as PushSubscriptionJSON;
+      setPrefs((p) => ({ ...p, browser_push_enabled: true, push_subscription: subJson }));
+      setPushStatus("ok");
+    } catch (e) {
+      setPushStatus("err");
+      setError(e instanceof Error ? e.message : "Failed to enable browser push");
+    }
+  }
+
+  async function disableBrowserPush() {
+    try {
+      const reg = await navigator.serviceWorker.getRegistration("/sw.js");
+      if (reg) {
+        const sub = await reg.pushManager.getSubscription();
+        if (sub) await sub.unsubscribe();
+      }
+    } catch (_) { /* ignore */ }
+    setPrefs((p) => ({ ...p, browser_push_enabled: false, push_subscription: null }));
+    setPushStatus("idle");
+  }
+
+  async function sendTestWebhook() {
+    if (!token) return;
+    setTestWebhookStatus("busy");
+    try {
+      const res = await fetch("/api/signals-test-webhook", {
+        method: "POST",
+        headers: authHeader,
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || !body.ok) throw new Error(`Server returned ${body.status ?? res.status}`);
+      setTestWebhookStatus("ok");
+      setTimeout(() => setTestWebhookStatus("idle"), 3000);
+    } catch (e) {
+      setTestWebhookStatus("err");
+      setError(e instanceof Error ? e.message : "Test failed");
+      setTimeout(() => setTestWebhookStatus("idle"), 3000);
+    }
+  }
+
+  function addRoutingRule() {
+    const key = newRuleKey.trim();
+    if (!key || newRuleChannels.length === 0) return;
+    setPrefs((p) => ({ ...p, routing_rules: { ...p.routing_rules, [key]: newRuleChannels } }));
+    setNewRuleKey("");
+    setNewRuleChannels([]);
+    setShowAddRule(false);
+  }
+
+  function removeRoutingRule(key: string) {
+    setPrefs((p) => {
+      const next = { ...p.routing_rules };
+      delete next[key];
+      return { ...p, routing_rules: next };
+    });
+  }
+
+  function toggleNewRuleChannel(ch: Channel) {
+    setNewRuleChannels((prev) =>
+      prev.includes(ch) ? prev.filter((c) => c !== ch) : [...prev, ch]
+    );
   }
 
   if (loading) {
@@ -124,113 +241,160 @@ export default function SignalsSettings() {
       )}
 
       <div className="flex flex-col gap-6">
+        {/* Email */}
         <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
           <label className="flex items-center justify-between">
             <span>
               <span className="block text-sm font-medium text-white">Email</span>
               <span className="block text-xs text-[#888]">Send me an email when something important happens.</span>
             </span>
-            <input
-              type="checkbox"
-              checked={prefs.email_enabled}
-              onChange={(e) => update("email_enabled", e.target.checked)}
-              className="h-4 w-4 rounded border-white/20 bg-[#111]"
-            />
+            <input type="checkbox" checked={prefs.email_enabled} onChange={(e) => update("email_enabled", e.target.checked)} className="h-4 w-4 rounded border-white/20 bg-[#111]" />
           </label>
           {prefs.email_enabled && (
-            <input
-              type="email"
-              value={prefs.email_address ?? ""}
-              onChange={(e) => update("email_address", e.target.value)}
-              placeholder="you@example.com"
-              className="mt-3 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555]"
-            />
+            <input type="email" value={prefs.email_address ?? ""} onChange={(e) => update("email_address", e.target.value)} placeholder="you@example.com" className="mt-3 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555]" />
           )}
         </section>
 
+        {/* Phone push */}
         <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
           <label className="flex items-center justify-between">
             <span>
               <span className="block text-sm font-medium text-white">Phone push</span>
               <span className="block text-xs text-[#888]">Get a notification on your phone when something needs your attention.</span>
             </span>
-            <input
-              type="checkbox"
-              checked={prefs.phone_push_enabled}
-              onChange={(e) => update("phone_push_enabled", e.target.checked)}
-              className="h-4 w-4 rounded border-white/20 bg-[#111]"
-            />
+            <input type="checkbox" checked={prefs.phone_push_enabled} onChange={(e) => update("phone_push_enabled", e.target.checked)} className="h-4 w-4 rounded border-white/20 bg-[#111]" />
           </label>
         </section>
 
+        {/* Telegram */}
         <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
           <label className="flex items-center justify-between">
             <span>
               <span className="block text-sm font-medium text-white">Telegram</span>
-              <span className="block text-xs text-[#888]">Ping me in Telegram.</span>
+              <span className="block text-xs text-[#888]">Ping me via @bailey_amarok_bot.</span>
             </span>
-            <input
-              type="checkbox"
-              checked={prefs.telegram_enabled}
-              onChange={(e) => update("telegram_enabled", e.target.checked)}
-              className="h-4 w-4 rounded border-white/20 bg-[#111]"
-            />
+            <input type="checkbox" checked={prefs.telegram_enabled} onChange={(e) => update("telegram_enabled", e.target.checked)} className="h-4 w-4 rounded border-white/20 bg-[#111]" />
           </label>
           {prefs.telegram_enabled && (
             <>
-              <input
-                type="text"
-                value={prefs.telegram_chat_id ?? ""}
-                onChange={(e) => update("telegram_chat_id", e.target.value)}
-                placeholder="123456789"
-                className="mt-3 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555]"
-              />
-              <p className="mt-1 text-xs text-[#666]">Your Telegram Chat ID (available from @userinfobot)</p>
+              <input type="text" value={prefs.telegram_chat_id ?? ""} onChange={(e) => update("telegram_chat_id", e.target.value)} placeholder="123456789" className="mt-3 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555]" />
+              <p className="mt-1 text-xs text-[#666]">Your Telegram Chat ID. Message @userinfobot to find it.</p>
             </>
           )}
         </section>
 
+        {/* Browser push */}
         <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
-          <h3 className="text-sm font-medium text-white">Quiet hours</h3>
-          <p className="mt-0.5 text-xs text-[#888]">Do not disturb me during these hours.</p>
-          <div className="mt-3 flex items-center gap-2 text-sm text-[#ccc]">
-            <span>Do not disturb from</span>
-            <input
-              type="time"
-              value={prefs.quiet_hours_start ?? ""}
-              onChange={(e) => update("quiet_hours_start", e.target.value)}
-              className="rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-2 py-1.5"
-            />
-            <span>to</span>
-            <input
-              type="time"
-              value={prefs.quiet_hours_end ?? ""}
-              onChange={(e) => update("quiet_hours_end", e.target.value)}
-              className="rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-2 py-1.5"
-            />
+          <div className="flex items-start justify-between gap-4">
+            <span>
+              <span className="block text-sm font-medium text-white">Browser push</span>
+              <span className="block text-xs text-[#888]">Get notifications in this browser even when the tab is in the background.</span>
+              {prefs.browser_push_enabled && (
+                <span className="mt-1 block text-xs text-[#61C1C4]">Active on this browser.</span>
+              )}
+            </span>
+            {prefs.browser_push_enabled ? (
+              <button onClick={disableBrowserPush} className="shrink-0 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs text-[#ccc] hover:bg-white/[0.05]">
+                Disable
+              </button>
+            ) : (
+              <button onClick={enableBrowserPush} disabled={pushStatus === "busy"} className="shrink-0 flex items-center gap-1.5 rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-1.5 text-xs font-semibold text-[#61C1C4] hover:bg-[#61C1C4]/20 disabled:opacity-50">
+                {pushStatus === "busy" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Bell className="h-3 w-3" />}
+                {pushStatus === "busy" ? "Enabling..." : "Enable"}
+              </button>
+            )}
           </div>
         </section>
 
+        {/* Webhook */}
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <h3 className="text-sm font-medium text-white">Webhook</h3>
+          <p className="mt-0.5 text-xs text-[#888]">POST a signed payload to your server when a signal fires.</p>
+          <input type="url" value={prefs.webhook_url ?? ""} onChange={(e) => update("webhook_url", e.target.value)} placeholder="https://your-server.example.com/hook" className="mt-3 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555]" />
+          <input type="text" value={prefs.webhook_secret ?? ""} onChange={(e) => update("webhook_secret", e.target.value)} placeholder="Signing secret (optional)" className="mt-2 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555]" />
+          <p className="mt-1 text-xs text-[#555]">We sign every request with <code className="text-[#888]">X-UnClick-Signature: sha256=...</code></p>
+          {prefs.webhook_url && (
+            <button onClick={sendTestWebhook} disabled={testWebhookStatus === "busy"} className="mt-3 flex items-center gap-2 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs text-[#ccc] hover:bg-white/[0.05] disabled:opacity-50">
+              {testWebhookStatus === "busy" && <Loader2 className="h-3 w-3 animate-spin" />}
+              {testWebhookStatus === "ok" ? "Test sent!" : testWebhookStatus === "err" ? "Test failed" : "Send test payload"}
+            </button>
+          )}
+        </section>
+
+        {/* Quiet hours */}
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <h3 className="text-sm font-medium text-white">Quiet hours</h3>
+          <p className="mt-0.5 text-xs text-[#888]">Notifications are held during these hours and delivered when quiet hours end.</p>
+          <div className="mt-3 flex items-center gap-2 text-sm text-[#ccc]">
+            <span>From</span>
+            <input type="time" value={prefs.quiet_hours_start ?? ""} onChange={(e) => update("quiet_hours_start", e.target.value)} className="rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-2 py-1.5" />
+            <span>to</span>
+            <input type="time" value={prefs.quiet_hours_end ?? ""} onChange={(e) => update("quiet_hours_end", e.target.value)} className="rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-2 py-1.5" />
+          </div>
+        </section>
+
+        {/* Min severity */}
         <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
           <h3 className="text-sm font-medium text-white">What to send</h3>
           <p className="mt-0.5 text-xs text-[#888]">Pick how noisy you want this to be.</p>
-          <select
-            value={prefs.min_severity}
-            onChange={(e) => update("min_severity", e.target.value as MinSeverity)}
-            className="mt-3 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc]"
-          >
+          <select value={prefs.min_severity} onChange={(e) => update("min_severity", e.target.value as MinSeverity)} className="mt-3 w-full rounded-lg border border-white/[0.08] bg-[#0A0A0A] px-3 py-2 text-sm text-[#ccc]">
             <option value="info">Everything</option>
             <option value="action_needed">Actions needed and critical only</option>
             <option value="critical">Critical only</option>
           </select>
         </section>
 
+        {/* Per-event routing */}
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <h3 className="text-sm font-medium text-white">Per-event routing</h3>
+          <p className="mt-0.5 text-xs text-[#888]">Control which channels fire for specific event types. Leave a rule off to use all enabled channels.</p>
+          <p className="mt-1 text-xs text-[#555]">Format: <code className="text-[#777]">tool:action</code> - for example <code className="text-[#777]">testpass:report_closed</code></p>
+
+          {Object.keys(prefs.routing_rules).length > 0 && (
+            <div className="mt-3 flex flex-col gap-2">
+              {Object.entries(prefs.routing_rules).map(([key, channels]) => (
+                <div key={key} className="flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-[#0A0A0A] px-3 py-2">
+                  <div className="min-w-0">
+                    <span className="block text-xs font-mono font-semibold text-[#ccc]">{key}</span>
+                    <span className="block text-xs text-[#666]">{channels.join(", ") || "in_admin"}</span>
+                  </div>
+                  <button onClick={() => removeRoutingRule(key)} className="shrink-0 text-[#555] hover:text-red-400">
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {showAddRule ? (
+            <div className="mt-3 rounded-lg border border-white/[0.08] bg-[#0A0A0A] p-3 flex flex-col gap-3">
+              <input value={newRuleKey} onChange={(e) => setNewRuleKey(e.target.value)} placeholder="tool:action (e.g. testpass:report_closed)" className="w-full rounded-lg border border-white/[0.08] bg-[#111] px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555] font-mono" />
+              <div className="flex flex-wrap gap-3">
+                {ALL_CHANNELS.map((ch) => (
+                  <label key={ch.id} className="flex items-center gap-1.5 text-xs text-[#ccc] cursor-pointer">
+                    <input type="checkbox" checked={newRuleChannels.includes(ch.id)} onChange={() => toggleNewRuleChannel(ch.id)} className="h-3.5 w-3.5 rounded border-white/20 bg-[#111]" />
+                    {ch.label}
+                  </label>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <button onClick={addRoutingRule} disabled={!newRuleKey.trim() || newRuleChannels.length === 0} className="rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-1.5 text-xs font-semibold text-[#61C1C4] hover:bg-[#61C1C4]/20 disabled:opacity-40">
+                  Add rule
+                </button>
+                <button onClick={() => setShowAddRule(false)} className="rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs text-[#888] hover:bg-white/[0.05]">
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button onClick={() => setShowAddRule(true)} className="mt-3 flex items-center gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs text-[#888] hover:bg-white/[0.05]">
+              <Plus className="h-3.5 w-3.5" /> Add rule
+            </button>
+          )}
+        </section>
+
         <div className="flex items-center gap-3">
-          <button
-            onClick={save}
-            disabled={saving}
-            className="flex items-center gap-2 rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-4 py-2 text-sm font-semibold text-[#61C1C4] hover:bg-[#61C1C4]/20 disabled:opacity-50"
-          >
+          <button onClick={save} disabled={saving} className="flex items-center gap-2 rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-4 py-2 text-sm font-semibold text-[#61C1C4] hover:bg-[#61C1C4]/20 disabled:opacity-50">
             {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
             {saving ? "Saving..." : "Save settings"}
           </button>

--- a/supabase/migrations/20260424000000_signals_phase_2.sql
+++ b/supabase/migrations/20260424000000_signals_phase_2.sql
@@ -1,0 +1,15 @@
+-- Phase 2: browser push, webhook, routing rules
+ALTER TABLE mc_signal_preferences
+  ADD COLUMN IF NOT EXISTS browser_push_enabled boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS push_subscription jsonb,
+  ADD COLUMN IF NOT EXISTS webhook_url text,
+  ADD COLUMN IF NOT EXISTS webhook_secret text,
+  ADD COLUMN IF NOT EXISTS routing_rules jsonb DEFAULT '{}'::jsonb;
+
+-- held_until lets the dispatch worker delay delivery until quiet hours end
+ALTER TABLE mc_signals
+  ADD COLUMN IF NOT EXISTS held_until timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_mc_signals_held
+  ON mc_signals(held_until)
+  WHERE held_until IS NOT NULL;


### PR DESCRIPTION
## Summary
- Implements 6 new capabilities extending Phase 1 (PR #123): Telegram channel, browser Web Push, outbound webhook with HMAC signatures, 60-second batch/dedup window, quiet hours hold-and-release, and per-event-type channel routing rules.
- All new dispatch logic lives in the existing `api/signals-dispatch.ts` worker; all new prefs land in `mc_signal_preferences` via one additive migration.
- Settings UI updated with idiot-proof sections for each new channel.

## Changes
- `api/signals-dispatch.ts` - full rewrite: adds `sendTelegram`, `sendWebhook`, `sendBrowserPush`, `buildBatchGroups`, quiet-hours check, routing-rules resolver
- `api/signals-test-webhook.ts` - new endpoint: server-side test-payload sender (avoids CORS on user webhook servers)
- `api/memory-admin.ts` - adds 5 new fields to `update_signal_preferences` allowlist
- `src/pages/admin/signals/SignalsSettings.tsx` - adds browser push (service worker registration + VAPID subscribe), webhook (URL + secret + test button), routing rules (add/remove per-event rules)
- `public/sw.js` - new service worker: handles `push` and `notificationclick` events
- `supabase/migrations/20260424000000_signals_phase_2.sql` - additive migration (5 new prefs columns + `held_until` on signals)
- `package.json` / `package-lock.json` - adds `web-push@^3.6.7` and `@types/web-push`

## Deletions
None - Phase 1 code extended in place, no files removed.

## Migration SQL (inline)
```sql
ALTER TABLE mc_signal_preferences
  ADD COLUMN IF NOT EXISTS browser_push_enabled boolean DEFAULT false,
  ADD COLUMN IF NOT EXISTS push_subscription jsonb,
  ADD COLUMN IF NOT EXISTS webhook_url text,
  ADD COLUMN IF NOT EXISTS webhook_secret text,
  ADD COLUMN IF NOT EXISTS routing_rules jsonb DEFAULT '{}'::jsonb;

ALTER TABLE mc_signals
  ADD COLUMN IF NOT EXISTS held_until timestamptz;

CREATE INDEX IF NOT EXISTS idx_mc_signals_held
  ON mc_signals(held_until)
  WHERE held_until IS NOT NULL;
```

## New env vars required
| Var | Purpose |
|-----|---------|
| `TELEGRAM_BOT_TOKEN` | @bailey_amarok_bot token for Telegram dispatch |
| `VAPID_PUBLIC_KEY` | Web Push VAPID public key (also expose as `VITE_VAPID_PUBLIC_KEY`) |
| `VAPID_PRIVATE_KEY` | Web Push VAPID private key |
| `VAPID_SUBJECT` | VAPID contact URI (defaults to `mailto:signals@unclick.world`) |

Generate VAPID keys once with: `npx web-push generate-vapid-keys`

## Archaeology
N/A - not a restore/reorg PR

## Testing
- TypeScript: `npx tsc --noEmit` - clean
- Build: `npm run build` - passes (pre-existing chunk size warning unrelated to this PR)
- Quiet hours logic: unit-testable via `isInQuietHours` helper
- Telegram: requires `TELEGRAM_BOT_TOKEN` + a real chat ID
- Browser push: requires VAPID keys + HTTPS
- Webhook: use `Send test payload` button in settings after saving a URL

## Conflict notes
If PR #124 (Orchestrator Wizard) or PR #125 (TestPass 9B) touch `api/memory-admin.ts`, a rebase may be needed after those merge. The only change here is 5 lines added to the `update_signal_preferences` allowed-fields array.

## LOC
683 code lines changed (559 added, 124 removed). `package-lock.json` is machine-generated and excluded from budget. Under the 800-LOC limit.

## UnClick Memory linkage
N/A