### PR TITLE
fix(ci): remove MCP publish tag trigger

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 # Auto-publishes @unclick/mcp-server to npm whenever files under
@@ -35,7 +33,7 @@ jobs:
       - name: Detect publish scope
         id: scope
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Remove the tag push trigger from the MCP publish workflow after repeated failing no-job runs
- Keep main push + manual dispatch as the supported publish paths
- Keep inside-job scope detection so non-MCP main pushes skip cleanly

## QC
- git diff --check

## Context
PR #195 and #196 proved the red publish check is not fixed by path filtering. The remaining oddity is the tag push trigger: the workflow keeps registering as the file path and creating zero-job failures. This trims to the simplest branch/manual model so the next main push can create a real job.