### PR TITLE
fix: idempotent triggers + constraints in migrations to drain auto-apply backlog

### DIFF
--- a/supabase/migrations/20260421040000_testpass_schema.sql
+++ b/supabase/migrations/20260421040000_testpass_schema.sql
@@ -69,6 +69,9 @@ begin
 end;
 $$;
 
+-- Idempotency guard: Postgres has no IF NOT EXISTS for CREATE TRIGGER, so drop-then-create
+-- ensures re-runs of this migration do not error with 42710 "trigger already exists".
+drop trigger if exists testpass_packs_updated_at on testpass_packs;
 create trigger testpass_packs_updated_at
   before update on testpass_packs
   for each row execute function testpass_set_updated_at();


### PR DESCRIPTION
## Summary

Wraps the lone unguarded `CREATE TRIGGER` in the pending migration backlog with `DROP TRIGGER IF EXISTS` so the auto-apply workflow can re-run safely. Postgres does not support `IF NOT EXISTS` on `CREATE TRIGGER`, so the `CREATE POLICY` guard pattern from #156 does not apply here.

## Files patched

| File | Statement guarded | Pattern |
|------|-------------------|---------|
| `supabase/migrations/20260421040000_testpass_schema.sql` | `CREATE TRIGGER testpass_packs_updated_at ON testpass_packs` | `DROP TRIGGER IF EXISTS ... ; CREATE TRIGGER ...` |

The trigger function (`testpass_set_updated_at`) is unchanged across runs, so drop-then-create is safe.

## Audit of pending migrations (>= 20260421040000)

Searched every queued migration for `CREATE TRIGGER`, `ADD CONSTRAINT`, `CREATE TYPE`, `CREATE INDEX`:

- `20260421040000_testpass_schema.sql` -> **patched above** (1 trigger). All `CREATE INDEX` already use `IF NOT EXISTS`.
- `20260422000000_add_memory_embeddings.sql` -> nothing risky.
- `20260422005000_facts_git_linkage.sql` -> nothing risky.
- `20260422010000_memory_bitemporal_and_provenance.sql` -> 2 `ADD CONSTRAINT` (`fk_mc_ef_doc`, `fk_ef_doc`) already wrapped in `DO $$` blocks with `information_schema.table_constraints` checks. Already idempotent.
- `20260423000000_crews_phase_b.sql` -> nothing risky.
- `20260423100000_crews_phase_c.sql` -> nothing risky.
- `20260423200000_account_deletions_audit.sql` -> nothing risky.
- `20260423200000_testpass_run_ui_fields.sql` -> nothing risky.
- `20260423300000_signals_phase_1.sql` -> nothing risky.
- `20260423400000_testpass_phase_9b.sql` -> nothing risky.
- `20260425000000_fishbowl_phase_1.sql` -> nothing risky.
- `20260425010000_seed_testpass_starter_packs.sql` -> nothing risky.

No bare `CREATE TYPE` exists in any pending migration.

## Context

Per Bailey's evidence: after #156 merged, `gh workflow run "Apply Supabase migrations"` drained 17 migrations (`_claude_migrations` 10 -> 27) before halting on:

```
File: 20260421040000_testpass_schema.sql
Error: 42710: trigger "testpass_packs_updated_at" for relation "testpass_packs" already exists
```

This PR removes that blocker. With only 1 unguarded statement in the backlog, the workflow should drain the remaining 12 queued migrations (Crews Phase B+C, Signals, account_deletions_audit, memory_bitemporal_and_provenance, fishbowl_phase_1, seed_testpass_starter_packs, etc.) once this lands.

## Test plan

- [ ] CI workflows pass on the PR
- [ ] After merge, re-run `gh workflow run "Apply Supabase migrations"` and confirm `_claude_migrations` advances past 27 to drain the remaining 12

## Constraints honored

- Touched only `supabase/migrations/*.sql` (1 file, +3 LOC)
- Schema effects unchanged; only an idempotency guard added
- Inline comment documents which statement was guarded and why

🤖 Generated with [Claude Code](https://claude.com/claude-code)