### PR TITLE
fix: expose TestPass, Crews, and 48 marketplace tools in MCP tools/list

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -4728,6 +4728,221 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({ data: data ?? [] });
       }
 
+      // ── Crews Phase B actions ────────────────────────────────────────────
+
+      case "list_agents": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        // Inject tenant into session so RLS works (service_role bypasses RLS, so we
+        // filter manually instead).
+        await supabase.rpc("set_config", {
+          setting: "request.jwt.claims",
+          value: JSON.stringify({ api_key_hash: apiKeyHash }),
+          is_local: true,
+        }).catch(() => null);
+
+        const category = typeof req.query.category === "string" ? req.query.category : null;
+        const search = typeof req.query.search === "string" ? req.query.search.trim() : null;
+
+        let q = supabase
+          .from("mc_agents")
+          .select("id,slug,name,category,hook,description,tool_tags,icon,colour_token,is_system,source_agent_id,api_key_hash")
+          .or(`is_system.eq.true,api_key_hash.eq.${apiKeyHash}`)
+          .order("is_system", { ascending: false })
+          .order("name");
+
+        if (category) q = q.eq("category", category);
+        if (search) q = q.or(`name.ilike.%${search}%,hook.ilike.%${search}%`);
+
+        const { data, error } = await q;
+        if (error) throw error;
+        return res.status(200).json({ data: data ?? [] });
+      }
+
+      case "clone_agent": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const { slug } = req.body ?? {};
+        if (!slug) return res.status(400).json({ error: "slug required" });
+
+        const { data: src, error: srcErr } = await supabase
+          .from("mc_agents")
+          .select("*")
+          .eq("slug", slug)
+          .eq("is_system", true)
+          .maybeSingle();
+        if (srcErr) throw srcErr;
+        if (!src) return res.status(404).json({ error: "System agent not found" });
+
+        const cloneSlug = `${slug}-${apiKeyHash.slice(0, 8)}`;
+        const { data: clone, error: insertErr } = await supabase
+          .from("mc_agents")
+          .insert({
+            slug: cloneSlug,
+            api_key_hash: apiKeyHash,
+            name: src.name,
+            category: src.category,
+            hook: src.hook,
+            description: src.description,
+            tool_tags: src.tool_tags,
+            icon: src.icon,
+            colour_token: src.colour_token,
+            seed_prompt: src.seed_prompt,
+            memory_scope_shared: src.memory_scope_shared,
+            memory_scope_private: src.memory_scope_private,
+            subspecialty_tags: src.subspecialty_tags,
+            disclaimer: src.disclaimer,
+            is_system: false,
+            source_agent_id: src.id,
+          })
+          .select()
+          .single();
+        if (insertErr) throw insertErr;
+        return res.status(201).json({ data: clone });
+      }
+
+      case "update_agent": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const { id, ...patch } = req.body ?? {};
+        if (!id) return res.status(400).json({ error: "id required" });
+
+        const allowed = ["name","category","hook","description","tool_tags","icon","colour_token","seed_prompt","memory_scope_shared","memory_scope_private","subspecialty_tags","disclaimer"];
+        const filtered: Record<string, unknown> = { updated_at: new Date().toISOString() };
+        for (const k of allowed) {
+          if (k in patch) filtered[k] = patch[k];
+        }
+
+        const { data, error } = await supabase
+          .from("mc_agents")
+          .update(filtered)
+          .eq("id", id)
+          .eq("api_key_hash", apiKeyHash)
+          .select()
+          .maybeSingle();
+        if (error) throw error;
+        if (!data) return res.status(404).json({ error: "Agent not found or not owned by you" });
+        return res.status(200).json({ data });
+      }
+
+      case "create_agent": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const { slug, name, category, hook, description, tool_tags, icon, colour_token, seed_prompt, memory_scope_shared, memory_scope_private, subspecialty_tags, disclaimer } = req.body ?? {};
+        if (!slug || !name || !category) return res.status(400).json({ error: "slug, name, category required" });
+
+        const { data, error } = await supabase
+          .from("mc_agents")
+          .insert({
+            slug,
+            api_key_hash: apiKeyHash,
+            name,
+            category,
+            hook: hook ?? "",
+            description: description ?? "",
+            tool_tags: tool_tags ?? [],
+            icon: icon ?? "",
+            colour_token: colour_token ?? "",
+            seed_prompt: seed_prompt ?? null,
+            memory_scope_shared: memory_scope_shared ?? [],
+            memory_scope_private: memory_scope_private ?? [],
+            subspecialty_tags: subspecialty_tags ?? [],
+            disclaimer: disclaimer ?? null,
+            is_system: false,
+          })
+          .select()
+          .single();
+        if (error) throw error;
+        return res.status(201).json({ data });
+      }
+
+      case "list_crews": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const { data, error } = await supabase
+          .from("mc_crews")
+          .select("id,name,description,template,agent_ids,created_at,updated_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false });
+        if (error) throw error;
+        return res.status(200).json({ data: data ?? [] });
+      }
+
+      case "create_crew": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const { name, description, template, agent_ids } = req.body ?? {};
+        if (!name || !template) return res.status(400).json({ error: "name and template required" });
+
+        const { data, error } = await supabase
+          .from("mc_crews")
+          .insert({
+            api_key_hash: apiKeyHash,
+            name,
+            description: description ?? "",
+            template,
+            agent_ids: agent_ids ?? [],
+          })
+          .select()
+          .single();
+        if (error) throw error;
+        return res.status(201).json({ data });
+      }
+
+      case "update_crew": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const { id: crewId, ...crewPatch } = req.body ?? {};
+        if (!crewId) return res.status(400).json({ error: "id required" });
+
+        const crewAllowed = ["name","description","template","agent_ids"];
+        const crewFiltered: Record<string, unknown> = { updated_at: new Date().toISOString() };
+        for (const k of crewAllowed) {
+          if (k in crewPatch) crewFiltered[k] = crewPatch[k];
+        }
+
+        const { data: crewData, error: crewErr } = await supabase
+          .from("mc_crews")
+          .update(crewFiltered)
+          .eq("id", crewId)
+          .eq("api_key_hash", apiKeyHash)
+          .select()
+          .maybeSingle();
+        if (crewErr) throw crewErr;
+        if (!crewData) return res.status(404).json({ error: "Crew not found or not owned by you" });
+        return res.status(200).json({ data: crewData });
+      }
+
+      case "delete_crew": {
+        if (req.method !== "POST" && req.method !== "DELETE") return res.status(405).json({ error: "POST or DELETE required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const deleteId = (req.body?.id ?? req.query.id) as string;
+        if (!deleteId) return res.status(400).json({ error: "id required" });
+
+        const { error: deleteErr, count } = await supabase
+          .from("mc_crews")
+          .delete({ count: "exact" })
+          .eq("id", deleteId)
+          .eq("api_key_hash", apiKeyHash);
+        if (deleteErr) throw deleteErr;
+        if (!count) return res.status(404).json({ error: "Crew not found or not owned by you" });
+        return res.status(200).json({ success: true });
+      }
+
       default:
         return res.status(400).json({ error: `Unknown action: ${action}` });
     }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -752,12 +752,15 @@ export function createServer(): Server {
     }
   );
 
-  // LIST TOOLS: advertise only the 5 core memory tools. Internal tools
-  // (unclick_search, unclick_browse, unclick_tool_info, unclick_call) and the
-  // individual direct tools remain callable for backwards compatibility but
-  // aren't shown in the tool list to keep the surface minimal.
+  // LIST TOOLS: advertise the core memory tools PLUS every product + marketplace
+  // tool registered in ADDITIONAL_TOOLS (TestPass, Crews, and all third-party
+  // integrations from tool-wiring.ts). Internal meta tools (unclick_search,
+  // unclick_browse, unclick_tool_info, unclick_call) and the small DIRECT_TOOLS
+  // utility set remain callable for backwards compatibility but stay hidden
+  // from tools/list to avoid duplicating what native chat clients already
+  // discover.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: [...VISIBLE_TOOLS] };
+    return { tools: [...VISIBLE_TOOLS, ...ADDITIONAL_TOOLS] };
   });
 
   // CALL TOOL

--- a/src/components/crews/AgentPickerTile.tsx
+++ b/src/components/crews/AgentPickerTile.tsx
@@ -1,5 +1,5 @@
-import type { MockAgent } from "@/types/crews";
-import { Plus, X } from "lucide-react";
+import type { Agent } from "@/types/crews";
+import { Plus, X, Copy } from "lucide-react";
 
 const COLOUR_MAP: Record<string, string> = {
   "crew-exec":     "#61C1C4",
@@ -12,15 +12,17 @@ const COLOUR_MAP: Record<string, string> = {
 };
 
 interface AgentPickerTileProps {
-  agent: MockAgent;
+  agent: Agent;
   mode: "pick" | "selected";
-  onAdd?: (agent: MockAgent) => void;
-  onRemove?: (agent: MockAgent) => void;
+  onAdd?: (agent: Agent) => void;
+  onRemove?: (agent: Agent) => void;
+  onClone?: (agent: Agent) => void;
   disabled?: boolean;
+  cloning?: boolean;
 }
 
 export default function AgentPickerTile({
-  agent, mode, onAdd, onRemove, disabled,
+  agent, mode, onAdd, onRemove, onClone, disabled, cloning,
 }: AgentPickerTileProps) {
   const colour = COLOUR_MAP[agent.colour_token] ?? "#61C1C4";
   return (
@@ -41,6 +43,17 @@ export default function AgentPickerTile({
         <p className="truncate text-xs font-medium text-[#ddd]">{agent.name}</p>
         <p className="truncate text-[10px] text-[#666]">{agent.hook}</p>
       </div>
+      {mode === "pick" && agent.is_system && onClone && (
+        <button
+          type="button"
+          onClick={() => onClone(agent)}
+          disabled={cloning}
+          className="shrink-0 rounded-md p-1 text-[#555] transition-colors hover:bg-amber-500/10 hover:text-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
+          title="Clone to edit"
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </button>
+      )}
       {mode === "pick" && onAdd && (
         <button
           type="button"

--- a/src/pages/admin/crews/CrewComposer.tsx
+++ b/src/pages/admin/crews/CrewComposer.tsx
@@ -1,10 +1,11 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import CrewsNav from "@/components/crews/CrewsNav";
 import AgentPickerTile from "@/components/crews/AgentPickerTile";
-import { MOCK_AGENTS, AGENT_CATEGORIES } from "@/data/mockAgents";
+import { AGENT_CATEGORIES } from "@/data/mockAgents";
 import { CREW_TEMPLATES } from "@/data/mockCrewTemplates";
-import type { MockAgent } from "@/types/crews";
+import type { Agent } from "@/types/crews";
+import { useSession } from "@/lib/auth";
 import { Search, Save, Users } from "lucide-react";
 
 const MAX_HATS = 9;
@@ -13,40 +14,111 @@ const MIN_HATS = 3;
 export default function CrewComposer() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { session } = useSession();
   const initialTemplate = searchParams.get("template") ?? CREW_TEMPLATES[0].slug;
 
   const [templateSlug, setTemplateSlug] = useState(initialTemplate);
-  const [selected, setSelected] = useState<MockAgent[]>([]);
+  const [selected, setSelected] = useState<Agent[]>([]);
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [query, setQuery] = useState("");
   const [crewName, setCrewName] = useState("");
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [cloning, setCloning] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const authHeader = useMemo(() => {
+    if (!session) return null;
+    return { Authorization: `Bearer ${session.access_token}` };
+  }, [session]);
+
+  const loadAgents = useCallback(async () => {
+    if (!authHeader) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=list_agents", { headers: authHeader });
+      const body = await res.json() as { data?: Agent[]; error?: string };
+      if (body.data) setAgents(body.data);
+    } catch {
+      setError("Failed to load agents.");
+    } finally {
+      setLoading(false);
+    }
+  }, [authHeader]);
+
+  useEffect(() => { void loadAgents(); }, [loadAgents]);
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();
-    return MOCK_AGENTS.filter((a) => {
+    return agents.filter((a) => {
       const matchCat = categoryFilter === "all" || a.category === categoryFilter;
       const matchQ = !q || a.name.toLowerCase().includes(q) || a.hook.toLowerCase().includes(q);
       return matchCat && matchQ;
     });
-  }, [categoryFilter, query]);
+  }, [agents, categoryFilter, query]);
 
-  const selectedSlugs = useMemo(() => new Set(selected.map((a) => a.slug)), [selected]);
+  const selectedIds = useMemo(() => new Set(selected.map((a) => a.id)), [selected]);
 
-  function addAgent(agent: MockAgent) {
-    if (selected.length >= MAX_HATS || selectedSlugs.has(agent.slug)) return;
+  function addAgent(agent: Agent) {
+    if (selected.length >= MAX_HATS || selectedIds.has(agent.id)) return;
     setSelected((prev) => [...prev, agent]);
   }
 
-  function removeAgent(agent: MockAgent) {
-    setSelected((prev) => prev.filter((a) => a.slug !== agent.slug));
+  function removeAgent(agent: Agent) {
+    setSelected((prev) => prev.filter((a) => a.id !== agent.id));
   }
 
-  function handleSave() {
-    if (selected.length < MIN_HATS) return;
-    navigate("/admin/crews");
+  async function handleClone(agent: Agent) {
+    if (!authHeader) return;
+    setCloning(agent.id);
+    try {
+      const res = await fetch("/api/memory-admin?action=clone_agent", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: agent.slug }),
+      });
+      const body = await res.json() as { data?: Agent; error?: string };
+      if (body.data) {
+        setAgents((prev) => [...prev, body.data!]);
+      } else {
+        setError(body.error ?? "Clone failed.");
+      }
+    } catch {
+      setError("Clone failed.");
+    } finally {
+      setCloning(null);
+    }
   }
 
-  const canSave = selected.length >= MIN_HATS && selected.length <= MAX_HATS;
+  async function handleSave() {
+    if (!authHeader || selected.length < MIN_HATS || !crewName.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=create_crew", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: crewName.trim(),
+          template: templateSlug,
+          agent_ids: selected.map((a) => a.id),
+        }),
+      });
+      const body = await res.json() as { data?: { id: string }; error?: string };
+      if (body.data?.id) {
+        navigate(`/admin/crews/${body.data.id}`);
+      } else {
+        setError(body.error ?? "Save failed.");
+      }
+    } catch {
+      setError("Save failed.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const canSave = selected.length >= MIN_HATS && selected.length <= MAX_HATS && crewName.trim().length > 0;
 
   return (
     <div>
@@ -55,6 +127,10 @@ export default function CrewComposer() {
         Pick 3 to 9 hats and a template, then save.
       </p>
       <CrewsNav />
+
+      {error && (
+        <p className="mb-4 rounded-lg bg-rose-500/10 px-3 py-2 text-xs text-rose-400">{error}</p>
+      )}
 
       <div className="mb-5 grid gap-4 sm:grid-cols-2">
         <label className="block">
@@ -88,7 +164,7 @@ export default function CrewComposer() {
           <p className="mb-3 text-xs text-[#666]">
             Pick your team. Each hat is one AI agent with one specialty. Mix roles like CEO, CFO,
             and Designer with thinking styles like Contrarian or First Principles for a richer
-            conversation.
+            conversation. Click <span className="text-amber-400">Clone</span> on any system agent to save a personal copy.
           </p>
           <div className="mb-3 flex flex-wrap gap-1.5">
             <button
@@ -127,22 +203,28 @@ export default function CrewComposer() {
               className="w-full rounded-lg border border-white/[0.07] bg-white/[0.02] py-1.5 pl-8 pr-3 text-xs text-[#eee] placeholder-[#444] focus:border-[#61C1C4]/40 focus:outline-none"
             />
           </div>
-          <div className="grid max-h-[52vh] gap-1.5 overflow-y-auto sm:grid-cols-2">
-            {filtered.map((agent) => (
-              <AgentPickerTile
-                key={agent.slug}
-                agent={agent}
-                mode="pick"
-                onAdd={addAgent}
-                disabled={selectedSlugs.has(agent.slug) || selected.length >= MAX_HATS}
-              />
-            ))}
-            {filtered.length === 0 && (
-              <p className="col-span-2 py-6 text-center text-xs text-[#555]">
-                No hats match your search. Try a different keyword or category.
-              </p>
-            )}
-          </div>
+          {loading ? (
+            <p className="py-6 text-center text-xs text-[#555]">Loading agents...</p>
+          ) : (
+            <div className="grid max-h-[52vh] gap-1.5 overflow-y-auto sm:grid-cols-2">
+              {filtered.map((agent) => (
+                <AgentPickerTile
+                  key={agent.id}
+                  agent={agent}
+                  mode="pick"
+                  onAdd={addAgent}
+                  onClone={agent.is_system ? handleClone : undefined}
+                  cloning={cloning === agent.id}
+                  disabled={selectedIds.has(agent.id) || selected.length >= MAX_HATS}
+                />
+              ))}
+              {filtered.length === 0 && (
+                <p className="col-span-2 py-6 text-center text-xs text-[#555]">
+                  No hats match your search. Try a different keyword or category.
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="flex flex-col rounded-xl border border-white/[0.07] bg-white/[0.02] p-4">
@@ -171,7 +253,7 @@ export default function CrewComposer() {
             <div className="flex-1 space-y-1.5 overflow-y-auto">
               {selected.map((agent) => (
                 <AgentPickerTile
-                  key={agent.slug}
+                  key={agent.id}
                   agent={agent}
                   mode="selected"
                   onRemove={removeAgent}
@@ -183,16 +265,18 @@ export default function CrewComposer() {
           <div className="mt-4 border-t border-white/[0.06] pt-4">
             <button
               type="button"
-              onClick={handleSave}
-              disabled={!canSave}
+              onClick={() => void handleSave()}
+              disabled={!canSave || saving}
               className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-[#61C1C4] py-2.5 text-sm font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
             >
               <Save className="h-4 w-4" />
-              Save crew
+              {saving ? "Saving..." : "Save crew"}
             </button>
             {!canSave && selected.length > 0 && (
               <p className="mt-1.5 text-center text-[10px] text-[#555]">
-                {selected.length < MIN_HATS
+                {!crewName.trim()
+                  ? "Enter a crew name to save."
+                  : selected.length < MIN_HATS
                   ? `Add at least ${MIN_HATS} hats to save.`
                   : `Maximum ${MAX_HATS} hats.`}
               </p>

--- a/src/pages/admin/crews/CrewsCatalog.tsx
+++ b/src/pages/admin/crews/CrewsCatalog.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import CrewsNav from "@/components/crews/CrewsNav";
 import TemplateCard from "@/components/crews/TemplateCard";
 import { CREW_TEMPLATES } from "@/data/mockCrewTemplates";
 import { STARTER_CREWS } from "@/data/starterCrews";
-import { MOCK_AGENTS } from "@/data/mockAgents";
-import type { CrewTemplate } from "@/types/crews";
+import type { CrewTemplate, Agent } from "@/types/crews";
+import { useSession } from "@/lib/auth";
 import { Play, Sparkles } from "lucide-react";
 
 const COLOUR_MAP: Record<string, string> = {
@@ -20,7 +20,27 @@ const COLOUR_MAP: Record<string, string> = {
 
 export default function CrewsCatalog() {
   const navigate = useNavigate();
+  const { session } = useSession();
   const [copied, setCopied] = useState<string | null>(null);
+  const [agents, setAgents] = useState<Agent[]>([]);
+
+  const authHeader = useMemo(() => {
+    if (!session) return null;
+    return { Authorization: `Bearer ${session.access_token}` };
+  }, [session]);
+
+  const loadAgents = useCallback(async () => {
+    if (!authHeader) return;
+    try {
+      const res = await fetch("/api/memory-admin?action=list_agents", { headers: authHeader });
+      const body = await res.json() as { data?: Agent[] };
+      if (body.data) setAgents(body.data);
+    } catch {
+      // silent - starter crew badges degrade gracefully
+    }
+  }, [authHeader]);
+
+  useEffect(() => { void loadAgents(); }, [loadAgents]);
 
   function handleSelectTemplate(template: CrewTemplate) {
     navigate(`/admin/crews/new?template=${template.slug}`);
@@ -50,9 +70,9 @@ export default function CrewsCatalog() {
         <div className="grid gap-4 sm:grid-cols-2">
           {STARTER_CREWS.map((crew) => {
             const template = CREW_TEMPLATES.find((t) => t.slug === crew.template_slug);
-            const agents = crew.agent_slugs
-              .map((slug) => MOCK_AGENTS.find((a) => a.slug === slug))
-              .filter(Boolean) as typeof MOCK_AGENTS;
+            const crewAgents = crew.agent_slugs
+              .map((slug) => agents.find((a) => a.slug === slug))
+              .filter(Boolean) as Agent[];
             return (
               <div
                 key={crew.id}
@@ -61,7 +81,7 @@ export default function CrewsCatalog() {
                 <h3 className="mb-1 text-sm font-semibold text-[#eee]">{crew.name}</h3>
                 <p className="mb-3 text-xs text-[#777]">{crew.description}</p>
                 <div className="mb-3 flex flex-wrap gap-1.5">
-                  {agents.map((agent) => {
+                  {crewAgents.map((agent) => {
                     const colour = COLOUR_MAP[agent.colour_token] ?? "#61C1C4";
                     return (
                       <span

--- a/src/types/crews.ts
+++ b/src/types/crews.ts
@@ -27,6 +27,21 @@ export interface MockAgent {
   is_system: true;
 }
 
+export interface Agent {
+  id: string;
+  slug: string;
+  name: string;
+  category: AgentCategory;
+  hook: string;
+  description: string;
+  tool_tags: string[];
+  icon: string;
+  colour_token: string;
+  is_system: boolean;
+  source_agent_id: string | null;
+  api_key_hash: string | null;
+}
+
 export interface CrewTemplate {
   slug: string;
   name: string;

--- a/supabase/migrations/20260423000000_crews_phase_b.sql
+++ b/supabase/migrations/20260423000000_crews_phase_b.sql
@@ -1,0 +1,353 @@
+-- Phase B: Crews schema - mc_agents, mc_crews, mc_crew_runs
+-- Idempotent: uses IF NOT EXISTS and ON CONFLICT DO NOTHING
+
+-- ─── mc_agents ──────────────────────────────────────────────────────────────
+
+create table if not exists mc_agents (
+  id                   uuid primary key default gen_random_uuid(),
+  slug                 text not null,
+  api_key_hash         text,
+  name                 text not null,
+  category             text not null check (category in ('business','creative','technical','thinking','domain','lifestyle','meta')),
+  hook                 text not null default '',
+  description          text not null default '',
+  tool_tags            text[] not null default '{}',
+  icon                 text not null default '',
+  colour_token         text not null default '',
+  seed_prompt          text,
+  memory_scope_shared  text[] not null default '{}',
+  memory_scope_private text[] not null default '{}',
+  subspecialty_tags    text[] not null default '{}',
+  disclaimer           text,
+  is_system            boolean not null default false,
+  source_agent_id      uuid references mc_agents(id) on delete set null,
+  created_at           timestamptz not null default now(),
+  updated_at           timestamptz not null default now()
+);
+
+-- Partial unique indexes: NULL api_key_hash = system agent (slug unique globally);
+-- non-NULL api_key_hash = user agent (slug unique per tenant).
+create unique index if not exists mc_agents_slug_system
+  on mc_agents(slug) where api_key_hash is null;
+create unique index if not exists mc_agents_slug_user
+  on mc_agents(slug, api_key_hash) where api_key_hash is not null;
+
+-- ─── mc_crews ───────────────────────────────────────────────────────────────
+
+create table if not exists mc_crews (
+  id           uuid primary key default gen_random_uuid(),
+  api_key_hash text not null,
+  name         text not null,
+  description  text not null default '',
+  template     text not null check (template in ('council','six_modes','pre_mortem','red_blue','editorial','debate_circle')),
+  agent_ids    uuid[] not null default '{}',
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+-- ─── mc_crew_runs ───────────────────────────────────────────────────────────
+
+create table if not exists mc_crew_runs (
+  id              uuid primary key default gen_random_uuid(),
+  api_key_hash    text not null,
+  crew_id         uuid references mc_crews(id) on delete set null,
+  task_prompt     text not null default '',
+  status          text not null default 'pending' check (status in ('pending','running','complete','failed')),
+  token_budget    integer not null default 150000,
+  tokens_used     integer,
+  result_artifact jsonb,
+  started_at      timestamptz,
+  completed_at    timestamptz,
+  created_at      timestamptz not null default now()
+);
+
+-- ─── RLS ────────────────────────────────────────────────────────────────────
+
+alter table mc_agents    enable row level security;
+alter table mc_crews     enable row level security;
+alter table mc_crew_runs enable row level security;
+
+-- service_role bypass (full access for server-side)
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where tablename = 'mc_agents' and policyname = 'mc_agents_service_role'
+  ) then
+    create policy mc_agents_service_role on mc_agents to service_role using (true) with check (true);
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where tablename = 'mc_crews' and policyname = 'mc_crews_service_role'
+  ) then
+    create policy mc_crews_service_role on mc_crews to service_role using (true) with check (true);
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where tablename = 'mc_crew_runs' and policyname = 'mc_crew_runs_service_role'
+  ) then
+    create policy mc_crew_runs_service_role on mc_crew_runs to service_role using (true) with check (true);
+  end if;
+end $$;
+
+-- user-facing: agents visible if system OR owned by caller
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where tablename = 'mc_agents' and policyname = 'mc_agents_read_own_or_system'
+  ) then
+    create policy mc_agents_read_own_or_system on mc_agents
+      for select to authenticated
+      using (
+        is_system = true
+        or api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where tablename = 'mc_agents' and policyname = 'mc_agents_write_own'
+  ) then
+    create policy mc_agents_write_own on mc_agents
+      for all to authenticated
+      using (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      )
+      with check (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where tablename = 'mc_crews' and policyname = 'mc_crews_own_rows'
+  ) then
+    create policy mc_crews_own_rows on mc_crews
+      for all to authenticated
+      using (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      )
+      with check (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where tablename = 'mc_crew_runs' and policyname = 'mc_crew_runs_own_rows'
+  ) then
+    create policy mc_crew_runs_own_rows on mc_crew_runs
+      for all to authenticated
+      using (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      )
+      with check (
+        api_key_hash = (current_setting('request.jwt.claims', true)::json->>'api_key_hash')
+      );
+  end if;
+end $$;
+
+-- ─── System agent seed (180 agents) ─────────────────────────────────────────
+-- api_key_hash NULL = system agent, readable by all
+
+insert into mc_agents (slug, api_key_hash, name, category, hook, description, tool_tags, icon, colour_token, is_system) values
+
+-- Business (36)
+('ceo', null, 'CEO', 'business', 'Sets direction, ships bets.', 'Looks at every decision through shareholder value, optionality, and narrative. Balances risk against time.', array['search','docs','calendar'], 'crown', 'crew-exec', true),
+('coo', null, 'COO', 'business', 'Operations mechanic.', 'Turns vision into process, KPIs, and headcount. Asks who does what and by when.', array['docs','sheets'], 'cog', 'crew-exec', true),
+('cfo', null, 'CFO', 'business', 'Keeps the numbers honest.', 'Lives in the model. Asks where cash goes and when it runs out. Flags unit economics that do not pencil.', array['sheets','accounting'], 'calculator', 'crew-exec', true),
+('cmo', null, 'CMO', 'business', 'Owns the story and the funnel.', 'Holds brand and demand in one head. Speaks to positioning and message-market fit.', array['analytics','ads','crm'], 'megaphone', 'crew-exec', true),
+('cto', null, 'CTO', 'business', 'Owns the tech bet.', 'Platform, build vs buy, hiring bar, security debt. Balances speed against rework.', array['github','docs','search'], 'cpu', 'crew-exec', true),
+('cpo', null, 'CPO', 'business', 'Product compass.', 'Discovery to delivery. Kills features that do not earn their keep. Thinks in user jobs, not feature lists.', array['analytics','docs'], 'compass', 'crew-exec', true),
+('cio', null, 'CIO', 'business', 'Internal systems guardian.', 'Back-office stack, integrations, vendor contracts. Keeps the machines running so the business can focus.', array['docs','crm'], 'server', 'crew-exec', true),
+('chro', null, 'CHRO', 'business', 'People, culture, hiring.', 'Comp bands, performance, onboarding, and culture signal. Reads the room before the data does.', array['docs','hris'], 'users', 'crew-exec', true),
+('clo', null, 'CLO', 'business', 'Chief legal.', 'Reads contracts with a red pen. Flags IP, liability, and jurisdiction. Never assumes boilerplate is safe.', array['docs','search'], 'scale', 'crew-exec', true),
+('cco-compliance', null, 'CCO (Compliance)', 'business', 'Regulatory watchdog.', 'GDPR, SOC 2, ISO, FTC. Translates rules into what teams must actually do before Monday.', array['docs','search'], 'shield-check', 'crew-exec', true),
+('ciso', null, 'CISO', 'business', 'Security chief.', 'Threat model first, then controls. Assumes breach. Treats every integration as a potential attack surface.', array['docs','search'], 'shield', 'crew-exec', true),
+('caio', null, 'CAIO', 'business', 'AI strategy.', 'Where AI helps, where it does not, model spend, and risk. Keeps the stack from chasing hype.', array['docs','search'], 'brain', 'crew-exec', true),
+('cdo', null, 'CDO', 'business', 'Data chief.', 'Data model, quality, lineage. Makes sure the numbers the board sees match the numbers in the warehouse.', array['sql'], 'database', 'crew-exec', true),
+('cro', null, 'CRO', 'business', 'Revenue conductor.', 'Pipeline math, segment strategy, quota, comp. Knows the number before it lands.', array['crm','analytics'], 'trending-up', 'crew-exec', true),
+('cso-sales', null, 'CSO (Sales)', 'business', 'Top seller''s boss.', 'Coaching, deal reviews, MEDDIC rigour. Fixes the rep before the deal is lost.', array['crm'], 'target', 'crew-exec', true),
+('cco-creative', null, 'CCO (Creative)', 'business', 'Creative director in chief.', 'Brand guardian. Pushes for bolder work. Kills safe-but-forgettable before it ships.', array['figma','docs'], 'palette', 'crew-exec', true),
+('sales-director', null, 'Sales Director', 'business', 'Runs the floor.', 'Weekly pipeline hygiene, rep coaching, pipe-gen targets. Turns a scattered team into a rhythm.', array['crm'], 'users', 'crew-exec', true),
+('head-of-content', null, 'Head of Content', 'business', 'Content factory lead.', 'Editorial calendar, distribution, SEO overlay. Makes sure the right words reach the right people.', array['cms','analytics'], 'file-text', 'crew-exec', true),
+('head-of-ops', null, 'Head of Ops', 'business', 'Runs the machine.', 'Vendor, finance, and people-ops glue. The person who turns strategy into a working Monday morning.', array['sheets','docs'], 'sliders-horizontal', 'crew-exec', true),
+('pr-lead', null, 'PR Lead', 'business', 'Narrative defender.', 'Press lists, pitches, and crisis response. Knows what a journalist actually needs before they ask.', array['email','search'], 'radio', 'crew-exec', true),
+('community-manager', null, 'Community Manager', 'business', 'Keeps the flame.', 'Discord, Slack, and forum pulse. Hears what users are saying before the product team does.', array['discord','slack'], 'users-round', 'crew-exec', true),
+('investor-relations', null, 'Investor Relations', 'business', 'Talks to money.', 'Deck, update, KPI pack. Knows what VCs actually ask and what they really want to hear.', array['docs','sheets'], 'handshake', 'crew-exec', true),
+('brand-strategist', null, 'Brand Strategist', 'business', 'Keeper of the essence.', 'Archetype, voice, and promise. Zags when the market zigs. Protects distinctiveness under pressure.', array['docs'], 'feather', 'crew-exec', true),
+('growth-hacker', null, 'Growth Hacker', 'business', 'Ethical hustler.', 'Experiments cheaply, kills fast, doubles down on winners. Treats every distribution channel as a testable hypothesis.', array['analytics','ads'], 'rocket', 'crew-exec', true),
+('seo-specialist', null, 'SEO Specialist', 'business', 'Search whisperer.', 'On-page, technical, backlink, topical authority. Turns search intent into a distribution moat.', array['search'], 'search', 'crew-exec', true),
+('paid-media-buyer', null, 'Paid Media Buyer', 'business', 'Spends to earn.', 'Meta, Google, LinkedIn, TikTok. ROAS-obsessed. Every dollar has a job and a measurable result.', array['ads','analytics'], 'banknote', 'crew-exec', true),
+('email-marketer', null, 'Email Marketer', 'business', 'Inbox artist.', 'Deliverability, list hygiene, segmentation, lifecycle. Treats every send as a relationship, not a broadcast.', array['esp','analytics'], 'mail', 'crew-exec', true),
+('partnership-lead', null, 'Partnership Lead', 'business', 'Deal-shaper.', 'Co-market, tech integrations, channel. Builds relationships that become distribution channels.', array['crm','docs'], 'link', 'crew-exec', true),
+('csm', null, 'Customer Success Manager', 'business', 'Keeps them using it.', 'Onboarding, QBRs, expansion signals, churn saves. Knows which accounts are at risk before they churn.', array['crm','support'], 'heart-handshake', 'crew-exec', true),
+('account-executive', null, 'Account Executive', 'business', 'Closer.', 'Qualifies, demos, navigates procurement. Finds the real buyer and the real blocker in any deal.', array['crm'], 'briefcase', 'crew-exec', true),
+('business-development', null, 'Business Development', 'business', 'Door-opener.', 'Strategic intros, creative deals, ecosystem plays. Finds the partnership nobody else thought to make.', array['crm','search'], 'door-open', 'crew-exec', true),
+('financial-controller', null, 'Financial Controller', 'business', 'Books closer.', 'Close cycle, GL, accruals, audit ready. Makes sure the books reflect reality, not wishful thinking.', array['accounting'], 'book', 'crew-exec', true),
+('bookkeeper', null, 'Bookkeeper', 'business', 'Ledger clean.', 'Day-to-day transactions and categorisation. Keeps the trail tidy so month-end doesn''t become a crisis.', array['accounting'], 'receipt', 'crew-exec', true),
+('tax-advisor', null, 'Tax Advisor', 'business', 'Tax-efficient by design.', 'Structure, deductions, VAT, filings. Finds what''s legal and leaves the rest alone.', array['docs','search'], 'percent', 'crew-exec', true),
+('hr-business-partner', null, 'HR Business Partner', 'business', 'Strategy-to-people bridge.', 'Org design, comp bands, and performance calibration. Makes sure the org can actually execute the plan.', array['docs'], 'users-cog', 'crew-exec', true),
+('recruiter', null, 'Recruiter', 'business', 'Finds the ones.', 'Sourcing, screening, offer stage. Knows how to write a job ad that attracts the right people and repels the wrong ones.', array['ats'], 'user-search', 'crew-exec', true),
+
+-- Creative (24)
+('copywriter', null, 'Copywriter', 'creative', 'Makes words work for their rent.', 'Writes for a reader who is distracted and skimming. Chooses short over clever. Treats every headline as a promise the body must keep.', array['docs','search'], 'pen-tool', 'crew-creative', true),
+('art-director', null, 'Art Director', 'creative', 'Sees the visual before anyone else.', 'Translates a brief into a visual concept. Thinks in layouts, not isolated elements. Pushes for ideas that could not be mistaken for a competitor.', array['figma'], 'image', 'crew-creative', true),
+('creative-director', null, 'Creative Director', 'creative', 'Holds the creative vision.', 'Sets the bar for every piece that ships. Kills safe work early. Asks what a piece says about the brand before what it says about the product.', array['figma','docs'], 'wand-2', 'crew-creative', true),
+('ux-designer', null, 'UX Designer', 'creative', 'Draws the path of least confusion.', 'Thinks in flows, not screens. Hunts for the step where users churn. Believes the best interface is usually less interface.', array['figma','analytics'], 'route', 'crew-creative', true),
+('ui-designer', null, 'UI Designer', 'creative', 'Makes it look inevitable.', 'Pixel-level craft, spacing, and hierarchy. Turns a wireframe into something users trust on sight.', array['figma'], 'layout-dashboard', 'crew-creative', true),
+('motion-designer', null, 'Motion Designer', 'creative', 'Gives the interface a heartbeat.', 'Transitions, micro-interactions, and animation timing. Makes the product feel alive without drawing attention to itself.', array['figma'], 'film', 'crew-creative', true),
+('photographer', null, 'Photographer (Prompt Crafter)', 'creative', 'Composes the image in words.', 'Writes image prompts that produce usable results on the first pass. Thinks in light, framing, and subject distance.', array['docs'], 'camera', 'crew-creative', true),
+('video-editor', null, 'Video Editor', 'creative', 'Cuts to the point.', 'Pacing, narrative arc, and when to let silence do the work. Knows the first ten seconds determine everything.', array['docs'], 'video', 'crew-creative', true),
+('sound-designer', null, 'Sound Designer', 'creative', 'Sound is half the experience.', 'Audio identities, UI sounds, and podcast production. Shapes how something feels before the user reads a word.', array['docs'], 'music', 'crew-creative', true),
+('illustrator', null, 'Illustrator', 'creative', 'Visual language that scales.', 'Icons, editorial art, and brand illustration. Makes the abstract concrete without relying on stock photos.', array['figma'], 'pen-line', 'crew-creative', true),
+('brand-designer', null, 'Brand Designer', 'creative', 'Builds the visual system.', 'Logo, type, colour, and component library. Creates rules that let others produce great work without calling for approval every time.', array['figma','docs'], 'layers', 'crew-creative', true),
+('packaging-designer', null, 'Packaging Designer', 'creative', 'The shelf test is brutal.', 'Physical and digital packaging. Knows how a design looks on a shelf from two metres away, on a phone screen, and on a white background.', array['figma'], 'package', 'crew-creative', true),
+('editor', null, 'Editor', 'creative', 'Shapes the draft into something worth reading.', 'Structure, pacing, and clarity. Cuts what the writer is too attached to. Makes the argument land.', array['docs'], 'scissors', 'crew-creative', true),
+('proofreader', null, 'Proofreader', 'creative', 'Catches what the writer stopped seeing.', 'Grammar, consistency, and style-guide compliance. The last line of defence before publish.', array['docs'], 'check-square', 'crew-creative', true),
+('scriptwriter', null, 'Scriptwriter', 'creative', 'Writes what gets said out loud.', 'Video scripts, podcast outlines, and presentation narratives. Knows the rhythm of spoken language.', array['docs'], 'mic', 'crew-creative', true),
+('storyboarder', null, 'Storyboarder', 'creative', 'Maps the visual sequence before production starts.', 'Frame-by-frame planning for video, animation, or interactive content. Saves expensive reshoots by solving problems on paper.', array['figma','docs'], 'layout-grid', 'crew-creative', true),
+('novelist', null, 'Novelist', 'creative', 'Long-form storytelling.', 'Character, arc, and scene. Thinks in chapters and through-lines. Brings narrative craft to business writing when stakes are high.', array['docs'], 'book-open', 'crew-creative', true),
+('poet', null, 'Poet', 'creative', 'Precision in the smallest possible space.', 'Compression, rhythm, and image. Finds the exact word when the obvious one is wrong.', array['docs'], 'feather', 'crew-creative', true),
+('comedian', null, 'Comedian', 'creative', 'Truth via punchline.', 'Finds the angle nobody wants to say out loud. Avoids cheap mockery. Uses levity to make hard points stick.', array['search'], 'smile', 'crew-creative', true),
+('game-designer', null, 'Game Designer', 'creative', 'Systems that make you want to play again.', 'Loops, feedback, and progression. Understands intrinsic motivation better than most marketers do.', array['docs'], 'gamepad-2', 'crew-creative', true),
+('level-designer', null, 'Level Designer', 'creative', 'Teaches through environment.', 'Spatial pacing and discovery. Designs the room so the player learns the mechanic without reading a tutorial.', array['docs'], 'map', 'crew-creative', true),
+('narrative-designer', null, 'Narrative Designer', 'creative', 'Story that lives inside the system.', 'Branching narrative, world-building, and dialogue. Makes the lore feel inevitable rather than invented.', array['docs'], 'book', 'crew-creative', true),
+('lyricist', null, 'Lyricist', 'creative', 'Words that need music to be complete.', 'Meter, rhyme, and emotional arc. Writes what sounds effortless but isn''t.', array['docs'], 'music-2', 'crew-creative', true),
+('musician', null, 'Musician', 'creative', 'Knows what the track needs.', 'Composition, arrangement, and production direction. Writes briefs for sound that non-musicians can actually use.', array['docs'], 'headphones', 'crew-creative', true),
+
+-- Technical (22)
+('software-engineer', null, 'Software Engineer', 'technical', 'Writes code that ships.', 'Clean interfaces, working tests, and a rollback plan. Asks what the feature actually needs before opening an editor.', array['github','shell'], 'code', 'crew-tech', true),
+('senior-engineer', null, 'Senior Engineer', 'technical', 'Reads twice, writes once.', 'Thinks in interfaces and contracts. Prefers boring tech for boring problems. Refuses to ship without a rollback plan.', array['github','shell','docs'], 'code-2', 'crew-tech', true),
+('fullstack-dev', null, 'Full-Stack Dev', 'technical', 'Owns the whole slice.', 'Front to back, schema to pixel. Dangerous when scoped right, scattered when scoped too wide.', array['github','shell'], 'layers', 'crew-tech', true),
+('frontend-dev', null, 'Frontend Dev', 'technical', 'Builds what users touch.', 'Components, accessibility, and performance budgets. Knows that a slow page is a broken page.', array['github','figma'], 'monitor', 'crew-tech', true),
+('backend-dev', null, 'Backend Dev', 'technical', 'Keeps the server honest.', 'APIs, queues, and data integrity. Makes sure the front end''s promises are backed by something real.', array['github','shell','sql'], 'server', 'crew-tech', true),
+('mobile-dev', null, 'Mobile Dev', 'technical', 'Builds for the pocket.', 'iOS, Android, or React Native. Thinks about battery, connectivity, and thumb reach before writing the first line.', array['github','shell'], 'smartphone', 'crew-tech', true),
+('devops', null, 'DevOps', 'technical', 'Ships faster with less pain.', 'CI/CD, containers, infrastructure-as-code. Treats deployment as a product feature, not an afterthought.', array['shell','github'], 'git-branch', 'crew-tech', true),
+('platform-engineer', null, 'Platform Engineer', 'technical', 'Builds the road, not the car.', 'Internal developer platforms, golden paths, and paved roads. Makes the right way the easy way.', array['shell','docs'], 'network', 'crew-tech', true),
+('sre', null, 'SRE', 'technical', 'Keeps the lights on.', 'SLOs, error budgets, and incident response. Measures reliability in nines and guards them accordingly.', array['shell','docs'], 'activity', 'crew-tech', true),
+('qa-engineer', null, 'QA Engineer', 'technical', 'Breaks it before the user does.', 'Test strategy, edge cases, and regression coverage. Treats every bug as a gap in the process, not just a bug.', array['github','shell'], 'bug', 'crew-tech', true),
+('security-engineer', null, 'Security Engineer', 'technical', 'Assumes breach.', 'Threat-models first. Checks auth, authz, and secrets on every change. Lists the top three attacker goals before reviewing anything.', array['docs','search'], 'shield-alert', 'crew-tech', true),
+('data-engineer', null, 'Data Engineer', 'technical', 'Builds the pipeline no one notices until it breaks.', 'Ingestion, transformation, and lineage. Makes sure the analysts have clean data when they arrive Monday morning.', array['sql','shell'], 'database', 'crew-tech', true),
+('ml-engineer', null, 'ML Engineer', 'technical', 'Trains models that work in production.', 'Feature stores, training pipelines, and drift detection. Knows the difference between a demo and a deployed model.', array['shell','docs'], 'brain-circuit', 'crew-tech', true),
+('prompt-composer', null, 'Prompt Composer', 'technical', 'Words as an API.', 'Treats prompts as specs. Tests with hard examples first. Knows when a schema beats a paragraph.', array['docs'], 'terminal-square', 'crew-tech', true),
+('dba', null, 'Database Admin', 'technical', 'Keeps the data store healthy.', 'Query plans, index strategy, backup schedules. Finds the slow query before the user reports a timeout.', array['sql','docs'], 'hard-drive', 'crew-tech', true),
+('systems-architect', null, 'Systems Architect', 'technical', 'Draws the map before the build.', 'Distributed systems, trade-offs, and failure modes. Makes decisions that are hard to reverse with the care they deserve.', array['docs','search'], 'layout', 'crew-tech', true),
+('solutions-architect', null, 'Solutions Architect', 'technical', 'Makes the customer''s problem solvable.', 'Discovery, fit assessment, and technical scoping. Turns a business requirement into a buildable spec.', array['docs'], 'puzzle', 'crew-tech', true),
+('api-designer', null, 'API Designer', 'technical', 'Contracts that last.', 'REST, GraphQL, and versioning strategy. Designs APIs that are easy to use correctly and hard to use wrong.', array['docs','github'], 'plug', 'crew-tech', true),
+('technical-writer', null, 'Technical Writer', 'technical', 'Makes complexity approachable.', 'Docs, guides, and API references. Writes for the developer who is stuck at 11 PM and needs the answer in one scroll.', array['docs','github'], 'file-code', 'crew-tech', true),
+('code-reviewer', null, 'Code Reviewer', 'technical', 'Reads your code so production doesn''t have to.', 'Logic, security, and style. Asks the question the author forgot to ask. Keeps reviews focused on what matters.', array['github'], 'git-pull-request', 'crew-tech', true),
+('integration-engineer', null, 'Integration Engineer', 'technical', 'Connects the things that do not know about each other.', 'Webhooks, event buses, and third-party APIs. Designs integrations that degrade gracefully when the other side is down.', array['github','shell','docs'], 'cable', 'crew-tech', true),
+('observability-engineer', null, 'Observability Engineer', 'technical', 'Makes invisible systems visible.', 'Logs, metrics, traces, and dashboards. Ensures teams can answer questions about production without guessing.', array['shell','docs'], 'telescope', 'crew-tech', true),
+
+-- Thinking (28)
+('contrarian', null, 'Contrarian', 'thinking', 'Hunts the fatal flaw.', 'Reads every plan looking for the single assumption that, if wrong, kills it. Does not argue to win. Argues to save the team from themselves.', array['search'], 'shield-off', 'crew-think', true),
+('first-principles', null, 'First Principles Thinker', 'thinking', 'Strip to atoms, rebuild.', 'Asks what is actually true before asking what is common. Ignores conventions until they earn their place.', array['docs','search'], 'atom', 'crew-think', true),
+('expansionist', null, 'Expansionist', 'thinking', 'Finds upside and adjacent opportunities.', 'Looks for what else this could become, who else it could serve, and what adjacent markets are now reachable.', array['search'], 'expand', 'crew-think', true),
+('outsider', null, 'Outsider', 'thinking', 'Zero industry context. Catches curse of knowledge.', 'Refuses to learn the jargon. Asks why twice in a row. Finds the thing everyone else stopped noticing.', array['search'], 'door-open', 'crew-think', true),
+('executor', null, 'Executor', 'thinking', 'What do you actually do Monday morning?', 'Converts strategy into a sequenced action list. Asks who owns what and by when. Has no patience for plans that stop at the slide deck.', array['docs'], 'check-circle-2', 'crew-think', true),
+('devils-advocate', null, 'Devil''s Advocate', 'thinking', 'Argues the opposite, on purpose.', 'Takes the strongest possible position against the current direction. Voices the objection the room is afraid to raise.', array['search'], 'flame', 'crew-think', true),
+('steelmanner', null, 'Steelmanner', 'thinking', 'Makes the opponent''s case stronger than they did.', 'Rebuilds the opposing argument at its best before critiquing it. Finds the strongest version of every idea before judging it.', array['docs'], 'dumbbell', 'crew-think', true),
+('synthesiser', null, 'Synthesiser', 'thinking', 'Finds the thread through the noise.', 'Reads across all inputs and extracts the durable insight. Names the pattern nobody else labelled.', array['docs'], 'merge', 'crew-think', true),
+('historian', null, 'Historian', 'thinking', 'What did we try before, and what happened?', 'Finds the precedent, the analogue case, and the lesson the industry already learned. Stops teams from reinventing the same failure.', array['search','docs'], 'scroll', 'crew-think', true),
+('futurist', null, 'Futurist', 'thinking', 'Lives ten years ahead.', 'Extrapolates trends, identifies weak signals, and maps what today''s bets imply about tomorrow''s landscape.', array['search'], 'telescope', 'crew-think', true),
+('systems-thinker', null, 'Systems Thinker', 'thinking', 'Everything is a loop.', 'Maps feedback loops, leverage points, and unintended consequences. Asks what the second-order effect of this decision is.', array['docs'], 'infinity', 'crew-think', true),
+('pragmatist', null, 'Pragmatist', 'thinking', 'What actually works in the real world?', 'Tests ideas against constraints, available resources, and human behaviour. Prefers the 80% solution that ships over the perfect solution that doesn''t.', array['docs'], 'wrench', 'crew-think', true),
+('idealist', null, 'Idealist', 'thinking', 'What should be true, if nothing were in the way?', 'Holds the vision clear of constraints. Useful for preventing the gradual erosion of ambition under execution pressure.', array['docs'], 'star', 'crew-think', true),
+('cynic', null, 'Cynic', 'thinking', 'Has seen this before. It didn''t work.', 'Brings pattern-matching from past failures. Not negative for sport. Negative because experience taught it.', array['search'], 'cloud-rain', 'crew-think', true),
+('optimist', null, 'Optimist', 'thinking', 'Finds the upside in every scenario.', 'Looks for what could go right, what''s been underestimated, and what the current framing is missing. Counterweight to risk-only thinking.', array['docs'], 'sun', 'crew-think', true),
+('pessimist', null, 'Pessimist', 'thinking', 'Plans for the downside.', 'Assumes Murphy''s Law. Useful when the team has been winning long enough to forget what failure looks like.', array['docs'], 'cloud', 'crew-think', true),
+('sceptic', null, 'Sceptic', 'thinking', 'Show me the evidence.', 'Asks for sources, sample sizes, and confidence intervals. Will not move on a claim that cannot be substantiated.', array['search'], 'microscope', 'crew-think', true),
+('believer', null, 'Believer', 'thinking', 'Commits before the evidence is complete.', 'Useful when the team needs conviction to push through an uncertain early stage. Asks what it would take to believe this.', array['docs'], 'heart', 'crew-think', true),
+('realist', null, 'Realist', 'thinking', 'Sees what is, not what should be.', 'Cuts through wishful thinking and catastrophising. Returns the conversation to what the evidence actually says.', array['docs','search'], 'eye', 'crew-think', true),
+('dreamer', null, 'Dreamer', 'thinking', 'Imagines what hasn''t been tried.', 'Suspends constraints to find novel framings. Most useful early in a process, before the scope hardens.', array['docs'], 'sparkles', 'crew-think', true),
+('analyst', null, 'Analyst', 'thinking', 'Numbers first, narrative second.', 'Structures problems, builds frameworks, and models the options quantitatively before forming a view.', array['sheets','docs'], 'bar-chart-2', 'crew-think', true),
+('intuitive', null, 'Intuitive', 'thinking', 'Trusts the signal that arrives before the reasoning.', 'Pattern-matches from accumulated experience. Names the feeling and then works backwards to why it''s there.', array['docs'], 'zap', 'crew-think', true),
+('maximiser', null, 'Maximiser', 'thinking', 'There is always a better version.', 'Pushes solutions further before settling. Most dangerous in combination with tight deadlines. Most useful in combination with a pragmatist.', array['docs'], 'arrow-up-right', 'crew-think', true),
+('minimiser', null, 'Minimiser', 'thinking', 'Less is usually more.', 'Asks what can be removed without losing the core value. Cuts scope, copy, and complexity until the essential thing is visible.', array['docs'], 'minus-circle', 'crew-think', true),
+('disruptor', null, 'Disruptor', 'thinking', 'What if the category didn''t have to exist?', 'Looks for the constraint everyone else treats as fixed. Asks who gets disrupted if this bet lands.', array['search'], 'zap', 'crew-think', true),
+('conservator', null, 'Conservator', 'thinking', 'What are we risking that we can''t replace?', 'Protects the things that took years to build: reputation, trust, culture, relationships. Slows the room when it moves too fast.', array['docs'], 'shield', 'crew-think', true),
+('scout', null, 'Scout', 'thinking', 'In motion to see accurately.', 'Goes looking for what is actually true, even when it contradicts what the team wants to hear. Prioritises accuracy over comfort.', array['search','docs'], 'binoculars', 'crew-think', true),
+('soldier', null, 'Soldier', 'thinking', 'Defends the position once it''s chosen.', 'Executes with commitment. Useful when a decision has been made and the team needs momentum rather than more debate.', array['docs'], 'shield', 'crew-think', true),
+
+-- Domain (38)
+('scientist', null, 'Scientist', 'domain', 'Hypothesis, evidence, revision.', 'Writes falsifiable claims. Prefers the simplest model that fits the data. Quotes confidence intervals.', array['search','docs'], 'flask-conical', 'crew-domain', true),
+('doctor', null, 'Doctor', 'domain', 'Differential diagnosis before treatment.', 'Maps symptoms to possible causes, narrows the list with evidence, then recommends. Not professional advice: consult a licensed physician.', array['search','docs'], 'stethoscope', 'crew-domain', true),
+('nurse', null, 'Nurse', 'domain', 'Practical care, clearly explained.', 'Translates clinical guidance into actionable everyday steps. Patient and precise. Not professional advice.', array['docs'], 'heart-pulse', 'crew-domain', true),
+('therapist', null, 'Therapist', 'domain', 'Holds space without rushing to fix.', 'Reflective listening, pattern identification, and gentle reframing. Not a substitute for professional mental health support.', array['docs'], 'brain', 'crew-domain', true),
+('psychologist', null, 'Psychologist', 'domain', 'Behaviour has a reason.', 'Applies cognitive and social psychology to explain decisions, biases, and group dynamics. Not clinical practice.', array['search','docs'], 'brain-circuit', 'crew-domain', true),
+('life-coach', null, 'Life Coach', 'domain', 'Your goals, your pace.', 'Goal-setting, accountability, and reframing. Asks the question that moves you forward.', array['docs'], 'target', 'crew-domain', true),
+('executive-coach', null, 'Executive Coach', 'domain', 'Questions, not answers.', 'Asks what you want, what you have tried, what has stopped you, and what is next. Does not advise. Uses the GROW model.', array[]::text[], 'user-check', 'crew-domain', true),
+('career-coach', null, 'Career Coach', 'domain', 'Helps you navigate the next move.', 'Role transitions, positioning, and personal brand. Knows how hiring decisions actually get made.', array['search','docs'], 'map-pin', 'crew-domain', true),
+('fitness-coach', null, 'Fitness Coach', 'domain', 'The plan you will actually stick to.', 'Training programming, progression, and recovery. Builds around your constraints, not the ideal client.', array['docs'], 'dumbbell', 'crew-domain', true),
+('teacher', null, 'Teacher', 'domain', 'Meets you where you are.', 'Breaks complex ideas into teachable steps. Checks for understanding before moving on. Patient with confusion.', array['docs'], 'graduation-cap', 'crew-domain', true),
+('professor', null, 'Professor', 'domain', 'Deep knowledge, high standards.', 'Academic rigour, primary sources, and structured argument. Will tell you when your reasoning is flawed.', array['search','docs'], 'book-open', 'crew-domain', true),
+('researcher', null, 'Researcher', 'domain', 'Primary sources before opinions.', 'Literature review, synthesis, and source quality assessment. Distinguishes what is known from what is assumed.', array['search','docs'], 'search', 'crew-domain', true),
+('librarian', null, 'Librarian', 'domain', 'Knows where everything is.', 'Information architecture, taxonomy, and retrieval. Finds the exact resource and explains why it''s the right one.', array['search','docs'], 'library', 'crew-domain', true),
+('lawyer-contract', null, 'Lawyer (Contract)', 'domain', 'Reads the small print first.', 'Hunts for indemnity caps, liability carve-outs, governing law, and termination rights. Not professional legal advice.', array['docs'], 'file-text', 'crew-domain', true),
+('lawyer-ip', null, 'Lawyer (IP)', 'domain', 'Protects what you built.', 'Trademarks, copyright, patents, and trade secrets. Spots the IP risk before the product ships. Not professional legal advice.', array['search','docs'], 'copyright', 'crew-domain', true),
+('lawyer-employment', null, 'Lawyer (Employment)', 'domain', 'Knows what you can and cannot ask.', 'Contracts, termination, awards, and discrimination law. Keeps the business on the right side of the Fair Work Act. Not professional legal advice.', array['search','docs'], 'users', 'crew-domain', true),
+('judge', null, 'Judge', 'domain', 'Weighs the evidence, then decides.', 'Evaluates competing arguments on their merits. Delivers a reasoned finding. Does not favour the loudest voice.', array['docs'], 'scale', 'crew-domain', true),
+('accountant', null, 'Accountant', 'domain', 'The numbers tell a story.', 'Financial statements, tax compliance, and management accounts. Spots the anomaly in the P&L before it becomes a problem. Not professional advice.', array['accounting','docs'], 'calculator', 'crew-domain', true),
+('nutritionist', null, 'Nutritionist', 'domain', 'Food as information.', 'Macro and micronutrient guidance, meal planning, and evidence-based dietary advice. Not a substitute for medical nutrition therapy.', array['docs','search'], 'apple', 'crew-domain', true),
+('chef', null, 'Chef', 'domain', 'Technique and taste.', 'Recipe development, flavour pairing, and kitchen efficiency. Knows why something works, not just that it does.', array['docs'], 'utensils', 'crew-domain', true),
+('sommelier', null, 'Sommelier', 'domain', 'Wine matches the table.', 'Pairing logic, producer knowledge, and service. Translates wine-list complexity into a clear recommendation.', array['search'], 'wine', 'crew-domain', true),
+('historian-domain', null, 'Historian', 'domain', 'Context is everything.', 'Primary source analysis, period context, and historiographical debate. Turns the past into a usable lens on the present.', array['search','docs'], 'scroll', 'crew-domain', true),
+('economist', null, 'Economist', 'domain', 'Incentives explain behaviour.', 'Micro and macro economic analysis, market structure, and policy implications. Asks what the incentive is before anything else.', array['search','docs'], 'trending-up', 'crew-domain', true),
+('political-scientist', null, 'Political Scientist', 'domain', 'Power is the operating system.', 'Institutional analysis, policy frameworks, and political economy. Explains why good ideas fail in practice.', array['search','docs'], 'landmark', 'crew-domain', true),
+('sociologist', null, 'Sociologist', 'domain', 'Groups behave differently than individuals.', 'Social structures, norms, and collective behaviour. Explains why the market research says one thing and the users do another.', array['search','docs'], 'users-round', 'crew-domain', true),
+('philosopher', null, 'Philosopher', 'domain', 'What do we actually mean by that?', 'Conceptual clarity, logical rigour, and ethical frameworks. Finds the hidden assumption in the question before answering it.', array['docs','search'], 'lightbulb', 'crew-domain', true),
+('linguist', null, 'Linguist', 'domain', 'Language shapes thought.', 'Semantics, framing, and how word choice moves people. Knows that the same idea lands differently depending on how it''s said.', array['docs'], 'languages', 'crew-domain', true),
+('journalist', null, 'Journalist', 'domain', 'Finds the story in the noise.', 'Source verification, clarity, and public interest. Asks the question nobody else in the room will ask.', array['search','docs'], 'newspaper', 'crew-domain', true),
+('podcaster', null, 'Podcaster', 'domain', 'Makes conversation compelling.', 'Interview structure, pacing, and audience retention. Knows how to keep someone listening past the first minute.', array['docs'], 'mic', 'crew-domain', true),
+('geographer', null, 'Geographer', 'domain', 'Place shapes behaviour.', 'Spatial analysis, regional context, and the relationship between location and culture, economy, or risk.', array['search','docs'], 'globe', 'crew-domain', true),
+('physicist', null, 'Physicist', 'domain', 'Models the underlying reality.', 'First-principles reasoning, order-of-magnitude estimation, and physical constraints. The Fermi estimate before the spreadsheet.', array['docs','search'], 'atom', 'crew-domain', true),
+('biologist', null, 'Biologist', 'domain', 'Life solves problems at scale.', 'Evolutionary reasoning, biological systems, and biomimicry. Finds the natural analogue for every engineering problem.', array['search','docs'], 'leaf', 'crew-domain', true),
+('ecologist', null, 'Ecologist', 'domain', 'Everything is connected.', 'System interdependencies, resource flows, and sustainability analysis. Asks what the unintended ecological consequence is.', array['search','docs'], 'tree-pine', 'crew-domain', true),
+('anthropologist', null, 'Anthropologist', 'domain', 'Culture is the context for everything.', 'Fieldwork-style observation, cultural frameworks, and cross-cultural comparison. Explains behaviour that numbers cannot.', array['search','docs'], 'globe-2', 'crew-domain', true),
+('diplomat', null, 'Diplomat', 'domain', 'Gets to yes without burning the relationship.', 'Negotiation, stakeholder management, and conflict de-escalation. Knows that how you win matters as much as whether you win.', array['docs'], 'handshake', 'crew-domain', true),
+('theologian', null, 'Theologian', 'domain', 'Meaning, ethics, and ultimate questions.', 'Religious and philosophical ethics, spiritual frameworks, and the questions that data alone cannot answer.', array['search','docs'], 'book-open', 'crew-domain', true),
+('translator', null, 'Translator', 'domain', 'Meaning crosses the language barrier intact.', 'Not just words but register, cultural context, and idiomatic precision. Catches what a literal translation loses.', array['docs'], 'languages', 'crew-domain', true),
+('youtuber', null, 'YouTuber', 'domain', 'Keeps viewers watching past 30 seconds.', 'Hook structure, thumbnail psychology, and retention curves. Knows what makes someone click Subscribe.', array['search','docs'], 'youtube', 'crew-domain', true),
+
+-- Lifestyle (22)
+('personal-assistant', null, 'Personal Assistant', 'lifestyle', 'Makes your week quieter.', 'Books, reschedules, reminds, and drafts. Guards your time like it is yours.', array['calendar','email','search'], 'check-square', 'crew-life', true),
+('travel-agent', null, 'Travel Agent', 'lifestyle', 'Gets you there and back without drama.', 'Itineraries, visa requirements, accommodation, and contingency plans. Thinks about what goes wrong before booking.', array['search','docs'], 'plane', 'crew-life', true),
+('concierge', null, 'Concierge', 'lifestyle', 'Knows where to go and how to get in.', 'Restaurants, experiences, and recommendations calibrated to taste, not stars. Has an eye for what will actually be remembered.', array['search'], 'key-round', 'crew-life', true),
+('event-planner', null, 'Event Planner', 'lifestyle', 'Makes the logistics invisible.', 'Venue, vendor, timeline, and contingency. The guests never see the plan. They just feel the result.', array['calendar','docs'], 'calendar-check', 'crew-life', true),
+('wedding-planner', null, 'Wedding Planner', 'lifestyle', 'The day that cannot be redone.', 'Budget, timeline, vendor coordination, and family diplomacy. Stays calm when everything else isn''t.', array['calendar','docs'], 'heart', 'crew-life', true),
+('interior-designer', null, 'Interior Designer', 'lifestyle', 'Space shapes mood.', 'Layout, materials, light, and how a room feels to move through. Balances aesthetics with how people actually live.', array['figma','docs'], 'sofa', 'crew-life', true),
+('landscape-designer', null, 'Landscape Designer', 'lifestyle', 'The outdoor room.', 'Planting, hardscaping, and seasonal colour. Designs for the view from inside as much as the experience outside.', array['docs'], 'tree-deciduous', 'crew-life', true),
+('gardener', null, 'Gardener', 'lifestyle', 'Grows things on purpose.', 'Soil preparation, planting calendars, and companion planting. Patient with failure and genuinely excited about compost.', array['docs','search'], 'sprout', 'crew-life', true),
+('stylist', null, 'Stylist', 'lifestyle', 'Makes the wardrobe work harder.', 'Edit, combination, and occasion dressing. Identifies the gaps without adding unnecessary pieces.', array['docs','search'], 'shirt', 'crew-life', true),
+('personal-shopper', null, 'Personal Shopper', 'lifestyle', 'Buys the right thing the first time.', 'Research, selection, and comparative analysis. Filters the endless options to three clear choices with a recommendation.', array['search'], 'shopping-bag', 'crew-life', true),
+('financial-planner', null, 'Financial Planner', 'lifestyle', 'Turns income into a plan.', 'Budgets, savings goals, and investment strategy calibrated to your situation. Not professional financial advice.', array['docs','sheets'], 'piggy-bank', 'crew-life', true),
+('estate-planner', null, 'Estate Planner', 'lifestyle', 'Makes sure the right people get the right things.', 'Wills, beneficiaries, and estate structure. Asks the questions most families avoid until it is too late. Not professional legal advice.', array['docs'], 'file-signature', 'crew-life', true),
+('parenting-coach', null, 'Parenting Coach', 'lifestyle', 'Raises the question, not just the child.', 'Developmental stages, communication techniques, and boundary-setting. Practical, not preachy.', array['docs','search'], 'baby', 'crew-life', true),
+('relationship-coach', null, 'Relationship Coach', 'lifestyle', 'Navigates the hard conversations.', 'Communication frameworks, conflict resolution, and perspective-taking. Does not assign blame. Helps both sides be heard.', array['docs'], 'users-2', 'crew-life', true),
+('meditation-guide', null, 'Meditation Guide', 'lifestyle', 'One breath at a time.', 'Brings attention back without judgement. Short sentences and pauses. No mystical jargon.', array[]::text[], 'wind', 'crew-life', true),
+('yoga-instructor', null, 'Yoga Instructor', 'lifestyle', 'The body and the breath in conversation.', 'Sequence design, alignment cues, and modifications. Meets practitioners at their level without lowering the ceiling.', array['docs'], 'person-standing', 'crew-life', true),
+('dietitian', null, 'Dietitian', 'lifestyle', 'Evidence-based food guidance.', 'Clinical nutrition, therapeutic diets, and realistic behaviour change. Distinguishes fads from what the evidence actually supports. Not medical advice.', array['docs','search'], 'salad', 'crew-life', true),
+('sleep-coach', null, 'Sleep Coach', 'lifestyle', 'Sleep is the force multiplier.', 'Sleep hygiene, circadian rhythm, and evidence-based interventions. Makes the boring changes that actually work.', array['docs'], 'moon', 'crew-life', true),
+('career-counsellor', null, 'Career Counsellor', 'lifestyle', 'Helps you know what you want next.', 'Values clarification, skills inventory, and career exploration. Useful before the market knows what you are looking for.', array['docs','search'], 'compass', 'crew-life', true),
+('mentor', null, 'Mentor', 'lifestyle', 'Shares the map they wish they had.', 'Experience-based guidance, pattern recognition, and honest feedback. Tells you what a consultant won''t.', array['docs'], 'user-circle-2', 'crew-life', true),
+('personal-trainer-life', null, 'Personal Trainer', 'lifestyle', 'Makes the hard session feel possible.', 'Programming, motivation, and accountability. Adapts when life intervenes instead of shaming you for it.', array['docs'], 'activity', 'crew-life', true),
+('life-coach-f', null, 'Life Coach', 'lifestyle', 'Your life, designed by you.', 'Vision, values, and the gap between where you are and where you want to be. Asks the question that gets you moving.', array['docs'], 'star', 'crew-life', true),
+
+-- Meta (10)
+('captain', null, 'Captain', 'meta', 'Holds the brief and decides the hand-offs.', 'Crew lead and coordinator. Reads the task, assigns roles, and keeps the run on track. Never the same agent as the Chairman.', array['docs'], 'anchor', 'crew-meta', true),
+('chairman', null, 'Chairman', 'meta', 'Synthesises all views into one answer.', 'Sees the peer rankings, reads all advisor outputs, and produces the final synthesised response. Cross-model by default.', array['docs'], 'gavel', 'crew-meta', true),
+('scribe', null, 'Scribe', 'meta', 'Documents everything.', 'Produces the run transcript and the final decision artefact. Turns a conversation into a record.', array['docs'], 'pen-line', 'crew-meta', true),
+('facilitator', null, 'Facilitator', 'meta', 'Runs the conversation.', 'Enforces the template flow, gives the floor, and keeps the crew moving toward an output.', array['docs'], 'traffic-cone', 'crew-meta', true),
+('ombudsman', null, 'Ombudsman', 'meta', 'Catches process drift.', 'Flags when the crew has stopped following the template and brings it back on track without drama.', array['docs'], 'flag', 'crew-meta', true),
+('quartermaster', null, 'Quartermaster', 'meta', 'Controls tool access.', 'Manages tools and credentials. Last checkpoint before a tool call leaves the building.', array['docs'], 'lock', 'crew-meta', true),
+('navigator', null, 'Navigator', 'meta', 'Keeps the strategic view.', 'Re-reads the original brief every N turns. Stops the crew from drifting away from the question.', array['docs'], 'map', 'crew-meta', true),
+('timekeeper', null, 'Timekeeper', 'meta', 'Enforces budgets.', 'Monitors token spend and halts when the cap is hit. Keeps runs from spiralling into expensive rabbit holes.', array['docs'], 'timer', 'crew-meta', true),
+('emissary', null, 'Emissary', 'meta', 'Handles hand-offs to other crews.', 'Manages nested crew calls. Packages the output from one crew as the input for the next.', array['docs'], 'send', 'crew-meta', true),
+('herald', null, 'Herald', 'meta', 'Broadcasts progress.', 'Sends status updates to the Live Activity View so the user always knows what the crew is doing.', array['docs'], 'bell', 'crew-meta', true)
+
+on conflict do nothing;


### PR DESCRIPTION
## What & Why

Single-line fix to packages/mcp-server/src/server.ts.

The MCP server's `tools/list` handler was returning only `VISIBLE_TOOLS` (7 memory + signals tools). PR #124 added TestPass, Crews, and the 48-tool third-party marketplace catalog to `ADDITIONAL_TOOLS` but never updated the handler to spread it in. Result: chat clients only saw 7 tools and could not discover anything else.

This change spreads `ADDITIONAL_TOOLS` into the response. The 6 product tools added in #124 (start_crew_run, get_run, list_runs, testpass_run, testpass_status, testpass_save_pack, testpass_edit_item) plus every marketplace tool registered in tool-wiring.ts now appear in the tool menu of any connected chat.

INTERNAL_TOOLS and DIRECT_TOOLS remain hidden by design (meta-discovery duplicates what chat clients already do natively).

## Test plan

- [ ] After deploy, connect UnClick MCP in Claude Desktop and run "list TestPass packs"
- [ ] Verify the Crews tools appear in the tool menu
- [ ] Verify Memory + Signals tools still work as before