### PR TITLE
chore: TestPass URL fix + Vercel security headers (ChatGPT QC Finds P1+P2)

### DIFF
--- a/.github/actions/testpass/action.yml
+++ b/.github/actions/testpass/action.yml
@@ -20,7 +20,7 @@ inputs:
   api_url:
     description: TestPass API endpoint.
     required: false
-    default: https://unclick.ai/api/testpass-run
+    default: https://unclick.world/api/testpass-run
 
 outputs:
   run_id:

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,18 @@
   "outputDirectory": "dist",
   "installCommand": "npm install",
   "framework": "vite",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/sitemap.xml",   "destination": "/api/sitemap" },
     { "source": "/v1/arena/(.*)", "destination": "/api/arena" },


### PR DESCRIPTION
## What & Why

Two fixes from the ChatGPT QC Finds review.

### 1. TestPass action: unclick.ai → unclick.world (P1)

`.github/actions/testpass/action.yml` defaulted the API URL to `https://unclick.ai/api/testpass-run`, a stale domain. PR #129's CI check was failing with curl connection reset against this URL. Updated to `https://unclick.world/api/testpass-run`. After this merges, re-run the check on PR #129 and it should hit the live API.

### 2. Vercel security headers (P2)

`vercel.json` had no `headers` block. Added one applying:

- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: geolocation=(), microphone=(), camera=()`

These are safe defaults for unclick.world: forces HTTPS, blocks MIME sniffing, blocks framing, leaks fewer referrers, and turns off browser features the site does not use.

### CSP intentionally deferred

`Content-Security-Policy` is NOT in this PR. CSP needs `report-only` testing first to avoid simultaneously breaking Vanta WAVES (cdnjs.cloudflare.com), Stripe.js, Supabase, PostHog, and Umami. Tracked as a follow-up.

## Test plan

- [ ] CI green on this PR
- [ ] After merge + Vercel deploy, re-trigger the TestPass check on PR #129. It should now reach the live `/api/testpass-run` endpoint instead of timing out.
- [ ] After merge + deploy, run `curl -I https://unclick.world` and verify the five new headers appear.
- [ ] Click around the site (homepage, admin, Stripe checkout) and confirm nothing broke (no headers should affect normal flows).