### PR TITLE
test(signals): cover generic fallback links

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -67,7 +67,7 @@ function failureSummary(toolName: string, result: unknown): string | null {
   return null;
 }
 
-function signalDeepLink(toolName: string): string {
+export function signalDeepLink(toolName: string): string {
   const explicitLinks: Record<string, string> = {
     github_action: "/admin/signals",
   };

--- a/packages/mcp-server/src/signals/deep-link.test.ts
+++ b/packages/mcp-server/src/signals/deep-link.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { signalDeepLink } from "../server.js";
+
+describe("signalDeepLink", () => {
+  it("keeps explicit tool links", () => {
+    expect(signalDeepLink("github_action")).toBe("/admin/signals");
+  });
+
+  it("defaults generic MCP failures to the signals admin page", () => {
+    expect(signalDeepLink("synthetic_future_mcp_tool")).toBe("/admin/signals");
+  });
+});


### PR DESCRIPTION
## Summary
- export signalDeepLink for direct unit coverage
- add tests for the explicit github_action link and the generic future MCP tool fallback
- closes the PR #217 verification gap Bailey flagged for vercel_* / future tools

## Tests
- npm run build --workspace=@unclick/mcp-server
- npm run test --workspace=@unclick/mcp-server

Closes Fishbowl todo 387ebcd2.