### PR TITLE
fix: TestPass admin Unknown action — align frontend action name with backend handler

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5335,7 +5335,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const host = req.headers.host ?? "localhost:3000";
         const proto = host.includes("localhost") ? "http" : "https";
-        const engineRes = await fetch(`${proto}://${host}/api/testpass`, {
+        const engineRes = await fetch(`${proto}://${host}/api/testpass?action=run`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Clicking the **Run TestPass** button on `/admin/testpass/new` returned `Unknown action` (404) for every user.

### Root cause

The action chain has two hops:

1. **Browser → `/api/memory-admin?action=start_testpass_run`** ✅ matches `case "start_testpass_run"` in `api/memory-admin.ts:5285`.
2. **`memory-admin.ts` → `/api/testpass`** ❌ proxied with `action: "run"` *in the JSON body only*.

`api/testpass.ts:343` reads `action` exclusively from `req.query.action`. The body-only action was invisible to the dispatcher, fell through to the default branch (`api/testpass.ts:503`), and returned `"Unknown action"` with status 404. `memory-admin.ts` then forwarded that 404 verbatim back to the browser.

So Chris's report wasn't a frontend/backend action *name* mismatch — it was a body-vs-query *transport* mismatch on the internal hop.

### Fix

One-line change in `api/memory-admin.ts:5338`: append `?action=run` to the proxied URL so the dispatcher matches the `action === "run"` case at `api/testpass.ts:393`. Body kept as-is — handler reads `target_url`, `pack_slug`, etc. from body either way.

Other callers (e.g. `packages/mcp-server/src/testpass-tool.ts`) already pass action via query, so this aligns `memory-admin.ts` with the existing convention.

## Test plan

- [x] `npm run build` green
- [x] `npx tsc --noEmit -p tsconfig.app.json` shows no new errors (pre-existing errors in `ArenaNav.tsx` and `signals/emit.ts` are unchanged)
- [x] No em dashes in diff
- [x] Diff scope: 1 file, +1 / -1 LOC
- [ ] Manual: open `/admin/testpass/new`, pick `testpass-core` or `testpass-fishbowl-v0`, click **Run TestPass** — should kick off a run and navigate to `/admin/testpass/runs/<run_id>` instead of throwing `Unknown action`

🤖 Generated with [Claude Code](https://claude.com/claude-code)