### PR TITLE
fix(fishbowl): normalize dash characters in posts

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -113,6 +113,10 @@ function sha256hex(input: string): string {
   return crypto.createHash("sha256").update(input).digest("hex");
 }
 
+function normalizeFishbowlText(input: string): string {
+  return input.replace(/[\u2013\u2014]/g, "-");
+}
+
 function deriveKey(apiKey: string, salt: Buffer): Buffer {
   return crypto.pbkdf2Sync(apiKey, salt, PBKDF2_ITERATIONS, KEY_BYTES, "sha256");
 }
@@ -403,6 +407,7 @@ async function postFishbowlEvent(
   text: string,
 ): Promise<void> {
   try {
+    const eventText = normalizeFishbowlText(text);
     const { data: profile } = await supabase
       .from("mc_fishbowl_profiles")
       .select("emoji, display_name")
@@ -434,7 +439,7 @@ async function postFishbowlEvent(
       author_name: profile?.display_name ?? null,
       author_agent_id: agentId,
       recipients: ["all"],
-      text,
+      text: eventText,
       tags: ["event", eventTag],
     });
   } catch (err) {
@@ -5997,7 +6002,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         }
         if (agentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
 
-        const text = (body.text ?? "").toString().trim();
+        const text = normalizeFishbowlText((body.text ?? "").toString().trim());
         if (!text) return res.status(400).json({ error: "text required" });
         if (text.length > 2000) return res.status(400).json({ error: "text must be at most 2000 characters" });
 

--- a/supabase/migrations/20260426031000_fishbowl_no_unicode_dashes.sql
+++ b/supabase/migrations/20260426031000_fishbowl_no_unicode_dashes.sql
@@ -1,0 +1,22 @@
+-- Normalize existing Fishbowl message text, then prevent future Unicode dashes.
+update public.mc_fishbowl_messages
+set text = replace(replace(text, chr(8212), '-'), chr(8211), '-')
+where text like '%' || chr(8212) || '%'
+   or text like '%' || chr(8211) || '%';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'mc_fishbowl_messages_no_unicode_dashes'
+      and conrelid = 'public.mc_fishbowl_messages'::regclass
+  ) then
+    alter table public.mc_fishbowl_messages
+      add constraint mc_fishbowl_messages_no_unicode_dashes
+      check (
+        position(chr(8212) in text) = 0
+        and position(chr(8211) in text) = 0
+      );
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- normalizes en dash and em dash to ASCII hyphen before Fishbowl posts are stored
- covers direct `fishbowl_post` messages and internal Fishbowl event posts such as todo broadcasts
- adds a Supabase migration that scrubs existing Fishbowl messages, then adds a CHECK constraint to block future en dash or em dash text

## Verification
- `git diff --cached --check` before the migration commit
- `git diff --check` before the first commit
- `npm run build` could not run locally because dependencies are not installed in this checkout (`vite` not found). GitHub Website CI is also currently blocked by the known root lockfile drift.

## Notes
- This completes todo d77b6fda in source: prevention at the API layer plus database guard on apply. Bailey still coordinates merge.