### PR TITLE
fix(crews): seed 4 starter crew templates

### DIFF
--- a/supabase/migrations/20260427150500_seed_starter_crews.sql
+++ b/supabase/migrations/20260427150500_seed_starter_crews.sql
@@ -1,0 +1,73 @@
+-- Seed the four starter Crews from src/data/starterCrews.ts.
+-- Idempotent: existing tenant/name/template rows are left alone.
+
+with tenant_hashes as (
+  select distinct api_key_hash from mc_fishbowl_messages where api_key_hash is not null
+  union
+  select distinct api_key_hash from mc_extracted_facts where api_key_hash is not null
+  union
+  select distinct api_key_hash from mc_business_context where api_key_hash is not null
+  union
+  select distinct api_key_hash from mc_session_summaries where api_key_hash is not null
+  union
+  select '9940983a9d420f63d298f2bc1b26b9a4018014dbc02d9263016dc64237ab9f1e'::text
+),
+starter_crews(name, description, template, agent_slugs) as (
+  values
+    (
+      'Business Council',
+      'CEO, CFO, CMO, CTO, and Creative Director deliberate your business decision together. Each brings their own lens. The Chairman synthesises.',
+      'council',
+      array['ceo','cfo','cmo','cto','cco-creative']::text[]
+    ),
+    (
+      'Launch Stress Test',
+      'A Contrarian, Security Engineer, Growth Hacker, and Customer Success Manager attack and defend your launch plan. Red attacks, blue defends, white scores.',
+      'red_blue',
+      array['contrarian','security-engineer','growth-hacker','csm']::text[]
+    ),
+    (
+      'Creative Studio',
+      'Creative Director, Copywriter, Art Director, and Brand Strategist collaborate on your brief. Draft, shape, verify, stress-test.',
+      'editorial',
+      array['creative-director','copywriter','art-director','brand-strategist']::text[]
+    ),
+    (
+      'Decision Desk',
+      'First Principles Thinker, Pragmatist, Outsider, Executor, and Chairman reason through your decision from five independent angles.',
+      'council',
+      array['first-principles','pragmatist','outsider','executor','chairman']::text[]
+    )
+),
+resolved_crews as (
+  select
+    tenant_hashes.api_key_hash,
+    starter_crews.name,
+    starter_crews.description,
+    starter_crews.template,
+    starter_crews.agent_slugs,
+    array_agg(mc_agents.id order by array_position(starter_crews.agent_slugs, mc_agents.slug)) as agent_ids,
+    count(mc_agents.id) as found_agents
+  from tenant_hashes
+  cross join starter_crews
+  join mc_agents
+    on mc_agents.api_key_hash is null
+   and mc_agents.slug = any(starter_crews.agent_slugs)
+  group by
+    tenant_hashes.api_key_hash,
+    starter_crews.name,
+    starter_crews.description,
+    starter_crews.template,
+    starter_crews.agent_slugs
+)
+insert into mc_crews (api_key_hash, name, description, template, agent_ids)
+select api_key_hash, name, description, template, agent_ids
+from resolved_crews
+where found_agents = cardinality(agent_slugs)
+  and not exists (
+    select 1
+    from mc_crews existing
+    where existing.api_key_hash = resolved_crews.api_key_hash
+      and existing.name = resolved_crews.name
+      and existing.template = resolved_crews.template
+  );


### PR DESCRIPTION
## Summary
- Adds an idempotent Supabase migration to seed the 4 starter crews from `src/data/starterCrews.ts`.
- Resolves system agent slugs from `mc_agents` so `mc_crews.agent_ids` points at real UUIDs.
- Seeds all tenants with existing managed-memory/Fishbowl activity, with Chris's current tenant hash included as a fallback so the dogfood tenant is covered.

## Starter Crews
- Business Council
- Launch Stress Test
- Creative Studio
- Decision Desk

## Verification
- `git diff --cached --check` before commit
- Checked migration for unicode dash characters
- SQL is idempotent via `not exists` on `(api_key_hash, name, template)` and only inserts crews whose full roster resolves

## Follow-up
- After deployment/migration apply, verify `select count(*) from mc_crews` returns at least 4 for the active tenant, then fire Council mode on the dogfooding question.