### PR TITLE
fix: testpass_run + testpass_status accept UnClick API key auth instead of requiring Supabase session

### DIFF
--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -12,7 +12,11 @@
  *   POST ?action=save_pack                            - validate + upsert a pack (owner = actor)
  *   POST ?action=complete_run                         - finalize an in-flight run
  *
- * Authentication: Supabase JWT Bearer token (session user = actor).
+ * Authentication: Bearer token in Authorization header. Two valid shapes:
+ *   1. Supabase JWT (browser admin UI session)
+ *   2. UnClick API key prefixed with "uc_" (MCP callers, e.g. testpass_run
+ *      tool from a connected agent). Resolved against api_keys.key_hash.
+ * Both paths resolve to the same actor_user_id used for tenancy and RLS.
  * Service role key used server-side for DB writes (bypasses RLS which
  * checks actor_user_id = auth.uid() - that match happens at read time).
  *
@@ -23,6 +27,7 @@
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+import * as crypto from "node:crypto";
 import { probeServer } from "../packages/testpass/src/probe.js";
 import {
   createRun,
@@ -75,6 +80,47 @@ async function getActorUserId(
   if (!r.ok) return null;
   const u = (await r.json()) as { id?: string };
   return u.id ?? null;
+}
+
+function sha256hex(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Resolve an UnClick API key (uc_...) to an actor user id by hashing it
+ * and looking up an active row in api_keys. Returns null if the key isn't
+ * found, isn't active, or has no linked user_id. Uses the service role key
+ * to bypass RLS on api_keys (same pattern as api/mcp.ts).
+ */
+async function getActorUserIdFromApiKey(
+  supabaseUrl: string,
+  serviceKey: string,
+  apiKey: string,
+): Promise<string | null> {
+  const apiKeyHash = sha256hex(apiKey);
+  const r = await fetch(
+    `${supabaseUrl}/rest/v1/api_keys?key_hash=eq.${encodeURIComponent(apiKeyHash)}&is_active=eq.true&select=user_id&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } },
+  );
+  if (!r.ok) return null;
+  const rows = (await r.json()) as Array<{ user_id: string | null }>;
+  return rows[0]?.user_id ?? null;
+}
+
+/**
+ * Resolve the bearer token to an actor user id. UnClick API keys are
+ * prefixed with "uc_" and looked up in api_keys; anything else is tried
+ * as a Supabase JWT. Returns null if neither path succeeds.
+ */
+async function resolveActorUserId(
+  supabaseUrl: string,
+  serviceKey: string,
+  token: string,
+): Promise<string | null> {
+  if (token.startsWith("uc_")) {
+    return getActorUserIdFromApiKey(supabaseUrl, serviceKey, token);
+  }
+  return getActorUserId(supabaseUrl, token);
 }
 
 async function getPackIdBySlug(
@@ -291,7 +337,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const token = (req.headers.authorization ?? "").replace(/^Bearer\s+/i, "");
   if (!token) return json(res, 401, { error: "Missing Bearer token" });
 
-  const actorUserId = await getActorUserId(supabaseUrl, token);
+  const actorUserId = await resolveActorUserId(supabaseUrl, serviceKey, token);
   if (!actorUserId) return json(res, 401, { error: "Invalid session" });
 
   const action = req.query.action as string;


### PR DESCRIPTION
## Diagnosis

Bailey called `testpass_run` from a connected MCP client (Cowork session) with `target_url=https://unclick.world/api/mcp`, `pack_id=testpass-core`, `profile=smoke`. The tool returned:

```
{ "error": "testpass start_run failed (HTTP 401)", "body": { "error": "Invalid session" } }
```

Trace:

1. `packages/mcp-server/src/testpass-tool.ts` reads `process.env.UNCLICK_API_KEY` (set by `api/mcp.ts` after validating the inbound MCP request) and forwards it as `Authorization: Bearer <UnClick API key>` to `/api/testpass?action=start_run`.
2. `api/testpass.ts` only knew how to validate the token as a Supabase JWT, by calling `${SUPABASE_URL}/auth/v1/user`. UnClick API keys (`uc_<32 hex>`) are not JWTs, so that call returned non-OK and the handler fell through to `{ error: "Invalid session" }` with status 401.
3. The runner endpoint `api/testpass-run.ts` (the CI escape hatch) is unrelated to this code path. The MCP path always goes through `api/testpass.ts`.

The user's UnClick API key already validated upstream at `/api/mcp` — it had to, otherwise the MCP request itself would have 401'd before reaching the testpass tool. The endpoint just didn't know how to read it.

## Fix (Option 2 from the brief)

Make `api/testpass.ts` accept the UnClick API key directly. This is the cleanest path because:

- The runner runs server-side anyway, with the service role key for DB writes.
- `api/mcp.ts` already has the exact validation pattern (sha256 the key, look up `api_keys` where `is_active=true`, return `user_id`). I inlined it here rather than adding a new shared module.
- The Supabase JWT path is preserved unchanged for the browser admin UI.
- No new module dependency for `api/testpass.ts`.

Token routing:
- Starts with `uc_` → resolve via `api_keys.key_hash` lookup (UnClick API key path)
- Anything else → existing `/auth/v1/user` path (Supabase JWT for admin UI)

## Auth surface

Not widened. Requests with no Bearer token still return 401. UnClick API keys must hash to an active row in `api_keys` linked to a real `user_id`. The `actor_user_id` resolved from either path is the same scoping value used everywhere downstream.

## What's reachable now

From any connected MCP client (Cowork, Claude Desktop, etc.) with a valid UnClick API key:

- `testpass_run` — start a run against an MCP target
- `testpass_status` — poll a run
- `testpass_save_pack` — save user packs (already gated by actor_user_id ownership)
- `testpass_edit_item` — set verdict on an item (already gated by run ownership)

All four MCP testpass tools share the auth flow that this PR fixes.

## Files / scope

1 file changed, 48 insertions(+), 2 deletions(-).

## Verification

- `npm run build --workspace=packages/mcp-server` passes (no MCP-side changes were needed; the existing tool wiring already forwards the key correctly).
- TypeScript check on `packages/mcp-server` clean.
- `api/testpass-run.ts` (CI escape hatch) untouched — that's a separate stale-secret problem.

## Test plan

- [ ] Deploy preview to Vercel, then from a connected MCP client call `testpass_run` with `target_url=https://unclick.world/api/mcp`, `pack_id=testpass-core`, `profile=smoke` and confirm a run id is returned (not 401).
- [ ] Confirm browser admin UI at `/admin/testpass` still works (Supabase JWT path).
- [ ] Confirm a request with neither a `uc_` prefix nor a valid JWT still returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)