### PR TITLE
feat(testpass): expand pack to ~20 checks + Phase 9A visual brief

### DIFF
--- a/docs/testpass-phase-9a-visual-brief.md
+++ b/docs/testpass-phase-9a-visual-brief.md
@@ -1,0 +1,300 @@
+# TestPass Phase 9A — Visual Brief
+
+Status: design intent for 🍿 (frontend specialist). Do NOT start React work
+from this doc — Chris reviews and approves first. Implementation is Phase 9B.
+
+Owner: 🐺 (Claude Opus, repo author of pack expansion)
+Reviewer: Chris Byrne
+Implementer: 🍿 (frontend, Phase 9B)
+Related: Phase 9D = marketplace tile badge integration (separate, out of scope)
+
+---
+
+## North star
+
+TestPass is a **public-facing product**. End users — not engineers — will see
+the result page after an agent or operator clicks "Run TestPass" against an
+MCP server, an UnClick tile, or any third-party endpoint.
+
+The page must be:
+
+- **Idiot-proof.** Anyone reading it should understand the result in 5 seconds
+  without knowing what JSON-RPC, capabilities, or RLS even mean.
+- **Shareable.** A run produces a URL. That URL is what gets pasted into Slack,
+  X, or onto the marketplace tile (9D wires the badge image, not 9A).
+- **Aligned with the existing UnClick admin look.** Dark theme, gold accent,
+  teal info pill. Not a new design language.
+
+The current `RunDetail.tsx` is functional but reads like an engineer's
+debug view. Phase 9A replaces that with a clean checkbox grid that an end
+user can scan, share, and trust.
+
+---
+
+## Layout
+
+A single page, three regions stacked vertically:
+
+1. **Header** — target name, score badge, single "Run TestPass" button, share
+   link affordance.
+2. **Checkbox grid** — one card per check (currently 26 in `testpass-core`).
+   Cards reflow into 2 / 3 / 4 columns by viewport.
+3. **Footer** — pack version, profile (smoke / standard / deep), elapsed time,
+   "Powered by UnClick TestPass" link.
+
+No tabs, no left sidebar on the public view. The admin view (under
+`/admin/testpass/runs/:id`) keeps its sidebar; the public route is
+`/testpass/r/:reportId` and is chrome-free apart from the UnClick top bar.
+
+---
+
+## State model — four visual states per check
+
+Every card lives in exactly one of these four states. Match the existing
+`VERDICT_ICON` map in `src/pages/admin/testpass/testpass-ui.ts` so we do not
+fork the icon set.
+
+| State    | Icon | Meaning                                          | Border / glow                 |
+|----------|------|--------------------------------------------------|-------------------------------|
+| pass     | ✅   | The check ran and the server behaved correctly. | green (`#22C55E` @ 30% alpha) |
+| fail     | ❌   | The check ran and the server failed.            | red (`#EF4444` @ 30% alpha)   |
+| warning  | ⚠️    | The check passed with caveats (slow, partial).  | gold (`#E2B93B` @ 30% alpha)  |
+| skipped  | ⏸    | The check was skipped (profile excluded it).    | grey (`#6B7280` @ 25% alpha)  |
+| pending  | ⏳   | (transient) The check is still running.         | teal pulse (`#61C1C4`)        |
+
+`pending` is transient — it shows during a live run and is replaced as soon
+as the verdict lands. Treat it as a fifth visual state in the component, not
+a fifth user-meaningful outcome.
+
+---
+
+## Per-check card content
+
+Each card is a self-contained explainer. Anatomy:
+
+```
+┌──────────────────────────────────────────┐
+│ ✅  Server says hello back                │  ← friendly title (idiot-proof)
+│                                          │
+│ Your MCP server replied to the           │  ← plain-English status
+│ handshake in 412 ms.                     │     (1–2 sentences max)
+│                                          │
+│ ▸ What this means                        │  ← expandable detail (collapsed)
+│                                          │
+│ [How to fix →]                           │  ← only shown on fail / warning
+└──────────────────────────────────────────┘
+```
+
+Mapping to the YAML pack fields (already present in `testpass-core.yaml`):
+
+- **Friendly title** = `title` (already rewritten to be idiot-proof in the
+  Phase 1 pack expansion).
+- **Plain-English status** = a one-liner generated from the verdict + measured
+  value, NOT the raw `description`. Example: a PASS on `MCP-008` reads
+  "Server replied to ping in 187 ms." A FAIL reads "Ping did not return within
+  2 seconds." 🍿 builds these formatters per check_type, with a generic
+  fallback derived from `description`.
+- **What this means** (expandable) = `description` from the YAML.
+- **How to fix** (link) = `on_fail` from the YAML, rendered as a panel that
+  slides in from the right when the user clicks the link. NOT a modal — a
+  modal interrupts; the slide-in keeps the grid context.
+
+A FAIL card with no `on_fail` (none currently exist after Phase 1 expansion,
+but defensive) renders "Contact the server author" as the fallback.
+
+---
+
+## Score badge
+
+Top-right of the header. Public-shareable, designed to be screenshotted.
+
+```
+┌─────────────────────┐
+│   24 / 26 passing   │
+│   ████████████░░    │
+│   testpass-core 0.1 │
+└─────────────────────┘
+```
+
+- Number is `pass / total_runnable` (skipped is excluded from total).
+- Bar is the same colour as the highest-severity failing check
+  (red for any critical/high fail, gold for medium/low fail, green for all
+  pass). This makes screenshots self-explanatory.
+- Pack name + version sits underneath in the existing teal `#61C1C4`.
+- Hover reveals a tooltip: "X failed, Y skipped, Z warnings."
+
+---
+
+## Run button
+
+Single primary button, header-right, replacing the wizard for the public flow.
+
+```
+┌──────────────────────┐
+│  ▶  Run TestPass     │
+└──────────────────────┘
+```
+
+- Background: gold `#E2B93B`. Text: black. Match the existing primary CTA
+  treatment in `AdminShell`.
+- Disabled while a run is in progress; replaced by a `Loader2` spinner +
+  "Running… (4 / 26)" counter that ticks as cards resolve.
+- No "select profile" dropdown on the public flow. The default profile is
+  `standard`. Power users go via the admin view to pick `smoke` or `deep`.
+
+---
+
+## Empty state — starter pack picker
+
+When the user lands on the public page with no run yet (e.g.
+`/testpass/r/new?target=https://example.com`), show a starter pack picker.
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Pick a checklist to run                             │
+│                                                      │
+│  ┌──────────────────┐  ┌──────────────────┐          │
+│  │ TestPass Core    │  │ Anti-Stomp v0    │          │
+│  │                  │  │                  │          │
+│  │ The basics every │  │ Catches silent   │          │
+│  │ MCP server must  │  │ deletions and    │          │
+│  │ get right. 26    │  │ orphaned code    │          │
+│  │ checks, ~30 sec. │  │ in PRs. 12 checks│          │
+│  └──────────────────┘  └──────────────────┘          │
+│                                                      │
+│           [▶ Run TestPass Core]                      │
+└──────────────────────────────────────────────────────┘
+```
+
+- One tile per available pack (read from the packs registry, do not hard-code).
+- Each tile shows: pack name, plain-English description, check count,
+  approximate run time.
+- The selected tile is highlighted with the gold accent border.
+- Default selection is `testpass-core`.
+- Run button text updates to match the selection ("Run Anti-Stomp", etc.).
+
+---
+
+## Export / share
+
+A run is identified by `report_id` and lives at `/testpass/r/:reportId`.
+
+- **Share link button** in the header next to the score badge. Click =
+  copies the canonical URL to clipboard, fires a toast "Link copied" on
+  the existing toast system. No social-share dropdown — one URL is enough.
+- **Download report** as JSON (existing capability in `RunDetail.tsx` —
+  preserve the `Download` icon button, just restyle to fit).
+- **Embed snippet** is **out of scope for 9A**. Phase 9D wires the badge
+  image / iframe target. 9A only needs the public URL to exist and look
+  good when opened directly.
+
+---
+
+## Color palette — anchor to existing UnClick admin
+
+Do not invent new colours. Pull from `testpass-ui.ts` and the existing
+admin shell. Reference values:
+
+| Use                     | Value                |
+|-------------------------|----------------------|
+| Page background         | `#0B0E14` (existing) |
+| Card background         | `#11151D` (existing) |
+| Card border (resting)   | `#1F2937` @ 60% alpha|
+| Primary accent (gold)   | `#E2B93B`            |
+| Info accent (teal)      | `#61C1C4`            |
+| Pass green              | `#22C55E`            |
+| Fail red                | `#EF4444`            |
+| Warning gold            | `#E2B93B` (reuse)    |
+| Skipped grey            | `#6B7280`            |
+| Body text               | `#E5E7EB`            |
+| Muted text              | `#9CA3AF`            |
+
+Verify exact values against `tailwind.config.ts` and `AdminShell.tsx`
+during implementation — these are the intent, not the source of truth.
+
+---
+
+## ASCII wireframe — full run dashboard
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  UnClick                                                       [Sign in]   │
+├────────────────────────────────────────────────────────────────────────────┤
+│                                                                            │
+│   TestPass · example.com/mcp                          ┌──────────────────┐ │
+│   testpass-core 0.1 · standard profile · 28 sec       │  24 / 26 passing │ │
+│                                                       │  ████████████░░  │ │
+│   [▶ Run TestPass]   [🔗 Share]   [⬇ Download]        │  testpass-core   │ │
+│                                                       └──────────────────┘ │
+│                                                                            │
+├────────────────────────────────────────────────────────────────────────────┤
+│                                                                            │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐          │
+│  │ ✅ jsonrpc field  │  │ ✅ id field set  │  │ ✅ error shape   │          │
+│  │ Every request    │  │ Requests carry   │  │ Errors return    │          │
+│  │ tags 2.0.        │  │ an id field.     │  │ code + message.  │          │
+│  │ ▸ What this means│  │ ▸ What this means│  │ ▸ What this means│          │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘          │
+│                                                                            │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐          │
+│  │ ❌ ping too slow  │  │ ✅ tools/list ok  │  │ ⚠️ slow init     │          │
+│  │ Ping took 4.1s,  │  │ 9 tools, all     │  │ Took 1.8s. Watch │          │
+│  │ over 2s budget.  │  │ have schemas.    │  │ for cold starts. │          │
+│  │ ▸ What this means│  │ ▸ What this means│  │ ▸ What this means│          │
+│  │ [How to fix →]   │  │                  │  │                  │          │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘          │
+│                                                                            │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐          │
+│  │ ✅ search_memory │  │ ✅ save_fact ok   │  │ ⏸ post_message  │          │
+│  │ Returns the     │  │ Returned an id   │  │ Skipped (deep    │          │
+│  │ right shape.    │  │ for new fact.    │  │ profile only).   │          │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘          │
+│                                                                            │
+│  … 17 more cards reflow below at 3 / 2 / 1 columns by viewport             │
+│                                                                            │
+├────────────────────────────────────────────────────────────────────────────┤
+│  testpass-core 0.1 · 26 checks · 28 sec · Powered by UnClick TestPass      │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+Notes on the wireframe:
+
+- Header score badge sits to the right of the action buttons, not inside
+  the button row. Gives it enough whitespace to read at a glance.
+- "How to fix →" only appears on `fail` and `warning` cards; pass / skipped
+  cards are shorter, so the grid does NOT need to enforce a fixed card
+  height. Let cards size to their content; CSS grid `auto-rows: min-content`.
+- Footer is muted text only. No logo, no extra CTA — the score badge is
+  the only thing worth screenshotting.
+
+---
+
+## Out of scope for Phase 9A
+
+- **Marketplace tile badge integration** — that is Phase 9D. 9A only needs
+  the shareable URL to exist; 9D wires the embeddable badge that links to it.
+- **Re-running individual checks** — out of scope. A run is atomic.
+- **Diffing two runs** — admin view already has this; do not port it to
+  the public view.
+- **Editing the pack from the UI** — packs are YAML, edited via PR.
+- **Auth UI on the public route** — the public report URL is anonymous-
+  readable. Auth-gated rerun is the existing admin flow.
+
+---
+
+## Hand-off checklist for 🍿
+
+When Chris approves this brief, 🍿 should:
+
+1. Create `src/pages/testpass/PublicReport.tsx` (new public route).
+2. Extract reusable `<CheckCard />` and `<ScoreBadge />` components into
+   `src/pages/testpass/components/`.
+3. Reuse `testpass-ui.ts` constants — do not fork the icon / colour maps.
+4. Wire the route into `App.tsx` at `/testpass/r/:reportId`.
+5. Add a starter-pack picker at `/testpass/r/new`.
+6. Leave the admin view (`src/pages/admin/testpass/RunDetail.tsx`) alone.
+   The two views can share components but should not share routes.
+
+Estimated effort: 1–2 sessions (~400 LOC component work + ~150 LOC route
+wiring). Test plan: Storybook stories for each card state, plus a
+Playwright smoke run against a known good MCP server.

--- a/packages/testpass/packs/testpass-core.yaml
+++ b/packages/testpass/packs/testpass-core.yaml
@@ -140,3 +140,250 @@ items:
     on_fail: A crash on unknown methods makes the server unusable after the first agent exploration call.
     tags: [lifecycle, resilience, error-handling]
     profiles: [smoke, standard, deep]
+
+  - id: MCP-007
+    title: tools/list returns at least one tool with a name, description, and inputSchema
+    category: mcp-lifecycle
+    severity: critical
+    check_type: agent
+    description: >
+      Call the tools/list method. The response must contain a non-empty tools array.
+      Every entry must have a string name, a string description, and an inputSchema
+      object. Missing any of these stops AI clients from rendering or calling the tool.
+    expected: { min_tools: 1, required_fields: [name, description, inputSchema] }
+    on_fail: >
+      tools/list did not return tools with name + description + inputSchema. Check that
+      every registered tool in the server defines all three fields and that the registry
+      is included in the tools/list response.
+    tags: [lifecycle, tools, discovery]
+    profiles: [smoke, standard, deep]
+
+  - id: MCP-008
+    title: ping method round-trips and returns an empty result
+    category: mcp-lifecycle
+    severity: high
+    check_type: agent
+    description: >
+      Call the ping method with no params. The server must return a JSON-RPC response
+      whose result is an empty object {} within 2 seconds. ping is the standard MCP
+      health probe and must always succeed when the server is alive.
+    expected: { result: {}, max_latency_ms: 2000 }
+    on_fail: >
+      ping did not round-trip cleanly. Check the request reached the server, the method
+      handler is registered, and the response shape is exactly { jsonrpc, id, result: {} }.
+    tags: [lifecycle, health, ping]
+    profiles: [smoke, standard, deep]
+
+  - id: MCP-009
+    title: Server advertises tools, resources, and prompts capabilities correctly
+    category: mcp-lifecycle
+    severity: high
+    check_type: agent
+    description: >
+      Per the Streamable HTTP MCP spec, InitializeResult.capabilities must declare
+      every category the server actually serves. If the server answers tools/list,
+      capabilities.tools must be present. Same for resources/list and prompts/list.
+      Mismatched capabilities cause clients to skip features or call missing methods.
+    expected: { capability_keys: [tools, resources, prompts], match_actual_methods: true }
+    on_fail: >
+      Server's declared capabilities do not match the methods it answers. Add the
+      missing capability key (tools, resources, or prompts) to InitializeResult, or
+      remove the corresponding list method handler if you did not mean to support it.
+    tags: [lifecycle, capabilities, spec-compliance]
+    profiles: [standard, deep]
+
+  # ── UnClick tool surface ───────────────────────────────────────────────────
+
+  - id: TOOL-001
+    title: search_memory returns the right shape for any query
+    category: tools
+    severity: high
+    check_type: agent
+    description: >
+      Call search_memory with any query string. The response must be a JSON object
+      with a results array (may be empty) and a numeric total field. Agents rely on
+      this exact shape to render recall results without crashing.
+    expected: { shape: { results: array, total: number } }
+    on_fail: >
+      search_memory did not return { results: [], total: number }. Check the handler
+      response in packages/mcp-server/src/memory/handlers.ts and confirm both fields
+      are always present, even on empty results.
+    tags: [tools, memory, contract]
+    profiles: [smoke, standard, deep]
+
+  - id: TOOL-002
+    title: save_fact accepts fact + tags and returns the inserted row id
+    category: tools
+    severity: high
+    check_type: agent
+    description: >
+      Call save_fact with { fact: "test fact", tags: ["testpass"] }. The server must
+      persist the fact and return an id (string or number) identifying the inserted
+      row. Without an id, agents cannot link, supersede, or audit the fact later.
+    expected: { input: { fact, tags }, output_contains: [id] }
+    on_fail: >
+      save_fact did not return an id for the inserted fact. Check the handler in
+      packages/mcp-server/src/memory/handlers.ts wraps the Supabase insert and
+      surfaces the row id back to the caller.
+    tags: [tools, memory, write]
+    profiles: [smoke, standard, deep]
+
+  - id: TOOL-003
+    title: post_message accepts agent_id + text and returns a message id
+    category: tools
+    severity: high
+    check_type: agent
+    description: >
+      Call post_message with { agent_id: "testpass-probe", text: "hello fishbowl" }.
+      The server must persist the message into the user's Fishbowl and return a
+      message id. Without an id agents cannot reference or thread their own posts.
+    expected: { input: { agent_id, text }, output_contains: [id] }
+    on_fail: >
+      post_message did not return a message id. Check the Fishbowl handler in
+      api/memory-admin.ts (action=fishbowl_post) returns the inserted row id and
+      that the MCP wrapper passes it back unchanged.
+    tags: [tools, fishbowl, write]
+    profiles: [smoke, standard, deep]
+
+  - id: TOOL-004
+    title: set_my_emoji accepts agent_id + emoji and confirms registration
+    category: tools
+    severity: high
+    check_type: agent
+    description: >
+      Call set_my_emoji with { agent_id: "testpass-probe", emoji: "🤖" }. The server
+      must register the agent in the Fishbowl and return a confirmation (ok flag or
+      the registered row). This is the handshake every agent runs once on first connect.
+    expected: { input: { agent_id, emoji }, output_contains_one_of: [ok, agent_id, id] }
+    on_fail: >
+      set_my_emoji did not confirm the registration. Check the Fishbowl handler
+      (action=fishbowl_set_emoji) returns a success indicator and that the MCP
+      wrapper is not swallowing the response.
+    tags: [tools, fishbowl, identity]
+    profiles: [standard, deep]
+
+  - id: TOOL-005
+    title: read_messages returns a list of messages for the calling agent
+    category: tools
+    severity: medium
+    check_type: agent
+    description: >
+      Call read_messages with { agent_id: "testpass-probe" }. The server must return
+      a JSON object containing an array of recent Fishbowl messages. Each message
+      should expose at minimum text + timestamp + author (emoji or agent_id).
+    expected: { input: { agent_id }, output_contains: [messages] }
+    on_fail: >
+      read_messages did not return a messages array. Confirm the Fishbowl read
+      handler (action=fishbowl_read) returns { messages: [] } even when empty,
+      and that each row carries text, timestamp, and author fields.
+    tags: [tools, fishbowl, read]
+    profiles: [standard, deep]
+
+  - id: TOOL-006
+    title: check_signals returns the right shape with no auth surprises
+    category: tools
+    severity: medium
+    check_type: agent
+    description: >
+      Call check_signals with no params. The server must return a JSON object with a
+      signals array (may be empty). check_signals is the start-of-session catch-up
+      tool and a broken shape blocks every agent from narrating updates.
+    expected: { shape: { signals: array } }
+    on_fail: >
+      check_signals did not return { signals: [] }. Check the handler in
+      packages/mcp-server/src/server.ts and the api/memory-admin.ts (action=check_signals)
+      branch always emit a signals array, even when there is nothing new.
+    tags: [tools, signals, contract]
+    profiles: [standard, deep]
+
+  # ── Auth ───────────────────────────────────────────────────────────────────
+
+  - id: AUTH-001
+    title: Missing Authorization header returns auth error -32001
+    category: auth
+    severity: critical
+    check_type: agent
+    description: >
+      Send any tool call without an Authorization header. The server must reject the
+      request with JSON-RPC error code -32001 (or the project's defined auth error
+      code) and must NOT execute the tool. Silent acceptance breaks tenancy.
+    expected: { error_code: -32001 }
+    on_fail: >
+      A request with no Authorization header was not rejected with -32001. Check the
+      auth middleware runs before the tool dispatcher and returns a structured JSON-RPC
+      error rather than a 401, an empty body, or a generic exception.
+    tags: [auth, security, mandatory]
+    profiles: [smoke, standard, deep]
+
+  - id: AUTH-002
+    title: Malformed bearer token returns auth error -32001
+    category: auth
+    severity: critical
+    check_type: agent
+    description: >
+      Send a tool call with Authorization "Bearer notarealtoken". The server must
+      reject with JSON-RPC error -32001 (or the project's defined auth error code)
+      and must NOT execute the tool. Garbage tokens must never fall through.
+    expected: { error_code: -32001 }
+    on_fail: >
+      A request with a malformed bearer token was not rejected with -32001. Confirm
+      the auth middleware validates the token shape (and signature) before tool
+      dispatch and returns a JSON-RPC error rather than passing through.
+    tags: [auth, security, mandatory]
+    profiles: [smoke, standard, deep]
+
+  - id: AUTH-003
+    title: Valid token plus correct tenant returns success
+    category: auth
+    severity: high
+    check_type: agent
+    description: >
+      Send a tool call with a known good Authorization header that maps to the
+      tenant under test. The server must accept the call and return the tool's
+      normal response. This pins the happy-path so the AUTH-001 / AUTH-002 fail
+      paths are not just blanket rejections.
+    expected: { success: true }
+    on_fail: >
+      A valid Authorization header was rejected. Confirm the token map / RLS policy
+      correctly recognises the test tenant and that the auth middleware is not
+      throwing on legitimate requests.
+    tags: [auth, security, happy-path]
+    profiles: [smoke, standard, deep]
+
+  # ── Tenancy ────────────────────────────────────────────────────────────────
+
+  - id: TENANT-001
+    title: Tenant scoping by api_key_hash holds across calls
+    category: tenancy
+    severity: critical
+    check_type: agent
+    description: >
+      Write a fact as tenant A. Read it back as tenant B (different api_key_hash).
+      Tenant B must NOT see tenant A's fact. This proves the api_key_hash scoping
+      and Supabase RLS policies actually isolate tenants.
+    expected: { cross_tenant_visibility: false }
+    on_fail: >
+      Tenant B saw tenant A's fact. This is a CRITICAL data-isolation failure.
+      Audit the RLS policies on every memory table and confirm api_key_hash is
+      part of every read and write query in packages/mcp-server/src/memory/db.ts.
+    tags: [tenancy, security, isolation, mandatory]
+    profiles: [smoke, standard, deep]
+
+  # ── Performance ────────────────────────────────────────────────────────────
+
+  - id: PERF-001
+    title: initialize handshake completes in under 2000ms
+    category: performance
+    severity: medium
+    check_type: agent
+    description: >
+      Time the initialize call from request send to response received. Must complete
+      in under 2000ms on a warm connection. Slow init blocks every downstream tool
+      call and makes the server feel broken to agent runtimes that use short timeouts.
+    expected: { max_latency_ms: 2000 }
+    on_fail: >
+      initialize took longer than 2000ms. Profile the handshake path: cold starts on
+      Vercel, Supabase connection setup, or large InitializeResult payloads are the
+      usual culprits. Cache what you can or move work out of the handshake.
+    tags: [performance, lifecycle, latency]
+    profiles: [standard, deep]

--- a/packages/testpass/src/__tests__/pack-loader.test.ts
+++ b/packages/testpass/src/__tests__/pack-loader.test.ts
@@ -10,7 +10,7 @@ describe("loadPackFromFile", () => {
     const pack = loadPackFromFile(CORE_PACK_PATH);
     expect(pack.id).toBe("testpass-core");
     expect(pack.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(pack.items.length).toBeGreaterThanOrEqual(12);
+    expect(pack.items.length).toBeGreaterThanOrEqual(26);
   });
 
   it("throws when file does not exist", () => {


### PR DESCRIPTION
## Summary

- **Pack expansion** — `testpass-core.yaml` grows from 12 → **26 checks**. New sections: MCP lifecycle (007-009), UnClick tool surface (TOOL-001..006), auth (AUTH-001..003), tenancy (TENANT-001), performance (PERF-001). Idiot-proof titles, plain-English descriptions, friendly `on_fail` recipes that name the file or handler to check.
- **Phase 9A visual brief** — `docs/testpass-phase-9a-visual-brief.md` is the design intent for the public-facing TestPass dashboard. Covers state model (✅ / ❌ / ⚠️ / ⏸), per-card anatomy, score badge, share/export, color palette anchored to the existing UnClick admin, ASCII wireframe, and the 9A vs 9D scope split (9A = view, 9D = marketplace badge — separate). Hand-off doc for 🍿; **no React written yet**.
- **One substitution from the brief**: `TOOL-005` was specced as `list_todos`, but that tool doesn't exist in the MCP server (verified by grep). Swapped to `read_messages`, which exists and aligns with the Fishbowl tool coverage intent.

## Test plan

- [x] `npm test -- src/__tests__/pack-loader.test.ts` in `packages/testpass` — 6/6 passing, pack loads + validates against zod schema, jsonb round-trip and YAML re-serialization both intact. Min item count bumped from 12 → 26.
- [ ] CI green on the standard suite (lint, type-check, full test run).
- [ ] Chris reviews the brief and the new check phrasing.
- [ ] 🐺 merges after CI green.

## Out of scope

- Implementing the React components for the visual brief (that's Phase 9B, follow-up PR by 🍿).
- Marketplace tile badge integration (Phase 9D, separate).
- Rewriting the existing 12 check titles — only the 14 new checks adopt the idiot-proof language. Re-titling the originals is a low-risk follow-up if Chris wants consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)