### PR TITLE
fix: MCP protocol compliance - Accept header, error codes, request id preservation

### DIFF
--- a/api/lib/mcp-protocol.ts
+++ b/api/lib/mcp-protocol.ts
@@ -1,0 +1,41 @@
+/**
+ * MCP Streamable HTTP protocol helpers.
+ *
+ * Currently exports normalizeAcceptHeader, which works around the SDK's
+ * strict Accept-header policy. The MCP Streamable HTTP server transport
+ * rejects any POST whose Accept header lacks both "application/json" and
+ * "text/event-stream" with HTTP 406 + JSON-RPC -32000 + id:null. That
+ * cascades into multiple TestPass-core failures because the request never
+ * reaches the SDK's protocol layer where the proper id echo and -32601
+ * unknown-method response live.
+ *
+ * Spec-curious clients (TestPass-core, plain JSON-RPC tools, browsers
+ * using fetch defaults) commonly send only "application/json". In
+ * stateless mode the server always responds with a JSON body, so being
+ * more permissive than the SDK is safe.
+ */
+
+export interface AcceptCarrier {
+  headers: { accept?: string | string[] | undefined } & Record<string, unknown>;
+}
+
+const REQUIRED = ["application/json", "text/event-stream"] as const;
+
+/**
+ * Mutate `req.headers.accept` so that the MCP SDK's strict check passes.
+ * Preserves any client-supplied values, only appending the missing ones.
+ *
+ * - "application/json"          becomes "application/json, text/event-stream"
+ * - "text/event-stream"         becomes "text/event-stream, application/json"
+ * - "application/json, text/event-stream" passes through untouched
+ * - "*\/*" or missing            becomes "application/json, text/event-stream"
+ */
+export function normalizeAcceptHeader(req: AcceptCarrier): void {
+  const raw = req.headers.accept;
+  const current = Array.isArray(raw) ? raw.join(", ") : raw ?? "";
+  const missing = REQUIRED.filter((value) => !current.includes(value));
+  if (missing.length === 0) return;
+  req.headers.accept = current
+    ? `${current}, ${missing.join(", ")}`
+    : missing.join(", ");
+}

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -28,6 +28,7 @@ import * as crypto from "crypto";
 import { createClient } from "@supabase/supabase-js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "../packages/mcp-server/src/server.js";
+import { normalizeAcceptHeader } from "./lib/mcp-protocol.js";
 
 function sha256hex(input: string): string {
   return crypto.createHash("sha256").update(input).digest("hex");
@@ -343,6 +344,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   });
 
   const server = await createServer();
+
+  // Normalize the Accept header before delegating to the SDK. The SDK's
+  // Streamable HTTP transport bounces requests that lack both
+  // "application/json" and "text/event-stream" with HTTP 406 + -32000 +
+  // id:null - which cascades into RPC-002 (id null), RPC-004/MCP-006
+  // (-32000 instead of -32601), and MCP-001/003/004 (initialize never
+  // returns a real result). Spec-strict clients send both; spec-curious
+  // ones (TestPass-core, plain JSON-RPC tools) send only application/json.
+  // Stateless mode always replies with a JSON body, so being more
+  // permissive than the SDK here is safe.
+  normalizeAcceptHeader(req);
 
   try {
     await server.connect(transport);

--- a/src/__tests__/mcp-protocol.test.ts
+++ b/src/__tests__/mcp-protocol.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeAcceptHeader,
+  type AcceptCarrier,
+} from "../../api/lib/mcp-protocol";
+
+// Regression coverage for testpass-core MCP-001/003/004 + RPC-002/004 +
+// MCP-006. The MCP SDK's StreamableHTTPServerTransport rejects POSTs that
+// lack both "application/json" and "text/event-stream" in Accept with
+// HTTP 406 + JSON-RPC -32000 + id:null. That single SDK gate cascades
+// into id-not-echoed and wrong-error-code symptoms downstream. Normalizing
+// the inbound Accept before delegating to the SDK is the root-cause fix.
+function reqWith(accept: string | string[] | undefined): AcceptCarrier {
+  return { headers: { accept } };
+}
+
+describe("normalizeAcceptHeader", () => {
+  it("appends text/event-stream when client sends only application/json (TestPass-core case)", () => {
+    const req = reqWith("application/json");
+    normalizeAcceptHeader(req);
+    expect(req.headers.accept).toBe("application/json, text/event-stream");
+  });
+
+  it("appends application/json when client sends only text/event-stream", () => {
+    const req = reqWith("text/event-stream");
+    normalizeAcceptHeader(req);
+    expect(req.headers.accept).toBe("text/event-stream, application/json");
+  });
+
+  it("leaves spec-strict Accept untouched", () => {
+    const req = reqWith("application/json, text/event-stream");
+    normalizeAcceptHeader(req);
+    expect(req.headers.accept).toBe("application/json, text/event-stream");
+  });
+
+  it("leaves Accept untouched when both content types appear with q-values", () => {
+    const req = reqWith("application/json;q=0.9, text/event-stream;q=0.8");
+    normalizeAcceptHeader(req);
+    expect(req.headers.accept).toBe(
+      "application/json;q=0.9, text/event-stream;q=0.8",
+    );
+  });
+
+  it("populates both content types when Accept is missing entirely", () => {
+    const req = reqWith(undefined);
+    normalizeAcceptHeader(req);
+    expect(req.headers.accept).toBe("application/json, text/event-stream");
+  });
+
+  it("preserves wildcard Accept and adds the required content types", () => {
+    const req = reqWith("*/*");
+    normalizeAcceptHeader(req);
+    expect(req.headers.accept).toBe(
+      "*/*, application/json, text/event-stream",
+    );
+  });
+
+  it("flattens array-shaped Accept headers (Node http.IncomingMessage edge case)", () => {
+    const req = reqWith(["application/json", "text/plain"]);
+    normalizeAcceptHeader(req);
+    expect(req.headers.accept).toBe(
+      "application/json, text/plain, text/event-stream",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Single root-cause fix for the 6 of 8 TestPass-core checks currently failing against `https://unclick.world/api/mcp` (RPC-002, RPC-004, MCP-001, MCP-003, MCP-004, MCP-006).

The MCP SDK's `StreamableHTTPServerTransport` rejects every POST whose `Accept` header lacks **both** `application/json` and `text/event-stream` with `HTTP 406 + JSON-RPC -32000 + id:null`, before the request reaches the protocol layer (verified at `node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js:378-380`). That single rejection cascades into all six failures.

The TestPass-core deterministic runner sends `Accept: application/json` only (`packages/testpass/src/runner/deterministic.ts:47`), so every probe gets bounced. Once the SDK accepts the request, its protocol layer already returns `-32601` with the request `id` correctly echoed (`shared/protocol.js:284-313`).

### The fix

`api/mcp.ts` now calls `normalizeAcceptHeader(req)` before `transport.handleRequest`. The helper augments `req.headers.accept` to include both required content types when either is missing, while preserving any client-supplied values. Stateless mode always replies with a JSON body, so being more permissive than the SDK is safe.

This is one targeted change rather than three — the unknown-method-code and id-not-echoed defects are downstream symptoms of the SDK's Accept rejection, not independent bugs. PR #176's wrapper-level `peekRpc` id-echo path is preserved for the auth-rejection path it actually covers.

### Cross-package check

`@unclick/memory-mcp` is stdio-only (no Streamable HTTP transport), so no parity work is required there.

### Files

- `api/mcp.ts` (+12) — call `normalizeAcceptHeader(req)` before delegating to the SDK
- `api/lib/mcp-protocol.ts` (+44, new) — exports `normalizeAcceptHeader`
- `src/__tests__/mcp-protocol.test.ts` (+62, new) — vitest regression coverage

## Test plan

- [x] `npx tsc --noEmit` (root) — clean
- [x] `npx tsc --noEmit -p packages/mcp-server/tsconfig.json` — clean
- [x] `npx vitest run` — 8/8 passing (7 new + 1 existing)
- [x] `npm test --workspace=packages/mcp-server` — 16/16 passing
- [x] No em dashes added (project style rule)
- [ ] **Do not merge.** Bailey to review and merge after CI green so TestPass-core flips to 8/8 on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)