### PR TITLE
fix(testpass): cron actor fallback for system packs

### DIFF
--- a/api/testpass-run.ts
+++ b/api/testpass-run.ts
@@ -119,8 +119,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const packRow = await getPackIdBySlug(supabaseUrl, serviceKey, packSlug);
   if (!packRow) return json(res, 404, { error: `Pack '${packSlug}' not found` });
 
-  const actorUserId = isCron ? packRow.owner_user_id : await getActorUserId(supabaseUrl, token);
-  if (!actorUserId) return json(res, 401, { error: "Invalid session" });
+  let actorUserId: string | null;
+  if (isCron) {
+    actorUserId = packRow.owner_user_id ?? process.env.TESTPASS_CRON_USER_ID ?? null;
+    if (!actorUserId) {
+      return json(res, 500, {
+        error:
+          "TESTPASS_CRON_USER_ID env var is not set; cron runs against system packs (owner_user_id NULL) cannot attribute runs to a user.",
+      });
+    }
+  } else {
+    actorUserId = await getActorUserId(supabaseUrl, token);
+    if (!actorUserId) return json(res, 401, { error: "Invalid session" });
+  }
 
   const packPath = path.resolve(__dirname, `../packages/testpass/packs/${packSlug}.yaml`);
   let pack;


### PR DESCRIPTION
## Summary
- Vercel cron for `/api/testpass-run` (added in PR #209) has been firing but immediately 401'ing because the seeded `testpass-core` pack is a system pack with `owner_user_id NULL`. The cron path uses `packRow.owner_user_id` as the run actor, so it short-circuits at the "Invalid session" check and never reaches `createRun`.
- Mirror the UXPass pattern: fall back to a `TESTPASS_CRON_USER_ID` env var when the pack has no owner. Returns a clear 500 if neither is set.
- This explains the gap: `max(started_at)` in `testpass_runs` stuck at 2026-04-26 07:41:36Z. PR runs from the GitHub Action also stopped landing rows around then, but that's a separate issue (stale `TESTPASS_TOKEN` secret) and the action workflow swallows infra failures via `continue-on-error: true` + `failure_kind` filtering, so green checks have been masking 401s.

## After merge
1. Set `TESTPASS_CRON_USER_ID` in Vercel env to a real `auth.users.id` (same shape as `UXPASS_CRON_USER_ID`).
2. Wait one 6-hour interval and confirm a fresh row appears in `testpass_runs`.
3. Separately, refresh the `TESTPASS_TOKEN` repo secret to restore PR-triggered runs (or switch the action to use `CRON_SECRET` against the same handler).

## Test plan
- [ ] After merge, set `TESTPASS_CRON_USER_ID` in Vercel
- [ ] Confirm a fresh `testpass_runs` row at the next cron tick
- [ ] Confirm `actor_user_id` on the new row matches the configured env value

🤖 Generated with [Claude Code](https://claude.com/claude-code)