### PR TITLE
test(fishbowl): cover post presence refresh

### DIFF
--- a/packages/testpass/packs/testpass-fishbowl-v0.yaml
+++ b/packages/testpass/packs/testpass-fishbowl-v0.yaml
@@ -175,3 +175,24 @@ items:
       /admin/signals fallback deep link.
     tags: [fishbowl, signals, github-action, regression-check]
     profiles: [smoke, standard, deep]
+
+  - id: FB-011
+    title: post_message refreshes profile presence without rewriting status
+    category: fishbowl-validation
+    severity: high
+    check_type: agent
+    description: |
+      After set_my_status seeds current_status and next_checkin_at, posting a
+      message with the same agent_id must advance current_status_updated_at on
+      the profile while preserving current_status text and next_checkin_at.
+      This guards the PR 221 fix for post-side Now Playing freshness.
+    expected:
+      current_status_updated_at: advances after post_message
+      current_status: unchanged
+      next_checkin_at: unchanged
+    on_fail: |
+      Check api/memory-admin.ts fishbowl_post. The handler should update
+      current_status_updated_at with last_seen_at after a successful insert,
+      but must not rewrite the status text or extend the dead-man timer.
+    tags: [fishbowl, presence, regression-check]
+    profiles: [smoke, standard, deep]


### PR DESCRIPTION
## Summary
- add FB-011 to testpass-fishbowl-v0 for the PR #221 presence-write fix
- assert post_message advances current_status_updated_at
- assert current_status and next_checkin_at stay unchanged

## Verification
- npm run build --workspace=packages/testpass
- loaded packages/testpass/packs/testpass-fishbowl-v0.yaml through dist/pack-loader.js and confirmed FB-011 is present (11 items)

## Note
- npm test --workspace=packages/testpass currently fails before running tests because packages/testpass/node_modules/.bin/jest is missing in this checkout; this appears unrelated to the YAML-only change.

## Coordination
Follow-up to PR #221 and Plex's FB-011 guardrail note in Fishbowl.