### PR TITLE
ci(testpass): distinguish infra failures from product regressions

### DIFF
--- a/.github/actions/testpass/action.yml
+++ b/.github/actions/testpass/action.yml
@@ -27,7 +27,7 @@ outputs:
     description: UUID of the created TestPass run.
     value: ${{ steps.call.outputs.run_id }}
   status:
-    description: Run status (running, complete, failed).
+    description: Run status (running, complete, failed, infra_auth_error, infra_http_error, infra_transport_error).
     value: ${{ steps.call.outputs.status }}
   pass_rate:
     description: Fraction of decided checks that passed (0-1).
@@ -39,8 +39,14 @@ outputs:
     description: Total checks in the run.
     value: ${{ steps.call.outputs.total }}
   response:
-    description: Raw JSON response from the API.
+    description: Raw JSON response from the API (or "{}" if no body).
     value: ${{ steps.call.outputs.response }}
+  failure_kind:
+    description: Bucket for the outcome - product, infra_auth, infra_http, infra_transport, or none.
+    value: ${{ steps.call.outputs.failure_kind }}
+  http_code:
+    description: HTTP status from the API call ("000" on transport failure).
+    value: ${{ steps.call.outputs.http_code }}
 
 runs:
   using: composite
@@ -54,7 +60,9 @@ runs:
         SERVER_URL: ${{ inputs.server_url }}
         API_URL: ${{ inputs.api_url }}
       run: |
-        set -euo pipefail
+        # Note: -e intentionally omitted so curl/jq failures don't abort
+        # before outputs are written. We classify failures explicitly below.
+        set -uo pipefail
 
         payload=$(jq -n \
           --arg pack_id "$PACK_ID" \
@@ -62,35 +70,72 @@ runs:
           --arg server_url "$SERVER_URL" \
           '{pack_id: $pack_id, profile: $profile} + (if $server_url == "" then {} else {server_url: $server_url} end)')
 
+        # Capture curl transport exit code separately from HTTP status.
+        # curl exits non-zero on DNS failure, connection refused, timeout, etc.
+        curl_exit=0
         http_code=$(curl -sS -o response.json -w "%{http_code}" \
+          --connect-timeout 10 \
+          --max-time 60 \
           -X POST "$API_URL" \
           -H "Authorization: Bearer $TESTPASS_TOKEN" \
           -H "Content-Type: application/json" \
-          -d "$payload")
+          -d "$payload") || curl_exit=$?
+        http_code="${http_code:-000}"
 
+        echo "curl exit: $curl_exit"
         echo "HTTP $http_code"
-        cat response.json
-        echo
+        if [ -f response.json ]; then cat response.json; echo; fi
 
-        if [ "$http_code" -ge 400 ]; then
-          echo "TestPass API call failed with status $http_code" >&2
-          exit 1
+        # Defaults for outputs - written even if every parse below fails.
+        run_id=""
+        status=""
+        pass_rate=0
+        fail_count=0
+        total=0
+        response="{}"
+        failure_kind="none"
+
+        if [ "$curl_exit" -ne 0 ]; then
+          echo "::warning::TestPass transport failure (curl exit $curl_exit) - DNS, connection, or timeout. Retry the workflow." >&2
+          status="infra_transport_error"
+          failure_kind="infra_transport"
+        elif [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
+          echo "::warning::TestPass auth failure (HTTP $http_code) - TESTPASS_TOKEN is likely stale. Refresh the secret and retry." >&2
+          status="infra_auth_error"
+          failure_kind="infra_auth"
+          response=$(jq -c '.' response.json 2>/dev/null || echo "{}")
+        elif [ "$http_code" -ge 400 ]; then
+          echo "::warning::TestPass API error (HTTP $http_code) - service-side issue, not a product regression." >&2
+          status="infra_http_error"
+          failure_kind="infra_http"
+          response=$(jq -c '.' response.json 2>/dev/null || echo "{}")
+        else
+          run_id=$(jq -r '.run_id // ""' response.json 2>/dev/null || echo "")
+          status=$(jq -r '.status // ""' response.json 2>/dev/null || echo "")
+          pass_rate=$(jq -r '.verdict_summary.pass_rate // 0' response.json 2>/dev/null || echo "0")
+          fail_count=$(jq -r '.verdict_summary.fail // 0' response.json 2>/dev/null || echo "0")
+          total=$(jq -r '.verdict_summary.total // 0' response.json 2>/dev/null || echo "0")
+          response=$(jq -c '.' response.json 2>/dev/null || echo "{}")
+          failure_kind="product"
         fi
 
-        run_id=$(jq -r '.run_id // ""' response.json)
-        status=$(jq -r '.status // ""' response.json)
-        pass_rate=$(jq -r '.verdict_summary.pass_rate // 0' response.json)
-        fail_count=$(jq -r '.verdict_summary.fail // 0' response.json)
-        total=$(jq -r '.verdict_summary.total // 0' response.json)
-        response=$(jq -c '.' response.json)
-
+        # Always write outputs, even on infra failure, so downstream
+        # comment / decision steps have something to read.
         {
           echo "run_id=$run_id"
           echo "status=$status"
           echo "pass_rate=$pass_rate"
           echo "fail_count=$fail_count"
           echo "total=$total"
+          echo "failure_kind=$failure_kind"
+          echo "http_code=$http_code"
           echo "response<<TESTPASS_EOF"
           echo "$response"
           echo "TESTPASS_EOF"
         } >> "$GITHUB_OUTPUT"
+
+        # Surface infra failures in the step status (red X), but the workflow
+        # decides whether to block the PR via failure_kind in a downstream step.
+        if [ "$failure_kind" != "product" ] && [ "$failure_kind" != "none" ]; then
+          exit 1
+        fi

--- a/.github/workflows/testpass-pr-check.yml
+++ b/.github/workflows/testpass-pr-check.yml
@@ -32,6 +32,10 @@ jobs:
 
       - name: Run TestPass
         id: testpass
+        # Don't abort the workflow on infra failures - we still want to post a
+        # PR comment that explains what happened so reviewers can tell infra
+        # noise (stale token, transport blip) from a real product regression.
+        continue-on-error: true
         uses: ./.github/actions/testpass
         with:
           token: ${{ secrets.TESTPASS_TOKEN }}
@@ -40,7 +44,9 @@ jobs:
           server_url: ${{ inputs.server_url || '' }}
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        # Run regardless of TestPass step outcome - infra failures still need a
+        # human-readable comment so the PR doesn't look mysteriously broken.
+        if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         env:
           RUN_ID: ${{ steps.testpass.outputs.run_id }}
@@ -49,6 +55,8 @@ jobs:
           FAIL_COUNT: ${{ steps.testpass.outputs.fail_count }}
           TOTAL: ${{ steps.testpass.outputs.total }}
           RESPONSE: ${{ steps.testpass.outputs.response }}
+          FAILURE_KIND: ${{ steps.testpass.outputs.failure_kind }}
+          HTTP_CODE: ${{ steps.testpass.outputs.http_code }}
         with:
           script: |
             const runId = process.env.RUN_ID || '(unknown)';
@@ -57,11 +65,58 @@ jobs:
             const passRate = Number.isFinite(passRateRaw) ? passRateRaw : 0;
             const failCount = parseInt(process.env.FAIL_COUNT || '0', 10) || 0;
             const total = parseInt(process.env.TOTAL || '0', 10) || 0;
+            const failureKind = process.env.FAILURE_KIND || 'unknown';
+            const httpCode = process.env.HTTP_CODE || '000';
 
             let summary = {};
             try { summary = JSON.parse(process.env.RESPONSE || '{}').verdict_summary || {}; }
             catch { summary = {}; }
 
+            const isInfra = failureKind && failureKind.startsWith('infra_');
+
+            // Infra path: short, friendly, "retry the workflow" tone. Don't
+            // dump a verdict table - the numbers are all zero and would just
+            // look like a real failure.
+            if (isInfra) {
+              const headlines = {
+                infra_auth:      ':warning: TestPass: infra issue (auth)',
+                infra_http:      ':warning: TestPass: infra issue (API error)',
+                infra_transport: ':warning: TestPass: infra issue (transport)',
+              };
+              const explanations = {
+                infra_auth:
+                  `The TestPass API rejected our token (HTTP ${httpCode}). ` +
+                  `This is almost always a stale \`TESTPASS_TOKEN\` secret, ` +
+                  `**not** a problem with this PR. Refresh the secret in repo ` +
+                  `settings and re-run the workflow.`,
+                infra_http:
+                  `The TestPass API returned HTTP ${httpCode}. This is a ` +
+                  `service-side issue, **not** a problem with this PR. ` +
+                  `Re-run the workflow in a few minutes.`,
+                infra_transport:
+                  `Could not reach the TestPass API (DNS, connection, or ` +
+                  `timeout). This is **not** a problem with this PR. ` +
+                  `Re-run the workflow.`,
+              };
+
+              const body = [
+                `### ${headlines[failureKind] || ':warning: TestPass: infra issue'}`,
+                ``,
+                explanations[failureKind] || `Infra failure: \`${failureKind}\` (HTTP ${httpCode}).`,
+                ``,
+                `_This comment is posted automatically because TestPass failed before it could check anything. The PR itself has not been evaluated._`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              return;
+            }
+
+            // Product path: real verdicts, real table.
             const statusEmoji =
               status === 'complete' && failCount === 0 ? ':white_check_mark: PASS' :
               status === 'failed' || failCount > 0    ? ':x: FAIL' :
@@ -96,7 +151,10 @@ jobs:
             });
 
       - name: Fail job if checks failed
-        if: ${{ steps.testpass.outputs.fail_count != '0' }}
+        # Only block the PR on real product regressions. Infra failures
+        # (stale token, transport, 5xx) are surfaced via the comment above
+        # and don't gate the merge.
+        if: ${{ steps.testpass.outputs.failure_kind == 'product' && steps.testpass.outputs.fail_count != '0' }}
         shell: bash
         run: |
           echo "TestPass reported ${{ steps.testpass.outputs.fail_count }} failed checks" >&2


### PR DESCRIPTION
## Summary

Stale `TESTPASS_TOKEN` false-positives have been hitting every chip PR (#181, #182, #183, #184) — the workflow aborted on the `curl` 401 before action outputs were written, so the PR comment step had nothing to read and the job just looked broken. This PR re-shapes the failure-mode handling so infra issues are visibly distinct from real test regressions.

**Only two files touched. No scan-logic changes.**

### `.github/actions/testpass/action.yml`
- Remove `set -e` from the shell block so curl/jq failures don't abort before outputs are written
- Capture curl transport exit code separately from HTTP status
- Map HTTP **401/403** → synthetic status `infra_auth_error` (likely stale token)
- Map other HTTP **>= 400** → `infra_http_error` (service-side issue)
- Map curl transport failures (DNS, conn refused, timeout) → `infra_transport_error`
- Always write **all** outputs before exit, plus two new outputs:
  - `failure_kind` — bucket: `product` / `infra_auth` / `infra_http` / `infra_transport` / `none`
  - `http_code` — raw HTTP code (`"000"` on transport failure)
- Step still exits non-zero on infra failure so the run shows red, but outputs are populated for downstream steps

### `.github/workflows/testpass-pr-check.yml`
- TestPass step: `continue-on-error: true` so an infra failure doesn't abort the workflow
- PR comment step: `if: always()` so it runs regardless of the TestPass step result
- Comment payload now distinguishes infra (`auth` / `http` / `transport`) from product with a friendly explanation ("this is not a problem with your PR, retry the workflow") instead of a misleading verdict table of zeros
- Final fail-job step keys on `failure_kind == 'product'`, so only **real product regressions** block the merge

## Test plan

- [ ] CI runs on this PR and posts a comment (either real verdict, or — if the token is still stale — a clearly-marked "infra issue" comment instead of a generic broken job)
- [ ] If the token is stale, the workflow should NOT block the merge (the fail-job step is gated on `failure_kind == 'product'`)
- [ ] If the token is fresh, behavior is unchanged from the existing flow
- [ ] YAML and embedded shell/JS validated locally (`js-yaml` parse + `bash -n` + `node --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)