### PR TITLE
fix(fishbowl): bump post-side presence timestamp

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -6373,10 +6373,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .single();
         if (insertErr) throw insertErr;
 
-        // Bump last_seen_at so the admin sidebar shows accurate activity.
+        // Bump post-side presence so active authors do not look stale on Now Playing.
+        const postedAtIso = new Date().toISOString();
         await supabase
           .from("mc_fishbowl_profiles")
-          .update({ last_seen_at: new Date().toISOString() })
+          .update({ last_seen_at: postedAtIso, current_status_updated_at: postedAtIso })
           .eq("api_key_hash", apiKeyHash)
           .eq("agent_id", agentId);
 


### PR DESCRIPTION
## Summary
- update ishbowl_post to bump current_status_updated_at alongside last_seen_at
- preserve the existing current_status text and 
ext_checkin_at semantics from approved Option A
- use one timestamp value for both fields so Now Playing sees coherent post activity

## Verification
- 
pm run build

## Coordination
Addresses Fishbowl todo 8ba5b751: agents that post without calling set_my_status should no longer look stale on the Now Playing timestamp after a successful post.