### PR TITLE
fix(signals): surface needs-doing as warning

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5680,7 +5680,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (unreadOnly) q = q.is("read_at", null);
         const { data, error } = await q;
         if (error) throw error;
-        return res.status(200).json({ signals: data ?? [] });
+        const signals = (data ?? []).map((signal) => {
+          const payload = (signal.payload ?? {}) as Record<string, unknown>;
+          const policyLabel =
+            signal.tool === "fishbowl" && payload.policy_label === "warning"
+              ? "warning"
+              : signal.severity;
+          return {
+            ...signal,
+            policy_label: policyLabel,
+            display_severity: policyLabel,
+          };
+        });
+        return res.status(200).json({ signals });
       }
 
       case "mark_signal_read": {
@@ -5841,24 +5853,36 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const { data: rows, error: fetchErr } = await supabase
           .from("mc_signals")
-          .select("id, tool, action, severity, summary, deep_link, created_at")
+          .select("id, tool, action, severity, summary, deep_link, payload, created_at")
           .eq("api_key_hash", apiKeyHash)
           .is("read_at", null)
           .order("created_at", { ascending: false })
           .limit(10);
         if (fetchErr) throw fetchErr;
 
-        const signals = rows ?? [];
+        const signals = (rows ?? []).map((signal) => {
+          const payload = (signal.payload ?? {}) as Record<string, unknown>;
+          const policyLabel =
+            signal.tool === "fishbowl" && payload.policy_label === "warning"
+              ? "warning"
+              : signal.severity;
+          return {
+            ...signal,
+            policy_label: policyLabel,
+            display_severity: policyLabel,
+          };
+        });
 
-        const bySeverity: Record<string, number> = { critical: 0, action_needed: 0, info: 0 };
+        const bySeverity: Record<string, number> = { critical: 0, action_needed: 0, warning: 0, info: 0 };
         const byTool: Record<string, number> = {};
         for (const s of signals) {
-          if (s.severity in bySeverity) bySeverity[s.severity]++;
+          if (s.display_severity in bySeverity) bySeverity[s.display_severity]++;
           byTool[s.tool] = (byTool[s.tool] ?? 0) + 1;
         }
         const parts: string[] = [];
         if (bySeverity.critical > 0) parts.push(`${bySeverity.critical} critical`);
         if (bySeverity.action_needed > 0) parts.push(`${bySeverity.action_needed} needing action`);
+        if (bySeverity.warning > 0) parts.push(`${bySeverity.warning} warning`);
         if (bySeverity.info > 0) parts.push(`${bySeverity.info} info`);
         const toolList = Object.entries(byTool)
           .map(([t, c]) => `${c} from ${t}`)
@@ -6264,6 +6288,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             const tagList = inserted.tags ?? [];
             const tagSet = new Set(tagList);
             const isBlocker = tagSet.has("blocker") || tagSet.has("tripwire");
+            const needsDoing = tagSet.has("needs-doing");
             const broadcastsAll = recipientList.includes("all");
 
             // Discover this tenant's human admin profiles so we can match
@@ -6290,6 +6315,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
             let severity: "info" | "action_needed" | "critical" = "info";
             if (targetsHuman) severity = "action_needed";
+            else if (needsDoing) severity = "action_needed";
             else if (broadcastsAll && isBlocker) severity = "action_needed";
             else if (isBlocker) severity = "action_needed";
 
@@ -6310,6 +6336,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 recipients: recipientList,
                 tags: tagList,
                 message_id: inserted.id,
+                policy_label: needsDoing ? "warning" : severity,
               },
             });
           } catch (publishErr) {

--- a/api/signals-dispatch.ts
+++ b/api/signals-dispatch.ts
@@ -32,6 +32,14 @@ const SEVERITY_RANK: Record<"info" | "action_needed" | "critical", number> = {
   critical: 2,
 };
 
+function displaySeverity(signal: SignalRow): string {
+  const payload = signal.payload ?? {};
+  if (signal.tool === "fishbowl" && payload.policy_label === "warning") {
+    return "warning";
+  }
+  return signal.severity;
+}
+
 async function sendEmail(params: {
   to: string;
   subject: string;
@@ -138,14 +146,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     let sent = false;
 
     if (prefs.email_enabled && prefs.email_address) {
-      const subjectPrefix = signal.severity === "critical" ? "Action needed" : "Update";
+      const severityLabel = displaySeverity(signal);
+      const subjectPrefix =
+        signal.severity === "critical"
+          ? "Action needed"
+          : severityLabel === "warning"
+            ? "Warning"
+            : "Update";
       const subject = `[UnClick] ${subjectPrefix}: ${signal.summary}`;
       const textBody = [
         signal.summary,
         "",
         `Tool: ${signal.tool}`,
         `Action: ${signal.action}`,
-        `Severity: ${signal.severity}`,
+        `Severity: ${severityLabel}`,
         `When: ${signal.created_at}`,
         signal.deep_link ? `Open: https://unclick.world${signal.deep_link}` : "",
         "",

--- a/src/pages/admin/signals/SignalsCatalog.tsx
+++ b/src/pages/admin/signals/SignalsCatalog.tsx
@@ -16,7 +16,8 @@ interface Signal {
   read_via: string | null;
 }
 
-type SeverityFilter = "all" | "info" | "action_needed" | "critical";
+type SeverityLabel = Signal["severity"] | "warning";
+type SeverityFilter = "all" | SeverityLabel;
 
 function relativeTime(iso: string): string {
   const then = new Date(iso).getTime();
@@ -38,11 +39,21 @@ const SEVERITY_STYLE: Record<Signal["severity"], string> = {
   info: "border-[#61C1C4]/30 bg-[#61C1C4]/10 text-[#61C1C4]",
 };
 
-const SEVERITY_LABEL: Record<Signal["severity"], string> = {
+const WARNING_STYLE = "border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#E2B93B]";
+
+const SEVERITY_LABEL: Record<SeverityLabel, string> = {
   critical: "Critical",
   action_needed: "Action needed",
+  warning: "Warning",
   info: "Info",
 };
+
+function displaySeverity(signal: Signal): SeverityLabel {
+  if (signal.tool === "fishbowl" && signal.payload?.policy_label === "warning") {
+    return "warning";
+  }
+  return signal.severity;
+}
 
 function toolBadgeColor(tool: string): string {
   let hash = 0;
@@ -96,7 +107,7 @@ export default function SignalsCatalog() {
   }, [token, fetchSignals]);
 
   const filtered = useMemo(
-    () => signals.filter((s) => severityFilter === "all" || s.severity === severityFilter),
+    () => signals.filter((s) => severityFilter === "all" || displaySeverity(s) === severityFilter),
     [signals, severityFilter],
   );
 
@@ -176,6 +187,7 @@ export default function SignalsCatalog() {
         >
           <option value="all">All severities</option>
           <option value="info">Info</option>
+          <option value="warning">Warning</option>
           <option value="action_needed">Action needed</option>
           <option value="critical">Critical</option>
         </select>
@@ -209,13 +221,16 @@ export default function SignalsCatalog() {
         </div>
       ) : (
         <div className="flex flex-col gap-2">
-          {filtered.map((s) => (
-            <div
-              key={s.id}
-              className={`rounded-xl border p-4 transition-colors ${
-                s.read_at ? "border-white/[0.06] bg-[#0f0f0f]" : "border-white/[0.12] bg-[#141414]"
-              }`}
-            >
+          {filtered.map((s) => {
+            const severityLabel = displaySeverity(s);
+            const severityStyle = severityLabel === "warning" ? WARNING_STYLE : SEVERITY_STYLE[s.severity];
+            return (
+              <div
+                key={s.id}
+                className={`rounded-xl border p-4 transition-colors ${
+                  s.read_at ? "border-white/[0.06] bg-[#0f0f0f]" : "border-white/[0.12] bg-[#141414]"
+                }`}
+              >
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
                   <p className={`text-sm font-medium ${s.read_at ? "text-[#aaa]" : "text-white"}`}>
@@ -225,8 +240,8 @@ export default function SignalsCatalog() {
                     <span className={`rounded-md px-2 py-0.5 font-semibold ${toolBadgeColor(s.tool)}`}>
                       {s.tool}
                     </span>
-                    <span className={`rounded-md border px-2 py-0.5 font-medium ${SEVERITY_STYLE[s.severity]}`}>
-                      {SEVERITY_LABEL[s.severity]}
+                    <span className={`rounded-md border px-2 py-0.5 font-medium ${severityStyle}`}>
+                      {SEVERITY_LABEL[severityLabel]}
                     </span>
                     <span className="text-[#666]">{relativeTime(s.created_at)}</span>
                   </div>
@@ -250,8 +265,9 @@ export default function SignalsCatalog() {
                   )}
                 </div>
               </div>
-            </div>
-          ))}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- route Fishbowl messages tagged needs-doing into the existing action_needed signal lane
- store a warning policy label in signal payload so no DB severity migration is required
- show those Fishbowl signals as Warning in the admin Signals feed and dispatch email copy

## Verification
- npm run build

Keeps the persisted severity contract at info/action_needed/critical while giving the room the warning label Chris locked.