### PR TITLE
feat(fishbowl): drafts queue + wake contracts + per-platform wake routes (B2)

### DIFF
--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -1,16 +1,22 @@
 /**
- * Fishbowl Watcher (B1) - Vercel cron, every 15 minutes.
+ * Fishbowl Watcher (B1 + B2) - Vercel cron, every 15 minutes.
  *
- * Two responsibilities:
+ * Three responsibilities:
  *   1. Dead-man's-switch: agents whose next_checkin_at has passed without a
  *      fresh pulse get a single mc_signals row per missed window so the human
  *      gets nudged via existing Signals delivery.
  *   2. Unread mention digest: if a tenant has unread fishbowl signals at
  *      severity action_needed older than 10 minutes, emit a digest signal so
  *      the human gets a second nudge if the original push was dismissed.
+ *   3. Draft escalation (B2): unread important/urgent drafts get escalated
+ *      via the recipient's declared wake_route. Urgent escalates after 15
+ *      minutes, important after 30. The route is read from
+ *      mc_fishbowl_profiles.wake_route_kind / wake_route_config; default
+ *      (NULL) falls through to a plain Signal so behavior matches B1.
  *
  * Dedup: each emission checks for a recent identical-action signal so we
- * never spam (30 min for missed check-ins, 60 min for digests).
+ * never spam (30 min for missed check-ins, 60 min for digests, 60 min per
+ * draft escalation).
  *
  * Auth: Bearer ${CRON_SECRET}, same shape as signals-dispatch.ts.
  */
@@ -34,9 +40,33 @@ interface SignalRow {
   created_at: string;
 }
 
+interface DraftRow {
+  id: string;
+  api_key_hash: string;
+  recipient_agent_id: string;
+  sender_agent_id: string;
+  sender_emoji: string | null;
+  text: string;
+  priority: "normal" | "important" | "urgent";
+  created_at: string;
+}
+
+interface RecipientProfileRow {
+  api_key_hash: string;
+  agent_id: string;
+  emoji: string;
+  display_name: string | null;
+  wake_route_kind: string | null;
+  wake_route_config: Record<string, unknown> | null;
+}
+
 const CHECKIN_DEDUP_WINDOW_MS = 30 * 60 * 1000;
 const MENTION_DIGEST_DEDUP_WINDOW_MS = 60 * 60 * 1000;
 const MENTION_AGE_THRESHOLD_MS = 10 * 60 * 1000;
+
+const URGENT_AGE_THRESHOLD_MS = 15 * 60 * 1000;
+const IMPORTANT_AGE_THRESHOLD_MS = 30 * 60 * 1000;
+const DRAFT_ESCALATION_DEDUP_WINDOW_MS = 60 * 60 * 1000;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const authHeader = req.headers.authorization ?? "";
@@ -174,10 +204,213 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   }
 
+  // ── 3. Draft escalation sweep (B2) ──────────────────────────────────────
+  // Find unread, unexpired drafts at priority important/urgent that have
+  // aged past their threshold. For each, look up the recipient's wake_route
+  // and dispatch via that channel. A Signal is always emitted as the
+  // baseline + dedup record; the wake_route adds platform-specific delivery
+  // on top when wired.
+  const draftAgeCutoff = new Date(nowMs - URGENT_AGE_THRESHOLD_MS).toISOString();
+  const { data: candidateDrafts } = await supabase
+    .from("mc_fishbowl_drafts")
+    .select("id, api_key_hash, recipient_agent_id, sender_agent_id, sender_emoji, text, priority, created_at, expires_at")
+    .in("priority", ["important", "urgent"])
+    .is("acknowledged_at", null)
+    .lt("created_at", draftAgeCutoff)
+    .or(`expires_at.is.null,expires_at.gt.${nowIso}`);
+
+  const escalatableDrafts = ((candidateDrafts ?? []) as DraftRow[]).filter((d) => {
+    const ageMs = nowMs - new Date(d.created_at).getTime();
+    if (d.priority === "urgent") return ageMs >= URGENT_AGE_THRESHOLD_MS;
+    if (d.priority === "important") return ageMs >= IMPORTANT_AGE_THRESHOLD_MS;
+    return false;
+  });
+
+  // Batch fetch recipient profiles per (tenant, agent_id) so we don't issue
+  // one supabase call per draft. Group by tenant first to keep queries cheap.
+  const draftsByTenant = new Map<string, DraftRow[]>();
+  for (const d of escalatableDrafts) {
+    const arr = draftsByTenant.get(d.api_key_hash) ?? [];
+    arr.push(d);
+    draftsByTenant.set(d.api_key_hash, arr);
+  }
+  const recipientProfileCache = new Map<string, RecipientProfileRow>();
+  for (const [tenantHash, drafts] of draftsByTenant.entries()) {
+    const recipientIds = Array.from(new Set(drafts.map((d) => d.recipient_agent_id)));
+    const { data: profiles } = await supabase
+      .from("mc_fishbowl_profiles")
+      .select("api_key_hash, agent_id, emoji, display_name, wake_route_kind, wake_route_config")
+      .eq("api_key_hash", tenantHash)
+      .in("agent_id", recipientIds);
+    for (const p of (profiles ?? []) as RecipientProfileRow[]) {
+      recipientProfileCache.set(`${p.api_key_hash}:${p.agent_id}`, p);
+    }
+  }
+
+  let draftEscalationsEmitted = 0;
+  let draftWakeRouteDispatches = 0;
+  const wakeRouteCounts: Record<string, number> = {};
+
+  for (const draft of escalatableDrafts) {
+    // Per-draft dedup: skip if we've already emitted an escalation in the
+    // last 60 minutes for this draft_id. This is what stops the watcher
+    // from re-poking on every 15-minute tick.
+    const dedupCutoff = new Date(nowMs - DRAFT_ESCALATION_DEDUP_WINDOW_MS).toISOString();
+    const { data: recentEscalations } = await supabase
+      .from("mc_signals")
+      .select("payload")
+      .eq("api_key_hash", draft.api_key_hash)
+      .eq("tool", "fishbowl")
+      .eq("action", "draft_escalated")
+      .gt("created_at", dedupCutoff);
+
+    const alreadyEscalated = ((recentEscalations ?? []) as { payload: Record<string, unknown> | null }[]).some(
+      (s) => (s.payload ?? {}).draft_id === draft.id,
+    );
+    if (alreadyEscalated) continue;
+
+    const recipient = recipientProfileCache.get(`${draft.api_key_hash}:${draft.recipient_agent_id}`);
+    const wakeKind = (recipient?.wake_route_kind ?? "signals_only").toString();
+    const wakeConfig = (recipient?.wake_route_config ?? {}) as Record<string, unknown>;
+
+    // Always emit the dedup Signal so existing delivery (push, email, telegram)
+    // gets a chance to wake the human even when the wake_route is bespoke.
+    const summarySource = draft.text;
+    const summary =
+      summarySource.length > 200 ? `${summarySource.slice(0, 197)}...` : summarySource;
+    const recipientLabel = recipient?.display_name ?? draft.recipient_agent_id;
+    const headline =
+      draft.priority === "urgent"
+        ? `🚨 Urgent draft for ${recipient?.emoji ?? ""} ${recipientLabel} (unread ${Math.round((nowMs - new Date(draft.created_at).getTime()) / 60_000)} min)`
+        : `📨 Important draft for ${recipient?.emoji ?? ""} ${recipientLabel} (unread ${Math.round((nowMs - new Date(draft.created_at).getTime()) / 60_000)} min)`;
+
+    const { error: signalErr } = await supabase.from("mc_signals").insert({
+      api_key_hash: draft.api_key_hash,
+      tool: "fishbowl",
+      action: "draft_escalated",
+      severity: "action_needed",
+      summary: `${headline}: ${summary}`,
+      deep_link: `/admin/fishbowl#draft-${draft.id}`,
+      payload: {
+        draft_id: draft.id,
+        recipient_agent_id: draft.recipient_agent_id,
+        sender_agent_id: draft.sender_agent_id,
+        priority: draft.priority,
+        wake_route_kind: wakeKind,
+      },
+    });
+    if (signalErr) {
+      console.error("[fishbowl-watcher] draft escalation signal insert error:", signalErr.message);
+      continue;
+    }
+    draftEscalationsEmitted++;
+    wakeRouteCounts[wakeKind] = (wakeRouteCounts[wakeKind] ?? 0) + 1;
+
+    // Wake-route dispatch (best-effort, never blocks the loop).
+    if (wakeKind === "github_issue" || wakeKind === "github_claude_mention") {
+      const dispatched = await dispatchGithubWakeRoute(wakeKind, wakeConfig, draft, recipient);
+      if (dispatched) draftWakeRouteDispatches++;
+    }
+    // 'cowork_scheduled_task', 'signals_only', and 'none' are covered by the
+    // Signal above. cowork_scheduled_task is flagged for v2 (see PR body).
+  }
+
   return res.status(200).json({
     checkin_signals_emitted: checkinSignalsEmitted,
     digest_signals_emitted: digestSignalsEmitted,
     overdue_candidates: candidates.length,
     tenants_with_unread_mentions: unreadCounts.size,
+    draft_escalations_emitted: draftEscalationsEmitted,
+    draft_wake_route_dispatches: draftWakeRouteDispatches,
+    draft_candidates: escalatableDrafts.length,
+    wake_route_breakdown: wakeRouteCounts,
   });
 }
+
+// ── Wake-route dispatch helpers ──────────────────────────────────────────
+//
+// GitHub-backed wake routes use REST calls (no LLM, no extra deps). They
+// require GITHUB_TOKEN in env; when missing, the function returns false so
+// the caller knows only the Signal landed. Errors never throw -- the
+// Watcher should keep processing other drafts even if one route is broken.
+
+async function dispatchGithubWakeRoute(
+  kind: "github_issue" | "github_claude_mention",
+  config: Record<string, unknown>,
+  draft: DraftRow,
+  recipient: RecipientProfileRow | undefined,
+): Promise<boolean> {
+  const token = process.env.GITHUB_TOKEN || process.env.GITHUB_PAT;
+  if (!token) {
+    console.warn(
+      `[fishbowl-watcher] wake_route ${kind} has no GITHUB_TOKEN; relying on Signal fallback.`,
+    );
+    return false;
+  }
+  const repo = typeof config.repo === "string" ? config.repo : "";
+  if (!repo) return false;
+
+  const recipientLabel = recipient?.display_name ?? draft.recipient_agent_id;
+  const recipientEmoji = recipient?.emoji ?? "";
+  const bodyText = [
+    draft.text,
+    "",
+    "---",
+    `priority: ${draft.priority}`,
+    `from: ${draft.sender_emoji ?? ""} ${draft.sender_agent_id}`,
+    `to: ${recipientEmoji} ${recipientLabel}`,
+    `draft_id: ${draft.id}`,
+    `dropped_at: ${draft.created_at}`,
+  ].join("\n");
+
+  try {
+    if (kind === "github_issue") {
+      const label = typeof config.label === "string" ? config.label : "wake-fishbowl";
+      const title = `[wake-${recipientEmoji || "fishbowl"}] ${draft.text.slice(0, 80)}${draft.text.length > 80 ? "..." : ""}`;
+      const resp = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title, body: bodyText, labels: [label] }),
+      });
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => "");
+        console.error(`[fishbowl-watcher] github_issue dispatch failed (${resp.status}): ${text}`);
+        return false;
+      }
+      return true;
+    }
+    if (kind === "github_claude_mention") {
+      const issueNumber = typeof config.issue_number === "number" ? config.issue_number : 0;
+      if (!issueNumber) return false;
+      const commentBody = `@claude wake: ${recipientEmoji} ${recipientLabel} has an unread ${draft.priority} draft.\n\n${bodyText}`;
+      const resp = await fetch(
+        `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ body: commentBody }),
+        },
+      );
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => "");
+        console.error(`[fishbowl-watcher] github_claude_mention dispatch failed (${resp.status}): ${text}`);
+        return false;
+      }
+      return true;
+    }
+  } catch (err) {
+    console.error(`[fishbowl-watcher] wake_route ${kind} threw: ${(err as Error).message}`);
+  }
+  return false;
+}
+

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -6168,8 +6168,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         if (!room) {
           // No room yet means no posts yet. Return empty so the admin page
-          // can render its empty state without an error.
-          return res.status(200).json({ room: null, messages: [], profiles: [] });
+          // can render its empty state without an error. Drafts can still
+          // exist before the first post, so we still query for them.
+          let draftsQ = supabase
+            .from("mc_fishbowl_drafts")
+            .select("id, recipient_agent_id, sender_agent_id, sender_emoji, text, priority, tags, created_at, expires_at")
+            .eq("api_key_hash", apiKeyHash)
+            .is("acknowledged_at", null)
+            .or(`expires_at.is.null,expires_at.gt.${new Date().toISOString()}`)
+            .order("created_at", { ascending: false })
+            .limit(50);
+          if (agentId) draftsQ = draftsQ.eq("recipient_agent_id", agentId);
+          const { data: earlyDrafts } = await draftsQ;
+          return res.status(200).json({
+            room: null,
+            messages: [],
+            profiles: [],
+            drafts: earlyDrafts ?? [],
+          });
         }
 
         let q = supabase
@@ -6181,16 +6197,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .limit(limit);
         if (sinceParam) q = q.gt("created_at", sinceParam);
 
-        const [{ data: messages, error: msgErr }, { data: profiles, error: profErr }] = await Promise.all([
+        // Drafts: served alongside messages so agents see them at the top of
+        // the response. Unread + unexpired only. Scoped to recipient when an
+        // agent_id is supplied; the admin UI (no agent_id) sees all unread
+        // drafts for visibility.
+        const nowIsoForDrafts = new Date().toISOString();
+        let draftsQ = supabase
+          .from("mc_fishbowl_drafts")
+          .select("id, recipient_agent_id, sender_agent_id, sender_emoji, text, priority, tags, created_at, expires_at")
+          .eq("api_key_hash", apiKeyHash)
+          .is("acknowledged_at", null)
+          .or(`expires_at.is.null,expires_at.gt.${nowIsoForDrafts}`)
+          .order("created_at", { ascending: false })
+          .limit(50);
+        if (agentId) draftsQ = draftsQ.eq("recipient_agent_id", agentId);
+
+        const [
+          { data: messages, error: msgErr },
+          { data: profiles, error: profErr },
+          { data: drafts, error: draftErr },
+        ] = await Promise.all([
           q,
           supabase
             .from("mc_fishbowl_profiles")
-            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at, next_checkin_at")
+            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at, next_checkin_at, wake_route_kind, wake_route_config")
             .eq("api_key_hash", apiKeyHash)
             .order("last_seen_at", { ascending: false, nullsFirst: false }),
+          draftsQ,
         ]);
         if (msgErr) throw msgErr;
         if (profErr) throw profErr;
+        if (draftErr) throw draftErr;
 
         // Auto-touch the caller's last_seen_at so a polling agent stays "active"
         // on the Now Playing strip without needing to post. Best-effort: skipped
@@ -6208,7 +6245,305 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           room,
           messages: messages ?? [],
           profiles: profiles ?? [],
+          drafts: drafts ?? [],
         });
+      }
+
+      case "fishbowl_drop_draft": {
+        // Sender drops a private message into a recipient's inbox. The
+        // recipient sees it the next time they call read_messages, before
+        // the public room feed. Sender and recipient must both be registered
+        // in this tenant's mc_fishbowl_profiles -- we validate the recipient
+        // explicitly so a typo can't silently route a draft into the void.
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
+          });
+        }
+        const body = (req.body ?? {}) as {
+          agent_id?: string | null;
+          recipient_agent_id?: string | null;
+          text?: string | null;
+          priority?: string | null;
+          tags?: string[] | null;
+          expires_in?: string | null;
+        };
+
+        const senderAgentId = (body.agent_id ?? "").toString().trim();
+        if (!senderAgentId) {
+          return res.status(400).json({
+            error: "agent_id required (sender)",
+            how_to_fix: "Pass your stable agent_id as the sender so the recipient knows who left them this draft.",
+          });
+        }
+        if (senderAgentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const recipientAgentId = (body.recipient_agent_id ?? "").toString().trim();
+        if (!recipientAgentId) {
+          return res.status(400).json({
+            error: "recipient_agent_id required",
+            how_to_fix: "Pass the stable agent_id of the agent you want to deliver this draft to. Use read_messages to discover registered agent_ids.",
+          });
+        }
+        if (recipientAgentId.length > 128) return res.status(400).json({ error: "recipient_agent_id must be at most 128 characters" });
+
+        const text = (body.text ?? "").toString().trim();
+        if (!text) return res.status(400).json({ error: "text required" });
+        if (text.length > 2000) return res.status(400).json({ error: "text must be at most 2000 characters" });
+
+        const priority = (body.priority ?? "normal").toString().trim() || "normal";
+        if (!["normal", "important", "urgent"].includes(priority)) {
+          return res.status(400).json({
+            error: "priority must be one of 'normal', 'important', 'urgent'",
+          });
+        }
+
+        let tags: string[] | null = null;
+        if (body.tags != null) {
+          if (!Array.isArray(body.tags)) return res.status(400).json({ error: "tags must be an array of strings" });
+          if (body.tags.length > 10) return res.status(400).json({ error: "tags must be at most 10 items" });
+          for (const t of body.tags) {
+            if (typeof t !== "string" || t.length < 1 || t.length > 32) {
+              return res.status(400).json({ error: "each tag must be 1 to 32 characters" });
+            }
+          }
+          tags = body.tags;
+        }
+
+        // expires_in: ISO 8601 timestamp OR relative duration ('30m', '2h',
+        // '1d', '90s'). Same parser shape as fishbowl_set_status.
+        const RELATIVE_RE = /^(\d+)\s*([smhd])$/i;
+        const MAX_FUTURE_MS = 30 * 86_400_000;
+        let expiresAtIso: string | null = null;
+        if (body.expires_in != null && body.expires_in !== "") {
+          const raw = String(body.expires_in).trim();
+          const m = raw.match(RELATIVE_RE);
+          if (m) {
+            const qty = parseInt(m[1], 10);
+            const unit = m[2].toLowerCase();
+            const factor = unit === "s" ? 1000 : unit === "m" ? 60_000 : unit === "h" ? 3_600_000 : 86_400_000;
+            const ms = qty * factor;
+            if (!Number.isFinite(ms) || ms <= 0 || ms > MAX_FUTURE_MS) {
+              return res.status(400).json({ error: "expires_in duration must be > 0 and <= 30d" });
+            }
+            expiresAtIso = new Date(Date.now() + ms).toISOString();
+          } else {
+            const t = Date.parse(raw);
+            if (Number.isNaN(t)) {
+              return res.status(400).json({
+                error: "expires_in must be ISO 8601 timestamp or relative duration like '2h', '1d'",
+              });
+            }
+            expiresAtIso = new Date(t).toISOString();
+          }
+        }
+
+        // Validate the recipient exists in this tenant. This is the key
+        // guard against a typo silently routing a draft into the void.
+        const { data: recipientProfile, error: recipientErr } = await supabase
+          .from("mc_fishbowl_profiles")
+          .select("agent_id")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("agent_id", recipientAgentId)
+          .maybeSingle();
+        if (recipientErr) throw recipientErr;
+        if (!recipientProfile) {
+          return res.status(400).json({
+            error: "recipient_agent_id is not a registered agent in this Fishbowl",
+            how_to_fix: "Call read_messages to see registered agents, or have the recipient call set_my_emoji first.",
+          });
+        }
+
+        // Look up the sender's emoji so the recipient sees it inline without
+        // a second profile fetch on read.
+        const { data: senderProfile } = await supabase
+          .from("mc_fishbowl_profiles")
+          .select("emoji")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("agent_id", senderAgentId)
+          .maybeSingle();
+
+        const { data: inserted, error: insertErr } = await supabase
+          .from("mc_fishbowl_drafts")
+          .insert({
+            api_key_hash: apiKeyHash,
+            recipient_agent_id: recipientAgentId,
+            sender_agent_id: senderAgentId,
+            sender_emoji: senderProfile?.emoji ?? null,
+            text,
+            priority,
+            tags,
+            expires_at: expiresAtIso,
+          })
+          .select("id, recipient_agent_id, sender_agent_id, sender_emoji, text, priority, tags, created_at, expires_at")
+          .single();
+        if (insertErr) throw insertErr;
+
+        // Bump sender's last_seen so the Now Playing strip stays accurate.
+        await supabase
+          .from("mc_fishbowl_profiles")
+          .update({ last_seen_at: new Date().toISOString() })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("agent_id", senderAgentId);
+
+        return res.status(200).json({ draft: inserted });
+      }
+
+      case "fishbowl_acknowledge_draft": {
+        // Recipient marks a draft as seen. Removes it from the unread queue
+        // and stops the watcher from escalating it further.
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'.",
+          });
+        }
+        const body = (req.body ?? {}) as {
+          agent_id?: string | null;
+          draft_id?: string | null;
+          status?: string | null;
+        };
+
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) {
+          return res.status(400).json({
+            error: "agent_id required (recipient)",
+            how_to_fix: "Pass your stable agent_id so we can confirm you are the intended recipient.",
+          });
+        }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const draftId = (body.draft_id ?? "").toString().trim();
+        const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!draftId || !UUID_RE.test(draftId)) {
+          return res.status(400).json({ error: "draft_id must be a valid uuid from read_messages" });
+        }
+
+        const status = (body.status ?? "").toString().trim();
+        if (!["received", "accepted", "declined"].includes(status)) {
+          return res.status(400).json({ error: "status must be one of 'received', 'accepted', 'declined'" });
+        }
+
+        // Match on api_key_hash + draft_id + recipient_agent_id so an agent
+        // can't acknowledge a draft addressed to someone else.
+        const nowIso = new Date().toISOString();
+        const { data: updated, error: updateErr } = await supabase
+          .from("mc_fishbowl_drafts")
+          .update({
+            acknowledged_at: nowIso,
+            acknowledgement_status: status,
+          })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", draftId)
+          .eq("recipient_agent_id", agentId)
+          .select("id, recipient_agent_id, sender_agent_id, sender_emoji, text, priority, tags, created_at, acknowledged_at, acknowledgement_status, expires_at")
+          .maybeSingle();
+        if (updateErr) throw updateErr;
+        if (!updated) {
+          return res.status(404).json({
+            error: "draft not found, already acknowledged, or not addressed to you",
+            how_to_fix: "Call read_messages to see the drafts in your inbox; the draft_id must match a row whose recipient_agent_id is your agent_id.",
+          });
+        }
+
+        return res.status(200).json({ draft: updated });
+      }
+
+      case "fishbowl_set_wake_route": {
+        // Each agent declares HOW it can be woken. The watcher reads the
+        // contract instead of guessing platform-specific wake mechanics.
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'.",
+          });
+        }
+        const body = (req.body ?? {}) as {
+          agent_id?: string | null;
+          kind?: string | null;
+          config?: Record<string, unknown> | null;
+        };
+
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) {
+          return res.status(400).json({
+            error: "agent_id required",
+            how_to_fix: "Pass your stable agent_id so we can attach the route to your profile.",
+          });
+        }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const ALLOWED_KINDS = [
+          "cowork_scheduled_task",
+          "github_issue",
+          "github_claude_mention",
+          "signals_only",
+          "none",
+        ] as const;
+        const kind = (body.kind ?? "").toString().trim();
+        if (!ALLOWED_KINDS.includes(kind as (typeof ALLOWED_KINDS)[number])) {
+          return res.status(400).json({
+            error: `kind must be one of ${ALLOWED_KINDS.join(", ")}`,
+          });
+        }
+
+        const config = body.config ?? {};
+        if (typeof config !== "object" || Array.isArray(config)) {
+          return res.status(400).json({ error: "config must be an object" });
+        }
+        // Per-kind shape validation. Permissive (extra keys allowed) but
+        // required keys must be present so the watcher can dispatch.
+        const cfg = config as Record<string, unknown>;
+        if (kind === "github_issue") {
+          if (typeof cfg.repo !== "string" || !/^[\w.-]+\/[\w.-]+$/.test(cfg.repo)) {
+            return res.status(400).json({
+              error: "github_issue config requires repo in 'owner/name' form",
+            });
+          }
+          if (cfg.label != null && typeof cfg.label !== "string") {
+            return res.status(400).json({ error: "github_issue config.label must be a string if provided" });
+          }
+        } else if (kind === "github_claude_mention") {
+          if (typeof cfg.repo !== "string" || !/^[\w.-]+\/[\w.-]+$/.test(cfg.repo)) {
+            return res.status(400).json({
+              error: "github_claude_mention config requires repo in 'owner/name' form",
+            });
+          }
+          if (typeof cfg.issue_number !== "number" || !Number.isInteger(cfg.issue_number) || cfg.issue_number <= 0) {
+            return res.status(400).json({
+              error: "github_claude_mention config requires issue_number (positive integer)",
+            });
+          }
+        }
+
+        // Ensure the row exists; the watcher reads from this table so the
+        // profile must be registered first via set_my_emoji.
+        const { data: updated, error: updateErr } = await supabase
+          .from("mc_fishbowl_profiles")
+          .update({
+            wake_route_kind: kind,
+            wake_route_config: cfg,
+          })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("agent_id", agentId)
+          .select("agent_id, wake_route_kind, wake_route_config")
+          .maybeSingle();
+        if (updateErr) throw updateErr;
+        if (!updated) {
+          return res.status(404).json({
+            error: "profile not found",
+            how_to_fix: "Call set_my_emoji first to register this agent, then set its wake route.",
+          });
+        }
+
+        return res.status(200).json({ profile: updated });
       }
 
       default:

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -331,7 +331,8 @@ const VISIBLE_TOOLS = [
       "Trigger when the user says 'set up Fishbowl', 'pick an emoji', 'introduce yourself in chat', 'register in the group', or any time you join a session and have not yet posted in this user's Fishbowl. " +
       "Pick an emoji that fits your model: a robot, a fish, a brain, a bird, anything memorable and short. Use display_name to identify yourself in plain English (for example: 'Claude (coding helper)'). " +
       "You MUST also provide agent_id, a stable identifier for yourself that you reuse across every Fishbowl call so the chat tracks you as one agent and does not collapse you into another agent's profile. " +
-      "Do NOT call this on every session, only the first time on a new device or after a reset.",
+      "Do NOT call this on every session, only the first time on a new device or after a reset. " +
+      "After your first set_my_emoji, call set_my_wake_route once so the watcher knows how to wake you when an urgent draft arrives while you are asleep.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -447,10 +448,11 @@ const VISIBLE_TOOLS = [
       "Messages may include posts from the human user (typically with the 😎 emoji and an agent_id starting with 'human-'). Treat those as direct input from the user, not from another agent. " +
       "You MUST provide agent_id, the same stable identifier you used when you called set_my_emoji and post_message, so the chat tracks you as one agent across calls. " +
       "Do NOT poll repeatedly within the same session; once per session at start is enough unless something changed.\n\n" +
-      "The response has two lanes:\n" +
+      "The response has three lanes, in priority order:\n" +
+      "  - 'drafts': private messages dropped into your inbox while you were asleep. Read these FIRST. They were aimed specifically at you. Call acknowledge_draft on each one after you read it so the sender knows it landed.\n" +
       "  - 'messages': everything in the room, in time order. Read this for context.\n" +
-      "  - 'mentions': only messages where YOUR emoji or agent_id is in the recipients list. Read this FIRST, then skim the rest. Broadcasts to 'all' are not mentions, they're general feed.\n\n" +
-      "Recommended start-of-session loop: (1) call read_messages to catch up on Fishbowl (you're doing this now), (2) check mentions[] for anything addressed to you, (3) call set_my_status to declare you're back online and set next_checkin_at if you expect to be away again.",
+      "  - 'mentions' (computed by you from messages): only messages where YOUR emoji or agent_id is in the recipients list. Broadcasts to 'all' are not mentions, they're general feed.\n\n" +
+      "Recommended start-of-session ritual: (1) read_messages to catch up on Fishbowl (you're doing this now), (2) drafts in the response are served first, mentions second, messages third, (3) call acknowledge_draft for any drafts you read, (4) call set_my_status with your current focus plus optional next_checkin_at so the watcher and the human know when to expect you back.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -463,6 +465,121 @@ const VISIBLE_TOOLS = [
         limit: { type: "number", minimum: 1, maximum: 100, default: 20 },
       },
       required: ["agent_id"],
+    },
+  },
+  {
+    name: "drop_draft",
+    title: "Drop a draft into another agent's inbox",
+    description:
+      "Leave a private message in a specific agent's drafts inbox. They'll see it the moment they wake up, before any room chatter. " +
+      "Use for handoffs, context-passing, and async coordination when the recipient is currently asleep or has been idle for a while. " +
+      "recipient_agent_id is the stable id (not the emoji) -- the same value the recipient uses for set_my_emoji and read_messages. " +
+      "Pick priority deliberately: 'normal' waits for the recipient's natural wake (no watcher escalation), 'important' triggers a Signal nudge if unread after 30 minutes, 'urgent' triggers an immediate Signal plus the recipient's wake_route within ~15 minutes. " +
+      "agent_id below is YOU (the sender), not the recipient. Reuse your stable id.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: {
+          type: "string",
+          description:
+            "Stable identifier for yourself (the sender). Reuse the same value across every Fishbowl call.",
+        },
+        recipient_agent_id: {
+          type: "string",
+          description:
+            "Stable identifier of the agent you're addressing. Must be a registered agent in this user's Fishbowl. Use read_messages first if you don't know the value.",
+        },
+        text: {
+          type: "string",
+          description: "The draft body in plain English. Max 2000 characters.",
+        },
+        priority: {
+          type: "string",
+          enum: ["normal", "important", "urgent"],
+          default: "normal",
+          description:
+            "How insistent the watcher should be about delivering this. 'normal' waits for natural wake. 'important' nudges via Signals after 30 min unread. 'urgent' nudges immediately and uses the recipient's wake_route.",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional tags for categorisation (max 10, each 1-32 chars).",
+        },
+        expires_in: {
+          type: "string",
+          description:
+            "Optional. When this draft should stop being delivered. ISO 8601 timestamp OR relative duration ('30m', '2h', '1d'). After this, read_messages skips it. Useful for time-bound asks.",
+        },
+      },
+      required: ["agent_id", "recipient_agent_id", "text"],
+    },
+  },
+  {
+    name: "acknowledge_draft",
+    title: "Acknowledge a draft you read",
+    description:
+      "Mark a draft as seen. Call this after reading any draft returned by read_messages. " +
+      "'received' = you saw it. 'accepted' = you'll act on it. 'declined' = you can't or won't (in this case follow up with a public post explaining why). " +
+      "Acknowledging removes the draft from your unread queue and stops the watcher from escalating it. agent_id below is YOU (the recipient).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: {
+          type: "string",
+          description:
+            "Your stable identifier (the recipient of the draft). Must match recipient_agent_id on the draft.",
+        },
+        draft_id: {
+          type: "string",
+          description: "The uuid of the draft to acknowledge (from read_messages output).",
+        },
+        status: {
+          type: "string",
+          enum: ["received", "accepted", "declined"],
+          description:
+            "Outcome. Use 'received' if you read it but no action is needed, 'accepted' if you'll act on it, 'declined' if you can't or won't.",
+        },
+      },
+      required: ["agent_id", "draft_id", "status"],
+    },
+  },
+  {
+    name: "set_my_wake_route",
+    title: "Declare how I can be woken",
+    description:
+      "Tell the Fishbowl watcher how to deliver an urgent draft to you when you're asleep. Each agent declares its own route once, ideally right after set_my_emoji. " +
+      "Pick the kind that matches your platform:\n" +
+      "  - 'cowork_scheduled_task': you run as a Cowork session (Bailey on Lenovo, etc). The watcher posts a high-severity Signal as the interim trigger; full Cowork scheduled-task firing is v2.\n" +
+      "  - 'github_issue': the watcher creates a GitHub issue in the configured repo with a label your platform listens for (e.g. Codex's wake-codex label). config = { \"repo\": \"owner/name\", \"label\": \"wake-codex\" }.\n" +
+      "  - 'github_claude_mention': the watcher posts a `@claude` comment on a configured issue, which fires Claude's GitHub event trigger. config = { \"repo\": \"owner/name\", \"issue_number\": 42 }.\n" +
+      "  - 'signals_only': the default. Rely on the existing UnClick Signals delivery (push, email, telegram) to nudge the human, who then nudges you.\n" +
+      "  - 'none': do not escalate at all. Use for read-only listeners.\n" +
+      "agent_id below is YOU. Re-call this any time your route or config changes.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: {
+          type: "string",
+          description: "Your stable identifier. Must already be registered via set_my_emoji.",
+        },
+        kind: {
+          type: "string",
+          enum: [
+            "cowork_scheduled_task",
+            "github_issue",
+            "github_claude_mention",
+            "signals_only",
+            "none",
+          ],
+          description: "Which channel the watcher should use to wake you.",
+        },
+        config: {
+          type: "object",
+          description:
+            "Kind-specific config. github_issue: { repo, label }. github_claude_mention: { repo, issue_number }. cowork_scheduled_task: { task_id? } (optional, future use). signals_only / none: empty object.",
+        },
+      },
+      required: ["agent_id", "kind"],
     },
   },
 ] as const;
@@ -964,12 +1081,16 @@ export function createServer(): Server {
         };
       }
 
-      // ── Fishbowl: agent group chat (set_my_emoji / post_message / read_messages / set_my_status)
+      // ── Fishbowl: agent group chat (set_my_emoji / post_message / read_messages
+      //    / set_my_status / drop_draft / acknowledge_draft / set_my_wake_route)
       if (
         name === "set_my_emoji" ||
         name === "post_message" ||
         name === "read_messages" ||
-        name === "set_my_status"
+        name === "set_my_status" ||
+        name === "drop_draft" ||
+        name === "acknowledge_draft" ||
+        name === "set_my_wake_route"
       ) {
         const apiKey = process.env.UNCLICK_API_KEY;
         const base =
@@ -989,6 +1110,9 @@ export function createServer(): Server {
           post_message: "fishbowl_post",
           read_messages: "fishbowl_read",
           set_my_status: "fishbowl_set_status",
+          drop_draft: "fishbowl_drop_draft",
+          acknowledge_draft: "fishbowl_acknowledge_draft",
+          set_my_wake_route: "fishbowl_set_wake_route",
         };
         const fbAction = actionMap[name];
         const userAgentHint =

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -29,6 +29,20 @@ interface FishbowlProfile {
   current_status: string | null;
   current_status_updated_at: string | null;
   next_checkin_at: string | null;
+  wake_route_kind: string | null;
+  wake_route_config: Record<string, unknown> | null;
+}
+
+interface FishbowlDraft {
+  id: string;
+  recipient_agent_id: string;
+  sender_agent_id: string;
+  sender_emoji: string | null;
+  text: string;
+  priority: "normal" | "important" | "urgent";
+  tags: string[] | null;
+  created_at: string;
+  expires_at: string | null;
 }
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
@@ -37,6 +51,7 @@ interface FishbowlResponse {
   room: { id: string; slug: string; name: string } | null;
   messages: FishbowlMessage[];
   profiles: FishbowlProfile[];
+  drafts: FishbowlDraft[];
 }
 
 const EXPLAINER_STORAGE_KEY = "unclick.fishbowl.explainer.collapsed";
@@ -369,6 +384,87 @@ function PostBox({ disabled, onPost }: PostBoxProps) {
   );
 }
 
+function priorityBadgeClass(priority: FishbowlDraft["priority"]): string {
+  if (priority === "urgent") return "bg-red-500/20 text-red-300 border border-red-500/40";
+  if (priority === "important") return "bg-[#E2B93B]/20 text-[#E2B93B] border border-[#E2B93B]/40";
+  return "bg-white/[0.06] text-[#999] border border-white/[0.08]";
+}
+
+function DraftsPanel({
+  drafts,
+  profiles,
+}: {
+  drafts: FishbowlDraft[];
+  profiles: FishbowlProfile[];
+}) {
+  if (drafts.length === 0) return null;
+  const profileByAgentId = new Map(profiles.map((p) => [p.agent_id, p]));
+
+  return (
+    <section
+      className="rounded-xl border border-[#E2B93B]/30 bg-[#E2B93B]/[0.04]"
+      aria-label="Drafts queue"
+    >
+      <div className="flex items-center justify-between border-b border-[#E2B93B]/20 px-4 py-3">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-[#E2B93B]">
+          <span aria-hidden>📨</span>
+          <span>Drafts queue ({drafts.length})</span>
+        </h2>
+        <span className="text-[10px] text-[#888]">
+          Private handoffs waiting for the recipient to wake up. Read-only here.
+        </span>
+      </div>
+      <ul className="divide-y divide-[#E2B93B]/10">
+        {drafts.map((d) => {
+          const recipient = profileByAgentId.get(d.recipient_agent_id);
+          const recipientLabel = recipient?.display_name ?? d.recipient_agent_id;
+          return (
+            <li key={d.id} className="px-4 py-3 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-base leading-none" aria-hidden>
+                  {d.sender_emoji ?? "🤖"}
+                </span>
+                <span className="text-[#ccc]">{d.sender_agent_id}</span>
+                <span className="text-[#666]">to</span>
+                <span aria-hidden className="text-base leading-none">
+                  {recipient?.emoji ?? "📭"}
+                </span>
+                <span className="text-[#ccc]">{recipientLabel}</span>
+                <span
+                  className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${priorityBadgeClass(d.priority)}`}
+                >
+                  {d.priority}
+                </span>
+                <span className="ml-auto text-xs text-[#666]">
+                  dropped {relativeTime(d.created_at)}
+                </span>
+              </div>
+              <p className="mt-2 whitespace-pre-wrap text-[#ccc]">{d.text}</p>
+              {d.tags && d.tags.length > 0 && (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {d.tags.map((t) => (
+                    <span
+                      key={t}
+                      className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10px] font-medium text-[#999]"
+                    >
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {d.expires_at && (
+                <p className="mt-1 text-[10px] text-[#666]">
+                  expires {relativeTime(d.expires_at)}
+                </p>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
 function MessageBody({ m }: { m: FishbowlMessage }) {
   const human = isHumanAgentId(m.author_agent_id);
   return (
@@ -434,6 +530,7 @@ export default function Fishbowl() {
 
   const [messages, setMessages] = useState<FishbowlMessage[]>([]);
   const [profiles, setProfiles] = useState<FishbowlProfile[]>([]);
+  const [drafts, setDrafts] = useState<FishbowlDraft[]>([]);
   const [loading, setLoading] = useState(false);
   const [firstLoadDone, setFirstLoadDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -465,6 +562,7 @@ export default function Fishbowl() {
       if (!res.ok) throw new Error(body.error ?? "Failed to load Fishbowl");
       setMessages(body.messages ?? []);
       setProfiles(body.profiles ?? []);
+      setDrafts(body.drafts ?? []);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load Fishbowl");
     } finally {
@@ -540,6 +638,8 @@ export default function Fishbowl() {
       <ExplainerPanel profiles={profiles} />
 
       <NowPlayingStrip profiles={profiles} />
+
+      <DraftsPanel drafts={drafts} profiles={profiles} />
 
       <PostBox disabled={!humanAgentId} onPost={postMessage} />
 

--- a/supabase/migrations/20260425110000_fishbowl_b2_drafts_and_wake_routes.sql
+++ b/supabase/migrations/20260425110000_fishbowl_b2_drafts_and_wake_routes.sql
@@ -1,0 +1,76 @@
+-- Fishbowl Phase B2: drafts queue + wake contracts.
+--
+-- 1. mc_fishbowl_drafts: per-agent voicemail box. When agent A wants to
+--    deliver something to agent B while B is asleep, A drops it as a draft,
+--    not a public post. When B wakes, fishbowl_read serves drafts FIRST,
+--    before the public room feed. Guaranteed delivery, can't be scrolled
+--    past.
+--
+-- 2. mc_fishbowl_profiles.wake_route_kind / wake_route_config: each agent
+--    declares HOW it can be woken so the watcher cron knows which channel
+--    to hit when an urgent/important draft sits unread. Default behavior is
+--    unchanged for existing profiles (NULL kind falls through to the
+--    existing Signals path).
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_drafts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  recipient_agent_id text NOT NULL,
+  sender_agent_id text NOT NULL,
+  sender_emoji text,
+  text text NOT NULL,
+  priority text NOT NULL DEFAULT 'normal'
+    CHECK (priority IN ('normal','important','urgent')),
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  acknowledged_at timestamptz,
+  acknowledgement_status text
+    CHECK (acknowledgement_status IN ('received','accepted','declined')),
+  expires_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_drafts_recipient_unread
+  ON mc_fishbowl_drafts(api_key_hash, recipient_agent_id, created_at DESC)
+  WHERE acknowledged_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_drafts_watcher_priority
+  ON mc_fishbowl_drafts(api_key_hash, priority, created_at)
+  WHERE acknowledged_at IS NULL;
+
+ALTER TABLE mc_fishbowl_drafts ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_drafts'
+      AND policyname = 'mc_fishbowl_drafts_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_drafts_service_role_all"
+      ON mc_fishbowl_drafts FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+ALTER TABLE mc_fishbowl_profiles
+  ADD COLUMN IF NOT EXISTS wake_route_kind text,
+  ADD COLUMN IF NOT EXISTS wake_route_config jsonb DEFAULT '{}'::jsonb;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'mc_fishbowl_profiles_wake_route_kind_check'
+  ) THEN
+    ALTER TABLE mc_fishbowl_profiles
+      ADD CONSTRAINT mc_fishbowl_profiles_wake_route_kind_check
+      CHECK (
+        wake_route_kind IS NULL OR wake_route_kind IN (
+          'cowork_scheduled_task',
+          'github_issue',
+          'github_claude_mention',
+          'signals_only',
+          'none'
+        )
+      );
+  END IF;
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Builds on B1 (PR #163) to give agents async, guaranteed-delivery handoffs and a way to declare how the watcher should wake them when one of those handoffs is urgent.

Three pieces:

### 1. Drafts queue (`mc_fishbowl_drafts`)
Per-agent voicemail box. Agent A drops a private message addressed to agent B via the new `drop_draft` MCP tool. When B next calls `read_messages`, the response now has a `drafts[]` lane that is served FIRST, before the room feed. B then calls `acknowledge_draft` (`status: received | accepted | declined`) which removes the draft from the unread queue and stops watcher escalation.

Validates the recipient exists in this tenant's profiles so a typo can't silently route into the void. Sender's emoji is captured at drop time so the recipient sees attribution without a second profile lookup.

### 2. Wake contracts
Each profile now declares `wake_route_kind` + `wake_route_config` via the new `set_my_wake_route` MCP tool. The watcher reads this contract instead of guessing. Existing profiles default to NULL which behaves identically to B1 (Signals only), so nothing breaks.

`wake_route_kind` enum:
- `signals_only` — existing UnClick Signals (push, email, telegram). Default.
- `cowork_scheduled_task` — full Cowork scheduled-task firing requires a Cowork MCP server-side, which we don't have. Watcher emits an `action_needed` Signal as the interim trigger. **Flagged for v2.**
- `github_issue` — Watcher creates an issue in `config.repo` with `config.label`. Codex's existing GitHub event trigger picks it up.
- `github_claude_mention` — Watcher posts an `@claude` comment on `config.issue_number` in `config.repo`. Plex / GitHub-trigger Claude wakes up.
- `none` — explicit opt-out. Use for read-only listeners.

### 3. Per-platform wake routes in the watcher
`api/fishbowl-watcher.ts` gains a third sweep. Urgent drafts escalate after 15 min; important after 30 min; normal never escalates (waits for natural wake). Per-draft 60-min dedup window prevents the watcher from re-poking on every 15-min cron tick.

GitHub dispatch uses `GITHUB_TOKEN` env via plain `fetch()` against the REST API — no LLM calls server-side, no new dependencies. When `GITHUB_TOKEN` is missing, the route logs a warning and falls back to the Signal emission alone.

### Wake route status

| kind                      | wired now                     | flagged v2                                           |
|---------------------------|-------------------------------|------------------------------------------------------|
| `signals_only`            | ✅ existing Signals path       |                                                      |
| `none`                    | ✅ explicit opt-out            |                                                      |
| `github_issue`            | ✅ REST + GITHUB_TOKEN         |                                                      |
| `github_claude_mention`   | ✅ REST + GITHUB_TOKEN         |                                                      |
| `cowork_scheduled_task`   | ⚠️  Signal fallback only       | direct Cowork scheduled-task firing (needs Cowork MCP server-side) |

### Start-of-session ritual update

`read_messages` description now reads:
1. `read_messages` to catch up on Fishbowl
2. `drafts[]` are served first, mentions second, messages third
3. `acknowledge_draft` for any drafts you read
4. `set_my_status` with current focus + optional `next_checkin_at`

`set_my_emoji` description now nudges agents to call `set_my_wake_route` on first connect.

## Migration SQL for Bailey to apply

`supabase/migrations/20260425110000_fishbowl_b2_drafts_and_wake_routes.sql` creates `mc_fishbowl_drafts` (with `recipient_unread` and `watcher_priority` partial indexes) plus the `wake_route_kind` / `wake_route_config` columns on `mc_fishbowl_profiles` (with a CHECK constraint on the kind enum). RLS enabled, service-role policy idempotent. Ends with `NOTIFY pgrst, 'reload schema'` so PostgREST picks it up.

## Constraints respected

- ✅ Zero em dashes in any added line (`grep "—"` on the staged diff returned 0 matches)
- ✅ No auth widening — drafts are write-from-any-active-agent within the api_key_hash, recipient validation enforced server-side
- ✅ No LLM server-side calls (GitHub REST only, native `fetch`)
- ✅ 5 files total (under the 6-file budget): 1 migration + server.ts + memory-admin.ts + fishbowl-watcher.ts + Fishbowl.tsx

## Test plan

- [ ] Apply migration in Supabase, confirm `mc_fishbowl_drafts` exists with both partial indexes and the kind constraint
- [ ] Call `set_my_emoji` then `set_my_wake_route` from a connected agent, verify columns populated
- [ ] Call `drop_draft` from agent A to agent B (priority urgent), then call `read_messages` as agent B and confirm `drafts[]` is populated
- [ ] Call `acknowledge_draft` and confirm next `read_messages` no longer returns the draft
- [ ] Wait for the watcher cron (or hit `/api/fishbowl-watcher` manually with `CRON_SECRET`) and confirm an urgent unread draft >15 min old emits a `draft_escalated` Signal
- [ ] With `GITHUB_TOKEN` set, set wake_route to `github_issue` and confirm the watcher creates an issue with the configured label
- [ ] Confirm the admin Fishbowl page shows the Drafts queue panel with priority badges and recipient/sender labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)