### PR TITLE
feat(wizard): Phase 1 - Card type scaffold + search_memory example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,6 @@ jobs:
         run: npm install --no-audit --no-fund
       - name: Typecheck + build
         run: npm run build
+      - name: Tests
+        run: npm test
+        continue-on-error: true

--- a/docs/wizard-phase-1-spec.md
+++ b/docs/wizard-phase-1-spec.md
@@ -1,0 +1,166 @@
+# UnClick Orchestrator Wizard - Phase 1 Spec
+
+Status: Phase 1 (foundation only).
+Owner: Bailey reviews and merges. Chris greenlit.
+Companion smoke test: `docs/orchestrator-wizard-phase-1-smoke.md`.
+
+## North star
+
+Every UnClick MCP tool, today and forever, callable through a friendly chat.
+No raw JSON ever shown to a human. The Wizard is the surface that turns a
+tool result into something a non-engineer can read, act on, and trust.
+
+The Wizard is not a new product line. It is one of several rails that
+attach to every tool the moment it registers itself with the marketplace.
+
+## Bolt-on rail framing
+
+UnClick has four rails. A tool registers once and lights up on all of them.
+
+| Rail | What it does for the tool |
+|---|---|
+| Signals | Emits a feed item every time the tool runs so other agents can see what happened. |
+| Backup | Persists the tool's relevant outputs into Memory so they survive across sessions. |
+| TestPass | Exposes a YAML pack the agent can run to QA the tool end to end. |
+| Wizard | Wraps the tool's response in a ConversationalCard so chat surfaces can render it. |
+
+Each rail is opt-in by default and additive. A tool that ignores the
+Wizard rail keeps working exactly as it does today; nothing about the
+existing response shape is taken away.
+
+## Phase 1 scope
+
+This phase ships the foundations the team can build on. Two pieces:
+
+1. The `ConversationalCard` TypeScript type, in a new `@unclick/wizard`
+   workspace package. Types only, no runtime dependencies.
+2. One example wrap on `search_memory` proving the shape works end to end
+   without breaking the existing response.
+
+Out of scope for Phase 1: the Wizard chat UI, the orchestrator-routed LLM,
+and wrapping the rest of the tool catalog.
+
+## Out of scope: Orchestrator-routed LLM (Phase 4)
+
+Today the MCP server pays for LLM calls per request. Every Crews run, every
+fact extraction, every blob expansion bills the UnClick API key. That
+metered cost grows linearly with adoption and turns every free tier user
+into a marginal loss.
+
+The fix is to route those calls through the user's own Orchestrator
+(Claude Desktop, ChatGPT, Cursor, anything that supports the MCP sampling
+spec). The MCP server stops calling Anthropic directly; instead it sends a
+sampling request back through the protocol and the user's client pays for
+it. Net cost to the UnClick server drops to zero.
+
+This work depends on every server-side LLM call being moved behind a
+sampling-aware abstraction. That work is separate. Phase 1 does not block
+on it; the Card layer ships value on its own.
+
+## ConversationalCard - the Phase 1 deliverable
+
+A card lives alongside a tool's existing payload, never inside it. Tools
+opt in by accepting an `include_card` flag (or, in later phases, by
+defaulting to card-on once consumers are ready).
+
+### Anatomy
+
+```
+ConversationalCard
+├── title         required   short headline shown in bold at the top
+├── summary       required   one or two sentence plain-English summary
+├── severity      optional   info | success | warning | error
+├── body          optional   ordered list of sections, each one of:
+│     ├── text             heading + paragraph
+│     ├── list             heading + bullet/ordered items
+│     ├── table            heading + columns + rows
+│     ├── link             label + href + optional description
+│     └── action-button    label + CardAction (tool name + args + confirmation)
+├── followUps     optional   suggested next-step labels, each may carry a CardAction
+└── meta          optional   small free-form key-value bag for surfaces, not user-visible
+```
+
+### Design rules
+
+1. Renderable without a schema lookup. A surface that has never seen the
+   calling tool should still produce a usable card.
+2. Severity drives icon and color. Default to info if omitted.
+3. Body sections render top to bottom in order. Unknown section kinds MUST
+   fall back to plain text so future kinds do not break old surfaces.
+4. CardAction.confirmation defaults to "confirm". Surfaces ask the user
+   before invoking a tool unless explicitly set to "auto".
+5. No HTML in any field. Plain text or lightweight markdown only.
+6. No em dashes anywhere in card content (project rule).
+
+### Backward compatibility
+
+A tool that wraps its response with a card must not remove fields a caller
+already depends on. The recommended pattern is:
+
+```ts
+// Before
+return results;
+
+// After (opt-in)
+if (includeCard) return { results, card };
+return results;
+```
+
+`include_card` defaults to false in Phase 1. Phase 2 may flip the default
+on a tool-by-tool basis once the Wizard surface ships.
+
+### Existing minimal card type
+
+`packages/mcp-server/src/cards/card.ts` already defines a five-field
+`ConversationalCard` (`headline`, `summary`, `keyFacts`, `nextActions`,
+`deepLink`) used by `crews-tool.ts`. The new `@unclick/wizard`
+`ConversationalCard` is a richer superset. Phase 1 leaves the existing
+minimal type in place so `crews-tool.ts` keeps working unchanged. Phase 2
+proposes to migrate `crews-tool.ts` onto the wizard type and delete the
+local one.
+
+## Roadmap
+
+| Phase | Deliverable |
+|---|---|
+| P1 (this PR) | ConversationalCard type scaffold in @unclick/wizard, one example wrap on search_memory, vitest coverage. |
+| P2 | Wrap the top five tools (search_memory always-on, save_fact, save_session, check_signals, list_runs). Migrate crews-tool from the local minimal card. |
+| P3 | Ship the Wizard chat UI surface. Renders ConversationalCards from any UnClick MCP tool over a single chat thread. |
+| P4 | Orchestrator-routed LLM. All server-side Anthropic calls moved behind MCP sampling so users' own clients foot the LLM bill. |
+
+## How to add a card to your tool
+
+1. Import the type:
+   ```ts
+   import type { ConversationalCard } from "@unclick/wizard";
+   ```
+2. Build the card from your existing result. Keep titles short and
+   factual. Lean on body sections to carry detail.
+3. Return the card alongside (not inside) your existing payload:
+   ```ts
+   return { results, card };
+   ```
+4. Add the `include_card` opt-in flag to your MCP input schema until the
+   Wizard surface is ready to be the default.
+
+## How to test a card
+
+1. Unit test the builder: assert title, summary, severity, body kinds, and
+   meta shape.
+2. Verify followUps wire to real MCP tool names with valid args.
+3. Run the MCP server locally and call the tool with `include_card: true`
+   to see the card in the JSON response.
+
+## What the Wizard surface will need (P3 preview)
+
+The chat UI renders one card per tool call. A surface should:
+
+- Show title and summary first.
+- Render body sections in order, falling back to plain text on unknown kinds.
+- Treat action-button and followUp actions as proposed tool calls. Always
+  confirm with the user unless the action is marked auto.
+- Use severity to color the card border and pick an icon.
+
+None of that is built in Phase 1. The point of this phase is that the
+type lands, one tool proves it works, and the rest of the team can start
+wrapping their tools the same way.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7859,6 +7859,10 @@
       "resolved": "packages/testpass",
       "link": true
     },
+    "node_modules/@unclick/wizard": {
+      "resolved": "packages/wizard",
+      "link": true
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -21189,8 +21193,10 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.0",
         "@types/turndown": "^5.0.6",
+        "@unclick/wizard": "*",
         "tsx": "^4.19.2",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=18"
@@ -21289,6 +21295,13 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/wizard": {
+      "name": "@unclick/wizard",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^5.8.3"
       }
     }
   }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -22,7 +22,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "tsx --test src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts",
+    "test": "tsx --test src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts && vitest run",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -45,8 +45,10 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.0",
     "@types/turndown": "^5.0.6",
+    "@unclick/wizard": "*",
     "tsx": "^4.19.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=18"

--- a/packages/mcp-server/src/cards/search-memory-card.test.ts
+++ b/packages/mcp-server/src/cards/search-memory-card.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildSearchMemoryCard } from "./search-memory-card.js";
+import type { ConversationalCard } from "@unclick/wizard";
+
+describe("buildSearchMemoryCard - Phase 1 Wizard wrap", () => {
+  it("renders an empty-state card when no results match", () => {
+    const card: ConversationalCard = buildSearchMemoryCard("functional programming", []);
+    expect(card.title).toContain("No memories found");
+    expect(card.title).toContain("functional programming");
+    expect(card.severity).toBe("info");
+    expect(card.followUps?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(card.meta?.result_count).toBe(0);
+  });
+
+  it("renders a results card with truncated previews when matches exist", () => {
+    const results = [
+      { id: "1", fact: "Chris prefers TypeScript over JavaScript", confidence: 0.95 },
+      { id: "2", fact: "Chris's timezone is Australia/Melbourne", confidence: 0.9 },
+      { id: "3", fact: "Bailey reviews and merges Phase 1 wizard PRs", confidence: 0.85 },
+    ];
+    const card = buildSearchMemoryCard("Chris", results);
+    expect(card.title).toBe('Found 3 memories matching "Chris"');
+    expect(card.severity).toBe("success");
+    expect(card.body?.[0]?.kind).toBe("list");
+    if (card.body?.[0]?.kind === "list") {
+      expect(card.body[0].items).toHaveLength(3);
+      expect(card.body[0].items[0]).toContain("TypeScript");
+    }
+    expect(card.meta?.result_count).toBe(3);
+  });
+
+  it("singular wording when exactly one match is returned", () => {
+    const card = buildSearchMemoryCard("timezone", [{ fact: "Australia/Melbourne" }]);
+    expect(card.title).toBe('Found 1 memory matching "timezone"');
+  });
+
+  it("truncates long fact previews to keep cards renderable", () => {
+    const longFact = "x".repeat(500);
+    const card = buildSearchMemoryCard("noisy", [{ fact: longFact }]);
+    if (card.body?.[0]?.kind === "list") {
+      expect(card.body[0].items[0].length).toBeLessThanOrEqual(140);
+      expect(card.body[0].items[0].endsWith("…")).toBe(true);
+    } else {
+      throw new Error("expected list section");
+    }
+  });
+
+  it("caps the preview list at five entries even with more matches", () => {
+    const results = Array.from({ length: 12 }, (_, i) => ({ fact: `fact ${i}` }));
+    const card = buildSearchMemoryCard("many", results);
+    expect(card.title).toBe('Found 12 memories matching "many"');
+    expect(card.summary).toContain("Showing the top 5 of 12");
+    if (card.body?.[0]?.kind === "list") {
+      expect(card.body[0].items).toHaveLength(5);
+    }
+  });
+
+  it("includes a save_fact follow-up wired with confirmation", () => {
+    const card = buildSearchMemoryCard("anything", [{ fact: "x" }]);
+    const saveFollowUp = card.followUps?.find((f) => f.action?.tool === "save_fact");
+    expect(saveFollowUp).toBeDefined();
+    expect(saveFollowUp?.action?.confirmation).toBe("confirm");
+  });
+});

--- a/packages/mcp-server/src/cards/search-memory-card.ts
+++ b/packages/mcp-server/src/cards/search-memory-card.ts
@@ -1,0 +1,95 @@
+/**
+ * Phase 1 example wrap. Builds a ConversationalCard summarising a
+ * search_memory result list. Only invoked when the caller opts in via
+ * include_card=true on search_memory; the legacy raw-array response is the
+ * default so existing agents keep working unchanged.
+ *
+ * Type imported from the new @unclick/wizard package (Phase 1 deliverable).
+ */
+
+import type { ConversationalCard } from "@unclick/wizard";
+
+const MAX_PREVIEW_RESULTS = 5;
+const MAX_PREVIEW_LENGTH = 140;
+
+interface MemoryRowLike {
+  id?: string;
+  fact?: string;
+  content?: string;
+  category?: string;
+  confidence?: number;
+  created_at?: string;
+}
+
+function rowText(row: MemoryRowLike): string {
+  const raw = row.fact ?? row.content ?? "";
+  const trimmed = raw.replace(/\s+/g, " ").trim();
+  if (trimmed.length <= MAX_PREVIEW_LENGTH) return trimmed;
+  return `${trimmed.slice(0, MAX_PREVIEW_LENGTH - 1)}…`;
+}
+
+export function buildSearchMemoryCard(
+  query: string,
+  results: unknown,
+): ConversationalCard {
+  const rows = Array.isArray(results) ? (results as MemoryRowLike[]) : [];
+  const total = rows.length;
+  const safeQuery = query.trim() || "(empty query)";
+
+  if (total === 0) {
+    return {
+      title: `No memories found for "${safeQuery}"`,
+      summary:
+        "Memory was searched but nothing matched. Try a broader query or save a new fact if this is novel context.",
+      severity: "info",
+      followUps: [
+        { label: "Refine the search query and try again" },
+        {
+          label: "Save this as a new fact",
+          action: {
+            tool: "save_fact",
+            args: { fact: "", category: "general" },
+            confirmation: "confirm",
+          },
+        },
+      ],
+      meta: { tool: "search_memory", query: safeQuery, result_count: 0 },
+    };
+  }
+
+  const preview = rows.slice(0, MAX_PREVIEW_RESULTS).map(rowText).filter(Boolean);
+  const shownCount = preview.length;
+  const hiddenCount = Math.max(0, total - shownCount);
+
+  return {
+    title: `Found ${total} memor${total === 1 ? "y" : "ies"} matching "${safeQuery}"`,
+    summary:
+      hiddenCount > 0
+        ? `Showing the top ${shownCount} of ${total}. The rest are in the raw results payload.`
+        : `Showing all ${total}.`,
+    severity: "success",
+    body: [
+      {
+        kind: "list",
+        heading: "Top matches",
+        items: preview,
+      },
+    ],
+    followUps: [
+      { label: "Refine the search query and try again" },
+      {
+        label: "Save a new fact related to this query",
+        action: {
+          tool: "save_fact",
+          args: { fact: "", category: "general" },
+          confirmation: "confirm",
+        },
+      },
+    ],
+    meta: {
+      tool: "search_memory",
+      query: safeQuery,
+      result_count: total,
+    },
+  };
+}

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -14,6 +14,7 @@ import {
 } from "./tool-awareness.js";
 import { resolveAgent, filterContextByLayers } from "./agent.js";
 import { emitSignal } from "../signals/emit.js";
+import { buildSearchMemoryCard } from "../cards/search-memory-card.js";
 
 function currentApiKeyHash(): string | null {
   return process.env.UNCLICK_API_KEY_HASH ?? null;
@@ -89,7 +90,14 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
   async search_memory(args) {
     const db = await getBackend();
     const asOf = typeof args.as_of === "string" ? args.as_of : undefined;
-    return db.searchMemory(str(args.query), num(args.max_results, 10), asOf);
+    const query = str(args.query);
+    const results = await db.searchMemory(query, num(args.max_results, 10), asOf);
+    // Phase 1 Wizard wrap: opt-in card alongside the existing array payload.
+    // Defaults off to keep backward compatibility for current consumers.
+    if (bool(args.include_card, false)) {
+      return { results, card: buildSearchMemoryCard(query, results) };
+    }
+    return results;
   },
 
   async search_facts(args) {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -272,6 +272,12 @@ const VISIBLE_TOOLS = [
         query: { type: "string", description: "Search query" },
         max_results: { type: "number", minimum: 1, maximum: 50, default: 10 },
         as_of: { type: "string", description: "ISO 8601 timestamp for point-in-time queries (returns facts valid at that moment)" },
+        include_card: {
+          type: "boolean",
+          default: false,
+          description:
+            "Phase 1 Wizard opt-in. When true, the response is { results, card } where card is a ConversationalCard summarising the matches for friendly chat surfaces. When false (default), returns the raw results array unchanged for backward compatibility.",
+        },
       },
       required: ["query"],
     },

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+    exclude: [
+      "node_modules/**",
+      "dist/**",
+      // node:test files run via `tsx --test` in the same npm script.
+      "src/memory/__tests__/**",
+    ],
+  },
+});

--- a/packages/wizard/package.json
+++ b/packages/wizard/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@unclick/wizard",
+  "version": "0.0.1",
+  "description": "UnClick Orchestrator Wizard - shared types for ConversationalCard responses across every UnClick MCP tool. Phase 1 ships types only.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./types/card": "./src/types/card.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/wizard/src/index.ts
+++ b/packages/wizard/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./types/index.js";

--- a/packages/wizard/src/types/card.ts
+++ b/packages/wizard/src/types/card.ts
@@ -1,0 +1,135 @@
+/**
+ * ConversationalCard - the response shape every UnClick MCP tool can attach
+ * alongside its raw payload so chat surfaces (the Wizard, Claude Desktop,
+ * ChatGPT, anything else) can render a friendly card instead of dumping JSON
+ * at the user.
+ *
+ * Phase 1 deliverable. See docs/wizard-phase-1-spec.md.
+ *
+ * Design rules:
+ *   - Pure types, zero runtime deps. Anything that imports this stays cheap.
+ *   - Backward compatible by construction: a tool's existing payload stays
+ *     where it was and the card sits next to it as an optional field.
+ *   - Renderable without a schema lookup. A surface that does not know the
+ *     calling tool should still be able to render the card.
+ */
+
+export type CardSeverity = "info" | "success" | "warning" | "error";
+
+/**
+ * A single body block inside a card. Surfaces render each block top to bottom.
+ * Phase 1 supports five kinds. New kinds may be added in later phases; renderers
+ * MUST treat unknown kinds as opaque and fall back to plain text.
+ */
+export type CardSection =
+  | CardTextSection
+  | CardListSection
+  | CardTableSection
+  | CardLinkSection
+  | CardActionButtonSection;
+
+export interface CardTextSection {
+  kind: "text";
+  /** Optional heading shown above the text block. */
+  heading?: string;
+  /** Plain text or lightweight markdown. No HTML. */
+  text: string;
+}
+
+export interface CardListSection {
+  kind: "list";
+  heading?: string;
+  /** Render as a bulleted list. Use ordered=true for numbered. */
+  items: string[];
+  ordered?: boolean;
+}
+
+export interface CardTableSection {
+  kind: "table";
+  heading?: string;
+  /** Column headings, in display order. */
+  columns: string[];
+  /** Rows, each the same length as columns. Cells are stringified for display. */
+  rows: Array<Array<string | number | boolean | null>>;
+}
+
+export interface CardLinkSection {
+  kind: "link";
+  heading?: string;
+  /** Visible label for the link. */
+  label: string;
+  /** Absolute URL or app-relative deep link (e.g. "/admin/memory"). */
+  href: string;
+  /** Optional one-line description shown beneath the link. */
+  description?: string;
+}
+
+/**
+ * A clickable action that maps to a follow-up tool call. The surface is
+ * responsible for invoking the tool with the supplied arguments. Carries no
+ * runtime behavior of its own.
+ */
+export interface CardActionButtonSection {
+  kind: "action-button";
+  heading?: string;
+  /** Button label shown to the user. */
+  label: string;
+  /** Optional one-line hint shown alongside the button. */
+  description?: string;
+  action: CardAction;
+}
+
+export interface CardAction {
+  /** MCP tool name to invoke when the action is taken. */
+  tool: string;
+  /** Arguments to pass to the tool. Surface MAY prompt for confirmation first. */
+  args: Record<string, unknown>;
+  /**
+   * If "confirm", the surface should ask the user before invoking the tool.
+   * If "auto", the surface may invoke directly. Defaults to "confirm".
+   */
+  confirmation?: "confirm" | "auto";
+}
+
+/**
+ * The full card. Every field except title and summary is optional so tools
+ * can ship the simplest useful card on day one and grow into richer bodies
+ * later.
+ */
+export interface ConversationalCard {
+  /** Short headline. Surfaces render as the card's bold top line. */
+  title: string;
+  /** One or two sentence plain-English summary of the result. */
+  summary: string;
+  /** Severity hint for icon and color. Defaults to "info" if omitted. */
+  severity?: CardSeverity;
+  /** Body sections rendered in order. */
+  body?: CardSection[];
+  /**
+   * Suggested follow-ups the agent may offer the user. Each is a short
+   * imperative phrase plus an optional action that wires it to a tool call.
+   */
+  followUps?: CardFollowUp[];
+  /**
+   * Free-form metadata for surfaces that want to deduplicate or correlate
+   * cards. Not user-visible. Keep small.
+   */
+  meta?: Record<string, string | number | boolean>;
+}
+
+export interface CardFollowUp {
+  /** Imperative label the surface shows to the user. */
+  label: string;
+  /** Optional tool action wired to the follow-up. */
+  action?: CardAction;
+}
+
+/**
+ * Helper type for tool responses that opt into the card layer. Tools should
+ * keep their existing payload shape on the `results` field and attach the
+ * card alongside.
+ */
+export interface WithCard<T> {
+  results: T;
+  card: ConversationalCard;
+}

--- a/packages/wizard/src/types/index.ts
+++ b/packages/wizard/src/types/index.ts
@@ -1,0 +1,13 @@
+export type {
+  CardAction,
+  CardActionButtonSection,
+  CardFollowUp,
+  CardLinkSection,
+  CardListSection,
+  CardSection,
+  CardSeverity,
+  CardTableSection,
+  CardTextSection,
+  ConversationalCard,
+  WithCard,
+} from "./card.js";

--- a/packages/wizard/tsconfig.json
+++ b/packages/wizard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Orchestrator Wizard. Lands the foundations the team can build on; does not ship the Wizard chat UI or the orchestrator-routed LLM (those are P3 / P4).

- New `@unclick/wizard` workspace package, **types only**, no runtime deps. Defines `ConversationalCard`, `CardSection` (text / list / table / link / action-button), `CardAction`, `CardSeverity`, `CardFollowUp`, `WithCard`.
- Example wrap on `search_memory` via a new `packages/mcp-server/src/cards/search-memory-card.ts` builder. Wired into `MEMORY_HANDLERS.search_memory` behind an opt-in `include_card` flag so the existing array response is unchanged for current consumers.
- `docs/wizard-phase-1-spec.md` covering the rail framing (Signals / Backup / TestPass / Wizard), card anatomy, backward-compat rules, and the 4-phase roadmap.
- vitest in `packages/mcp-server` with 6 cases covering the new card shape (empty state, multi-result, singular wording, preview truncation, list cap, follow-up wiring).
- CI now runs the mcp-server test suite on every PR (continue-on-error to match the existing root style).

## Structural finding (please weigh in)

`packages/mcp-server/src/cards/card.ts` already defines a five-field `ConversationalCard` (`headline`, `summary`, `keyFacts`, `nextActions`, `deepLink`) used by `crews-tool.ts`. The new `@unclick/wizard` `ConversationalCard` is a richer superset with named body sections, severity, and tool-wired follow-ups.

I left the existing minimal type **in place** so `crews-tool.ts` keeps working unchanged in this PR. The spec doc proposes Phase 2 migrates `crews-tool.ts` onto the wizard type and deletes the local copy. Open to a different call: e.g. fold the wizard type onto the existing one and skip the migration step, or split body kinds further. Naming is also up for grabs (the existing fields are `headline`/`keyFacts`/`nextActions`; the new shape uses `title`/`body`/`followUps` to match the chip's brief).

## Backward compatibility

`search_memory` defaults to `include_card: false`, returning the same array it always has. Setting `include_card: true` switches the response to `{ results, card }`. Phase 2 may flip the default tool by tool once the Wizard surface ships.

## Workspace plumbing

- `packages/wizard` is a new workspace, picked up automatically by the existing `"packages/*"` glob in the root `package.json`. No workspace array edit needed.
- `@unclick/wizard` is a **devDependency** of `@unclick/mcp-server` so `import type` works at compile time without dragging the wizard package into the published `@unclick/mcp-server` tarball.

## Test plan

- [x] `npm run build --workspace=packages/wizard` (tsc --noEmit, clean)
- [x] `npm run build --workspace=packages/mcp-server` (tsc, clean)
- [x] `cd packages/mcp-server && npm test` (15 node:test pass + 6 vitest pass)
- [x] `npx vite build` from repo root (clean)
- [x] `npx vitest run` from repo root (1/1 existing test still passes)
- [ ] Reviewer to call `search_memory` with `include_card: true` against a live backend and eyeball the rendered card payload.

## Out of scope (and why)

- Wizard chat UI surface: P3.
- Orchestrator-routed LLM (sampling-based): P4. Today the MCP server pays for LLM calls per request; routing through the user's own client kills that cost. Independent track, doesn't block the card layer.
- Wrapping more than one tool: P2 picks the next four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)