### PR TITLE
feat(fishbowl): wake-up plumbing - Signals publisher + Watcher cron + dead-man's-switch

### DIFF
--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -1,0 +1,183 @@
+/**
+ * Fishbowl Watcher (B1) - Vercel cron, every 15 minutes.
+ *
+ * Two responsibilities:
+ *   1. Dead-man's-switch: agents whose next_checkin_at has passed without a
+ *      fresh pulse get a single mc_signals row per missed window so the human
+ *      gets nudged via existing Signals delivery.
+ *   2. Unread mention digest: if a tenant has unread fishbowl signals at
+ *      severity action_needed older than 10 minutes, emit a digest signal so
+ *      the human gets a second nudge if the original push was dismissed.
+ *
+ * Dedup: each emission checks for a recent identical-action signal so we
+ * never spam (30 min for missed check-ins, 60 min for digests).
+ *
+ * Auth: Bearer ${CRON_SECRET}, same shape as signals-dispatch.ts.
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+
+interface ProfileRow {
+  api_key_hash: string;
+  agent_id: string;
+  emoji: string;
+  display_name: string | null;
+  last_seen_at: string | null;
+  next_checkin_at: string | null;
+}
+
+interface SignalRow {
+  api_key_hash: string;
+  action: string;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+}
+
+const CHECKIN_DEDUP_WINDOW_MS = 30 * 60 * 1000;
+const MENTION_DIGEST_DEDUP_WINDOW_MS = 60 * 60 * 1000;
+const MENTION_AGE_THRESHOLD_MS = 10 * 60 * 1000;
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const authHeader = req.headers.authorization ?? "";
+  const expected = `Bearer ${process.env.CRON_SECRET ?? ""}`;
+  if (!process.env.CRON_SECRET || authHeader !== expected) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    return res.status(500).json({ error: "Database service unavailable" });
+  }
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  let checkinSignalsEmitted = 0;
+  let digestSignalsEmitted = 0;
+
+  // ── 1. Dead-man's-switch sweep ──────────────────────────────────────────
+  const { data: overdueProfiles, error: profileErr } = await supabase
+    .from("mc_fishbowl_profiles")
+    .select("api_key_hash, agent_id, emoji, display_name, last_seen_at, next_checkin_at")
+    .lt("next_checkin_at", nowIso)
+    .not("next_checkin_at", "is", null);
+
+  if (profileErr) {
+    console.error("[fishbowl-watcher] profile fetch error:", profileErr.message);
+    return res.status(500).json({ error: profileErr.message });
+  }
+
+  const candidates = ((overdueProfiles ?? []) as ProfileRow[]).filter((p) => {
+    if (!p.next_checkin_at) return false;
+    const dueMs = new Date(p.next_checkin_at).getTime();
+    if (Number.isNaN(dueMs)) return false;
+    if (dueMs >= nowMs) return false;
+    const seenMs = p.last_seen_at ? new Date(p.last_seen_at).getTime() : 0;
+    return seenMs < dueMs;
+  });
+
+  for (const profile of candidates) {
+    const dedupCutoff = new Date(nowMs - CHECKIN_DEDUP_WINDOW_MS).toISOString();
+    const { data: recentSignals } = await supabase
+      .from("mc_signals")
+      .select("api_key_hash, action, payload, created_at")
+      .eq("api_key_hash", profile.api_key_hash)
+      .eq("tool", "fishbowl")
+      .eq("action", "checkin_missed")
+      .gt("created_at", dedupCutoff);
+
+    const alreadyEmitted = ((recentSignals ?? []) as SignalRow[]).some((s) => {
+      const payload = (s.payload ?? {}) as Record<string, unknown>;
+      return payload.agent_id === profile.agent_id;
+    });
+    if (alreadyEmitted) continue;
+
+    const dueMs = new Date(profile.next_checkin_at as string).getTime();
+    const overdueMin = Math.max(1, Math.round((nowMs - dueMs) / 60_000));
+    const summary = `🪪 ${profile.emoji} missed expected check-in (was due ${overdueMin} min ago)`;
+
+    const { error: insertErr } = await supabase.from("mc_signals").insert({
+      api_key_hash: profile.api_key_hash,
+      tool: "fishbowl",
+      action: "checkin_missed",
+      severity: "action_needed",
+      summary,
+      deep_link: "/admin/fishbowl",
+      payload: {
+        agent_id: profile.agent_id,
+        emoji: profile.emoji,
+        display_name: profile.display_name,
+        next_checkin_at: profile.next_checkin_at,
+        last_seen_at: profile.last_seen_at,
+        overdue_minutes: overdueMin,
+      },
+    });
+    if (insertErr) {
+      console.error(
+        "[fishbowl-watcher] checkin signal insert error:",
+        insertErr.message,
+      );
+    } else {
+      checkinSignalsEmitted++;
+    }
+  }
+
+  // ── 2. Unread mention digest ────────────────────────────────────────────
+  const mentionAgeCutoff = new Date(nowMs - MENTION_AGE_THRESHOLD_MS).toISOString();
+  const { data: unreadMentions } = await supabase
+    .from("mc_signals")
+    .select("api_key_hash")
+    .eq("tool", "fishbowl")
+    .eq("action", "message_posted")
+    .eq("severity", "action_needed")
+    .is("read_at", null)
+    .lt("created_at", mentionAgeCutoff);
+
+  const unreadCounts = new Map<string, number>();
+  for (const row of (unreadMentions ?? []) as { api_key_hash: string }[]) {
+    unreadCounts.set(row.api_key_hash, (unreadCounts.get(row.api_key_hash) ?? 0) + 1);
+  }
+
+  for (const [apiKeyHash, count] of unreadCounts.entries()) {
+    const dedupCutoff = new Date(nowMs - MENTION_DIGEST_DEDUP_WINDOW_MS).toISOString();
+    const { data: recentDigest } = await supabase
+      .from("mc_signals")
+      .select("id")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("tool", "fishbowl")
+      .eq("action", "mention_digest")
+      .gt("created_at", dedupCutoff)
+      .limit(1);
+
+    if ((recentDigest ?? []).length > 0) continue;
+
+    const summary = `📬 ${count} unread fishbowl mention${count === 1 ? "" : "s"} to you`;
+    const { error: digestErr } = await supabase.from("mc_signals").insert({
+      api_key_hash: apiKeyHash,
+      tool: "fishbowl",
+      action: "mention_digest",
+      severity: "action_needed",
+      summary,
+      deep_link: "/admin/fishbowl",
+      payload: { unread_count: count },
+    });
+    if (digestErr) {
+      console.error(
+        "[fishbowl-watcher] digest signal insert error:",
+        digestErr.message,
+      );
+    } else {
+      digestSignalsEmitted++;
+    }
+  }
+
+  return res.status(200).json({
+    checkin_signals_emitted: checkinSignalsEmitted,
+    digest_signals_emitted: digestSignalsEmitted,
+    overdue_candidates: candidates.length,
+    tenants_with_unread_mentions: unreadCounts.size,
+  });
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5747,7 +5747,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             },
             { onConflict: "api_key_hash,agent_id" },
           )
-          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at, next_checkin_at")
           .single();
         if (error) throw error;
         return res.status(200).json({ profile: data });
@@ -5809,7 +5809,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             },
             { onConflict: "api_key_hash,agent_id" },
           )
-          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at, next_checkin_at")
           .single();
         if (error) throw error;
         return res.status(200).json({ profile: data });
@@ -5828,7 +5828,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
           });
         }
-        const body = (req.body ?? {}) as { agent_id?: string | null; status?: string | null };
+        const body = (req.body ?? {}) as {
+          agent_id?: string | null;
+          status?: string | null;
+          next_checkin_at?: string | null;
+        };
 
         const agentId = (body.agent_id ?? "").toString().trim();
         if (!agentId) {
@@ -5848,17 +5852,60 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (statusRaw.length > 200) return res.status(400).json({ error: "status must be at most 200 characters" });
         const statusValue: string | null = statusRaw.trim().length === 0 ? null : statusRaw;
 
+        // next_checkin_at (optional): ISO 8601 timestamp OR a relative
+        // duration like '30m', '2h', '1d', '90s'. Empty string or null clears
+        // the field. Stored as an absolute timestamp so the watcher can
+        // compare directly against last_seen_at.
+        const RELATIVE_RE = /^(\d+)\s*([smhd])$/i;
+        const MAX_FUTURE_MS = 30 * 86_400_000;
+        let nextCheckinUpdate: { apply: boolean; iso: string | null } = { apply: false, iso: null };
+        if (Object.prototype.hasOwnProperty.call(body, "next_checkin_at")) {
+          const raw = body.next_checkin_at;
+          if (raw == null || (typeof raw === "string" && raw.trim() === "")) {
+            nextCheckinUpdate = { apply: true, iso: null };
+          } else if (typeof raw !== "string") {
+            return res.status(400).json({
+              error: "next_checkin_at must be a string (ISO 8601 timestamp or relative duration like '30m', '2h')",
+            });
+          } else {
+            const trimmed = raw.trim();
+            const m = trimmed.match(RELATIVE_RE);
+            if (m) {
+              const qty = parseInt(m[1], 10);
+              const unit = m[2].toLowerCase();
+              const factor = unit === "s" ? 1000 : unit === "m" ? 60_000 : unit === "h" ? 3_600_000 : 86_400_000;
+              const ms = qty * factor;
+              if (!Number.isFinite(ms) || ms <= 0 || ms > MAX_FUTURE_MS) {
+                return res.status(400).json({ error: "next_checkin_at duration must be > 0 and <= 30d" });
+              }
+              nextCheckinUpdate = { apply: true, iso: new Date(Date.now() + ms).toISOString() };
+            } else {
+              const t = Date.parse(trimmed);
+              if (Number.isNaN(t)) {
+                return res.status(400).json({
+                  error: "next_checkin_at must be ISO 8601 timestamp or relative duration like '30m', '2h'",
+                });
+              }
+              nextCheckinUpdate = { apply: true, iso: new Date(t).toISOString() };
+            }
+          }
+        }
+
         const nowIso = new Date().toISOString();
+        const updatePayload: Record<string, unknown> = {
+          current_status: statusValue,
+          current_status_updated_at: nowIso,
+          last_seen_at: nowIso,
+        };
+        if (nextCheckinUpdate.apply) {
+          updatePayload.next_checkin_at = nextCheckinUpdate.iso;
+        }
         const { data, error } = await supabase
           .from("mc_fishbowl_profiles")
-          .update({
-            current_status: statusValue,
-            current_status_updated_at: nowIso,
-            last_seen_at: nowIso,
-          })
+          .update(updatePayload)
           .eq("api_key_hash", apiKeyHash)
           .eq("agent_id", agentId)
-          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
+          .select("id, agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at, next_checkin_at")
           .maybeSingle();
         if (error) throw error;
         if (!data) {
@@ -6020,6 +6067,72 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("api_key_hash", apiKeyHash)
           .eq("agent_id", agentId);
 
+        // Wake-up plumbing: publish a Signal so existing dispatch (phone push,
+        // email, telegram per mc_signal_preferences) can wake the human if a
+        // message warrants it. Fire-and-forget so a Signals failure never
+        // blocks the post response.
+        void (async () => {
+          try {
+            const recipientList = inserted.recipients ?? [];
+            const tagList = inserted.tags ?? [];
+            const tagSet = new Set(tagList);
+            const isBlocker = tagSet.has("blocker") || tagSet.has("tripwire");
+            const broadcastsAll = recipientList.includes("all");
+
+            // Discover this tenant's human admin profiles so we can match
+            // recipients against the human's actual emoji and agent_id, not
+            // just the canonical 😎 fallback.
+            const { data: humanRows } = await supabase
+              .from("mc_fishbowl_profiles")
+              .select("agent_id, emoji")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("user_agent_hint", "admin-ui");
+            const humanEmojis = new Set<string>(["😎"]);
+            const humanAgentIds = new Set<string>();
+            for (const h of humanRows ?? []) {
+              if (h?.emoji) humanEmojis.add(h.emoji);
+              if (h?.agent_id) humanAgentIds.add(h.agent_id);
+            }
+
+            const targetsHuman = recipientList.some(
+              (r: string) =>
+                humanEmojis.has(r) ||
+                humanAgentIds.has(r) ||
+                (typeof r === "string" && r.startsWith("human-")),
+            );
+
+            let severity: "info" | "action_needed" | "critical" = "info";
+            if (targetsHuman) severity = "action_needed";
+            else if (broadcastsAll && isBlocker) severity = "action_needed";
+            else if (isBlocker) severity = "action_needed";
+
+            const summarySource = inserted.text ?? text;
+            const summary =
+              summarySource.length > 200 ? `${summarySource.slice(0, 197)}...` : summarySource;
+
+            await supabase.from("mc_signals").insert({
+              api_key_hash: apiKeyHash,
+              tool: "fishbowl",
+              action: "message_posted",
+              severity,
+              summary,
+              deep_link: `/admin/fishbowl#msg-${inserted.id}`,
+              payload: {
+                author_emoji: inserted.author_emoji,
+                author_agent_id: inserted.author_agent_id,
+                recipients: recipientList,
+                tags: tagList,
+                message_id: inserted.id,
+              },
+            });
+          } catch (publishErr) {
+            console.error(
+              "[fishbowl_post] signal publish failed:",
+              (publishErr as Error).message,
+            );
+          }
+        })();
+
         return res.status(200).json({ message: inserted });
       }
 
@@ -6072,7 +6185,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           q,
           supabase
             .from("mc_fishbowl_profiles")
-            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at")
+            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at, next_checkin_at")
             .eq("api_key_hash", apiKeyHash)
             .order("last_seen_at", { ascending: false, nullsFirst: false }),
         ]);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -412,7 +412,8 @@ const VISIBLE_TOOLS = [
     name: "set_my_status",
     title: "Update my Now Playing status",
     description:
-      "Update what you're currently doing so it shows on the human's Fishbowl Now Playing strip. Call when you start a task, change focus, or idle out. Short, plain English, present-tense. Persists until you change it. agent_id required.",
+      "Update what you're currently doing so it shows on the human's Fishbowl Now Playing strip. Call when you start a task, change focus, or idle out. Short, plain English, present-tense. Persists until you change it. agent_id required.\n\n" +
+      "Optional next_checkin_at acts as a dead-man's-switch. Set it when you expect to be away (sleeping session, long-running job, scheduled task) and want the watcher to nudge the human if you do not pulse again by then. Pass either an ISO 8601 timestamp ('2026-04-25T18:30:00Z') or a relative duration ('30m', '2h', '1d', '90s'). The Now Playing strip shows 'back in 23m' while it's in the future and a red MIA badge once it passes without a fresh pulse. Pass an empty string to clear it.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -425,6 +426,11 @@ const VISIBLE_TOOLS = [
           type: "string",
           description:
             "What you're doing right now in plain English (max 200 chars). Pass an empty string to clear your status back to idle.",
+        },
+        next_checkin_at: {
+          type: "string",
+          description:
+            "Optional dead-man's-switch. ISO 8601 timestamp OR relative duration ('30m', '2h', '1d', '90s'). If you do not call set_my_status or post_message again before this passes, the watcher emits a Signal so the human knows to nudge you. Empty string clears it.",
         },
       },
       required: ["agent_id", "status"],
@@ -443,7 +449,8 @@ const VISIBLE_TOOLS = [
       "Do NOT poll repeatedly within the same session; once per session at start is enough unless something changed.\n\n" +
       "The response has two lanes:\n" +
       "  - 'messages': everything in the room, in time order. Read this for context.\n" +
-      "  - 'mentions': only messages where YOUR emoji or agent_id is in the recipients list. Read this FIRST, then skim the rest. Broadcasts to 'all' are not mentions, they're general feed.",
+      "  - 'mentions': only messages where YOUR emoji or agent_id is in the recipients list. Read this FIRST, then skim the rest. Broadcasts to 'all' are not mentions, they're general feed.\n\n" +
+      "Recommended start-of-session loop: (1) call read_messages to catch up on Fishbowl (you're doing this now), (2) check mentions[] for anything addressed to you, (3) call set_my_status to declare you're back online and set next_checkin_at if you expect to be away again.",
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -28,6 +28,7 @@ interface FishbowlProfile {
   last_seen_at: string | null;
   current_status: string | null;
   current_status_updated_at: string | null;
+  next_checkin_at: string | null;
 }
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
@@ -57,6 +58,17 @@ function relativeTime(iso: string | null): string {
   const diffDay = Math.floor(diffHr / 24);
   if (diffDay < 7) return `${diffDay}d ago`;
   return new Date(iso).toLocaleDateString();
+}
+
+function relativeFromNow(targetMs: number, nowMs: number): string {
+  const diffSec = Math.max(1, Math.floor((targetMs - nowMs) / 1000));
+  if (diffSec < 60) return `${diffSec}s`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d`;
 }
 
 function formatUtcTime(iso: string): string {
@@ -219,22 +231,26 @@ function NowPlayingStrip({ profiles }: { profiles: FishbowlProfile[] }) {
             const statusText = p.current_status?.trim();
             const hasStatus = statusText && statusText.length > 0;
             const timeIso = p.current_status_updated_at ?? p.last_seen_at;
+            const checkinMs = p.next_checkin_at ? new Date(p.next_checkin_at).getTime() : null;
+            const seenMs = p.last_seen_at ? new Date(p.last_seen_at).getTime() : 0;
+            const isMia = checkinMs !== null && checkinMs < nowMs && seenMs < checkinMs;
+            const isComingBack = checkinMs !== null && checkinMs >= nowMs;
             return (
               <li
                 key={p.agent_id}
-                className={`flex w-56 shrink-0 flex-col gap-1 rounded-lg border border-[#222] bg-black/30 px-3 py-2 ${stale ? "opacity-50" : ""}`}
+                className={`flex w-56 shrink-0 flex-col gap-1 rounded-lg border border-[#222] bg-black/30 px-3 py-2 ${stale && !isMia ? "opacity-50" : ""}`}
                 title={p.agent_id}
               >
                 <div className="flex items-center gap-2">
                   <span className="text-base leading-none" aria-hidden>{p.emoji}</span>
                   <span
-                    className={`flex-1 truncate text-xs font-medium ${stale ? "text-[#888]" : "text-[#E2B93B]"}`}
+                    className={`flex-1 truncate text-xs font-medium ${isMia ? "text-red-400" : stale ? "text-[#888]" : "text-[#E2B93B]"}`}
                   >
                     {p.display_name ?? p.agent_id}
                   </span>
                   <span
                     aria-hidden
-                    className={`text-[10px] leading-none ${stale ? "text-[#555]" : "text-[#E2B93B]"}`}
+                    className={`text-[10px] leading-none ${isMia ? "text-red-400" : stale ? "text-[#555]" : "text-[#E2B93B]"}`}
                   >
                     {stale ? "○" : "●"}
                   </span>
@@ -245,9 +261,25 @@ function NowPlayingStrip({ profiles }: { profiles: FishbowlProfile[] }) {
                 >
                   {hasStatus ? statusText : "idle"}
                 </p>
-                <p className="truncate text-[10px] text-[#555]">
-                  {relativeTime(timeIso)}
-                </p>
+                {isMia ? (
+                  <p
+                    className="truncate text-[10px] font-semibold uppercase tracking-wide text-red-400"
+                    title={`Missed check-in (was due ${relativeTime(p.next_checkin_at)})`}
+                  >
+                    MIA
+                  </p>
+                ) : isComingBack && checkinMs !== null ? (
+                  <p
+                    className="truncate text-[10px] text-[#E2B93B]"
+                    title={`Expects to pulse again at ${new Date(checkinMs).toLocaleString()}`}
+                  >
+                    back in {relativeFromNow(checkinMs, nowMs)}
+                  </p>
+                ) : (
+                  <p className="truncate text-[10px] text-[#555]">
+                    {relativeTime(timeIso)}
+                  </p>
+                )}
               </li>
             );
           })}

--- a/supabase/migrations/20260425100000_fishbowl_next_checkin.sql
+++ b/supabase/migrations/20260425100000_fishbowl_next_checkin.sql
@@ -1,0 +1,14 @@
+-- Fishbowl wake-up plumbing (B1): adds an optional dead-man's-switch field on
+-- every agent profile. When set, the watcher cron compares it against
+-- last_seen_at and emits a Signal if the agent missed its expected check-in.
+-- The set_my_status tool accepts either an ISO 8601 timestamp or a relative
+-- duration (e.g. '30m', '2h') and stores the absolute value here.
+
+ALTER TABLE mc_fishbowl_profiles
+  ADD COLUMN IF NOT EXISTS next_checkin_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_profiles_next_checkin
+  ON mc_fishbowl_profiles(api_key_hash, next_checkin_at)
+  WHERE next_checkin_at IS NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/vercel.json
+++ b/vercel.json
@@ -35,6 +35,10 @@
     {
       "path": "/api/signals-dispatch",
       "schedule": "*/1 * * * *"
+    },
+    {
+      "path": "/api/fishbowl-watcher",
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Wires Fishbowl into the existing Signals bus so a sleeping LLM session can be woken via the human's phone push, plus a tiny dead-man's-switch field for the Plex Claude / Codex idea. Three pieces, no new delivery code, no LLM calls server-side.

### 1. Fishbowl -> Signals publisher

`fishbowl_post` now publishes a row into `mc_signals` after every successful message insert. Severity rules (matches the existing `info | action_needed | critical` enum):

- Recipients explicitly include `😎`, an admin-ui profile's emoji or agent_id, or any `human-*` id -> `action_needed`
- Recipients include `all` AND tagged `blocker` or `tripwire` -> `action_needed`
- Tagged `blocker` regardless of recipients -> `action_needed`
- Otherwise -> `info`

Signal carries `tool='fishbowl'`, `action='message_posted'`, summary truncated to 200 chars, `deep_link='/admin/fishbowl#msg-<id>'`, and a payload with author_emoji / author_agent_id / recipients / tags / message_id. Fire-and-forget so a Signals failure never blocks the post response. Existing `signals-dispatch` cron handles delivery.

### 2. Watcher cron MVP

New Vercel cron at `/api/fishbowl-watcher`, scheduled `*/15 * * * *`. Two responsibilities:

- **Dead-man's-switch**: profiles where `next_checkin_at < now()` AND `last_seen_at < next_checkin_at` get a `checkin_missed` Signal at severity `action_needed`. Summary: `🪪 <emoji> missed expected check-in (was due X min ago)`. Deduped against any identical-agent signal in the last 30 min.
- **Unread mention digest**: per-tenant, if there are unread `fishbowl/message_posted` signals at `action_needed` older than 10 min, emit one `mention_digest` Signal. Deduped against any digest in the last 60 min.

Auth identical to `signals-dispatch` (`Bearer ${CRON_SECRET}`).

### 3. `next_checkin_at` field

`alter table mc_fishbowl_profiles add column if not exists next_checkin_at timestamptz` (Bailey will apply via Supabase MCP). `set_my_status` MCP tool gains an optional `next_checkin_at` parameter that accepts either ISO 8601 or relative durations (`30m`, `2h`, `1d`, `90s`); backend stores the absolute timestamp. Now Playing strip shows:

- Future + set: `back in 23m` (yellow)
- Past + no fresh pulse: red `MIA` badge in place of relative time
- Unset: existing relative time

Plus a small docs-only update on `read_messages` advertising the start-of-session ritual: read -> check mentions -> `set_my_status` with optional `next_checkin_at`.

### Out of scope

- B2 (tripwire rules + on-call routing + quiet hours + digest formatting) is the next chip.
- Admin lane visualization is Chip A.

## Test plan

- [ ] Apply migration via Supabase MCP
- [ ] `npm run build` (root) and `cd packages/mcp-server && npx tsc --noEmit` both green locally
- [ ] Post a message in Fishbowl with `recipients: ["😎"]` and confirm `mc_signals` row lands at severity `action_needed` with `deep_link=/admin/fishbowl#msg-<id>`
- [ ] Post a broadcast with `tags: ["blocker"]` and confirm severity `action_needed`
- [ ] Post a benign broadcast with no special tags and confirm severity `info`
- [ ] Call `set_my_status` with `next_checkin_at: "30m"`, verify the profile row has the absolute timestamp and the Now Playing strip shows `back in 30m`
- [ ] Set `next_checkin_at` to a past timestamp via DB, hit `/api/fishbowl-watcher` with the cron secret, confirm a `checkin_missed` row lands and the strip flips to red `MIA`
- [ ] Re-fire the watcher within 30 min and confirm no duplicate `checkin_missed` row
- [ ] Generate an unread fishbowl mention older than 10 min, fire watcher, confirm one `mention_digest` row; fire again within 60 min and confirm no duplicate

## Migration block (for Bailey)

```sql
ALTER TABLE mc_fishbowl_profiles
  ADD COLUMN IF NOT EXISTS next_checkin_at timestamptz;

CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_profiles_next_checkin
  ON mc_fishbowl_profiles(api_key_hash, next_checkin_at)
  WHERE next_checkin_at IS NOT NULL;

NOTIFY pgrst, 'reload schema';
```

## Verification

- `npm run build` (root mcp-server tsc): green (exit 0)
- `cd packages/mcp-server && npx tsc --noEmit`: green (exit 0)
- `npx tsx --check api/fishbowl-watcher.ts`: green (exit 0)
- Em-dash grep across the diff: zero hits
- Auth widening: none (publisher uses the same supabase client already auth'd by `resolveApiKeyHash`; watcher requires `CRON_SECRET`)
- LLM calls server-side: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)