### PR TITLE
fix(crews): seed starter crews on list fallback

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -232,7 +232,10 @@ async function ensureStarterCrews(
     .filter((row): row is NonNullable<typeof row> => Boolean(row));
 
   if (rows.length === 0) return;
-  const { error } = await supabase.from("mc_crews").insert(rows);
+  const { error } = await supabase.from("mc_crews").upsert(rows, {
+    onConflict: "api_key_hash,name,template",
+    ignoreDuplicates: true,
+  });
   if (error) throw error;
 }
 

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -150,6 +150,92 @@ function queueMemoryEmbedding(req: VercelRequest, table: string, id: string, tex
   });
 }
 
+const STARTER_CREW_DEFS = [
+  {
+    name: "Business Council",
+    description:
+      "CEO, CFO, CMO, CTO, and Creative Director deliberate your business decision together. Each brings their own lens. The Chairman synthesises.",
+    template: "council",
+    agentSlugs: ["ceo", "cfo", "cmo", "cto", "cco-creative"],
+  },
+  {
+    name: "Launch Stress Test",
+    description:
+      "A Contrarian, Security Engineer, Growth Hacker, and Customer Success Manager attack and defend your launch plan. Red attacks, blue defends, white scores.",
+    template: "red_blue",
+    agentSlugs: ["contrarian", "security-engineer", "growth-hacker", "csm"],
+  },
+  {
+    name: "Creative Studio",
+    description:
+      "Creative Director, Copywriter, Art Director, and Brand Strategist collaborate on your brief. Draft, shape, verify, stress-test.",
+    template: "editorial",
+    agentSlugs: ["creative-director", "copywriter", "art-director", "brand-strategist"],
+  },
+  {
+    name: "Decision Desk",
+    description:
+      "First Principles Thinker, Pragmatist, Outsider, Executor, and Chairman reason through your decision from five independent angles.",
+    template: "council",
+    agentSlugs: ["first-principles", "pragmatist", "outsider", "executor", "chairman"],
+  },
+] as const;
+
+async function ensureStarterCrews(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+): Promise<void> {
+  const { data: existingRows, error: existingError } = await supabase
+    .from("mc_crews")
+    .select("name,template")
+    .eq("api_key_hash", apiKeyHash);
+  if (existingError) throw existingError;
+
+  const existing = new Set(
+    ((existingRows ?? []) as Array<{ name: string; template: string }>).map(
+      (row) => `${row.name}::${row.template}`,
+    ),
+  );
+  const missingDefs = STARTER_CREW_DEFS.filter(
+    (crew) => !existing.has(`${crew.name}::${crew.template}`),
+  );
+  if (missingDefs.length === 0) return;
+
+  const slugs = Array.from(new Set(missingDefs.flatMap((crew) => crew.agentSlugs)));
+  const [systemAgents, tenantAgents] = await Promise.all([
+    supabase.from("mc_agents").select("id,slug").is("api_key_hash", null).in("slug", slugs),
+    supabase.from("mc_agents").select("id,slug").eq("api_key_hash", apiKeyHash).in("slug", slugs),
+  ]);
+  if (systemAgents.error) throw systemAgents.error;
+  if (tenantAgents.error) throw tenantAgents.error;
+
+  const bySlug = new Map<string, string>();
+  for (const row of (systemAgents.data ?? []) as Array<{ id: string; slug: string }>) {
+    bySlug.set(row.slug, row.id);
+  }
+  for (const row of (tenantAgents.data ?? []) as Array<{ id: string; slug: string }>) {
+    bySlug.set(row.slug, row.id);
+  }
+
+  const rows = missingDefs
+    .map((crew) => {
+      const agentIds = crew.agentSlugs.map((slug) => bySlug.get(slug));
+      if (agentIds.some((id) => !id)) return null;
+      return {
+        api_key_hash: apiKeyHash,
+        name: crew.name,
+        description: crew.description,
+        template: crew.template,
+        agent_ids: agentIds,
+      };
+    })
+    .filter((row): row is NonNullable<typeof row> => Boolean(row));
+
+  if (rows.length === 0) return;
+  const { error } = await supabase.from("mc_crews").insert(rows);
+  if (error) throw error;
+}
+
 function deriveKey(apiKey: string, salt: Buffer): Buffer {
   return crypto.pbkdf2Sync(apiKey, salt, PBKDF2_ITERATIONS, KEY_BYTES, "sha256");
 }
@@ -5063,6 +5149,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       case "list_crews": {
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        await ensureStarterCrews(supabase, apiKeyHash);
 
         const { data, error } = await supabase
           .from("mc_crews")

--- a/supabase/migrations/20260427182300_crews_unique_starter_keys.sql
+++ b/supabase/migrations/20260427182300_crews_unique_starter_keys.sql
@@ -1,0 +1,22 @@
+-- Crews: prevent duplicate starter templates per tenant.
+-- The runtime list_crews fallback can be hit by simultaneous first loads, so the
+-- database owns idempotency for tenant/name/template.
+
+with ranked_crews as (
+  select
+    id,
+    row_number() over (
+      partition by api_key_hash, name, template
+      order by created_at asc, id asc
+    ) as duplicate_rank
+  from mc_crews
+)
+delete from mc_crews
+where id in (
+  select id
+  from ranked_crews
+  where duplicate_rank > 1
+);
+
+create unique index if not exists mc_crews_tenant_name_template_unique
+  on mc_crews(api_key_hash, name, template);


### PR DESCRIPTION
## Summary
- add the four starter crew definitions to the server path
- seed missing starter crews for the current tenant before list_crews returns
- resolve agent_ids from system agents, with tenant agents as fallback, preserving starter order

## Verification
- npm run build
- npx eslint api/memory-admin.ts --ignore-pattern ".claude/**" (fails on pre-existing lint in memory-admin.ts:1098,1776,1777; no new lint surfaced)

Refs todo f9d7b496.