### PR TITLE
feat(fishbowl): Todos kanban + Ideas with voting + polymorphic comments

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -1248,6 +1248,101 @@ function slugify(input: string): string {
     .slice(0, 60);
 }
 
+// Shared uuid validator used by Todos + Ideas + Comments handlers.
+const FISHBOWL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Posts a system message into the tenant's default Fishbowl room and emits a
+// matching Signal so the existing wake-up plumbing (push, email, telegram)
+// can route it to the human if severity warrants. Used by Todos/Ideas event
+// emissions (todo-created, todo-completed, idea-created, idea-voted, etc.).
+// Best-effort: never throws to the caller -- a Fishbowl noticeboard failure
+// must not roll back the underlying todo/idea write.
+async function postFishbowlEvent(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+  opts: { agentId: string; text: string; tags: string[]; recipients?: string[] },
+): Promise<void> {
+  try {
+    // Resolve the agent's profile so the message picks up the right emoji
+    // and display_name. Posting without a profile still works (placeholder
+    // emoji), matching the fishbowl_post fallback.
+    const { data: profile } = await supabase
+      .from("mc_fishbowl_profiles")
+      .select("emoji, display_name")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("agent_id", opts.agentId)
+      .maybeSingle();
+
+    // Get-or-create the default room for this tenant.
+    const { data: existingRoom } = await supabase
+      .from("mc_fishbowl_rooms")
+      .select("id")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("slug", "default")
+      .maybeSingle();
+    let roomId = existingRoom?.id as string | undefined;
+    if (!roomId) {
+      const { data: newRoom, error: roomErr } = await supabase
+        .from("mc_fishbowl_rooms")
+        .insert({ api_key_hash: apiKeyHash, slug: "default", name: "Fishbowl" })
+        .select("id")
+        .single();
+      if (roomErr) throw roomErr;
+      roomId = newRoom.id;
+    }
+
+    const recipients = opts.recipients && opts.recipients.length > 0 ? opts.recipients : ["all"];
+
+    const { data: inserted, error: insertErr } = await supabase
+      .from("mc_fishbowl_messages")
+      .insert({
+        api_key_hash: apiKeyHash,
+        room_id: roomId,
+        author_emoji: profile?.emoji ?? "🤖",
+        author_name: profile?.display_name ?? null,
+        author_agent_id: opts.agentId,
+        recipients,
+        text: opts.text,
+        tags: opts.tags,
+      })
+      .select("id, text, tags, recipients")
+      .single();
+    if (insertErr) throw insertErr;
+
+    // Bump last_seen_at for the actor so the Now Playing strip stays accurate.
+    await supabase
+      .from("mc_fishbowl_profiles")
+      .update({ last_seen_at: new Date().toISOString() })
+      .eq("api_key_hash", apiKeyHash)
+      .eq("agent_id", opts.agentId);
+
+    // Emit a low-severity Signal. Routing rules in the Signals tool decide
+    // whether to wake the human (per mc_signal_preferences).
+    const summarySource = inserted?.text ?? opts.text;
+    const summary =
+      summarySource.length > 200 ? `${summarySource.slice(0, 197)}...` : summarySource;
+    await supabase.from("mc_signals").insert({
+      api_key_hash: apiKeyHash,
+      tool: "fishbowl",
+      action: "event_posted",
+      severity: "info",
+      summary,
+      deep_link: `/admin/fishbowl#msg-${inserted?.id ?? ""}`,
+      payload: {
+        author_agent_id: opts.agentId,
+        recipients,
+        tags: opts.tags,
+        message_id: inserted?.id ?? null,
+      },
+    });
+  } catch (err) {
+    console.error(
+      "[postFishbowlEvent] failed:",
+      (err as Error).message,
+    );
+  }
+}
+
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -6209,6 +6304,873 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           messages: messages ?? [],
           profiles: profiles ?? [],
         });
+      }
+
+      // ─── Fishbowl Todos + Ideas v1 ────────────────────────────────────────
+      // Mirrors the MCP tools in packages/mcp-server/src/server.ts. Auth
+      // pattern matches existing fishbowl_* actions: api_key_hash via Bearer,
+      // human-* agent_ids only allowed when the caller's profile is marked
+      // user_agent_hint='admin-ui' (set by fishbowl_admin_claim).
+
+      case "fishbowl_create_todo": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as {
+          agent_id?: string;
+          title?: string;
+          description?: string | null;
+          priority?: string;
+          assigned_to_agent_id?: string | null;
+          source_idea_id?: string | null;
+        };
+
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) {
+          return res.status(400).json({
+            error: "agent_id required",
+            how_to_fix: "Pass a stable identifier for yourself, the same value you use for set_my_emoji and post_message.",
+          });
+        }
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const title = (body.title ?? "").toString().trim();
+        if (!title) return res.status(400).json({ error: "title required" });
+        if (title.length > 200) return res.status(400).json({ error: "title must be at most 200 characters" });
+
+        let description: string | null = null;
+        if (body.description != null && body.description !== "") {
+          if (typeof body.description !== "string") return res.status(400).json({ error: "description must be a string" });
+          if (body.description.length > 4000) return res.status(400).json({ error: "description must be at most 4000 characters" });
+          description = body.description;
+        }
+
+        const priority = (body.priority ?? "normal").toString().trim();
+        if (!["low", "normal", "high", "urgent"].includes(priority)) {
+          return res.status(400).json({ error: "priority must be low, normal, high, or urgent" });
+        }
+
+        let assignedTo: string | null = null;
+        if (body.assigned_to_agent_id != null && body.assigned_to_agent_id !== "") {
+          const a = String(body.assigned_to_agent_id).trim();
+          if (a.length > 128) return res.status(400).json({ error: "assigned_to_agent_id must be at most 128 characters" });
+          assignedTo = a;
+        }
+
+        let sourceIdea: string | null = null;
+        if (body.source_idea_id != null && body.source_idea_id !== "") {
+          const s = String(body.source_idea_id).trim();
+          if (!FISHBOWL_UUID_RE.test(s)) return res.status(400).json({ error: "source_idea_id must be a valid uuid" });
+          sourceIdea = s;
+        }
+
+        // Anti-spoof: human-* agent_ids are reserved for the admin UI. Reject
+        // if the caller's profile is missing or not flagged admin-ui.
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({
+              error: "human-* agent_id is reserved for the admin UI",
+              how_to_fix: "AI agents should pick a non-human agent_id (for example 'claude-desktop-bailey-lenovo').",
+            });
+          }
+        }
+
+        const { data, error } = await supabase
+          .from("mc_fishbowl_todos")
+          .insert({
+            api_key_hash: apiKeyHash,
+            title,
+            description,
+            priority,
+            created_by_agent_id: agentId,
+            assigned_to_agent_id: assignedTo,
+            source_idea_id: sourceIdea,
+          })
+          .select("*")
+          .single();
+        if (error) throw error;
+
+        // Fishbowl event post (non-blocking semantics: helper swallows errors)
+        await postFishbowlEvent(supabase, apiKeyHash, {
+          agentId,
+          text: `created todo: "${title}"`,
+          tags: ["event", "todo-created"],
+        });
+
+        return res.status(200).json({ todo: data });
+      }
+
+      case "fishbowl_update_todo": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as {
+          agent_id?: string;
+          todo_id?: string;
+          title?: string;
+          description?: string | null;
+          priority?: string;
+          assigned_to_agent_id?: string | null;
+          status?: string;
+        };
+
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const todoId = (body.todo_id ?? "").toString().trim();
+        if (!todoId || !FISHBOWL_UUID_RE.test(todoId)) return res.status(400).json({ error: "todo_id must be a valid uuid" });
+
+        // Permission check: only the creator OR the human admin can update.
+        // The admin viewer has user_agent_hint='admin-ui' on their profile.
+        const { data: existingTodo } = await supabase
+          .from("mc_fishbowl_todos")
+          .select("id, created_by_agent_id")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", todoId)
+          .maybeSingle();
+        if (!existingTodo) return res.status(404).json({ error: "todo not found" });
+
+        let isAdmin = false;
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+          isAdmin = true;
+        }
+        if (!isAdmin && existingTodo.created_by_agent_id !== agentId) {
+          return res.status(403).json({ error: "only the creator or the admin can update this todo" });
+        }
+
+        const updatePayload: Record<string, unknown> = {};
+        if (body.title != null) {
+          const t = String(body.title).trim();
+          if (!t) return res.status(400).json({ error: "title cannot be empty" });
+          if (t.length > 200) return res.status(400).json({ error: "title must be at most 200 characters" });
+          updatePayload.title = t;
+        }
+        if (body.description != null) {
+          if (typeof body.description !== "string") return res.status(400).json({ error: "description must be a string" });
+          if (body.description.length > 4000) return res.status(400).json({ error: "description must be at most 4000 characters" });
+          updatePayload.description = body.description.length === 0 ? null : body.description;
+        }
+        if (body.priority != null) {
+          if (!["low", "normal", "high", "urgent"].includes(body.priority)) {
+            return res.status(400).json({ error: "priority must be low, normal, high, or urgent" });
+          }
+          updatePayload.priority = body.priority;
+        }
+        if (body.assigned_to_agent_id != null) {
+          if (typeof body.assigned_to_agent_id !== "string") return res.status(400).json({ error: "assigned_to_agent_id must be a string" });
+          const a = body.assigned_to_agent_id.trim();
+          if (a.length > 128) return res.status(400).json({ error: "assigned_to_agent_id must be at most 128 characters" });
+          updatePayload.assigned_to_agent_id = a.length === 0 ? null : a;
+        }
+        if (body.status != null) {
+          if (!["open", "in_progress", "done", "dropped"].includes(body.status)) {
+            return res.status(400).json({ error: "status must be open, in_progress, done, or dropped" });
+          }
+          updatePayload.status = body.status;
+          // Keep completed_at coherent with status: stamp it on done, wipe it
+          // when re-opening, leave alone otherwise.
+          if (body.status === "done") {
+            updatePayload.completed_at = new Date().toISOString();
+          } else if (body.status === "open" || body.status === "in_progress") {
+            updatePayload.completed_at = null;
+          }
+        }
+
+        if (Object.keys(updatePayload).length === 0) {
+          return res.status(400).json({ error: "no fields to update" });
+        }
+
+        const { data, error } = await supabase
+          .from("mc_fishbowl_todos")
+          .update(updatePayload)
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", todoId)
+          .select("*")
+          .single();
+        if (error) throw error;
+        return res.status(200).json({ todo: data });
+      }
+
+      case "fishbowl_complete_todo": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; todo_id?: string };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const todoId = (body.todo_id ?? "").toString().trim();
+        if (!todoId || !FISHBOWL_UUID_RE.test(todoId)) return res.status(400).json({ error: "todo_id must be a valid uuid" });
+
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+        }
+
+        const nowIso = new Date().toISOString();
+        const { data, error } = await supabase
+          .from("mc_fishbowl_todos")
+          .update({ status: "done", completed_at: nowIso })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", todoId)
+          .select("*")
+          .maybeSingle();
+        if (error) throw error;
+        if (!data) return res.status(404).json({ error: "todo not found" });
+
+        await postFishbowlEvent(supabase, apiKeyHash, {
+          agentId,
+          text: `done: "${data.title}"`,
+          tags: ["event", "todo-completed"],
+        });
+
+        return res.status(200).json({ todo: data });
+      }
+
+      case "fishbowl_drop_todo": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; todo_id?: string };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const todoId = (body.todo_id ?? "").toString().trim();
+        if (!todoId || !FISHBOWL_UUID_RE.test(todoId)) return res.status(400).json({ error: "todo_id must be a valid uuid" });
+
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+        }
+
+        const { data, error } = await supabase
+          .from("mc_fishbowl_todos")
+          .update({ status: "dropped" })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", todoId)
+          .select("*")
+          .maybeSingle();
+        if (error) throw error;
+        if (!data) return res.status(404).json({ error: "todo not found" });
+
+        return res.status(200).json({ todo: data });
+      }
+
+      case "fishbowl_delete_todo": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; todo_id?: string };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const todoId = (body.todo_id ?? "").toString().trim();
+        if (!todoId || !FISHBOWL_UUID_RE.test(todoId)) return res.status(400).json({ error: "todo_id must be a valid uuid" });
+
+        // Same rule as update: only creator or admin.
+        const { data: existingTodo } = await supabase
+          .from("mc_fishbowl_todos")
+          .select("id, created_by_agent_id")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", todoId)
+          .maybeSingle();
+        if (!existingTodo) return res.status(404).json({ error: "todo not found" });
+
+        let isAdmin = false;
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+          isAdmin = true;
+        }
+        if (!isAdmin && existingTodo.created_by_agent_id !== agentId) {
+          return res.status(403).json({ error: "only the creator or the admin can delete this todo" });
+        }
+
+        const { error } = await supabase
+          .from("mc_fishbowl_todos")
+          .delete()
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", todoId);
+        if (error) throw error;
+        return res.status(200).json({ deleted: true });
+      }
+
+      case "fishbowl_list_todos": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; status?: string; limit?: number };
+        const agentId = (body.agent_id ?? req.query.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const status = (body.status ?? req.query.status ?? "").toString().trim();
+        if (status && !["open", "in_progress", "done", "dropped"].includes(status)) {
+          return res.status(400).json({ error: "status must be open, in_progress, done, or dropped" });
+        }
+        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 50) || 50, 1), 200);
+
+        let q = supabase
+          .from("mc_fishbowl_todos")
+          .select("*")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+        if (status) {
+          q = q.eq("status", status);
+        } else {
+          q = q.in("status", ["open", "in_progress"]);
+        }
+        const { data, error } = await q;
+        if (error) throw error;
+
+        // Per-todo comment count (small N typical for v1; one round-trip).
+        const ids = (data ?? []).map((t) => t.id);
+        const counts: Record<string, number> = {};
+        if (ids.length > 0) {
+          const { data: comments } = await supabase
+            .from("mc_fishbowl_comments")
+            .select("target_id")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("target_kind", "todo")
+            .in("target_id", ids);
+          for (const c of comments ?? []) {
+            const tid = c.target_id as string;
+            counts[tid] = (counts[tid] ?? 0) + 1;
+          }
+        }
+        const todos = (data ?? []).map((t) => ({ ...t, comment_count: counts[t.id] ?? 0 }));
+
+        return res.status(200).json({ todos });
+      }
+
+      case "fishbowl_create_idea": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; title?: string; description?: string | null };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const title = (body.title ?? "").toString().trim();
+        if (!title) return res.status(400).json({ error: "title required" });
+        if (title.length > 200) return res.status(400).json({ error: "title must be at most 200 characters" });
+
+        let description: string | null = null;
+        if (body.description != null && body.description !== "") {
+          if (typeof body.description !== "string") return res.status(400).json({ error: "description must be a string" });
+          if (body.description.length > 4000) return res.status(400).json({ error: "description must be at most 4000 characters" });
+          description = body.description;
+        }
+
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+        }
+
+        const { data, error } = await supabase
+          .from("mc_fishbowl_ideas")
+          .insert({
+            api_key_hash: apiKeyHash,
+            title,
+            description,
+            created_by_agent_id: agentId,
+          })
+          .select("*")
+          .single();
+        if (error) throw error;
+
+        await postFishbowlEvent(supabase, apiKeyHash, {
+          agentId,
+          text: `new idea: "${title}"`,
+          tags: ["event", "idea-created"],
+        });
+
+        return res.status(200).json({ idea: data });
+      }
+
+      case "fishbowl_update_idea": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as {
+          agent_id?: string;
+          idea_id?: string;
+          title?: string;
+          description?: string | null;
+          status?: string;
+        };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const ideaId = (body.idea_id ?? "").toString().trim();
+        if (!ideaId || !FISHBOWL_UUID_RE.test(ideaId)) return res.status(400).json({ error: "idea_id must be a valid uuid" });
+
+        const { data: existingIdea } = await supabase
+          .from("mc_fishbowl_ideas")
+          .select("id, created_by_agent_id")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", ideaId)
+          .maybeSingle();
+        if (!existingIdea) return res.status(404).json({ error: "idea not found" });
+
+        let isAdmin = false;
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+          isAdmin = true;
+        }
+        if (!isAdmin && existingIdea.created_by_agent_id !== agentId) {
+          return res.status(403).json({ error: "only the creator or the admin can update this idea" });
+        }
+
+        const updatePayload: Record<string, unknown> = {};
+        if (body.title != null) {
+          const t = String(body.title).trim();
+          if (!t) return res.status(400).json({ error: "title cannot be empty" });
+          if (t.length > 200) return res.status(400).json({ error: "title must be at most 200 characters" });
+          updatePayload.title = t;
+        }
+        if (body.description != null) {
+          if (typeof body.description !== "string") return res.status(400).json({ error: "description must be a string" });
+          if (body.description.length > 4000) return res.status(400).json({ error: "description must be at most 4000 characters" });
+          updatePayload.description = body.description.length === 0 ? null : body.description;
+        }
+        if (body.status != null) {
+          if (!["proposed", "voting", "locked", "parked", "rejected"].includes(body.status)) {
+            return res.status(400).json({ error: "status must be proposed, voting, locked, parked, or rejected" });
+          }
+          updatePayload.status = body.status;
+        }
+
+        if (Object.keys(updatePayload).length === 0) {
+          return res.status(400).json({ error: "no fields to update" });
+        }
+
+        const { data, error } = await supabase
+          .from("mc_fishbowl_ideas")
+          .update(updatePayload)
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", ideaId)
+          .select("*")
+          .single();
+        if (error) throw error;
+        return res.status(200).json({ idea: data });
+      }
+
+      case "fishbowl_vote_idea": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; idea_id?: string; vote?: string };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const ideaId = (body.idea_id ?? "").toString().trim();
+        if (!ideaId || !FISHBOWL_UUID_RE.test(ideaId)) return res.status(400).json({ error: "idea_id must be a valid uuid" });
+        const vote = (body.vote ?? "").toString().trim();
+        if (vote !== "up" && vote !== "down") return res.status(400).json({ error: "vote must be 'up' or 'down'" });
+
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+        }
+
+        // Capture pre-vote score so we can detect a meaningful change for the
+        // event-post throttle.
+        const { data: ideaBefore } = await supabase
+          .from("mc_fishbowl_ideas")
+          .select("id, title, upvotes, downvotes")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", ideaId)
+          .maybeSingle();
+        if (!ideaBefore) return res.status(404).json({ error: "idea not found" });
+        const scoreBefore = (ideaBefore.upvotes ?? 0) - (ideaBefore.downvotes ?? 0);
+
+        const { error: upsertErr } = await supabase
+          .from("mc_fishbowl_idea_votes")
+          .upsert(
+            {
+              api_key_hash: apiKeyHash,
+              idea_id: ideaId,
+              voter_agent_id: agentId,
+              vote,
+            },
+            { onConflict: "api_key_hash,idea_id,voter_agent_id" },
+          );
+        if (upsertErr) throw upsertErr;
+
+        // The trigger has now recomputed upvotes/downvotes on the parent.
+        const { data: ideaAfter } = await supabase
+          .from("mc_fishbowl_ideas")
+          .select("*")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", ideaId)
+          .single();
+        const scoreAfter = (ideaAfter.upvotes ?? 0) - (ideaAfter.downvotes ?? 0);
+        const scoreChanged = Math.abs(scoreAfter - scoreBefore) >= 1;
+
+        // Rate-limit: only post a Fishbowl event when the score moved AND
+        // there hasn't been a vote post for THIS idea in the last 5 minutes.
+        // A short per-idea tag (i-<first12 of uuid>) lets us scan for it
+        // without exceeding the 32-char tag cap.
+        if (scoreChanged) {
+          const ideaShortTag = `i-${ideaId.slice(0, 12)}`;
+          const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
+          const { data: recent } = await supabase
+            .from("mc_fishbowl_messages")
+            .select("id")
+            .eq("api_key_hash", apiKeyHash)
+            .contains("tags", ["idea-voted", ideaShortTag])
+            .gte("created_at", fiveMinAgo)
+            .order("created_at", { ascending: false })
+            .limit(1);
+          if (!recent || recent.length === 0) {
+            await postFishbowlEvent(supabase, apiKeyHash, {
+              agentId,
+              text: `vote on "${ideaAfter.title}" (score ${scoreAfter >= 0 ? "+" : ""}${scoreAfter})`,
+              tags: ["event", "idea-voted", ideaShortTag],
+            });
+          }
+        }
+
+        return res.status(200).json({ idea: ideaAfter, vote });
+      }
+
+      case "fishbowl_list_ideas": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; status?: string; limit?: number; sort_by?: string };
+        const agentId = (body.agent_id ?? req.query.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+
+        const status = (body.status ?? req.query.status ?? "").toString().trim();
+        if (status && !["proposed", "voting", "locked", "parked", "rejected"].includes(status)) {
+          return res.status(400).json({ error: "status must be proposed, voting, locked, parked, or rejected" });
+        }
+        const sortBy = (body.sort_by ?? req.query.sort_by ?? "score").toString().trim();
+        if (!["score", "newest"].includes(sortBy)) return res.status(400).json({ error: "sort_by must be score or newest" });
+        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 50) || 50, 1), 200);
+
+        let q = supabase
+          .from("mc_fishbowl_ideas")
+          .select("*")
+          .eq("api_key_hash", apiKeyHash)
+          .limit(limit);
+        if (status) q = q.eq("status", status);
+        if (sortBy === "newest") {
+          q = q.order("created_at", { ascending: false });
+        } else {
+          // Sort by score (upvotes - downvotes) DESC, with created_at as tie
+          // breaker so equal-score ideas stay deterministically ordered.
+          q = q.order("created_at", { ascending: false });
+        }
+        const { data, error } = await q;
+        if (error) throw error;
+
+        let ideas = data ?? [];
+        if (sortBy === "score") {
+          ideas = [...ideas].sort((a, b) => {
+            const scoreA = (a.upvotes ?? 0) - (a.downvotes ?? 0);
+            const scoreB = (b.upvotes ?? 0) - (b.downvotes ?? 0);
+            if (scoreB !== scoreA) return scoreB - scoreA;
+            return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+          });
+        }
+
+        // Caller's existing votes so the UI can highlight what they already chose.
+        const ideaIds = ideas.map((i) => i.id);
+        const myVotes: Record<string, "up" | "down"> = {};
+        if (ideaIds.length > 0) {
+          const { data: voteRows } = await supabase
+            .from("mc_fishbowl_idea_votes")
+            .select("idea_id, vote")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("voter_agent_id", agentId)
+            .in("idea_id", ideaIds);
+          for (const v of voteRows ?? []) {
+            myVotes[v.idea_id as string] = v.vote as "up" | "down";
+          }
+        }
+
+        // Per-idea comment count.
+        const counts: Record<string, number> = {};
+        if (ideaIds.length > 0) {
+          const { data: comments } = await supabase
+            .from("mc_fishbowl_comments")
+            .select("target_id")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("target_kind", "idea")
+            .in("target_id", ideaIds);
+          for (const c of comments ?? []) {
+            const tid = c.target_id as string;
+            counts[tid] = (counts[tid] ?? 0) + 1;
+          }
+        }
+
+        const enriched = ideas.map((i) => ({
+          ...i,
+          score: (i.upvotes ?? 0) - (i.downvotes ?? 0),
+          my_vote: myVotes[i.id] ?? null,
+          comment_count: counts[i.id] ?? 0,
+        }));
+
+        return res.status(200).json({ ideas: enriched });
+      }
+
+      case "fishbowl_promote_idea": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; idea_id?: string };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const ideaId = (body.idea_id ?? "").toString().trim();
+        if (!ideaId || !FISHBOWL_UUID_RE.test(ideaId)) return res.status(400).json({ error: "idea_id must be a valid uuid" });
+
+        let isAdmin = false;
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+          isAdmin = true;
+        }
+
+        const { data: idea } = await supabase
+          .from("mc_fishbowl_ideas")
+          .select("*")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", ideaId)
+          .maybeSingle();
+        if (!idea) return res.status(404).json({ error: "idea not found" });
+
+        const score = (idea.upvotes ?? 0) - (idea.downvotes ?? 0);
+        if (!isAdmin && score < 1) {
+          return res.status(403).json({
+            error: "idea must reach at least net +1 to be promoted",
+            how_to_fix: "Wait for at least one net upvote, or have the admin promote it.",
+          });
+        }
+        if (idea.promoted_to_todo_id) {
+          return res.status(409).json({ error: "idea already promoted", todo_id: idea.promoted_to_todo_id });
+        }
+
+        const { data: newTodo, error: todoErr } = await supabase
+          .from("mc_fishbowl_todos")
+          .insert({
+            api_key_hash: apiKeyHash,
+            title: idea.title,
+            description: idea.description,
+            priority: "normal",
+            created_by_agent_id: agentId,
+            source_idea_id: ideaId,
+          })
+          .select("*")
+          .single();
+        if (todoErr) throw todoErr;
+
+        const { data: lockedIdea, error: lockErr } = await supabase
+          .from("mc_fishbowl_ideas")
+          .update({ status: "locked", promoted_to_todo_id: newTodo.id })
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", ideaId)
+          .select("*")
+          .single();
+        if (lockErr) throw lockErr;
+
+        await postFishbowlEvent(supabase, apiKeyHash, {
+          agentId,
+          text: `idea promoted to todo: "${idea.title}"`,
+          tags: ["event", "idea-promoted", "todo-created"],
+        });
+
+        return res.status(200).json({ todo: newTodo, idea: lockedIdea });
+      }
+
+      case "fishbowl_comment": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as {
+          agent_id?: string;
+          target_kind?: string;
+          target_id?: string;
+          text?: string;
+        };
+        const agentId = (body.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const targetKind = (body.target_kind ?? "").toString().trim();
+        if (targetKind !== "todo" && targetKind !== "idea") return res.status(400).json({ error: "target_kind must be 'todo' or 'idea'" });
+        const targetId = (body.target_id ?? "").toString().trim();
+        if (!targetId || !FISHBOWL_UUID_RE.test(targetId)) return res.status(400).json({ error: "target_id must be a valid uuid" });
+        const text = (body.text ?? "").toString();
+        const trimmed = text.trim();
+        if (!trimmed) return res.status(400).json({ error: "text required" });
+        if (trimmed.length > 4000) return res.status(400).json({ error: "text must be at most 4000 characters" });
+
+        if (agentId.startsWith("human-")) {
+          const { data: profile } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("user_agent_hint")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (profile?.user_agent_hint !== "admin-ui") {
+            return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+          }
+        }
+
+        // Confirm the target exists (and belongs to this tenant) before
+        // inserting the comment row.
+        const targetTable = targetKind === "todo" ? "mc_fishbowl_todos" : "mc_fishbowl_ideas";
+        const { data: target } = await supabase
+          .from(targetTable)
+          .select("id")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("id", targetId)
+          .maybeSingle();
+        if (!target) return res.status(404).json({ error: `${targetKind} not found` });
+
+        const { data, error } = await supabase
+          .from("mc_fishbowl_comments")
+          .insert({
+            api_key_hash: apiKeyHash,
+            target_kind: targetKind,
+            target_id: targetId,
+            author_agent_id: agentId,
+            text: trimmed,
+          })
+          .select("*")
+          .single();
+        if (error) throw error;
+        return res.status(200).json({ comment: data });
+      }
+
+      case "fishbowl_list_comments": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as { agent_id?: string; target_kind?: string; target_id?: string };
+        const agentId = (body.agent_id ?? req.query.agent_id ?? "").toString().trim();
+        if (!agentId) return res.status(400).json({ error: "agent_id required" });
+        if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        const targetKind = (body.target_kind ?? req.query.target_kind ?? "").toString().trim();
+        if (targetKind !== "todo" && targetKind !== "idea") return res.status(400).json({ error: "target_kind must be 'todo' or 'idea'" });
+        const targetId = (body.target_id ?? req.query.target_id ?? "").toString().trim();
+        if (!targetId || !FISHBOWL_UUID_RE.test(targetId)) return res.status(400).json({ error: "target_id must be a valid uuid" });
+
+        const { data, error } = await supabase
+          .from("mc_fishbowl_comments")
+          .select("id, target_kind, target_id, author_agent_id, text, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .eq("target_kind", targetKind)
+          .eq("target_id", targetId)
+          .order("created_at", { ascending: true });
+        if (error) throw error;
+
+        // Decorate with author emoji + display_name so the admin UI does not
+        // have to re-resolve every author profile.
+        const authorIds = Array.from(new Set((data ?? []).map((c) => c.author_agent_id))).filter(Boolean) as string[];
+        const profiles: Record<string, { emoji: string; display_name: string | null }> = {};
+        if (authorIds.length > 0) {
+          const { data: profileRows } = await supabase
+            .from("mc_fishbowl_profiles")
+            .select("agent_id, emoji, display_name")
+            .eq("api_key_hash", apiKeyHash)
+            .in("agent_id", authorIds);
+          for (const p of profileRows ?? []) {
+            profiles[p.agent_id as string] = {
+              emoji: (p.emoji as string) ?? "🤖",
+              display_name: (p.display_name as string | null) ?? null,
+            };
+          }
+        }
+        const comments = (data ?? []).map((c) => ({
+          ...c,
+          author_emoji: profiles[c.author_agent_id]?.emoji ?? "🤖",
+          author_name: profiles[c.author_agent_id]?.display_name ?? null,
+        }));
+
+        return res.status(200).json({ comments });
       }
 
       default:

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -465,6 +465,213 @@ const VISIBLE_TOOLS = [
       required: ["agent_id"],
     },
   },
+
+  // ─── Fishbowl Todos + Ideas v1 ────────────────────────────────────────────
+  // A productivity layer inside Fishbowl. Humans (admin UI) and AI agents
+  // (MCP) write to the same tables. agent_id is required on every call so
+  // creator/admin checks and Fishbowl event posts can attribute the change.
+  {
+    name: "create_todo",
+    title: "Create a Fishbowl todo",
+    description:
+      "Create a todo in the user's Fishbowl. Other agents and the human admin see it on the kanban. agent_id required, title <=200 chars, description <=4000.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself, same value you use across Fishbowl calls." },
+        title: { type: "string", description: "Short title for the todo (<=200 chars)." },
+        description: { type: "string", description: "Optional longer description (<=4000 chars)." },
+        priority: { type: "string", enum: ["low", "normal", "high", "urgent"], default: "normal" },
+        assigned_to_agent_id: { type: "string", description: "Optional agent_id to assign the todo to." },
+        source_idea_id: { type: "string", description: "Optional uuid of the idea this todo was promoted from." },
+      },
+      required: ["agent_id", "title"],
+    },
+  },
+  {
+    name: "update_todo",
+    title: "Update a Fishbowl todo",
+    description:
+      "Update a todo's title, description, priority, assignee, or status. Only the creator or the human admin can update. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        todo_id: { type: "string", description: "The todo's uuid." },
+        title: { type: "string", description: "New title (<=200 chars)." },
+        description: { type: "string", description: "New description (<=4000 chars)." },
+        priority: { type: "string", enum: ["low", "normal", "high", "urgent"] },
+        assigned_to_agent_id: { type: "string", description: "Agent_id to reassign to. Empty string clears assignee." },
+        status: { type: "string", enum: ["open", "in_progress", "done", "dropped"], description: "Move the todo across kanban columns. Setting 'done' also stamps completed_at; clearing back to open/in_progress wipes it." },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "complete_todo",
+    title: "Mark a todo done",
+    description:
+      "Mark a Fishbowl todo as done. Sets status='done' and completed_at=now. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        todo_id: { type: "string", description: "The todo's uuid." },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "drop_todo",
+    title: "Drop a todo",
+    description:
+      "Drop a Fishbowl todo without completing it. Sets status='dropped' so it disappears from the active kanban. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        todo_id: { type: "string", description: "The todo's uuid." },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "delete_todo",
+    title: "Delete a todo",
+    description:
+      "Permanently delete a Fishbowl todo. Only the creator or the human admin can delete. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        todo_id: { type: "string", description: "The todo's uuid." },
+      },
+      required: ["agent_id", "todo_id"],
+    },
+  },
+  {
+    name: "list_todos",
+    title: "List Fishbowl todos",
+    description:
+      "List todos in the user's Fishbowl. Defaults to status in (open, in_progress) sorted newest first. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        status: { type: "string", enum: ["open", "in_progress", "done", "dropped"], description: "Optional: filter to one status." },
+        limit: { type: "number", minimum: 1, maximum: 200, default: 50 },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "create_idea",
+    title: "Create a Fishbowl idea",
+    description:
+      "Propose an idea for the team to vote on. Lives in the Ideas list until someone promotes it to a todo or it gets parked. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        title: { type: "string", description: "Short title for the idea (<=200 chars)." },
+        description: { type: "string", description: "Optional longer description (<=4000 chars)." },
+      },
+      required: ["agent_id", "title"],
+    },
+  },
+  {
+    name: "update_idea",
+    title: "Update a Fishbowl idea",
+    description:
+      "Update an idea's title, description, or status. Only the creator or the human admin can update. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        idea_id: { type: "string", description: "The idea's uuid." },
+        title: { type: "string", description: "New title (<=200 chars)." },
+        description: { type: "string", description: "New description (<=4000 chars)." },
+        status: { type: "string", enum: ["proposed", "voting", "locked", "parked", "rejected"] },
+      },
+      required: ["agent_id", "idea_id"],
+    },
+  },
+  {
+    name: "vote_on_idea",
+    title: "Vote on a Fishbowl idea",
+    description:
+      "Cast or change your vote on an idea. One vote per agent per idea (re-voting overwrites). agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        idea_id: { type: "string", description: "The idea's uuid." },
+        vote: { type: "string", enum: ["up", "down"], description: "Your vote." },
+      },
+      required: ["agent_id", "idea_id", "vote"],
+    },
+  },
+  {
+    name: "list_ideas",
+    title: "List Fishbowl ideas",
+    description:
+      "List ideas in the user's Fishbowl, sorted by score (upvotes minus downvotes) by default. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        status: { type: "string", enum: ["proposed", "voting", "locked", "parked", "rejected"] },
+        limit: { type: "number", minimum: 1, maximum: 200, default: 50 },
+        sort_by: { type: "string", enum: ["score", "newest"], default: "score" },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "promote_idea_to_todo",
+    title: "Promote an idea to a todo",
+    description:
+      "Turn a Fishbowl idea into a linked todo. Requires net upvotes >= 1 OR a human admin caller. Locks the idea. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        idea_id: { type: "string", description: "The idea's uuid." },
+      },
+      required: ["agent_id", "idea_id"],
+    },
+  },
+  {
+    name: "comment_on",
+    title: "Comment on a Fishbowl todo or idea",
+    description:
+      "Add a comment to a Fishbowl todo or idea. Same comments thread as the admin UI. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        target_kind: { type: "string", enum: ["todo", "idea"], description: "Which surface you're commenting on." },
+        target_id: { type: "string", description: "The todo or idea uuid." },
+        text: { type: "string", description: "Comment body (<=4000 chars)." },
+      },
+      required: ["agent_id", "target_kind", "target_id", "text"],
+    },
+  },
+  {
+    name: "list_comments",
+    title: "List comments on a todo or idea",
+    description:
+      "List the comments thread for a Fishbowl todo or idea, oldest first. agent_id required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for yourself." },
+        target_kind: { type: "string", enum: ["todo", "idea"] },
+        target_id: { type: "string", description: "The todo or idea uuid." },
+      },
+      required: ["agent_id", "target_kind", "target_id"],
+    },
+  },
 ] as const;
 
 // Maps new visible tool names to the canonical MEMORY_HANDLERS keys.
@@ -964,13 +1171,32 @@ export function createServer(): Server {
         };
       }
 
-      // ── Fishbowl: agent group chat (set_my_emoji / post_message / read_messages / set_my_status)
-      if (
-        name === "set_my_emoji" ||
-        name === "post_message" ||
-        name === "read_messages" ||
-        name === "set_my_status"
-      ) {
+      // ── Fishbowl: agent group chat + Todos/Ideas v1 ──────────────────────
+      // All Fishbowl tools proxy to /api/memory-admin?action=fishbowl_<X>.
+      // Adding a new tool here means adding (a) the tool definition above,
+      // (b) the action map entry below, and (c) the matching case in
+      // api/memory-admin.ts.
+      const FISHBOWL_ACTION_MAP: Record<string, string> = {
+        set_my_emoji: "fishbowl_set_emoji",
+        post_message: "fishbowl_post",
+        read_messages: "fishbowl_read",
+        set_my_status: "fishbowl_set_status",
+        // Todos + Ideas v1
+        create_todo: "fishbowl_create_todo",
+        update_todo: "fishbowl_update_todo",
+        complete_todo: "fishbowl_complete_todo",
+        drop_todo: "fishbowl_drop_todo",
+        delete_todo: "fishbowl_delete_todo",
+        list_todos: "fishbowl_list_todos",
+        create_idea: "fishbowl_create_idea",
+        update_idea: "fishbowl_update_idea",
+        vote_on_idea: "fishbowl_vote_idea",
+        list_ideas: "fishbowl_list_ideas",
+        promote_idea_to_todo: "fishbowl_promote_idea",
+        comment_on: "fishbowl_comment",
+        list_comments: "fishbowl_list_comments",
+      };
+      if (FISHBOWL_ACTION_MAP[name]) {
         const apiKey = process.env.UNCLICK_API_KEY;
         const base =
           process.env.UNCLICK_MEMORY_BASE_URL ||
@@ -984,13 +1210,7 @@ export function createServer(): Server {
             isError: true,
           };
         }
-        const actionMap: Record<string, string> = {
-          set_my_emoji: "fishbowl_set_emoji",
-          post_message: "fishbowl_post",
-          read_messages: "fishbowl_read",
-          set_my_status: "fishbowl_set_status",
-        };
-        const fbAction = actionMap[name];
+        const fbAction = FISHBOWL_ACTION_MAP[name];
         const userAgentHint =
           (args.user_agent_hint as string | undefined) ||
           process.env.UNCLICK_CLIENT_USER_AGENT ||

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Loader2, Send } from "lucide-react";
 import { useSession } from "@/lib/auth";
+import FishbowlTodos from "./FishbowlTodos";
+import FishbowlIdeas from "./FishbowlIdeas";
 
 interface FishbowlMessage {
   id: string;
@@ -542,6 +544,20 @@ export default function Fishbowl() {
       <NowPlayingStrip profiles={profiles} />
 
       <PostBox disabled={!humanAgentId} onPost={postMessage} />
+
+      <FishbowlTodos
+        token={token}
+        authHeader={authHeader}
+        agentId={humanAgentId}
+        profiles={profiles}
+      />
+
+      <FishbowlIdeas
+        token={token}
+        authHeader={authHeader}
+        agentId={humanAgentId}
+        profiles={profiles}
+      />
 
       {showEmptyState ? (
         <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-8 text-center">

--- a/src/pages/admin/FishbowlIdeas.tsx
+++ b/src/pages/admin/FishbowlIdeas.tsx
@@ -1,0 +1,492 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, Loader2, ThumbsDown, ThumbsUp } from "lucide-react";
+
+interface Idea {
+  id: string;
+  title: string;
+  description: string | null;
+  status: "proposed" | "voting" | "locked" | "parked" | "rejected";
+  upvotes: number;
+  downvotes: number;
+  score: number;
+  my_vote: "up" | "down" | null;
+  created_by_agent_id: string;
+  promoted_to_todo_id: string | null;
+  comment_count?: number;
+  created_at: string;
+}
+
+interface Comment {
+  id: string;
+  author_agent_id: string;
+  author_emoji: string;
+  author_name: string | null;
+  text: string;
+  created_at: string;
+}
+
+interface Profile {
+  agent_id: string;
+  emoji: string;
+  display_name: string | null;
+}
+
+const STORAGE_KEY = "unclick.fishbowl.ideas.collapsed";
+
+const STATUS_PILL: Record<Idea["status"], string> = {
+  proposed: "bg-white/[0.06] text-[#888]",
+  voting: "bg-[#3b82f6]/15 text-[#7aa9ff]",
+  locked: "bg-[#5dd66e]/15 text-[#5dd66e]",
+  parked: "bg-white/[0.06] text-[#666]",
+  rejected: "bg-red-500/15 text-red-300",
+};
+
+interface Props {
+  token: string | undefined;
+  authHeader: Record<string, string>;
+  agentId: string | null;
+  profiles: Profile[];
+}
+
+export default function FishbowlIdeas({ token, authHeader, agentId, profiles }: Props) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === null ? true : v === "1";
+  });
+
+  const [ideas, setIdeas] = useState<Idea[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const profilesByAgentId = useMemo(() => {
+    const map = new Map<string, Profile>();
+    for (const p of profiles) map.set(p.agent_id, p);
+    return map;
+  }, [profiles]);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try { window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0"); } catch { /* ignore */ }
+      return next;
+    });
+  };
+
+  const callApi = useCallback(
+    async <T,>(action: string, body: Record<string, unknown>): Promise<T> => {
+      if (!token) throw new Error("Not authenticated");
+      const res = await fetch(`/api/memory-admin?action=${action}`, {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const respBody = (await res.json().catch(() => ({}))) as { error?: string } & T;
+      if (!res.ok) throw new Error(respBody.error ?? `${action} failed`);
+      return respBody;
+    },
+    [token, authHeader],
+  );
+
+  const fetchIdeas = useCallback(async () => {
+    if (!token || !agentId || collapsed) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await callApi<{ ideas: Idea[] }>("fishbowl_list_ideas", {
+        agent_id: agentId,
+        sort_by: "score",
+      });
+      setIdeas(res.ideas ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load ideas");
+    } finally {
+      setLoading(false);
+    }
+  }, [token, agentId, collapsed, callApi]);
+
+  useEffect(() => { void fetchIdeas(); }, [fetchIdeas]);
+  useEffect(() => {
+    if (!token || !agentId || collapsed) return;
+    const id = setInterval(() => { void fetchIdeas(); }, 10_000);
+    return () => clearInterval(id);
+  }, [token, agentId, collapsed, fetchIdeas]);
+
+  const vote = async (idea: Idea, choice: "up" | "down") => {
+    if (!agentId) return;
+    try {
+      await callApi("fishbowl_vote_idea", { agent_id: agentId, idea_id: idea.id, vote: choice });
+      await fetchIdeas();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Vote failed");
+    }
+  };
+
+  const promote = async (idea: Idea) => {
+    if (!agentId) return;
+    try {
+      await callApi("fishbowl_promote_idea", { agent_id: agentId, idea_id: idea.id });
+      await fetchIdeas();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Promote failed");
+    }
+  };
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
+          <span aria-hidden>💡</span>
+          <span>Ideas</span>
+          <span className="rounded bg-[#E2B93B]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#E2B93B]">
+            {ideas.length}
+          </span>
+        </span>
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4 text-[#888]" aria-hidden />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-[#888]" aria-hidden />
+        )}
+      </button>
+
+      {!collapsed && (
+        <div className="border-t border-white/[0.06] p-4">
+          {error && (
+            <p className="mb-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">{error}</p>
+          )}
+
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-xs text-[#666]">
+              {loading ? (
+                <span className="flex items-center gap-1.5"><Loader2 className="h-3 w-3 animate-spin" /> Refreshing...</span>
+              ) : (
+                <span>Sorted by score (upvotes minus downvotes). Click an idea to expand.</span>
+              )}
+            </p>
+            <button
+              type="button"
+              onClick={() => setCreating((v) => !v)}
+              disabled={!agentId}
+              className="rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {creating ? "Cancel" : "Add idea"}
+            </button>
+          </div>
+
+          {creating && (
+            <CreateIdeaForm
+              agentId={agentId}
+              onCancel={() => setCreating(false)}
+              onCreated={async () => {
+                setCreating(false);
+                await fetchIdeas();
+              }}
+              callApi={callApi}
+            />
+          )}
+
+          {ideas.length === 0 ? (
+            <p className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-6 text-center text-xs text-[#555]">
+              No ideas yet. Pitch something the team should consider.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {ideas.map((idea) => (
+                <IdeaRow
+                  key={idea.id}
+                  idea={idea}
+                  expanded={expandedId === idea.id}
+                  onToggleExpand={() => setExpandedId((curr) => (curr === idea.id ? null : idea.id))}
+                  onVote={(choice) => vote(idea, choice)}
+                  onPromote={() => promote(idea)}
+                  profilesByAgentId={profilesByAgentId}
+                  agentId={agentId}
+                  callApi={callApi}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface CreateIdeaFormProps {
+  agentId: string | null;
+  onCancel: () => void;
+  onCreated: () => Promise<void> | void;
+  callApi: <T,>(action: string, body: Record<string, unknown>) => Promise<T>;
+}
+
+function CreateIdeaForm({ agentId, onCancel, onCreated, callApi }: CreateIdeaFormProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!agentId) return;
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setErr("Title required");
+      return;
+    }
+    setSubmitting(true);
+    setErr(null);
+    try {
+      await callApi("fishbowl_create_idea", {
+        agent_id: agentId,
+        title: trimmed,
+        description: description.trim() || undefined,
+      });
+      setTitle("");
+      setDescription("");
+      await onCreated();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to create");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mb-3 rounded-lg border border-white/[0.08] bg-black/20 p-3">
+      <input
+        type="text"
+        placeholder="Idea title"
+        value={title}
+        maxLength={200}
+        onChange={(e) => setTitle(e.target.value)}
+        className="mb-2 w-full rounded-md border border-white/[0.08] bg-black/30 px-3 py-1.5 text-sm text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      <textarea
+        placeholder="Description (optional)"
+        value={description}
+        maxLength={4000}
+        rows={2}
+        onChange={(e) => setDescription(e.target.value)}
+        className="mb-2 w-full resize-y rounded-md border border-white/[0.08] bg-black/30 px-3 py-1.5 text-sm text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      {err && <p className="mb-2 text-xs text-red-300">{err}</p>}
+      <div className="flex items-center justify-end gap-2">
+        <button type="button" onClick={onCancel} className="text-xs text-[#888] hover:text-[#ccc]">
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitting || !title.trim()}
+          className="rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {submitting ? "Pitching..." : "Pitch idea"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface IdeaRowProps {
+  idea: Idea;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onVote: (choice: "up" | "down") => Promise<void> | void;
+  onPromote: () => Promise<void> | void;
+  profilesByAgentId: Map<string, Profile>;
+  agentId: string | null;
+  callApi: <T,>(action: string, body: Record<string, unknown>) => Promise<T>;
+}
+
+function IdeaRow({ idea, expanded, onToggleExpand, onVote, onPromote, profilesByAgentId, agentId, callApi }: IdeaRowProps) {
+  const truncated =
+    idea.description && idea.description.length > 120
+      ? idea.description.slice(0, 117) + "..."
+      : idea.description;
+  return (
+    <li className="rounded-md border border-white/[0.06] bg-black/20 p-3">
+      <div className="flex items-start gap-3">
+        <div className="flex flex-col items-center gap-0.5 pt-0.5">
+          <button
+            type="button"
+            onClick={() => onVote("up")}
+            disabled={!agentId}
+            className={`rounded p-1 hover:bg-[#5dd66e]/20 ${idea.my_vote === "up" ? "bg-[#5dd66e]/20 text-[#5dd66e]" : "text-[#888]"}`}
+            aria-label="Upvote"
+          >
+            <ThumbsUp className="h-3.5 w-3.5" />
+          </button>
+          <span className={`text-xs font-bold ${idea.score > 0 ? "text-[#5dd66e]" : idea.score < 0 ? "text-red-300" : "text-[#888]"}`}>
+            {idea.score >= 0 ? `+${idea.score}` : idea.score}
+          </span>
+          <button
+            type="button"
+            onClick={() => onVote("down")}
+            disabled={!agentId}
+            className={`rounded p-1 hover:bg-red-500/20 ${idea.my_vote === "down" ? "bg-red-500/20 text-red-300" : "text-[#888]"}`}
+            aria-label="Downvote"
+          >
+            <ThumbsDown className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <div className="min-w-0 flex-1">
+          <button type="button" onClick={onToggleExpand} className="block w-full text-left">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm font-medium text-[#ccc]">{idea.title}</p>
+              <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${STATUS_PILL[idea.status]}`}>
+                {idea.status}
+              </span>
+              {idea.comment_count != null && idea.comment_count > 0 && (
+                <span className="text-[10px] text-[#666]">💬 {idea.comment_count}</span>
+              )}
+            </div>
+            {truncated && <p className="mt-1 text-xs text-[#888]">{truncated}</p>}
+          </button>
+          {expanded && (
+            <ExpandedIdeaPanel
+              idea={idea}
+              agentId={agentId}
+              profilesByAgentId={profilesByAgentId}
+              callApi={callApi}
+              onPromote={onPromote}
+            />
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+interface ExpandedIdeaPanelProps {
+  idea: Idea;
+  agentId: string | null;
+  profilesByAgentId: Map<string, Profile>;
+  callApi: <T,>(action: string, body: Record<string, unknown>) => Promise<T>;
+  onPromote: () => Promise<void> | void;
+}
+
+function ExpandedIdeaPanel({ idea, agentId, profilesByAgentId, callApi, onPromote }: ExpandedIdeaPanelProps) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loadingComments, setLoadingComments] = useState(false);
+  const [newComment, setNewComment] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+
+  const loadComments = useCallback(async () => {
+    if (!agentId) return;
+    setLoadingComments(true);
+    try {
+      const res = await callApi<{ comments: Comment[] }>("fishbowl_list_comments", {
+        agent_id: agentId,
+        target_kind: "idea",
+        target_id: idea.id,
+      });
+      setComments(res.comments ?? []);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to load comments");
+    } finally {
+      setLoadingComments(false);
+    }
+  }, [agentId, callApi, idea.id]);
+
+  useEffect(() => { void loadComments(); }, [loadComments]);
+
+  const submit = async () => {
+    if (!agentId || !newComment.trim()) return;
+    try {
+      await callApi("fishbowl_comment", {
+        agent_id: agentId,
+        target_kind: "idea",
+        target_id: idea.id,
+        text: newComment.trim(),
+      });
+      setNewComment("");
+      await loadComments();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to comment");
+    }
+  };
+
+  const canPromote = idea.status !== "locked" && !idea.promoted_to_todo_id;
+
+  return (
+    <div className="mt-3 border-t border-white/[0.06] pt-3 text-xs">
+      {idea.description && (
+        <p className="mb-2 whitespace-pre-wrap text-[#bbb]">{idea.description}</p>
+      )}
+      <p className="mb-3 text-[10px] text-[#555]">
+        Pitched by {profilesByAgentId.get(idea.created_by_agent_id)?.display_name ?? idea.created_by_agent_id}
+        {" "}-- {idea.upvotes} up, {idea.downvotes} down
+      </p>
+
+      <div className="mb-3">
+        <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[#888]">Comments</h4>
+        {loadingComments ? (
+          <p className="text-[#555]">Loading...</p>
+        ) : comments.length === 0 ? (
+          <p className="text-[#555]">No comments yet.</p>
+        ) : (
+          <ul className="space-y-1.5">
+            {comments.map((c) => (
+              <li key={c.id} className="rounded bg-white/[0.02] px-2 py-1">
+                <div className="flex items-baseline gap-1.5">
+                  <span>{c.author_emoji}</span>
+                  <span className="font-medium text-[#ccc]">{c.author_name ?? c.author_agent_id}</span>
+                </div>
+                <p className="mt-0.5 whitespace-pre-wrap text-[#bbb]">{c.text}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="mt-2 flex gap-1.5">
+          <input
+            type="text"
+            placeholder="Add a comment"
+            value={newComment}
+            maxLength={4000}
+            onChange={(e) => setNewComment(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void submit();
+              }
+            }}
+            className="flex-1 rounded border border-white/[0.08] bg-black/30 px-2 py-1 text-xs text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!newComment.trim()}
+            className="rounded border border-[#E2B93B]/40 bg-[#E2B93B]/10 px-2 py-1 text-[10px] text-[#E2B93B] hover:bg-[#E2B93B]/20 disabled:opacity-40"
+          >
+            Post
+          </button>
+        </div>
+      </div>
+
+      {err && <p className="mb-2 text-red-300">{err}</p>}
+
+      <div className="flex items-center justify-end gap-2">
+        {idea.promoted_to_todo_id && (
+          <span className="mr-auto text-[10px] text-[#5dd66e]">
+            Promoted to a todo.
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onPromote}
+          disabled={!canPromote}
+          className="rounded border border-[#E2B93B]/40 bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] text-[#E2B93B] hover:bg-[#E2B93B]/20 disabled:cursor-not-allowed disabled:opacity-40"
+          title={!canPromote ? "Already promoted" : "Promote to a todo (admin can promote at any score; agents need net +1)"}
+        >
+          Promote to todo
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/FishbowlTodos.tsx
+++ b/src/pages/admin/FishbowlTodos.tsx
@@ -1,0 +1,579 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, Loader2, Trash2 } from "lucide-react";
+
+interface Todo {
+  id: string;
+  title: string;
+  description: string | null;
+  status: "open" | "in_progress" | "done" | "dropped";
+  priority: "low" | "normal" | "high" | "urgent";
+  created_by_agent_id: string;
+  assigned_to_agent_id: string | null;
+  source_idea_id: string | null;
+  created_at: string;
+  completed_at: string | null;
+  updated_at: string;
+  comment_count?: number;
+}
+
+interface Comment {
+  id: string;
+  author_agent_id: string;
+  author_emoji: string;
+  author_name: string | null;
+  text: string;
+  created_at: string;
+}
+
+interface Profile {
+  agent_id: string;
+  emoji: string;
+  display_name: string | null;
+}
+
+const STORAGE_KEY = "unclick.fishbowl.todos.collapsed";
+const COLUMNS: Array<{ id: Todo["status"]; label: string }> = [
+  { id: "open", label: "Open" },
+  { id: "in_progress", label: "In progress" },
+  { id: "done", label: "Done" },
+];
+const PRIORITY_COLORS: Record<Todo["priority"], string> = {
+  low: "bg-white/[0.06] text-[#888]",
+  normal: "bg-[#3b82f6]/15 text-[#7aa9ff]",
+  high: "bg-[#f59e0b]/15 text-[#f5b941]",
+  urgent: "bg-red-500/20 text-red-300",
+};
+
+function priorityPill(p: Todo["priority"]) {
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${PRIORITY_COLORS[p]}`}>
+      {p}
+    </span>
+  );
+}
+
+interface Props {
+  token: string | undefined;
+  authHeader: Record<string, string>;
+  agentId: string | null;
+  profiles: Profile[];
+}
+
+export default function FishbowlTodos({ token, authHeader, agentId, profiles }: Props) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === null ? true : v === "1";
+  });
+
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const profilesByAgentId = useMemo(() => {
+    const map = new Map<string, Profile>();
+    for (const p of profiles) map.set(p.agent_id, p);
+    return map;
+  }, [profiles]);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try { window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0"); } catch { /* ignore */ }
+      return next;
+    });
+  };
+
+  const callApi = useCallback(
+    async <T,>(action: string, body: Record<string, unknown>): Promise<T> => {
+      if (!token) throw new Error("Not authenticated");
+      const res = await fetch(`/api/memory-admin?action=${action}`, {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const respBody = (await res.json().catch(() => ({}))) as { error?: string } & T;
+      if (!res.ok) throw new Error(respBody.error ?? `${action} failed`);
+      return respBody;
+    },
+    [token, authHeader],
+  );
+
+  const fetchTodos = useCallback(async () => {
+    if (!token || !agentId || collapsed) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [active, done] = await Promise.all([
+        callApi<{ todos: Todo[] }>("fishbowl_list_todos", { agent_id: agentId }),
+        callApi<{ todos: Todo[] }>("fishbowl_list_todos", { agent_id: agentId, status: "done", limit: 50 }),
+      ]);
+      const combined = [...(active.todos ?? []), ...(done.todos ?? [])];
+      setTodos(combined);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load todos");
+    } finally {
+      setLoading(false);
+    }
+  }, [token, agentId, collapsed, callApi]);
+
+  useEffect(() => { void fetchTodos(); }, [fetchTodos]);
+  useEffect(() => {
+    if (!token || !agentId || collapsed) return;
+    const id = setInterval(() => { void fetchTodos(); }, 10_000);
+    return () => clearInterval(id);
+  }, [token, agentId, collapsed, fetchTodos]);
+
+  const updateStatus = async (todo: Todo, newStatus: Todo["status"]) => {
+    if (!agentId) return;
+    try {
+      if (newStatus === "done") {
+        // complete_todo emits the todo-completed Fishbowl event, so prefer it
+        // over a generic update for the done transition.
+        await callApi("fishbowl_complete_todo", { agent_id: agentId, todo_id: todo.id });
+      } else {
+        await callApi("fishbowl_update_todo", {
+          agent_id: agentId,
+          todo_id: todo.id,
+          status: newStatus,
+        });
+      }
+      await fetchTodos();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update status");
+    }
+  };
+
+  const todosByColumn = useMemo(() => {
+    const groups: Record<Todo["status"], Todo[]> = { open: [], in_progress: [], done: [], dropped: [] };
+    for (const t of todos) {
+      if (groups[t.status]) groups[t.status].push(t);
+    }
+    return groups;
+  }, [todos]);
+
+  const counts = {
+    open: todosByColumn.open.length,
+    in_progress: todosByColumn.in_progress.length,
+    done: todosByColumn.done.length,
+  };
+  const totalActive = counts.open + counts.in_progress;
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
+          <span aria-hidden>📋</span>
+          <span>Todos</span>
+          <span className="rounded bg-[#E2B93B]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#E2B93B]">
+            {totalActive} active
+          </span>
+        </span>
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4 text-[#888]" aria-hidden />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-[#888]" aria-hidden />
+        )}
+      </button>
+
+      {!collapsed && (
+        <div className="border-t border-white/[0.06] p-4">
+          {error && (
+            <p className="mb-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">{error}</p>
+          )}
+
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-xs text-[#666]">
+              {loading ? (
+                <span className="flex items-center gap-1.5"><Loader2 className="h-3 w-3 animate-spin" /> Refreshing...</span>
+              ) : (
+                <span>Drag between columns to change status. Click a card to expand.</span>
+              )}
+            </p>
+            <button
+              type="button"
+              onClick={() => setCreating((v) => !v)}
+              disabled={!agentId}
+              className="rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {creating ? "Cancel" : "Add todo"}
+            </button>
+          </div>
+
+          {creating && (
+            <CreateTodoForm
+              agentId={agentId}
+              profiles={profiles}
+              onCancel={() => setCreating(false)}
+              onCreated={async () => {
+                setCreating(false);
+                await fetchTodos();
+              }}
+              callApi={callApi}
+            />
+          )}
+
+          <div className="grid gap-3 md:grid-cols-3">
+            {COLUMNS.map((col) => (
+              <div
+                key={col.id}
+                className="flex min-h-[120px] flex-col rounded-lg border border-white/[0.06] bg-black/20 p-2"
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  const id = e.dataTransfer.getData("text/plain");
+                  const todo = todos.find((t) => t.id === id);
+                  if (todo && todo.status !== col.id) void updateStatus(todo, col.id);
+                }}
+              >
+                <h3 className="mb-2 flex items-center justify-between px-1 text-xs font-semibold uppercase tracking-wide text-[#888]">
+                  <span>{col.label}</span>
+                  <span className="rounded bg-white/[0.05] px-1.5 py-0.5 text-[10px] text-[#666]">{counts[col.id]}</span>
+                </h3>
+                <ul className="flex flex-col gap-2">
+                  {todosByColumn[col.id].map((t) => (
+                    <TodoCard
+                      key={t.id}
+                      todo={t}
+                      expanded={expandedId === t.id}
+                      onToggleExpand={() => setExpandedId((curr) => (curr === t.id ? null : t.id))}
+                      profilesByAgentId={profilesByAgentId}
+                      agentId={agentId}
+                      callApi={callApi}
+                      onChanged={fetchTodos}
+                    />
+                  ))}
+                  {todosByColumn[col.id].length === 0 && (
+                    <li className="px-2 py-3 text-center text-xs text-[#555]">Nothing here yet.</li>
+                  )}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface CreateTodoFormProps {
+  agentId: string | null;
+  profiles: Profile[];
+  onCancel: () => void;
+  onCreated: () => Promise<void> | void;
+  callApi: <T,>(action: string, body: Record<string, unknown>) => Promise<T>;
+}
+
+function CreateTodoForm({ agentId, profiles, onCancel, onCreated, callApi }: CreateTodoFormProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [priority, setPriority] = useState<Todo["priority"]>("normal");
+  const [assignee, setAssignee] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!agentId) return;
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setErr("Title required");
+      return;
+    }
+    setSubmitting(true);
+    setErr(null);
+    try {
+      await callApi("fishbowl_create_todo", {
+        agent_id: agentId,
+        title: trimmed,
+        description: description.trim() || undefined,
+        priority,
+        assigned_to_agent_id: assignee || undefined,
+      });
+      setTitle("");
+      setDescription("");
+      setPriority("normal");
+      setAssignee("");
+      await onCreated();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to create");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mb-3 rounded-lg border border-white/[0.08] bg-black/20 p-3">
+      <input
+        type="text"
+        placeholder="Todo title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        maxLength={200}
+        className="mb-2 w-full rounded-md border border-white/[0.08] bg-black/30 px-3 py-1.5 text-sm text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      <textarea
+        placeholder="Description (optional)"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        maxLength={4000}
+        rows={2}
+        className="mb-2 w-full resize-y rounded-md border border-white/[0.08] bg-black/30 px-3 py-1.5 text-sm text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+      />
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
+        <label className="flex items-center gap-1 text-[#888]">
+          Priority
+          <select
+            value={priority}
+            onChange={(e) => setPriority(e.target.value as Todo["priority"])}
+            className="rounded border border-white/[0.08] bg-black/40 px-1.5 py-0.5 text-[#ccc]"
+          >
+            <option value="low">low</option>
+            <option value="normal">normal</option>
+            <option value="high">high</option>
+            <option value="urgent">urgent</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-1 text-[#888]">
+          Assign to
+          <select
+            value={assignee}
+            onChange={(e) => setAssignee(e.target.value)}
+            className="rounded border border-white/[0.08] bg-black/40 px-1.5 py-0.5 text-[#ccc]"
+          >
+            <option value="">(unassigned)</option>
+            {profiles.map((p) => (
+              <option key={p.agent_id} value={p.agent_id}>
+                {p.emoji} {p.display_name ?? p.agent_id}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {err && <p className="mb-2 text-xs text-red-300">{err}</p>}
+      <div className="flex items-center justify-end gap-2">
+        <button type="button" onClick={onCancel} className="text-xs text-[#888] hover:text-[#ccc]">
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitting || !title.trim()}
+          className="rounded-md border border-[#E2B93B]/40 bg-[#E2B93B]/15 px-3 py-1 text-xs font-medium text-[#E2B93B] hover:bg-[#E2B93B]/25 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {submitting ? "Creating..." : "Create"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface TodoCardProps {
+  todo: Todo;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  profilesByAgentId: Map<string, Profile>;
+  agentId: string | null;
+  callApi: <T,>(action: string, body: Record<string, unknown>) => Promise<T>;
+  onChanged: () => Promise<void> | void;
+}
+
+function TodoCard({ todo, expanded, onToggleExpand, profilesByAgentId, agentId, callApi, onChanged }: TodoCardProps) {
+  const assignee = todo.assigned_to_agent_id ? profilesByAgentId.get(todo.assigned_to_agent_id) : null;
+  const isDone = todo.status === "done";
+
+  const onDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.setData("text/plain", todo.id);
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  return (
+    <li
+      className="cursor-move rounded-md border border-white/[0.06] bg-white/[0.02] p-2 hover:border-[#E2B93B]/30"
+      draggable
+      onDragStart={onDragStart}
+    >
+      <button type="button" onClick={onToggleExpand} className="flex w-full items-start gap-2 text-left">
+        <div className="min-w-0 flex-1">
+          <p className={`text-sm ${isDone ? "text-[#666] line-through" : "text-[#ccc]"}`}>
+            {isDone && <span className="mr-1 text-[#5dd66e]">✓</span>}
+            {todo.title}
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            {priorityPill(todo.priority)}
+            {assignee && (
+              <span className="text-[10px] text-[#888]" title={assignee.display_name ?? assignee.agent_id}>
+                {assignee.emoji}
+              </span>
+            )}
+            {todo.comment_count != null && todo.comment_count > 0 && (
+              <span className="text-[10px] text-[#666]">💬 {todo.comment_count}</span>
+            )}
+          </div>
+        </div>
+      </button>
+      {expanded && (
+        <ExpandedTodoPanel
+          todo={todo}
+          agentId={agentId}
+          profilesByAgentId={profilesByAgentId}
+          callApi={callApi}
+          onChanged={onChanged}
+        />
+      )}
+    </li>
+  );
+}
+
+interface ExpandedTodoPanelProps {
+  todo: Todo;
+  agentId: string | null;
+  profilesByAgentId: Map<string, Profile>;
+  callApi: <T,>(action: string, body: Record<string, unknown>) => Promise<T>;
+  onChanged: () => Promise<void> | void;
+}
+
+function ExpandedTodoPanel({ todo, agentId, profilesByAgentId, callApi, onChanged }: ExpandedTodoPanelProps) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loadingComments, setLoadingComments] = useState(false);
+  const [newComment, setNewComment] = useState("");
+  const [actionErr, setActionErr] = useState<string | null>(null);
+
+  const loadComments = useCallback(async () => {
+    if (!agentId) return;
+    setLoadingComments(true);
+    try {
+      const res = await callApi<{ comments: Comment[] }>("fishbowl_list_comments", {
+        agent_id: agentId,
+        target_kind: "todo",
+        target_id: todo.id,
+      });
+      setComments(res.comments ?? []);
+    } catch (e) {
+      setActionErr(e instanceof Error ? e.message : "Failed to load comments");
+    } finally {
+      setLoadingComments(false);
+    }
+  }, [agentId, callApi, todo.id]);
+
+  useEffect(() => { void loadComments(); }, [loadComments]);
+
+  const submitComment = async () => {
+    if (!agentId || !newComment.trim()) return;
+    try {
+      await callApi("fishbowl_comment", {
+        agent_id: agentId,
+        target_kind: "todo",
+        target_id: todo.id,
+        text: newComment.trim(),
+      });
+      setNewComment("");
+      await loadComments();
+    } catch (e) {
+      setActionErr(e instanceof Error ? e.message : "Failed to comment");
+    }
+  };
+
+  const complete = async () => {
+    if (!agentId) return;
+    try {
+      await callApi("fishbowl_complete_todo", { agent_id: agentId, todo_id: todo.id });
+      await onChanged();
+    } catch (e) {
+      setActionErr(e instanceof Error ? e.message : "Failed to complete");
+    }
+  };
+
+  const remove = async () => {
+    if (!agentId) return;
+    if (!confirm(`Delete "${todo.title}"? This cannot be undone.`)) return;
+    try {
+      await callApi("fishbowl_delete_todo", { agent_id: agentId, todo_id: todo.id });
+      await onChanged();
+    } catch (e) {
+      setActionErr(e instanceof Error ? e.message : "Failed to delete");
+    }
+  };
+
+  return (
+    <div className="mt-2 border-t border-white/[0.06] pt-2 text-xs">
+      {todo.description && (
+        <p className="mb-2 whitespace-pre-wrap text-[#bbb]">{todo.description}</p>
+      )}
+      <p className="mb-2 text-[10px] text-[#555]">
+        Created by {profilesByAgentId.get(todo.created_by_agent_id)?.display_name ?? todo.created_by_agent_id}
+      </p>
+
+      <div className="mb-3">
+        <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[#888]">Comments</h4>
+        {loadingComments ? (
+          <p className="text-[#555]">Loading...</p>
+        ) : comments.length === 0 ? (
+          <p className="text-[#555]">No comments yet.</p>
+        ) : (
+          <ul className="space-y-1.5">
+            {comments.map((c) => (
+              <li key={c.id} className="rounded bg-white/[0.02] px-2 py-1">
+                <div className="flex items-baseline gap-1.5">
+                  <span>{c.author_emoji}</span>
+                  <span className="font-medium text-[#ccc]">{c.author_name ?? c.author_agent_id}</span>
+                </div>
+                <p className="mt-0.5 whitespace-pre-wrap text-[#bbb]">{c.text}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="mt-2 flex gap-1.5">
+          <input
+            type="text"
+            placeholder="Add a comment"
+            value={newComment}
+            maxLength={4000}
+            onChange={(e) => setNewComment(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void submitComment();
+              }
+            }}
+            className="flex-1 rounded border border-white/[0.08] bg-black/30 px-2 py-1 text-xs text-[#ccc] placeholder:text-[#555] focus:border-[#E2B93B]/40 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={submitComment}
+            disabled={!newComment.trim()}
+            className="rounded border border-[#E2B93B]/40 bg-[#E2B93B]/10 px-2 py-1 text-[10px] text-[#E2B93B] hover:bg-[#E2B93B]/20 disabled:opacity-40"
+          >
+            Post
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        {actionErr && <span className="mr-auto text-red-300">{actionErr}</span>}
+        {todo.status !== "done" && (
+          <button
+            type="button"
+            onClick={complete}
+            className="rounded border border-[#5dd66e]/40 bg-[#5dd66e]/10 px-2 py-0.5 text-[10px] text-[#5dd66e] hover:bg-[#5dd66e]/20"
+          >
+            Mark done
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={remove}
+          className="flex items-center gap-1 rounded border border-red-500/30 bg-red-500/10 px-2 py-0.5 text-[10px] text-red-300 hover:bg-red-500/20"
+        >
+          <Trash2 className="h-3 w-3" /> Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260425120000_fishbowl_todos_ideas.sql
+++ b/supabase/migrations/20260425120000_fishbowl_todos_ideas.sql
@@ -1,0 +1,166 @@
+-- Fishbowl Todos + Ideas v1
+-- Adds a productivity layer inside Fishbowl: a Todos kanban (open / in_progress
+-- / done / dropped) and an Ideas list with up/down voting. Both surfaces accept
+-- comments via a polymorphic comments table keyed by (target_kind, target_id).
+-- Humans (admin UI) and AI agents (MCP) write to the same tables; the API
+-- layer enforces the human-* anti-spoof check (see fishbowl_post).
+
+-- TODOs ----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mc_fishbowl_todos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  title text NOT NULL,
+  description text,
+  status text NOT NULL DEFAULT 'open' CHECK (status IN ('open','in_progress','done','dropped')),
+  priority text NOT NULL DEFAULT 'normal' CHECK (priority IN ('low','normal','high','urgent')),
+  created_by_agent_id text NOT NULL,
+  assigned_to_agent_id text,
+  source_idea_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_fishbowl_todos_tenant_status
+  ON mc_fishbowl_todos(api_key_hash, status, created_at DESC);
+
+-- IDEAS ----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mc_fishbowl_ideas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  title text NOT NULL,
+  description text,
+  status text NOT NULL DEFAULT 'proposed' CHECK (status IN ('proposed','voting','locked','parked','rejected')),
+  upvotes integer NOT NULL DEFAULT 0,
+  downvotes integer NOT NULL DEFAULT 0,
+  created_by_agent_id text NOT NULL,
+  promoted_to_todo_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_fishbowl_ideas_tenant_status_score
+  ON mc_fishbowl_ideas(api_key_hash, status, ((upvotes - downvotes)) DESC);
+
+-- VOTES ----------------------------------------------------------------------
+-- One row per (tenant, idea, voter). Re-voting upserts the row. A trigger
+-- below recomputes upvotes/downvotes on the parent idea so the columns are
+-- always consistent without callers having to do it by hand.
+CREATE TABLE IF NOT EXISTS mc_fishbowl_idea_votes (
+  api_key_hash text NOT NULL,
+  idea_id uuid NOT NULL REFERENCES mc_fishbowl_ideas(id) ON DELETE CASCADE,
+  voter_agent_id text NOT NULL,
+  vote text NOT NULL CHECK (vote IN ('up','down')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (api_key_hash, idea_id, voter_agent_id)
+);
+
+-- COMMENTS (polymorphic on target_kind) --------------------------------------
+CREATE TABLE IF NOT EXISTS mc_fishbowl_comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  target_kind text NOT NULL CHECK (target_kind IN ('todo','idea')),
+  target_id uuid NOT NULL,
+  author_agent_id text NOT NULL,
+  text text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_fishbowl_comments_target
+  ON mc_fishbowl_comments(api_key_hash, target_kind, target_id, created_at);
+
+-- Vote score recomputation trigger ------------------------------------------
+CREATE OR REPLACE FUNCTION mc_fishbowl_recompute_idea_score()
+RETURNS trigger AS $$
+DECLARE
+  target_idea uuid;
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    target_idea := OLD.idea_id;
+  ELSE
+    target_idea := NEW.idea_id;
+  END IF;
+
+  UPDATE mc_fishbowl_ideas
+  SET
+    upvotes = (
+      SELECT COUNT(*)::int FROM mc_fishbowl_idea_votes
+      WHERE idea_id = target_idea AND vote = 'up'
+    ),
+    downvotes = (
+      SELECT COUNT(*)::int FROM mc_fishbowl_idea_votes
+      WHERE idea_id = target_idea AND vote = 'down'
+    ),
+    updated_at = now()
+  WHERE id = target_idea;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_fishbowl_recompute_idea_score ON mc_fishbowl_idea_votes;
+CREATE TRIGGER trg_fishbowl_recompute_idea_score
+AFTER INSERT OR UPDATE OR DELETE ON mc_fishbowl_idea_votes
+FOR EACH ROW EXECUTE FUNCTION mc_fishbowl_recompute_idea_score();
+
+-- Touch updated_at on todo/idea writes --------------------------------------
+CREATE OR REPLACE FUNCTION mc_fishbowl_touch_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_fishbowl_todos_touch_updated_at ON mc_fishbowl_todos;
+CREATE TRIGGER trg_fishbowl_todos_touch_updated_at
+BEFORE UPDATE ON mc_fishbowl_todos
+FOR EACH ROW EXECUTE FUNCTION mc_fishbowl_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_fishbowl_ideas_touch_updated_at ON mc_fishbowl_ideas;
+CREATE TRIGGER trg_fishbowl_ideas_touch_updated_at
+BEFORE UPDATE ON mc_fishbowl_ideas
+FOR EACH ROW EXECUTE FUNCTION mc_fishbowl_touch_updated_at();
+
+-- RLS: service-role-only on all four (matches existing fishbowl pattern) ----
+ALTER TABLE mc_fishbowl_todos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_ideas ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_idea_votes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_fishbowl_comments ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_todos'
+      AND policyname = 'mc_fishbowl_todos_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_todos_service_role_all"
+      ON mc_fishbowl_todos FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_ideas'
+      AND policyname = 'mc_fishbowl_ideas_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_ideas_service_role_all"
+      ON mc_fishbowl_ideas FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_idea_votes'
+      AND policyname = 'mc_fishbowl_idea_votes_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_idea_votes_service_role_all"
+      ON mc_fishbowl_idea_votes FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_fishbowl_comments'
+      AND policyname = 'mc_fishbowl_comments_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_fishbowl_comments_service_role_all"
+      ON mc_fishbowl_comments FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Phase 1.2 of Fishbowl: a productivity layer that humans (admin UI) and AI agents (MCP) drive together. One npm install gives every UnClick tenant a shared backlog and idea board their pack of agents can act on autonomously.

Branched from origin/main at 1b12e02 (post #167). Pushed to `feat/fishbowl-todos-ideas-v1-mccarthy` because the canonical `feat/fishbowl-todos-ideas-v1` already existed on origin from a parallel chip run.

## What ships

### Schema (`supabase/migrations/20260425120000_fishbowl_todos_ideas.sql`)

Four new tables, all RLS service-role-only matching the existing fishbowl pattern:

- **mc_fishbowl_todos** -- kanban-shaped: open / in_progress / done / dropped, low/normal/high/urgent priority, optional assignee, optional source_idea_id link.
- **mc_fishbowl_ideas** -- proposed / voting / locked / parked / rejected, upvotes/downvotes columns kept consistent by an AFTER trigger on the votes table.
- **mc_fishbowl_idea_votes** -- PK (api_key_hash, idea_id, voter_agent_id) so re-voting upserts. ON DELETE CASCADE follows the parent idea.
- **mc_fishbowl_comments** -- polymorphic on (target_kind, target_id) so one thread powers both surfaces.

Plus BEFORE UPDATE triggers to touch `updated_at` on todos and ideas, and idempotent CREATE POLICY guards.

### MCP tools (`packages/mcp-server/src/server.ts`)

13 new visible tools added to the tool list:

- `create_todo`, `update_todo`, `complete_todo`, `drop_todo`, `delete_todo`, `list_todos`
- `create_idea`, `update_idea`, `vote_on_idea`, `list_ideas`, `promote_idea_to_todo`
- `comment_on`, `list_comments`

Every tool requires `agent_id`. Validation: `agent_id` <=128, `title` <=200, descriptions/comments <=4000 (matches Phase 1.1 hotfix caps). Status changes are routed through `update_todo` so kanban drag-and-drop works in every direction (open <-> in_progress <-> done).

### Backend actions (`api/memory-admin.ts`)

One `fishbowl_<X>` case per tool. Auth pattern identical to existing fishbowl actions:

- Bearer api key resolves `api_key_hash`.
- `human-*` agent_ids only honored when the caller's profile has `user_agent_hint='admin-ui'` (the PR #155 anti-spoof rule). AI agents using a `human-*` id get a 403 with a corrective message.
- Update / delete / promote: only the creator OR the human admin can mutate.
- `promote_idea_to_todo` requires net upvotes >= 1 OR an admin caller. It inserts a linked todo with `source_idea_id`, locks the idea, stamps `promoted_to_todo_id`.

Material changes emit a Fishbowl event-tagged post AND a Signal via a shared `postFishbowlEvent` helper, so the existing wake-up plumbing (push, email, Telegram per `mc_signal_preferences`) routes notifications:

- `create_todo` -> `created todo: "<title>"` tagged `event,todo-created`
- `complete_todo` -> `done: "<title>"` tagged `event,todo-completed`
- `create_idea` -> `new idea: "<title>"` tagged `event,idea-created`
- `vote_on_idea` -> rate-limited (per idea, per 5 minutes): only posts `event,idea-voted` when score moved AND the last vote post on this idea is older than 5 min. Per-idea identification uses a short `i-<first12-of-uuid>` tag (full UUIDs exceed the 32-char tag cap).
- `promote_idea_to_todo` -> `idea promoted to todo: "<title>"` tagged `event,idea-promoted,todo-created`

These feed the Events lane planned in Chip A.

### Admin UI (`src/pages/admin/Fishbowl.tsx` + two new component files)

- **Todos** (`FishbowlTodos.tsx`, default-collapsed): kanban with Open / In progress / Done columns. Drag-and-drop between columns. Inline add form with title, description, priority, assignee dropdown sourced from connected agent profiles. Each card shows priority pill, assignee emoji, comment count. Click expands to full description, comments thread, mark-done, delete.
- **Ideas** (`FishbowlIdeas.tsx`, default-collapsed): list sorted by score (upvotes - downvotes) DESC. Inline add form. Per-row up/down vote buttons with the current vote highlighted, score badge, status pill, comment count. Click expands to full description, comments thread, Promote-to-TODO button (admin can promote at any score; agents need net +1).
- Both poll every 10s while open. Match the existing dark theme and amber accent.

## Verification

- File budget: **6 files** (1 migration + server.ts + memory-admin.ts + Fishbowl.tsx + FishbowlTodos.tsx + FishbowlIdeas.tsx). Within the <=7 cap.
- LOC: +2,449 / -14
- `npx tsc --noEmit` (root): clean
- `npm run build --workspace=packages/mcp-server`: clean
- `npm run build` (root vite build): clean (existing chunk-size warning unrelated)
- Em-dash grep across all six touched files: **zero occurrences**.
- Auth model unchanged: same Bearer + admin-ui anti-spoof pattern as existing fishbowl actions; no new public actions.

## Migration SQL

The migration file is committed at `supabase/migrations/20260425120000_fishbowl_todos_ideas.sql`. Bailey to apply via the Supabase MCP. Idempotent (`CREATE TABLE IF NOT EXISTS`, `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER`, idempotent policy guards), so re-running is safe.

## Test plan

- [ ] Run `supabase db push` (or apply migration via MCP) -- four new tables, two triggers, four policies created.
- [ ] Hit `/admin/fishbowl` -- 📋 Todos and 💡 Ideas sections render default-collapsed.
- [ ] Expand 📋 Todos, click Add todo, fill form, submit -- card appears in Open column. Drag to In progress -- status flips. Drag to Done -- card strikes through and moves. Drag back to Open -- completed_at clears.
- [ ] Expand 💡 Ideas, pitch an idea, upvote it -- score increments live. Vote post appears in main feed tagged `event,idea-voted` (first one per idea per 5 min only).
- [ ] Promote-to-TODO from a +1 idea -- linked todo appears in Open column with `source_idea_id` set; idea flips to status=locked.
- [ ] Comment on a todo and an idea -- thread renders inline; agent-authored comments via `comment_on` MCP tool show alongside admin comments.
- [ ] AI agent calling `create_todo` with `agent_id='human-fake'` -- 403 anti-spoof.
- [ ] Non-creator agent trying to `delete_todo` -- 403 unless `human-*` admin.

Do **not** auto-merge.