### PR TITLE
fix(crews): roster reorder + run-snapshot for Pass-template reproducibility

### DIFF
--- a/src/lib/crews/engine.test.ts
+++ b/src/lib/crews/engine.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { supabaseUpdates, makeBuilder } = vi.hoisted(() => {
+  const updates: { table: string; patch: Record<string, unknown> }[] = [];
+
+  function makeBuilder(table: string) {
+    const state: {
+      op: "select" | "update" | "insert";
+      patch: Record<string, unknown> | undefined;
+      filters: Record<string, unknown>;
+      inFilter: { col: string; vals: string[] } | null;
+    } = { op: "select", patch: undefined, filters: {}, inFilter: null };
+
+    const resolve = async () => {
+      if (state.op === "update") {
+        updates.push({ table, patch: state.patch ?? {} });
+        return { data: null, error: null };
+      }
+      if (state.op === "insert") {
+        return { data: null, error: null };
+      }
+      if (table === "mc_crews") {
+        return {
+          data: { agent_ids: ["B-uuid", "A-uuid", "C-uuid"], template: "council" },
+          error: null,
+        };
+      }
+      if (table === "mc_agents") {
+        if (state.inFilter) {
+          // Postgres-style: returns rows in arbitrary order, NOT the order of agent_ids.
+          return {
+            data: [
+              { id: "A-uuid", slug: "a", name: "A", category: "thinking", seed_prompt: null },
+              { id: "B-uuid", slug: "b", name: "B", category: "thinking", seed_prompt: null },
+              { id: "C-uuid", slug: "c", name: "C", category: "thinking", seed_prompt: null },
+            ],
+            error: null,
+          };
+        }
+        if (state.filters.slug === "chairman") {
+          return {
+            data: {
+              id: "chairman-uuid",
+              slug: "chairman",
+              name: "Chairman",
+              category: "meta",
+              seed_prompt: null,
+            },
+            error: null,
+          };
+        }
+      }
+      if (table === "mc_extracted_facts") {
+        return { data: [], error: null };
+      }
+      return { data: null, error: null };
+    };
+
+    const b = {
+      select: (_cols?: string) => { state.op = "select"; return b; },
+      update: (patch: Record<string, unknown>) => { state.op = "update"; state.patch = patch; return b; },
+      insert: (_rows: unknown) => { state.op = "insert"; return b; },
+      eq: (col: string, val: unknown) => { state.filters[col] = val; return b; },
+      in: (col: string, vals: string[]) => { state.inFilter = { col, vals }; return b; },
+      order: () => b,
+      limit: () => b,
+      single: () => resolve(),
+      maybeSingle: () => resolve(),
+      then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+        resolve().then(onF, onR),
+    };
+    return b;
+  }
+
+  return { supabaseUpdates: updates, makeBuilder };
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({ from: (table: string) => makeBuilder(table) }),
+}));
+
+import { runCouncilEngine, reorderAgentsByIds, computeConfigHash } from "./engine";
+
+beforeEach(() => {
+  supabaseUpdates.length = 0;
+});
+
+describe("reorderAgentsByIds", () => {
+  it("restores stored order even when fetched rows arrive scrambled", () => {
+    const stored = ["B", "A", "C"];
+    const fetched = [
+      { id: "A", name: "Alice" },
+      { id: "B", name: "Bob" },
+      { id: "C", name: "Carol" },
+    ];
+    expect(reorderAgentsByIds(stored, fetched).map((a) => a.id)).toEqual(["B", "A", "C"]);
+  });
+
+  it("drops ids that the server did not return", () => {
+    const stored = ["A", "B", "C"];
+    const fetched = [{ id: "A" }, { id: "C" }];
+    expect(reorderAgentsByIds(stored, fetched).map((a) => a.id)).toEqual(["A", "C"]);
+  });
+});
+
+describe("computeConfigHash", () => {
+  it("is deterministic for the same inputs", () => {
+    const h1 = computeConfigHash({
+      templateKey: "uxpass.v1",
+      templateVersion: "1.0.0",
+      resolvedAgentIds: ["a", "b", "c"],
+    });
+    const h2 = computeConfigHash({
+      templateKey: "uxpass.v1",
+      templateVersion: "1.0.0",
+      resolvedAgentIds: ["a", "b", "c"],
+    });
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("changes when roster order changes", () => {
+    const base = {
+      templateKey: "uxpass.v1",
+      templateVersion: "1.0.0",
+      resolvedAgentIds: ["a", "b", "c"],
+    };
+    const swapped = { ...base, resolvedAgentIds: ["b", "a", "c"] };
+    expect(computeConfigHash(base)).not.toBe(computeConfigHash(swapped));
+  });
+});
+
+describe("runCouncilEngine roster snapshot", () => {
+  it("snapshots resolved_agent_ids in stored crew order with chairman appended", async () => {
+    const sampler = vi.fn(async () => ({ content: "ok", tokensIn: 10, tokensOut: 10 }));
+
+    await runCouncilEngine({
+      runId: "run-1",
+      crewId: "crew-1",
+      apiKeyHash: "hash",
+      taskPrompt: "test prompt",
+      tokenBudget: 100000,
+      supabaseUrl: "http://stub",
+      serviceRoleKey: "stub",
+      sampler,
+      supportsSampling: true,
+      templateVersion: "1.0.0",
+    });
+
+    const snapshot = supabaseUpdates.find(
+      (u) => u.table === "mc_crew_runs" && Array.isArray(u.patch.resolved_agent_ids),
+    );
+    expect(snapshot, "expected a run-row update with resolved_agent_ids").toBeDefined();
+    expect(snapshot!.patch.resolved_agent_ids).toEqual([
+      "B-uuid",
+      "A-uuid",
+      "C-uuid",
+      "chairman-uuid",
+    ]);
+    expect(snapshot!.patch.template_key).toBe("council");
+    expect(snapshot!.patch.template_version).toBe("1.0.0");
+    expect(snapshot!.patch.config_hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/src/lib/crews/engine.ts
+++ b/src/lib/crews/engine.ts
@@ -1,7 +1,46 @@
+/// <reference types="node" />
 import { createClient } from "@supabase/supabase-js";
+import { createHash } from "node:crypto";
 
 const MAX_PER_CALL = 2048;
 const LABELS = "ABCDEFGHIJKLMNOP".split("");
+
+/**
+ * Postgres returns rows from `.in('id', ids)` in arbitrary order, which would
+ * make advisor labels (Opinion A/B/C) drift between runs of the same crew.
+ * Reorder fetched rows to match the stored id list so labels stay stable and
+ * Pass-template scoring can compare like-for-like runs.
+ */
+export function reorderAgentsByIds<T extends { id: string }>(
+  storedIds: readonly string[],
+  fetched: readonly T[],
+): T[] {
+  const byId = new Map(fetched.map((a) => [a.id, a]));
+  const out: T[] = [];
+  for (const id of storedIds) {
+    const a = byId.get(id);
+    if (a) out.push(a);
+  }
+  return out;
+}
+
+/**
+ * Deterministic snapshot hash for a run. Inputs are serialised in a fixed key
+ * order so two runs with the same template + version + resolved roster always
+ * produce the same hash regardless of caller-supplied object shape.
+ */
+export function computeConfigHash(input: {
+  templateKey: string | null;
+  templateVersion: string | null;
+  resolvedAgentIds: readonly string[];
+}): string {
+  const canonical = JSON.stringify({
+    template_key: input.templateKey,
+    template_version: input.templateVersion,
+    resolved_agent_ids: input.resolvedAgentIds,
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
 
 export interface SamplerResult {
   content: string;
@@ -38,6 +77,10 @@ export interface EngineCtx {
   sampler?: Sampler;
   /** Explicit capability flag from MCP `initialize`. When false the engine aborts. */
   supportsSampling?: boolean;
+  /** Pass-template identifier (e.g. "uxpass.v1"). Snapshotted on the run row. */
+  templateKey?: string;
+  /** Pass-template version (e.g. "1.0.0"). Snapshotted on the run row. */
+  templateVersion?: string;
 }
 
 interface AgentRow {
@@ -122,18 +165,24 @@ export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
     // Load crew (api_key_hash filter is mandatory - service_role bypasses RLS)
     const { data: crew } = await sb
       .from("mc_crews")
-      .select("agent_ids")
+      .select("agent_ids,template")
       .eq("id", crewId)
       .eq("api_key_hash", apiKeyHash)
       .single();
     if (!crew) throw new Error("Crew not found");
 
-    const agentIds: string[] = (crew as { agent_ids: string[] }).agent_ids ?? [];
+    const crewRow = crew as { agent_ids: string[]; template?: string | null };
+    const agentIds: string[] = crewRow.agent_ids ?? [];
     const { data: rawAgents } = await sb
       .from("mc_agents")
       .select("id,slug,name,category,seed_prompt")
       .in("id", agentIds);
-    const agents: AgentRow[] = (rawAgents ?? []) as AgentRow[];
+    // Postgres returns .in() rows in arbitrary order; restore the stored
+    // order so advisor labels (Opinion A/B/C) are stable across runs.
+    const agents: AgentRow[] = reorderAgentsByIds(
+      agentIds,
+      (rawAgents ?? []) as AgentRow[],
+    );
 
     const advisors = agents.filter((a) => a.category !== "meta");
     let chairman: AgentRow | null = agents.find((a) => a.slug === "chairman") ?? null;
@@ -148,6 +197,23 @@ export async function runCouncilEngine(ctx: EngineCtx): Promise<void> {
         .maybeSingle();
       chairman = (sys as AgentRow | null) ?? null;
     }
+
+    // Snapshot the run config so Pass-template scoring can compare
+    // like-for-like runs even after a crew is edited or an agent is rotated.
+    const resolvedRoster: AgentRow[] = chairman ? [...advisors, chairman] : [...advisors];
+    const resolvedAgentIds = resolvedRoster.map((a) => a.id);
+    const templateKey = ctx.templateKey ?? crewRow.template ?? null;
+    const templateVersion = ctx.templateVersion ?? null;
+    await updateRun({
+      template_key: templateKey,
+      template_version: templateVersion,
+      resolved_agent_ids: resolvedAgentIds,
+      config_hash: computeConfigHash({
+        templateKey,
+        templateVersion,
+        resolvedAgentIds,
+      }),
+    });
 
     // Pre-run: load relevant facts from UnClick Memory (search_memory equivalent)
     const { data: factRows } = await sb

--- a/supabase/migrations/20260426000000_crews_run_snapshot.sql
+++ b/supabase/migrations/20260426000000_crews_run_snapshot.sql
@@ -1,0 +1,12 @@
+-- Crews: run-snapshot fields for Pass-template reproducibility.
+-- Records the template, version, resolved roster, and a config hash on each
+-- mc_crew_runs row so UXPass / FlowPass scoring can compare like-for-like runs.
+-- Idempotent: ADD COLUMN IF NOT EXISTS per project migration discipline.
+
+alter table mc_crew_runs
+  add column if not exists template_key       text,
+  add column if not exists template_version   text,
+  add column if not exists resolved_agent_ids jsonb,
+  add column if not exists config_hash        text;
+
+create index if not exists mc_crew_runs_config_hash on mc_crew_runs(config_hash);


### PR DESCRIPTION
## Summary

Two foundational gaps in `runCouncilEngine` that would silently break UXPass / FlowPass scoring stability once Pass templates run on top of Crews. Both flagged in Fishbowl 2026-04-26 in the "Crews=engine, Pass=templates" architecture thread.

- **Roster reorder.** `mc_crews.agent_ids` defines a deterministic crew order, but the engine's `mc_agents.select(...).in('id', agentIds)` returned rows in arbitrary Postgres order, drifting advisor labels (Opinion A/B/C) between runs of the same crew. New `reorderAgentsByIds` helper restores the stored order after the fetch.
- **Run snapshot.** New `template_key`, `template_version`, `resolved_agent_ids`, `config_hash` columns on `mc_crew_runs` (idempotent ADD COLUMN IF NOT EXISTS migration). Engine writes all four at run start; `config_hash = sha256({template_key, template_version, resolved_agent_ids})`. Resolved roster includes the auto-added system chairman so the snapshot reflects what actually ran.

Closes todo `d2b9a833-7f1b-4d59-a635-12a093640bef`. **Do not merge** until Bailey reviews and CI is green; the Crews dogfood chip (todo b0576781) gates on this landing first.

## Files

- `supabase/migrations/20260426000000_crews_run_snapshot.sql` (new, idempotent)
- `src/lib/crews/engine.ts` (helper extraction + reorder + snapshot)
- `src/lib/crews/engine.test.ts` (new vitest, 5 cases)

## Test plan

- [x] `npx vitest run src/lib/crews/engine.test.ts` - 5/5 pass
  - `reorderAgentsByIds` restores stored order from scrambled fetch
  - `reorderAgentsByIds` drops missing ids
  - `computeConfigHash` deterministic for same inputs
  - `computeConfigHash` changes when roster order changes
  - `runCouncilEngine` snapshots `resolved_agent_ids = [B, A, C, chairman]` from stored `[B, A, C]` even when supabase returns `[A, B, C]`
- [x] `npx vitest run` - full suite green (no regressions)
- [x] `npx tsc --noEmit -p tsconfig.app.json` - no new errors (2 pre-existing ArenaNav errors untouched)
- [x] No em-dashes (U+2014) in any changed file
- [ ] CI green (waiting for review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)