### PR TITLE
testpass: add FB-010 github_action signal fallback check

### DIFF
--- a/packages/testpass/packs/testpass-fishbowl-v0.yaml
+++ b/packages/testpass/packs/testpass-fishbowl-v0.yaml
@@ -153,3 +153,25 @@ items:
       severity value.
     tags: [fishbowl, signals, warning, regression-check]
     profiles: [smoke, standard, deep]
+
+  - id: FB-010
+    title: github_action failures carry deterministic Signals fallback context
+    category: fishbowl-signals
+    severity: high
+    check_type: deterministic
+    description: |
+      Trigger a controlled github_action get_repo failure through the live MCP
+      tool wrapper, then verify the tenant-scoped mc_signals row includes the
+      synthetic owner marker and deep_link='/admin/signals'. This guards the
+      PR 214/215 fallback path without racing on newest-row timing.
+    expected:
+      tool: github_action
+      payload.github_action.owner: unclick-fb010-fixture-*
+      deep_link: /admin/signals
+      api_key_hash: matches TESTPASS_TOKEN tenant
+    on_fail: |
+      Check packages/mcp-server/src/server.ts. github_action failure signals
+      must preserve sanitized action/owner/repo payload context and use the
+      /admin/signals fallback deep link.
+    tags: [fishbowl, signals, github-action, regression-check]
+    profiles: [smoke, standard, deep]

--- a/packages/testpass/src/runner/deterministic.ts
+++ b/packages/testpass/src/runner/deterministic.ts
@@ -12,6 +12,7 @@
 import type { Pack, RunProfile } from "../types.js";
 import type { RunManagerConfig } from "../run-manager.js";
 import { updateItem, createEvidence } from "../run-manager.js";
+import { createHash } from "node:crypto";
 
 // ─── Internal types ────────────────────────────────────────────────
 
@@ -74,7 +75,45 @@ function rpcReq(method: string, params: unknown, id?: number): unknown {
 
 // ─── Check handlers ────────────────────────────────────────────────
 
-type CheckHandler = (targetUrl: string) => Promise<CheckOutcome>;
+type CheckHandler = (targetUrl: string, config: RunManagerConfig) => Promise<CheckOutcome>;
+
+function apiKeyHash(): string | null {
+  const token = process.env.TESTPASS_TOKEN?.trim();
+  if (!token) return null;
+  return createHash("sha256").update(token).digest("hex");
+}
+
+async function fetchSignals(
+  config: RunManagerConfig,
+  hash: string,
+): Promise<Array<Record<string, unknown>>> {
+  const select = "id,tool,action,severity,summary,deep_link,payload,created_at";
+  const path = [
+    "mc_signals",
+    `?api_key_hash=eq.${encodeURIComponent(hash)}`,
+    "&tool=eq.github_action",
+    `&select=${encodeURIComponent(select)}`,
+    "&order=created_at.desc",
+    "&limit=20",
+  ].join("");
+  const res = await fetch(`${config.supabaseUrl}/rest/v1/${path}`, {
+    headers: {
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+    },
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`Supabase GET ${path} -> ${res.status}: ${text}`);
+  return text ? JSON.parse(text) as Array<Record<string, unknown>> : [];
+}
+
+function matchingGithubSignal(rows: Array<Record<string, unknown>>, owner: string): Record<string, unknown> | undefined {
+  return rows.find((row) => {
+    const payload = row.payload as Record<string, unknown> | undefined;
+    const githubAction = payload?.github_action as Record<string, unknown> | undefined;
+    return githubAction?.owner === owner;
+  });
+}
 
 const HANDLERS: Record<string, CheckHandler> = {
 
@@ -273,6 +312,51 @@ const HANDLERS: Record<string, CheckHandler> = {
     if (err) return { verdict: "fail", note: `Expected error.code -32601, got ${JSON.stringify(err.code)}`, traces: [trace] };
     return { verdict: "fail", note: `Unknown method must return error, got ${JSON.stringify(body)}`, traces: [trace] };
   },
+
+  // FB-010: github_action failures must create tenant-scoped Signals with
+  // an /admin/signals fallback and fixture marker context.
+  "FB-010": async (url, config) => {
+    const hash = apiKeyHash();
+    if (!hash) {
+      return { verdict: "na", note: "TESTPASS_TOKEN is unset, cannot run authenticated signal smoke.", traces: [] };
+    }
+
+    const fixtureOwner = `unclick-fb010-fixture-${Date.now()}`;
+    const fixtureRepo = "missing-repo";
+    const req = rpcReq("tools/call", {
+      name: "github_action",
+      arguments: {
+        action: "get_repo",
+        owner: fixtureOwner,
+        repo: fixtureRepo,
+      },
+    }, 410);
+    const r = await send(url, req, 15_000);
+    const trace: HttpTrace = { request: { url, body: req }, response: r };
+
+    let lastRows: Array<Record<string, unknown>> = [];
+    for (let attempt = 0; attempt < 10; attempt++) {
+      lastRows = await fetchSignals(config, hash);
+      const match = matchingGithubSignal(lastRows, fixtureOwner);
+      if (match) {
+        if (match.deep_link === "/admin/signals") {
+          return { verdict: "check", traces: [trace] };
+        }
+        return {
+          verdict: "fail",
+          note: `Expected deep_link /admin/signals for ${fixtureOwner}, got ${JSON.stringify(match.deep_link)}`,
+          traces: [trace],
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    return {
+      verdict: "fail",
+      note: `No github_action signal found for fixture owner ${fixtureOwner}; recent rows: ${JSON.stringify(lastRows.slice(0, 3))}`,
+      traces: [trace],
+    };
+  },
 };
 
 // ─── Public API ─────────────────────────────────────────────────────
@@ -301,7 +385,7 @@ export async function runDeterministicChecks(
       const checkStart = Date.now();
       let outcome: CheckOutcome;
       try {
-        outcome = await handler(targetUrl);
+        outcome = await handler(targetUrl, config);
       } catch (err) {
         outcome = {
           verdict: "other",


### PR DESCRIPTION
## Summary
- add FB-010 to testpass-fishbowl-v0 as a deterministic regression check
- trigger a synthetic github_action get_repo failure through MCP
- poll tenant-scoped mc_signals for payload.github_action.owner and deep_link=/admin/signals
- mark the check n/a when TESTPASS_TOKEN is absent to avoid false local/preview reds

## Verification
- npm run build --workspace=@unclick/testpass

## Notes
- npm run test --workspace=@unclick/testpass is currently broken before/independent of this patch: it points at packages/testpass/node_modules/.bin/jest, which is not installed in this workspace. Running the root Jest binary also discovers dist/*.d.ts and ESM tests that expect a global jest object, producing pre-existing harness failures unrelated to FB-010.