### PR TITLE
fix(signals): default MCP failure links

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -67,9 +67,11 @@ function failureSummary(toolName: string, result: unknown): string | null {
   return null;
 }
 
-function signalDeepLink(toolName: string): string | undefined {
-  if (toolName === "github_action") return "/admin/signals";
-  return undefined;
+function signalDeepLink(toolName: string): string {
+  const explicitLinks: Record<string, string> = {
+    github_action: "/admin/signals",
+  };
+  return explicitLinks[toolName] ?? "/admin/signals";
 }
 
 function signalPayload(toolName: string, args?: unknown): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- default MCP-server failure and exception signals to /admin/signals
- keep github_action as an explicit override point for future richer per-tool links
- covers vercel_* sister failures without touching other signal producers

## Tests
- npm run build --workspace=@unclick/mcp-server
- npm run test --workspace=@unclick/mcp-server

Closes Fishbowl todo 92860158.