### PR TITLE
fix(crews): seed starters before run

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5237,6 +5237,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        await ensureStarterCrews(supabase, apiKeyHash);
         const { crew_id, task_prompt, token_budget } = (req.body ?? {}) as {
           crew_id?: string;
           task_prompt?: string;


### PR DESCRIPTION
## Summary
- call the shared starter crew seeding guard from `start_crew_run`
- keeps the existing `list_crews` self-heal path from PR #210
- reuses the tenant/name/template unique key and upsert behavior, so repeated run attempts stay idempotent

## Verification
- npm run build
- npx eslint api/memory-admin.ts --ignore-pattern ".claude/**" (fails only on pre-existing memory-admin.ts lint at 1101, 1779, 1780)

Refs Crews cold-start follow-up from Fishbowl todo 32520f2b / PR #210.