### PR TITLE
fix: idempotent guards on migrations + auto-apply workflow recovery

### DIFF
--- a/supabase/migrations/20260410100000_keychain_mvp.sql
+++ b/supabase/migrations/20260410100000_keychain_mvp.sql
@@ -57,14 +57,49 @@ ALTER TABLE platform_credentials ENABLE ROW LEVEL SECURITY;
 ALTER TABLE platform_connectors ENABLE ROW LEVEL SECURITY;
 ALTER TABLE metering_events ENABLE ROW LEVEL SECURITY;
 
--- Service role access for all tables
-CREATE POLICY "service_role_all" ON api_keys FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON platform_credentials FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON platform_connectors FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON metering_events FOR ALL TO service_role USING (true) WITH CHECK (true);
+-- Service role access for all tables.
+--
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so a re-run on a database where the policy already exists raises
+-- "policy already exists" and aborts the migration. Wrap each policy in
+-- a pg_policies existence check so re-running is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'api_keys' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON api_keys FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
 
--- Anon can read connectors (public catalog)
-CREATE POLICY "anon_read_connectors" ON platform_connectors FOR SELECT TO anon USING (true);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'platform_credentials' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON platform_credentials FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'platform_connectors' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON platform_connectors FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'metering_events' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON metering_events FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  -- Anon can read connectors (public catalog)
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'platform_connectors' AND policyname = 'anon_read_connectors'
+  ) THEN
+    CREATE POLICY "anon_read_connectors" ON platform_connectors FOR SELECT TO anon USING (true);
+  END IF;
+END $$;
 
 -- Seed the 5 MVP platform connectors
 INSERT INTO platform_connectors (id, name, category, auth_type, description, setup_url, test_endpoint, sort_order) VALUES

--- a/supabase/migrations/20260410160000_connection_tests.sql
+++ b/supabase/migrations/20260410160000_connection_tests.sql
@@ -17,7 +17,16 @@ CREATE INDEX idx_connection_tests_success ON connection_tests(success, created_a
 
 ALTER TABLE connection_tests ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "service_role_all" ON connection_tests FOR ALL TO service_role USING (true) WITH CHECK (true);
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so wrap in a pg_policies check so re-running this migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'connection_tests' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON connection_tests FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 
 -- View for quality dashboard (success rate per platform)
 CREATE OR REPLACE VIEW platform_quality AS

--- a/supabase/migrations/20260415000000_memory_managed_cloud.sql
+++ b/supabase/migrations/20260415000000_memory_managed_cloud.sql
@@ -625,13 +625,62 @@ ALTER TABLE mc_code_dumps ENABLE ROW LEVEL SECURITY;
 -- Service role gets full access (this is also the default in Supabase
 -- since service_role bypasses RLS, but the explicit policy makes intent
 -- visible).
-CREATE POLICY "service_role_all" ON mc_business_context FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON mc_knowledge_library FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON mc_knowledge_library_history FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON mc_session_summaries FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON mc_extracted_facts FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON mc_conversation_log FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON mc_code_dumps FOR ALL TO service_role USING (true) WITH CHECK (true);
+--
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so a re-run on a database where the policy already exists raises
+-- "policy already exists" and aborts the whole migration. This blocked
+-- auto-apply for ~20 subsequent migrations. Each policy is wrapped in a
+-- pg_policies existence check so re-running is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_business_context' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_business_context FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_knowledge_library' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_knowledge_library FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_knowledge_library_history' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_knowledge_library_history FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_session_summaries' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_session_summaries FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_extracted_facts' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_extracted_facts FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_conversation_log' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_conversation_log FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_code_dumps' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_code_dumps FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 
 -- No policies for anon / authenticated: deny by default.
 

--- a/supabase/migrations/20260418000000_agent_profiles.sql
+++ b/supabase/migrations/20260418000000_agent_profiles.sql
@@ -70,7 +70,35 @@ ALTER TABLE agent_tools ENABLE ROW LEVEL SECURITY;
 ALTER TABLE agent_memory_scope ENABLE ROW LEVEL SECURITY;
 ALTER TABLE agent_activity ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "service_role_all" ON agents FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON agent_tools FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON agent_memory_scope FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_all" ON agent_activity FOR ALL TO service_role USING (true) WITH CHECK (true);
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so each policy is wrapped in a pg_policies check so re-running this
+-- migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'agents' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON agents FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'agent_tools' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON agent_tools FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'agent_memory_scope' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON agent_memory_scope FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'agent_activity' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON agent_activity FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;

--- a/supabase/migrations/20260420030000_user_credentials.sql
+++ b/supabase/migrations/20260420030000_user_credentials.sql
@@ -34,11 +34,32 @@ ALTER TABLE user_credentials ENABLE ROW LEVEL SECURITY;
 
 -- Block all direct client access; only the service role (in Vercel API
 -- functions) may read or write.
-CREATE POLICY "service_role_all" ON user_credentials
-  FOR ALL TO service_role USING (true) WITH CHECK (true);
+--
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so each policy is wrapped in a pg_policies check so re-running this
+-- migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'user_credentials' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON user_credentials
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
 
-CREATE POLICY "block_anon_access" ON user_credentials
-  FOR ALL TO anon USING (false) WITH CHECK (false);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'user_credentials' AND policyname = 'block_anon_access'
+  ) THEN
+    CREATE POLICY "block_anon_access" ON user_credentials
+      FOR ALL TO anon USING (false) WITH CHECK (false);
+  END IF;
 
-CREATE POLICY "block_authenticated_direct_access" ON user_credentials
-  FOR ALL TO authenticated USING (false) WITH CHECK (false);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'user_credentials' AND policyname = 'block_authenticated_direct_access'
+  ) THEN
+    CREATE POLICY "block_authenticated_direct_access" ON user_credentials
+      FOR ALL TO authenticated USING (false) WITH CHECK (false);
+  END IF;
+END $$;

--- a/supabase/migrations/20260420050000_agent_trace.sql
+++ b/supabase/migrations/20260420050000_agent_trace.sql
@@ -73,14 +73,34 @@ CREATE INDEX IF NOT EXISTS idx_agent_trace_surface_outcome
 -- analytics reads via the admin surface.
 ALTER TABLE agent_trace ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "service_role_all" ON agent_trace
-  FOR ALL TO service_role USING (true) WITH CHECK (true);
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so each policy is wrapped in a pg_policies check so re-running this
+-- migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'agent_trace' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON agent_trace
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
 
-CREATE POLICY "block_anon_access" ON agent_trace
-  FOR ALL TO anon USING (false) WITH CHECK (false);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'agent_trace' AND policyname = 'block_anon_access'
+  ) THEN
+    CREATE POLICY "block_anon_access" ON agent_trace
+      FOR ALL TO anon USING (false) WITH CHECK (false);
+  END IF;
 
-CREATE POLICY "block_authenticated_direct_access" ON agent_trace
-  FOR ALL TO authenticated USING (false) WITH CHECK (false);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'agent_trace' AND policyname = 'block_authenticated_direct_access'
+  ) THEN
+    CREATE POLICY "block_authenticated_direct_access" ON agent_trace
+      FOR ALL TO authenticated USING (false) WITH CHECK (false);
+  END IF;
+END $$;
 
 COMMENT ON TABLE agent_trace IS
   'Append-only per-turn trace log of every agent run. Input to future meta-harness / nightly-scorer work. See /api/trace. (Renamed from agent_activity to avoid collision with pre-existing usage-ledger table.)';

--- a/supabase/migrations/20260420100000_backstagepass_audit.sql
+++ b/supabase/migrations/20260420100000_backstagepass_audit.sql
@@ -84,14 +84,34 @@ CREATE INDEX IF NOT EXISTS idx_bp_audit_failures
 -- The /api/backstagepass endpoint is the sole read/write path.
 ALTER TABLE backstagepass_audit ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "service_role_all" ON backstagepass_audit
-  FOR ALL TO service_role USING (true) WITH CHECK (true);
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so each policy is wrapped in a pg_policies check so re-running this
+-- migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'backstagepass_audit' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON backstagepass_audit
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
 
-CREATE POLICY "block_anon_access" ON backstagepass_audit
-  FOR ALL TO anon USING (false) WITH CHECK (false);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'backstagepass_audit' AND policyname = 'block_anon_access'
+  ) THEN
+    CREATE POLICY "block_anon_access" ON backstagepass_audit
+      FOR ALL TO anon USING (false) WITH CHECK (false);
+  END IF;
 
-CREATE POLICY "block_authenticated_direct_access" ON backstagepass_audit
-  FOR ALL TO authenticated USING (false) WITH CHECK (false);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'backstagepass_audit' AND policyname = 'block_authenticated_direct_access'
+  ) THEN
+    CREATE POLICY "block_authenticated_direct_access" ON backstagepass_audit
+      FOR ALL TO authenticated USING (false) WITH CHECK (false);
+  END IF;
+END $$;
 
 COMMENT ON TABLE backstagepass_audit IS
   'Append-only audit log of every action against user_credentials via the BackstagePass admin surface. Source of truth for "who revealed/updated/deleted what, when". Read via /api/backstagepass?action=audit.';

--- a/supabase/migrations/20260422010000_memory_bitemporal_and_provenance.sql
+++ b/supabase/migrations/20260422010000_memory_bitemporal_and_provenance.sql
@@ -641,23 +641,51 @@ $$;
 ALTER TABLE mc_canonical_docs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc_facts_audit    ENABLE ROW LEVEL SECURITY;
 
--- Service role has full access (same pattern as all other mc_* tables)
-CREATE POLICY "service_role_all" ON mc_canonical_docs
-  FOR ALL TO service_role USING (true) WITH CHECK (true);
+-- Service role has full access (same pattern as all other mc_* tables).
+--
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so each policy is wrapped in a pg_policies check so re-running this
+-- migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_canonical_docs' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_canonical_docs
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
 
-CREATE POLICY "service_role_all" ON mc_facts_audit
-  FOR ALL TO service_role USING (true) WITH CHECK (true);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_facts_audit' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON mc_facts_audit
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 
 -- BYOD tables use the same per-user auth pattern as existing tables
 ALTER TABLE canonical_docs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE facts_audit    ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Users can manage their own canonical_docs" ON canonical_docs
-  FOR ALL TO authenticated
-  USING ((SELECT auth.uid()) IS NOT NULL)
-  WITH CHECK ((SELECT auth.uid()) IS NOT NULL);
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'canonical_docs' AND policyname = 'Users can manage their own canonical_docs'
+  ) THEN
+    CREATE POLICY "Users can manage their own canonical_docs" ON canonical_docs
+      FOR ALL TO authenticated
+      USING ((SELECT auth.uid()) IS NOT NULL)
+      WITH CHECK ((SELECT auth.uid()) IS NOT NULL);
+  END IF;
 
-CREATE POLICY "Users can manage their own facts_audit" ON facts_audit
-  FOR ALL TO authenticated
-  USING ((SELECT auth.uid()) IS NOT NULL)
-  WITH CHECK ((SELECT auth.uid()) IS NOT NULL);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'facts_audit' AND policyname = 'Users can manage their own facts_audit'
+  ) THEN
+    CREATE POLICY "Users can manage their own facts_audit" ON facts_audit
+      FOR ALL TO authenticated
+      USING ((SELECT auth.uid()) IS NOT NULL)
+      WITH CHECK ((SELECT auth.uid()) IS NOT NULL);
+  END IF;
+END $$;

--- a/supabase/migrations/20260423300000_signals_phase_1.sql
+++ b/supabase/migrations/20260423300000_signals_phase_1.sql
@@ -19,8 +19,17 @@ CREATE INDEX IF NOT EXISTS idx_mc_signals_tool_action ON mc_signals(tool, action
 
 ALTER TABLE mc_signals ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "mc_signals_service_role_all"
-  ON mc_signals FOR ALL USING (auth.role() = 'service_role');
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so wrap in a pg_policies check so re-running this migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_signals' AND policyname = 'mc_signals_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_signals_service_role_all"
+      ON mc_signals FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
 
 CREATE TABLE IF NOT EXISTS mc_signal_preferences (
   api_key_hash text PRIMARY KEY,
@@ -37,5 +46,15 @@ CREATE TABLE IF NOT EXISTS mc_signal_preferences (
 );
 
 ALTER TABLE mc_signal_preferences ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "mc_signal_preferences_service_role_all"
-  ON mc_signal_preferences FOR ALL USING (auth.role() = 'service_role');
+
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so wrap in a pg_policies check so re-running this migration is safe.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'mc_signal_preferences' AND policyname = 'mc_signal_preferences_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_signal_preferences_service_role_all"
+      ON mc_signal_preferences FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;


### PR DESCRIPTION
## Root cause (from Codex QC pass)

\`supabase/migrations/20260415000000_memory_managed_cloud.sql\` contained
seven bare \`CREATE POLICY service_role_all ON mc_*\` statements. Postgres
has **no** \`IF NOT EXISTS\` form for \`CREATE POLICY\`, so a re-run against
a database where the policy already exists raises \`"policy ... already
exists"\` and aborts the entire migration.

\`apply_migrations.py\` exits with \`return 1\` on the first failure
**without** writing the version row to \`public._claude_migrations\`. So:

1. The failing migration is **not** marked applied.
2. Every subsequent migration is blocked behind it (~20+ files unapplied
   to prod).
3. On the next workflow run, the same migration is retried and fails
   the same way, indefinitely.

Bailey worked around this by hand-applying critical migrations
(Fishbowl Phase 1, TestPass starter packs) via the Supabase MCP, but the
auto-apply chain is still wedged.

## What this PR changes

Wraps every bare \`CREATE POLICY\` in nine migration files with a
\`pg_policies\` existence guard:

\`\`\`sql
DO $$ BEGIN
  IF NOT EXISTS (
    SELECT 1 FROM pg_policies
    WHERE schemaname = 'public' AND tablename = '...' AND policyname = '...'
  ) THEN
    CREATE POLICY ... ;
  END IF;
END $$;
\`\`\`

**Schema effects are unchanged.** The original \`CREATE POLICY\` (roles,
\`USING\`, \`WITH CHECK\`, predicate body) is preserved verbatim inside the
guard. Comments explain the guard so future readers don't think it's noise.

### Files patched (32 policies guarded total)

| Migration | Policies guarded | The bare CREATE that was the risk |
|---|---|---|
| \`20260410100000_keychain_mvp.sql\` | 5 | \`service_role_all\` x4 + \`anon_read_connectors\` |
| \`20260410160000_connection_tests.sql\` | 1 | \`service_role_all\` on \`connection_tests\` |
| \`20260415000000_memory_managed_cloud.sql\` | 7 | **The original blocker** (\`service_role_all\` x7 on \`mc_*\` tables) |
| \`20260418000000_agent_profiles.sql\` | 4 | \`service_role_all\` x4 on \`agents/agent_tools/agent_memory_scope/agent_activity\` |
| \`20260420030000_user_credentials.sql\` | 3 | \`service_role_all\` + \`block_anon_access\` + \`block_authenticated_direct_access\` |
| \`20260420050000_agent_trace.sql\` | 3 | same trio on \`agent_trace\` |
| \`20260420100000_backstagepass_audit.sql\` | 3 | same trio on \`backstagepass_audit\` |
| \`20260422010000_memory_bitemporal_and_provenance.sql\` | 4 | \`service_role_all\` on \`mc_canonical_docs/mc_facts_audit\` + per-user policies on \`canonical_docs/facts_audit\` |
| \`20260423300000_signals_phase_1.sql\` | 2 | \`mc_signals_service_role_all\` + \`mc_signal_preferences_service_role_all\` |

### Files audited and left alone (already safe)

The following had \`CREATE POLICY\` but were already guarded (either by
\`DROP POLICY IF EXISTS\` first or by \`DO $$ ... IF NOT EXISTS\` blocks):

- \`20260414100000_install_tickets.sql\`
- \`20260416000000_auth_foundation.sql\`
- \`20260418000000_channels_orchestrator.sql\`
- \`20260420000000_mc_skills.sql\`
- \`20260420010000_memory_health.sql\`
- \`20260423200000_account_deletions_audit.sql\`
- \`20260423400000_testpass_phase_9b.sql\`
- \`20260425000000_fishbowl_phase_1.sql\`

\`CREATE FUNCTION\`, \`CREATE TABLE\`, \`CREATE INDEX\`, \`CREATE TYPE\` were
also audited across the full migrations folder. All are already
\`OR REPLACE\` / \`IF NOT EXISTS\`. No changes needed there.

\`CREATE TRIGGER\` already follows the \`DROP TRIGGER IF EXISTS\` + \`CREATE
TRIGGER\` pattern in every file that has one.

## How the workflow picks up the backlog

\`apply_migrations.py\` doesn't need a code change for this:

- \`20260415000000_memory_managed_cloud.sql\` was **never** recorded as
  applied (script \`return 1\`s before \`record_applied()\` runs).
- After this merge, the next push to \`main\` (or a manual
  \`workflow_dispatch\`) will retry it. The guards short-circuit the
  already-existing policies, the migration completes, and \`record_applied\`
  finally fires.
- The script then iterates through every later migration in version
  order and tries each one. Every later migration in the repo is
  idempotent (verified by the audit above), so the queue drains.

### Caveat: Bailey's hand-applied migrations

Migrations Bailey applied directly via Supabase MCP have their schema
effects in prod but **no row in \`_claude_migrations\`**. The workflow
will try to re-apply each one. They're all idempotent (Fishbowl uses
\`DO $$ ... IF NOT EXISTS\` guards already; the seed pack uses
\`ON CONFLICT (slug) DO NOTHING\`), so they will succeed harmlessly and
their version rows will get written. **No manual backfill of
\`_claude_migrations\` required.**

## Local testing

Not run locally: the worktree has no Supabase project to run against
(no shadow DB, no \`supabase start\`). Verification is by code review of
the diff. The guard pattern (\`pg_policies\` check + \`DO $$\` block) is
already used elsewhere in this repo (\`20260416000000_auth_foundation.sql\`,
\`20260425000000_fishbowl_phase_1.sql\`) and is the canonical Postgres
idiom for idempotent CREATE POLICY.

## Post-merge action

Trigger the workflow manually once after merge:

\`\`\`
gh workflow run "Apply Supabase migrations"
\`\`\`

Watch the run log to confirm \`20260415000000_memory_managed_cloud.sql\`
applies cleanly and the script then walks the rest of the backlog. If
any later migration fails, the failure mode will be specific (and
recoverable), not the silent stall the chain had been in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)