### PR TITLE
security: critical RLS + audit + tenant scoping + dep CVE bumps (PR #128 floor patches)

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -1815,6 +1815,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const agentId = String(req.body?.agent_id ?? req.query.agent_id ?? "").trim();
         if (!agentId) return res.status(400).json({ error: "agent_id required" });
 
+        // SECURITY: audit log BEFORE destructive op; abort if insert fails. audit PR #128
+        const { error: auditErr } = await supabase.from("mc_admin_audit").insert({
+          api_key_hash: apiKeyHash,
+          action: "admin_agent_delete",
+          payload: { agent_id: agentId },
+        });
+        if (auditErr) {
+          console.error("admin_agent_delete: audit insert failed, aborting:", auditErr.message);
+          return res.status(500).json({ error: "Audit log failed; delete aborted for safety." });
+        }
+
         const { error } = await supabase
           .from("agents")
           .delete()
@@ -2049,6 +2060,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       case "admin_connectors_list": {
+        // SECURITY: platform_connectors is a global connector catalog with no per-tenant rows.
+        // anon_read_connectors RLS allows public read by design. audit PR #128
         const { data, error } = await supabase
           .from("platform_connectors")
           .select("id, name, category, description, icon, sort_order")
@@ -3468,6 +3481,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         if (!existing) return res.status(404).json({ error: "No API key to reset" });
 
+        // SECURITY: audit log BEFORE key rotation; abort if insert fails. audit PR #128
+        const existingKeyHash = (await supabase
+          .from("api_keys")
+          .select("key_hash")
+          .eq("id", existing.id)
+          .maybeSingle()).data?.key_hash as string | null;
+        const { error: auditErr } = await supabase.from("mc_admin_audit").insert({
+          api_key_hash: existingKeyHash ?? "unknown",
+          action: "reset_api_key",
+          payload: { key_id: existing.id, tier: existing.tier },
+        });
+        if (auditErr) {
+          console.error("reset_api_key: audit insert failed, aborting:", auditErr.message);
+          return res.status(500).json({ error: "Audit log failed; reset aborted for safety." });
+        }
+
         const rawKey = `uc_${crypto.randomBytes(16).toString("hex")}`;
         const { error: updateError } = await supabase
           .from("api_keys")
@@ -3655,11 +3684,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           meteringMap[op].count++;
         }
 
-        // Platform connectors with user's credential status
+        // SECURITY: platform_connectors is a global connector catalog with no per-tenant rows.
+        // anon_read_connectors RLS allows public read by design. audit PR #128
         const { data: connectors } = await supabase
           .from("platform_connectors")
           .select("*");
 
+        // SECURITY: tenant scope required, audit PR #128
         const { data: creds } = await supabase
           .from("platform_credentials")
           .select("platform, is_valid, last_tested_at")
@@ -4054,6 +4085,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           "mc_knowledge_library",
           "mc_knowledge_library_history",
         ];
+
+        // SECURITY: audit log BEFORE destructive op; abort if insert fails. audit PR #128
+        const { error: auditErr } = await supabase.from("mc_admin_audit").insert({
+          api_key_hash: apiKeyHash,
+          action: "admin_clear_all",
+          payload: { tables_affected: tables },
+        });
+        if (auditErr) {
+          console.error("admin_clear_all: audit insert failed, aborting:", auditErr.message);
+          return res.status(500).json({ error: "Audit log failed; delete aborted for safety." });
+        }
 
         const deleted: Record<string, number | null> = {};
         for (const t of tables) {

--- a/supabase/migrations/20260424100000_security_patch_bundle.sql
+++ b/supabase/migrations/20260424100000_security_patch_bundle.sql
@@ -7,6 +7,13 @@ DO $$ BEGIN
   END IF;
 END $$;
 
+ALTER TABLE memory_devices ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='memory_devices' AND policyname='memory_devices_service_role_all') THEN
+    CREATE POLICY "memory_devices_service_role_all" ON memory_devices FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
 CREATE TABLE IF NOT EXISTS mc_admin_audit (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   api_key_hash text NOT NULL,

--- a/supabase/migrations/20260424100000_security_patch_bundle.sql
+++ b/supabase/migrations/20260424100000_security_patch_bundle.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+ALTER TABLE memory_configs ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='memory_configs' AND policyname='memory_configs_service_role_all') THEN
+    CREATE POLICY "memory_configs_service_role_all" ON memory_configs FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS mc_admin_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  action text NOT NULL,
+  payload jsonb DEFAULT '{}'::jsonb,
+  performed_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE mc_admin_audit ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "mc_admin_audit_service_role_all" ON mc_admin_audit FOR ALL USING (auth.role() = 'service_role');
+
+CREATE INDEX IF NOT EXISTS mc_admin_audit_api_key_hash_idx ON mc_admin_audit(api_key_hash);
+CREATE INDEX IF NOT EXISTS mc_admin_audit_performed_at_idx ON mc_admin_audit(performed_at DESC);
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;


### PR DESCRIPTION
## Summary

Closes C1, C2, C3, C4 from the PR #128 Phase 1 Ground Floor QC security audit, plus the ChatGPT QC Finds P1 on `memory_devices` RLS.
Single PR, no auto-merge - Chris reviews before merge.

---

## Fix 1 (C1 + ChatGPT P1): RLS on memory_configs AND memory_devices

**File**: `supabase/migrations/20260424100000_security_patch_bundle.sql`

Enables RLS on `memory_configs` (which stores per-tenant AES-256-GCM encrypted Supabase service-role keys) AND on `memory_devices` (which stores per-tenant device fingerprints). Both restrict all access to `service_role`. Also creates the `mc_admin_audit` table used by Fix 3.

The ChatGPT QC pass flagged `memory_devices` as a P1 alongside `memory_configs` because it's the same shape (per-user records, no RLS). Folded into this PR so they ship together.

**Chris: paste this migration SQL into your Supabase SQL editor post-merge:**

```sql
BEGIN;

ALTER TABLE memory_configs ENABLE ROW LEVEL SECURITY;
DO $$ BEGIN
  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='memory_configs' AND policyname='memory_configs_service_role_all') THEN
    CREATE POLICY "memory_configs_service_role_all" ON memory_configs FOR ALL USING (auth.role() = 'service_role');
  END IF;
END $$;

ALTER TABLE memory_devices ENABLE ROW LEVEL SECURITY;
DO $$ BEGIN
  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='memory_devices' AND policyname='memory_devices_service_role_all') THEN
    CREATE POLICY "memory_devices_service_role_all" ON memory_devices FOR ALL USING (auth.role() = 'service_role');
  END IF;
END $$;

CREATE TABLE IF NOT EXISTS mc_admin_audit (
  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
  api_key_hash text NOT NULL,
  action text NOT NULL,
  payload jsonb DEFAULT '{}'::jsonb,
  performed_at timestamptz DEFAULT now()
);

ALTER TABLE mc_admin_audit ENABLE ROW LEVEL SECURITY;
CREATE POLICY "mc_admin_audit_service_role_all" ON mc_admin_audit FOR ALL USING (auth.role() = 'service_role');

CREATE INDEX IF NOT EXISTS mc_admin_audit_api_key_hash_idx ON mc_admin_audit(api_key_hash);
CREATE INDEX IF NOT EXISTS mc_admin_audit_performed_at_idx ON mc_admin_audit(performed_at DESC);

NOTIFY pgrst, 'reload schema';
COMMIT;
```

---

## Fix 2 (C3): Tenant-scope audit on admin_tools

**File**: `api/memory-admin.ts`

Audited all reads of `platform_connectors`, `platform_credentials`, and `memory_configs`:

- `platform_connectors` (lines 1994, 3601): global connector catalog with no per-tenant rows. Has `anon_read_connectors` RLS policy allowing public read by design. Added explicit comments confirming this - closes the C3 "confirm or scope" requirement.
- `platform_credentials`: already correctly scoped with `.eq("key_hash", tenant.apiKeyHash)`. Added `// SECURITY: tenant scope required, audit PR #128` comment.
- `memory_configs`: all six read/write sites already have `.eq("api_key_hash", ...)` filters. No changes needed.

---

## Fix 3 (C2): Audit log for destructive admin actions

**File**: `api/memory-admin.ts`

- `admin_clear_all`: inserts to `mc_admin_audit` (with `tables_affected` payload) BEFORE the delete cascade. If the audit insert fails, the operation aborts - no silent data loss without a trail.
- `reset_api_key`: same pre-op audit pattern (key rotation invalidates the old key).
- `admin_agent_delete`: same pre-op audit pattern.
- `delete_account` already had audit logging (unchanged).

---

## Fix 4 (C4): Dependency CVE reduction

**Before**: 32 vulnerabilities (3 low, 11 moderate, 18 high)
**After**: 19 vulnerabilities (3 low, 7 moderate, 9 high)

`npm audit fix` (no `--force`) patched what could be safely upgraded. Changes are lockfile-only.

**Packages bumped** (all minor/patch, no breaking changes): transitive deps via the auto-fix run. Full diff in `package-lock.json`.

**Remaining 9 high - all undici, upstream-blocked:**

All 9 remaining high-severity CVEs are in `undici`, transitive from `@vercel/node`. We tried bumping `@vercel/node` to v5 in PR #131 - that did NOT close the CVEs because Vercel bundles `undici@5.28.4` in v3, v4, and v5. The patch requires `undici >= 6.x`, which Vercel hasn't shipped yet. PR #131 closed; documented as upstream-blocked. Will revisit weekly via `npm audit`.

---

## What Chris does post-merge

1. Paste the migration SQL above into the Supabase SQL editor (or run via Supabase CLI migrations).
2. Verify `memory_configs` AND `memory_devices` show RLS enabled in the Supabase dashboard.

---

## Review checklist

- [ ] Migration SQL reviewed and pasted in Supabase SQL editor
- [ ] RLS on memory_configs AND memory_devices confirmed enabled in dashboard
- [ ] audit comments in memory-admin.ts look correct
- [ ] admin_clear_all abort-on-audit-fail behavior acceptable
- [ ] NO auto-merge - Chris approves before squash