### PR TITLE
fix(vercel): accept project id alias for env reads

### DIFF
--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -2129,10 +2129,13 @@ export const ADDITIONAL_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        projectId: { type: "string" },
+        project_id: { type: "string" },
+        projectId: { type: "string", description: "Legacy alias for project_id." },
+        team_id: { type: "string" },
+        decrypt: { type: "boolean" },
         api_key: { type: "string" },
       },
-      required: ["projectId"],
+      anyOf: [{ required: ["project_id"] }, { required: ["projectId"] }],
     },
   },
   {

--- a/packages/mcp-server/src/vercel-tool.test.ts
+++ b/packages/mcp-server/src/vercel-tool.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { vercelProjectIdArg } from "./vercel-tool.js";
+
+describe("vercelProjectIdArg", () => {
+  it("uses project_id as the canonical key", () => {
+    expect(vercelProjectIdArg({ project_id: " prj_canonical " })).toBe("prj_canonical");
+  });
+
+  it("accepts projectId as a legacy alias", () => {
+    expect(vercelProjectIdArg({ projectId: " prj_legacy " })).toBe("prj_legacy");
+  });
+});

--- a/packages/mcp-server/src/vercel-tool.ts
+++ b/packages/mcp-server/src/vercel-tool.ts
@@ -178,11 +178,15 @@ export async function getVercelDomain(args: Record<string, unknown>): Promise<un
   }
 }
 
+export function vercelProjectIdArg(args: Record<string, unknown>): string {
+  return String(args.project_id ?? args.projectId ?? "").trim();
+}
+
 // get_vercel_env
 export async function getVercelEnv(args: Record<string, unknown>): Promise<unknown> {
   try {
     const token = getApiKey(args);
-    const projectId = String(args.project_id ?? "").trim();
+    const projectId = vercelProjectIdArg(args);
     if (!projectId) return { error: "project_id is required." };
     const params: Record<string, string> = {};
     if (args.team_id) params.teamId = String(args.team_id);


### PR DESCRIPTION
## Summary
- make project_id the canonical ercel_get_env schema key to match the other Vercel tools
- keep projectId as a legacy alias during rollout
- add a focused unit test for both forms of the project id argument

## Verification
- 
pm run build --workspace=packages/mcp-server
- 
pm run test --workspace=packages/mcp-server

## Coordination
Closes the schema/handler mismatch in Fishbowl todo 7976c359; this unblocks agent-side Vercel env verification for the embedding recovery lane.