### PR TITLE
fix(testpass): stamp run start time

### DIFF
--- a/packages/testpass/src/run-manager.ts
+++ b/packages/testpass/src/run-manager.ts
@@ -52,6 +52,7 @@ export async function createRun(
     profile: params.profile,
     actor_user_id: params.actorUserId,
     status: "running",
+    started_at: new Date().toISOString(),
     verdict_summary: { total: 0, check: 0, na: 0, fail: 0, other: 0, pending: 0, pass_rate: 0 },
   };
   if (params.packName) payload.pack_name = params.packName;


### PR DESCRIPTION
## Summary
- stamp `started_at` when TestPass creates a run in the shared run manager
- preserves the existing `completed_at` behavior for non-running terminal updates
- unblocks the dispatcher acceptance check that expects cron-created runs to have a non-null start timestamp

## Verification
- npm run build
- npm --prefix packages/testpass run build
- npx eslint packages/testpass/src/run-manager.ts --ignore-pattern ".claude/**"

Refs todo 320804d2.