### PR TITLE
fix(migrations): unblock pending queue (idempotency guard on mc_admin_audit policy)

### DIFF
--- a/supabase/migrations/20260424100000_security_patch_bundle.sql
+++ b/supabase/migrations/20260424100000_security_patch_bundle.sql
@@ -23,7 +23,11 @@ CREATE TABLE IF NOT EXISTS mc_admin_audit (
 );
 
 ALTER TABLE mc_admin_audit ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "mc_admin_audit_service_role_all" ON mc_admin_audit FOR ALL USING (auth.role() = 'service_role');
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='mc_admin_audit' AND policyname='mc_admin_audit_service_role_all') THEN
+    CREATE POLICY "mc_admin_audit_service_role_all" ON mc_admin_audit FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS mc_admin_audit_api_key_hash_idx ON mc_admin_audit(api_key_hash);
 CREATE INDEX IF NOT EXISTS mc_admin_audit_performed_at_idx ON mc_admin_audit(performed_at DESC);


### PR DESCRIPTION
## Summary

The bare \`CREATE POLICY \"mc_admin_audit_service_role_all\"\` on line 26 of \`20260424100000_security_patch_bundle.sql\` was applied to prod on a previous attempt, but the bookkeeping insert in \`_claude_migrations\` never landed (likely worker death between \`run_sql\` and \`record_applied\` in \`.github/scripts/apply_migrations.py\`).

Since then every \`Apply Supabase migrations\` workflow run has aborted on this same file with \`42710: policy \"mc_admin_audit_service_role_all\" for table \"mc_admin_audit\" already exists\` (see e.g. run \`25032049434\`, \`25012986730\`, \`25003097395\`). The script aborts on first failure, so **5 pending migrations have been blocked from applying since 2026-04-24**, including the just-merged UXPass schema (PR #227).

This wraps the policy in the same \`DO \$\$ ... IF NOT EXISTS ... CREATE POLICY ... END \$\$\` guard the other two policies in the same file already use. Pure idempotency fix — the policy is already in prod, so this is a no-op against current schema state, but it lets the workflow record the version and move on to the queue.

## Test plan

- [x] Diff is identical pattern to lines 4-8 and 11-15 of the same file
- [x] No DB schema change against current prod state (policy already exists)
- [ ] After merge, \`apply-migrations.yml\` completes successfully and applies the 5 queued migrations (security_patch_bundle, plus four others including \`20260428100000_uxpass_schema.sql\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)