### PR TITLE
fix: wrap Supabase errors so save_fact stops returning "[object Object]" (clean refire)

### DIFF
--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -28,6 +28,17 @@ import type {
   LibraryDocInput,
 } from "./types.js";
 
+function pgError(context: string, err: unknown): Error {
+  if (err instanceof Error) return err;
+  const e = (err ?? {}) as { message?: string; code?: string; details?: string; hint?: string };
+  const parts: string[] = [`${context} failed`];
+  if (e.message) parts.push(e.message);
+  if (e.code) parts.push(`(code: ${e.code})`);
+  if (e.details) parts.push(`details: ${e.details}`);
+  if (e.hint) parts.push(`hint: ${e.hint}`);
+  return new Error(parts.join(" "));
+}
+
 function contentHash(text: string): string {
   return createHash("sha256").update(text.toLowerCase().trim(), "utf8").digest("hex");
 }
@@ -331,7 +342,7 @@ export class SupabaseBackend implements MemoryBackend {
       )
       .select()
       .single();
-    if (error) throw error;
+    if (error) throw pgError("writeSessionSummary insert", error);
     return { id: row.id };
   }
 
@@ -383,7 +394,7 @@ export class SupabaseBackend implements MemoryBackend {
       )
       .select()
       .single();
-    if (error) throw error;
+    if (error) throw pgError("addFact insert", error);
 
     // Append audit row (fire-and-forget; never blocks the main insert)
     this.writeFactAudit(row.id, "insert", { category: data.category }).catch(() => {});
@@ -413,7 +424,7 @@ export class SupabaseBackend implements MemoryBackend {
             ? { api_key_hash: this.tenancy.apiKeyHash, title: data.category, body: data.fact, content_hash: hash }
             : { title: data.category, body: data.fact, content_hash: hash };
         const { data: doc, error } = await this.client.from(docTable).insert(insertRow).select().single();
-        if (error) throw error;
+        if (error) throw pgError("saveBlob canonical_docs insert", error);
         docId = (doc as { id: string }).id;
       }
     }
@@ -462,7 +473,7 @@ export class SupabaseBackend implements MemoryBackend {
         )
         .select()
         .single();
-      if (ferr && (ferr as { code?: string }).code !== "23505") throw ferr;
+      if (ferr && (ferr as { code?: string }).code !== "23505") throw pgError("saveBlob extracted_facts insert", ferr);
       if (!ferr && frow) factIds.push((frow as { id: string }).id);
     }
 
@@ -530,7 +541,7 @@ export class SupabaseBackend implements MemoryBackend {
           has_code: data.has_code,
         })
       );
-    if (error) throw error;
+    if (error) throw pgError("logConversation insert", error);
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {
@@ -557,7 +568,7 @@ export class SupabaseBackend implements MemoryBackend {
       )
       .select()
       .single();
-    if (error) throw error;
+    if (error) throw pgError("storeCode insert", error);
     return { id: row.id };
   }
 
@@ -571,7 +582,7 @@ export class SupabaseBackend implements MemoryBackend {
       query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
     }
     const { data, error } = await query;
-    if (error) throw error;
+    if (error) throw pgError("getBusinessContext select", error);
     return data ?? [];
   }
 
@@ -608,7 +619,7 @@ export class SupabaseBackend implements MemoryBackend {
       .upsert(this.withTenancy(row), { onConflict })
       .select()
       .single();
-    if (error) throw error;
+    if (error) throw pgError("setBusinessContext upsert", error);
   }
 
   async upsertLibraryDoc(data: LibraryDocInput): Promise<string> {
@@ -635,7 +646,7 @@ export class SupabaseBackend implements MemoryBackend {
           decay_tier: "hot",
         })
         .eq("id", existing.id);
-      if (error) throw error;
+      if (error) throw pgError("upsertLibraryDoc update", error);
       return `Library doc updated: "${data.title}" (v${existing.version + 1})`;
     } else {
       const { error } = await this.client
@@ -652,7 +663,7 @@ export class SupabaseBackend implements MemoryBackend {
             last_accessed: now(),
           })
         );
-      if (error) throw error;
+      if (error) throw pgError("upsertLibraryDoc insert", error);
       return `Library doc created: "${data.title}" (v1)`;
     }
   }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1026,7 +1026,21 @@ export function createServer(): Server {
         isError: true,
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      let message: string;
+      if (err instanceof Error) {
+        message = err.message;
+      } else if (err && typeof err === "object" && "message" in err && typeof (err as { message: unknown }).message === "string") {
+        // Postgres / Supabase / PostgREST errors are plain objects, not Error instances.
+        // Surface code / details / hint when present so agents can self-diagnose.
+        const e = err as { message: string; code?: string; details?: string; hint?: string };
+        const parts: string[] = [e.message];
+        if (e.code) parts.push(`(code: ${e.code})`);
+        if (e.details) parts.push(`details: ${e.details}`);
+        if (e.hint) parts.push(`hint: ${e.hint}`);
+        message = parts.join(" ");
+      } else {
+        message = String(err);
+      }
       return {
         content: [{ type: "text", text: `Error: ${message}` }],
         isError: true,


### PR DESCRIPTION
## What & Why

Clean refire of PR #135 (closed/replaced because its branch picked up unrelated Crews Phase B work from a stale host base, same pattern that hit PR #133).

Original bug: save_fact returned the literal string "[object Object]" because Supabase / Postgrest errors are plain objects, not Error instances, and the outer catch in server.ts was doing `String(err)` on them.

Fix:
- New `pgError(context, err)` helper in supabase.ts wraps raw Supabase errors as proper `new Error()` with code/details/hint.
- Every raw `throw error` in the SupabaseBackend class methods now uses `pgError(...)`.
- Outer catch in server.ts hardened to extract message/code/details/hint from non-Error objects.

Two files only: server.ts + memory/supabase.ts. Verified `check_signals` still appears 2x in server.ts.

## Test plan

- [ ] Build green
- [ ] save_fact from a chat client returns a real fact id (now that the 4/22 facts migrations are applied in prod)
- [ ] Existing tools (load_memory, search_memory, save_identity, save_session, invalidate_fact, check_signals) keep working