### PR TITLE
feat(fishbowl): Todos kanban + Ideas voting + polymorphic comments

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -389,6 +389,59 @@ async function resolveApiKeyHash(
   }
 }
 
+// ─── Fishbowl event helper ──────────────────────────────────────────────────
+//
+// Posts a system event message into the tenant's default Fishbowl room.
+// Used by the Todos / Ideas handlers to announce material changes
+// (todo-created, idea-promoted, etc.) without each handler duplicating the
+// room-resolve + insert logic. Best-effort: errors are logged, never thrown.
+async function postFishbowlEvent(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+  agentId: string,
+  eventTag: string,
+  text: string,
+): Promise<void> {
+  try {
+    const { data: profile } = await supabase
+      .from("mc_fishbowl_profiles")
+      .select("emoji, display_name")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("agent_id", agentId)
+      .maybeSingle();
+
+    const { data: existingRoom } = await supabase
+      .from("mc_fishbowl_rooms")
+      .select("id")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("slug", "default")
+      .maybeSingle();
+    let roomId = existingRoom?.id as string | undefined;
+    if (!roomId) {
+      const { data: newRoom } = await supabase
+        .from("mc_fishbowl_rooms")
+        .insert({ api_key_hash: apiKeyHash, slug: "default", name: "Fishbowl" })
+        .select("id")
+        .single();
+      roomId = newRoom?.id;
+    }
+    if (!roomId) return;
+
+    await supabase.from("mc_fishbowl_messages").insert({
+      api_key_hash: apiKeyHash,
+      room_id: roomId,
+      author_emoji: profile?.emoji ?? "🤖",
+      author_name: profile?.display_name ?? null,
+      author_agent_id: agentId,
+      recipients: ["all"],
+      text,
+      tags: ["event", eventTag],
+    });
+  } catch (err) {
+    console.error(`[fishbowl postEvent ${eventTag}] failed:`, (err as Error).message);
+  }
+}
+
 // ─── Setup guide content ────────────────────────────────────────────────────
 //
 // Static, client-specific instructions for maximising memory auto-load
@@ -6209,6 +6262,644 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           messages: messages ?? [],
           profiles: profiles ?? [],
         });
+      }
+
+      // ─── Fishbowl Todos + Ideas v1 ────────────────────────────────────────
+      //
+      // All thirteen handlers below share the same shape:
+      //   1. Require POST.
+      //   2. Resolve api_key_hash.
+      //   3. Validate agent_id (<= 128 chars).
+      //   4. Anti-spoof human-* agent_ids (must match a profile with
+      //      user_agent_hint='admin-ui').
+      //   5. Validate inputs.
+      //   6. Mutate or read.
+      //   7. For material changes (todo-created, todo-completed, idea-created,
+      //      idea-promoted), post a tagged event into the Fishbowl feed.
+      //
+      // Tables: mc_fishbowl_todos, mc_fishbowl_ideas, mc_fishbowl_idea_votes,
+      // mc_fishbowl_comments. Service-role-only RLS. See migration
+      // 20260425120000_fishbowl_todos_ideas.sql.
+
+      case "fishbowl_create_todo":
+      case "fishbowl_update_todo":
+      case "fishbowl_complete_todo":
+      case "fishbowl_drop_todo":
+      case "fishbowl_delete_todo":
+      case "fishbowl_list_todos":
+      case "fishbowl_create_idea":
+      case "fishbowl_update_idea":
+      case "fishbowl_vote_on_idea":
+      case "fishbowl_list_ideas":
+      case "fishbowl_promote_idea_to_todo":
+      case "fishbowl_comment_on":
+      case "fishbowl_list_comments": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'.",
+          });
+        }
+        const body = (req.body ?? {}) as Record<string, unknown>;
+
+        const agentId = String(body.agent_id ?? "").trim();
+        if (!agentId) {
+          return res.status(400).json({
+            error: "agent_id required",
+            how_to_fix: "Pass the same stable identifier you used for set_my_emoji so writes attribute to your profile.",
+          });
+        }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        // Anti-spoof on human-<userid>: only allow if a profile exists with
+        // user_agent_hint='admin-ui' for that exact agent_id. AI agents must
+        // pick a non-human identifier.
+        let isAdminCaller = false;
+        if (agentId.startsWith("human-")) {
+          const { data: humanProfile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (humanProfile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({
+              error: "human-* agent_id is reserved for the admin UI",
+              how_to_fix: "AI agents should pick a different agent_id.",
+            });
+          }
+          isAdminCaller = true;
+        }
+
+        const validateTitle = (raw: unknown): string | { error: string } => {
+          const t = typeof raw === "string" ? raw.trim() : "";
+          if (!t) return { error: "title required" };
+          if (t.length > 200) return { error: "title must be at most 200 characters" };
+          return t;
+        };
+        const validateDescription = (raw: unknown): string | null | { error: string } => {
+          if (raw == null || raw === "") return null;
+          if (typeof raw !== "string") return { error: "description must be a string" };
+          if (raw.length > 4000) return { error: "description must be at most 4000 characters" };
+          return raw;
+        };
+        const validateUuid = (raw: unknown, field: string): string | { error: string } => {
+          const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+          const t = typeof raw === "string" ? raw.trim() : "";
+          if (!t) return { error: `${field} required` };
+          if (!UUID_RE.test(t)) return { error: `${field} must be a uuid` };
+          return t;
+        };
+
+        // ── Todos ──────────────────────────────────────────────────────────
+
+        if (action === "fishbowl_create_todo") {
+          const titleRes = validateTitle(body.title);
+          if (typeof titleRes !== "string") return res.status(400).json(titleRes);
+          const descRes = validateDescription(body.description);
+          if (descRes && typeof descRes === "object") return res.status(400).json(descRes);
+
+          const priority = String(body.priority ?? "normal");
+          if (!["low", "normal", "high", "urgent"].includes(priority)) {
+            return res.status(400).json({ error: "priority must be low|normal|high|urgent" });
+          }
+
+          let assignee: string | null = null;
+          if (body.assigned_to_agent_id != null && body.assigned_to_agent_id !== "") {
+            const a = String(body.assigned_to_agent_id).trim();
+            if (a.length > 128) return res.status(400).json({ error: "assigned_to_agent_id must be at most 128 characters" });
+            assignee = a;
+          }
+
+          const { data, error } = await supabase
+            .from("mc_fishbowl_todos")
+            .insert({
+              api_key_hash: apiKeyHash,
+              title: titleRes,
+              description: descRes,
+              priority,
+              status: "open",
+              created_by_agent_id: agentId,
+              assigned_to_agent_id: assignee,
+            })
+            .select("*")
+            .single();
+          if (error) throw error;
+
+          void postFishbowlEvent(
+            supabase,
+            apiKeyHash,
+            agentId,
+            "todo-created",
+            `New todo: ${titleRes}`,
+          );
+          return res.status(200).json({ todo: data });
+        }
+
+        if (action === "fishbowl_update_todo") {
+          const idRes = validateUuid(body.todo_id, "todo_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+
+          const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+          if (body.title != null) {
+            const titleRes = validateTitle(body.title);
+            if (typeof titleRes !== "string") return res.status(400).json(titleRes);
+            update.title = titleRes;
+          }
+          if (body.description !== undefined) {
+            const descRes = validateDescription(body.description);
+            if (descRes && typeof descRes === "object") return res.status(400).json(descRes);
+            update.description = descRes;
+          }
+          if (body.status != null) {
+            const s = String(body.status);
+            if (!["open", "in_progress", "done", "dropped"].includes(s)) {
+              return res.status(400).json({ error: "status must be open|in_progress|done|dropped" });
+            }
+            update.status = s;
+            if (s === "done") update.completed_at = new Date().toISOString();
+          }
+          if (body.priority != null) {
+            const p = String(body.priority);
+            if (!["low", "normal", "high", "urgent"].includes(p)) {
+              return res.status(400).json({ error: "priority must be low|normal|high|urgent" });
+            }
+            update.priority = p;
+          }
+          if (body.assigned_to_agent_id !== undefined) {
+            const a = String(body.assigned_to_agent_id ?? "").trim();
+            if (a.length > 128) return res.status(400).json({ error: "assigned_to_agent_id must be at most 128 characters" });
+            update.assigned_to_agent_id = a.length === 0 ? null : a;
+          }
+
+          const { data, error } = await supabase
+            .from("mc_fishbowl_todos")
+            .update(update)
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .select("*")
+            .maybeSingle();
+          if (error) throw error;
+          if (!data) return res.status(404).json({ error: "todo not found" });
+          return res.status(200).json({ todo: data });
+        }
+
+        if (action === "fishbowl_complete_todo") {
+          const idRes = validateUuid(body.todo_id, "todo_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const nowIso = new Date().toISOString();
+          const { data, error } = await supabase
+            .from("mc_fishbowl_todos")
+            .update({ status: "done", completed_at: nowIso, updated_at: nowIso })
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .select("*")
+            .maybeSingle();
+          if (error) throw error;
+          if (!data) return res.status(404).json({ error: "todo not found" });
+
+          void postFishbowlEvent(
+            supabase,
+            apiKeyHash,
+            agentId,
+            "todo-completed",
+            `Todo done: ${data.title}`,
+          );
+          return res.status(200).json({ todo: data });
+        }
+
+        if (action === "fishbowl_drop_todo") {
+          const idRes = validateUuid(body.todo_id, "todo_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const { data, error } = await supabase
+            .from("mc_fishbowl_todos")
+            .update({ status: "dropped", updated_at: new Date().toISOString() })
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .select("*")
+            .maybeSingle();
+          if (error) throw error;
+          if (!data) return res.status(404).json({ error: "todo not found" });
+          return res.status(200).json({ todo: data });
+        }
+
+        if (action === "fishbowl_delete_todo") {
+          const idRes = validateUuid(body.todo_id, "todo_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+          // Cascade comments manually since target_id is polymorphic (no FK).
+          await supabase
+            .from("mc_fishbowl_comments")
+            .delete()
+            .eq("api_key_hash", apiKeyHash)
+            .eq("target_kind", "todo")
+            .eq("target_id", idRes);
+          const { data, error } = await supabase
+            .from("mc_fishbowl_todos")
+            .delete()
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .select("id")
+            .maybeSingle();
+          if (error) throw error;
+          if (!data) return res.status(404).json({ error: "todo not found" });
+          return res.status(200).json({ deleted: true, id: idRes });
+        }
+
+        if (action === "fishbowl_list_todos") {
+          const limit = Math.min(Math.max(Number(body.limit ?? 50) || 50, 1), 200);
+          let q = supabase
+            .from("mc_fishbowl_todos")
+            .select("*")
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(limit);
+          if (body.status != null) {
+            const s = String(body.status);
+            if (!["open", "in_progress", "done", "dropped"].includes(s)) {
+              return res.status(400).json({ error: "status filter must be open|in_progress|done|dropped" });
+            }
+            q = q.eq("status", s);
+          }
+          if (body.assigned_to_agent_id != null) {
+            const a = String(body.assigned_to_agent_id);
+            q = q.eq("assigned_to_agent_id", a);
+          }
+          const { data, error } = await q;
+          if (error) throw error;
+
+          // Decorate with comment_count for the kanban cards.
+          const todos = data ?? [];
+          let countMap: Record<string, number> = {};
+          if (todos.length > 0) {
+            const ids = todos.map((t) => t.id);
+            const { data: comments } = await supabase
+              .from("mc_fishbowl_comments")
+              .select("target_id")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("target_kind", "todo")
+              .in("target_id", ids);
+            countMap = (comments ?? []).reduce<Record<string, number>>((acc, c) => {
+              const k = c.target_id as string;
+              acc[k] = (acc[k] ?? 0) + 1;
+              return acc;
+            }, {});
+          }
+          const decorated = todos.map((t) => ({ ...t, comment_count: countMap[t.id as string] ?? 0 }));
+          return res.status(200).json({ todos: decorated });
+        }
+
+        // ── Ideas ──────────────────────────────────────────────────────────
+
+        if (action === "fishbowl_create_idea") {
+          const titleRes = validateTitle(body.title);
+          if (typeof titleRes !== "string") return res.status(400).json(titleRes);
+          const descRes = validateDescription(body.description);
+          if (descRes && typeof descRes === "object") return res.status(400).json(descRes);
+
+          const { data, error } = await supabase
+            .from("mc_fishbowl_ideas")
+            .insert({
+              api_key_hash: apiKeyHash,
+              title: titleRes,
+              description: descRes,
+              status: "proposed",
+              created_by_agent_id: agentId,
+            })
+            .select("*")
+            .single();
+          if (error) throw error;
+
+          void postFishbowlEvent(
+            supabase,
+            apiKeyHash,
+            agentId,
+            "idea-created",
+            `New idea: ${titleRes}`,
+          );
+          return res.status(200).json({ idea: data });
+        }
+
+        if (action === "fishbowl_update_idea") {
+          const idRes = validateUuid(body.idea_id, "idea_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+          if (body.title != null) {
+            const titleRes = validateTitle(body.title);
+            if (typeof titleRes !== "string") return res.status(400).json(titleRes);
+            update.title = titleRes;
+          }
+          if (body.description !== undefined) {
+            const descRes = validateDescription(body.description);
+            if (descRes && typeof descRes === "object") return res.status(400).json(descRes);
+            update.description = descRes;
+          }
+          if (body.status != null) {
+            const s = String(body.status);
+            if (!["proposed", "voting", "locked", "parked", "rejected"].includes(s)) {
+              return res.status(400).json({ error: "status must be proposed|voting|locked|parked|rejected" });
+            }
+            update.status = s;
+          }
+          const { data, error } = await supabase
+            .from("mc_fishbowl_ideas")
+            .update(update)
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .select("*")
+            .maybeSingle();
+          if (error) throw error;
+          if (!data) return res.status(404).json({ error: "idea not found" });
+          return res.status(200).json({ idea: data });
+        }
+
+        if (action === "fishbowl_vote_on_idea") {
+          const idRes = validateUuid(body.idea_id, "idea_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const vote = String(body.vote ?? "");
+          if (vote !== "up" && vote !== "down") {
+            return res.status(400).json({ error: "vote must be 'up' or 'down'" });
+          }
+
+          // Verify the idea exists in this tenant.
+          const { data: existing } = await supabase
+            .from("mc_fishbowl_ideas")
+            .select("id, upvotes, downvotes")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .maybeSingle();
+          if (!existing) return res.status(404).json({ error: "idea not found" });
+
+          // What was the previous vote, if any? Needed to adjust counters.
+          const { data: prior } = await supabase
+            .from("mc_fishbowl_idea_votes")
+            .select("vote")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("idea_id", idRes)
+            .eq("voter_agent_id", agentId)
+            .maybeSingle();
+
+          const { error: voteErr } = await supabase
+            .from("mc_fishbowl_idea_votes")
+            .upsert(
+              {
+                api_key_hash: apiKeyHash,
+                idea_id: idRes,
+                voter_agent_id: agentId,
+                vote,
+                created_at: new Date().toISOString(),
+              },
+              { onConflict: "api_key_hash,idea_id,voter_agent_id" },
+            );
+          if (voteErr) throw voteErr;
+
+          // Recompute aggregate counters from the source of truth (the votes
+          // table). Cheaper to derive than to keep deltas in sync, and avoids
+          // skew if a vote ever lands twice.
+          const { data: voteRows, error: aggErr } = await supabase
+            .from("mc_fishbowl_idea_votes")
+            .select("vote")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("idea_id", idRes);
+          if (aggErr) throw aggErr;
+          let up = 0;
+          let down = 0;
+          for (const row of voteRows ?? []) {
+            if (row.vote === "up") up++;
+            else if (row.vote === "down") down++;
+          }
+          const { data: updated, error: updErr } = await supabase
+            .from("mc_fishbowl_ideas")
+            .update({ upvotes: up, downvotes: down, updated_at: new Date().toISOString() })
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .select("*")
+            .maybeSingle();
+          if (updErr) throw updErr;
+
+          // Rate-limited vote event: only post if the most recent
+          // 'idea-voted' message for this idea is older than 5 minutes.
+          // Keeps the feed quiet during a flurry.
+          const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
+          const { data: recentVoteEvents } = await supabase
+            .from("mc_fishbowl_messages")
+            .select("id, created_at, text")
+            .eq("api_key_hash", apiKeyHash)
+            .contains("tags", ["event", "idea-voted"])
+            .gte("created_at", fiveMinAgo)
+            .ilike("text", `%${idRes}%`)
+            .limit(1);
+          if (!recentVoteEvents || recentVoteEvents.length === 0) {
+            void postFishbowlEvent(
+              supabase,
+              apiKeyHash,
+              agentId,
+              "idea-voted",
+              `Vote on idea ${idRes}: ${up} up, ${down} down`,
+            );
+          }
+
+          return res.status(200).json({
+            idea: updated,
+            previous_vote: prior?.vote ?? null,
+          });
+        }
+
+        if (action === "fishbowl_list_ideas") {
+          const limit = Math.min(Math.max(Number(body.limit ?? 50) || 50, 1), 200);
+          let q = supabase
+            .from("mc_fishbowl_ideas")
+            .select("*")
+            .eq("api_key_hash", apiKeyHash)
+            .order("score", { ascending: false })
+            .order("created_at", { ascending: false })
+            .limit(limit);
+          if (body.status != null) {
+            const s = String(body.status);
+            if (!["proposed", "voting", "locked", "parked", "rejected"].includes(s)) {
+              return res.status(400).json({ error: "status filter invalid" });
+            }
+            q = q.eq("status", s);
+          }
+          const { data, error } = await q;
+          if (error) throw error;
+          const ideas = data ?? [];
+
+          // Decorate with the caller's own vote and comment_count so the UI
+          // can render highlighted vote buttons and a comment badge.
+          let myVoteMap: Record<string, "up" | "down"> = {};
+          let countMap: Record<string, number> = {};
+          if (ideas.length > 0) {
+            const ids = ideas.map((i) => i.id);
+            const [{ data: myVotes }, { data: comments }] = await Promise.all([
+              supabase
+                .from("mc_fishbowl_idea_votes")
+                .select("idea_id, vote")
+                .eq("api_key_hash", apiKeyHash)
+                .eq("voter_agent_id", agentId)
+                .in("idea_id", ids),
+              supabase
+                .from("mc_fishbowl_comments")
+                .select("target_id")
+                .eq("api_key_hash", apiKeyHash)
+                .eq("target_kind", "idea")
+                .in("target_id", ids),
+            ]);
+            myVoteMap = (myVotes ?? []).reduce<Record<string, "up" | "down">>((acc, v) => {
+              acc[v.idea_id as string] = v.vote as "up" | "down";
+              return acc;
+            }, {});
+            countMap = (comments ?? []).reduce<Record<string, number>>((acc, c) => {
+              const k = c.target_id as string;
+              acc[k] = (acc[k] ?? 0) + 1;
+              return acc;
+            }, {});
+          }
+          const decorated = ideas.map((i) => ({
+            ...i,
+            my_vote: myVoteMap[i.id as string] ?? null,
+            comment_count: countMap[i.id as string] ?? 0,
+          }));
+          return res.status(200).json({ ideas: decorated });
+        }
+
+        if (action === "fishbowl_promote_idea_to_todo") {
+          const idRes = validateUuid(body.idea_id, "idea_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+
+          const { data: idea } = await supabase
+            .from("mc_fishbowl_ideas")
+            .select("*")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .maybeSingle();
+          if (!idea) return res.status(404).json({ error: "idea not found" });
+          if (idea.promoted_to_todo_id) {
+            return res.status(409).json({
+              error: "idea already promoted",
+              promoted_to_todo_id: idea.promoted_to_todo_id,
+            });
+          }
+
+          const netUp = (idea.upvotes ?? 0) - (idea.downvotes ?? 0);
+          if (!isAdminCaller && netUp < 1) {
+            return res.status(403).json({
+              error: "idea needs net upvotes >= 1 (or admin caller) to promote",
+              how_to_fix: "Vote it up first, or have the human admin promote it from the Fishbowl admin UI.",
+            });
+          }
+
+          const priority = String(body.priority ?? "normal");
+          if (!["low", "normal", "high", "urgent"].includes(priority)) {
+            return res.status(400).json({ error: "priority must be low|normal|high|urgent" });
+          }
+          let assignee: string | null = null;
+          if (body.assigned_to_agent_id != null && body.assigned_to_agent_id !== "") {
+            const a = String(body.assigned_to_agent_id).trim();
+            if (a.length > 128) return res.status(400).json({ error: "assigned_to_agent_id must be at most 128 characters" });
+            assignee = a;
+          }
+
+          const { data: newTodo, error: todoErr } = await supabase
+            .from("mc_fishbowl_todos")
+            .insert({
+              api_key_hash: apiKeyHash,
+              title: idea.title,
+              description: idea.description,
+              status: "open",
+              priority,
+              created_by_agent_id: agentId,
+              assigned_to_agent_id: assignee,
+              source_idea_id: idea.id,
+            })
+            .select("*")
+            .single();
+          if (todoErr) throw todoErr;
+
+          const { data: lockedIdea, error: ideaErr } = await supabase
+            .from("mc_fishbowl_ideas")
+            .update({
+              status: "locked",
+              promoted_to_todo_id: newTodo.id,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idea.id)
+            .select("*")
+            .single();
+          if (ideaErr) throw ideaErr;
+
+          void postFishbowlEvent(
+            supabase,
+            apiKeyHash,
+            agentId,
+            "idea-promoted",
+            `Idea promoted to todo: ${idea.title}`,
+          );
+          return res.status(200).json({ todo: newTodo, idea: lockedIdea });
+        }
+
+        // ── Comments (polymorphic) ─────────────────────────────────────────
+
+        if (action === "fishbowl_comment_on") {
+          const targetKind = String(body.target_kind ?? "");
+          if (targetKind !== "todo" && targetKind !== "idea") {
+            return res.status(400).json({ error: "target_kind must be 'todo' or 'idea'" });
+          }
+          const idRes = validateUuid(body.target_id, "target_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const text = typeof body.text === "string" ? body.text.trim() : "";
+          if (!text) return res.status(400).json({ error: "text required" });
+          if (text.length > 4000) return res.status(400).json({ error: "text must be at most 4000 characters" });
+
+          // Verify the target exists in this tenant before letting an orphan
+          // comment land.
+          const targetTable = targetKind === "todo" ? "mc_fishbowl_todos" : "mc_fishbowl_ideas";
+          const { data: target } = await supabase
+            .from(targetTable)
+            .select("id")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .maybeSingle();
+          if (!target) return res.status(404).json({ error: `${targetKind} not found` });
+
+          const { data, error } = await supabase
+            .from("mc_fishbowl_comments")
+            .insert({
+              api_key_hash: apiKeyHash,
+              target_kind: targetKind,
+              target_id: idRes,
+              author_agent_id: agentId,
+              text,
+            })
+            .select("*")
+            .single();
+          if (error) throw error;
+          return res.status(200).json({ comment: data });
+        }
+
+        if (action === "fishbowl_list_comments") {
+          const targetKind = String(body.target_kind ?? "");
+          if (targetKind !== "todo" && targetKind !== "idea") {
+            return res.status(400).json({ error: "target_kind must be 'todo' or 'idea'" });
+          }
+          const idRes = validateUuid(body.target_id, "target_id");
+          if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const limit = Math.min(Math.max(Number(body.limit ?? 100) || 100, 1), 200);
+          const { data, error } = await supabase
+            .from("mc_fishbowl_comments")
+            .select("*")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("target_kind", targetKind)
+            .eq("target_id", idRes)
+            .order("created_at", { ascending: true })
+            .limit(limit);
+          if (error) throw error;
+          return res.status(200).json({ comments: data ?? [] });
+        }
+
+        return res.status(400).json({ error: `Unhandled fishbowl action: ${action}` });
       }
 
       default:

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -437,6 +437,213 @@ const VISIBLE_TOOLS = [
     },
   },
   {
+    name: "create_todo",
+    title: "Create a Fishbowl todo",
+    description:
+      "Creates a new todo card on the Fishbowl Todos kanban so the agent pack and the human can both see what's on deck. " +
+      "Use when you decide an action item needs tracking beyond a single message: a follow-up task, a chore, a deliverable. " +
+      "Provide agent_id (yours), a short title, and optional description, priority, and assignee. " +
+      "Posts a 'todo-created' Fishbowl event so other agents notice without polling.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for the calling agent. Same value as set_my_emoji." },
+        title: { type: "string", description: "Short title (max 200 chars)" },
+        description: { type: "string", description: "Optional longer description (max 4000 chars)" },
+        priority: { type: "string", enum: ["low", "normal", "high", "urgent"], default: "normal" },
+        assigned_to_agent_id: { type: "string", description: "Optional agent_id of the agent who should own this todo" },
+      },
+      required: ["agent_id", "title"],
+    },
+  },
+  {
+    name: "update_todo",
+    title: "Update a Fishbowl todo",
+    description:
+      "Update a todo's title, description, priority, status, or assignee. Use when scope changes, ownership shifts, or you move it between kanban columns ('open', 'in_progress', 'done', 'dropped'). agent_id required for attribution.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for the calling agent." },
+        todo_id: { type: "string", description: "UUID of the todo to update" },
+        title: { type: "string" },
+        description: { type: "string" },
+        status: { type: "string", enum: ["open", "in_progress", "done", "dropped"] },
+        priority: { type: "string", enum: ["low", "normal", "high", "urgent"] },
+        assigned_to_agent_id: { type: "string", description: "Pass empty string to unassign" },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "complete_todo",
+    title: "Mark a Fishbowl todo done",
+    description:
+      "Shortcut for marking a todo as done. Sets status='done' and stamps completed_at. Posts a 'todo-completed' Fishbowl event. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        todo_id: { type: "string" },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "drop_todo",
+    title: "Drop a Fishbowl todo",
+    description:
+      "Marks a todo as dropped (decided not to do it). Soft state, not a delete. Use when a todo is obsolete but the history still matters. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        todo_id: { type: "string" },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "delete_todo",
+    title: "Delete a Fishbowl todo",
+    description:
+      "Hard-deletes a todo and any comments on it. Use sparingly: prefer drop_todo so history is preserved. agent_id required for the audit log.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        todo_id: { type: "string" },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "list_todos",
+    title: "List Fishbowl todos",
+    description:
+      "Returns todos for this tenant, optionally filtered by status. Use to render a kanban view, find your assignments, or pick the next thing to work on. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        status: { type: "string", enum: ["open", "in_progress", "done", "dropped"], description: "Optional filter" },
+        assigned_to_agent_id: { type: "string", description: "Optional filter to a specific assignee" },
+        limit: { type: "number", minimum: 1, maximum: 200, default: 50 },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "create_idea",
+    title: "Propose a Fishbowl idea",
+    description:
+      "Drops a new idea into the Fishbowl Ideas board so the pack can react and vote. Use when something is too speculative for a todo but worth capturing. agent_id required. Posts an 'idea-created' Fishbowl event.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        title: { type: "string", description: "Short title (max 200 chars)" },
+        description: { type: "string", description: "Optional longer description (max 4000 chars)" },
+      },
+      required: ["agent_id", "title"],
+    },
+  },
+  {
+    name: "update_idea",
+    title: "Update a Fishbowl idea",
+    description:
+      "Edit an idea's title, description, or status ('proposed', 'voting', 'locked', 'parked', 'rejected'). agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        idea_id: { type: "string" },
+        title: { type: "string" },
+        description: { type: "string" },
+        status: { type: "string", enum: ["proposed", "voting", "locked", "parked", "rejected"] },
+      },
+      required: ["agent_id", "idea_id"],
+    },
+  },
+  {
+    name: "vote_on_idea",
+    title: "Vote on a Fishbowl idea",
+    description:
+      "Cast or change your vote on an idea ('up' or 'down'). One vote per agent per idea; calling again overwrites your previous vote. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        idea_id: { type: "string" },
+        vote: { type: "string", enum: ["up", "down"] },
+      },
+      required: ["agent_id", "idea_id", "vote"],
+    },
+  },
+  {
+    name: "list_ideas",
+    title: "List Fishbowl ideas",
+    description:
+      "Returns ideas for this tenant sorted by score (upvotes minus downvotes) desc, optionally filtered by status. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        status: { type: "string", enum: ["proposed", "voting", "locked", "parked", "rejected"] },
+        limit: { type: "number", minimum: 1, maximum: 200, default: 50 },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "promote_idea_to_todo",
+    title: "Promote an idea to a todo",
+    description:
+      "Converts an idea into a tracked todo and locks the idea. Requires either net upvotes >= 1, or admin caller. Sets idea.status='locked' and idea.promoted_to_todo_id. Posts an 'idea-promoted' Fishbowl event. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        idea_id: { type: "string" },
+        priority: { type: "string", enum: ["low", "normal", "high", "urgent"], default: "normal" },
+        assigned_to_agent_id: { type: "string" },
+      },
+      required: ["agent_id", "idea_id"],
+    },
+  },
+  {
+    name: "comment_on",
+    title: "Comment on a todo or idea",
+    description:
+      "Adds a comment to a Fishbowl todo or idea. Use for discussion that belongs scoped to that item rather than as a top-level Fishbowl message. target_kind is 'todo' or 'idea'. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        target_kind: { type: "string", enum: ["todo", "idea"] },
+        target_id: { type: "string" },
+        text: { type: "string", description: "Comment body (max 4000 chars)" },
+      },
+      required: ["agent_id", "target_kind", "target_id", "text"],
+    },
+  },
+  {
+    name: "list_comments",
+    title: "List comments on a todo or idea",
+    description:
+      "Returns comments on a specific Fishbowl todo or idea, in chronological order. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string" },
+        target_kind: { type: "string", enum: ["todo", "idea"] },
+        target_id: { type: "string" },
+        limit: { type: "number", minimum: 1, maximum: 200, default: 100 },
+      },
+      required: ["agent_id", "target_kind", "target_id"],
+    },
+  },
+  {
     name: "read_messages",
     title: "Read the Fishbowl",
     description:
@@ -964,13 +1171,30 @@ export function createServer(): Server {
         };
       }
 
-      // ── Fishbowl: agent group chat (set_my_emoji / post_message / read_messages / set_my_status)
-      if (
-        name === "set_my_emoji" ||
-        name === "post_message" ||
-        name === "read_messages" ||
-        name === "set_my_status"
-      ) {
+      // ── Fishbowl: agent group chat + todos + ideas + comments.
+      // All routes go through /api/memory-admin?action=<fishbowl_*> so the
+      // backend stays the single source of truth for validation, anti-spoof,
+      // and side effects (event posts, score updates).
+      const FISHBOWL_TOOL_ACTIONS: Record<string, string> = {
+        set_my_emoji: "fishbowl_set_emoji",
+        post_message: "fishbowl_post",
+        read_messages: "fishbowl_read",
+        set_my_status: "fishbowl_set_status",
+        create_todo: "fishbowl_create_todo",
+        update_todo: "fishbowl_update_todo",
+        complete_todo: "fishbowl_complete_todo",
+        drop_todo: "fishbowl_drop_todo",
+        delete_todo: "fishbowl_delete_todo",
+        list_todos: "fishbowl_list_todos",
+        create_idea: "fishbowl_create_idea",
+        update_idea: "fishbowl_update_idea",
+        vote_on_idea: "fishbowl_vote_on_idea",
+        list_ideas: "fishbowl_list_ideas",
+        promote_idea_to_todo: "fishbowl_promote_idea_to_todo",
+        comment_on: "fishbowl_comment_on",
+        list_comments: "fishbowl_list_comments",
+      };
+      if (FISHBOWL_TOOL_ACTIONS[name]) {
         const apiKey = process.env.UNCLICK_API_KEY;
         const base =
           process.env.UNCLICK_MEMORY_BASE_URL ||
@@ -984,13 +1208,7 @@ export function createServer(): Server {
             isError: true,
           };
         }
-        const actionMap: Record<string, string> = {
-          set_my_emoji: "fishbowl_set_emoji",
-          post_message: "fishbowl_post",
-          read_messages: "fishbowl_read",
-          set_my_status: "fishbowl_set_status",
-        };
-        const fbAction = actionMap[name];
+        const fbAction = FISHBOWL_TOOL_ACTIONS[name];
         const userAgentHint =
           (args.user_agent_hint as string | undefined) ||
           process.env.UNCLICK_CLIENT_USER_AGENT ||

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Loader2, Send } from "lucide-react";
 import { useSession } from "@/lib/auth";
+import FishbowlTodos from "./fishbowl/Todos";
+import FishbowlIdeas from "./fishbowl/Ideas";
 
 interface FishbowlMessage {
   id: string;
@@ -540,6 +542,10 @@ export default function Fishbowl() {
       <ExplainerPanel profiles={profiles} />
 
       <NowPlayingStrip profiles={profiles} />
+
+      <FishbowlTodos authHeader={authHeader} humanAgentId={humanAgentId} />
+
+      <FishbowlIdeas authHeader={authHeader} humanAgentId={humanAgentId} />
 
       <PostBox disabled={!humanAgentId} onPost={postMessage} />
 

--- a/src/pages/admin/fishbowl/Comments.tsx
+++ b/src/pages/admin/fishbowl/Comments.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+interface Comment {
+  id: string;
+  target_kind: "todo" | "idea";
+  target_id: string;
+  author_agent_id: string;
+  text: string;
+  created_at: string;
+}
+
+interface CommentsProps {
+  authHeader: Record<string, string>;
+  humanAgentId: string | null;
+  targetKind: "todo" | "idea";
+  targetId: string;
+  pollSeq: number;
+}
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.max(1, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export default function Comments({
+  authHeader,
+  humanAgentId,
+  targetKind,
+  targetId,
+  pollSeq,
+}: CommentsProps) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchComments = useCallback(async () => {
+    if (!humanAgentId) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_list_comments", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_id: humanAgentId,
+          target_kind: targetKind,
+          target_id: targetId,
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { comments?: Comment[]; error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to load comments");
+      setComments(body.comments ?? []);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [authHeader, humanAgentId, targetKind, targetId]);
+
+  useEffect(() => {
+    void fetchComments();
+  }, [fetchComments, pollSeq]);
+
+  const submit = async () => {
+    const trimmed = text.trim();
+    if (!humanAgentId || !trimmed || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_comment_on", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_id: humanAgentId,
+          target_kind: targetKind,
+          target_id: targetId,
+          text: trimmed,
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to comment");
+      setText("");
+      await fetchComments();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to comment");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-[#888]">
+          Comments {comments.length > 0 && <span className="text-[#666]">({comments.length})</span>}
+        </h4>
+        {loading && <Loader2 className="h-3 w-3 animate-spin text-[#888]" />}
+      </div>
+
+      {comments.length > 0 && (
+        <ul className="space-y-2">
+          {comments.map((c) => (
+            <li
+              key={c.id}
+              className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-xs"
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-medium text-[#ccc]">{c.author_agent_id}</span>
+                <span className="text-[10px] text-[#666]">{relativeTime(c.created_at)}</span>
+              </div>
+              <p className="mt-1 whitespace-pre-wrap text-[#ccc]">{c.text}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={humanAgentId ? "Add a comment..." : "Setting up profile..."}
+          rows={2}
+          disabled={!humanAgentId || submitting}
+          className="w-full resize-y rounded-md border border-white/[0.08] bg-black/20 px-3 py-2 text-xs text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none disabled:opacity-50"
+        />
+        <div className="flex items-center justify-between gap-2">
+          {error ? (
+            <p className="text-xs text-red-300">{error}</p>
+          ) : (
+            <span className="text-[10px] text-[#666]">{text.trim().length} / 4000</span>
+          )}
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!humanAgentId || submitting || text.trim().length === 0}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {submitting ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+            Post
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/fishbowl/Ideas.tsx
+++ b/src/pages/admin/fishbowl/Ideas.tsx
@@ -1,0 +1,430 @@
+import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, ChevronRight, Loader2, Plus, ThumbsDown, ThumbsUp } from "lucide-react";
+import Comments from "./Comments";
+
+interface Idea {
+  id: string;
+  title: string;
+  description: string | null;
+  status: "proposed" | "voting" | "locked" | "parked" | "rejected";
+  upvotes: number;
+  downvotes: number;
+  score: number;
+  created_by_agent_id: string;
+  promoted_to_todo_id: string | null;
+  created_at: string;
+  updated_at: string;
+  my_vote?: "up" | "down" | null;
+  comment_count?: number;
+}
+
+interface IdeasProps {
+  authHeader: Record<string, string>;
+  humanAgentId: string | null;
+}
+
+const STORAGE_KEY = "unclick.fishbowl.ideas.collapsed";
+
+const STATUS_STYLE: Record<Idea["status"], string> = {
+  proposed: "bg-white/[0.05] text-[#aaa]",
+  voting: "bg-[#E2B93B]/15 text-[#E2B93B]",
+  locked: "bg-green-400/15 text-green-300",
+  parked: "bg-[#333]/40 text-[#888]",
+  rejected: "bg-red-500/15 text-red-300",
+};
+
+function statusPill(s: Idea["status"]) {
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${STATUS_STYLE[s]}`}
+    >
+      {s}
+    </span>
+  );
+}
+
+function AddIdeaForm({
+  authHeader,
+  humanAgentId,
+  onCreated,
+}: {
+  authHeader: Record<string, string>;
+  humanAgentId: string | null;
+  onCreated: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!humanAgentId) return;
+    const t = title.trim();
+    if (!t) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_create_idea", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_id: humanAgentId,
+          title: t,
+          description: description.trim() || null,
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to create idea");
+      setTitle("");
+      setDescription("");
+      setOpen(false);
+      onCreated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={!humanAgentId}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1.5 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:opacity-40"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Propose idea
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-lg border border-white/[0.08] bg-black/20 p-3">
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Short title"
+        maxLength={200}
+        className="w-full rounded-md border border-white/[0.08] bg-black/30 px-2 py-1.5 text-sm text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Why this idea? Optional but helpful."
+        rows={3}
+        maxLength={4000}
+        className="w-full resize-y rounded-md border border-white/[0.08] bg-black/30 px-2 py-1.5 text-xs text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      <div className="flex items-center justify-end gap-2">
+        {error && <span className="text-xs text-red-300">{error}</span>}
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="rounded-md border border-white/[0.08] px-2 py-1 text-xs text-[#888] hover:bg-white/[0.05]"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitting || title.trim().length === 0}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:opacity-40"
+        >
+          {submitting && <Loader2 className="h-3 w-3 animate-spin" />}
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function IdeaRow({
+  idea,
+  expanded,
+  onToggle,
+  authHeader,
+  humanAgentId,
+  pollSeq,
+  onMutated,
+}: {
+  idea: Idea;
+  expanded: boolean;
+  onToggle: () => void;
+  authHeader: Record<string, string>;
+  humanAgentId: string | null;
+  pollSeq: number;
+  onMutated: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const callAction = async (action: string, payload: Record<string, unknown>) => {
+    if (!humanAgentId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/memory-admin?action=${action}`, {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: humanAgentId, ...payload }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Action failed");
+      onMutated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Action failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const truncatedDesc =
+    idea.description && idea.description.length > 120
+      ? `${idea.description.slice(0, 117)}...`
+      : idea.description;
+
+  const isLocked = idea.status === "locked";
+
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-black/30 p-3">
+      <div className="flex items-start gap-3">
+        <div className="flex flex-col items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() => callAction("fishbowl_vote_on_idea", { idea_id: idea.id, vote: "up" })}
+            disabled={busy || isLocked}
+            className={`rounded p-1 transition ${idea.my_vote === "up" ? "bg-green-400/20 text-green-300" : "text-[#888] hover:bg-white/[0.05] hover:text-green-300"} disabled:opacity-40`}
+            aria-label="Upvote"
+          >
+            <ThumbsUp className="h-3.5 w-3.5" />
+          </button>
+          <span
+            className={`text-xs font-bold ${idea.score > 0 ? "text-green-300" : idea.score < 0 ? "text-red-300" : "text-[#888]"}`}
+          >
+            {idea.score > 0 ? `+${idea.score}` : idea.score}
+          </span>
+          <button
+            type="button"
+            onClick={() => callAction("fishbowl_vote_on_idea", { idea_id: idea.id, vote: "down" })}
+            disabled={busy || isLocked}
+            className={`rounded p-1 transition ${idea.my_vote === "down" ? "bg-red-500/20 text-red-300" : "text-[#888] hover:bg-white/[0.05] hover:text-red-300"} disabled:opacity-40`}
+            aria-label="Downvote"
+          >
+            <ThumbsDown className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex min-w-0 flex-1 items-start justify-between gap-2 text-left"
+          aria-expanded={expanded}
+        >
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-[#ccc]">{idea.title}</p>
+            {truncatedDesc && (
+              <p className="mt-0.5 truncate text-xs text-[#888]">{truncatedDesc}</p>
+            )}
+            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-[#666]">
+              {statusPill(idea.status)}
+              <span>by {idea.created_by_agent_id}</span>
+              {(idea.comment_count ?? 0) > 0 && (
+                <span className="text-[#888]">💬 {idea.comment_count}</span>
+              )}
+            </div>
+          </div>
+          {expanded ? (
+            <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-[#888]" />
+          ) : (
+            <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-[#888]" />
+          )}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="mt-3 space-y-3 border-t border-white/[0.06] pt-3">
+          {idea.description && (
+            <p className="whitespace-pre-wrap text-xs text-[#bbb]">{idea.description}</p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            {!isLocked && (
+              <button
+                type="button"
+                onClick={() =>
+                  callAction("fishbowl_promote_idea_to_todo", { idea_id: idea.id })
+                }
+                disabled={busy}
+                className="inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-2 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:opacity-40"
+                title="Admin can promote any idea; agents need net upvotes >= 1"
+              >
+                Promote to TODO
+              </button>
+            )}
+            {isLocked && idea.promoted_to_todo_id && (
+              <span className="text-xs text-[#888]">
+                Locked. Promoted to todo {idea.promoted_to_todo_id.slice(0, 8)}.
+              </span>
+            )}
+          </div>
+
+          {error && <p className="text-xs text-red-300">{error}</p>}
+
+          <Comments
+            authHeader={authHeader}
+            humanAgentId={humanAgentId}
+            targetKind="idea"
+            targetId={idea.id}
+            pollSeq={pollSeq}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function FishbowlIdeas({ authHeader, humanAgentId }: IdeasProps) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return window.localStorage.getItem(STORAGE_KEY) !== "0";
+  });
+
+  const [ideas, setIdeas] = useState<Idea[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [pollSeq, setPollSeq] = useState(0);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        // localStorage may be unavailable; ignore.
+      }
+      return next;
+    });
+  };
+
+  const fetchIdeas = useCallback(async () => {
+    if (!humanAgentId) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_list_ideas", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: humanAgentId, limit: 200 }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { ideas?: Idea[]; error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to load ideas");
+      setIdeas(body.ideas ?? []);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [authHeader, humanAgentId]);
+
+  useEffect(() => {
+    if (collapsed) return;
+    void fetchIdeas();
+  }, [collapsed, fetchIdeas]);
+
+  useEffect(() => {
+    if (collapsed) return;
+    const id = setInterval(() => {
+      void fetchIdeas();
+      setPollSeq((s) => s + 1);
+    }, 10_000);
+    return () => clearInterval(id);
+  }, [collapsed, fetchIdeas]);
+
+  const onMutated = useCallback(() => {
+    void fetchIdeas();
+    setPollSeq((s) => s + 1);
+  }, [fetchIdeas]);
+
+  const toggleRow = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const activeCount = ideas.filter((i) => i.status === "proposed" || i.status === "voting").length;
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
+          <span aria-hidden>💡</span>
+          <span>Ideas</span>
+          {activeCount > 0 && (
+            <span className="rounded-full bg-[#E2B93B]/15 px-2 py-0.5 text-[10px] font-medium text-[#E2B93B]">
+              {activeCount} open
+            </span>
+          )}
+        </span>
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4 text-[#888]" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-[#888]" />
+        )}
+      </button>
+
+      {!collapsed && (
+        <div className="space-y-3 border-t border-white/[0.06] px-4 py-4">
+          <div className="flex items-center justify-between gap-2">
+            <AddIdeaForm
+              authHeader={authHeader}
+              humanAgentId={humanAgentId}
+              onCreated={onMutated}
+            />
+            {loading && <Loader2 className="h-3.5 w-3.5 animate-spin text-[#888]" />}
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+              {error}
+            </p>
+          )}
+
+          {ideas.length === 0 ? (
+            <p className="rounded-md border border-white/[0.04] bg-black/20 px-3 py-4 text-center text-xs text-[#666]">
+              No ideas yet. Propose one above.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {ideas.map((i) => (
+                <li key={i.id}>
+                  <IdeaRow
+                    idea={i}
+                    expanded={expanded.has(i.id)}
+                    onToggle={() => toggleRow(i.id)}
+                    authHeader={authHeader}
+                    humanAgentId={humanAgentId}
+                    pollSeq={pollSeq}
+                    onMutated={onMutated}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/admin/fishbowl/Todos.tsx
+++ b/src/pages/admin/fishbowl/Todos.tsx
@@ -1,0 +1,540 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, Loader2, Plus, Trash2 } from "lucide-react";
+import Comments from "./Comments";
+
+interface Todo {
+  id: string;
+  title: string;
+  description: string | null;
+  status: "open" | "in_progress" | "done" | "dropped";
+  priority: "low" | "normal" | "high" | "urgent";
+  created_by_agent_id: string;
+  assigned_to_agent_id: string | null;
+  source_idea_id: string | null;
+  created_at: string;
+  completed_at: string | null;
+  updated_at: string;
+  comment_count?: number;
+}
+
+interface TodosProps {
+  authHeader: Record<string, string>;
+  humanAgentId: string | null;
+}
+
+const STORAGE_KEY = "unclick.fishbowl.todos.collapsed";
+
+const COLUMNS: Array<{ key: "open" | "in_progress" | "done"; label: string }> = [
+  { key: "open", label: "Open" },
+  { key: "in_progress", label: "In progress" },
+  { key: "done", label: "Done" },
+];
+
+const PRIORITY_STYLE: Record<Todo["priority"], string> = {
+  low: "bg-[#333]/40 text-[#888]",
+  normal: "bg-[#444]/40 text-[#aaa]",
+  high: "bg-[#E2B93B]/15 text-[#E2B93B]",
+  urgent: "bg-red-500/20 text-red-300",
+};
+
+function priorityPill(p: Todo["priority"]) {
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${PRIORITY_STYLE[p]}`}
+    >
+      {p}
+    </span>
+  );
+}
+
+function AddTodoForm({
+  authHeader,
+  humanAgentId,
+  onCreated,
+}: {
+  authHeader: Record<string, string>;
+  humanAgentId: string | null;
+  onCreated: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [priority, setPriority] = useState<Todo["priority"]>("normal");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setTitle("");
+    setDescription("");
+    setPriority("normal");
+    setError(null);
+  };
+
+  const submit = async () => {
+    if (!humanAgentId) return;
+    const t = title.trim();
+    if (!t) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_create_todo", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_id: humanAgentId,
+          title: t,
+          description: description.trim() || null,
+          priority,
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to create todo");
+      reset();
+      setOpen(false);
+      onCreated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={!humanAgentId}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1.5 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:opacity-40"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add todo
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-lg border border-white/[0.08] bg-black/20 p-3">
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Short title"
+        maxLength={200}
+        className="w-full rounded-md border border-white/[0.08] bg-black/30 px-2 py-1.5 text-sm text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Optional description"
+        rows={2}
+        maxLength={4000}
+        className="w-full resize-y rounded-md border border-white/[0.08] bg-black/30 px-2 py-1.5 text-xs text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      <div className="flex items-center justify-between gap-2">
+        <select
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as Todo["priority"])}
+          className="rounded-md border border-white/[0.08] bg-black/30 px-2 py-1 text-xs text-[#ccc] focus:border-[#E2B93B]/40 focus:outline-none"
+        >
+          <option value="low">low</option>
+          <option value="normal">normal</option>
+          <option value="high">high</option>
+          <option value="urgent">urgent</option>
+        </select>
+        <div className="flex items-center gap-2">
+          {error && <span className="text-xs text-red-300">{error}</span>}
+          <button
+            type="button"
+            onClick={() => {
+              reset();
+              setOpen(false);
+            }}
+            className="rounded-md border border-white/[0.08] px-2 py-1 text-xs text-[#888] hover:bg-white/[0.05]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting || title.trim().length === 0}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:opacity-40"
+          >
+            {submitting && <Loader2 className="h-3 w-3 animate-spin" />}
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TodoCard({
+  todo,
+  expanded,
+  onToggle,
+  authHeader,
+  humanAgentId,
+  pollSeq,
+  onMutated,
+}: {
+  todo: Todo;
+  expanded: boolean;
+  onToggle: () => void;
+  authHeader: Record<string, string>;
+  humanAgentId: string | null;
+  pollSeq: number;
+  onMutated: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(todo.title);
+  const [draftDesc, setDraftDesc] = useState(todo.description ?? "");
+  const [draftPriority, setDraftPriority] = useState<Todo["priority"]>(todo.priority);
+
+  const callMutation = async (action: string, payload: Record<string, unknown>) => {
+    if (!humanAgentId) return;
+    setBusy(true);
+    try {
+      await fetch(`/api/memory-admin?action=${action}`, {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: humanAgentId, ...payload }),
+      });
+      onMutated();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveEdits = async () => {
+    await callMutation("fishbowl_update_todo", {
+      todo_id: todo.id,
+      title: draftTitle.trim(),
+      description: draftDesc.trim() || null,
+      priority: draftPriority,
+    });
+    setEditing(false);
+  };
+
+  const isDone = todo.status === "done";
+
+  return (
+    <div
+      className={`rounded-lg border border-white/[0.06] bg-black/30 p-3 ${isDone ? "opacity-70" : ""}`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-start justify-between gap-2 text-left"
+        aria-expanded={expanded}
+      >
+        <div className="min-w-0 flex-1">
+          <p
+            className={`truncate text-sm font-medium ${isDone ? "text-[#666] line-through" : "text-[#ccc]"}`}
+          >
+            {isDone && <span className="mr-1 text-green-400">✓</span>}
+            {todo.title}
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-[#666]">
+            {priorityPill(todo.priority)}
+            {todo.assigned_to_agent_id && (
+              <span className="rounded bg-white/[0.05] px-1.5 py-0.5">
+                @{todo.assigned_to_agent_id}
+              </span>
+            )}
+            {(todo.comment_count ?? 0) > 0 && (
+              <span className="text-[#888]">💬 {todo.comment_count}</span>
+            )}
+            {todo.source_idea_id && (
+              <span className="rounded bg-[#E2B93B]/10 px-1.5 py-0.5 text-[#E2B93B]">
+                from idea
+              </span>
+            )}
+          </div>
+        </div>
+        {expanded ? (
+          <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-[#888]" />
+        ) : (
+          <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-[#888]" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-3 border-t border-white/[0.06] pt-3">
+          {editing ? (
+            <div className="space-y-2">
+              <input
+                type="text"
+                value={draftTitle}
+                onChange={(e) => setDraftTitle(e.target.value)}
+                maxLength={200}
+                className="w-full rounded-md border border-white/[0.08] bg-black/30 px-2 py-1 text-sm text-[#ccc] focus:border-[#E2B93B]/40 focus:outline-none"
+              />
+              <textarea
+                value={draftDesc}
+                onChange={(e) => setDraftDesc(e.target.value)}
+                rows={3}
+                maxLength={4000}
+                className="w-full resize-y rounded-md border border-white/[0.08] bg-black/30 px-2 py-1 text-xs text-[#ccc] focus:border-[#E2B93B]/40 focus:outline-none"
+              />
+              <div className="flex items-center justify-between gap-2">
+                <select
+                  value={draftPriority}
+                  onChange={(e) => setDraftPriority(e.target.value as Todo["priority"])}
+                  className="rounded-md border border-white/[0.08] bg-black/30 px-2 py-1 text-xs text-[#ccc] focus:outline-none"
+                >
+                  <option value="low">low</option>
+                  <option value="normal">normal</option>
+                  <option value="high">high</option>
+                  <option value="urgent">urgent</option>
+                </select>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDraftTitle(todo.title);
+                      setDraftDesc(todo.description ?? "");
+                      setDraftPriority(todo.priority);
+                      setEditing(false);
+                    }}
+                    className="rounded-md border border-white/[0.08] px-2 py-1 text-xs text-[#888] hover:bg-white/[0.05]"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={saveEdits}
+                    disabled={busy || draftTitle.trim().length === 0}
+                    className="rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-2 py-1 text-xs font-medium text-[#E2B93B] disabled:opacity-40"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : (
+            todo.description && (
+              <p className="whitespace-pre-wrap text-xs text-[#bbb]">{todo.description}</p>
+            )
+          )}
+
+          {!editing && (
+            <div className="flex flex-wrap items-center gap-2">
+              {!isDone && (
+                <button
+                  type="button"
+                  onClick={() => callMutation("fishbowl_complete_todo", { todo_id: todo.id })}
+                  disabled={busy}
+                  className="inline-flex items-center gap-1 rounded-md border border-green-400/40 bg-green-400/10 px-2 py-1 text-xs font-medium text-green-300 hover:bg-green-400/20 disabled:opacity-40"
+                >
+                  ✓ Complete
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                disabled={busy}
+                className="rounded-md border border-white/[0.08] px-2 py-1 text-xs text-[#888] hover:bg-white/[0.05]"
+              >
+                Edit
+              </button>
+              {todo.status !== "dropped" && !isDone && (
+                <button
+                  type="button"
+                  onClick={() => callMutation("fishbowl_drop_todo", { todo_id: todo.id })}
+                  disabled={busy}
+                  className="rounded-md border border-white/[0.08] px-2 py-1 text-xs text-[#888] hover:bg-white/[0.05]"
+                >
+                  Drop
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  if (window.confirm("Delete this todo permanently?")) {
+                    void callMutation("fishbowl_delete_todo", { todo_id: todo.id });
+                  }
+                }}
+                disabled={busy}
+                className="inline-flex items-center gap-1 rounded-md border border-red-400/30 px-2 py-1 text-xs text-red-300 hover:bg-red-500/10 disabled:opacity-40"
+              >
+                <Trash2 className="h-3 w-3" />
+                Delete
+              </button>
+            </div>
+          )}
+
+          <Comments
+            authHeader={authHeader}
+            humanAgentId={humanAgentId}
+            targetKind="todo"
+            targetId={todo.id}
+            pollSeq={pollSeq}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function FishbowlTodos({ authHeader, humanAgentId }: TodosProps) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return window.localStorage.getItem(STORAGE_KEY) !== "0";
+  });
+
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [pollSeq, setPollSeq] = useState(0);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        // localStorage may be unavailable; ignore.
+      }
+      return next;
+    });
+  };
+
+  const fetchTodos = useCallback(async () => {
+    if (!humanAgentId) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_list_todos", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: humanAgentId, limit: 200 }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { todos?: Todo[]; error?: string };
+      if (!res.ok) throw new Error(body.error ?? "Failed to load todos");
+      setTodos(body.todos ?? []);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [authHeader, humanAgentId]);
+
+  useEffect(() => {
+    if (collapsed) return;
+    void fetchTodos();
+  }, [collapsed, fetchTodos]);
+
+  useEffect(() => {
+    if (collapsed) return;
+    const id = setInterval(() => {
+      void fetchTodos();
+      setPollSeq((s) => s + 1);
+    }, 10_000);
+    return () => clearInterval(id);
+  }, [collapsed, fetchTodos]);
+
+  const onMutated = useCallback(() => {
+    void fetchTodos();
+    setPollSeq((s) => s + 1);
+  }, [fetchTodos]);
+
+  const grouped = useMemo(() => {
+    const map: Record<string, Todo[]> = { open: [], in_progress: [], done: [] };
+    for (const t of todos) {
+      if (t.status === "dropped") continue;
+      if (map[t.status]) map[t.status].push(t);
+    }
+    return map;
+  }, [todos]);
+
+  const toggleCard = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const totalActive = grouped.open.length + grouped.in_progress.length;
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
+          <span aria-hidden>📋</span>
+          <span>Todos</span>
+          {totalActive > 0 && (
+            <span className="rounded-full bg-[#E2B93B]/15 px-2 py-0.5 text-[10px] font-medium text-[#E2B93B]">
+              {totalActive} active
+            </span>
+          )}
+        </span>
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4 text-[#888]" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-[#888]" />
+        )}
+      </button>
+
+      {!collapsed && (
+        <div className="space-y-4 border-t border-white/[0.06] px-4 py-4">
+          <div className="flex items-center justify-between gap-2">
+            <AddTodoForm
+              authHeader={authHeader}
+              humanAgentId={humanAgentId}
+              onCreated={onMutated}
+            />
+            {loading && <Loader2 className="h-3.5 w-3.5 animate-spin text-[#888]" />}
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+              {error}
+            </p>
+          )}
+
+          <div className="grid gap-3 md:grid-cols-3">
+            {COLUMNS.map((col) => (
+              <div
+                key={col.key}
+                className="flex flex-col gap-2 rounded-lg border border-white/[0.04] bg-black/20 p-2"
+              >
+                <div className="flex items-center justify-between px-1">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-[#888]">
+                    {col.label}
+                  </h3>
+                  <span className="text-[10px] text-[#666]">{grouped[col.key].length}</span>
+                </div>
+                {grouped[col.key].length === 0 ? (
+                  <p className="px-1 py-2 text-[11px] italic text-[#555]">empty</p>
+                ) : (
+                  grouped[col.key].map((t) => (
+                    <TodoCard
+                      key={t.id}
+                      todo={t}
+                      expanded={expanded.has(t.id)}
+                      onToggle={() => toggleCard(t.id)}
+                      authHeader={authHeader}
+                      humanAgentId={humanAgentId}
+                      pollSeq={pollSeq}
+                      onMutated={onMutated}
+                    />
+                  ))
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/supabase/migrations/20260425120000_fishbowl_todos_ideas.sql
+++ b/supabase/migrations/20260425120000_fishbowl_todos_ideas.sql
@@ -1,0 +1,113 @@
+-- Fishbowl Todos + Ideas v1: a productivity layer that lives inside the
+-- Fishbowl admin so the agent pack and the human can both contribute.
+-- Adds four tables (todos, ideas, idea votes, polymorphic comments) plus
+-- service-role-only RLS that mirrors the existing fishbowl pattern.
+--
+-- Idempotent: tables, indexes, and policies all guarded with IF NOT EXISTS
+-- or pg_policies pre-checks so re-applying is a safe no-op.
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_todos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  title text NOT NULL,
+  description text,
+  status text NOT NULL DEFAULT 'open'
+    CHECK (status IN ('open', 'in_progress', 'done', 'dropped')),
+  priority text NOT NULL DEFAULT 'normal'
+    CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
+  created_by_agent_id text NOT NULL,
+  assigned_to_agent_id text,
+  source_idea_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_todos_tenant_status
+  ON mc_fishbowl_todos(api_key_hash, status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_ideas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  title text NOT NULL,
+  description text,
+  status text NOT NULL DEFAULT 'proposed'
+    CHECK (status IN ('proposed', 'voting', 'locked', 'parked', 'rejected')),
+  upvotes int NOT NULL DEFAULT 0,
+  downvotes int NOT NULL DEFAULT 0,
+  score int GENERATED ALWAYS AS (upvotes - downvotes) STORED,
+  created_by_agent_id text NOT NULL,
+  promoted_to_todo_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_ideas_tenant_status_score
+  ON mc_fishbowl_ideas(api_key_hash, status, score DESC);
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_idea_votes (
+  api_key_hash text NOT NULL,
+  idea_id uuid NOT NULL REFERENCES mc_fishbowl_ideas(id) ON DELETE CASCADE,
+  voter_agent_id text NOT NULL,
+  vote text NOT NULL CHECK (vote IN ('up', 'down')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (api_key_hash, idea_id, voter_agent_id)
+);
+
+CREATE TABLE IF NOT EXISTS mc_fishbowl_comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  target_kind text NOT NULL CHECK (target_kind IN ('todo', 'idea')),
+  target_id uuid NOT NULL,
+  author_agent_id text NOT NULL,
+  text text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_comments_target
+  ON mc_fishbowl_comments(api_key_hash, target_kind, target_id, created_at);
+
+ALTER TABLE mc_fishbowl_todos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_ideas ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_idea_votes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_comments ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_todos'
+      AND policyname = 'mc_fishbowl_todos_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_todos_service_role_all"
+      ON mc_fishbowl_todos FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_ideas'
+      AND policyname = 'mc_fishbowl_ideas_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_ideas_service_role_all"
+      ON mc_fishbowl_ideas FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_idea_votes'
+      AND policyname = 'mc_fishbowl_idea_votes_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_idea_votes_service_role_all"
+      ON mc_fishbowl_idea_votes FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_comments'
+      AND policyname = 'mc_fishbowl_comments_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_comments_service_role_all"
+      ON mc_fishbowl_comments FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Productivity layer inside the Fishbowl admin per Chris's greenlight on the design post in Fishbowl. Schema + MCP tools + backend actions + admin UI all in one chip. The agent pack and the human can both contribute to a running todo board and propose ideas with voting.

- **Schema** (1 idempotent migration): `mc_fishbowl_todos`, `mc_fishbowl_ideas` (with generated `score = upvotes - downvotes`), `mc_fishbowl_idea_votes` (composite PK + ON DELETE CASCADE), `mc_fishbowl_comments` (polymorphic). Service-role-only RLS matching existing fishbowl pattern.
- **13 MCP tools** (each requires `agent_id`): create/update/complete/drop/delete/list_todos, create/update/vote_on/list_ideas/promote_idea_to_todo, comment_on/list_comments. All routed through `/api/memory-admin?action=fishbowl_<tool>`.
- **Backend actions** in `api/memory-admin.ts`: shared validation, anti-spoof on `human-*` agent_ids (only allowed with `user_agent_hint='admin-ui'`), per-tool length caps (agent_id ≤128, title ≤200, description/text ≤4000).
- **Event posts** for material changes (`event,todo-created`, `event,todo-completed`, `event,idea-created`, `event,idea-promoted`). Vote events rate-limited to one post per idea per 5 minutes so a flurry doesn't spam the feed.
- **Promote-to-TODO rules**: net upvotes ≥ 1 OR admin caller. Locks the idea, sets `idea.promoted_to_todo_id`, creates a linked todo with `source_idea_id`.
- **Admin UI**: two new default-collapsed sections under Now Playing (state persisted via localStorage). Todos as a 3-column kanban (Open / In progress / Done) with inline add, edit, complete, drop, delete. Ideas as score-sorted list with vote buttons, status pills, and Promote-to-TODO. Shared Comments component. 10s polling while expanded. Dark theme + amber accent reused, no new design system.

File budget: 7 files (1 migration, server.ts, memory-admin.ts, Fishbowl.tsx, 3 small components in `src/pages/admin/fishbowl/`).

## Test plan

- [ ] Bailey applies migration via Supabase MCP (SQL in migration file)
- [ ] Verify `tools/list` includes the 13 new tools after MCP server reload
- [ ] From an agent client: `create_todo`, `complete_todo`, `create_idea`, `vote_on_idea`, `promote_idea_to_todo` end-to-end
- [ ] From the admin UI: add a todo, complete it, drop it, delete it
- [ ] From the admin UI: propose an idea, upvote it, promote it to a todo, verify it appears under Open
- [ ] Comment on a todo and an idea, confirm comment count badge updates
- [ ] Verify event posts appear in the Fishbowl feed for create/complete/promote
- [ ] Confirm AI agents using `human-*` agent_id are rejected with 403
- [ ] DO NOT auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)