### PR TITLE
fix(testpass): persist run pack names

### DIFF
--- a/api/testpass-run.ts
+++ b/api/testpass-run.ts
@@ -4,7 +4,7 @@
  * Bearer-auth (Supabase JWT) entry point for CI pipelines. Runs a named
  * pack against a target MCP server without going through MCP.
  *
- * Body: { pack_id: string, profile?: "smoke"|"standard"|"deep", server_url?: string }
+ * Body: { pack_id: string, pack_name?: string, profile?: "smoke"|"standard"|"deep", server_url?: string }
  * Returns: { run_id: string, status: RunStatus, verdict_summary?: VerdictSummary }
  *
  * Smoke profile runs synchronously and returns the final verdict.
@@ -88,6 +88,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const body = (req.body ?? {}) as {
     pack_id?: string;
+    pack_name?: string;
     profile?: RunProfile;
     server_url?: string;
   };
@@ -117,6 +118,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const runId = await createRun(config, {
     packId,
+    packName: body.pack_name ?? pack.name ?? packSlug,
     target,
     profile,
     actorUserId,

--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -217,6 +217,7 @@ async function performStartRun(
   const config = { supabaseUrl: ctx.supabaseUrl, serviceRoleKey: ctx.serviceKey };
   const runId = await createRun(config, {
     packId,
+    packName: pack.name ?? slug,
     target: body.target,
     profile,
     actorUserId: ctx.actorUserId,

--- a/packages/testpass/src/__tests__/run-manager.test.ts
+++ b/packages/testpass/src/__tests__/run-manager.test.ts
@@ -1,0 +1,38 @@
+import { jest } from "@jest/globals";
+import { createRun } from "../run-manager.js";
+
+describe("run-manager", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("persists pack_name when a run is created with a pack label", async () => {
+    const fetchMock = jest.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      expect(body.pack_id).toBe("pack-id-1");
+      expect(body.pack_name).toBe("TestPass Core");
+      return {
+        ok:     true,
+        status: 200,
+        text:   async () => JSON.stringify([{ id: "run-id-1" }]),
+      } as Response;
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const runId = await createRun(
+      { supabaseUrl: "https://supabase.test", serviceRoleKey: "service-key" },
+      {
+        packId: "pack-id-1",
+        packName: "TestPass Core",
+        target: { type: "url", url: "https://unclick.world/api/mcp" },
+        profile: "smoke",
+        actorUserId: "user-1",
+      },
+    );
+
+    expect(runId).toBe("run-id-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/testpass/src/run-manager.ts
+++ b/packages/testpass/src/run-manager.ts
@@ -40,19 +40,22 @@ export async function createRun(
   config: RunManagerConfig,
   params: {
     packId: string;
+    packName?: string;
     target: RunTarget;
     profile: RunProfile;
     actorUserId: string;
   }
 ): Promise<string> {
-  const rows = (await supaFetch(config, "testpass_runs", "POST", {
+  const payload: Record<string, unknown> = {
     pack_id: params.packId,
     target: params.target,
     profile: params.profile,
     actor_user_id: params.actorUserId,
     status: "running",
     verdict_summary: { total: 0, check: 0, na: 0, fail: 0, other: 0, pending: 0, pass_rate: 0 },
-  })) as Array<{ id: string }>;
+  };
+  if (params.packName) payload.pack_name = params.packName;
+  const rows = (await supaFetch(config, "testpass_runs", "POST", payload)) as Array<{ id: string }>;
   return rows[0].id;
 }
 


### PR DESCRIPTION
## Summary
- Persist `pack_name` when TestPass runs are created from `/api/testpass`
- Accept and fallback `pack_name` in `/api/testpass-run`
- Add regression coverage for the run-manager insert payload

## Why
The `testpass_runs` table has a `pack_name` column, but run creation only populated `pack_id`. That loses the human-readable pack label in run history/reporting.

## Validation
- `node --experimental-vm-modules .\node_modules\jest\bin\jest.js packages/testpass/src/__tests__/run-manager.test.ts --config packages/testpass/package.json`
- `npm run -w @unclick/testpass build`
- `npm run -w packages/mcp-server build`
- `npm run build`
- `git diff --check`

## Notes
- `npm run -w @unclick/testpass test` is currently blocked by an existing package script path issue: it invokes `packages/testpass/node_modules/.bin/jest` even though Jest is installed at the root workspace.
- Running the whole TestPass Jest folder via the root binary exposes existing ESM `jest is not defined` failures in older tests, unrelated to this patch. The new regression passes.

Addresses Fishbowl todo `1bed9394-605d-4dd1-a5ad-5f2b45913cd6`.