### PR TITLE
fix: search_memory P0 regression - restore hybrid retrieval

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
@@ -105,6 +105,69 @@ describe("embedText", () => {
   });
 });
 
+// ─── 2b. Keyword-fallback regression (P0) ─────────────────────────────────────
+//
+// Reproduces the production bug: a fact with NULL embedding whose proper-noun
+// content does not survive plainto_tsquery('english', ...) tokenization.
+// Hybrid returns []. ILIKE fallback must surface the row anyway.
+
+describe("acceptance: keyword fallback restores search when hybrid returns []", () => {
+  test("ILIKE fallback finds proper-noun fact with NULL embedding", async () => {
+    const url = process.env.TEST_SUPABASE_URL ?? process.env.SUPABASE_URL;
+    const key = process.env.TEST_SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) {
+      console.log("    [skipped] set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY to run");
+      return;
+    }
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
+
+    const factText = "Test owner is Chris Byrne for P0 search-memory regression";
+    const { data: inserted, error: insertErr } = await supabase
+      .from("extracted_facts")
+      .insert({
+        fact: factText,
+        category: "test",
+        confidence: 0.9,
+        status: "active",
+        source_type: "test",
+        decay_tier: "hot",
+        // Deliberately leave embedding NULL to simulate legacy / un-backfilled rows
+      })
+      .select("id")
+      .single();
+    assert.ok(!insertErr, `insert failed: ${insertErr?.message}`);
+    const factId = (inserted as { id: string }).id;
+
+    try {
+      // Force the keyword path by removing OPENAI_API_KEY: searchMemory will
+      // skip the hybrid lane and exercise keywordFallback directly.
+      const savedOpenAI = process.env.OPENAI_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+      try {
+        const { SupabaseBackend } = await import("../supabase.js");
+        const backend = new SupabaseBackend({
+          url,
+          serviceRoleKey: key,
+          tenancy: { mode: "byod" },
+        });
+        const results = (await backend.searchMemory("Chris", 10)) as Array<{ id: string }>;
+        assert.ok(Array.isArray(results), "fallback should return an array");
+        const ids = results.map((r) => r.id);
+        assert.ok(
+          ids.includes(factId),
+          `Expected fact ${factId} via ILIKE fallback. Got ${ids.length} rows: ${JSON.stringify(results.slice(0, 3))}`
+        );
+        console.log(`    [passed] keyword fallback surfaced fact at position ${ids.indexOf(factId) + 1}`);
+      } finally {
+        if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+      }
+    } finally {
+      await supabase.from("extracted_facts").delete().eq("id", factId);
+    }
+  });
+});
+
 // ─── 3. Acceptance test (LOCOMO-style) ────────────────────────────────────────
 //
 // Requires real credentials. Skipped automatically when env vars are absent.

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -268,30 +268,104 @@ export class SupabaseBackend implements MemoryBackend {
   }
 
   async searchMemory(query: string, maxResults: number, asOf?: string): Promise<unknown> {
-    // Attempt hybrid RRF search (keyword + vector) with bi-temporal filter.
-    // Falls back to keyword-only when OPENAI_API_KEY absent or RPC not deployed.
+    // Hybrid lane: BM25 + pgvector RRF over mc_extracted_facts and
+    // mc_session_summaries. Two well-known failure modes turn this into a
+    // black hole and force a fallback:
+    //
+    //   1. Per-row embeddings are NULL (legacy facts, BYOD installs without
+    //      backfill, or facts written before embedding wiring) so the vector
+    //      lane drops them.
+    //   2. plainto_tsquery('english', ...) tokenizes proper nouns and short
+    //      identifiers ("Chris", "Bailey", "UnClick") in ways that don't
+    //      align with the matching to_tsvector lexemes, so the keyword lane
+    //      misses too. Both branches fail, hybrid returns [].
+    //
+    // To stop returning [] when matching content exists, we run a robust
+    // ILIKE keyword fallback over the same tables whenever the hybrid call
+    // throws OR returns an empty result.
     try {
       const { embedText } = await import("./embeddings.js");
       const embedding = await embedText(query);
       if (embedding) {
-        const results = await this.rpc(
+        const results = await this.rpc<unknown>(
           "search_memory_hybrid",
           { search_query: query, query_embedding: embedding, max_results: maxResults, as_of: asOf ?? null },
           "mc_search_memory_hybrid",
           { p_search_query: query, p_query_embedding: embedding, p_max_results: maxResults, p_as_of: asOf ?? null }
         );
-        return results;
+        if (Array.isArray(results) && results.length > 0) return results;
       }
     } catch (err) {
       console.error("[search_memory] hybrid search failed, falling back to keyword:", err);
     }
+    return this.keywordFallback(query, maxResults);
+  }
 
-    return this.rpc(
-      "search_memory",
-      { search_query: query, max_results: maxResults },
-      "mc_search_memory",
-      { p_search_query: query, p_max_results: maxResults }
-    );
+  /**
+   * ILIKE-based keyword fallback over mc_extracted_facts +
+   * mc_session_summaries. Used when hybrid retrieval returns []. Returns
+   * rows shaped to mirror mc_search_memory_hybrid so callers don't branch.
+   * Never widens RLS: tenant scoping via api_key_hash is preserved.
+   */
+  private async keywordFallback(query: string, maxResults: number): Promise<unknown[]> {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    const pattern = `%${trimmed.replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
+    const half = Math.max(1, Math.ceil(maxResults / 2));
+
+    let factQ = this.client
+      .from(this.tables.extracted_facts)
+      .select("id, fact, category, confidence, created_at")
+      .eq("status", "active")
+      .is("invalidated_at", null)
+      .ilike("fact", pattern)
+      .order("confidence", { ascending: false })
+      .order("created_at", { ascending: false })
+      .limit(half);
+    if (this.tenancy.mode === "managed") {
+      factQ = factQ.eq("api_key_hash", this.tenancy.apiKeyHash);
+    }
+
+    let sessQ = this.client
+      .from(this.tables.session_summaries)
+      .select("id, summary, created_at")
+      .ilike("summary", pattern)
+      .order("created_at", { ascending: false })
+      .limit(half);
+    if (this.tenancy.mode === "managed") {
+      sessQ = sessQ.eq("api_key_hash", this.tenancy.apiKeyHash);
+    }
+
+    const [factsRes, sessRes] = await Promise.all([factQ, sessQ]);
+    type FactRow = { id: string; fact: string; category: string; confidence: number; created_at: string };
+    type SessRow = { id: string; summary: string; created_at: string };
+    const facts = ((factsRes.data ?? []) as FactRow[]).map((r) => ({
+      id: r.id,
+      source: "fact",
+      content: r.fact,
+      category: r.category,
+      confidence: r.confidence,
+      created_at: r.created_at,
+      final_score: r.confidence ?? 0,
+      rrf_score: 0,
+      kw_score: 1,
+      cosine_score: 0,
+    }));
+    const sessions = ((sessRes.data ?? []) as SessRow[]).map((r) => ({
+      id: r.id,
+      source: "session",
+      content: r.summary,
+      category: "session",
+      confidence: 1,
+      created_at: r.created_at,
+      final_score: 0.5,
+      rrf_score: 0,
+      kw_score: 1,
+      cosine_score: 0,
+    }));
+    return [...facts, ...sessions]
+      .sort((a, b) => (b.final_score ?? 0) - (a.final_score ?? 0))
+      .slice(0, maxResults);
   }
 
   async searchFacts(query: string): Promise<unknown> {
@@ -343,6 +417,9 @@ export class SupabaseBackend implements MemoryBackend {
       .select()
       .single();
     if (error) throw pgError("writeSessionSummary insert", error);
+    // Embed the summary so it joins the vector lane immediately (same
+    // motivation as addFact above). Fire-and-forget.
+    this.embedAndStore(this.tables.session_summaries, row.id, data.summary).catch(() => {});
     return { id: row.id };
   }
 
@@ -399,7 +476,27 @@ export class SupabaseBackend implements MemoryBackend {
     // Append audit row (fire-and-forget; never blocks the main insert)
     this.writeFactAudit(row.id, "insert", { category: data.category }).catch(() => {});
 
+    // Embed the fact so it joins the vector lane immediately. Without this,
+    // every newly inserted fact has NULL embedding and only the keyword lane
+    // can find it. Fire-and-forget so embedding latency / OpenAI outages
+    // never block the primary insert.
+    this.embedAndStore(this.tables.extracted_facts, row.id, data.fact).catch(() => {});
+
     return { id: row.id };
+  }
+
+  private async embedAndStore(table: string, id: string, text: string): Promise<void> {
+    const { embedText, EMBEDDING_MODEL } = await import("./embeddings.js");
+    const vec = await embedText(text);
+    if (!vec) return;
+    await this.client
+      .from(table)
+      .update({
+        embedding: JSON.stringify(vec),
+        embedding_model: EMBEDDING_MODEL,
+        embedding_created_at: now(),
+      })
+      .eq("id", id);
   }
 
   private async saveBlob(data: FactInput): Promise<{ id: string; fact_ids?: string[] }> {


### PR DESCRIPTION
## Summary

`search_memory` returned `[]` for every query in production (single-word probes for `Chris`, `Bailey`, `UnClick` all empty), confirmed across 6+ heartbeat sessions. `load_memory` worked, write path was alive, read path was dead. This restores it without merging.

## Root cause

Two gaps in the hybrid retrieval pipeline introduced by #107 / #109:

1. **`addFact` never wrote the `embedding` column.** Every fact inserted after migration `20260422000000_add_memory_embeddings` had `NULL embedding`. The vector lane in `mc_search_memory_hybrid` filters `embedding IS NOT NULL` and silently dropped them.
2. **No keyword fallback when hybrid returned `[]`.** Combined with (1), the keyword lane (`to_tsvector('english', fact) @@ plainto_tsquery('english', q)`) misses proper nouns / unstemmed identifiers like `Chris` / `Bailey` / `UnClick` through English tokenization. Both lanes returned 0 rows. The legacy fallback `mc_search_memory` searches `mc_conversation_log` (not `mc_extracted_facts`), so it could not surface the facts either.

## Fix (≤4 files, 170/10 LOC, no RLS widening, no migration)

- `addFact` and `writeSessionSummary` now embed inserted text inline (fire-and-forget, never blocks the insert) so new rows enter the vector lane immediately.
- `searchMemory` falls back to a robust ILIKE keyword scan over `extracted_facts` and `session_summaries` whenever the hybrid call throws OR returns `[]`. Tenant scoping via `api_key_hash` is preserved (managed mode) and rows are shaped to match `mc_search_memory_hybrid` so callers don't branch.
- Adds integration regression test for the NULL-embedding case (skipped without `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`).

Legacy rows still benefit from running the existing `scripts/backfill-embeddings.ts` to re-enter the vector lane; this fix makes search work *regardless* of backfill status.

## Probe results (local unit suite)

```
▶ RRF scoring math (6 tests)            ✔ 6/6
▶ embedText                             ✔ 1/1
▶ acceptance: keyword fallback (P0)     ✔ skipped (no DB env)
▶ acceptance: hybrid semantic           ✔ skipped (no DB env)
tests 9, pass 9, fail 0
```

`tsc --noEmit` clean.

## Test plan

- [ ] Deploy preview / staging, set `OPENAI_API_KEY` + Supabase env, run unit suite with creds to exercise the regression test (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`).
- [ ] In a heartbeat session, call `search_memory` with `"Chris"`, `"Bailey"`, `"UnClick"`. Expect non-empty results that contain those tokens.
- [ ] Verify `load_memory` still returns the full dump (unchanged code path).
- [ ] Run `scripts/backfill-embeddings.ts` against managed Supabase to upgrade legacy rows to the vector lane (non-blocking; fallback covers them in the meantime).

DON'T merge — per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)