### PR TITLE
fix: idempotent CREATE POLICY in testpass_schema migration (#156 follow-up)

### DIFF
--- a/supabase/migrations/20260421040000_testpass_schema.sql
+++ b/supabase/migrations/20260421040000_testpass_schema.sql
@@ -82,40 +82,107 @@ alter table testpass_runs     enable row level security;
 alter table testpass_items    enable row level security;
 alter table testpass_evidence enable row level security;
 
+-- Idempotency guard: CREATE POLICY has no IF NOT EXISTS form in Postgres,
+-- so each policy is wrapped in a DO block that checks pg_policies first.
+-- Without these guards, re-running this migration errors with 42710.
+
 -- Packs: public readable if no owner (built-in); owner-scoped otherwise
-create policy "testpass_packs_read" on testpass_packs
-  for select using (owner_user_id is null or owner_user_id = auth.uid());
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'testpass_packs'
+      and policyname = 'testpass_packs_read'
+  ) then
+    create policy "testpass_packs_read" on testpass_packs
+      for select using (owner_user_id is null or owner_user_id = auth.uid());
+  end if;
+end $$;
 
-create policy "testpass_packs_insert" on testpass_packs
-  for insert with check (owner_user_id = auth.uid());
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'testpass_packs'
+      and policyname = 'testpass_packs_insert'
+  ) then
+    create policy "testpass_packs_insert" on testpass_packs
+      for insert with check (owner_user_id = auth.uid());
+  end if;
+end $$;
 
-create policy "testpass_packs_update" on testpass_packs
-  for update using (owner_user_id = auth.uid());
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'testpass_packs'
+      and policyname = 'testpass_packs_update'
+  ) then
+    create policy "testpass_packs_update" on testpass_packs
+      for update using (owner_user_id = auth.uid());
+  end if;
+end $$;
 
-create policy "testpass_packs_delete" on testpass_packs
-  for delete using (owner_user_id = auth.uid());
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'testpass_packs'
+      and policyname = 'testpass_packs_delete'
+  ) then
+    create policy "testpass_packs_delete" on testpass_packs
+      for delete using (owner_user_id = auth.uid());
+  end if;
+end $$;
 
 -- Runs: actor-scoped
-create policy "testpass_runs_all" on testpass_runs
-  for all using (actor_user_id = auth.uid());
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'testpass_runs'
+      and policyname = 'testpass_runs_all'
+  ) then
+    create policy "testpass_runs_all" on testpass_runs
+      for all using (actor_user_id = auth.uid());
+  end if;
+end $$;
 
 -- Items: scoped via run ownership
-create policy "testpass_items_all" on testpass_items
-  for all using (
-    exists (
-      select 1 from testpass_runs r
-      where r.id = testpass_items.run_id
-        and r.actor_user_id = auth.uid()
-    )
-  );
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'testpass_items'
+      and policyname = 'testpass_items_all'
+  ) then
+    create policy "testpass_items_all" on testpass_items
+      for all using (
+        exists (
+          select 1 from testpass_runs r
+          where r.id = testpass_items.run_id
+            and r.actor_user_id = auth.uid()
+        )
+      );
+  end if;
+end $$;
 
 -- Evidence: accessible if the related item's run belongs to the user
-create policy "testpass_evidence_all" on testpass_evidence
-  for all using (
-    exists (
-      select 1 from testpass_items i
-      join testpass_runs r on r.id = i.run_id
-      where i.evidence_ref = testpass_evidence.id
-        and r.actor_user_id = auth.uid()
-    )
-  );
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'testpass_evidence'
+      and policyname = 'testpass_evidence_all'
+  ) then
+    create policy "testpass_evidence_all" on testpass_evidence
+      for all using (
+        exists (
+          select 1 from testpass_items i
+          join testpass_runs r on r.id = i.run_id
+          where i.evidence_ref = testpass_evidence.id
+            and r.actor_user_id = auth.uid()
+        )
+      );
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

Auto-apply workflow re-ran `20260421040000_testpass_schema.sql` and tripped on the bare `CREATE POLICY` statements once #159 cleared the `CREATE TRIGGER` blocker in the same file. PR #156 had wrapped `CREATE POLICY` across 9 files but skipped this one because it was originally tracked as applied. 🤖's diagnostic finding pinpointed `policy "testpass_packs_read" for table "testpass_packs" already exists` as the failing statement.

This wraps each `CREATE POLICY` in `20260421040000_testpass_schema.sql` with the same `pg_policies` guard pattern used in #156. No schema effects change; only re-run safety improves.

## Guarded statements

All 7 in `supabase/migrations/20260421040000_testpass_schema.sql`:

| Statement | Table | Policy name |
| --- | --- | --- |
| CREATE POLICY (FOR SELECT, USING) | `testpass_packs` | `testpass_packs_read` |
| CREATE POLICY (FOR INSERT, WITH CHECK) | `testpass_packs` | `testpass_packs_insert` |
| CREATE POLICY (FOR UPDATE, USING) | `testpass_packs` | `testpass_packs_update` |
| CREATE POLICY (FOR DELETE, USING) | `testpass_packs` | `testpass_packs_delete` |
| CREATE POLICY (FOR ALL, USING) | `testpass_runs` | `testpass_runs_all` |
| CREATE POLICY (FOR ALL, USING) | `testpass_items` | `testpass_items_all` |
| CREATE POLICY (FOR ALL, USING) | `testpass_evidence` | `testpass_evidence_all` |

## Audit of other 20260421+ migrations

Audited every migration from `20260421040000` onward for bare `CREATE POLICY` / `CREATE TRIGGER` / `ADD CONSTRAINT` / `CREATE TYPE`. All occurrences in newer files are already wrapped in `DO` blocks (verified `20260422010000_memory_bitemporal_and_provenance.sql` constraints, `20260423000000_crews_phase_b.sql` policies, `20260423300000_signals_phase_1.sql`, `20260423400000_testpass_phase_9b.sql`, `20260425000000_fishbowl_phase_1.sql`). The `CREATE TRIGGER` in this file is already protected by `drop trigger if exists` from #159.

## Files / LOC

1 file changed, 94 insertions, 27 deletions.

## Test plan

- [ ] Re-run drain workflow (recommended once merged) so the testpass migration replays cleanly.
- [ ] Verify subsequent migrations in the queue (`20260422000000` onward) advance.

## Do not auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)