### PR TITLE
fix(testpass): preserve falsy expected in healer

### DIFF
--- a/packages/testpass/src/__tests__/healer.test.ts
+++ b/packages/testpass/src/__tests__/healer.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { healFailedChecks } from "../runner/healer.js";
+import type { JudgeSampler } from "../runner/agent.js";
+import type { Pack } from "../types.js";
+
+describe("healFailedChecks", () => {
+  const originalFetch = globalThis.fetch;
+  const config = { supabaseUrl: "https://supabase.test", serviceRoleKey: "service-key" };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("includes explicit falsy expected values in the healer prompt", async () => {
+    const userPrompts: string[] = [];
+    const fetchMock = jest.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (method === "GET" && url.includes("testpass_items")) {
+        return {
+          ok: true,
+          json: async () => [
+            { check_id: "NULL" },
+            { check_id: "FALSE" },
+            { check_id: "ZERO" },
+            { check_id: "EMPTY" },
+          ],
+        } as Response;
+      }
+      return {
+        ok: true,
+        text: async () => JSON.stringify([{ id: "evidence-1" }]),
+      } as Response;
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const sampler: JudgeSampler = async ({ user }) => {
+      userPrompts.push(user);
+      return { text: JSON.stringify({ verdict: "check", reasoning: "ok" }), model: "test-model" };
+    };
+    const pack: Pack = {
+      id: "healer-falsy-expected",
+      name: "Healer Falsy Expected",
+      version: "0.1.0",
+      description: "",
+      items: [
+        { id: "NULL", title: "null", category: "deterministic", severity: "low", check_type: "deterministic", tags: [], profiles: ["standard"], expected: null },
+        { id: "FALSE", title: "false", category: "deterministic", severity: "low", check_type: "deterministic", tags: [], profiles: ["standard"], expected: false },
+        { id: "ZERO", title: "zero", category: "deterministic", severity: "low", check_type: "deterministic", tags: [], profiles: ["standard"], expected: 0 },
+        { id: "EMPTY", title: "empty", category: "deterministic", severity: "low", check_type: "deterministic", tags: [], profiles: ["standard"], expected: "" },
+      ],
+    };
+
+    const healed = await healFailedChecks(config, "run-1", pack, sampler);
+
+    expect(healed).toBe(4);
+    expect(userPrompts).toHaveLength(4);
+    expect(userPrompts).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Expected: null"),
+        expect.stringContaining("Expected: false"),
+        expect.stringContaining("Expected: 0"),
+        expect.stringContaining('Expected: ""'),
+      ]),
+    );
+  });
+});

--- a/packages/testpass/src/runner/healer.ts
+++ b/packages/testpass/src/runner/healer.ts
@@ -71,7 +71,7 @@ export async function healFailedChecks(
         `Check ID: ${checkId}`,
         `Title: ${spec.title}`,
         spec.description ? `Description: ${spec.description}` : null,
-        spec.expected ? `Expected: ${JSON.stringify(spec.expected)}` : null,
+        spec.expected !== undefined ? `Expected: ${JSON.stringify(spec.expected)}` : null,
         spec.on_fail ? `On fail guidance: ${spec.on_fail}` : null,
       ].filter(Boolean) as string[];
 


### PR DESCRIPTION
## Summary
- match the runner prompt fix in the healer retry path
- include explicit null/false/0/empty-string expected values in healer prompts
- add a focused healer regression test

## Tests
- npm run build --workspace=packages/testpass
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath packages/testpass/src/__tests__/agent.test.ts packages/testpass/src/__tests__/healer.test.ts --config packages/testpass/package.json
- git diff --check