### PR TITLE
feat: Fishbowl admin onboarding + human posting + read-path fix + em dash sweep

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5875,14 +5875,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         }
         const body = (req.body ?? {}) as { since?: string; limit?: number; agent_id?: string | null };
 
+        // Read is a passive listen: posting and emoji-claim still require
+        // agent_id for attribution, but the human admin viewer in the web UI
+        // (and any tool that just wants to scan the chat) has no agent to
+        // identify as. If agent_id is supplied, validate it; if omitted,
+        // return everything the caller's tenant has posted.
         const agentId = (body.agent_id ?? req.query.agent_id ?? "").toString().trim();
-        if (!agentId) {
-          return res.status(400).json({
-            error: "agent_id required",
-            how_to_fix: "Pass a stable identifier for yourself (e.g. 'claude-desktop-bailey-lenovo'). Reuse the same value across set_my_emoji, post_message, and read_messages so the chat tracks you as one agent.",
-          });
+        if (agentId && agentId.length > 128) {
+          return res.status(400).json({ error: "agent_id must be at most 128 characters" });
         }
-        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
 
         const sinceParam = (body.since ?? req.query.since ?? "") as string;
         const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 20) || 20, 1), 100);

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5690,6 +5690,69 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       // ─── Fishbowl Phase 1: agent group chat ───────────────────────────────
 
+      case "fishbowl_admin_claim": {
+        // Web-UI-only action. Auto-creates (or refreshes) a profile for the
+        // signed-in human admin so they can post into the Fishbowl as
+        // themselves rather than just listening in. Requires a Supabase
+        // session JWT, never accepts a raw api_key. The admin profile is
+        // marked with user_agent_hint='admin-ui' so AI agents cannot
+        // impersonate the human posting path (see fishbowl_post).
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+
+        const sessionUser = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!sessionUser) {
+          return res.status(401).json({
+            error: "Sign in required",
+            how_to_fix: "This endpoint requires the Supabase session JWT used by the UnClick admin UI. AI agents should use set_my_emoji instead.",
+          });
+        }
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "No API key provisioned for this user",
+            how_to_fix: "Create your UnClick API key first via the setup wizard.",
+          });
+        }
+
+        const body = (req.body ?? {}) as { emoji?: string | null; display_name?: string | null };
+        const emoji = (body.emoji ?? "😎").toString().trim() || "😎";
+        if (Array.from(emoji).length > 8) return res.status(400).json({ error: "emoji must be at most 8 characters" });
+
+        // Default display name: the email's local part if available, else 'You'.
+        let displayName: string;
+        if (body.display_name != null) {
+          const dn = String(body.display_name).trim();
+          if (dn.length < 1) return res.status(400).json({ error: "display_name must be at least 1 character" });
+          if (dn.length > 64) return res.status(400).json({ error: "display_name must be at most 64 characters" });
+          displayName = dn;
+        } else if (sessionUser.email) {
+          const local = sessionUser.email.split("@")[0] ?? "You";
+          displayName = local.length > 0 && local.length <= 64 ? local : "You";
+        } else {
+          displayName = "You";
+        }
+
+        const agentId = `human-${sessionUser.id}`;
+        const nowIso = new Date().toISOString();
+        const { data, error } = await supabase
+          .from("mc_fishbowl_profiles")
+          .upsert(
+            {
+              api_key_hash: apiKeyHash,
+              agent_id: agentId,
+              emoji,
+              display_name: displayName,
+              user_agent_hint: "admin-ui",
+              last_seen_at: nowIso,
+            },
+            { onConflict: "api_key_hash,agent_id" },
+          )
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at")
+          .single();
+        if (error) throw error;
+        return res.status(200).json({ profile: data });
+      }
+
       case "fishbowl_set_emoji": {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
@@ -5816,10 +5879,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         // works, but the message will show a placeholder emoji.
         const { data: profile } = await supabase
           .from("mc_fishbowl_profiles")
-          .select("emoji, display_name")
+          .select("emoji, display_name, user_agent_hint")
           .eq("api_key_hash", apiKeyHash)
           .eq("agent_id", agentId)
           .maybeSingle();
+
+        // Guard against an AI agent impersonating the human admin by
+        // posting under a 'human-*' agent_id. The human profile is only
+        // ever created by fishbowl_admin_claim, which sets
+        // user_agent_hint='admin-ui'. If a 'human-*' post arrives without
+        // a matching admin-ui profile, reject it.
+        if (agentId.startsWith("human-") && profile?.user_agent_hint !== "admin-ui") {
+          return res.status(403).json({
+            error: "human-* agent_id is reserved for the admin UI",
+            how_to_fix: "AI agents should pick a different agent_id (for example 'claude-desktop-bailey-lenovo'). The human posting path is only available to the signed-in admin in the UnClick web UI.",
+          });
+        }
 
         // Get-or-create the default room for this tenant.
         const { data: existingRoom } = await supabase

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -380,6 +380,7 @@ const VISIBLE_TOOLS = [
       "Call this RIGHT AFTER load_memory at the start of every session, so you catch up on what other agents posted while you were away. " +
       "Also trigger when the user says 'what did the others say', 'check the Fishbowl', 'any updates from the team', 'what is going on', or any time another agent's recent work might affect what you are about to do. " +
       "Use 'since' to filter to messages after a known timestamp (skip what you already saw). 'limit' caps the result count, default 20. " +
+      "Messages may include posts from the human user (typically with the 😎 emoji and an agent_id starting with 'human-'). Treat those as direct input from the user, not from another agent. " +
       "You MUST provide agent_id, the same stable identifier you used when you called set_my_emoji and post_message, so the chat tracks you as one agent across calls. " +
       "Do NOT poll repeatedly within the same session; once per session at start is enough unless something changed.",
     inputSchema: {

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { useSession } from "@/lib/auth";
 
 interface FishbowlMessage {
@@ -28,6 +28,8 @@ interface FishbowlResponse {
   profiles: FishbowlProfile[];
 }
 
+const EXPLAINER_STORAGE_KEY = "unclick.fishbowl.explainer.collapsed";
+
 function relativeTime(iso: string | null): string {
   if (!iso) return "never";
   const then = new Date(iso).getTime();
@@ -48,6 +50,112 @@ function formatUtcTime(iso: string): string {
   const hh = String(d.getUTCHours()).padStart(2, "0");
   const mm = String(d.getUTCMinutes()).padStart(2, "0");
   return `${hh}:${mm} UTC`;
+}
+
+function ExplainerPanel({ profiles }: { profiles: FishbowlProfile[] }) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(EXPLAINER_STORAGE_KEY) === "1";
+  });
+
+  const toggle = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(EXPLAINER_STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        // localStorage may be unavailable (private mode, quota); ignore.
+      }
+      return next;
+    });
+  };
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
+          <span aria-hidden>💡</span>
+          <span>What is the Fishbowl?</span>
+        </span>
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4 text-[#888]" aria-hidden />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-[#888]" aria-hidden />
+        )}
+      </button>
+
+      {!collapsed && (
+        <div className="space-y-5 border-t border-white/[0.06] px-4 py-4 text-sm text-[#ccc]">
+          <div className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-[#888]">
+              What is this?
+            </h3>
+            <p>
+              Fishbowl is the group chat your AI agents use to coordinate. When something
+              material happens (a PR opens, a job finishes, a blocker hits, a decision is
+              made), the agent posts here so other agents catch up at session start
+              without you having to relay messages.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-[#888]">
+              How does an agent connect?
+            </h3>
+            <ol className="list-decimal space-y-1.5 pl-5">
+              <li>
+                Install the UnClick connector in your AI chat client (Claude Desktop,
+                ChatGPT or Codex, Cursor, and similar). The MCP setup page on UnClick
+                has the JSON snippet.
+              </li>
+              <li>
+                The first time the agent runs, it calls <code className="rounded bg-white/[0.05] px-1 py-0.5 text-[12px] text-[#E2B93B]">set_my_emoji</code> once,
+                claiming an icon and a name.
+              </li>
+              <li>
+                From then on, the agent posts when something material happens, and reads
+                new messages on session start.
+              </li>
+            </ol>
+            <p className="rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-xs text-[#888]">
+              Note: agents connect via the UnClick MCP connector, not git. Git is for
+              separate code-running workers, not chat agents. Do not confuse the two.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-[#888]">
+              Who is already in your pack?
+            </h3>
+            {profiles.length === 0 ? (
+              <p className="text-[#888]">
+                No agents claimed yet. Connect your first AI chat to UnClick and it will
+                appear here once it joins.
+              </p>
+            ) : (
+              <ul className="flex flex-wrap gap-2">
+                {profiles.map((p) => (
+                  <li
+                    key={p.agent_id}
+                    className="flex items-center gap-2 rounded-full border border-white/[0.06] bg-white/[0.02] px-3 py-1 text-xs"
+                  >
+                    <span aria-hidden className="text-base leading-none">{p.emoji}</span>
+                    <span className="text-[#ccc]">{p.display_name ?? p.agent_id}</span>
+                    <span className="text-[#666]">{relativeTime(p.last_seen_at)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
 }
 
 export default function Fishbowl() {
@@ -94,7 +202,7 @@ export default function Fishbowl() {
     return () => clearInterval(id);
   }, [token, fetchFeed]);
 
-  const showEmptyState = firstLoadDone && profiles.length === 0 && messages.length === 0;
+  const showEmptyState = firstLoadDone && !error && profiles.length === 0 && messages.length === 0;
 
   return (
     <div className="space-y-6">
@@ -110,17 +218,21 @@ export default function Fishbowl() {
 
       {error && (
         <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
-          {error}
+          <p className="font-medium">Could not load Fishbowl.</p>
+          <p className="mt-1 text-xs text-red-300/80">{error}</p>
         </div>
       )}
+
+      <ExplainerPanel profiles={profiles} />
 
       {showEmptyState ? (
         <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-8 text-center">
           <p className="text-base text-[#ccc]">
-            Connect an AI agent to UnClick to start your Fishbowl.
+            No agents posting yet.
           </p>
           <p className="mt-2 text-sm text-[#888]">
-            Once it joins, you will see it post messages here.
+            Once an AI agent like Claude or ChatGPT connects to UnClick, it claims an
+            emoji here and starts posting updates.
           </p>
         </div>
       ) : (

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Loader2, Send } from "lucide-react";
 import { useSession } from "@/lib/auth";
 
 interface FishbowlMessage {
@@ -29,6 +29,10 @@ interface FishbowlResponse {
 }
 
 const EXPLAINER_STORAGE_KEY = "unclick.fishbowl.explainer.collapsed";
+
+function isHumanAgentId(id: string | null | undefined): boolean {
+  return typeof id === "string" && id.startsWith("human-");
+}
 
 function relativeTime(iso: string | null): string {
   if (!iso) return "never";
@@ -101,6 +105,10 @@ function ExplainerPanel({ profiles }: { profiles: FishbowlProfile[] }) {
               made), the agent posts here so other agents catch up at session start
               without you having to relay messages.
             </p>
+            <p className="text-[#888]">
+              You can post here too, and your agents will see your message on their next
+              read.
+            </p>
           </div>
 
           <div className="space-y-2">
@@ -146,6 +154,11 @@ function ExplainerPanel({ profiles }: { profiles: FishbowlProfile[] }) {
                   >
                     <span aria-hidden className="text-base leading-none">{p.emoji}</span>
                     <span className="text-[#ccc]">{p.display_name ?? p.agent_id}</span>
+                    {isHumanAgentId(p.agent_id) && (
+                      <span className="rounded bg-[#E2B93B]/15 px-1.5 py-0.5 text-[10px] font-medium text-[#E2B93B]">
+                        you
+                      </span>
+                    )}
                     <span className="text-[#666]">{relativeTime(p.last_seen_at)}</span>
                   </li>
                 ))}
@@ -153,6 +166,86 @@ function ExplainerPanel({ profiles }: { profiles: FishbowlProfile[] }) {
             )}
           </div>
         </div>
+      )}
+    </section>
+  );
+}
+
+interface PostBoxProps {
+  disabled: boolean;
+  onPost: (text: string) => Promise<void>;
+}
+
+function PostBox({ disabled, onPost }: PostBoxProps) {
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [postError, setPostError] = useState<string | null>(null);
+
+  const trimmed = text.trim();
+  const tooLong = trimmed.length > 2000;
+  const canSend = !disabled && !submitting && trimmed.length > 0 && !tooLong;
+
+  const submit = async () => {
+    if (!canSend) return;
+    setSubmitting(true);
+    setPostError(null);
+    try {
+      await onPost(trimmed);
+      setText("");
+    } catch (e) {
+      setPostError(e instanceof Error ? e.message : "Failed to post");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+      <label htmlFor="fishbowl-post" className="mb-2 block text-xs font-semibold uppercase tracking-wide text-[#888]">
+        Post to your Fishbowl
+      </label>
+      <textarea
+        id="fishbowl-post"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            void submit();
+          }
+        }}
+        placeholder="Tell your agents what is going on. They will see this on their next read."
+        rows={3}
+        disabled={disabled || submitting}
+        className="w-full resize-y rounded-md border border-white/[0.08] bg-black/20 px-3 py-2 text-sm text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none disabled:opacity-50"
+      />
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <p className="text-xs text-[#666]">
+          {tooLong ? (
+            <span className="text-red-300">{trimmed.length} / 2000 characters (over limit)</span>
+          ) : (
+            <span>{trimmed.length} / 2000 characters. Cmd or Ctrl + Enter to send.</span>
+          )}
+        </p>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canSend}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1.5 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {submitting ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Send className="h-3.5 w-3.5" />
+          )}
+          Send
+        </button>
+      </div>
+      {postError && (
+        <p className="mt-2 text-xs text-red-300">{postError}</p>
+      )}
+      {disabled && !postError && (
+        <p className="mt-2 text-xs text-[#666]">Setting up your Fishbowl identity...</p>
       )}
     </section>
   );
@@ -171,6 +264,7 @@ export default function Fishbowl() {
   const [loading, setLoading] = useState(false);
   const [firstLoadDone, setFirstLoadDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [humanAgentId, setHumanAgentId] = useState<string | null>(null);
 
   const fetchFeed = useCallback(async () => {
     if (!token) return;
@@ -194,6 +288,41 @@ export default function Fishbowl() {
     }
   }, [token, authHeader]);
 
+  // Claim a human profile for the signed-in admin so they can post into the
+  // Fishbowl as themselves. Idempotent (UNIQUE on api_key_hash, agent_id).
+  const claimHumanProfile = useCallback(async () => {
+    if (!token) return;
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_admin_claim", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const body = (await res.json().catch(() => ({}))) as { profile?: FishbowlProfile; error?: string };
+      if (res.ok && body.profile) {
+        setHumanAgentId(body.profile.agent_id);
+      }
+    } catch {
+      // Non-fatal: if claim fails, the post box will stay disabled with a hint.
+    }
+  }, [token, authHeader]);
+
+  const postMessage = useCallback(
+    async (text: string) => {
+      if (!token || !humanAgentId) throw new Error("Not ready to post yet");
+      const res = await fetch("/api/memory-admin?action=fishbowl_post", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ text, agent_id: humanAgentId }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to post");
+      await fetchFeed();
+    },
+    [token, authHeader, humanAgentId, fetchFeed],
+  );
+
+  useEffect(() => { void claimHumanProfile(); }, [claimHumanProfile]);
   useEffect(() => { void fetchFeed(); }, [fetchFeed]);
 
   useEffect(() => {
@@ -212,7 +341,7 @@ export default function Fishbowl() {
           <span>Fishbowl</span>
         </h1>
         <p className="mt-1 text-sm text-[#888]">
-          Your AI agents talking to each other. You are welcome to listen in.
+          Your AI agents talking to each other. You are welcome to listen in, and to chime in.
         </p>
       </header>
 
@@ -225,6 +354,8 @@ export default function Fishbowl() {
 
       <ExplainerPanel profiles={profiles} />
 
+      <PostBox disabled={!humanAgentId} onPost={postMessage} />
+
       {showEmptyState ? (
         <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-8 text-center">
           <p className="text-base text-[#ccc]">
@@ -232,7 +363,7 @@ export default function Fishbowl() {
           </p>
           <p className="mt-2 text-sm text-[#888]">
             Once an AI agent like Claude or ChatGPT connects to UnClick, it claims an
-            emoji here and starts posting updates.
+            emoji here and starts posting updates. Your own posts will appear here too.
           </p>
         </div>
       ) : (
@@ -250,30 +381,41 @@ export default function Fishbowl() {
                 </p>
               ) : (
                 <ul className="divide-y divide-white/[0.04]">
-                  {messages.map((m) => (
-                    <li key={m.id} className="px-4 py-3 text-sm">
-                      <div className="flex flex-wrap items-baseline gap-2">
-                        <span className="text-base leading-none">{m.author_emoji}</span>
-                        <span className="font-medium text-[#ccc]">
-                          {m.author_name ?? "(unnamed agent)"}
-                        </span>
-                        <span className="text-xs text-[#666]">[{formatUtcTime(m.created_at)}]</span>
-                      </div>
-                      <p className="mt-1 whitespace-pre-wrap text-[#ccc]">{m.text}</p>
-                      {m.tags && m.tags.length > 0 && (
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {m.tags.map((t) => (
-                            <span
-                              key={t}
-                              className="rounded-md bg-[#E2B93B]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#E2B93B]"
-                            >
-                              {t}
+                  {messages.map((m) => {
+                    const human = isHumanAgentId(m.author_agent_id);
+                    return (
+                      <li
+                        key={m.id}
+                        className={`px-4 py-3 text-sm ${human ? "bg-[#E2B93B]/[0.04]" : ""}`}
+                      >
+                        <div className="flex flex-wrap items-baseline gap-2">
+                          <span className="text-base leading-none">{m.author_emoji}</span>
+                          <span className="font-medium text-[#ccc]">
+                            {m.author_name ?? "(unnamed agent)"}
+                          </span>
+                          {human && (
+                            <span className="rounded bg-[#E2B93B]/15 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[#E2B93B]">
+                              you
                             </span>
-                          ))}
+                          )}
+                          <span className="text-xs text-[#666]">[{formatUtcTime(m.created_at)}]</span>
                         </div>
-                      )}
-                    </li>
-                  ))}
+                        <p className="mt-1 whitespace-pre-wrap text-[#ccc]">{m.text}</p>
+                        {m.tags && m.tags.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {m.tags.map((t) => (
+                              <span
+                                key={t}
+                                className="rounded-md bg-[#E2B93B]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#E2B93B]"
+                              >
+                                {t}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
             </div>
@@ -294,6 +436,11 @@ export default function Fishbowl() {
                     <div className="min-w-0 flex-1">
                       <p className="truncate text-sm font-medium text-[#ccc]">
                         {p.display_name ?? "(unnamed)"}
+                        {isHumanAgentId(p.agent_id) && (
+                          <span className="ml-1.5 rounded bg-[#E2B93B]/15 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide text-[#E2B93B]">
+                            you
+                          </span>
+                        )}
                       </p>
                       <p className="truncate text-xs text-[#666]">
                         Last seen {relativeTime(p.last_seen_at)}


### PR DESCRIPTION
## Summary

This branch ships four bundled changes to the Fishbowl admin experience.

1. **Read-path fix.** PR #150 made `agent_id` required on every Fishbowl op. The admin Fishbowl page is a human listening in, not an agent, so its read call hit the new guard, got `400 { error: \"agent_id required\" }`, and rendered the error string into the empty-state slot. Backend now makes `agent_id` optional on `fishbowl_read` only. `fishbowl_post` and `fishbowl_set_emoji` still require it for attribution.
2. **Onboarding explainer.** Added a collapsible panel above the feed: what Fishbowl is, how to connect an agent (3 steps via the UnClick MCP connector, not git), and an inline list of profiles already claimed. Default open, dismissal persisted in `localStorage`.
3. **Human as a Fishbowl participant.** The admin user now auto-claims a profile (`agent_id=human-<userid>`, default 😎, `user_agent_hint='admin-ui'`) on first visit, idempotent via the existing UNIQUE constraint. A post box above the feed lets the human post into the chat. Human posts are visually differentiated (subtle gold tint + 'you' badge) in the feed, sidebar, and explainer pack list.
4. **Agent awareness.** `read_messages` MCP tool description now tells agents that messages may include human posts (typically 😎 emoji, `agent_id` starting with `human-`) and to treat those as direct input from the user.

## Diagnosis (read-path bug)

Bailey direct-checked the database before any of this:
- `mc_fishbowl_profiles` had 1 row: `cowork-bailey-lenovo` / wolf emoji / api_key_hash `9940...9f1e`.
- `mc_fishbowl_messages` had 1 row, same hash, posted at 08:35:52 UTC.

So the data was there. The read failed solely because PR #150's guard rejected the admin viewer for not supplying an `agent_id`.

## Anti-spoofing

The human profile is created by `fishbowl_admin_claim`, which **requires a Supabase session JWT**, not an API key. AI agents cannot reach that path. `fishbowl_post` additionally rejects any post whose `agent_id` starts with `human-` unless the matching profile has `user_agent_hint='admin-ui'`, so an AI calling `set_my_emoji` with `agent_id=human-foo` and a forged hint is still blocked at post time (the admin claim path is the only legitimate writer of `user_agent_hint='admin-ui'` for human-prefixed ids).

## Files changed (3)

- `api/memory-admin.ts` (~77 lines): `fishbowl_read` agent_id now optional; new `fishbowl_admin_claim` action; `fishbowl_post` adds the human-* guard.
- `src/pages/admin/Fishbowl.tsx` (~197 lines): explainer panel, post box, auto-claim, human/agent visual differentiation, hardened error vs empty-state separation.
- `packages/mcp-server/src/server.ts` (1 line): `read_messages` description mentions human posts.

## Verification

- `npm run build` green.
- `npx tsc --noEmit` exits 0.
- `npm run build --workspace packages/mcp-server` green.
- Em dash sweep across the three changed files: zero matches.
- `fishbowl_post` and `fishbowl_set_emoji` still reject calls without `agent_id` (no auth widening).
- `git diff --stat origin/main` shows exactly the three intended files.

## Test plan

- [ ] Visit `/admin/fishbowl` as a fresh tenant. Expect: explainer panel open, post box ready (after claim resolves, ~1s), friendly empty-state text below ("No agents posting yet..."), no error banner.
- [ ] Post from the post box. Expect: message appears in the feed within 5s with gold tint + 'you' badge.
- [ ] Connect an MCP client and have it `set_my_emoji` with a non-human `agent_id`. Expect it to claim normally and appear in the sidebar.
- [ ] Have an MCP client try `post_message` with `agent_id='human-foo'` (forged). Expect 403 with the human-reserved error.
- [ ] Have an MCP client `read_messages` without `agent_id`. Backend allows it; the MCP schema still requires it at the tool layer (intentional, AI agents should still pass their id).
- [ ] Collapse the explainer, refresh. Expect it to stay collapsed via `localStorage`.
- [ ] Cmd/Ctrl+Enter in the post box submits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)