### PR TITLE
fix(signals): attribute agent reads

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5649,11 +5649,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
-        const { signal_id, read_via } = (req.body ?? {}) as { signal_id?: string; read_via?: string };
+        const { signal_id, read_via, read_by_agent_id } = (req.body ?? {}) as {
+          signal_id?: string;
+          read_via?: string;
+          read_by_agent_id?: string;
+        };
         if (!signal_id) return res.status(400).json({ error: "signal_id required" });
+        const patch: Record<string, string> = {
+          read_at: new Date().toISOString(),
+          read_via: read_via ?? "ui",
+        };
+        if (typeof read_by_agent_id === "string" && read_by_agent_id.length > 0) {
+          patch.read_by_agent_id = read_by_agent_id;
+        }
         const { error } = await supabase
           .from("mc_signals")
-          .update({ read_at: new Date().toISOString(), read_via: read_via ?? "ui" })
+          .update(patch)
           .eq("id", signal_id)
           .eq("api_key_hash", apiKeyHash);
         if (error) throw error;
@@ -5664,14 +5675,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
-        const { signal_ids, read_via } = (req.body ?? {}) as { signal_ids?: string[]; read_via?: string };
+        const { signal_ids, read_via, read_by_agent_id } = (req.body ?? {}) as {
+          signal_ids?: string[];
+          read_via?: string;
+          read_by_agent_id?: string;
+        };
         const ids = Array.isArray(signal_ids)
           ? signal_ids.filter((id): id is string => typeof id === "string" && id.length > 0)
           : [];
         if (ids.length === 0) return res.status(400).json({ error: "signal_ids required" });
+        const patch: Record<string, string> = {
+          read_at: new Date().toISOString(),
+          read_via: read_via ?? "agent",
+        };
+        if (typeof read_by_agent_id === "string" && read_by_agent_id.length > 0) {
+          patch.read_by_agent_id = read_by_agent_id;
+        }
         const { data, error } = await supabase
           .from("mc_signals")
-          .update({ read_at: new Date().toISOString(), read_via: read_via ?? "agent" })
+          .update(patch)
           .eq("api_key_hash", apiKeyHash)
           .is("read_at", null)
           .in("id", ids)

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5634,7 +5634,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const toolFilter = (body.tool ?? req.query.tool ?? "") as string;
         let q = supabase
           .from("mc_signals")
-          .select("id, tool, action, severity, summary, deep_link, payload, created_at, read_at, read_via")
+          .select("id, tool, action, severity, summary, deep_link, payload, created_at, read_at, read_via, read_by_agent_id")
           .eq("api_key_hash", apiKeyHash)
           .order("created_at", { ascending: false })
           .limit(limit);
@@ -5710,9 +5710,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const { read_via, read_by_agent_id } = (req.body ?? {}) as {
+          read_via?: string;
+          read_by_agent_id?: string;
+        };
+        const patch: Record<string, string> = {
+          read_at: new Date().toISOString(),
+          read_via: read_via ?? "dismiss",
+        };
+        if (typeof read_by_agent_id === "string" && read_by_agent_id.length > 0) {
+          patch.read_by_agent_id = read_by_agent_id;
+        }
         const { data, error } = await supabase
           .from("mc_signals")
-          .update({ read_at: new Date().toISOString(), read_via: "dismiss" })
+          .update(patch)
           .eq("api_key_hash", apiKeyHash)
           .is("read_at", null)
           .select("id");

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -361,7 +361,12 @@ const VISIBLE_TOOLS = [
       "Automatically marks them as read so you do not re-narrate later.",
     inputSchema: {
       type: "object" as const,
-      properties: {},
+      properties: {
+        agent_id: {
+          type: "string",
+          description: "Stable Fishbowl agent_id for read attribution, e.g. chatgpt-codex-worker2.",
+        },
+      },
     },
   },
   {
@@ -1222,7 +1227,11 @@ export function createServer(): Server {
               Authorization: `Bearer ${apiKey}`,
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ signal_ids: signalIds, read_via: "agent" }),
+            body: JSON.stringify({
+              signal_ids: signalIds,
+              read_via: "agent",
+              read_by_agent_id: typeof args.agent_id === "string" ? args.agent_id : undefined,
+            }),
           });
           if (!ackResp.ok) {
             const ackBody = await ackResp.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- Allows signal read endpoints to persist `read_by_agent_id` when supplied.
- Adds optional `agent_id` to the `check_signals` MCP tool schema.
- Sends that `agent_id` through the `mark_many_signals_read` acknowledgement path.

## Why
`mc_signals.read_by_agent_id` existed but was never populated for agent reads. Bailey's audit found 716/716 read signals with `read_via='agent'` and `read_by_agent_id IS NULL`, which made signal audit trails useless for distinguishing Bailey, Plex, Codex, or other readers.

## Validation
- `npm run -w packages/mcp-server build`
- `npm run build`
- `git diff --check`

Addresses Fishbowl todo `976e8af3-03d6-4e23-bc68-12992480e422`.