### PR TITLE
feat(fishbowl): Now Playing status strip - live agent pulse on admin page

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5747,7 +5747,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             },
             { onConflict: "api_key_hash,agent_id" },
           )
-          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at")
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
           .single();
         if (error) throw error;
         return res.status(200).json({ profile: data });
@@ -5809,9 +5809,64 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             },
             { onConflict: "api_key_hash,agent_id" },
           )
-          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at")
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
           .single();
         if (error) throw error;
+        return res.status(200).json({ profile: data });
+      }
+
+      case "fishbowl_set_status": {
+        // Updates the agent's free-form Now Playing line. The row must already
+        // exist (set_my_emoji creates it). An empty string clears the status
+        // back to idle. Always bumps last_seen_at so the status timestamp and
+        // the activity timestamp stay coherent.
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
+          });
+        }
+        const body = (req.body ?? {}) as { agent_id?: string | null; status?: string | null };
+
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) {
+          return res.status(400).json({
+            error: "agent_id required",
+            how_to_fix: "Pass the same stable identifier you used for set_my_emoji so the status updates the right profile.",
+          });
+        }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        // Status is required by the schema but an empty string is a valid
+        // "clear me" value, so we only validate length and reject non-strings.
+        if (body.status == null || typeof body.status !== "string") {
+          return res.status(400).json({ error: "status required (string; empty string clears)" });
+        }
+        const statusRaw = body.status;
+        if (statusRaw.length > 200) return res.status(400).json({ error: "status must be at most 200 characters" });
+        const statusValue: string | null = statusRaw.trim().length === 0 ? null : statusRaw;
+
+        const nowIso = new Date().toISOString();
+        const { data, error } = await supabase
+          .from("mc_fishbowl_profiles")
+          .update({
+            current_status: statusValue,
+            current_status_updated_at: nowIso,
+            last_seen_at: nowIso,
+          })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("agent_id", agentId)
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
+          .maybeSingle();
+        if (error) throw error;
+        if (!data) {
+          return res.status(404).json({
+            error: "profile not found",
+            how_to_fix: "Call set_my_emoji first to register this agent before setting a status.",
+          });
+        }
         return res.status(200).json({ profile: data });
       }
 
@@ -6017,12 +6072,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           q,
           supabase
             .from("mc_fishbowl_profiles")
-            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at")
+            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
             .eq("api_key_hash", apiKeyHash)
             .order("last_seen_at", { ascending: false, nullsFirst: false }),
         ]);
         if (msgErr) throw msgErr;
         if (profErr) throw profErr;
+
+        // Auto-touch the caller's last_seen_at so a polling agent stays "active"
+        // on the Now Playing strip without needing to post. Best-effort: skipped
+        // when no agent_id is supplied (e.g. the human admin viewer), and never
+        // surfaced as an error if the row does not exist yet.
+        if (agentId) {
+          await supabase
+            .from("mc_fishbowl_profiles")
+            .update({ last_seen_at: new Date().toISOString() })
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId);
+        }
 
         return res.status(200).json({
           room,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -409,6 +409,28 @@ const VISIBLE_TOOLS = [
     },
   },
   {
+    name: "set_my_status",
+    title: "Update my Now Playing status",
+    description:
+      "Update what you're currently doing so it shows on the human's Fishbowl Now Playing strip. Call when you start a task, change focus, or idle out. Short, plain English, present-tense. Persists until you change it. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: {
+          type: "string",
+          description:
+            "Stable identifier for yourself, e.g. 'claude-desktop-bailey-lenovo' or 'chatgpt-codex-creativelead'. Use the same value across calls so the chat tracks you as one agent.",
+        },
+        status: {
+          type: "string",
+          description:
+            "What you're doing right now in plain English (max 200 chars). Pass an empty string to clear your status back to idle.",
+        },
+      },
+      required: ["agent_id", "status"],
+    },
+  },
+  {
     name: "read_messages",
     title: "Read the Fishbowl",
     description:
@@ -935,8 +957,13 @@ export function createServer(): Server {
         };
       }
 
-      // ── Fishbowl: agent group chat (set_my_emoji / post_message / read_messages)
-      if (name === "set_my_emoji" || name === "post_message" || name === "read_messages") {
+      // ── Fishbowl: agent group chat (set_my_emoji / post_message / read_messages / set_my_status)
+      if (
+        name === "set_my_emoji" ||
+        name === "post_message" ||
+        name === "read_messages" ||
+        name === "set_my_status"
+      ) {
         const apiKey = process.env.UNCLICK_API_KEY;
         const base =
           process.env.UNCLICK_MEMORY_BASE_URL ||
@@ -954,6 +981,7 @@ export function createServer(): Server {
           set_my_emoji: "fishbowl_set_emoji",
           post_message: "fishbowl_post",
           read_messages: "fishbowl_read",
+          set_my_status: "fishbowl_set_status",
         };
         const fbAction = actionMap[name];
         const userAgentHint =

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -26,7 +26,11 @@ interface FishbowlProfile {
   user_agent_hint: string | null;
   created_at: string;
   last_seen_at: string | null;
+  current_status: string | null;
+  current_status_updated_at: string | null;
 }
+
+const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
 interface FishbowlResponse {
   room: { id: string; slug: string; name: string } | null;
@@ -173,6 +177,82 @@ function ExplainerPanel({ profiles }: { profiles: FishbowlProfile[] }) {
           </div>
         </div>
       )}
+    </section>
+  );
+}
+
+function isStale(profile: FishbowlProfile, nowMs: number): boolean {
+  if (!profile.last_seen_at) return true;
+  return nowMs - new Date(profile.last_seen_at).getTime() > STALE_THRESHOLD_MS;
+}
+
+function NowPlayingStrip({ profiles }: { profiles: FishbowlProfile[] }) {
+  // Re-render every 30s so the relative timestamps and stale state stay fresh
+  // even if no new poll has come back from the server.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  void tick;
+
+  if (profiles.length === 0) return null;
+
+  const nowMs = Date.now();
+
+  return (
+    <section
+      className="rounded-xl border border-[#222] bg-[#111]"
+      aria-label="Now Playing"
+    >
+      <div className="flex items-center justify-between border-b border-[#222] px-4 py-2">
+        <h2 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#888]">
+          <span aria-hidden>🎧</span>
+          <span>Now Playing</span>
+        </h2>
+        <span className="text-[10px] text-[#555]">Live, polled every 5s</span>
+      </div>
+      <div className="overflow-x-auto">
+        <ul className="flex gap-2 px-3 py-3">
+          {profiles.map((p) => {
+            const stale = isStale(p, nowMs);
+            const statusText = p.current_status?.trim();
+            const hasStatus = statusText && statusText.length > 0;
+            const timeIso = p.current_status_updated_at ?? p.last_seen_at;
+            return (
+              <li
+                key={p.agent_id}
+                className={`flex w-56 shrink-0 flex-col gap-1 rounded-lg border border-[#222] bg-black/30 px-3 py-2 ${stale ? "opacity-50" : ""}`}
+                title={p.agent_id}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-base leading-none" aria-hidden>{p.emoji}</span>
+                  <span
+                    className={`flex-1 truncate text-xs font-medium ${stale ? "text-[#888]" : "text-[#E2B93B]"}`}
+                  >
+                    {p.display_name ?? p.agent_id}
+                  </span>
+                  <span
+                    aria-hidden
+                    className={`text-[10px] leading-none ${stale ? "text-[#555]" : "text-[#E2B93B]"}`}
+                  >
+                    {stale ? "○" : "●"}
+                  </span>
+                </div>
+                <p
+                  className={`truncate text-xs ${hasStatus ? "text-[#bbb]" : "italic text-[#555]"}`}
+                  title={hasStatus ? statusText : "idle"}
+                >
+                  {hasStatus ? statusText : "idle"}
+                </p>
+                <p className="truncate text-[10px] text-[#555]">
+                  {relativeTime(timeIso)}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
     </section>
   );
 }
@@ -426,6 +506,8 @@ export default function Fishbowl() {
       )}
 
       <ExplainerPanel profiles={profiles} />
+
+      <NowPlayingStrip profiles={profiles} />
 
       <PostBox disabled={!humanAgentId} onPost={postMessage} />
 

--- a/supabase/migrations/20260425090000_fishbowl_now_playing.sql
+++ b/supabase/migrations/20260425090000_fishbowl_now_playing.sql
@@ -1,0 +1,11 @@
+-- Fishbowl Phase 1.2: Now Playing status strip.
+-- Each agent profile gets a free-form current_status string plus a timestamp
+-- so the admin UI can render a live "what is this agent doing right now"
+-- pulse above the message feed. Agents update via the set_my_status MCP tool
+-- (route fishbowl_set_status). Idempotent so re-applying is a no-op.
+
+ALTER TABLE mc_fishbowl_profiles
+  ADD COLUMN IF NOT EXISTS current_status text,
+  ADD COLUMN IF NOT EXISTS current_status_updated_at timestamptz;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Phase 1.2 enhancement to Fishbowl: a horizontal Now Playing strip above the message feed on /admin/fishbowl so the room never feels dead. Each connected agent gets a live pill (emoji, name, current status, last-seen relative time, active/stale dot). Polled every 5s by the existing fetchFeed loop.

## What changed

- **Migration `supabase/migrations/20260425090000_fishbowl_now_playing.sql`** - adds `current_status text` and `current_status_updated_at timestamptz` to `mc_fishbowl_profiles`. Idempotent (`ADD COLUMN IF NOT EXISTS`).
- **MCP tool `set_my_status`** in `packages/mcp-server/src/server.ts` - agents publish what they're doing right now in plain English (≤200 chars). Empty string clears back to idle. agent_id required.
- **Backend route `fishbowl_set_status`** in `api/memory-admin.ts` - validates and `UPDATE`s the row by `(api_key_hash, agent_id)`, also bumps `last_seen_at`. Returns 404 if the agent never claimed an emoji. Read SELECTs now expose the new columns.
- **Auto-touch on `fishbowl_read`** - polling agents stay active without needing to post. `fishbowl_post` already had this; now both lanes match.
- **Frontend `NowPlayingStrip`** in `src/pages/admin/Fishbowl.tsx` - horizontal scrollable strip above the post box. Per-agent pill: top line `emoji + display_name + ●/○`, middle line `current_status` (italic "idle" when null), bottom line relative time. Stale rule: `last_seen_at` more than 5 min ago renders at 50% opacity with a hollow circle. Local 30s tick keeps relative timestamps fresh between server polls.

## Cadence + thresholds

- Admin page polls `fishbowl_read` every 5s (existing setInterval, unchanged).
- Strip locally re-renders every 30s for relative-time freshness.
- Stale = `last_seen_at` older than 5 min OR null.

## v2 note

The strip is currently agent-driven via `set_my_status`. v2 may auto-pull from courier task state once those migrations clear and the queue is empty, so the strip can show "Claude is running task #42 (3m left)" without the agent self-reporting.

## Test plan

- [ ] Apply migration via Supabase MCP (or `supabase migration up`) and confirm `mc_fishbowl_profiles` now has `current_status` + `current_status_updated_at`.
- [ ] Call `set_my_status` from a connected MCP client, confirm the strip on /admin/fishbowl updates within 5s.
- [ ] Send empty string status, confirm the pill flips to italic "idle".
- [ ] Stop a connected agent for 5+ minutes, confirm its pill goes 50% opacity with a hollow circle.
- [ ] Check `npm run build` (root + packages/mcp-server) and `npx tsc --noEmit` are still green.

## Build status

Local: `npx tsc --noEmit` clean (root + packages/mcp-server). `npm run build` green for both.

DO NOT auto-merge.