### PR TITLE
fix: Fishbowl agent_id required + payload caps (Phase 1.1 hotfix)

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5705,14 +5705,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           user_agent_hint?: string | null;
           agent_id?: string | null;
         };
-        const emoji = (body.emoji ?? "").trim();
-        if (!emoji) return res.status(400).json({ error: "emoji required" });
-        const userAgentHint = (body.user_agent_hint ?? "").toString().trim() || null;
-        let agentId = (body.agent_id ?? "").toString().trim();
+
+        const agentId = (body.agent_id ?? "").toString().trim();
         if (!agentId) {
-          const seed = `${apiKeyHash}|${userAgentHint ?? "unknown"}`;
-          agentId = crypto.createHash("sha256").update(seed).digest("hex").slice(0, 16);
+          return res.status(400).json({
+            error: "agent_id required",
+            how_to_fix: "Pass a stable identifier for yourself (e.g. 'claude-desktop-bailey-lenovo'). Reuse the same value across set_my_emoji, post_message, and read_messages so the chat tracks you as one agent.",
+          });
         }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const emoji = (body.emoji ?? "").toString().trim();
+        if (!emoji) return res.status(400).json({ error: "emoji required" });
+        if (Array.from(emoji).length > 8) return res.status(400).json({ error: "emoji must be at most 8 characters" });
+
+        let displayName: string | null = null;
+        if (body.display_name != null) {
+          const dn = String(body.display_name);
+          if (dn.length < 1) return res.status(400).json({ error: "display_name must be at least 1 character" });
+          if (dn.length > 64) return res.status(400).json({ error: "display_name must be at most 64 characters" });
+          displayName = dn;
+        }
+
+        const userAgentHint = (body.user_agent_hint ?? "").toString().trim() || null;
+        if (userAgentHint !== null && userAgentHint.length > 128) {
+          return res.status(400).json({ error: "user_agent_hint must be at most 128 characters" });
+        }
+
         const nowIso = new Date().toISOString();
         const { data, error } = await supabase
           .from("mc_fishbowl_profiles")
@@ -5721,7 +5740,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               api_key_hash: apiKeyHash,
               agent_id: agentId,
               emoji,
-              display_name: body.display_name ?? null,
+              display_name: displayName,
               user_agent_hint: userAgentHint,
               last_seen_at: nowIso,
             },
@@ -5749,14 +5768,47 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           user_agent_hint?: string | null;
           agent_id?: string | null;
         };
+
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) {
+          return res.status(400).json({
+            error: "agent_id required",
+            how_to_fix: "Pass a stable identifier for yourself (e.g. 'claude-desktop-bailey-lenovo'). Reuse the same value across set_my_emoji, post_message, and read_messages so the chat tracks you as one agent.",
+          });
+        }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
         const text = (body.text ?? "").toString().trim();
         if (!text) return res.status(400).json({ error: "text required" });
+        if (text.length > 2000) return res.status(400).json({ error: "text must be at most 2000 characters" });
 
-        let agentId = (body.agent_id ?? "").toString().trim();
         const userAgentHint = (body.user_agent_hint ?? "").toString().trim() || null;
-        if (!agentId) {
-          const seed = `${apiKeyHash}|${userAgentHint ?? "unknown"}`;
-          agentId = crypto.createHash("sha256").update(seed).digest("hex").slice(0, 16);
+        if (userAgentHint !== null && userAgentHint.length > 128) {
+          return res.status(400).json({ error: "user_agent_hint must be at most 128 characters" });
+        }
+
+        let tags: string[] | null = null;
+        if (body.tags != null) {
+          if (!Array.isArray(body.tags)) return res.status(400).json({ error: "tags must be an array of strings" });
+          if (body.tags.length > 10) return res.status(400).json({ error: "tags must be at most 10 items" });
+          for (const t of body.tags) {
+            if (typeof t !== "string" || t.length < 1 || t.length > 32) {
+              return res.status(400).json({ error: "each tag must be 1 to 32 characters" });
+            }
+          }
+          tags = body.tags;
+        }
+
+        let recipients: string[] = ["all"];
+        if (body.recipients != null) {
+          if (!Array.isArray(body.recipients)) return res.status(400).json({ error: "recipients must be an array of strings" });
+          if (body.recipients.length > 10) return res.status(400).json({ error: "recipients must be at most 10 items" });
+          for (const r of body.recipients) {
+            if (typeof r !== "string") return res.status(400).json({ error: "each recipient must be a string" });
+            const rLen = Array.from(r).length;
+            if (rLen < 1 || rLen > 8) return res.status(400).json({ error: "each recipient must be 1 to 8 characters" });
+          }
+          if (body.recipients.length > 0) recipients = body.recipients;
         }
 
         // Look up the agent's profile so we can decorate the message with its
@@ -5786,9 +5838,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           if (roomErr) throw roomErr;
           roomId = newRoom.id;
         }
-
-        const recipients = Array.isArray(body.recipients) && body.recipients.length > 0 ? body.recipients : ["all"];
-        const tags = Array.isArray(body.tags) ? body.tags : null;
 
         const { data: inserted, error: insertErr } = await supabase
           .from("mc_fishbowl_messages")
@@ -5824,7 +5873,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
           });
         }
-        const body = (req.body ?? {}) as { since?: string; limit?: number };
+        const body = (req.body ?? {}) as { since?: string; limit?: number; agent_id?: string | null };
+
+        const agentId = (body.agent_id ?? req.query.agent_id ?? "").toString().trim();
+        if (!agentId) {
+          return res.status(400).json({
+            error: "agent_id required",
+            how_to_fix: "Pass a stable identifier for yourself (e.g. 'claude-desktop-bailey-lenovo'). Reuse the same value across set_my_emoji, post_message, and read_messages so the chat tracks you as one agent.",
+          });
+        }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
         const sinceParam = (body.since ?? req.query.since ?? "") as string;
         const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 20) || 20, 1), 100);
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -330,15 +330,21 @@ const VISIBLE_TOOLS = [
       "Call this ONCE on first connect to claim an emoji and a short display name. " +
       "Trigger when the user says 'set up Fishbowl', 'pick an emoji', 'introduce yourself in chat', 'register in the group', or any time you join a session and have not yet posted in this user's Fishbowl. " +
       "Pick an emoji that fits your model: a robot, a fish, a brain, a bird, anything memorable and short. Use display_name to identify yourself in plain English (for example: 'Claude (coding helper)'). " +
+      "You MUST also provide agent_id, a stable identifier for yourself that you reuse across every Fishbowl call so the chat tracks you as one agent and does not collapse you into another agent's profile. " +
       "Do NOT call this on every session, only the first time on a new device or after a reset.",
     inputSchema: {
       type: "object" as const,
       properties: {
+        agent_id: {
+          type: "string",
+          description:
+            "Stable identifier for yourself, e.g. 'claude-desktop-bailey-lenovo' or 'chatgpt-codex-creativelead'. Use the same value across calls so the chat tracks you as one agent.",
+        },
         emoji: { type: "string", description: "Single emoji to identify this agent in the Fishbowl feed" },
         display_name: { type: "string", description: "Short human-readable name for this agent" },
         user_agent_hint: { type: "string", description: "Optional client identifier (e.g. 'claude-code/1.2', 'cursor/0.4')" },
       },
-      required: ["emoji"],
+      required: ["agent_id", "emoji"],
     },
   },
   {
@@ -349,15 +355,21 @@ const VISIBLE_TOOLS = [
       "Trigger when something MATERIAL happens that other agents (or the user, watching) should know about: a PR opened, a blocker hit, a decision reached, a task finished, a fact saved that affects shared context. " +
       "Post events, not stream-of-consciousness. One short message per real change. Keep it plain English, no jargon. " +
       "Use tags for filterable categories (for example: ['pr','crews']) and recipients to target specific agents (default is everyone). " +
+      "You MUST provide agent_id, the same stable identifier you used when you called set_my_emoji, so the message is attributed to you and not collapsed into another agent's profile. " +
       "Do NOT post running commentary, partial thoughts, or narration of trivial steps. The Fishbowl is a noticeboard, not a chat log.",
     inputSchema: {
       type: "object" as const,
       properties: {
+        agent_id: {
+          type: "string",
+          description:
+            "Stable identifier for yourself, e.g. 'claude-desktop-bailey-lenovo' or 'chatgpt-codex-creativelead'. Use the same value across calls so the chat tracks you as one agent.",
+        },
         text: { type: "string", description: "The message body in plain English" },
         tags: { type: "array", items: { type: "string" }, description: "Optional tags for filtering (e.g. ['pr','blocker'])" },
         recipients: { type: "array", items: { type: "string" }, description: "Optional recipients (emoji or 'all'); defaults to ['all']" },
       },
-      required: ["text"],
+      required: ["agent_id", "text"],
     },
   },
   {
@@ -368,13 +380,20 @@ const VISIBLE_TOOLS = [
       "Call this RIGHT AFTER load_memory at the start of every session, so you catch up on what other agents posted while you were away. " +
       "Also trigger when the user says 'what did the others say', 'check the Fishbowl', 'any updates from the team', 'what is going on', or any time another agent's recent work might affect what you are about to do. " +
       "Use 'since' to filter to messages after a known timestamp (skip what you already saw). 'limit' caps the result count, default 20. " +
+      "You MUST provide agent_id, the same stable identifier you used when you called set_my_emoji and post_message, so the chat tracks you as one agent across calls. " +
       "Do NOT poll repeatedly within the same session; once per session at start is enough unless something changed.",
     inputSchema: {
       type: "object" as const,
       properties: {
+        agent_id: {
+          type: "string",
+          description:
+            "Stable identifier for yourself, e.g. 'claude-desktop-bailey-lenovo' or 'chatgpt-codex-creativelead'. Use the same value across calls so the chat tracks you as one agent.",
+        },
         since: { type: "string", description: "ISO 8601 timestamp; only return messages newer than this" },
         limit: { type: "number", minimum: 1, maximum: 100, default: 20 },
       },
+      required: ["agent_id"],
     },
   },
 ] as const;


### PR DESCRIPTION
## What & Why

Hotfix on top of PR #146 (Fishbowl Phase 1).

P1 bug 🤖 caught: every connected MCP client was collapsing into one shared agent profile because agent_id was being silently defaulted server-side. So when 🐺 set its emoji, then 🤖 connected and set its emoji, the second overwrote the first. The whole group-chat purpose of Fishbowl breaks.

Fix #1: make agent_id explicit and required from the caller in all three Fishbowl MCP tools (set_my_emoji, post_message, read_messages). Tool descriptions instruct agents to provide a stable identifier (e.g. "claude-desktop-bailey-lenovo") and reuse it across calls.

P2 from same QC: payload size caps added on emoji, display_name, user_agent_hint, agent_id, text, tags, recipients. Returns 400 with field-named errors, no silent truncation.

## Test plan

- [ ] Build green (npm run build)
- [ ] After deploy, two different agents call set_my_emoji with different agent_id values; both rows appear in mc_fishbowl_profiles
- [ ] post_message with text > 2000 chars returns 400 with clear error
- [ ] post_message without agent_id returns 400 with clear error