### PR TITLE
fix(fishbowl): emitSignal regression + Heartbeat Settings panel

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -94,6 +94,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
+import { emitSignal } from "../packages/mcp-server/src/signals/emit.js";
 import { streamText, tool, stepCountIs, convertToModelMessages, type UIMessage, type ModelMessage } from "ai";
 import { google } from "@ai-sdk/google";
 import { z } from "zod";

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Loader2, Send } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import FishbowlTodos from "./fishbowl/Todos";
 import FishbowlIdeas from "./fishbowl/Ideas";
+import FishbowlSettings from "./fishbowl/Settings";
 
 interface FishbowlMessage {
   id: string;
@@ -542,6 +543,8 @@ export default function Fishbowl() {
       <ExplainerPanel profiles={profiles} />
 
       <NowPlayingStrip profiles={profiles} />
+
+      <FishbowlSettings profiles={profiles} />
 
       <FishbowlTodos authHeader={authHeader} humanAgentId={humanAgentId} />
 

--- a/src/pages/admin/fishbowl/Settings.tsx
+++ b/src/pages/admin/fishbowl/Settings.tsx
@@ -1,0 +1,282 @@
+// src/pages/admin/fishbowl/Settings.tsx
+//
+// Fishbowl heartbeat Settings panel - collapsible, dark theme, localStorage prefs.
+// Slot: after <NowPlayingStrip /> in Fishbowl.tsx main component.
+// Import: import FishbowlSettings from "./fishbowl/Settings";
+// Usage: <FishbowlSettings profiles={profiles} />
+//
+// This is frontend-only MVP. Prefs stored in localStorage.
+// Phase 2: persist to mc_fishbowl_settings table via API.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, Settings as SettingsIcon } from "lucide-react";
+
+/* -- types -- */
+interface FishbowlProfile {
+  agent_id: string;
+  emoji: string;
+  display_name: string | null;
+  user_agent_hint: string | null;
+  created_at: string;
+  last_seen_at: string | null;
+  current_status: string | null;
+  current_status_updated_at: string | null;
+  next_checkin_at: string | null;
+}
+
+interface HeartbeatPrefs {
+  pulseIntervalMin: 15 | 30 | 60;
+  staleThresholdMin: 5 | 10 | 15 | 30;
+  hideIdleAgents: boolean;
+  tagFilters: string[];           // empty = show all
+  mutedAgentIds: string[];        // agent_ids to hide from feed
+  eventsBotEnabled: boolean;      // placeholder for future events bot
+}
+
+const DEFAULT_PREFS: HeartbeatPrefs = {
+  pulseIntervalMin: 15,
+  staleThresholdMin: 5,
+  hideIdleAgents: false,
+  tagFilters: [],
+  mutedAgentIds: [],
+  eventsBotEnabled: false,
+};
+
+const STORAGE_KEY = "unclick.fishbowl.heartbeat.settings";
+const CANONICAL_TAGS = [
+  "heartbeat", "qc", "pr", "decision", "question",
+  "answer", "handoff", "blocker", "done", "fyi",
+];
+
+/* -- helpers -- */
+function loadPrefs(): HeartbeatPrefs {
+  if (typeof window === "undefined") return DEFAULT_PREFS;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_PREFS;
+    return { ...DEFAULT_PREFS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_PREFS;
+  }
+}
+
+function savePrefs(prefs: HeartbeatPrefs): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // localStorage may be unavailable; ignore.
+  }
+}
+
+/* -- component -- */
+export default function FishbowlSettings({
+  profiles,
+}: {
+  profiles: FishbowlProfile[];
+}) {
+  const [collapsed, setCollapsed] = useState(true); // default-collapsed
+  const [prefs, setPrefs] = useState<HeartbeatPrefs>(loadPrefs);
+
+  // Persist on change
+  useEffect(() => {
+    savePrefs(prefs);
+  }, [prefs]);
+
+  const update = useCallback(
+    <K extends keyof HeartbeatPrefs>(key: K, value: HeartbeatPrefs[K]) => {
+      setPrefs((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const toggleTag = useCallback((tag: string) => {
+    setPrefs((prev) => {
+      const next = prev.tagFilters.includes(tag)
+        ? prev.tagFilters.filter((t) => t !== tag)
+        : [...prev.tagFilters, tag];
+      return { ...prev, tagFilters: next };
+    });
+  }, []);
+
+  const toggleMute = useCallback((agentId: string) => {
+    setPrefs((prev) => {
+      const next = prev.mutedAgentIds.includes(agentId)
+        ? prev.mutedAgentIds.filter((id) => id !== agentId)
+        : [...prev.mutedAgentIds, agentId];
+      return { ...prev, mutedAgentIds: next };
+    });
+  }, []);
+
+  // Only show non-human agents in mute list
+  const agentProfiles = useMemo(
+    () => profiles.filter((p) => !p.agent_id.startsWith("human-")),
+    [profiles],
+  );
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={() => setCollapsed((p) => !p)}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
+          <SettingsIcon className="h-3.5 w-3.5 text-[#888]" />
+          <span>Heartbeat Settings</span>
+        </span>
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4 text-[#555]" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-[#555]" />
+        )}
+      </button>
+
+      {!collapsed && (
+        <div className="space-y-5 border-t border-white/[0.06] px-4 py-4">
+          {/* -- Pulse interval -- */}
+          <fieldset>
+            <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
+              Pulse interval
+            </legend>
+            <div className="flex gap-2">
+              {([15, 30, 60] as const).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => update("pulseIntervalMin", v)}
+                  className={`rounded-md border px-3 py-1 text-xs font-medium transition ${
+                    prefs.pulseIntervalMin === v
+                      ? "border-[#E2B93B]/40 bg-[#E2B93B]/15 text-[#E2B93B]"
+                      : "border-white/[0.08] bg-white/[0.03] text-[#888] hover:text-[#ccc]"
+                  }`}
+                >
+                  {v}m
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* -- Stale threshold -- */}
+          <fieldset>
+            <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
+              Stale threshold
+            </legend>
+            <div className="flex gap-2">
+              {([5, 10, 15, 30] as const).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => update("staleThresholdMin", v)}
+                  className={`rounded-md border px-3 py-1 text-xs font-medium transition ${
+                    prefs.staleThresholdMin === v
+                      ? "border-[#E2B93B]/40 bg-[#E2B93B]/15 text-[#E2B93B]"
+                      : "border-white/[0.08] bg-white/[0.03] text-[#888] hover:text-[#ccc]"
+                  }`}
+                >
+                  {v}m
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* -- Toggles row -- */}
+          <div className="flex flex-wrap gap-x-6 gap-y-2">
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-[#888]">
+              <input
+                type="checkbox"
+                checked={prefs.hideIdleAgents}
+                onChange={(e) => update("hideIdleAgents", e.target.checked)}
+                className="accent-[#E2B93B]"
+              />
+              Hide idle agents on strip
+            </label>
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-[#888]">
+              <input
+                type="checkbox"
+                checked={prefs.eventsBotEnabled}
+                onChange={(e) => update("eventsBotEnabled", e.target.checked)}
+                className="accent-[#E2B93B]"
+              />
+              Events bot
+              <span className="rounded bg-white/[0.06] px-1 py-0.5 text-[9px] uppercase text-[#555]">
+                soon
+              </span>
+            </label>
+          </div>
+
+          {/* -- Tag filters -- */}
+          <fieldset>
+            <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
+              Tag filters
+              {prefs.tagFilters.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => update("tagFilters", [])}
+                  className="ml-2 text-[10px] text-[#E2B93B] hover:underline"
+                >
+                  clear
+                </button>
+              )}
+            </legend>
+            <div className="flex flex-wrap gap-1.5">
+              {CANONICAL_TAGS.map((tag) => {
+                const active = prefs.tagFilters.includes(tag);
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => toggleTag(tag)}
+                    className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition ${
+                      active
+                        ? "border-[#E2B93B]/40 bg-[#E2B93B]/15 text-[#E2B93B]"
+                        : "border-white/[0.08] bg-white/[0.03] text-[#666] hover:text-[#888]"
+                    }`}
+                  >
+                    {tag}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-1 text-[10px] text-[#555]">
+              {prefs.tagFilters.length === 0
+                ? "Showing all tags"
+                : `Showing: ${prefs.tagFilters.join(", ")}`}
+            </p>
+          </fieldset>
+
+          {/* -- Mute per agent -- */}
+          {agentProfiles.length > 0 && (
+            <fieldset>
+              <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
+                Mute agents
+              </legend>
+              <div className="flex flex-wrap gap-2">
+                {agentProfiles.map((p) => {
+                  const muted = prefs.mutedAgentIds.includes(p.agent_id);
+                  return (
+                    <button
+                      key={p.agent_id}
+                      type="button"
+                      onClick={() => toggleMute(p.agent_id)}
+                      className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs transition ${
+                        muted
+                          ? "border-red-400/30 bg-red-400/10 text-red-300 line-through"
+                          : "border-white/[0.08] bg-white/[0.03] text-[#888] hover:text-[#ccc]"
+                      }`}
+                    >
+                      <span>{p.emoji}</span>
+                      <span className="max-w-[100px] truncate">
+                        {p.display_name ?? p.agent_id}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Two related Fishbowl chips in one PR.

### Chip 1: emitSignal regression (urgent, from PR #174 follow-up work)

`api/memory-admin.ts` in the `start_testpass_run` action was calling `emitSignal()` (lines 5446, 5455, 5466) without importing it, so once the engine completed and the closing-signal block ran, the admin UI surfaced:

> Failed to execute start_testpass_run: emitSignal is not defined

The MCP `testpass_run` tool path uses a different code path and was unaffected, which is why this only showed up via the admin UI.

Fix: add `import { emitSignal } from \"../packages/mcp-server/src/signals/emit.js\";` matching the existing `buildCard` import convention in the same file. One-line change.

### Chip 2: Heartbeat Settings panel

Ships 🍿's draft `FishbowlSettings` component as `src/pages/admin/fishbowl/Settings.tsx`, wired into `Fishbowl.tsx` after `<NowPlayingStrip />`. Shares the `profiles` prop already present.

Features:
- Default-collapsed panel
- Pulse interval picker (15 / 30 / 60m)
- Stale threshold picker (5 / 10 / 15 / 30m)
- Hide idle agents toggle
- Events bot toggle (with `soon` badge)
- Canonical 10-tag filter chips with clear-all
- Per-agent mute (non-human agents only)
- localStorage persistence under `unclick.fishbowl.heartbeat.settings`

Frontend-only MVP, dark theme, lucide-react icons, amber `#E2B93B` accents matching existing pattern.

## Files changed

| File | Change |
|------|--------|
| `api/memory-admin.ts` | +1 line (import) |
| `src/pages/admin/Fishbowl.tsx` | +3 lines (import + render slot) |
| `src/pages/admin/fishbowl/Settings.tsx` | new, 282 lines |

3 files, 286 insertions, 0 deletions. Within the ≤4 file touch budget.

## Verification

- [x] `npm run build` (root) green
- [x] `npx tsc --noEmit` clean at root
- [x] `npx tsc --noEmit -p packages/mcp-server` clean
- [x] Zero em-dash characters (U+2014) in any added line
- [x] Branched from `origin/main`

## Manual smoke (post-merge + Vercel redeploy)

- Run button on `/admin/testpass/new` should not throw `emitSignal is not defined` after the engine completes.
- `/admin/fishbowl` should render the new collapsed Heartbeat Settings panel beneath NowPlayingStrip.

## Notes

Do NOT auto-merge. Bailey will merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)