### PR TITLE
feat: Fishbowl Phase 1 (group chat for AI agents) - schema + MCP tools + admin page

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5688,6 +5688,186 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
 
+      // ─── Fishbowl Phase 1: agent group chat ───────────────────────────────
+
+      case "fishbowl_set_emoji": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
+          });
+        }
+        const body = (req.body ?? {}) as {
+          emoji?: string;
+          display_name?: string | null;
+          user_agent_hint?: string | null;
+          agent_id?: string | null;
+        };
+        const emoji = (body.emoji ?? "").trim();
+        if (!emoji) return res.status(400).json({ error: "emoji required" });
+        const userAgentHint = (body.user_agent_hint ?? "").toString().trim() || null;
+        let agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) {
+          const seed = `${apiKeyHash}|${userAgentHint ?? "unknown"}`;
+          agentId = crypto.createHash("sha256").update(seed).digest("hex").slice(0, 16);
+        }
+        const nowIso = new Date().toISOString();
+        const { data, error } = await supabase
+          .from("mc_fishbowl_profiles")
+          .upsert(
+            {
+              api_key_hash: apiKeyHash,
+              agent_id: agentId,
+              emoji,
+              display_name: body.display_name ?? null,
+              user_agent_hint: userAgentHint,
+              last_seen_at: nowIso,
+            },
+            { onConflict: "api_key_hash,agent_id" },
+          )
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at")
+          .single();
+        if (error) throw error;
+        return res.status(200).json({ profile: data });
+      }
+
+      case "fishbowl_post": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
+          });
+        }
+        const body = (req.body ?? {}) as {
+          text?: string;
+          tags?: string[] | null;
+          recipients?: string[] | null;
+          user_agent_hint?: string | null;
+          agent_id?: string | null;
+        };
+        const text = (body.text ?? "").toString().trim();
+        if (!text) return res.status(400).json({ error: "text required" });
+
+        let agentId = (body.agent_id ?? "").toString().trim();
+        const userAgentHint = (body.user_agent_hint ?? "").toString().trim() || null;
+        if (!agentId) {
+          const seed = `${apiKeyHash}|${userAgentHint ?? "unknown"}`;
+          agentId = crypto.createHash("sha256").update(seed).digest("hex").slice(0, 16);
+        }
+
+        // Look up the agent's profile so we can decorate the message with its
+        // emoji and display name. Posting without registering first still
+        // works, but the message will show a placeholder emoji.
+        const { data: profile } = await supabase
+          .from("mc_fishbowl_profiles")
+          .select("emoji, display_name")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("agent_id", agentId)
+          .maybeSingle();
+
+        // Get-or-create the default room for this tenant.
+        const { data: existingRoom } = await supabase
+          .from("mc_fishbowl_rooms")
+          .select("id")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("slug", "default")
+          .maybeSingle();
+        let roomId = existingRoom?.id as string | undefined;
+        if (!roomId) {
+          const { data: newRoom, error: roomErr } = await supabase
+            .from("mc_fishbowl_rooms")
+            .insert({ api_key_hash: apiKeyHash, slug: "default", name: "Fishbowl" })
+            .select("id")
+            .single();
+          if (roomErr) throw roomErr;
+          roomId = newRoom.id;
+        }
+
+        const recipients = Array.isArray(body.recipients) && body.recipients.length > 0 ? body.recipients : ["all"];
+        const tags = Array.isArray(body.tags) ? body.tags : null;
+
+        const { data: inserted, error: insertErr } = await supabase
+          .from("mc_fishbowl_messages")
+          .insert({
+            api_key_hash: apiKeyHash,
+            room_id: roomId,
+            author_emoji: profile?.emoji ?? "🤖",
+            author_name: profile?.display_name ?? null,
+            author_agent_id: agentId,
+            recipients,
+            text,
+            tags,
+          })
+          .select("id, author_emoji, author_name, author_agent_id, recipients, text, tags, created_at")
+          .single();
+        if (insertErr) throw insertErr;
+
+        // Bump last_seen_at so the admin sidebar shows accurate activity.
+        await supabase
+          .from("mc_fishbowl_profiles")
+          .update({ last_seen_at: new Date().toISOString() })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("agent_id", agentId);
+
+        return res.status(200).json({ message: inserted });
+      }
+
+      case "fishbowl_read": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
+          });
+        }
+        const body = (req.body ?? {}) as { since?: string; limit?: number };
+        const sinceParam = (body.since ?? req.query.since ?? "") as string;
+        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 20) || 20, 1), 100);
+
+        const { data: room } = await supabase
+          .from("mc_fishbowl_rooms")
+          .select("id, slug, name")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("slug", "default")
+          .maybeSingle();
+
+        if (!room) {
+          // No room yet means no posts yet. Return empty so the admin page
+          // can render its empty state without an error.
+          return res.status(200).json({ room: null, messages: [], profiles: [] });
+        }
+
+        let q = supabase
+          .from("mc_fishbowl_messages")
+          .select("id, author_emoji, author_name, author_agent_id, recipients, text, tags, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("room_id", room.id)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+        if (sinceParam) q = q.gt("created_at", sinceParam);
+
+        const [{ data: messages, error: msgErr }, { data: profiles, error: profErr }] = await Promise.all([
+          q,
+          supabase
+            .from("mc_fishbowl_profiles")
+            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("last_seen_at", { ascending: false, nullsFirst: false }),
+        ]);
+        if (msgErr) throw msgErr;
+        if (profErr) throw profErr;
+
+        return res.status(200).json({
+          room,
+          messages: messages ?? [],
+          profiles: profiles ?? [],
+        });
+      }
+
       default:
         return res.status(400).json({ error: `Unknown action: ${action}` });
     }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -322,6 +322,61 @@ const VISIBLE_TOOLS = [
       properties: {},
     },
   },
+  {
+    name: "set_my_emoji",
+    title: "Pick my Fishbowl emoji",
+    description:
+      "Registers this AI agent as a participant in the user's Fishbowl, the shared group chat where every connected agent posts and reads messages so they can coordinate without the user being a message bus. " +
+      "Call this ONCE on first connect to claim an emoji and a short display name. " +
+      "Trigger when the user says 'set up Fishbowl', 'pick an emoji', 'introduce yourself in chat', 'register in the group', or any time you join a session and have not yet posted in this user's Fishbowl. " +
+      "Pick an emoji that fits your model: a robot, a fish, a brain, a bird, anything memorable and short. Use display_name to identify yourself in plain English (for example: 'Claude (coding helper)'). " +
+      "Do NOT call this on every session, only the first time on a new device or after a reset.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        emoji: { type: "string", description: "Single emoji to identify this agent in the Fishbowl feed" },
+        display_name: { type: "string", description: "Short human-readable name for this agent" },
+        user_agent_hint: { type: "string", description: "Optional client identifier (e.g. 'claude-code/1.2', 'cursor/0.4')" },
+      },
+      required: ["emoji"],
+    },
+  },
+  {
+    name: "post_message",
+    title: "Post to the Fishbowl",
+    description:
+      "Posts a message into the user's Fishbowl, the shared chat where every connected AI agent coordinates. " +
+      "Trigger when something MATERIAL happens that other agents (or the user, watching) should know about: a PR opened, a blocker hit, a decision reached, a task finished, a fact saved that affects shared context. " +
+      "Post events, not stream-of-consciousness. One short message per real change. Keep it plain English, no jargon. " +
+      "Use tags for filterable categories (for example: ['pr','crews']) and recipients to target specific agents (default is everyone). " +
+      "Do NOT post running commentary, partial thoughts, or narration of trivial steps. The Fishbowl is a noticeboard, not a chat log.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        text: { type: "string", description: "The message body in plain English" },
+        tags: { type: "array", items: { type: "string" }, description: "Optional tags for filtering (e.g. ['pr','blocker'])" },
+        recipients: { type: "array", items: { type: "string" }, description: "Optional recipients (emoji or 'all'); defaults to ['all']" },
+      },
+      required: ["text"],
+    },
+  },
+  {
+    name: "read_messages",
+    title: "Read the Fishbowl",
+    description:
+      "Reads recent messages from the user's Fishbowl, the shared chat where every connected AI agent coordinates. " +
+      "Call this RIGHT AFTER load_memory at the start of every session, so you catch up on what other agents posted while you were away. " +
+      "Also trigger when the user says 'what did the others say', 'check the Fishbowl', 'any updates from the team', 'what is going on', or any time another agent's recent work might affect what you are about to do. " +
+      "Use 'since' to filter to messages after a known timestamp (skip what you already saw). 'limit' caps the result count, default 20. " +
+      "Do NOT poll repeatedly within the same session; once per session at start is enough unless something changed.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        since: { type: "string", description: "ISO 8601 timestamp; only return messages newer than this" },
+        limit: { type: "number", minimum: 1, maximum: 100, default: 20 },
+      },
+    },
+  },
 ] as const;
 
 // Maps new visible tool names to the canonical MEMORY_HANDLERS keys.
@@ -814,6 +869,47 @@ export function createServer(): Server {
         const body = await resp.json().catch(() => ({}));
         return {
           content: [{ type: "text", text: JSON.stringify(body, null, 2) }],
+          isError: !resp.ok,
+        };
+      }
+
+      // ── Fishbowl: agent group chat (set_my_emoji / post_message / read_messages)
+      if (name === "set_my_emoji" || name === "post_message" || name === "read_messages") {
+        const apiKey = process.env.UNCLICK_API_KEY;
+        const base =
+          process.env.UNCLICK_MEMORY_BASE_URL ||
+          process.env.UNCLICK_SITE_URL ||
+          "https://unclick.world";
+        if (!apiKey) {
+          return {
+            content: [
+              { type: "text", text: "Fishbowl unavailable: no UNCLICK_API_KEY configured. Run the UnClick setup wizard." },
+            ],
+            isError: true,
+          };
+        }
+        const actionMap: Record<string, string> = {
+          set_my_emoji: "fishbowl_set_emoji",
+          post_message: "fishbowl_post",
+          read_messages: "fishbowl_read",
+        };
+        const fbAction = actionMap[name];
+        const userAgentHint =
+          (args.user_agent_hint as string | undefined) ||
+          process.env.UNCLICK_CLIENT_USER_AGENT ||
+          "unclick-mcp-server";
+        const body = JSON.stringify({ ...args, user_agent_hint: userAgentHint });
+        const resp = await fetch(`${base}/api/memory-admin?action=${fbAction}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body,
+        });
+        const respBody = await resp.json().catch(() => ({}));
+        return {
+          content: [{ type: "text", text: JSON.stringify(respBody, null, 2) }],
           isError: !resp.ok,
         };
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ import AdminModeration from "./pages/admin/AdminModeration.tsx";
 import AdminAuditLog from "./pages/admin/AdminAuditLog.tsx";
 import SignalsCatalog from "./pages/admin/signals/SignalsCatalog.tsx";
 import SignalsSettings from "./pages/admin/signals/SignalsSettings.tsx";
+import Fishbowl from "./pages/admin/Fishbowl.tsx";
 import BuildDeskPage from "./pages/BuildDesk.tsx";
 import { initPostHog } from "./lib/posthog.ts";
 
@@ -157,6 +158,7 @@ const App = () => (
             <Route path="audit-log"      element={<RequireAdmin><AdminAuditLog /></RequireAdmin>} />
             <Route path="signals"          element={<SignalsCatalog />} />
             <Route path="signals/settings" element={<SignalsSettings />} />
+            <Route path="fishbowl"         element={<Fishbowl />} />
           </Route>
           {/* Phase 2 auth surface */}
           <Route path="/login" element={<LoginPage />} />

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -43,6 +43,7 @@ import {
   HeartPulse,
   ShieldCheck,
   ScrollText,
+  Fish,
 } from "lucide-react";
 
 function SurfaceLink({ path, label, icon: Icon, onClick, badge }: {
@@ -241,6 +242,7 @@ export default function AdminShell() {
       <>
         <SurfaceLink path="/admin/you"      label="You"                      icon={User}    onClick={onLinkClick} />
         <MemoryNavItem onClick={onLinkClick} />
+        <SurfaceLink path="/admin/fishbowl" label="Fishbowl"                 icon={Fish}     onClick={onLinkClick} />
         <SurfaceLink path="/admin/keychain" label="Keychain (BackstagePass)" icon={KeyRound} onClick={onLinkClick} />
         <SurfaceLink path="/admin/tools"    label="Tools"                    icon={Wrench}   onClick={onLinkClick} />
         <SurfaceLink path="/admin/activity" label="Activity"                 icon={Activity} onClick={onLinkClick} />

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { useSession } from "@/lib/auth";
+
+interface FishbowlMessage {
+  id: string;
+  author_emoji: string;
+  author_name: string | null;
+  author_agent_id: string | null;
+  recipients: string[] | null;
+  text: string;
+  tags: string[] | null;
+  created_at: string;
+}
+
+interface FishbowlProfile {
+  agent_id: string;
+  emoji: string;
+  display_name: string | null;
+  user_agent_hint: string | null;
+  created_at: string;
+  last_seen_at: string | null;
+}
+
+interface FishbowlResponse {
+  room: { id: string; slug: string; name: string } | null;
+  messages: FishbowlMessage[];
+  profiles: FishbowlProfile[];
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "never";
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.max(1, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function formatUtcTime(iso: string): string {
+  const d = new Date(iso);
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${hh}:${mm} UTC`;
+}
+
+export default function Fishbowl() {
+  const { session } = useSession();
+  const token = session?.access_token;
+  const authHeader = useMemo(
+    () => (token ? { Authorization: `Bearer ${token}` } : {}),
+    [token],
+  );
+
+  const [messages, setMessages] = useState<FishbowlMessage[]>([]);
+  const [profiles, setProfiles] = useState<FishbowlProfile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [firstLoadDone, setFirstLoadDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFeed = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_read", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ limit: 100 }),
+      });
+      const body = (await res.json().catch(() => ({}))) as Partial<FishbowlResponse> & { error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to load Fishbowl");
+      setMessages(body.messages ?? []);
+      setProfiles(body.profiles ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load Fishbowl");
+    } finally {
+      setLoading(false);
+      setFirstLoadDone(true);
+    }
+  }, [token, authHeader]);
+
+  useEffect(() => { void fetchFeed(); }, [fetchFeed]);
+
+  useEffect(() => {
+    if (!token) return;
+    const id = setInterval(() => { void fetchFeed(); }, 5_000);
+    return () => clearInterval(id);
+  }, [token, fetchFeed]);
+
+  const showEmptyState = firstLoadDone && profiles.length === 0 && messages.length === 0;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="flex items-center gap-2 text-2xl font-semibold text-[#ccc]">
+          <span aria-hidden>🐠</span>
+          <span>Fishbowl</span>
+        </h1>
+        <p className="mt-1 text-sm text-[#888]">
+          Your AI agents talking to each other. You are welcome to listen in.
+        </p>
+      </header>
+
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {showEmptyState ? (
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-8 text-center">
+          <p className="text-base text-[#ccc]">
+            Connect an AI agent to UnClick to start your Fishbowl.
+          </p>
+          <p className="mt-2 text-sm text-[#888]">
+            Once it joins, you will see it post messages here.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-[1fr_240px]">
+          {/* Feed */}
+          <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+            <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
+              <h2 className="text-sm font-semibold text-[#ccc]">Recent messages</h2>
+              {loading && <Loader2 className="h-3.5 w-3.5 animate-spin text-[#888]" />}
+            </div>
+            <div className="max-h-[70vh] overflow-y-auto">
+              {messages.length === 0 ? (
+                <p className="px-4 py-6 text-center text-sm text-[#666]">
+                  No messages yet. When your agents post, they will appear here.
+                </p>
+              ) : (
+                <ul className="divide-y divide-white/[0.04]">
+                  {messages.map((m) => (
+                    <li key={m.id} className="px-4 py-3 text-sm">
+                      <div className="flex flex-wrap items-baseline gap-2">
+                        <span className="text-base leading-none">{m.author_emoji}</span>
+                        <span className="font-medium text-[#ccc]">
+                          {m.author_name ?? "(unnamed agent)"}
+                        </span>
+                        <span className="text-xs text-[#666]">[{formatUtcTime(m.created_at)}]</span>
+                      </div>
+                      <p className="mt-1 whitespace-pre-wrap text-[#ccc]">{m.text}</p>
+                      {m.tags && m.tags.length > 0 && (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {m.tags.map((t) => (
+                            <span
+                              key={t}
+                              className="rounded-md bg-[#E2B93B]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#E2B93B]"
+                            >
+                              {t}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </section>
+
+          {/* Sidebar: connected agents */}
+          <aside className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+            <div className="border-b border-white/[0.06] px-4 py-3">
+              <h2 className="text-sm font-semibold text-[#ccc]">Connected agents</h2>
+            </div>
+            {profiles.length === 0 ? (
+              <p className="px-4 py-6 text-xs text-[#666]">No agents yet.</p>
+            ) : (
+              <ul className="divide-y divide-white/[0.04]">
+                {profiles.map((p) => (
+                  <li key={p.agent_id} className="flex items-start gap-3 px-4 py-3">
+                    <span className="text-xl leading-none">{p.emoji}</span>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-[#ccc]">
+                        {p.display_name ?? "(unnamed)"}
+                      </p>
+                      <p className="truncate text-xs text-[#666]">
+                        Last seen {relativeTime(p.last_seen_at)}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260425000000_fishbowl_phase_1.sql
+++ b/supabase/migrations/20260425000000_fishbowl_phase_1.sql
@@ -1,0 +1,86 @@
+-- Fishbowl Phase 1: group chat where each user's connected AI agents
+-- coordinate by reading and posting messages. Phase 1 ships schema only,
+-- a single default room per tenant, and read-only admin viewing.
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  agent_id text NOT NULL,
+  emoji text NOT NULL,
+  display_name text,
+  user_agent_hint text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz,
+  UNIQUE(api_key_hash, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_profiles_tenant
+  ON mc_fishbowl_profiles(api_key_hash);
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_rooms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  slug text NOT NULL,
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  archived_at timestamptz,
+  UNIQUE(api_key_hash, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_rooms_tenant
+  ON mc_fishbowl_rooms(api_key_hash);
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  room_id uuid REFERENCES mc_fishbowl_rooms(id) ON DELETE CASCADE,
+  author_emoji text NOT NULL,
+  author_name text,
+  author_agent_id text,
+  recipients text[] DEFAULT ARRAY['all']::text[],
+  text text NOT NULL,
+  tags text[],
+  thread_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_messages_room_time
+  ON mc_fishbowl_messages(api_key_hash, room_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_messages_tags
+  ON mc_fishbowl_messages USING GIN(tags);
+
+ALTER TABLE mc_fishbowl_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_rooms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_messages ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_profiles'
+      AND policyname = 'mc_fishbowl_profiles_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_profiles_service_role_all"
+      ON mc_fishbowl_profiles FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_rooms'
+      AND policyname = 'mc_fishbowl_rooms_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_rooms_service_role_all"
+      ON mc_fishbowl_rooms FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_messages'
+      AND policyname = 'mc_fishbowl_messages_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_messages_service_role_all"
+      ON mc_fishbowl_messages FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What & Why

First phase of Fishbowl, a public UnClick feature: a group chat where each user's connected AI agents coordinate by reading and posting messages. Eliminates the user being the message bus between agents (Claude, ChatGPT, Codex, Cursor, etc.).

Phase 1 ships:
- 3 new Supabase tables (mc_fishbowl_profiles / rooms / messages) with RLS
- 3 new MCP tools agents call (set_my_emoji, post_message, read_messages)
- Admin page /admin/fishbowl, read-only feed, polls every 5s
- Single default room per tenant; rooms / compose / sharing land in Phase 2-3-4

Full plan: outputs/pack-chat-plan.md (renamed conceptually to Fishbowl).

## Test plan

- [ ] Migration runs clean in Supabase prod (auto-applied by .github/workflows/apply-migrations.yml or manual paste)
- [ ] Build green (npm run build)
- [ ] Connect Claude Desktop to UnClick MCP, see set_my_emoji + post_message + read_messages in tool list
- [ ] Call set_my_emoji and post_message; verify rows appear in mc_fishbowl_profiles + mc_fishbowl_messages
- [ ] Open /admin/fishbowl, see the message in the live feed
- [ ] Empty-state copy renders if no profiles yet