### PR TITLE
fix(signals): split check_signals read and ack

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5660,6 +5660,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({ success: true });
       }
 
+      case "mark_many_signals_read": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const { signal_ids, read_via } = (req.body ?? {}) as { signal_ids?: string[]; read_via?: string };
+        const ids = Array.isArray(signal_ids)
+          ? signal_ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+          : [];
+        if (ids.length === 0) return res.status(400).json({ error: "signal_ids required" });
+        const { data, error } = await supabase
+          .from("mc_signals")
+          .update({ read_at: new Date().toISOString(), read_via: read_via ?? "agent" })
+          .eq("api_key_hash", apiKeyHash)
+          .is("read_at", null)
+          .in("id", ids)
+          .select("id");
+        if (error) throw error;
+        return res.status(200).json({
+          success: true,
+          updated_count: data?.length ?? 0,
+          signal_ids: data?.map((row) => row.id) ?? [],
+        });
+      }
+
       case "mark_all_read": {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
@@ -5754,15 +5778,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (fetchErr) throw fetchErr;
 
         const signals = rows ?? [];
-        if (signals.length > 0) {
-          const ids = signals.map((s) => s.id);
-          const { error: updateErr } = await supabase
-            .from("mc_signals")
-            .update({ read_at: new Date().toISOString(), read_via: "agent" })
-            .in("id", ids)
-            .eq("api_key_hash", apiKeyHash);
-          if (updateErr) throw updateErr;
-        }
 
         const bySeverity: Record<string, number> = { critical: 0, action_needed: 0, info: 0 };
         const byTool: Record<string, number> = {};

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1210,6 +1210,25 @@ export function createServer(): Server {
           body: "{}",
         });
         const body = await resp.json().catch(() => ({}));
+        const signalIds = Array.isArray((body as { signals?: unknown }).signals)
+          ? (body as { signals: Array<{ id?: unknown }> }).signals
+              .map((signal) => signal.id)
+              .filter((id): id is string => typeof id === "string" && id.length > 0)
+          : [];
+        if (resp.ok && signalIds.length > 0) {
+          const ackResp = await fetch(`${base}/api/memory-admin?action=mark_many_signals_read`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ signal_ids: signalIds, read_via: "agent" }),
+          });
+          if (!ackResp.ok) {
+            const ackBody = await ackResp.json().catch(() => ({}));
+            (body as { ack_warning?: unknown }).ack_warning = ackBody;
+          }
+        }
         return {
           content: [{ type: "text", text: JSON.stringify(body, null, 2) }],
           isError: !resp.ok,


### PR DESCRIPTION
## Summary

Closes Fishbowl todo \9a46d4b1\.

Splits \check_signals\ into a safer read-then-ack flow:

- Adds \mark_many_signals_read\ for idempotent bulk acknowledgement scoped by \pi_key_hash\, unread rows, and explicit ids.
- Makes \check_signals\ read unread signals without consuming them inside the API route.
- Updates the MCP \check_signals\ wrapper to acknowledge only after it successfully receives and parses the response body.
- Preserves the existing client-facing \{ unread_count, signals, narrative_hint }\ response shape.

## Verification

- \
pm run build\
- \
pm run -w packages/mcp-server build\
- \git diff --check\

## Notes

This PR was created from a clean worktree so it avoids the unrelated dirty-branch edits in the active desktop workspace.