### PR TITLE
docs: Phase 2 Ground Floor QC - PRDs, ADRs, security policies, architecture overview

### DIFF
--- a/docs/adr/0001-mcp-first-agent-protocol.md
+++ b/docs/adr/0001-mcp-first-agent-protocol.md
@@ -1,0 +1,26 @@
+# ADR-0001: MCP-first agent protocol
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+Agent-to-tool communication has no dominant standard. OpenAI function calling, LangChain tools, LlamaIndex callbacks, custom REST shims, and the Model Context Protocol (MCP) all compete for the same surface area. UnClick can either try to serve every protocol (thin, fragile) or commit to one and be the best at it. MCP is gaining adoption across Claude Desktop, Cursor, and a growing ecosystem of clients. It is open, versioned, and designed for agent-tool composition from the start.
+
+## Decision
+
+UnClick exposes every capability through MCP. The agent-facing surface is one marketplace search tool (`unclick_search`) plus five direct memory tools (`load_memory`, `save_session`, `save_fact`, `search_memory`, `save_identity`). The raw meta-tools (`unclick_browse`, `unclick_tool_info`, `unclick_call`) remain callable but are hidden from the default tool list for readability. Every other capability, including all 17 memory operations and 450+ wired endpoints, is reachable through `unclick_call` with an `endpoint_id`. No parallel REST-only protocol is maintained as a first-class agent surface. The website and admin shell exist for humans; MCP is the canonical surface for agents.
+
+## Consequences
+
+**Benefits:**
+- Single protocol to support, document, and optimise. Deep rather than wide.
+- Compatible out of the box with Claude Desktop, Cursor, and every MCP-compliant client.
+- Discovery is dynamic. A user can install UnClick and gain 450+ tools without wiring each one into their client config.
+- TestPass enforces MCP contracts. Compliance is a known concept.
+
+**Drawbacks / trade-offs:**
+- Clients that do not speak MCP cannot reach UnClick without a thin adapter. Today this is an acceptable cost; MCP adoption is trending.
+- The meta-tool discovery pattern adds one hop between the agent and the real endpoint. Clients with poor tool-call latency notice.
+- Tying ourselves to MCP means we carry its versioning risk. When MCP releases a breaking change, we adopt it; we do not fork.

--- a/docs/adr/0002-subscription-only-billing.md
+++ b/docs/adr/0002-subscription-only-billing.md
@@ -1,0 +1,26 @@
+# ADR-0002: Subscription-only billing
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+Agent platforms have two billing models. The first is to sit between the user and the LLM provider, meter tokens, mark them up, and bill the user for consumption. The second is to stay out of the LLM relationship entirely and charge for platform features. Many emerging platforms pick the first because it promises usage-based revenue that scales with the user's activity. The hidden costs are significant: negotiating provider rates, handling failed charges, explaining margin to users who already pay the provider directly, and taking on the fraud and billing-dispute surface of a payment middleware business. Users already have Claude Pro, ChatGPT Plus, Cursor Pro, or Gemini Advanced subscriptions. They do not want a second token bill for the same tokens.
+
+## Decision
+
+Users pay their own AI provider subscription (Claude, GPT, Cursor, Gemini, or any other MCP-compatible client). UnClick does NOT proxy or meter LLM usage. UnClick charges for platform features: memory storage and extraction tier, BackstagePass vault size, Crews seats, worker fleet size, and the marketplace revenue share. Tools that call LLMs do so via the user's own credentials, not an UnClick-managed model account. A user who uses UnClick heavily sees one bill from Anthropic (or OpenAI, etc.) plus one bill from UnClick. The two are unrelated.
+
+## Consequences
+
+**Benefits:**
+- Pricing is predictable and explainable. Users already know what they pay their AI provider; the UnClick line is separate and fixed for their tier.
+- Zero margin compression risk from provider price changes. If Anthropic drops or raises prices, we are unaffected.
+- No billing middleware surface. No 3D Secure disputes over token cost, no payment processor risk on LLM charges.
+- Aligns with user mental model. "I pay OpenAI for the AI. I pay UnClick for the agent infrastructure." Clean separation.
+
+**Drawbacks / trade-offs:**
+- Revenue does not scale linearly with a user's LLM burn. A user who makes 10x more tool calls pays the same tier.
+- We cannot offer a single bundled price with LLM cost included, which is sometimes a customer ask.
+- Some tools (e.g. Crews) that orchestrate model calls still hit the user's provider. A misconfigured crew spends the user's tokens; we need to make the cost model transparent in the UI.

--- a/docs/adr/0003-stripe-model-not-windows.md
+++ b/docs/adr/0003-stripe-model-not-windows.md
@@ -1,0 +1,26 @@
+# ADR-0003: Stripe model, not Windows model
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+Two paths exist for a company in the agent-infrastructure layer. Path A is to become a vertically integrated agent operating system: build the harness, build the chat UI, build the model orchestration, own the device experience end-to-end. This is the Windows model. Path B is to be the identity, memory, credentials, and economy layer every harness needs: do one thing, do it well, and be embedded in everyone else's product. This is the Stripe model. Stripe did not build an e-commerce site; it became the rails every site runs on. The Windows model competes with every harness for the user's primary interface. The Stripe model is complementary to every harness.
+
+## Decision
+
+UnClick follows Path B. We are the identity, memory, credentials, and economy layer that every agent harness needs. We are not a harness, not a chat UI, not a model, not a device operating system. Claude Desktop, Cursor, ChatGPT, and the next ten entrants to the space are our substrate, not our competition. Every decision is measured against this: if the change moves UnClick toward becoming a harness, it is out of scope. If it strengthens UnClick as rails, it is in scope.
+
+## Consequences
+
+**Benefits:**
+- We do not compete with Anthropic, OpenAI, or any harness vendor. We enable all of them.
+- Addressable market is every agent user, regardless of which harness they use.
+- Focus. One category, one bar. We are the best memory + credentials + catalog layer rather than a second-rate everything.
+- Clean investor story. "Stripe for agents" is a one-sentence pitch that maps to a known business shape.
+
+**Drawbacks / trade-offs:**
+- We rely on the harnesses to ship MCP support. If a major harness refuses MCP, our reach through it is limited.
+- We give up the device UX play. A user's front door is their harness, not UnClick. We surface inside; we do not own the glass.
+- Feature requests that look like "build a chat" or "build your own agent" are permanent no's. We must say no consistently, including when the ask is tempting.

--- a/docs/adr/0004-multi-tenant-via-api-key-hash.md
+++ b/docs/adr/0004-multi-tenant-via-api-key-hash.md
@@ -1,0 +1,28 @@
+# ADR-0004: Multi-tenant via `api_key_hash`
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+UnClick serves agents via MCP and humans via a web app. Agents authenticate with a bearer API key (`uc_*` or `agt_*`). Humans authenticate with Supabase Auth, which issues JWTs. Both surfaces need a single tenant identifier so every row in the database can be scoped to one owner. The obvious choice is Supabase `user_id`, but that path fails immediately: memory predates the Supabase Auth wiring (`api_keys.user_id` was added later as a nullable column), and BYOD users store memory in their own Supabase project where our `auth.users` table does not exist. A tenant key that works for both auth paths and for BYOD mode must live above the auth table.
+
+## Decision
+
+`api_key_hash` (SHA-256 of the user's API key) is the canonical tenant identifier. Every user-scoped row includes an `api_key_hash` column. Every serverless handler that uses `service_role` adds a manual `.eq("api_key_hash", tenant.apiKeyHash)` filter to every query in addition to Row Level Security policies. RLS alone is not enough because most application code uses service_role which bypasses RLS; manual filters alone are not enough because any future unfiltered query leaks cross-tenant. Both layers are required, not either.
+
+For the browser auth path, the client never supplies its own `api_key_hash`. `resolveSessionUser()` validates the Supabase JWT server-side, then re-derives the hash from `api_keys` by `user_id`. For the bearer path, `resolveApiKeyHash()` SHA-256s the inbound key directly. The two helpers unify into a single `TenantContext` shape used by every handler.
+
+## Consequences
+
+**Benefits:**
+- One tenant key across managed cloud, BYOD, and both auth modes.
+- Independent of Supabase Auth mode changes (OAuth, magic link, MFA, etc.).
+- Works in BYOD where UnClick's `auth.users` is not reachable.
+- Replayed localStorage tokens cannot cross tenants because the hash is always re-derived server-side.
+
+**Drawbacks / trade-offs:**
+- Two layers of enforcement (RLS + manual filter) are both required at every query site. A missed manual filter leaks today even with RLS on; a table with no RLS leaks if a non-service_role path is ever introduced. See `docs/security/current-posture.md` C1 and C3 for the class of bug this creates.
+- No compile-time guarantee that every query is scoped. The structural fix is the repository layer proposed in `docs/architecture/target-state.md` section 4.
+- Tenants cannot change their api_key without a hash rotation. `reset_api_key` is supported but requires downstream data migration for users running agents with the old key cached.

--- a/docs/adr/0005-two-layer-admin-gating.md
+++ b/docs/adr/0005-two-layer-admin-gating.md
@@ -1,0 +1,27 @@
+# ADR-0005: Two-layer admin gating
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+Several UnClick surfaces are admin-only: `/admin/users`, `/admin/moderation`, `/admin/system-health`, `/admin/audit-log`, `/admin/orchestrator`, `/admin/analytics`, `/admin/codebase`. Gating has two components that interact. The server must refuse unauthorised actions, because anything less is a security failure. The frontend must also hide the unauthorised UI, because showing a broken link or a 403 page creates noise for normal users and makes non-admin tenants think the product is buggy. Relying on only one layer picks between a security hole and a broken user experience.
+
+## Decision
+
+Every admin-only action is refused at the server level AND hidden at the frontend level. Both layers are required for every admin surface. Server-side refusal uses the `ADMIN_EMAILS` env var checked in the tenant resolver; unauthorised requests get `{ error: "admin only" }` with the appropriate status. Frontend hiding uses the `<RequireAdmin>` component which removes the route from the sidebar and redirects away if accessed directly by URL.
+
+An admin feature that ships server-only refusal without frontend hiding (or vice versa) is treated as a bug, not a partial win. A PR adding an admin surface must wire both layers in the same change.
+
+## Consequences
+
+**Benefits:**
+- Defence in depth. A frontend bug that leaks a link does not leak data; a server bug that misses a check does not reach a user who does not know the endpoint exists.
+- Clean non-admin UX. Normal users never see admin surfaces or get 403 pages for features they are not meant to have.
+- Security review is simpler. Both layers are checked together; we do not argue about whether one was "enough."
+
+**Drawbacks / trade-offs:**
+- Every admin PR has a double surface: backend check plus frontend gate. Slightly more code per feature.
+- `ADMIN_EMAILS` env var rotation requires a redeploy. Low cost, but not runtime-configurable. A future enhancement is an admin role column on `api_keys`.
+- Two layers means two test paths: the server refusal path and the frontend hide path must both be covered.

--- a/docs/adr/0006-orchestrator-is-user-chat.md
+++ b/docs/adr/0006-orchestrator-is-user-chat.md
@@ -1,0 +1,26 @@
+# ADR-0006: Orchestrator is user chat
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: Extends [ADR-0003](./0003-stripe-model-not-windows.md)
+
+## Context
+
+Many platforms in the agent space build their own chat interface. It is tempting because it is the most visible surface, because every competitor has one, and because users ask for it. But the user already has a chat: Claude Desktop, Cursor, ChatGPT, Gemini, or any MCP-compatible client they have chosen. Building an UnClick chat puts us in direct competition with those clients for the user's primary interface. It also forks the product surface: we would need a chat UI, a model abstraction, a session manager, and a long-form prompting story that other teams at Anthropic, OpenAI, and Cursor employ many people to build.
+
+## Decision
+
+The user's own LLM chat client IS the orchestrator. UnClick does not host a chat interface. Every user-facing interaction starts in their chat of choice and flows through MCP into UnClick's capabilities. The UnClick website and admin shell exist for settings, observability, and management of persistent artefacts (crews, signals, BackstagePass entries). They are not where the user talks to their agent.
+
+## Consequences
+
+**Benefits:**
+- We do not compete with Claude Desktop, Cursor, or any other chat. We make all of them better.
+- Product scope stays tight. No model abstraction, no session manager, no long-form prompting infrastructure.
+- We ship MCP features and every compatible client gets them automatically. Leverage is maximised.
+- Users stay in the client they already use. Switching cost to UnClick is zero; the agent they already trust just gains new capabilities.
+
+**Drawbacks / trade-offs:**
+- We cede the front-door UX to other vendors. If the chat they use is bad, our tools feel bad by association. We cannot fix that directly.
+- Features that genuinely need a chat (like free-form conversation with a crew) are harder to deliver without building one. We route these through MCP tools that emit text the host chat renders.
+- Users who want a unified "everything in one place" experience sometimes ask for a chat. We say no consistently.

--- a/docs/adr/0007-idiot-proof-as-platform-rule.md
+++ b/docs/adr/0007-idiot-proof-as-platform-rule.md
@@ -1,0 +1,34 @@
+# ADR-0007: Idiot-proof UX as a platform rule
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+UnClick has two audiences: creative professionals and business operators (non-coders) on one side, developers submitting to the marketplace on the other. When a product serves both, the default bias is usually to optimise for developers because developers are easier to please and give the loudest feedback. That choice quietly makes the product unusable for the larger non-coder audience. Every dialog, error message, setup step, and glossary term becomes a cliff the non-coder cannot climb.
+
+We have seen this on prior projects. A feature ships, developers love it, real users never adopt it because they bounce off the first unfamiliar word. The fix is always slower than building the non-coder path in the first place.
+
+## Decision
+
+Non-coder UX is the bar for every surface. If a non-coder cannot understand it, it ships with better UX or does not ship. This rule applies to setup wizards, admin pages, error messages, and tool descriptions. Developer power-user features are additive, never the default. When a conflict arises between "make this easier for developers" and "make this easier for non-coders," non-coders win unless the feature is explicitly and exclusively for developers (e.g. the TestPass CLI).
+
+Practical implications:
+- Dialogs use plain language. No jargon without a parenthetical explanation.
+- Setup flows default to the managed path. BYOD is a toggle, not a required step.
+- Error messages state what happened and what to do next, in user terms, not system terms.
+- Every new feature has a non-coder walkthrough before launch. If we cannot explain it to a non-coder, we cannot ship it.
+
+## Consequences
+
+**Benefits:**
+- Adoption widens. Non-coders are the larger market; our default surface reaches them.
+- Support burden drops. Error messages that explain themselves prevent tickets.
+- Design discipline. The rule forces every feature to be simple enough to explain.
+- Brand differentiation. The agent space is littered with developer-first tools. Being the one that is actually usable is a moat.
+
+**Drawbacks / trade-offs:**
+- Developer users sometimes want raw power and get a wizard instead. Escape hatches mitigate this but they are extra work.
+- Shipping velocity is lower than a developer-first product of the same scope; hand-holding UI costs real time.
+- The rule is subjective. Judgement calls about what counts as "idiot-proof" can slow down PR review; mitigate with explicit non-coder walkthrough gates.

--- a/docs/adr/0008-monorepo-with-bounded-contexts.md
+++ b/docs/adr/0008-monorepo-with-bounded-contexts.md
@@ -1,0 +1,30 @@
+# ADR-0008: Monorepo with bounded contexts
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+UnClick has six first-class products (Memory, BackstagePass, Crews, TestPass, Signals, Build Desk) plus the umbrella platform and marketplace. Two structural options exist for organising the code. Option A is multiple repos, one per product, each independently released and versioned. Option B is a single monorepo with packages split by product. A third, bad option is a single monorepo split by layer: `controllers/`, `services/`, `models/`.
+
+Multi-repo works for independent teams with independent release cycles, but creates friction for tightly-coupled products that must ship coordinated changes. UnClick's products share a tenant model, a memory layer, and an MCP tool-wiring surface; coordinated releases are the norm, not the exception. Layer-based splits create cross-cutting dependencies: every feature touches the controllers, services, and models folders, so a PR is spread across the tree and review becomes difficult.
+
+## Decision
+
+Single git repository. Packages split by product (crews, testpass, memory, etc.) and not by layer (controllers, services, models). Each product package owns its domain logic, types, and API surface. Shared concerns (auth resolution, crypto primitives, generated Supabase types) live in dedicated shared packages. The monorepo is a pnpm/npm workspaces setup with Turbo for task orchestration.
+
+The current layout has drift (see `docs/architecture/current-state.md` sections 1 and 2): `src/` is the website at the repo root rather than `apps/web`, `apps/api` coexists with the Vercel `api/` functions, and `packages/memory-mcp` is deprecated. The target layout (see `docs/architecture/target-state.md` section 1) codifies the bounded-context split. Rearranging is incremental; the rule is that new work lives in the correct bounded context.
+
+## Consequences
+
+**Benefits:**
+- Products are independently deployable via the build graph. Turbo runs only what changed.
+- Domain logic stays co-located with its package. A developer working on Crews reads `packages/crews/` top to bottom.
+- Cross-product refactors ship as a single PR. Coordination is cheap.
+- Shared packages (types, crypto, auth) prevent duplication of security-critical code.
+
+**Drawbacks / trade-offs:**
+- Single repo means a single blast radius for pushes. A broken `main` blocks every product.
+- Monorepo tooling (Turbo, pnpm workspaces) adds complexity over a simple repo.
+- The current layout has legacy drift. Migrating to the bounded-context target is a multi-phase job; mixed states will exist in the meantime.

--- a/docs/adr/0009-path-3-vibe-kanban-routing.md
+++ b/docs/adr/0009-path-3-vibe-kanban-routing.md
@@ -1,0 +1,33 @@
+# ADR-0009: Path 3 Vibe Kanban routing for multi-chunk code work
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+AI coding work happens in three size classes. Small fixes are one line, one file, one turn: a typo, a renamed variable, a missing null check. Medium tasks are a few files, a few turns, but still a single focused session: add a new API endpoint, wire a new MCP tool. Large tasks span many turns, touch many files, may hit dead ends, and need rollback: refactor the auth pipeline, build a new product pillar. Treating all three the same is a source of repeated mistakes. Small fixes done in a full worktree waste setup time. Large tasks done in a direct chat overflow context and corrupt earlier work with no rollback path.
+
+Three routing paths have evolved. Path 1: `@claude` comments on GitHub issues or PRs, for small in-place fixes. Path 2: direct courier session, for medium tasks where the full context fits. Path 3: Vibe Kanban (VK), which creates an isolated worktree branch and enforces a mandatory PR completion protocol, for multi-chunk work.
+
+## Decision
+
+Code tasks longer than a single chat turn are routed through Vibe Kanban as isolated worktrees with mandatory PR completion protocol. The cloud repo is the source of truth; the VK worktree is scratch space. Every task completes with a PR against `main` (or a feature branch), never a direct commit. Path 1 and Path 2 remain available for their respective size classes; Path 3 is the default for anything that does not fit Path 1 or Path 2 cleanly.
+
+Practical rules:
+- A VK worktree is ephemeral. If the work succeeds, the PR merges and the worktree is discarded. If it fails, the branch is deleted.
+- No VK agent pushes to `main` directly. Completion means "PR opened and URL reported."
+- The harness enforces the completion protocol. An agent that tries to call work done without a PR URL has not completed the task.
+
+## Consequences
+
+**Benefits:**
+- Multi-chunk work has isolation. A failed experiment does not contaminate `main` or earlier sessions.
+- PR review is mandatory. A human sees every significant change before it lands.
+- Context windows are cleaner. The VK worktree starts from repo HEAD, not from a chat that has drifted over hours.
+- Rollback is a branch delete. No post-hoc surgery on `main`.
+
+**Drawbacks / trade-offs:**
+- VK setup is a small overhead for tasks that turn out to be smaller than they looked.
+- Multiple VK worktrees for the same product can diverge. Coordinated PRs may require rebases.
+- The harness must faithfully enforce PR-on-completion, or the benefit evaporates. Tooling correctness is a load-bearing assumption.

--- a/docs/adr/0010-bolt-on-signals-pattern.md
+++ b/docs/adr/0010-bolt-on-signals-pattern.md
@@ -1,0 +1,30 @@
+# ADR-0010: Bolt-on `withSignals` pattern for tool observability
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Supersedes/Extends**: None
+
+## Context
+
+UnClick wires 450+ callable endpoints across 60+ integrations. Every one of those endpoints can succeed, fail, or hit a user-alert condition (quota reached, auth expired, rate limited). Users need a uniform way to see what happened. The Signals product is the inbox surface; the question is how each tool emits into it.
+
+Option A is to require every tool implementation to write to the `mc_signals` table directly. This scales linearly with tool count, and every new tool adds boilerplate that can drift: different field names, missing emission on failure, forgotten emission on success. After 450 tools, uniformity collapses.
+
+Option B is a higher-order wrapper applied at the wiring layer. One piece of code observes every tool call, reads its name and outcome, and writes a signal with a uniform shape. Tool implementations stay focused on business logic.
+
+## Decision
+
+All UnClick tools emit observability signals through a shared `withSignals` wrapper rather than inline telemetry code per tool. The wrapper is applied in `packages/mcp-server/src/tool-wiring.ts` at the site where each tool is registered, so every new tool gains signal emission on day one. Tool implementations do not call `mc_signals` directly in the normal case. Special cases that need non-default signal shape (e.g. a long-running tool emitting progress signals) extend the wrapper rather than bypass it.
+
+## Consequences
+
+**Benefits:**
+- Uniform signal shape across all 450+ tools. Clients render identical cards regardless of source.
+- Zero per-tool overhead. A new tool is observable immediately on registration.
+- Centralised telemetry policy. Changing severity rules, mute logic, or retention is one file, not 450.
+- Lower risk of drift. New tools cannot accidentally ship without observability.
+
+**Drawbacks / trade-offs:**
+- The wrapper must handle every tool's success and failure shape. When a tool returns something odd, the wrapper has to be smart or the signal degrades gracefully.
+- Per-tool customisation requires extending the wrapper, which is a mild coupling. Tools with genuinely unique signal needs (progress bars, multi-step outputs) pay a small cost.
+- Centralised patterns hide behaviour. A developer tracing "why did this signal appear" has to know to look in the wrapper, not in the tool.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,119 @@
+# UnClick Architecture Overview
+
+## Elevator description
+
+UnClick is the identity, memory, credentials, and economy layer every agent harness needs. One npm install gives an agent access to 450+ callable endpoints across 60+ integrations AND persistent cross-session memory, all via the MCP protocol. The user's own LLM chat client is the orchestrator; UnClick is the infrastructure that sits behind it. The platform follows the Stripe model (rails for the industry), not the Windows model (a competing OS), and bills only for platform features, never for LLM tokens.
+
+---
+
+## System diagram
+
+```mermaid
+flowchart TD
+    User[User]
+    Chat[Chat Client<br/>Claude Desktop / Cursor / ChatGPT]
+    MCP[MCP Server<br/>@unclick/mcp-server]
+    Edge[Vercel Edge + SPA]
+    API[Vercel Serverless API<br/>api/*.ts]
+    Auth[Auth Resolver<br/>api_key_hash + JWT]
+    Memory[Memory Service<br/>6 layers + pgvector]
+    BP[BackstagePass<br/>AES-256-GCM vault]
+    Crews[Crews + Council Engine]
+    TP[TestPass Runner]
+    Signals[Signals + withSignals]
+    Build[Build Desk]
+    Supabase[(Supabase<br/>Postgres + pgvector + RLS)]
+    AI[User's AI Provider<br/>Anthropic / OpenAI / Google]
+    Stripe[Stripe Connect<br/>80 / 20 marketplace split]
+
+    User --> Chat
+    Chat --> MCP
+    MCP --> Edge
+    Edge --> API
+    API --> Auth
+    Auth --> Memory
+    Auth --> BP
+    Auth --> Crews
+    Auth --> TP
+    Auth --> Signals
+    Auth --> Build
+    Memory --> Supabase
+    BP --> Supabase
+    Crews --> Supabase
+    Crews --> AI
+    TP --> Supabase
+    Signals --> Supabase
+    Build --> Supabase
+    Build --> AI
+    API --> Stripe
+```
+
+Nodes: user, chat client, MCP server, Vercel Edge + SPA, serverless API, auth resolver, six product services (Memory, BackstagePass, Crews, TestPass, Signals, Build Desk), Supabase, the user's AI provider, and Stripe Connect. Thirteen boxes, every edge is a real wire in today's codebase.
+
+---
+
+## The 7 product pillars
+
+1. **Memory.** Six layers (business context, sessions, facts, library, conversations, code), bi-temporal schema, hybrid retrieval via pgvector. Managed cloud default; BYOD escape hatch with AES-256-GCM encrypted service-role keys. Five direct MCP tools name the session protocol.
+2. **BackstagePass.** Encrypted credential vault. AES-256-GCM at rest, PBKDF2 key derivation, proof-of-possession auth (JWT plus plaintext api_key, timing-safe compare), full audit log on every action.
+3. **Crews.** Composable AI crews from agent personas (developer, researcher, writer, organiser). Council engine at `src/lib/crews/engine.ts` orchestrates runs; `mc_crew_runs` records input, output, tokens, and provenance.
+4. **TestPass.** QA pack runner for MCP servers. YAML packs, probe runner, compliance reports, GitHub Action, visual run UI at `/admin/testpass`. Anti-stomp pack guards against tools tampering with memory.
+5. **Signals.** Notifications hub with a shared `withSignals` wrapper applied at tool-wiring time. Every tool emits uniform signals for success, failure, and user-alert cases. Cron-dispatched delivery every minute.
+6. **Build Desk (Agents).** Task and worker orchestration. Multi-backend workers (Claude Code, Codex, Cursor, Gemini CLI). Task composer UI at `src/pages/BuildDesk.tsx`. Every dispatch event is audited; completion is PR-gated.
+7. **Marketplace.** Developer portal with Stripe Connect and 80/20 revenue split (developer 80, UnClick 20). Built but doors closed pending curation layer. TestPass compliance is the gate for listings.
+
+---
+
+## Tenant data flow
+
+```
+user creates account
+    -> api_keys row: { user_id, email, key_hash, tier }
+    -> api_key_hash = SHA-256(user's raw api_key)
+
+every request (browser or MCP):
+    Bearer token OR Supabase JWT
+    -> resolveApiKeyHash / resolveSessionUser
+    -> server-derives api_key_hash (never trusts client-supplied)
+    -> TenantContext = { userId, apiKeyHash, tier, isAdmin }
+
+every DB query:
+    .eq("api_key_hash", tenant.apiKeyHash)  // manual filter, required
+    + RLS policy on the table                // second layer
+    -> scoped rows returned
+```
+
+The client never supplies `api_key_hash`. Two layers of enforcement: manual `.eq` filters in every service_role query plus Row Level Security policies on every user-scoped table. Either layer alone has a failure mode; both together give defence-in-depth. See [ADR-0004](../adr/0004-multi-tenant-via-api-key-hash.md) and `docs/security/policies.md` section 3.
+
+---
+
+## Deployment topology
+
+- **Vercel** hosts the website SPA (Vite build) and the serverless functions under `api/`. The Hobby plan caps the function count at 12, which forces the `memory-admin.ts` god-handler pattern today. Phase 3 migrates to Hono-on-Vercel to lift that cap without re-platforming. Two Vercel cron schedules: `nightly_decay` at 04:00 UTC and `signals-dispatch` every minute.
+- **Supabase** is the single database and auth provider. Postgres with pgvector for hybrid retrieval, RLS enabled on 31 user-scoped tables (Phase 3 closes the remaining gaps), Supabase Auth for magic-link and OAuth (Google, Microsoft, GitHub).
+- **Cloudflare** is the CDN in front of the Vercel edge for the marketing pages and static assets.
+- **GitHub** is the source of truth. `main` deploys via Vercel GitHub integration on push. Supabase migrations apply via the `apply-migrations` workflow.
+- **Stripe Connect** handles marketplace payouts to developers at the 80/20 split when the marketplace opens.
+
+---
+
+## The three dev paths
+
+- **Path 1: `@claude` GitHub comments.** For small in-place fixes. A user or reviewer comments `@claude` on an issue or PR; `claude.yml` triggers a Claude Code run against the cloud repo. Output is a direct commit or a small PR. Right size: one-line fixes, typo corrections, obvious null checks.
+- **Path 2: Direct courier session.** For medium tasks that fit in a single chat. The developer pairs with Claude Code in their terminal. The cloud repo is the source of truth; the developer pushes when work is done. Right size: add a new MCP tool, wire a new API endpoint, ship a small feature.
+- **Path 3: Vibe Kanban (VK) worktree routing.** For multi-chunk work. VK creates an isolated git worktree branch, runs the agent against it, and enforces a mandatory PR completion protocol. No agent pushes to `main` directly; every completed task raises a PR for human review. The worktree is ephemeral; the PR is the durable artefact. Right size: refactor the auth pipeline, build a new product pillar, any task that spans many turns and files. See [ADR-0009](../adr/0009-path-3-vibe-kanban-routing.md).
+
+---
+
+## How tools get added
+
+1. **Handler.** Create `api/*-tool.ts` (or extend an existing action handler) with the Vercel handler and endpoint logic. Tenant context comes from `resolveApiKeyHash` / `resolveSessionUser`. Input is validated with a Zod schema.
+2. **Wire.** Add the tool to `packages/mcp-server/src/tool-wiring.ts` with name, description, category, and endpoint mapping. The `withSignals` wrapper applies automatically at wiring time. See [ADR-0010](../adr/0010-bolt-on-signals-pattern.md).
+3. **Surface.** Add a tile in `src/pages/tools/Tools.tsx` for the website marketplace grid.
+4. **Compliance.** Every new tool gets a TestPass pack entry in `packages/testpass/` so the `testpass-pr-check.yml` CI check covers it.
+
+No per-tool MCP registration is added to `server.ts`. The 450+ endpoints are reached through the meta-tools (`unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call`). The only direct MCP registrations are the five memory tools (`load_memory`, `save_session`, `save_fact`, `search_memory`, `save_identity`). This keeps the client-facing tool list readable and lets the catalog scale without per-tool plumbing. See [ADR-0001](../adr/0001-mcp-first-agent-protocol.md).
+
+---
+
+**End of overview.md.**

--- a/docs/prd/agents.md
+++ b/docs/prd/agents.md
@@ -1,0 +1,54 @@
+# PRD: Agents (Build Desk)
+
+**Status**: Shipped through Phase 5. Multi-backend worker support live.
+**Last updated**: 2026-04-25.
+
+## Problem statement
+
+A user who wants a coding task done has to choose a harness (Claude Code, Codex, Cursor, Gemini CLI), paste context into it, shepherd it through the work, and then track what it produced. Every harness is its own silo: different repo state, different context, different output format. A user who wants to use more than one is running three or four dashboards at once.
+
+Build Desk is the single orchestration surface: one desk, many engines. A user creates a task, picks a worker backend, and watches progress. Context and credentials come from UnClick. The harness is an interchangeable runtime.
+
+## Target user
+
+- **Solo developers and small teams.** People who code daily and want to route work across whichever AI coder is best for the job today.
+- **Non-developer tenants running code-adjacent work.** A marketer who wants a one-off script. An operator who wants a data export. Build Desk turns code-based work into a task they can delegate.
+- **Power users orchestrating multi-worker workflows.** The same user who composes Crews for writing can compose worker fleets for code.
+
+## Core capabilities
+
+1. **Task registry.** `build_tasks` table stores user-created tasks with title, description, status, assigned worker, and a link to the resulting PR or artifact. Status moves through todo, in-progress, review, done.
+2. **Worker registry.** `build_workers` captures every coder backend the tenant has registered: Claude Code, Codex, Cursor, Gemini CLI. Each worker has a health check and last-seen timestamp.
+3. **Dispatch events.** `build_dispatch_events` records every task handoff: when, to which worker, with what context, and what came back. Audit trail and debugging surface in one.
+4. **Multi-backend support.** Workers are pluggable. Adding a new backend is a registration entry plus a dispatch adapter; the UI treats all backends uniformly.
+5. **Task composer UI.** `src/pages/BuildDesk.tsx` provides the card-based task composer. Non-developers can file a task and pick a worker without writing a prompt.
+6. **Integration with Crews and Memory.** A Build Desk task can include facts, library docs, or a crew run as context. The worker starts with the tenant's shared knowledge, not a blank slate.
+
+## Success metrics
+
+- **Tasks completed per active tenant per week.** Primary adoption metric.
+- **Workers registered per tenant.** A tenant running multiple backends is using the desk as designed.
+- **Worker health SLO.** Percentage of registered workers passing health check at any moment. Dormant workers are acceptable; unhealthy workers are a UX failure.
+- **Dispatch success rate.** Percentage of dispatches that return a valid result. Low rates indicate backend or context issues.
+- **Average task turnaround.** Time from created to done. Signals whether the orchestration is saving the user time.
+
+## Out-of-scope
+
+- **We do not embed a code editor.** Workers are external harnesses. Build Desk is the orchestration surface, not an IDE.
+- **We do not ship our own coding agent.** Backends are third-party. UnClick stays in the orchestration lane. See [ADR-0003](../adr/0003-stripe-model-not-windows.md).
+- **We do not auto-merge PRs from workers.** Completed tasks raise a PR; the human reviews and merges. No silent writes to `main`.
+- **We do not store the worker's API keys beyond what BackstagePass holds.** Credentials used by a worker flow through BackstagePass; Build Desk does not duplicate them.
+
+## Key decisions and why
+
+- **Worker registry instead of hardcoded backend list.** Tenants run whatever harness they prefer. Hardcoding `backends = ["claude-code", "cursor"]` would freeze the product against the user's environment.
+- **`build_dispatch_events` as audit and debug.** Multi-backend orchestration fails in creative ways. An event log per dispatch is the only way to investigate a bad handoff.
+- **PR-gated completion.** Workers never push to `main` directly. Every task outcome is a PR against a branch the user can review. This mirrors Path 3 Vibe Kanban routing. See [ADR-0009](../adr/0009-path-3-vibe-kanban-routing.md).
+- **Context comes from UnClick, not the worker.** Memory facts, library docs, credentials all travel with the task. A Codex worker with the user's memory is a different product from a Codex worker without it.
+- **No RLS on `build_*` tables today.** Documented in `docs/security/current-posture.md` as a known gap. Scoping is enforced at the service layer; RLS is planned in Phase 3 security work.
+
+## Platform philosophy alignment
+
+- **Idiot-proof UX.** The task card asks for title, description, and worker choice. Three inputs. A user filing a task does not see a prompt template, tool list, or context wiring.
+- **Subscription-based (no LLM billing).** Workers burn the user's own AI subscription. A Claude Code worker spends against the user's Anthropic bill, not UnClick's. The platform tier covers the orchestration layer itself.
+- **MCP-first.** Build Desk exposes task create, dispatch, and status via `unclick_call`. An agent can file its own task, watch it complete, and act on the outcome. The web UI is for humans; agents reach the desk through MCP.

--- a/docs/prd/backstagepass.md
+++ b/docs/prd/backstagepass.md
@@ -1,0 +1,53 @@
+# PRD: BackstagePass
+
+**Status**: Shipped. Vault live at `api/backstagepass.ts`. Proof-of-possession auth enforced.
+**Last updated**: 2026-04-25.
+
+## Problem statement
+
+Agents need credentials to do real work. A user who wants Claude to post to Slack, read their Xero books, or list their Shopify orders has to hand an API key or OAuth token to their agent. Today that happens through one of three bad paths: typing the key into the chat (leaked to the model provider), pasting it into a config file (leaked to the harness), or wiring a server-side integration per tool (not portable).
+
+The credentials belong to the user. The agent needs them just-in-time, not always, and every access should be auditable. A vault purpose-built for agent-mediated access is the missing piece.
+
+## Target user
+
+- **Agent-native users connecting real business tools.** Anyone who wants their agent to act on Stripe, Slack, Gmail, Xero, GitHub, Shopify, Notion, and the 50+ other connectors UnClick supports.
+- **Privacy-aware users.** People who understand that a token in a config file on a harness machine is a liability.
+- **Developers submitting tools to the marketplace.** Marketplace tools must read credentials through BackstagePass, never through ambient env vars.
+
+## Core capabilities
+
+1. **Encrypted credential vault.** AES-256-GCM at rest with a per-row IV and auth tag. PBKDF2 key derivation from the user's own api_key. UnClick staff cannot decrypt user credentials.
+2. **Proof-of-possession auth.** Reveal requires the Supabase session JWT **and** the plaintext api_key in the body, compared with a timing-safe equality check. A stolen JWT alone cannot unlock the vault.
+3. **Full audit log.** Every list, reveal, update, and delete writes `backstagepass_audit` with actor, action, credential name, and timestamp. The log is append-only at the RLS layer.
+4. **Scoped RLS.** `user_credentials` has `block_anon_access` and `block_authenticated_direct_access` policies. Only service_role with a verified tenant context can touch the rows.
+5. **CORS restricted.** The endpoint accepts requests only from `https://unclick.world`. No wildcard origins on credential traffic.
+6. **Per-tenant scoping.** Every read and write adds `.eq("api_key_hash", hash)` on top of RLS. Defence-in-depth at both layers.
+
+## Success metrics
+
+- **Vault fill rate.** Number of credentials stored per active tenant. A tenant with 0 credentials has not moved real work onto the platform.
+- **Reveal events.** Rate of successful reveals. A sudden spike is a product signal; a sudden spike on one tenant is a security signal.
+- **Zero cross-tenant reveal incidents.** The blocker metric. Any cross-tenant reveal is a full-stop incident.
+- **Audit coverage.** 100 percent of destructive actions logged. Currently at 100 percent for BackstagePass; enforced by service-side contract.
+
+## Out-of-scope
+
+- **We do not proxy credential usage.** BackstagePass stores and reveals; it does not broker the outbound API call. The calling tool uses the revealed credential directly.
+- **We do not support shared team vaults in this phase.** Each vault is per-tenant. Team sharing is a future phase.
+- **We do not rotate credentials automatically.** Rotation is the provider's responsibility; BackstagePass supports rotation by update but does not initiate it.
+- **We do not store credentials without encryption.** There is no plaintext-at-rest mode, even for debug.
+
+## Key decisions and why
+
+- **AES-256-GCM with PBKDF2, not KMS.** The encryption key is derived from the user's own api_key. Losing the api_key means losing access to the vault, which is the correct security posture for a proof-of-possession system. A managed KMS would make UnClick staff able to decrypt, which we deliberately do not want.
+- **Reveal requires JWT and api_key.** Single-factor access was ruled out. A JWT alone proves browser session possession but not device possession; pairing it with the api_key binds reveal to an artefact the user controls.
+- **Timing-safe compare on api_key.** Constant-time comparison resists timing attacks. The api_key is a secret; leaking it bit-by-bit through response timing is the class of bug BackstagePass was designed to prevent.
+- **Full audit log, no exceptions.** Destructive-write-without-log is a repudiation risk. The audit surface exists so incident response has a trail.
+- **No multi-factor on reveal in v1.** The combination of JWT plus api_key plus timing-safe compare plus scoped CORS is judged sufficient for the current threat model. Adding second-factor confirmation is on the roadmap as the vault scales.
+
+## Platform philosophy alignment
+
+- **Idiot-proof UX.** The BackstagePass page presents credentials as cards. Add, reveal, rotate, delete. No concepts like IV, salt, or GCM auth tag reach the user. The complexity is fully hidden.
+- **Subscription-based (no LLM billing).** BackstagePass is priced by vault size in the platform tier. It never touches the user's LLM provider relationship.
+- **MCP-first.** Credentials are retrievable through `unclick_call` with the BackstagePass endpoint. Agents list and reveal credentials using the same meta-tool surface they use for everything else. The web UI is a human convenience, not a parallel path.

--- a/docs/prd/crews.md
+++ b/docs/prd/crews.md
@@ -1,0 +1,54 @@
+# PRD: Crews
+
+**Status**: Shipped through Phase C. Council template execution engine live.
+**Last updated**: 2026-04-25.
+
+## Problem statement
+
+One agent is not enough for real work. A blog post benefits from a researcher, a writer, and a critic. A product launch benefits from an organiser, a marketer, and a developer. Today a user who wants multi-agent collaboration has to wire it themselves: manage prompts, pass context between turns, handle token budgets, record outputs. The engineering cost of "use three agents instead of one" is the reason most users run a single agent despite the obvious gains from teamwork.
+
+Crews removes the wiring. Users compose a crew from pre-built personas, hit run, and get coordinated output. Agents stay specialised; the engine does the plumbing.
+
+## Target user
+
+- **Creative professionals running multi-step projects.** The blogger, the product marketer, the consultant, the researcher. Anyone who mentally splits a project into roles.
+- **Business operators managing recurring workflows.** Weekly brief, monthly review, quarterly plan. Crews captured once; run on demand.
+- **Developers prototyping agent orchestration.** Hand-written loops are slow to iterate. Crews is a known-good baseline that can be extended.
+
+## Core capabilities
+
+1. **Composable agent personas.** Pre-built roles (developer, researcher, writer, organiser) with tuned seed prompts. Users clone a system persona, adjust the seed, and add it to a crew.
+2. **Crew templates.** Ready-to-run crews (Council, Writer-Researcher, Launch Team) that drop in with one click. Starter data in `src/data/starterCrews.ts`.
+3. **Phase C execution engine.** The Council engine (`src/lib/crews/engine.ts`) runs a multi-turn orchestration with token budgets, per-agent output capture, and structured completion. `mc_crew_runs` records input, output, token spend, and provenance per run.
+4. **Per-run audit trail.** Every run writes `mc_crew_runs` plus `agent_trace` entries. Users can replay, fork, or export any run.
+5. **Tenant isolation.** Crews, agents, and runs all scope to `api_key_hash`. System personas (marked `is_system`) are shared in read-only form; user clones live inside their own tenant.
+6. **Admin UI.** Crew Composer, crew list, run detail, settings. Card-based, idiot-proof. Non-coders assemble a crew in under five minutes.
+
+## Success metrics
+
+- **Active crews per tenant.** A tenant with at least one running crew has adopted the product.
+- **Runs per active crew per week.** Recurrence is the retention signal.
+- **Template adoption vs custom.** Ratio shows whether our starter set covers the common jobs.
+- **Run success rate.** Percentage of runs that complete without error or timeout. Target above 95 percent.
+- **Average agents per crew.** Above 2 means users are genuinely using teamwork; at 1 the product is a fancy single-agent wrapper.
+
+## Out-of-scope
+
+- **We do not host the model.** Crew runs use the user's configured AI provider. UnClick orchestrates; the user's subscription supplies the tokens. See [ADR-0002](../adr/0002-subscription-only-billing.md).
+- **We do not run arbitrary code inside a crew step.** Tool calls go through the standard UnClick MCP surface. Crews is orchestration, not a sandboxed runtime.
+- **We do not support real-time streaming crews in v1.** Runs are turn-based; output appears when each agent finishes. Streaming is a future enhancement.
+- **We do not permit cross-tenant persona sharing at runtime.** Clones are the supported sharing model; direct runtime reference would couple tenants.
+
+## Key decisions and why
+
+- **System persona clone model over live reference.** If a tenant edits a cloned persona, only their crew changes. System personas are versioned; a propagation path is deliberate rather than implicit. Blast radius is self-contained.
+- **`is_system` flag over a separate table.** One `mc_agents` table with a boolean keeps the query path simple and lets admin UIs list system and user agents side-by-side.
+- **Engine in `src/lib/crews/engine.ts`, imported from the API layer.** Today's layout crosses the React-bundle / serverless boundary. The target-state architecture moves it to `packages/engine`; we accepted the boundary crossing for speed during Phases A through C. See `docs/architecture/current-state.md` section 5.
+- **Token budget enforced per run.** `mc_crew_runs.token_budget` caps runaway crew cost. The user's provider still bills them; the cap prevents a misconfigured crew from draining their subscription.
+- **Per-turn audit trail.** `agent_trace` records every model and tool invocation. The crew run record is the summary; the trace is the forensic detail.
+
+## Platform philosophy alignment
+
+- **Idiot-proof UX.** The Crew Composer uses plain-language role names (Writer, Researcher, Critic) and a card-based builder. No YAML, no prompt templates, no orchestration glossary.
+- **Subscription-based (no LLM billing).** Crew runs burn the user's own token allowance at their AI provider. UnClick bills for the platform tier and seats. Token cost never routes through UnClick's bill.
+- **MCP-first.** Crew runs are startable via `unclick_call` with the crews endpoint. An agent can kick off a crew from inside its own conversation, read the result, and act on it. The admin UI is a human-friendly layer over the same API.

--- a/docs/prd/memory.md
+++ b/docs/prd/memory.md
@@ -1,0 +1,61 @@
+# PRD: Memory
+
+**Status**: Shipped. Phase 1 memory backend complete. Bi-temporal + pgvector hybrid retrieval live.
+**Last updated**: 2026-04-25.
+
+## Problem statement
+
+Agents forget. A user who spent an hour yesterday teaching Claude their preferences starts from scratch the next morning, or loses that context when they switch to Cursor, or loses it when a new model drops. Session-scoped memory is the default across every LLM harness. For a user who lives in agents, this is a productivity tax: every session starts with a catch-up tax that humans never agree to pay twice.
+
+Memory belongs to the user, not the harness. It should survive model upgrades, harness switches, and new devices. It should be private by default, encrypted at rest, and recoverable by export.
+
+## Target user
+
+- **Agent-native users.** People whose primary interface to their work is an LLM chat. They notice immediately when a new session does not know them.
+- **Business operators who switch harnesses.** Claude this morning, ChatGPT at a client meeting, Cursor in the afternoon. Memory must be harness-agnostic.
+- **Privacy-first power users.** BYOD (bring your own database) mode lets users store memory in their own Supabase project with service-role keys encrypted client-side so UnClick staff cannot decrypt.
+
+## Core capabilities
+
+1. **Six memory layers, each mapped to a real agent workflow.**
+   - Business context: standing rules the agent loads on every turn.
+   - Sessions: summaries of prior conversations.
+   - Facts: atomic statements with confidence, category, and supersede chain.
+   - Library: canonical documents with provenance and history.
+   - Conversations: raw conversation log for replay and debugging.
+   - Code: code dumps and architecture snapshots.
+2. **Bi-temporal schema.** Every fact has `valid_from` and `valid_to`. Soft-deletes retain provenance. The write path is defensible; the audit trail is auditable.
+3. **Hybrid retrieval.** pgvector semantic search combined with keyword filters and recency. Sub-second recall across millions of rows.
+4. **Managed cloud by default, BYOD as an escape hatch.** Free-tier users get a managed Supabase slice scoped by `api_key_hash`. Power users configure their own Supabase via the Memory Setup wizard and keep their service-role key encrypted with PBKDF2 from their own api_key.
+5. **Five direct MCP tools.** `load_memory`, `save_session`, `save_fact`, `search_memory`, `save_identity`. These name the session protocol agents should follow. The other 12 operations are callable via `unclick_call`.
+6. **Tier-based caps and decay.** Free tier: 50 MB and 5,000 facts with basic layers. Pro tier removes caps and enables nightly extraction plus hot/warm/cold decay.
+7. **Data portability as a first-class feature.** `admin_export_all` returns the user's full memory in a portable shape. "Bring your own database anytime" is the trust anchor.
+
+## Success metrics
+
+- **Session-two recall rate.** Percentage of users whose second session calls `load_memory`. Ceiling: 100% via auto-load in supported harnesses.
+- **Memory volume per active user.** Average facts per tenant after 30 days. A user with 0 facts has not adopted memory; a user with 500 facts has.
+- **Retrieval latency (p95).** Sub-second at any corpus size we support on-tier.
+- **BYOD activation rate.** Power-user segment proxy. Low-single-digit percentage is expected and healthy.
+- **Export events.** Users who export confirm the portability promise. A high export-without-churn rate is positive; export-then-churn flags a product issue.
+
+## Out-of-scope
+
+- **We do not index files on the user's disk.** Memory is what the user or agent explicitly saves, not ambient capture.
+- **We do not run embeddings on arbitrary URLs.** The library layer accepts canonical docs that the user or agent submits.
+- **We do not sell memory separately.** Memory is bundled with the platform tier. See [ADR-0002](../adr/0002-subscription-only-billing.md).
+- **We do not share memory across tenants.** Every row is scoped by `api_key_hash`. Cross-tenant retrieval is structurally impossible via the supported API.
+
+## Key decisions and why
+
+- **`api_key_hash` is the tenant key, not `user_id`.** Memory predated the Supabase Auth wiring. Hash-scoping keeps memory independent of auth mode and works for both BYOD and managed. See [ADR-0004](../adr/0004-multi-tenant-via-api-key-hash.md).
+- **Bi-temporal over hard-delete.** The 2026-04-22 near-miss incident made the case for provenance. Soft-delete with `valid_from` / `valid_to` columns plus `mc_facts_audit` records every mutation.
+- **pgvector over a vector database.** Supabase is the single source of truth. One database simplifies ops, backups, and tenant scoping. Hybrid retrieval closes the precision gap.
+- **Managed cloud default, BYOD escape hatch.** One-click onboarding beats five-step setup every time. Users who need air-gap control can still move to BYOD without losing their data.
+- **Five direct memory tools (not all 17).** The five cover the session protocol an agent should follow. The other 12 stay behind `unclick_call` to keep the tool list readable in clients with limited UI.
+
+## Platform philosophy alignment
+
+- **Idiot-proof UX.** Managed cloud needs zero Supabase knowledge. The Memory Setup wizard for BYOD walks the user through schema install. No one has to paste SQL to get memory working.
+- **Subscription-based (no LLM billing).** Memory is priced by storage, facts, and extraction jobs. Users supply their own embedding model calls or use the default OpenAI adapter at their own cost. UnClick never marks up model tokens.
+- **MCP-first.** The five direct memory tools are the canonical agent interface. The admin UI exists for humans and for support; MCP is what agents see.

--- a/docs/prd/signals.md
+++ b/docs/prd/signals.md
@@ -1,0 +1,54 @@
+# PRD: Signals
+
+**Status**: Shipped. Phase 1 MVP live. `withSignals` wrapper applied at tool wiring.
+**Last updated**: 2026-04-25.
+
+## Problem statement
+
+An agent that runs in the background without observability is a liability. Users who have hundreds of tool calls a day need a way to see what happened, what succeeded, what failed, and what needs their attention. Today most MCP harnesses throw model output at the user and call it done; anything that happens inside a tool call is invisible unless the agent narrates it.
+
+UnClick is also the layer that needs to alert users: memory cap approaching, credential expiring, crew run finished, marketplace tool updated. A uniform notifications surface is the only sane way to do that across 450+ endpoints without bolting a notification stanza onto every tool.
+
+## Target user
+
+- **Agent-native users running many actions.** The more an agent does per day, the more a user needs a signals inbox.
+- **Business operators coordinating multi-step workflows.** Crew runs, TestPass runs, long-running tasks need completion notifications.
+- **Developers shipping tools.** A tool that wants to alert the user (quota hit, auth expired, integration degraded) uses Signals rather than inventing its own channel.
+
+## Core capabilities
+
+1. **Notifications hub.** `mc_signals` table stores every signal with title, body, severity, category, read state, and source tool. Accessible via the admin Signals page and directly through MCP.
+2. **`withSignals` bolt-on wrapper.** A higher-order wrapper applied at tool wiring time. Every wrapped tool emits signals for success, failure, and user-alert cases without per-tool code.
+3. **Preferences per category.** Users mute categories, choose email digest vs realtime, and set quiet hours. `mc_signal_preferences` stores the per-tenant settings.
+4. **Cron-driven dispatch.** `api/signals-dispatch.ts` runs every minute via `vercel.json` cron. Fan-out handles email, web push (future), and webhook delivery.
+5. **Read state and bulk actions.** Mark one, mark all, filter unread, search. The surface is designed as an inbox, not a log.
+6. **Uniform shape.** Every signal regardless of source has the same fields. Clients never special-case per tool.
+
+## Success metrics
+
+- **Signals per active tenant per day.** A tenant with 0 signals is not yet getting value from their integrations. A tenant with thousands is being spammed.
+- **Read rate.** Percentage of signals the user marks read (or that are auto-marked by open events). Low read rates suggest noise.
+- **Mute rate by category.** High mute on a category is a signal to the category owner that its noise-to-signal ratio is bad.
+- **Time-to-read on High-severity.** How fast users acknowledge incidents. A latency signal for the product surface itself.
+- **Cron job SLO.** `signals-dispatch` completes inside its one-minute budget 99.9 percent of the time.
+
+## Out-of-scope
+
+- **We do not send SMS in v1.** Email, in-app, and webhook only. SMS has carrier complexity that does not fit Phase 1.
+- **We do not support per-signal routing rules.** Routing is per-category. A rules engine is a Phase 3 feature if demand proves out.
+- **We do not store signal bodies forever.** A retention window applies; users who need permanent record should export.
+- **We do not relay third-party notifications we did not generate.** Signals is UnClick's bus, not an aggregator.
+
+## Key decisions and why
+
+- **One bolt-on wrapper, not per-tool emit code.** 450+ tools cannot each have bespoke observability code. `withSignals` at the wiring layer guarantees coverage and uniform shape. See [ADR-0010](../adr/0010-bolt-on-signals-pattern.md).
+- **Cron over long-polling worker.** Vercel's Hobby plan has no always-on worker; a one-minute cron is cheap, reliable, and idempotent. Latency under 60 seconds is acceptable for the MVP.
+- **Category-based preferences over per-tool.** Scaling per-tool preferences to 450+ integrations would drown the user in setting rows. Categories (billing, memory, credentials, runs) keep the preference surface small.
+- **Same schema regardless of source.** A crew run signal and an integration signal share a shape. Clients stay simple; future channels (mobile, webhook) do not need source-specific code.
+- **Phase 1 MVP over a perfect build.** The current system does in-app read, basic email digest, and webhook. Advanced routing, mobile, and SMS are Phase 2+. We shipped minimum viable to close the observability gap, not the perfect inbox.
+
+## Platform philosophy alignment
+
+- **Idiot-proof UX.** The Signals page is a familiar inbox. Click, read, mark. Preferences are three toggles per category. No concept of webhooks or delivery rules is required for the default user.
+- **Subscription-based (no LLM billing).** Signals is part of the platform tier. Free tier gets a daily digest; Pro gets realtime. No LLM calls are involved; no token costs flow through UnClick.
+- **MCP-first.** Agents read and act on signals through `unclick_call` (list, mark, preferences). An agent can process its own inbox as part of a planning turn. The web UI is human-facing, the MCP path is agent-facing.

--- a/docs/prd/testpass.md
+++ b/docs/prd/testpass.md
@@ -1,0 +1,53 @@
+# PRD: TestPass
+
+**Status**: Shipped. Phase 9A visual run UI live. GitHub Action wired. Anti-stomp pack published.
+**Last updated**: 2026-04-25.
+
+## Problem statement
+
+MCP servers are easy to ship and hard to trust. A user who installs a tool has no guarantee that its endpoints match its documentation, that it handles bad input gracefully, that it respects rate limits, or that it behaves predictably under load. The MCP spec does not mandate compliance; every server is whatever the developer wrote.
+
+A marketplace without a compliance bar is a malware distribution system. A QA runner that proves basic correctness before a tool reaches users is a prerequisite for opening the marketplace doors.
+
+## Target user
+
+- **Developers submitting tools to the UnClick marketplace.** TestPass is the gate; submissions must pass.
+- **Developers building MCP servers in general.** TestPass is released as a standalone package. Any MCP server author can run it in CI regardless of whether they intend to list with UnClick.
+- **UnClick internal QA.** We run TestPass against every first-party tool before catalog changes ship.
+
+## Core capabilities
+
+1. **YAML test packs.** Packs declare probes against MCP server endpoints: expected input, expected output, timeout, repeat count. Human-readable, version-controlled, reviewable.
+2. **Probe runner.** Executes the pack against a live MCP server (local or remote). Records pass, fail, skip, timeout per probe.
+3. **Compliance reports.** Machine-readable JSON plus human-readable markdown. Designed for PR comments and CI output.
+4. **Anti-stomp pack.** Detects tools that overwrite or inject into the user's memory without consent. A known class of misbehaviour by non-UnClick MCP servers; the anti-stomp pack is how we guard our users.
+5. **GitHub Action.** `testpass-pr-check.yml` runs TestPass on every PR touching tool wiring. The check is required on `main`.
+6. **Visual run UI.** Phase 9A shipped a live run page (`/admin/testpass`) with idiot-proof pack catalog and a wizard. Non-developer users can kick off a run against their own tools and see results without leaving the browser.
+
+## Success metrics
+
+- **First-party tool coverage.** Percentage of wired UnClick tools with a passing TestPass run per release. Target 100 percent.
+- **Third-party submission pass rate.** For the eventual marketplace: percentage of submissions that pass first try. Low numbers here mean the bar is unclear; high numbers mean the developer experience is healthy.
+- **Mean time to first successful run.** From `testpass init` to first passing probe. Target under five minutes for a developer.
+- **Anti-stomp detections per month.** Detections of tools trying to tamper with memory. Zero is the target; non-zero is the justification for the pack.
+
+## Out-of-scope
+
+- **We do not run security fuzzing.** TestPass proves declared behaviour; it does not probe for injection, auth bypasses, or timing attacks. That is a security scan, not a compliance run.
+- **We do not certify tool usefulness.** A tool can pass TestPass and still be worthless. Compliance is not quality.
+- **We do not guarantee market fitness.** Passing tools appear in the marketplace; marketplace curation is a separate product surface.
+- **We do not host the MCP servers under test.** TestPass connects to a server the developer supplies.
+
+## Key decisions and why
+
+- **YAML packs, not code.** Tests are config, reviewable by non-developers, diffable in PRs. Anyone comfortable with a compose file can write or audit a pack.
+- **Standalone npm package.** `packages/testpass/` is independently installable. A developer who never uses UnClick can still run our compliance suite. This also makes it trivial to open-source if we choose.
+- **Anti-stomp as a first-class pack.** The cross-tenant memory-tampering risk is real (see `docs/security/threat-model.md` UC-4). Anti-stomp is the structural defence that lets users install third-party MCP tools without UnClick losing control of their memory.
+- **GitHub Action over homegrown CI.** We live on GitHub. TestPass feedback appears where developers already work: in the PR.
+- **Visual run UI in addition to CLI.** Developers use CLI; users of the platform need a GUI. The Phase 9A run page lets a non-developer tenant verify a tool they installed without opening a terminal.
+
+## Platform philosophy alignment
+
+- **Idiot-proof UX.** The admin run page lists packs as cards, the wizard walks through pack selection and target server input. A non-developer can run TestPass on a tool they installed and get a clear pass or fail.
+- **Subscription-based (no LLM billing).** TestPass does not call LLMs. It is deterministic probing against MCP servers. No token spend passes through UnClick.
+- **MCP-first.** TestPass is the compliance floor for MCP servers. By design it speaks MCP and nothing else. Every UnClick tool and every third-party submission is validated against its MCP contract.

--- a/docs/prd/unclick-platform.md
+++ b/docs/prd/unclick-platform.md
@@ -1,0 +1,60 @@
+# PRD: UnClick Platform
+
+**Status**: Active. Umbrella PRD for the platform. Child PRDs cover each product pillar.
+**Last updated**: 2026-04-25.
+
+## Problem statement
+
+Agents are powerful but homeless. Every harness (Claude Desktop, Cursor, ChatGPT, custom clients) re-invents the same missing layer: identity, persistent memory, shared credentials, a trustworthy tool catalog, and a way for developers to earn from what they build. Today a user who switches harnesses loses their memory, loses their tool wiring, and starts from zero. Developers who build tools have nowhere to distribute them at scale.
+
+The market is producing agents faster than the infrastructure they need to be useful. UnClick closes the infrastructure gap. One npm install gives an agent access to 450+ callable endpoints across 60+ integrations and persistent cross-session memory, all via the MCP protocol.
+
+## Target user
+
+Two audiences, one platform:
+
+- **Creative professionals and business operators.** Non-coders who pay for Claude, ChatGPT, or Cursor and want their agent to remember them, take actions across their tools (Notion, Slack, Stripe, Gmail, GitHub), and coordinate real work. They do not want to install six MCP servers and wire credentials by hand.
+- **Developers building MCP tools.** People who want to ship a tool, reach an installed base, and earn from usage. Marketplace infrastructure is built; doors are closed until the curation layer is ready.
+
+## Core capabilities
+
+1. **MCP-first surface.** Every capability is exposed through the Model Context Protocol. One marketplace search tool (`unclick_search`) plus five direct memory tools. Agents discover and invoke the rest dynamically.
+2. **Persistent cross-session memory.** Six layers (business context, sessions, facts, library, conversations, code), bi-temporal schema, hybrid retrieval. Users keep context when they switch models or harnesses.
+3. **Credential vault (BackstagePass).** AES-256-GCM at rest, PBKDF2 key derivation, proof-of-possession auth, full audit log. One place for user-owned API keys and OAuth tokens.
+4. **Signals.** Notifications hub with a shared `withSignals` bolt-on so every tool emits the same shape of events.
+5. **Crews.** Composable AI crews assembled from agent personas (developer, researcher, writer, organiser). Users run multi-agent workflows without writing orchestration code.
+6. **TestPass.** QA pack runner for MCP servers. Developers ship a tool; TestPass proves it meets compliance before it reaches users.
+7. **Agents (Build Desk).** Task and worker orchestration across multiple code backends (Claude Code, Codex, Cursor, Gemini CLI). One desk, many engines.
+8. **Marketplace.** Developer portal with Stripe Connect and an 80/20 revenue split. Coming soon.
+
+## Success metrics
+
+- **Agent reach.** 450+ callable endpoints across 60+ integrations is the baseline. Growth of the wired catalog is tracked against integration demand.
+- **Retention via memory.** Users who call `load_memory` on session two and beyond are the retention signal. A user who never recalls memory is not yet locked in.
+- **BackstagePass activation.** Credential vault usage correlates with the user moving real work onto the platform.
+- **Marketplace GMV (post-launch).** Gross developer revenue run through Stripe Connect is the marketplace proof point.
+- **TestPass coverage.** Percentage of cataloged tools with a passing TestPass compliance run.
+
+## Out-of-scope
+
+- **We do not host a chat interface.** The user's own LLM client is the orchestrator. Building a competing chat creates a category conflict.
+- **We do not middle-man LLM costs.** Users bring their own Claude, GPT, or Gemini subscription. We do not proxy tokens, meter prompts, or mark up model usage.
+- **We do not build a harness.** Claude Desktop, Cursor, ChatGPT are our substrate, not our competition.
+- **We do not ship a device OS.** Path B is locked: infrastructure, not operating system. See [ADR-0003](../adr/0003-stripe-model-not-windows.md).
+- **We do not publish closed-source tools as developer work.** Marketplace submissions must pass TestPass and disclose their endpoints.
+
+## Key decisions and why
+
+- **MCP-first protocol.** Every capability exposed through MCP. Pick one protocol, be the best at it. See [ADR-0001](../adr/0001-mcp-first-agent-protocol.md).
+- **Subscription-only billing.** Users pay their own AI provider. UnClick bills for platform features (memory quota, BackstagePass slots, Crews seats, marketplace revenue share), never for LLM tokens. See [ADR-0002](../adr/0002-subscription-only-billing.md).
+- **Stripe model, not Windows model.** UnClick is the identity, memory, credentials, and economy rails for every agent harness. It is not itself a harness, a chat, or a device OS. See [ADR-0003](../adr/0003-stripe-model-not-windows.md).
+- **Multi-tenant via `api_key_hash`.** SHA-256 of the user's API key is the canonical tenant identifier. Two-layer JWT-to-api_key_hash resolution in every handler. See [ADR-0004](../adr/0004-multi-tenant-via-api-key-hash.md).
+- **Two-layer admin gating.** Server refuses AND frontend hides. Frontend-only hiding is not security; server-only refusal is bad UX. See [ADR-0005](../adr/0005-two-layer-admin-gating.md).
+- **Orchestrator is user chat.** Claude Desktop, Cursor, and friends orchestrate. UnClick is infrastructure. See [ADR-0006](../adr/0006-orchestrator-is-user-chat.md).
+- **Idiot-proof UX as platform rule.** Non-coder UX is the bar for every surface. See [ADR-0007](../adr/0007-idiot-proof-as-platform-rule.md).
+
+## Platform philosophy alignment
+
+- **Idiot-proof UX.** Every product pillar ships with a non-coder path. Wizards, sensible defaults, card-based UI. A creative professional can set up memory in under three minutes and never see a Supabase dashboard.
+- **Subscription-based (no LLM billing).** UnClick charges for platform features, not for tokens. Users keep their own AI subscriptions. The commercial relationship is with the user, not with the model provider.
+- **MCP-first.** Every capability is reachable through the MCP protocol. No parallel REST-only surface is the supported path for agents. The website and admin shell exist for humans; MCP is the canonical surface for agents.

--- a/docs/security/policies.md
+++ b/docs/security/policies.md
@@ -1,0 +1,103 @@
+# UnClick Security Policies
+
+**Baseline**: PR #128 ground-floor QC audit (2026-04-24, commit `4f655f2`).
+**Fixes applied**: PR #129 (open) closes C1 (RLS on `memory_configs` + new `mc_admin_audit` table), C2 (audit log before destructive admin actions: `admin_clear_all`, `reset_api_key`, `admin_agent_delete`), C3 (confirmed `platform_connectors` is global-public by design, added explicit scope comments, verified `platform_credentials` and `memory_configs` are correctly tenant-scoped), and C4 in part (32 -> 19 npm vulnerabilities via `npm audit fix`; remaining 9 high are in `undici` via `@vercel/node@^3` and require an approved major bump).
+
+These policies codify the operating rules. Every engineer and agent working on UnClick follows them.
+
+---
+
+## 1. Secret management
+
+- No hardcoded keys anywhere in the repo. Not in source, not in tests, not in fixtures, not in docs.
+- Secrets live in environment variables only. Vercel environment vars for runtime, GitHub Actions secrets for CI, local `.env.local` files (gitignored) for development.
+- User-provided credentials are stored in BackstagePass (`api/backstagepass.ts`). Storage format is AES-256-GCM at rest with PBKDF2 key derivation from the user's own api_key.
+- `.gitignore` excludes `*.local`, `*.local.json`, `.vercel`, and standard credential file patterns. `.env*` files have never been committed and must never be committed.
+- GitHub push protection with secret scanning must remain enabled on the repo. If it is ever disabled, the repo is frozen until it is re-enabled.
+- Service-role Supabase keys must be used only from server-side code. The anon key is the only Supabase key that ever reaches the browser.
+
+## 2. Two-layer gating
+
+- Every admin-only action is refused at the server level AND hidden at the frontend level. Both layers are required, not either. See [ADR-0005](../adr/0005-two-layer-admin-gating.md).
+- Server-side refusal uses the `ADMIN_EMAILS` env var checked in the tenant resolver.
+- Frontend hiding uses `<RequireAdmin>` which removes the route from the sidebar and redirects on direct URL access.
+- A PR that adds an admin surface without both layers is blocked at review.
+
+## 3. Tenant isolation
+
+- Every `service_role` query MUST have a manual `WHERE api_key_hash = <tenant_hash>` filter. Row Level Security policies are the second layer, not the first.
+- `api_key_hash` is the canonical tenant identifier (SHA-256 of the user's API key). See [ADR-0004](../adr/0004-multi-tenant-via-api-key-hash.md).
+- The client never supplies `api_key_hash`. Browser sessions re-derive it server-side from the Supabase JWT via `resolveSessionUser()`. Bearer requests derive it by hashing the inbound key via `resolveApiKeyHash()`.
+- Every new table that holds user-scoped data gets RLS enabled in its creation migration. No exceptions. `service_role_all`, `block_anon_access`, and `block_authenticated_direct_access` are the default policy set.
+- PR #129 enabled RLS on `memory_configs`. Phase 3 completes the remaining gaps: `memory_devices`, `build_tasks`, `build_workers`, `build_dispatch_events`, `memory_load_events`, `tenant_settings`, `conflict_detections`, `tool_detections`, and an RLS audit of `mc_agents`, `mc_crews`, `mc_crew_runs`.
+
+## 4. Destructive operations
+
+- Every destructive action writes to `mc_admin_audit` (or a product-specific audit table such as `backstagepass_audit`, `account_deletions_audit`) BEFORE the destructive operation executes.
+- The audit write must succeed before the destructive write proceeds. If the audit insert fails, the destructive operation aborts. PR #129 established this pattern on `admin_clear_all`, `reset_api_key`, and `admin_agent_delete`.
+- Audit rows include: `api_key_hash`, action name, timestamp, payload (tables affected, row counts, reason).
+- Audit tables are append-only at the RLS layer. Only `service_role` can insert; no client path can update or delete rows.
+- Phase 3 extends the pattern to `delete_fact`, `delete_session`, `delete_crew`, `update_business_context`, and `admin_update_fact`.
+
+## 5. Input validation
+
+- Every new API input must have a Zod schema at the handler boundary. No handler executes business logic on unvalidated input.
+- Schemas live alongside the handler file and are exported for testability.
+- Validation failure returns a structured 400 with a field-level error list. No generic "bad request" responses.
+- Existing handlers in `api/memory-admin.ts` that use ad-hoc `if (!field)` checks are migrated to Zod schemas incrementally in Phase 4 (see target-state section 4).
+- JSON parse operations (e.g. `JSON.parse(body.value)`) must be wrapped in try/catch. Never call `JSON.parse` on unvalidated input.
+
+## 6. Rate limiting
+
+- Every public endpoint must have rate limiting. No unlimited-access surface ships.
+- Authenticated endpoints: per-tenant limits keyed on `api_key_hash`. Tier-based (free=60, pro=300, team=1000 req/min as the current baseline).
+- Unauthenticated endpoints (`/api/arena`, `/api/mcp` discovery, `/api/report-bug`): per-IP limits with burst tolerance.
+- The Hono rate limiter in `apps/api/src/middleware/rate-limit.ts` is the reference implementation. Phase 3 either ports it into a helper used by Vercel handlers or migrates the surface to Hono on Vercel (see target-state section 2.3).
+- A rate-limit breach returns 429 with a `Retry-After` header. Breach events log to Signals for the tenant.
+
+## 7. Pre-commit hooks
+
+- Pre-commit hooks block `.env` files, `.env.*` files (except `.env.local.example`), and raw key strings matching known patterns: `sk-`, `eyJ`, `AKIA`, `xoxb-`, `ghp_`, `ghs_`, `ya29.`.
+- Pre-commit hooks run on every commit locally. Repository-level GitHub push protection enforces the same rules server-side.
+- Disabling hooks via `--no-verify` is not permitted. If a hook fires a false positive, fix the hook regex or explicitly allowlist the path in the hook config.
+- Hook bypass attempts (`--no-verify`, `--no-gpg-sign`) in pushed commits are flagged in review.
+
+## 8. PR review requirements
+
+- PRs touching authentication, RLS, credential handling, or tenant-scoping logic require at minimum one human review pass. An `@claude`-authored PR does not satisfy this requirement; a human reviewer must sign off.
+- Security-critical paths: `api/backstagepass.ts`, `api/memory-admin.ts` tenant resolvers (lines 205-391), `api/credentials.ts`, any `supabase/migrations/*` that adds or alters RLS, any change to `packages/mcp-server/src/memory/supabase.ts` tenancy wrapper, any change to `ADMIN_EMAILS` checks.
+- TestPass compliance must pass on the PR check (`testpass-pr-check.yml`).
+- `npm audit` results are reviewed on every PR; new High/Critical findings block merge.
+- PR descriptions for security-critical changes reference the relevant ADR and threat-model scenarios affected.
+
+## 9. Dependency management
+
+- `npm audit` runs weekly (nightly pipeline, see target-state section 8.1). High/Critical findings are triaged within 72 hours.
+- Triage outcomes: (a) apply `npm audit fix` and merge, (b) pin to a safe version with a rationale, (c) file a tracking issue if no fix exists and document the residual risk in `docs/security/current-posture.md`.
+- Major-version dependency bumps require an approving review from Chris. Example: the `@vercel/node@^3` to `@vercel/node@^5` bump needed to close the remaining undici CVEs is queued and awaits approval.
+- Transitive dependency risk is monitored via the lockfile. Lockfile diffs on PRs are reviewed as part of the security pass.
+- Dependencies that carry High CVEs known at install time are not added. The exception is a written rationale in the PR description.
+
+---
+
+## Known baseline (PR #128 findings, as of 2026-04-24 commit `4f655f2`)
+
+These are the critical findings from Phase 1 and the current status after PR #129. The pre-PR-#129 state is documented for continuity.
+
+- **C1 (closed by PR #129)**: `memory_configs` and `memory_devices` have no RLS enabled. `memory_configs` holds AES-256-GCM encrypted Supabase service-role keys per user. Status: PR #129 enables RLS with `service_role`-only policy on `memory_configs` and adds the `mc_admin_audit` table. `memory_devices` RLS closure remains a Phase 3 item.
+- **C2 (closed by PR #129)**: `admin_clear_all` nuked user memory with no audit log before the cascade. Status: PR #129 adds pre-op audit rows to `mc_admin_audit` for `admin_clear_all`, `reset_api_key`, and `admin_agent_delete`. Additional destructive actions (`delete_fact`, `delete_session`, `delete_crew`, `update_business_context`, `admin_update_fact`) remain Phase 3.
+- **C3 (closed by PR #129)**: `admin_tools` read `platform_connectors` with no tenant filter. Status: PR #129 confirms `platform_connectors` is a global connector catalog with an explicit `anon_read_connectors` RLS policy allowing public read by design. Explicit comments added. Per-tenant scoping was already correct on `platform_credentials` and `memory_configs`.
+- **C4 (partially closed by PR #129)**: 32 npm vulnerabilities, 18 High. Status: PR #129 ran `npm audit fix` (no `--force`), reducing to 19 vulnerabilities (9 High). The remaining 9 High are in `undici` pulled transitively via `@vercel/node@^3` and require a major bump to `@vercel/node@^5`, which is queued for a follow-up PR after Chris approves the `vercel.json` runtime migration.
+
+Residual items to close in Phase 3 per `docs/security/current-posture.md` and `docs/security/threat-model.md`:
+
+- Enable RLS on the remaining gap tables (`memory_devices`, `build_*`, `memory_load_events`, `tenant_settings`, `conflict_detections`, `tool_detections`).
+- Remove `?api_key=...` query-string auth from `setup_status`, `conflict_check`, `health_summary`.
+- Add security headers (CSP, X-Frame-Options, X-Content-Type-Options, HSTS, Referrer-Policy, Permissions-Policy).
+- Land application-level rate limiting on the Vercel surface.
+- Complete the `@vercel/node@^5` major bump to close the remaining 9 undici High CVEs.
+- Promote `backstagepass_audit` and similar into a unified `audit_events` table with read-optimised views.
+
+---
+
+**End of policies.md.**


### PR DESCRIPTION
## Phase 2: Ground Floor QC - Docs Only

No application code was changed.

### Deliverables

**PRDs (docs/prd/)**: crews, testpass, signals, memory, backstagepass, agents, unclick-platform (7 files)

**ADRs (docs/adr/)**: ADR-0001 through ADR-0010 - MCP-first, subscription billing, Stripe model, multi-tenancy, two-layer gating, orchestrator design, idiot-proof rule, monorepo, Path-3 routing, withSignals (10 files)

**Security policies (docs/security/policies.md)**: codified operating rules, baseline from PR #128, fixes tracked against PR #129

**Architecture overview (docs/architecture/overview.md)**: system diagram, 7 pillars, 3 dev paths, tenant data flow

### Review checklist
- [ ] No em dashes in any file
- [ ] Every PRD has Platform philosophy alignment section
- [ ] Every ADR has Supersedes/Extends line
- [ ] Security policies cites PR #128 as baseline
- [ ] No code or migration changes