### PR TITLE
fix(ci): parse MCP publish workflow

### DIFF
--- a/.github/workflows/publish-mcp-package.yml
+++ b/.github/workflows/publish-mcp-package.yml
@@ -97,7 +97,8 @@ jobs:
       - name: Bump patch version
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
         working-directory: packages/mcp-server
-        run: npm version patch -m "chore: bump mcp-server to %s [skip ci]"
+        run: |
+          npm version patch -m "chore: bump mcp-server to %s [skip ci]"
 
       - name: Push version bump
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'


### PR DESCRIPTION
## Summary
- Fix the invalid YAML scalar in the MCP publish workflow by moving the npm version command into a block scalar
- Confirmed locally with js-yaml that the workflow now parses with name, triggers, and publish job present

## QC
- node/js-yaml parse check for .github/workflows/publish-mcp-package.yml
- git diff --check

## Root Cause
The zero-job Actions failures were caused by the npm version command containing a colon inside an unquoted scalar. GitHub could list the workflow file, but could not parse jobs/triggers from it, which explains the path-name workflow, no logs/jobs, and rejected workflow_dispatch.
