### PR TITLE
fix(memory): bound strict client responses

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -22,7 +22,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "tsx --test src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts && vitest run",
+    "test": "tsx --test src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts src/memory/__tests__/response-bounds.test.ts && vitest run",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/mcp-server/src/catalog.ts
+++ b/packages/mcp-server/src/catalog.ts
@@ -1918,19 +1918,23 @@ export const CATALOG: ToolDef[] = [
       {
         id: "memory.get_startup_context",
         name: "Load Session Context",
-        description: "Load Session Context - Loads business context, recent sessions, and hot facts. Call FIRST in every new session.",
+        description: "Load Session Context - compact by default for strict clients. Loads business context, hot facts, and counts; call search_memory for detail.",
         method: "POST",
         path: "/v1/memory/startup",
         requiresAuth: false,
         inputSchema: {
           type: "object",
-          properties: { num_sessions: { type: "number", minimum: 1, maximum: 20, default: 5 } },
+          properties: {
+            num_sessions: { type: "number", minimum: 1, maximum: 20, default: 3 },
+            lite: { type: "boolean", default: true },
+            full_content: { type: "boolean", default: false },
+          },
         },
       },
       {
         id: "memory.search_memory",
         name: "Search Conversations",
-        description: "Search Conversations - Full-text search across conversation logs.",
+        description: "Search Conversations - search facts and sessions. Result text is capped by default; pass full_content=true for full rows.",
         method: "POST",
         path: "/v1/memory/search",
         requiresAuth: false,
@@ -1939,6 +1943,7 @@ export const CATALOG: ToolDef[] = [
           properties: {
             query: { type: "string" },
             max_results: { type: "number", minimum: 1, maximum: 50, default: 10 },
+            full_content: { type: "boolean", default: false },
           },
           required: ["query"],
         },

--- a/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
@@ -1,0 +1,74 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  compactSearchMemoryForStrictClients,
+  compactStartupContextForStrictClients,
+} from "../handlers.js";
+
+const long = (prefix: string, size: number) => `${prefix} ${"x".repeat(size)}`;
+
+describe("strict-client memory response bounds", () => {
+  test("load_memory compact mode skips session bodies and keeps payload small", () => {
+    const raw = {
+      business_context: Array.from({ length: 20 }, (_, i) => ({
+        category: "rule",
+        key: `rule-${i}`,
+        value: long("business", 2000),
+        priority: i,
+      })),
+      knowledge_library_index: Array.from({ length: 20 }, (_, i) => ({
+        slug: `doc-${i}`,
+        title: long("title", 300),
+        category: "docs",
+        tags: ["alpha", "beta", long("tag", 500)],
+        content: long("body", 5000),
+        updated_at: "2026-04-28T00:00:00Z",
+      })),
+      recent_sessions: Array.from({ length: 5 }, (_, i) => ({
+        session_id: `s-${i}`,
+        platform: "chatgpt",
+        summary: long("summary", 4000),
+        decisions: [long("decision", 500)],
+        open_loops: [long("loop", 500)],
+        topics: [long("topic", 500)],
+        created_at: "2026-04-28T00:00:00Z",
+      })),
+      active_facts: Array.from({ length: 50 }, (_, i) => ({
+        fact: long(`fact-${i}`, 1000),
+        category: "general",
+        confidence: 1,
+        created_at: "2026-04-28T00:00:00Z",
+      })),
+    };
+
+    const compact = compactStartupContextForStrictClients(raw);
+    const text = JSON.stringify(compact);
+    assert.ok(text.length < 8000, `payload was ${text.length} chars`);
+    assert.equal((compact as { recent_sessions: unknown[] }).recent_sessions.length, 0);
+  });
+
+  test("load_memory non-lite mode returns truncated session summaries", () => {
+    const compact = compactStartupContextForStrictClients({
+      recent_sessions: [{ session_id: "s-1", summary: long("summary", 4000) }],
+    }, true) as { recent_sessions: Array<{ summary: string }> };
+
+    assert.equal(compact.recent_sessions.length, 1);
+    assert.ok(compact.recent_sessions[0].summary.length < 500);
+    assert.match(compact.recent_sessions[0].summary, /truncated/);
+  });
+
+  test("search_memory caps content previews by default", () => {
+    const compact = compactSearchMemoryForStrictClients(
+      Array.from({ length: 10 }, (_, i) => ({
+        id: `r-${i}`,
+        source: "session",
+        content: long("content", 5000),
+      }))
+    );
+
+    const text = JSON.stringify(compact);
+    assert.ok(text.length < 12000, `payload was ${text.length} chars`);
+    assert.match((compact as Array<{ content: string }>)[0].content, /truncated/);
+  });
+});

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -38,16 +38,110 @@ function bool(v: unknown, fallback = false): boolean {
   return typeof v === "boolean" ? v : fallback;
 }
 
+function capText(text: string, max: number): string {
+  return text.length > max
+    ? `${text.slice(0, max)}...[truncated, call search_memory for full]`
+    : text;
+}
+
+function compactJsonValue(value: unknown, max = 500): unknown {
+  if (typeof value === "string") return capText(value, max);
+  if (value === null || typeof value !== "object") return value;
+  const serialized = JSON.stringify(value);
+  return serialized.length > max ? capText(serialized, max) : value;
+}
+
+function compactStringArray(value: unknown, limit = 5, max = 120): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.slice(0, limit).map((item) => capText(String(item), max));
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function compactStartupContextForStrictClients(
+  value: unknown,
+  includeSessionSummaries = false
+): unknown {
+  const context = asRecord(value);
+  if (!context) return value;
+
+  const out: Record<string, unknown> = { ...context };
+  const business = Array.isArray(context.business_context) ? context.business_context : [];
+  const library = Array.isArray(context.knowledge_library_index) ? context.knowledge_library_index : [];
+  const sessions = Array.isArray(context.recent_sessions) ? context.recent_sessions : [];
+  const facts = Array.isArray(context.active_facts) ? context.active_facts : [];
+
+  out.business_context = business.slice(0, 6).map((row) => {
+    const r = asRecord(row) ?? {};
+    return { category: r.category, key: r.key, value: compactJsonValue(r.value, 250), priority: r.priority };
+  });
+  out.knowledge_library_index = library.slice(0, 6).map((row) => {
+    const r = asRecord(row) ?? {};
+    return { slug: r.slug, title: typeof r.title === "string" ? capText(r.title, 120) : r.title, category: r.category, tags: compactStringArray(r.tags, 4, 50), updated_at: r.updated_at };
+  });
+  out.recent_sessions = includeSessionSummaries
+    ? sessions.slice(0, 3).map((row) => {
+        const r = asRecord(row) ?? {};
+        return {
+          session_id: r.session_id,
+          platform: r.platform,
+          summary: typeof r.summary === "string" ? capText(r.summary, 350) : r.summary,
+          decisions: compactStringArray(r.decisions),
+          open_loops: compactStringArray(r.open_loops),
+          topics: compactStringArray(r.topics),
+          created_at: r.created_at,
+        };
+      })
+    : [];
+  out.active_facts = facts.slice(0, 12).map((row) => {
+    const r = asRecord(row) ?? {};
+    return { fact: typeof r.fact === "string" ? capText(r.fact, 140) : r.fact, category: r.category, confidence: r.confidence, created_at: r.created_at };
+  });
+  out.response_bounds = {
+    compact: true,
+    business_context_returned: Math.min(business.length, 6),
+    knowledge_library_returned: Math.min(library.length, 6),
+    recent_sessions_returned: includeSessionSummaries ? Math.min(sessions.length, 3) : 0,
+    recent_sessions_available_in_loaded_window: sessions.length,
+    active_facts_returned: Math.min(facts.length, 12),
+    active_facts_available_in_loaded_window: facts.length,
+  };
+  return out;
+}
+
+export function compactSearchMemoryForStrictClients(value: unknown): unknown {
+  if (!Array.isArray(value)) return value;
+  return value.map((row) => {
+    const r = asRecord(row);
+    if (!r) return row;
+    const out = { ...r };
+    for (const key of ["content", "summary", "fact"]) {
+      if (typeof out[key] === "string") out[key] = capText(out[key] as string, 800);
+    }
+    return out;
+  });
+}
+
 export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> = {
   async get_startup_context(args) {
     const db = await getBackend();
     const slug = typeof args.agent_slug === "string" ? args.agent_slug : undefined;
     const id = typeof args.agent_id === "string" ? args.agent_id : undefined;
+    const fullContent = bool(args.full_content, false);
+    const lite = bool(args.lite, true);
+    const sessionCount = fullContent ? num(args.num_sessions, 5) : Math.min(num(args.num_sessions, 3), 3);
 
     const [baseContext, resolved] = await Promise.all([
-      db.getStartupContext(num(args.num_sessions, 5)),
+      db.getStartupContext(sessionCount),
       resolveAgent({ agent_slug: slug, agent_id: id }),
     ]);
+    const boundedContext = fullContent
+      ? baseContext
+      : compactStartupContextForStrictClients(baseContext, !lite);
 
     // Optional: if the client passed the list of other tools in this session,
     // classify them and attach tool_guidance so the agent can nudge the user.
@@ -63,11 +157,11 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
     }
 
     if (!resolved) {
-      if (tool_guidance === undefined) return baseContext;
-      return { ...(baseContext as Record<string, unknown>), tool_guidance };
+      if (tool_guidance === undefined) return boundedContext;
+      return { ...(boundedContext as Record<string, unknown>), tool_guidance };
     }
 
-    const scoped = filterContextByLayers(baseContext, resolved.enabled_memory_layers);
+    const scoped = filterContextByLayers(boundedContext, resolved.enabled_memory_layers);
     const result: Record<string, unknown> = {
       agent: {
         id: resolved.agent.id,
@@ -75,7 +169,7 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
         name: resolved.agent.name,
         role: resolved.agent.role,
         description: resolved.agent.description,
-        system_prompt: resolved.agent.system_prompt,
+        system_prompt: fullContent ? resolved.agent.system_prompt : capText(resolved.agent.system_prompt ?? "", 1000),
         is_default: resolved.agent.is_default,
       },
       enabled_tools: resolved.enabled_tools,
@@ -92,12 +186,15 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
     const asOf = typeof args.as_of === "string" ? args.as_of : undefined;
     const query = str(args.query);
     const results = await db.searchMemory(query, num(args.max_results, 10), asOf);
+    const boundedResults = bool(args.full_content, false)
+      ? results
+      : compactSearchMemoryForStrictClients(results);
     // Phase 1 Wizard wrap: opt-in card alongside the existing array payload.
     // Defaults off to keep backward compatibility for current consumers.
     if (bool(args.include_card, false)) {
-      return { results, card: buildSearchMemoryCard(query, results) };
+      return { results: boundedResults, card: buildSearchMemoryCard(query, boundedResults) };
     }
-    return results;
+    return boundedResults;
   },
 
   async search_facts(args) {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -235,6 +235,7 @@ const VISIBLE_TOOLS = [
     title: "Load memory",
     description:
       "Loads the user's identity, preferences, facts, and recent session history from persistent cross-session storage. " +
+      "Default output is compact for strict MCP clients; call search_memory for narrow questions or pass full_content=true only when the full raw payload is required. " +
       "Use IMMEDIATELY at the start of every session -- before responding to the user's first message, before calling any other tool. " +
       "Trigger even when the opening message looks trivial: keywords like 'remember', 'recall', 'context', 'profile', " +
       "'facts about me', 'who am I', 'last time', 'preferences', 'pick up where we left off' all signal stored context exists. " +
@@ -246,8 +247,18 @@ const VISIBLE_TOOLS = [
       properties: {
         num_sessions: {
           type: "number",
-          description: "Number of recent session summaries to load (1-20, default 5)",
-          default: 5,
+          description: "Number of recent session summaries to load when lite=false (1-20, default 3)",
+          default: 3,
+        },
+        lite: {
+          type: "boolean",
+          description: "When true, skips session summary bodies and returns compact identity, facts, and counts (default true)",
+          default: true,
+        },
+        full_content: {
+          type: "boolean",
+          description: "When true, returns the full raw memory payload. Use sparingly; strict clients may reject large tool results.",
+          default: false,
         },
       },
     },
@@ -287,6 +298,7 @@ const VISIBLE_TOOLS = [
     title: "Search memory",
     description:
       "Searches the user's stored facts and session history using hybrid semantic + keyword retrieval. " +
+      "Result content is capped to keep strict MCP clients under response limits; pass full_content=true only when the full matching row is required. " +
       "Use whenever the user asks about anything that might be stored: 'remember', 'recall', 'do you know', " +
       "'what did I say about', 'last time', 'context', 'profile', 'facts about me', 'who am I', 'my preferences', " +
       "'what have I told you', or when you need background on a topic before answering. " +
@@ -300,6 +312,11 @@ const VISIBLE_TOOLS = [
         query: { type: "string", description: "Search query" },
         max_results: { type: "number", minimum: 1, maximum: 50, default: 10 },
         as_of: { type: "string", description: "ISO 8601 timestamp for point-in-time queries (returns facts valid at that moment)" },
+        full_content: {
+          type: "boolean",
+          description: "When true, returns full result content instead of 800-character previews. Use sparingly for strict clients.",
+          default: false,
+        },
         include_card: {
           type: "boolean",
           default: false,


### PR DESCRIPTION
## Summary
- compact load_memory by default for strict MCP clients, with lite/full_content controls
- cap search_memory result text by default, with full_content escape hatch
- update MCP tool/catalog schemas and add response-bound tests

## Tests
- npm run build --workspace=packages/mcp-server
- npm test --workspace=packages/mcp-server
- git diff --check