### PR TITLE
fix: expose TestPass, Crews, and 48 marketplace tools in MCP tools/list (clean refire)

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -765,12 +765,15 @@ export function createServer(): Server {
     }
   );
 
-  // LIST TOOLS: advertise only the 5 core memory tools. Internal tools
-  // (unclick_search, unclick_browse, unclick_tool_info, unclick_call) and the
-  // individual direct tools remain callable for backwards compatibility but
-  // aren't shown in the tool list to keep the surface minimal.
+  // LIST TOOLS: advertise the core memory tools PLUS every product + marketplace
+  // tool registered in ADDITIONAL_TOOLS (TestPass, Crews, and all third-party
+  // integrations from tool-wiring.ts). Internal meta tools (unclick_search,
+  // unclick_browse, unclick_tool_info, unclick_call) and the small DIRECT_TOOLS
+  // utility set remain callable for backwards compatibility but stay hidden
+  // from tools/list to avoid duplicating what native chat clients already
+  // discover.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: [...VISIBLE_TOOLS] };
+    return { tools: [...VISIBLE_TOOLS, ...ADDITIONAL_TOOLS] };
   });
 
   // CALL TOOL


### PR DESCRIPTION
## What & Why

Re-fires the closed PR #133 from a clean main checkout. Original PR was closed because its base was a stale worktree that had check_signals already removed; merging it would have silently deleted check_signals from main.

This PR is byte-for-byte the surgical change: comment update + spread `[...VISIBLE_TOOLS, ...ADDITIONAL_TOOLS]` in the tools/list handler. No other lines touched.

After merge + Vercel deploy, chat clients (Claude Desktop, ChatGPT, Codex) will see TestPass + Crews + all 48 marketplace tools in their tool menu.

## Test plan

- [ ] grep -c '"check_signals"' returns 2
- [ ] After deploy, "list TestPass packs" works in Claude Desktop
- [ ] Crews tools appear in tool menu
- [ ] Memory + Signals tools still work unchanged