### PR TITLE
fix(memory-mcp): port search_memory keyword fallback

### DIFF
--- a/packages/memory-mcp/package.json
+++ b/packages/memory-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unclick/memory-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Persistent cross-session memory for AI agents. Zero-config local mode or Supabase cloud sync. 6-layer architecture, 17 MCP tools.",
   "type": "module",
   "bin": {
@@ -15,6 +15,8 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "setup": "node dist/setup.js setup",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "keywords": ["mcp", "memory", "ai-agent", "claude-code", "supabase", "persistent-memory", "unclick", "zero-config"],
@@ -31,7 +33,8 @@
   },
   "devDependencies": {
     "typescript": "^5.7.3",
-    "@types/node": "^22.15.3"
+    "@types/node": "^22.15.3",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=18"

--- a/packages/memory-mcp/src/__tests__/search-memory-fallback.test.ts
+++ b/packages/memory-mcp/src/__tests__/search-memory-fallback.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the search_memory hybrid + ILIKE keyword fallback ported from
+ * @unclick/mcp-server.
+ *
+ * Run from packages/memory-mcp:
+ *   npm test
+ *
+ * The integration test (skipped without TEST_SUPABASE_URL +
+ * TEST_SUPABASE_SERVICE_ROLE_KEY) reproduces the production bug: a fact
+ * with NULL embedding whose proper-noun content does not survive
+ * plainto_tsquery tokenization. Hybrid returns []. ILIKE fallback must
+ * surface the row anyway.
+ *
+ * The unit tests use a recording fake of the supabase-js client so we
+ * can verify the tokenization rules and AND/OR mode logic without a
+ * database.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// ─── Recording supabase-js fake ────────────────────────────────────────────
+//
+// The real supabase-js client returns a thenable QueryBuilder where every
+// modifier (.eq, .ilike, .or, .order, .limit, .select) returns the same
+// builder. This fake records the modifier chain on each table call so we
+// can assert on tokenization, AND/OR mode, and api_key_hash scoping
+// without standing up a real database.
+
+interface RecordedCall {
+  table: string;
+  filters: Array<{ kind: string; args: unknown[] }>;
+  result: { data: unknown[]; error: null };
+}
+
+function makeFakeClient(opts: { factsRows: unknown[]; sessionsRows: unknown[]; calls: RecordedCall[] }) {
+  return {
+    from(table: string) {
+      const recorded: RecordedCall = {
+        table,
+        filters: [],
+        result: {
+          data: table.endsWith("extracted_facts") ? opts.factsRows : opts.sessionsRows,
+          error: null,
+        },
+      };
+      opts.calls.push(recorded);
+
+      const builder: Record<string, unknown> = {};
+      const chain = (kind: string) =>
+        (...args: unknown[]) => {
+          recorded.filters.push({ kind, args });
+          return builder;
+        };
+      builder.select = chain("select");
+      builder.eq = chain("eq");
+      builder.ilike = chain("ilike");
+      builder.or = chain("or");
+      builder.order = chain("order");
+      builder.limit = chain("limit");
+      builder.is = chain("is");
+      // The keywordFallback awaits the builder directly, so it must be
+      // thenable and resolve to the recorded result.
+      builder.then = (onFulfilled: (v: typeof recorded.result) => unknown) =>
+        Promise.resolve(recorded.result).then(onFulfilled);
+      return builder;
+    },
+  };
+}
+
+function loadBackendWithFake(client: unknown, tenancy: { mode: "byod" } | { mode: "managed"; apiKeyHash: string }) {
+  // The constructor calls createClient when given url + serviceRoleKey.
+  // We bypass that by injecting our fake into the private `sb` field
+  // after construction. This keeps the public API unchanged while still
+  // exercising the real keywordFallback code.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return import("../supabase.js").then(({ SupabaseBackend }: any) => {
+    const instance = Object.create(SupabaseBackend.prototype);
+    instance.sb = client;
+    instance.tenancy = tenancy;
+    instance.tables =
+      tenancy.mode === "managed"
+        ? { extracted_facts: "mc_extracted_facts", session_summaries: "mc_session_summaries" }
+        : { extracted_facts: "extracted_facts", session_summaries: "session_summaries" };
+    return instance;
+  });
+}
+
+describe("keywordFallback tokenization", () => {
+  const savedOpenAI = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.OPENAI_API_KEY; // force keyword path
+  });
+
+  afterEach(() => {
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+    else delete process.env.OPENAI_API_KEY;
+  });
+
+  it("returns [] when query yields no usable tokens", async () => {
+    const calls: RecordedCall[] = [];
+    const client = makeFakeClient({ factsRows: [], sessionsRows: [], calls });
+    const backend = await loadBackendWithFake(client, { mode: "byod" });
+
+    // All tokens dropped: too short or only metacharacters.
+    const result = await backend.searchMemory("a , ( ) :", 10);
+    expect(result).toEqual([]);
+    // Should never have hit the database since every token was filtered.
+    expect(calls.length).toBe(0);
+  });
+
+  it("AND mode: every token becomes a chained ilike on each table", async () => {
+    const calls: RecordedCall[] = [];
+    const client = makeFakeClient({
+      factsRows: [
+        { id: "f1", fact: "Fishbowl active topic", category: "test", confidence: 0.9, created_at: "2026-01-01" },
+      ],
+      sessionsRows: [],
+      calls,
+    });
+    const backend = await loadBackendWithFake(client, { mode: "byod" });
+
+    await backend.searchMemory("active Fishbowl topic", 10);
+
+    // First scan: AND mode hits both tables (extracted_facts + session_summaries).
+    const factCall = calls.find((c) => c.table === "extracted_facts");
+    expect(factCall, "facts table queried").toBeTruthy();
+    const ilikes = factCall!.filters.filter((f) => f.kind === "ilike");
+    expect(ilikes.length).toBe(3); // active, fishbowl, topic
+    const patterns = ilikes.map((f) => f.args[1] as string);
+    expect(patterns).toContain("%active%");
+    expect(patterns).toContain("%fishbowl%");
+    expect(patterns).toContain("%topic%");
+    // No `.or` should have been used in AND mode.
+    expect(factCall!.filters.find((f) => f.kind === "or")).toBeUndefined();
+  });
+
+  it("OR fallback fires only when AND returns [] and tokens >= 2", async () => {
+    const calls: RecordedCall[] = [];
+    // First two calls (AND scan over facts + sessions) return [].
+    // Next two calls (OR scan) return a partial match.
+    let callIdx = 0;
+    const client = {
+      from(table: string) {
+        const idx = callIdx++;
+        const isAnd = idx < 2;
+        const recorded: RecordedCall = {
+          table,
+          filters: [],
+          result: {
+            data: isAnd
+              ? []
+              : table === "extracted_facts"
+                ? [{ id: "f-or", fact: "Memory architecture uses six layers", category: "test", confidence: 0.8, created_at: "2026-01-01" }]
+                : [],
+            error: null,
+          },
+        };
+        calls.push(recorded);
+        const builder: Record<string, unknown> = {};
+        const chain = (kind: string) =>
+          (...args: unknown[]) => {
+            recorded.filters.push({ kind, args });
+            return builder;
+          };
+        builder.select = chain("select");
+        builder.eq = chain("eq");
+        builder.ilike = chain("ilike");
+        builder.or = chain("or");
+        builder.order = chain("order");
+        builder.limit = chain("limit");
+        builder.is = chain("is");
+        builder.then = (onFulfilled: (v: typeof recorded.result) => unknown) =>
+          Promise.resolve(recorded.result).then(onFulfilled);
+        return builder;
+      },
+    };
+    const backend = await loadBackendWithFake(client, { mode: "byod" });
+
+    const result = (await backend.searchMemory("architecture thread zzznonexistentzzz", 10)) as Array<{ id: string }>;
+
+    // 4 calls total: AND-facts, AND-sessions, OR-facts, OR-sessions.
+    expect(calls.length).toBe(4);
+    expect(calls[0].filters.find((f) => f.kind === "ilike")).toBeTruthy(); // AND mode: ilike chain
+    expect(calls[2].filters.find((f) => f.kind === "or")).toBeTruthy(); // OR mode: single .or() call
+    // Partial match still surfaces.
+    expect(result.map((r) => r.id)).toContain("f-or");
+  });
+
+  it("does NOT degrade to OR mode when tokens.length < 2", async () => {
+    const calls: RecordedCall[] = [];
+    const client = makeFakeClient({ factsRows: [], sessionsRows: [], calls });
+    const backend = await loadBackendWithFake(client, { mode: "byod" });
+
+    // Single token, no match → AND returns [], should NOT retry as OR.
+    const result = await backend.searchMemory("zzznoresults", 10);
+    expect(result).toEqual([]);
+    // Only the AND scan ran (2 calls: facts + sessions). No OR retry.
+    expect(calls.length).toBe(2);
+    expect(calls.every((c) => c.filters.find((f) => f.kind === "or") === undefined)).toBe(true);
+  });
+
+  it("managed mode adds api_key_hash filter to keyword fallback", async () => {
+    const calls: RecordedCall[] = [];
+    const client = makeFakeClient({ factsRows: [], sessionsRows: [], calls });
+    const backend = await loadBackendWithFake(client, { mode: "managed", apiKeyHash: "test-tenant-hash" });
+
+    await backend.searchMemory("tenant scoping check", 10);
+
+    // Managed mode targets mc_-prefixed tables.
+    const factCall = calls.find((c) => c.table === "mc_extracted_facts");
+    expect(factCall, "managed mode hits mc_extracted_facts").toBeTruthy();
+    const sessCall = calls.find((c) => c.table === "mc_session_summaries");
+    expect(sessCall, "managed mode hits mc_session_summaries").toBeTruthy();
+    // Each table must be filtered by api_key_hash.
+    const factEqs = factCall!.filters.filter((f) => f.kind === "eq");
+    expect(factEqs.some((f) => f.args[0] === "api_key_hash" && f.args[1] === "test-tenant-hash")).toBe(true);
+    const sessEqs = sessCall!.filters.filter((f) => f.kind === "eq");
+    expect(sessEqs.some((f) => f.args[0] === "api_key_hash" && f.args[1] === "test-tenant-hash")).toBe(true);
+  });
+
+  it("BYOD mode does NOT add api_key_hash filter", async () => {
+    const calls: RecordedCall[] = [];
+    const client = makeFakeClient({ factsRows: [], sessionsRows: [], calls });
+    const backend = await loadBackendWithFake(client, { mode: "byod" });
+
+    await backend.searchMemory("byod scoping check", 10);
+
+    const factCall = calls.find((c) => c.table === "extracted_facts");
+    const eqs = factCall!.filters.filter((f) => f.kind === "eq");
+    expect(eqs.some((f) => f.args[0] === "api_key_hash")).toBe(false);
+  });
+});
+
+// ─── Integration test ──────────────────────────────────────────────────────
+//
+// Skipped unless TEST_SUPABASE_URL + TEST_SUPABASE_SERVICE_ROLE_KEY are
+// set. Reproduces the proper-noun + NULL-embedding case the fallback was
+// built to fix.
+
+describe("acceptance: keyword fallback restores search when hybrid returns []", () => {
+  it("ILIKE fallback finds proper-noun fact with NULL embedding", async () => {
+    const url = process.env.TEST_SUPABASE_URL ?? process.env.SUPABASE_URL;
+    const key = process.env.TEST_SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) {
+      console.log("    [skipped] set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY to run");
+      return;
+    }
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
+
+    const factText = "Test owner is Chris Byrne for memory-mcp keyword-fallback regression";
+    const { data: inserted, error: insertErr } = await supabase
+      .from("extracted_facts")
+      .insert({
+        fact: factText,
+        category: "test",
+        confidence: 0.9,
+        status: "active",
+        source_type: "test",
+        decay_tier: "hot",
+      })
+      .select("id")
+      .single();
+    expect(insertErr, `insert failed: ${insertErr?.message}`).toBeNull();
+    const factId = (inserted as { id: string }).id;
+
+    try {
+      const savedOpenAI = process.env.OPENAI_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+      try {
+        const { SupabaseBackend } = await import("../supabase.js");
+        const backend = new SupabaseBackend({ url, serviceRoleKey: key, tenancy: { mode: "byod" } });
+        const results = (await backend.searchMemory("Chris", 10)) as Array<{ id: string }>;
+        expect(Array.isArray(results)).toBe(true);
+        const ids = results.map((r) => r.id);
+        expect(
+          ids.includes(factId),
+        ).toBe(true);
+      } finally {
+        if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+      }
+    } finally {
+      await supabase.from("extracted_facts").delete().eq("id", factId);
+    }
+  });
+});
+
+// ─── Embeddings helper ────────────────────────────────────────────────────
+
+describe("embedText", () => {
+  it("returns null when OPENAI_API_KEY is not set", async () => {
+    const saved = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      const { embedText } = await import("../embeddings.js");
+      const result = await embedText("test query");
+      expect(result).toBeNull();
+    } finally {
+      if (saved !== undefined) process.env.OPENAI_API_KEY = saved;
+    }
+  });
+});

--- a/packages/memory-mcp/src/embeddings.ts
+++ b/packages/memory-mcp/src/embeddings.ts
@@ -1,0 +1,45 @@
+/**
+ * Thin wrapper around OpenAI text-embedding-3-small.
+ *
+ * Returns null instead of throwing so callers can fall back gracefully
+ * to keyword-only search when OpenAI is unavailable or unconfigured.
+ */
+
+export const EMBEDDING_MODEL = "text-embedding-3-small";
+export const EMBEDDING_DIMS = 1536;
+
+// OpenAI hard limit for text-embedding-3-small is 8191 tokens (~32K chars).
+// Slicing at 32000 chars is a safe approximation.
+const MAX_INPUT_CHARS = 32_000;
+
+interface OpenAIEmbeddingResponse {
+  data: Array<{ embedding: number[] }>;
+}
+
+export async function embedText(text: string): Promise<number[] | null> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+
+  try {
+    const res = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: EMBEDDING_MODEL,
+        input: text.slice(0, MAX_INPUT_CHARS),
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[embeddings] OpenAI error ${res.status}: ${await res.text()}`);
+      return null;
+    }
+    const data = (await res.json()) as OpenAIEmbeddingResponse;
+    return data.data[0]?.embedding ?? null;
+  } catch (err) {
+    console.error("[embeddings] fetch failed:", err);
+    return null;
+  }
+}

--- a/packages/memory-mcp/src/supabase.ts
+++ b/packages/memory-mcp/src/supabase.ts
@@ -1,8 +1,16 @@
 /**
  * Supabase backend for UnClick Memory.
  *
- * Cloud mode: data lives in the user's own Supabase project (BYOD).
- * Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars.
+ * Two tenancy modes:
+ *
+ *   BYOD     - data lives in the user's own Supabase project. Single-tenant
+ *              tables (extracted_facts, session_summaries, ...) and the
+ *              original RPC names. This is the default.
+ *
+ *   managed  - data lives in UnClick's central Supabase. Multi-tenant
+ *              tables (mc_extracted_facts, mc_session_summaries, ...) where
+ *              every row is tagged with api_key_hash. RPCs are mc_-prefixed
+ *              and take p_api_key_hash as their first parameter.
  */
 
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
@@ -37,13 +45,6 @@ function getSupabase(): SupabaseClient {
   return client;
 }
 
-async function rpc<T = unknown>(fn: string, params: Record<string, unknown> = {}): Promise<T> {
-  const sb = getSupabase();
-  const { data, error } = await sb.rpc(fn, params);
-  if (error) throw new Error(`rpc(${fn}) failed: ${error.message}`);
-  return data as T;
-}
-
 function now(): string {
   return new Date().toISOString();
 }
@@ -52,79 +53,291 @@ function truncate(s: string, max = 8000): string {
   return s.length > max ? s.slice(0, max) + "\n...[truncated]" : s;
 }
 
+export type Tenancy =
+  | { mode: "byod" }
+  | { mode: "managed"; apiKeyHash: string };
+
+export interface SupabaseBackendConfig {
+  url?: string;
+  serviceRoleKey?: string;
+  tenancy?: Tenancy;
+}
+
+interface TableNames {
+  extracted_facts: string;
+  session_summaries: string;
+}
+
+const BYOD_TABLES: TableNames = {
+  extracted_facts: "extracted_facts",
+  session_summaries: "session_summaries",
+};
+
+const MANAGED_TABLES: TableNames = {
+  extracted_facts: "mc_extracted_facts",
+  session_summaries: "mc_session_summaries",
+};
+
 export class SupabaseBackend implements MemoryBackend {
-  constructor() {
-    // Verify connection on creation
-    getSupabase();
-    console.error("UnClick Memory: Supabase cloud mode");
+  private sb: SupabaseClient;
+  private tenancy: Tenancy;
+  private tables: TableNames;
+
+  constructor(config?: SupabaseBackendConfig) {
+    if (config?.url && config?.serviceRoleKey) {
+      this.sb = createClient(config.url, config.serviceRoleKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+    } else {
+      this.sb = getSupabase();
+    }
+    this.tenancy = config?.tenancy ?? { mode: "byod" };
+    this.tables = this.tenancy.mode === "managed" ? MANAGED_TABLES : BYOD_TABLES;
+    console.error(
+      `UnClick Memory: Supabase ${this.tenancy.mode === "managed" ? "managed cloud" : "BYOD"} mode`
+    );
+  }
+
+  /** Adds api_key_hash to a row in managed mode; passes through in BYOD. */
+  private withTenancy<T extends Record<string, unknown>>(row: T): T {
+    if (this.tenancy.mode === "managed") {
+      return { ...row, api_key_hash: this.tenancy.apiKeyHash };
+    }
+    return row;
+  }
+
+  private async rpc<T = unknown>(fn: string, params: Record<string, unknown> = {}): Promise<T> {
+    const { data, error } = await this.sb.rpc(fn, params);
+    if (error) throw new Error(`rpc(${fn}) failed: ${error.message}`);
+    return data as T;
   }
 
   async getStartupContext(numSessions: number): Promise<unknown> {
-    return rpc<Record<string, unknown>>("get_startup_context", { num_sessions: numSessions });
+    return this.rpc<Record<string, unknown>>("get_startup_context", { num_sessions: numSessions });
   }
 
   async searchMemory(query: string, maxResults: number): Promise<unknown> {
-    return rpc("search_memory", { search_query: query, max_results: maxResults });
+    // Hybrid lane: BM25 + pgvector RRF over extracted_facts and
+    // session_summaries. Two well-known failure modes turn this into a
+    // black hole and force a fallback:
+    //
+    //   1. Per-row embeddings are NULL (legacy facts, BYOD installs without
+    //      backfill, or facts written before embedding wiring) so the vector
+    //      lane drops them.
+    //   2. plainto_tsquery('english', ...) tokenizes proper nouns and short
+    //      identifiers ("Chris", "Bailey", "UnClick") in ways that don't
+    //      align with the matching to_tsvector lexemes, so the keyword lane
+    //      misses too. Both branches fail, hybrid returns [].
+    //
+    // To stop returning [] when matching content exists, we run a robust
+    // ILIKE keyword fallback over the same tables whenever the hybrid call
+    // throws OR returns an empty result.
+    try {
+      const { embedText } = await import("./embeddings.js");
+      const embedding = await embedText(query);
+      if (embedding) {
+        const fn = this.tenancy.mode === "managed" ? "mc_search_memory_hybrid" : "search_memory_hybrid";
+        const params: Record<string, unknown> = this.tenancy.mode === "managed"
+          ? { p_api_key_hash: this.tenancy.apiKeyHash, p_search_query: query, p_query_embedding: embedding, p_max_results: maxResults }
+          : { search_query: query, query_embedding: embedding, max_results: maxResults };
+        const results = await this.rpc<unknown>(fn, params);
+        if (Array.isArray(results) && results.length > 0) return results;
+      }
+    } catch (err) {
+      console.error("[search_memory] hybrid search failed, falling back to keyword:", err);
+    }
+    return this.keywordFallback(query, maxResults);
+  }
+
+  /**
+   * ILIKE-based keyword fallback over extracted_facts + session_summaries.
+   * Used when hybrid retrieval returns []. Returns rows shaped to mirror
+   * search_memory_hybrid so callers don't branch. Never widens RLS: tenant
+   * scoping via api_key_hash is preserved when in managed mode.
+   *
+   * Phrase support: the query is tokenized on whitespace. Tokens shorter
+   * than 2 chars or containing PostgREST .or() metacharacters are dropped.
+   * We try AND-of-tokens first (every token must appear, in any order); if
+   * that returns nothing we degrade to OR-of-tokens and rank rows by how
+   * many tokens they contain so partial matches at least surface something.
+   */
+  private async keywordFallback(query: string, maxResults: number): Promise<unknown[]> {
+    const tokens = query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length >= 2 && !/[,():]/.test(t));
+    if (tokens.length === 0) return [];
+    const patterns = tokens.map((t) => `%${t.replace(/[\\%_]/g, (c) => `\\${c}`)}%`);
+    const score = (text: string): number => {
+      const lower = text.toLowerCase();
+      let n = 0;
+      for (const t of tokens) if (lower.includes(t)) n++;
+      return n;
+    };
+
+    const runScan = async (mode: "and" | "or"): Promise<unknown[]> => {
+      let factQ = this.sb
+        .from(this.tables.extracted_facts)
+        .select("id, fact, category, confidence, created_at")
+        .eq("status", "active");
+      let sessQ = this.sb
+        .from(this.tables.session_summaries)
+        .select("id, summary, created_at");
+
+      if (mode === "and") {
+        for (const p of patterns) {
+          factQ = factQ.ilike("fact", p);
+          sessQ = sessQ.ilike("summary", p);
+        }
+      } else {
+        factQ = factQ.or(patterns.map((p) => `fact.ilike.${p}`).join(","));
+        sessQ = sessQ.or(patterns.map((p) => `summary.ilike.${p}`).join(","));
+      }
+      if (this.tenancy.mode === "managed") {
+        factQ = factQ.eq("api_key_hash", this.tenancy.apiKeyHash);
+        sessQ = sessQ.eq("api_key_hash", this.tenancy.apiKeyHash);
+      }
+      factQ = factQ
+        .order("confidence", { ascending: false })
+        .order("created_at", { ascending: false })
+        .limit(maxResults);
+      sessQ = sessQ.order("created_at", { ascending: false }).limit(maxResults);
+
+      const [factsRes, sessRes] = await Promise.all([factQ, sessQ]);
+      type FactRow = { id: string; fact: string; category: string; confidence: number; created_at: string };
+      type SessRow = { id: string; summary: string; created_at: string };
+      const facts = ((factsRes.data ?? []) as FactRow[]).map((r) => {
+        const s = score(r.fact);
+        return {
+          id: r.id,
+          source: "fact",
+          content: r.fact,
+          category: r.category,
+          confidence: r.confidence,
+          created_at: r.created_at,
+          final_score: (s / tokens.length) * (r.confidence ?? 0),
+          rrf_score: 0,
+          kw_score: s,
+          cosine_score: 0,
+        };
+      });
+      const sessions = ((sessRes.data ?? []) as SessRow[]).map((r) => {
+        const s = score(r.summary);
+        return {
+          id: r.id,
+          source: "session",
+          content: r.summary,
+          category: "session",
+          confidence: 1,
+          created_at: r.created_at,
+          final_score: (s / tokens.length) * 0.5,
+          rrf_score: 0,
+          kw_score: s,
+          cosine_score: 0,
+        };
+      });
+      return [...facts, ...sessions]
+        .sort((a, b) => {
+          const d = (b.final_score ?? 0) - (a.final_score ?? 0);
+          return d !== 0 ? d : (b.created_at ?? "").localeCompare(a.created_at ?? "");
+        })
+        .slice(0, maxResults);
+    };
+
+    const andResults = await runScan("and");
+    if (andResults.length > 0 || tokens.length < 2) return andResults;
+    return runScan("or");
   }
 
   async searchFacts(query: string): Promise<unknown> {
-    return rpc("search_facts", { search_query: query });
+    return this.rpc("search_facts", { search_query: query });
   }
 
   async searchLibrary(query: string): Promise<unknown> {
-    return rpc("search_library", { search_query: query });
+    return this.rpc("search_library", { search_query: query });
   }
 
   async getLibraryDoc(slug: string): Promise<unknown> {
-    return rpc("get_library_doc", { doc_slug: slug });
+    return this.rpc("get_library_doc", { doc_slug: slug });
   }
 
   async listLibrary(): Promise<unknown> {
-    return rpc("list_library");
+    return this.rpc("list_library");
   }
 
   async writeSessionSummary(data: SessionSummaryInput): Promise<{ id: string }> {
-    const sb = getSupabase();
-    const { data: row, error } = await sb.from("session_summaries").insert({
-      session_id: data.session_id,
-      summary: data.summary,
-      topics: data.topics,
-      open_loops: data.open_loops,
-      decisions: data.decisions,
-      platform: data.platform,
-      duration_minutes: data.duration_minutes,
-    }).select().single();
+    const { data: row, error } = await this.sb
+      .from(this.tables.session_summaries)
+      .insert(
+        this.withTenancy({
+          session_id: data.session_id,
+          summary: data.summary,
+          topics: data.topics,
+          open_loops: data.open_loops,
+          decisions: data.decisions,
+          platform: data.platform,
+          duration_minutes: data.duration_minutes,
+        })
+      )
+      .select()
+      .single();
     if (error) throw error;
+    // Embed the summary so it joins the vector lane immediately. Without
+    // this, every newly inserted row has NULL embedding and only the
+    // keyword lane can find it. Fire-and-forget so embedding latency /
+    // OpenAI outages never block the primary insert.
+    this.embedAndStore(this.tables.session_summaries, row.id, data.summary).catch(() => {});
     return { id: row.id };
   }
 
   async addFact(data: FactInput): Promise<{ id: string }> {
-    const sb = getSupabase();
-    const { data: row, error } = await sb.from("extracted_facts").insert({
-      fact: data.fact,
-      category: data.category,
-      confidence: data.confidence,
-      source_session_id: data.source_session_id ?? null,
-      source_type: "manual",
-      status: "active",
-      decay_tier: "hot",
-      last_accessed: now(),
-    }).select().single();
+    const { data: row, error } = await this.sb
+      .from(this.tables.extracted_facts)
+      .insert(
+        this.withTenancy({
+          fact: data.fact,
+          category: data.category,
+          confidence: data.confidence,
+          source_session_id: data.source_session_id ?? null,
+          source_type: "manual",
+          status: "active",
+          decay_tier: "hot",
+          last_accessed: now(),
+        })
+      )
+      .select()
+      .single();
     if (error) throw error;
+    // Embed the fact so it joins the vector lane immediately. Same
+    // motivation as writeSessionSummary above. Fire-and-forget.
+    this.embedAndStore(this.tables.extracted_facts, row.id, data.fact).catch(() => {});
     return { id: row.id };
+  }
+
+  private async embedAndStore(table: string, id: string, text: string): Promise<void> {
+    const { embedText, EMBEDDING_MODEL } = await import("./embeddings.js");
+    const vec = await embedText(text);
+    if (!vec) return;
+    await this.sb
+      .from(table)
+      .update({
+        embedding: JSON.stringify(vec),
+        embedding_model: EMBEDDING_MODEL,
+        embedding_created_at: now(),
+      })
+      .eq("id", id);
   }
 
   async supersedeFact(oldId: string, newText: string, category?: string, confidence?: number): Promise<string> {
     const params: Record<string, unknown> = { old_fact_id: oldId, new_fact_text: newText };
     if (category !== undefined) params.new_category = category;
     if (confidence !== undefined) params.new_confidence = confidence;
-    const data = await rpc("supersede_fact", params);
+    const data = await this.rpc("supersede_fact", params);
     return String(data);
   }
 
   async logConversation(data: ConversationInput): Promise<void> {
-    const sb = getSupabase();
-    const { error } = await sb.from("conversation_log").insert({
+    const { error } = await this.sb.from("conversation_log").insert({
       session_id: data.session_id,
       role: data.role,
       content: truncate(data.content),
@@ -134,12 +347,11 @@ export class SupabaseBackend implements MemoryBackend {
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {
-    return rpc("get_conversation_detail", { sid: sessionId });
+    return this.rpc("get_conversation_detail", { sid: sessionId });
   }
 
   async storeCode(data: CodeInput): Promise<{ id: string }> {
-    const sb = getSupabase();
-    const { data: row, error } = await sb.from("code_dumps").insert({
+    const { data: row, error } = await this.sb.from("code_dumps").insert({
       session_id: data.session_id,
       language: data.language,
       filename: data.filename ?? null,
@@ -151,14 +363,12 @@ export class SupabaseBackend implements MemoryBackend {
   }
 
   async getBusinessContext(): Promise<unknown[]> {
-    const sb = getSupabase();
-    const { data, error } = await sb.from("business_context").select("*").order("category").order("key");
+    const { data, error } = await this.sb.from("business_context").select("*").order("category").order("key");
     if (error) throw error;
     return data ?? [];
   }
 
   async setBusinessContext(category: string, key: string, value: unknown, priority?: number): Promise<void> {
-    const sb = getSupabase();
     const row: Record<string, unknown> = {
       category,
       key,
@@ -167,20 +377,19 @@ export class SupabaseBackend implements MemoryBackend {
       decay_tier: "hot",
     };
     if (priority !== undefined) row.priority = priority;
-    const { error } = await sb.from("business_context")
+    const { error } = await this.sb.from("business_context")
       .upsert(row, { onConflict: "category,key" })
       .select().single();
     if (error) throw error;
   }
 
   async upsertLibraryDoc(data: LibraryDocInput): Promise<string> {
-    const sb = getSupabase();
-    const { data: existing } = await sb.from("knowledge_library")
+    const { data: existing } = await this.sb.from("knowledge_library")
       .select("id, version").eq("slug", data.slug).single();
 
     if (existing) {
       // DB trigger auto-archives old content and bumps version
-      const { error } = await sb.from("knowledge_library").update({
+      const { error } = await this.sb.from("knowledge_library").update({
         title: data.title,
         category: data.category,
         content: data.content,
@@ -191,7 +400,7 @@ export class SupabaseBackend implements MemoryBackend {
       if (error) throw error;
       return `Library doc updated: "${data.title}" (v${existing.version + 1})`;
     } else {
-      const { error } = await sb.from("knowledge_library").insert({
+      const { error } = await this.sb.from("knowledge_library").insert({
         slug: data.slug,
         title: data.title,
         category: data.category,
@@ -207,22 +416,21 @@ export class SupabaseBackend implements MemoryBackend {
   }
 
   async manageDecay(): Promise<unknown> {
-    return rpc("manage_decay");
+    return this.rpc("manage_decay");
   }
 
   async getMemoryStatus(): Promise<unknown> {
-    const sb = getSupabase();
     const tables = ["business_context", "knowledge_library", "session_summaries", "extracted_facts", "conversation_log", "code_dumps"];
     const counts: Record<string, unknown> = {};
     for (const table of tables) {
-      const { count } = await sb.from(table).select("*", { count: "exact", head: true });
+      const { count } = await this.sb.from(table).select("*", { count: "exact", head: true });
       counts[table] = count;
     }
-    const { data: factTiers } = await sb.from("extracted_facts").select("decay_tier").eq("status", "active");
+    const { data: factTiers } = await this.sb.from("extracted_facts").select("decay_tier").eq("status", "active");
     const tiers = { hot: 0, warm: 0, cold: 0 };
     for (const row of factTiers ?? []) {
       tiers[row.decay_tier as keyof typeof tiers]++;
     }
-    return { mode: "supabase", table_counts: counts, fact_decay_tiers: tiers };
+    return { mode: this.tenancy.mode === "managed" ? "supabase-managed" : "supabase-byod", table_counts: counts, fact_decay_tiers: tiers };
   }
 }

--- a/packages/memory-mcp/tsconfig.json
+++ b/packages/memory-mcp/tsconfig.json
@@ -15,5 +15,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts", "src/__tests__/**"]
 }

--- a/packages/memory-mcp/vitest.config.ts
+++ b/packages/memory-mcp/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+    testTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary

Mirrors the hybrid → ILIKE keyword fallback that ships in `@unclick/mcp-server` into the standalone `@unclick/memory-mcp` package, so the same `search_memory` P0 (empty results for proper-noun queries / rows with NULL embeddings) is fixed there too. Closes the Memory P0 cron path (todo `146e0d0d`).

### What ports over from `packages/mcp-server/src/memory/supabase.ts`

- **`searchMemory`** — try `search_memory_hybrid` (or `mc_search_memory_hybrid` in managed mode) with an OpenAI embedding; on throw or empty result, run an ILIKE fallback over `extracted_facts` + `session_summaries`.
- **Multi-word handling** — tokenize on whitespace, drop tokens shorter than 2 chars or containing PostgREST `.or()` metacharacters (`,():`). AND-of-tokens by default; OR-of-tokens when AND returns `[]` and `tokens.length >= 2`.
- **Tenant scoping via `api_key_hash`** — preserved in managed mode (`mc_*` tables and the keyword fallback's `.eq("api_key_hash", ...)`); BYOD path is unchanged.
- **`addFact` + `writeSessionSummary`** — now embed inline (fire-and-forget) so freshly inserted rows join the vector lane without waiting for a nightly backfill.

### Tests

- Added `vitest` (`^4.1.5`) to `packages/memory-mcp` with a recording fake of the `supabase-js` client to assert: tokenization rules, AND-mode default, OR fallback only when AND empty AND `tokens.length >= 2`, and `api_key_hash` scoping in managed mode (and absence in BYOD).
- Acceptance test (proper noun + NULL embedding) is gated on `TEST_SUPABASE_URL` / `TEST_SUPABASE_SERVICE_ROLE_KEY`.

Bumps `@unclick/memory-mcp` from `0.2.0` → `0.2.1`. All changes are confined to `packages/memory-mcp/`.

## Test plan

- [x] `npx tsc --noEmit` (no errors)
- [x] `npm test` in `packages/memory-mcp` → 8 tests passing
- [x] `npm run build` in `packages/memory-mcp` → clean
- [ ] Optional: run the gated acceptance test against a real Supabase project with `TEST_SUPABASE_URL` + `TEST_SUPABASE_SERVICE_ROLE_KEY` set
- [ ] Optional: smoke `search_memory` end-to-end via the MCP server in a session with a fact whose proper-noun content does not match `plainto_tsquery('english', ...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)