### PR TITLE
fix(testpass): preserve falsy expected prompts

### DIFF
--- a/packages/testpass/src/__tests__/agent.test.ts
+++ b/packages/testpass/src/__tests__/agent.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { runAgentChecks, type JudgeSampler } from "../runner/agent.js";
+import type { Pack } from "../types.js";
+
+describe("runAgentChecks", () => {
+  const config = { supabaseUrl: "http://unused", serviceRoleKey: "unused" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { check_id: "NULL" },
+        { check_id: "FALSE" },
+        { check_id: "ZERO" },
+        { check_id: "EMPTY" },
+      ],
+      text: async () => "",
+    } as Response);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("includes explicit falsy expected values in the judge prompt", async () => {
+    const userPrompts: string[] = [];
+    const sampler: JudgeSampler = async ({ user }) => {
+      userPrompts.push(user);
+      return { text: JSON.stringify({ verdict: "check", reasoning: "ok" }), model: "test-model" };
+    };
+    const pack: Pack = {
+      id: "falsy-expected",
+      name: "Falsy Expected",
+      version: "0.1.0",
+      description: "",
+      items: [
+        { id: "NULL", title: "null", category: "agent", severity: "low", check_type: "agent", tags: [], profiles: ["standard"], expected: null },
+        { id: "FALSE", title: "false", category: "agent", severity: "low", check_type: "agent", tags: [], profiles: ["standard"], expected: false },
+        { id: "ZERO", title: "zero", category: "agent", severity: "low", check_type: "agent", tags: [], profiles: ["standard"], expected: 0 },
+        { id: "EMPTY", title: "empty", category: "agent", severity: "low", check_type: "agent", tags: [], profiles: ["standard"], expected: "" },
+      ],
+    };
+
+    await runAgentChecks(config, "run-1", "https://example.test", pack, "standard", undefined, sampler);
+
+    expect(userPrompts).toHaveLength(4);
+    expect(userPrompts).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Expected: null"),
+        expect.stringContaining("Expected: false"),
+        expect.stringContaining("Expected: 0"),
+        expect.stringContaining('Expected: ""'),
+      ]),
+    );
+  });
+});

--- a/packages/testpass/src/runner/agent.ts
+++ b/packages/testpass/src/runner/agent.ts
@@ -80,7 +80,7 @@ async function evaluateCheck(
     `Check ID: ${checkId}`,
     `Title: ${title}`,
     description ? `Description: ${description}` : null,
-    expected ? `Expected: ${JSON.stringify(expected)}` : null,
+    expected !== undefined ? `Expected: ${JSON.stringify(expected)}` : null,
     onFail ? `On fail guidance: ${onFail}` : null,
     `Target URL: ${targetUrl}`,
     probeData


### PR DESCRIPTION
## Summary
- include explicit falsy expected values in TestPass agent judge prompts
- add a regression covering null, false, 0, and empty-string expected values

## Verification
- npm run build --workspace=packages/testpass
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath packages/testpass/src/__tests__/agent.test.ts --config packages/testpass/package.json

Note: a full package Jest run still hits pre-existing harness issues: it discovers dist/*.d.ts as tests and older ESM tests that expect global jest.