### PR TITLE
feat(idempotency): client-generated task_id for run-creating tools

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5238,13 +5238,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
         await ensureStarterCrews(supabase, apiKeyHash);
-        const { crew_id, task_prompt, token_budget } = (req.body ?? {}) as {
+        const { crew_id, task_prompt, token_budget, task_id } = (req.body ?? {}) as {
           crew_id?: string;
           task_prompt?: string;
           token_budget?: number;
+          task_id?: string;
         };
         if (!crew_id || !task_prompt?.trim()) {
           return res.status(400).json({ error: "crew_id and task_prompt required" });
+        }
+        const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+        let normalizedTaskId: string | undefined;
+        if (task_id !== undefined && task_id !== null && task_id !== "") {
+          if (typeof task_id !== "string" || !UUID_RE.test(task_id)) {
+            return res.status(400).json({ error: "task_id must be a UUID (v1-v5, recommended v5)" });
+          }
+          normalizedTaskId = task_id.toLowerCase();
         }
         const { data: crewRow, error: crewErr } = await supabase
           .from("mc_crews")
@@ -5259,42 +5268,81 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         // User-facing runs now route LLM traffic through MCP sampling. The HTTP
         // path cannot do bidirectional sampling, so we create the run row for
         // bookkeeping and return a card asking the caller to re-run via MCP.
+        const insertPayload: Record<string, unknown> = {
+          api_key_hash: apiKeyHash,
+          crew_id,
+          task_prompt: task_prompt.trim(),
+          token_budget: token_budget ?? 150000,
+          status: "failed",
+          result_artifact: {
+            error: "SAMPLING_NOT_SUPPORTED",
+            message:
+              "Orchestrator does not support sampling. Use Claude Desktop or another sampling-capable client.",
+          },
+          completed_at: new Date().toISOString(),
+        };
+        if (normalizedTaskId) insertPayload.task_id = normalizedTaskId;
         const { data: runRow, error: runErr } = await supabase
           .from("mc_crew_runs")
-          .insert({
-            api_key_hash: apiKeyHash,
-            crew_id,
-            task_prompt: task_prompt.trim(),
-            token_budget: token_budget ?? 150000,
-            status: "failed",
-            result_artifact: {
-              error: "SAMPLING_NOT_SUPPORTED",
-              message:
-                "Orchestrator does not support sampling. Use Claude Desktop or another sampling-capable client.",
-            },
-            completed_at: new Date().toISOString(),
-          })
+          .insert(insertPayload)
           .select()
           .single();
-        if (runErr) throw runErr;
+        // 23505 = unique_violation against (api_key_hash, task_id) partial index.
+        // Look up the original row, return it with was_duplicate=true so the
+        // caller can short-circuit duplicate dispatch (MCP SEP-1686).
+        let resolvedRunId: string;
+        let wasDuplicate = false;
+        if (runErr) {
+          const errCode = (runErr as { code?: string }).code;
+          if (normalizedTaskId && errCode === "23505") {
+            const { data: existing } = await supabase
+              .from("mc_crew_runs")
+              .select("id")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("task_id", normalizedTaskId)
+              .maybeSingle();
+            if (existing?.id) {
+              console.log(
+                `[duplicate_dispatch_avoided] table=mc_crew_runs task_id=${normalizedTaskId} run_id=${existing.id}`,
+              );
+              resolvedRunId = existing.id;
+              wasDuplicate = true;
+            } else {
+              throw runErr;
+            }
+          } else {
+            throw runErr;
+          }
+        } else {
+          resolvedRunId = runRow.id;
+        }
         const card: ConversationalCard = buildCard({
-          headline: "Crews Council run needs MCP sampling",
-          summary:
-            "This HTTP endpoint cannot run a Council round because LLM traffic now flows through MCP sampling. Start the run from a sampling-capable client (e.g. Claude Desktop) using the start_crew_run MCP tool.",
+          headline: wasDuplicate
+            ? "Crews Council run already created"
+            : "Crews Council run needs MCP sampling",
+          summary: wasDuplicate
+            ? "A run with this task_id already exists for your tenant. Returning the original run_id; no new row was created."
+            : "This HTTP endpoint cannot run a Council round because LLM traffic now flows through MCP sampling. Start the run from a sampling-capable client (e.g. Claude Desktop) using the start_crew_run MCP tool.",
           keyFacts: [
-            `run_id: ${runRow.id}`,
+            `run_id: ${resolvedRunId}`,
             `crew_id: ${crew_id}`,
-            "status: failed (SAMPLING_NOT_SUPPORTED)",
+            ...(wasDuplicate
+              ? ["was_duplicate: true"]
+              : ["status: failed (SAMPLING_NOT_SUPPORTED)"]),
           ],
-          nextActions: [
-            "Install the UnClick MCP server in a sampling-capable client",
-            "Call the start_crew_run MCP tool with the same crew_id and task_prompt",
-          ],
-          deepLink: `/admin/crews/runs/${runRow.id}`,
+          nextActions: wasDuplicate
+            ? ["Call get_run with the run_id to inspect the original run"]
+            : [
+                "Install the UnClick MCP server in a sampling-capable client",
+                "Call the start_crew_run MCP tool with the same crew_id and task_prompt",
+              ],
+          deepLink: `/admin/crews/runs/${resolvedRunId}`,
         });
-        return res.status(409).json({
-          error: "SAMPLING_NOT_SUPPORTED",
-          run_id: runRow.id,
+        return res.status(wasDuplicate ? 200 : 409).json({
+          error: wasDuplicate ? undefined : "SAMPLING_NOT_SUPPORTED",
+          run_id: resolvedRunId,
+          was_duplicate: wasDuplicate,
+          task_id: normalizedTaskId ?? null,
           card,
         });
       }

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5295,6 +5295,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (runErr) {
           const errCode = (runErr as { code?: string }).code;
           if (normalizedTaskId && errCode === "23505") {
+            // STALE_RUN check intentionally omitted — relies on synchronous handler invariant.
+            // If a runner is ever made async, add a `last_heartbeat`-based stale-run gate here
+            // before returning was_duplicate=true on a still-running task_id.
             const { data: existing } = await supabase
               .from("mc_crew_runs")
               .select("id")

--- a/api/testpass-run.ts
+++ b/api/testpass-run.ts
@@ -98,15 +98,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         pack_name: queryString(req.query.pack_name),
         profile: queryString(req.query.profile) as RunProfile | undefined,
         server_url: queryString(req.query.server_url),
+        task_id: queryString(req.query.task_id),
       }
     : ((req.body ?? {}) as {
         pack_id?: string;
         pack_name?: string;
         profile?: RunProfile;
         server_url?: string;
+        task_id?: string;
       });
 
   if (!input.pack_id) return json(res, 400, { error: "pack_id required" });
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (input.task_id !== undefined && input.task_id !== "" && !UUID_RE.test(input.task_id)) {
+    return json(res, 400, { error: "task_id must be a UUID (v1-v5, recommended v5)" });
+  }
+  const taskId = input.task_id && input.task_id !== "" ? input.task_id.toLowerCase() : undefined;
 
   const profile: RunProfile = input.profile ?? "smoke";
   if (!["smoke", "standard", "deep"].includes(profile)) {
@@ -132,13 +139,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const target: RunTarget = { type: "url", url: input.server_url ?? "" };
 
-  const runId = await createRun(config, {
+  const { id: runId, was_duplicate } = await createRun(config, {
     packId: packRow.id,
     packName: input.pack_name ?? pack.name ?? packSlug,
     target,
     profile,
     actorUserId,
+    taskId,
   });
+
+  if (was_duplicate) {
+    const summary = await computeVerdictSummary(config, runId);
+    const status = summary.pending === 0 ? (summary.fail > 0 ? "failed" : "complete") : "running";
+    return json(res, 200, {
+      run_id: runId,
+      status,
+      verdict_summary: summary,
+      was_duplicate: true,
+      task_id: taskId,
+    });
+  }
 
   const runWork = async () => {
     let evidenceRef: string | undefined;
@@ -180,11 +200,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (profile === "smoke") {
     const summary = await runWork();
     const status = summary.pending === 0 ? (summary.fail > 0 ? "failed" : "complete") : "running";
-    return json(res, 200, { run_id: runId, status, verdict_summary: summary });
+    return json(res, 200, {
+      run_id: runId,
+      status,
+      verdict_summary: summary,
+      was_duplicate: false,
+      task_id: taskId ?? null,
+    });
   }
 
   runWork().catch((err) => {
     console.error(`testpass-run background work failed for ${runId}:`, (err as Error).message);
   });
-  return json(res, 202, { run_id: runId, status: "running" });
+  return json(res, 202, {
+    run_id: runId,
+    status: "running",
+    was_duplicate: false,
+    task_id: taskId ?? null,
+  });
 }

--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -178,6 +178,19 @@ interface StartRunBody {
   pack_id?: string;
   target?: RunTarget;
   profile?: RunProfile;
+  task_id?: string;
+}
+
+// Accept any canonical UUID (v1-v5). UUIDv5 is the recommended derivation but
+// strict version-pinning would needlessly reject conformant clients that pick
+// a different deterministic scheme. Bad input gets a 400 so the partial unique
+// index never sees a malformed key.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+function validateTaskId(raw: unknown): { value?: string; error?: string } {
+  if (raw === undefined || raw === null || raw === "") return {};
+  if (typeof raw !== "string") return { error: "task_id must be a string UUID" };
+  if (!UUID_RE.test(raw)) return { error: "task_id must be a UUID (v1-v5, recommended v5)" };
+  return { value: raw.toLowerCase() };
 }
 
 interface StartRunContext {
@@ -196,6 +209,9 @@ async function performStartRun(
   if (!body.pack_slug && !body.pack_id) {
     return { status: 400, payload: { error: "pack_slug or pack_id required" } };
   }
+  const taskIdCheck = validateTaskId(body.task_id);
+  if (taskIdCheck.error) return { status: 400, payload: { error: taskIdCheck.error } };
+
   const profile: RunProfile = body.profile ?? "standard";
   const slug = body.pack_slug ?? "testpass-core";
 
@@ -215,13 +231,29 @@ async function performStartRun(
   }
 
   const config = { supabaseUrl: ctx.supabaseUrl, serviceRoleKey: ctx.serviceKey };
-  const runId = await createRun(config, {
+  const { id: runId, was_duplicate } = await createRun(config, {
     packId,
     packName: pack.name ?? slug,
     target: body.target,
     profile,
     actorUserId: ctx.actorUserId,
+    taskId: taskIdCheck.value,
   });
+
+  if (was_duplicate) {
+    // Skip probe/seed/run; surface the existing row's current state so the
+    // caller can poll status as if it had submitted the original request.
+    const summary = await computeVerdictSummary(config, runId);
+    return {
+      status: 200,
+      payload: {
+        run_id: runId,
+        was_duplicate: true,
+        task_id: taskIdCheck.value,
+        summary,
+      },
+    };
+  }
 
   let evidenceRef: string | undefined;
   try {
@@ -264,7 +296,16 @@ async function performStartRun(
     summary,
   );
 
-  return { status: 201, payload: { run_id: runId, evidence_ref: evidenceRef ?? null, summary } };
+  return {
+    status: 201,
+    payload: {
+      run_id: runId,
+      evidence_ref: evidenceRef ?? null,
+      summary,
+      was_duplicate: false,
+      task_id: taskIdCheck.value ?? null,
+    },
+  };
 }
 
 async function upsertPack(
@@ -398,12 +439,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       profile?: RunProfile;
       pack_slug?: string;
       pack_id?: string;
+      task_id?: string;
     };
     const target: RunTarget | undefined = raw.target
       ?? (raw.target_url ? { type: "mcp", url: raw.target_url } : undefined);
     const result = await performStartRun(
       { supabaseUrl, serviceKey, actorUserId },
-      { target, profile: raw.profile, pack_slug: raw.pack_slug, pack_id: raw.pack_id },
+      { target, profile: raw.profile, pack_slug: raw.pack_slug, pack_id: raw.pack_id, task_id: raw.task_id },
     );
     return json(res, result.status, result.payload);
   }

--- a/api/uxpass-run.ts
+++ b/api/uxpass-run.ts
@@ -87,8 +87,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const input = req.method === "GET"
     ? {
         url: queryString(req.query.url) ?? queryString(req.query.target_url),
+        task_id: queryString(req.query.task_id),
       }
-    : ((req.body ?? {}) as { url?: string; target_url?: string });
+    : ((req.body ?? {}) as { url?: string; target_url?: string; task_id?: string });
 
   const targetUrl = input.url ?? input.target_url ?? "";
   if (!targetUrl) return json(res, 400, { error: "url required" });
@@ -103,14 +104,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return json(res, 400, { error: "url must use http or https" });
   }
 
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (input.task_id !== undefined && input.task_id !== "" && !UUID_RE.test(input.task_id)) {
+    return json(res, 400, { error: "task_id must be a UUID (v1-v5, recommended v5)" });
+  }
+  const taskId = input.task_id && input.task_id !== "" ? input.task_id.toLowerCase() : undefined;
+
   const config = { supabaseUrl, serviceRoleKey: serviceKey };
-  const runId = await createRun(config, {
+  const { id: runId, was_duplicate } = await createRun(config, {
     targetUrl,
     actorUserId,
     hats: CORE_HATS,
     viewports: ["desktop"],
     themes: ["light"],
+    taskId,
   });
+
+  if (was_duplicate) {
+    const lookup = await fetch(
+      `${supabaseUrl}/rest/v1/uxpass_runs?id=eq.${runId}&actor_user_id=eq.${actorUserId}&select=status,ux_score,target_url,breakdown&limit=1`,
+      { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } },
+    );
+    const rows = (await lookup.json()) as Array<{
+      status?: string;
+      ux_score?: number | null;
+      target_url?: string;
+      breakdown?: unknown;
+    }>;
+    const existing = rows[0] ?? {};
+    return json(res, 200, {
+      run_id: runId,
+      was_duplicate: true,
+      task_id: taskId,
+      status: existing.status ?? "running",
+      ux_score: existing.ux_score ?? null,
+      target_url: existing.target_url ?? targetUrl,
+      stats: existing.breakdown ?? {},
+    });
+  }
 
   try {
     const result = await runDeterministicChecks(config, runId, targetUrl);
@@ -120,11 +151,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ux_score: result.uxScore,
       target_url: targetUrl,
       stats: result.stats,
+      was_duplicate: false,
+      task_id: taskId ?? null,
     });
   } catch (err) {
     return json(res, 500, {
       run_id: runId,
       error: `runner failed: ${(err as Error).message}`,
+      was_duplicate: false,
+      task_id: taskId ?? null,
     });
   }
 }

--- a/api/uxpass.ts
+++ b/api/uxpass.ts
@@ -98,6 +98,15 @@ interface StartRunBody {
   url?: string;
   target?: { type?: string; url?: string };
   pack_slug?: string;
+  task_id?: string;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+function validateTaskId(raw: unknown): { value?: string; error?: string } {
+  if (raw === undefined || raw === null || raw === "") return {};
+  if (typeof raw !== "string") return { error: "task_id must be a string UUID" };
+  if (!UUID_RE.test(raw)) return { error: "task_id must be a UUID (v1-v5, recommended v5)" };
+  return { value: raw.toLowerCase() };
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -187,13 +196,41 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return json(res, 400, { error: "url must use http or https" });
     }
 
-    const runId = await createRun(config, {
+    const taskIdCheck = validateTaskId(body.task_id);
+    if (taskIdCheck.error) return json(res, 400, { error: taskIdCheck.error });
+
+    const { id: runId, was_duplicate } = await createRun(config, {
       targetUrl,
       actorUserId,
       hats: CORE_HATS,
       viewports: ["desktop"],
       themes: ["light"],
+      taskId: taskIdCheck.value,
     });
+
+    if (was_duplicate) {
+      // Skip re-running checks; surface the existing row's current state.
+      const lookup = await fetch(
+        `${supabaseUrl}/rest/v1/uxpass_runs?id=eq.${runId}&actor_user_id=eq.${actorUserId}&select=status,ux_score,target_url,breakdown&limit=1`,
+        { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } },
+      );
+      const rows = (await lookup.json()) as Array<{
+        status?: string;
+        ux_score?: number | null;
+        target_url?: string;
+        breakdown?: unknown;
+      }>;
+      const existing = rows[0] ?? {};
+      return json(res, 200, {
+        run_id: runId,
+        was_duplicate: true,
+        task_id: taskIdCheck.value,
+        status: existing.status ?? "running",
+        ux_score: existing.ux_score ?? null,
+        target_url: existing.target_url ?? targetUrl,
+        stats: existing.breakdown ?? {},
+      });
+    }
 
     try {
       const result = await runDeterministicChecks(config, runId, targetUrl);
@@ -203,11 +240,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         ux_score: result.uxScore,
         target_url: targetUrl,
         stats: result.stats,
+        was_duplicate: false,
+        task_id: taskIdCheck.value ?? null,
       });
     } catch (err) {
       return json(res, 500, {
         run_id: runId,
         error: `runner failed: ${(err as Error).message}`,
+        was_duplicate: false,
+        task_id: taskIdCheck.value ?? null,
       });
     }
   }

--- a/docs/migrations-pending/20260428200000_idempotent_task_ids.sql
+++ b/docs/migrations-pending/20260428200000_idempotent_task_ids.sql
@@ -1,0 +1,35 @@
+-- Idempotent task IDs for run-creating tools (MCP SEP-1686 pattern).
+--
+-- Adds an optional, client-generated `task_id` to the three run-creating
+-- tables and enforces uniqueness PER ACTOR via a partial unique index. The
+-- index is partial so historical rows (where task_id is NULL) do not all
+-- collide on a single NULL value. The index is compound (actor + task_id)
+-- so that a UUIDv5 collision across two different actors is treated as
+-- two distinct rows, not a 23505 leaked across tenants.
+--
+-- This file lives outside supabase/migrations/ on purpose. The repo's
+-- apply-migrations workflow had a 4-day silent failure that PR #229 just
+-- unblocked, so this migration is intended to be applied via Supabase
+-- MCP `apply_migration` rather than the file-based workflow. After it
+-- lands in production, the file may be moved into supabase/migrations/
+-- (or deleted) at the maintainer's discretion.
+
+-- ── testpass_runs ───────────────────────────────────────────────────────────
+alter table testpass_runs add column if not exists task_id text;
+create unique index if not exists testpass_runs_task_id_actor_uniq
+  on testpass_runs(actor_user_id, task_id)
+  where task_id is not null;
+
+-- ── uxpass_runs ─────────────────────────────────────────────────────────────
+alter table uxpass_runs add column if not exists task_id text;
+create unique index if not exists uxpass_runs_task_id_actor_uniq
+  on uxpass_runs(actor_user_id, task_id)
+  where task_id is not null;
+
+-- ── mc_crew_runs ────────────────────────────────────────────────────────────
+-- mc_crew_runs is API-key-scoped (api_key_hash) rather than user-scoped, so
+-- the compound key uses api_key_hash for the same defense-in-depth purpose.
+alter table mc_crew_runs add column if not exists task_id text;
+create unique index if not exists mc_crew_runs_task_id_tenant_uniq
+  on mc_crew_runs(api_key_hash, task_id)
+  where task_id is not null;

--- a/packages/mcp-server/src/crews-tool.ts
+++ b/packages/mcp-server/src/crews-tool.ts
@@ -42,12 +42,19 @@ async function adminCall(
   return { ok: res.ok, status: res.status, json };
 }
 
-type AdminCard = { card?: ConversationalCard; error?: string; message?: string; run_id?: string };
+type AdminCard = {
+  card?: ConversationalCard;
+  error?: string;
+  message?: string;
+  run_id?: string;
+  was_duplicate?: boolean;
+};
 
 export async function crewsStartRun(args: Record<string, unknown>): Promise<ConversationalCard> {
   const crewId = String(args.crew_id ?? "").trim();
   const taskPrompt = String(args.task_prompt ?? "").trim();
   const tokenBudget = typeof args.token_budget === "number" ? args.token_budget : undefined;
+  const taskId = typeof args.task_id === "string" && args.task_id ? args.task_id : undefined;
   if (!crewId) {
     return buildCard({
       headline: "start_crew_run needs a crew_id",
@@ -66,6 +73,7 @@ export async function crewsStartRun(args: Record<string, unknown>): Promise<Conv
   }
   const body: Record<string, unknown> = { crew_id: crewId, task_prompt: taskPrompt };
   if (tokenBudget) body.token_budget = tokenBudget;
+  if (taskId) body.task_id = taskId;
   const { ok, status, json } = await adminCall("start_crew_run", body, "POST");
   const payload = (json ?? {}) as AdminCard;
   if (payload.card) return payload.card;
@@ -81,9 +89,14 @@ export async function crewsStartRun(args: Record<string, unknown>): Promise<Conv
     });
   }
   return buildCard({
-    headline: "Crews run accepted",
-    summary: "The run row was created. Poll get_run to follow progress.",
-    keyFacts: payload.run_id ? [`run_id: ${payload.run_id}`] : [],
+    headline: payload.was_duplicate ? "Crews run already exists" : "Crews run accepted",
+    summary: payload.was_duplicate
+      ? "A run with this task_id already exists for your tenant. Returning the original run_id; no new row was created."
+      : "The run row was created. Poll get_run to follow progress.",
+    keyFacts: [
+      ...(payload.run_id ? [`run_id: ${payload.run_id}`] : []),
+      ...(payload.was_duplicate ? ["was_duplicate: true"] : []),
+    ],
     nextActions: ["Call get_run with the run_id to check status"],
     deepLink: payload.run_id ? `/admin/crews/runs/${payload.run_id}` : undefined,
   });

--- a/packages/mcp-server/src/testpass-tool.ts
+++ b/packages/mcp-server/src/testpass-tool.ts
@@ -20,20 +20,23 @@ export async function testpassRun(args: Record<string, unknown>): Promise<unknow
   const targetUrl = String(args.target_url ?? "");
   const packId = String(args.pack_id ?? "testpass-core");
   const profile = String(args.profile ?? "smoke");
+  const taskId = typeof args.task_id === "string" && args.task_id ? args.task_id : undefined;
   if (!targetUrl) return { error: "target_url is required" };
 
   const apiKey = getApiKey();
+  const requestBody: Record<string, unknown> = {
+    pack_slug: packId,
+    target: { type: "mcp", url: targetUrl },
+    profile,
+  };
+  if (taskId) requestBody.task_id = taskId;
   const res = await fetch(`${API_BASE}/api/testpass?action=start_run`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
-    body: JSON.stringify({
-      pack_slug: packId,
-      target: { type: "mcp", url: targetUrl },
-      profile,
-    }),
+    body: JSON.stringify(requestBody),
   });
   const text = await res.text();
   let body: unknown = text;

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -11077,13 +11077,17 @@ export const ADDITIONAL_TOOLS = [
   // ── testpass-tool.ts ────────────────────────────────────────────────────────
   {
     name: "testpass_run",
-    description: "Start a TestPass run against an MCP server. Seeds deterministic and agent checks from the given pack and returns the run id plus an initial verdict summary.",
+    description: "Start a TestPass run against an MCP server. Seeds deterministic and agent checks from the given pack and returns the run id plus an initial verdict summary. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry).",
     inputSchema: {
       type: "object" as const,
       properties: {
         target_url: { type: "string", description: "HTTP URL of the MCP server to test" },
         pack_id: { type: "string", description: "Pack slug (default: testpass-core)" },
         profile: { type: "string", enum: ["smoke", "standard", "deep"], description: "Run profile (default: smoke)" },
+        task_id: {
+          type: "string",
+          description: "Client-generated idempotency key (UUIDv5 from thread_id + prompt_hash + time_bucket recommended). Required for safe retry. If omitted, the server creates a fresh row and you lose retry safety; sending the same task_id twice returns the original run_id with was_duplicate=true instead of creating a duplicate.",
+        },
       },
       required: ["target_url"],
     },
@@ -11129,7 +11133,7 @@ export const ADDITIONAL_TOOLS = [
   // ── uxpass-tool.ts (UI/UX QC, sister to TestPass) ──────────────────────────
   {
     name: "uxpass_run",
-    description: "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk.",
+    description: "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry).",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -11139,6 +11143,10 @@ export const ADDITIONAL_TOOLS = [
           type: "array",
           items: { type: "string" },
           description: "Reserved for future use. Currently ignored; the deterministic runner evaluates the full uxpass-core check set on every run.",
+        },
+        task_id: {
+          type: "string",
+          description: "Client-generated idempotency key (UUIDv5 from thread_id + prompt_hash + time_bucket recommended). Required for safe retry. If omitted, the server creates a fresh row and you lose retry safety; sending the same task_id twice returns the original run_id with was_duplicate=true instead of creating a duplicate.",
         },
       },
     },
@@ -11202,13 +11210,17 @@ export const ADDITIONAL_TOOLS = [
   // ── crews-tool.ts (Orchestrator Wizard) ──────────────────────────────────────
   {
     name: "start_crew_run",
-    description: "Call this tool when the user wants to start a Crews Council run. Creates the run row on the UnClick API and returns a ConversationalCard with next actions. LLM turns are expected to flow through MCP sampling; if the Orchestrator does not support sampling the card reports SAMPLING_NOT_SUPPORTED.",
+    description: "Call this tool when the user wants to start a Crews Council run. Creates the run row on the UnClick API and returns a ConversationalCard with next actions. LLM turns are expected to flow through MCP sampling; if the Orchestrator does not support sampling the card reports SAMPLING_NOT_SUPPORTED. Response card surfaces was_duplicate when an existing run is returned for an already-seen task_id.",
     inputSchema: {
       type: "object" as const,
       properties: {
         crew_id: { type: "string", description: "The UUID of the Crew to run" },
         task_prompt: { type: "string", description: "The task the Council should deliberate on" },
         token_budget: { type: "number", description: "Optional token budget (default 150000)" },
+        task_id: {
+          type: "string",
+          description: "Client-generated idempotency key (UUIDv5 from thread_id + prompt_hash + time_bucket recommended). Required for safe retry. If omitted, the server creates a fresh row and you lose retry safety; sending the same task_id twice returns the original run_id with was_duplicate=true instead of creating a duplicate.",
+        },
       },
       required: ["crew_id", "task_prompt"],
     },

--- a/packages/mcp-server/src/uxpass-tool.ts
+++ b/packages/mcp-server/src/uxpass-tool.ts
@@ -82,6 +82,7 @@ function safeFilename(name: string): string {
 export async function uxpassRun(args: Record<string, unknown>): Promise<unknown> {
   const url = typeof args.url === "string" ? args.url : undefined;
   const packName = typeof args.pack_name === "string" ? args.pack_name : undefined;
+  const taskId = typeof args.task_id === "string" && args.task_id ? args.task_id : undefined;
 
   if (!url && !packName) {
     return { error: "Either url or pack_name is required" };
@@ -105,9 +106,11 @@ export async function uxpassRun(args: Record<string, unknown>): Promise<unknown>
     }
   }
 
+  const body: Record<string, unknown> = { target_url: targetUrl, pack_slug: "uxpass-core" };
+  if (taskId) body.task_id = taskId;
   return callApi("?action=start_run", {
     method: "POST",
-    body: { target_url: targetUrl, pack_slug: "uxpass-core" },
+    body,
   });
 }
 

--- a/packages/testpass/src/__tests__/run-manager.test.ts
+++ b/packages/testpass/src/__tests__/run-manager.test.ts
@@ -21,7 +21,7 @@ describe("run-manager", () => {
     });
     globalThis.fetch = fetchMock as typeof fetch;
 
-    const runId = await createRun(
+    const result = await createRun(
       { supabaseUrl: "https://supabase.test", serviceRoleKey: "service-key" },
       {
         packId: "pack-id-1",
@@ -32,7 +32,109 @@ describe("run-manager", () => {
       },
     );
 
-    expect(runId).toBe("run-id-1");
+    expect(result.id).toBe("run-id-1");
+    expect(result.was_duplicate).toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns was_duplicate=false when no task_id is supplied", async () => {
+    const fetchMock = jest.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify([{ id: "run-fresh" }]),
+    } as Response));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await createRun(
+      { supabaseUrl: "https://supabase.test", serviceRoleKey: "service-key" },
+      {
+        packId: "pack-id-1",
+        target: { type: "url", url: "https://example.com" },
+        profile: "smoke",
+        actorUserId: "user-1",
+      },
+    );
+
+    expect(result.was_duplicate).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns was_duplicate=true when the same task_id collides with an existing row", async () => {
+    const taskId = "550e8400-e29b-51d4-a716-446655440000";
+    let call = 0;
+    const fetchMock = jest.fn(async (url: string, init?: RequestInit) => {
+      call++;
+      if (call === 1) {
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        expect(body.task_id).toBe(taskId);
+        return {
+          ok: false,
+          status: 409,
+          text: async () =>
+            JSON.stringify({ code: "23505", message: "duplicate key value violates unique constraint" }),
+        } as Response;
+      }
+      // second call: lookup of existing row
+      expect(url).toContain(`task_id=eq.${taskId}`);
+      expect(url).toContain("actor_user_id=eq.user-1");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [{ id: "existing-run-id" }],
+      } as unknown as Response;
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await createRun(
+      { supabaseUrl: "https://supabase.test", serviceRoleKey: "service-key" },
+      {
+        packId: "pack-id-1",
+        target: { type: "url", url: "https://example.com" },
+        profile: "smoke",
+        actorUserId: "user-1",
+        taskId,
+      },
+    );
+
+    expect(result.id).toBe("existing-run-id");
+    expect(result.was_duplicate).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates two distinct rows when two different task_ids are submitted", async () => {
+    const taskA = "aaaaaaaa-aaaa-5aaa-aaaa-aaaaaaaaaaaa";
+    const taskB = "bbbbbbbb-bbbb-5bbb-9bbb-bbbbbbbbbbbb";
+    const fetchMock = jest.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      const id = body.task_id === taskA ? "run-a" : body.task_id === taskB ? "run-b" : "run-other";
+      return {
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify([{ id }]),
+      } as Response;
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const config = { supabaseUrl: "https://supabase.test", serviceRoleKey: "service-key" };
+    const a = await createRun(config, {
+      packId: "pack-id-1",
+      target: { type: "url", url: "https://example.com" },
+      profile: "smoke",
+      actorUserId: "user-1",
+      taskId: taskA,
+    });
+    const b = await createRun(config, {
+      packId: "pack-id-1",
+      target: { type: "url", url: "https://example.com" },
+      profile: "smoke",
+      actorUserId: "user-1",
+      taskId: taskB,
+    });
+
+    expect(a.id).toBe("run-a");
+    expect(a.was_duplicate).toBe(false);
+    expect(b.id).toBe("run-b");
+    expect(b.was_duplicate).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/testpass/src/run-manager.ts
+++ b/packages/testpass/src/run-manager.ts
@@ -83,6 +83,9 @@ export async function createRun(
     return { id: rows[0].id, was_duplicate: false };
   }
   if (params.taskId && (res.status === 409 || res.status === 400) && /23505|duplicate key/.test(text)) {
+    // STALE_RUN check intentionally omitted — relies on synchronous handler invariant.
+    // If a runner is ever made async, add a `last_heartbeat`-based stale-run gate here
+    // before returning was_duplicate=true on a still-running task_id.
     const lookup = await fetch(
       `${config.supabaseUrl}/rest/v1/testpass_runs?task_id=eq.${encodeURIComponent(params.taskId)}&actor_user_id=eq.${params.actorUserId}&select=id&limit=1`,
       {

--- a/packages/testpass/src/run-manager.ts
+++ b/packages/testpass/src/run-manager.ts
@@ -36,6 +36,11 @@ async function supaFetch(
   return text ? JSON.parse(text) : null;
 }
 
+export interface CreateRunResult {
+  id: string;
+  was_duplicate: boolean;
+}
+
 export async function createRun(
   config: RunManagerConfig,
   params: {
@@ -44,8 +49,9 @@ export async function createRun(
     target: RunTarget;
     profile: RunProfile;
     actorUserId: string;
+    taskId?: string;
   }
-): Promise<string> {
+): Promise<CreateRunResult> {
   const payload: Record<string, unknown> = {
     pack_id: params.packId,
     target: params.target,
@@ -56,8 +62,47 @@ export async function createRun(
     verdict_summary: { total: 0, check: 0, na: 0, fail: 0, other: 0, pending: 0, pass_rate: 0 },
   };
   if (params.packName) payload.pack_name = params.packName;
-  const rows = (await supaFetch(config, "testpass_runs", "POST", payload)) as Array<{ id: string }>;
-  return rows[0].id;
+  if (params.taskId) payload.task_id = params.taskId;
+
+  // Insert. On unique-violation against the (actor_user_id, task_id) partial
+  // index, look up the existing row and surface it with was_duplicate=true so
+  // the caller can short-circuit work and avoid double-dispatch (MCP SEP-1686).
+  const res = await fetch(`${config.supabaseUrl}/rest/v1/testpass_runs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+      Prefer: "return=representation",
+    },
+    body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  if (res.ok) {
+    const rows = (text ? JSON.parse(text) : []) as Array<{ id: string }>;
+    return { id: rows[0].id, was_duplicate: false };
+  }
+  if (params.taskId && (res.status === 409 || res.status === 400) && /23505|duplicate key/.test(text)) {
+    const lookup = await fetch(
+      `${config.supabaseUrl}/rest/v1/testpass_runs?task_id=eq.${encodeURIComponent(params.taskId)}&actor_user_id=eq.${params.actorUserId}&select=id&limit=1`,
+      {
+        headers: {
+          apikey: config.serviceRoleKey,
+          Authorization: `Bearer ${config.serviceRoleKey}`,
+        },
+      },
+    );
+    if (lookup.ok) {
+      const rows = (await lookup.json()) as Array<{ id: string }>;
+      if (rows[0]) {
+        console.log(
+          `[duplicate_dispatch_avoided] table=testpass_runs task_id=${params.taskId} run_id=${rows[0].id}`,
+        );
+        return { id: rows[0].id, was_duplicate: true };
+      }
+    }
+  }
+  throw new Error(`Supabase POST testpass_runs → ${res.status}: ${text}`);
 }
 
 export async function updateRunStatus(

--- a/packages/uxpass/src/__tests__/run-manager.test.ts
+++ b/packages/uxpass/src/__tests__/run-manager.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRun } from "../run-manager.js";
+
+describe("uxpass run-manager createRun idempotency", () => {
+  const config = { supabaseUrl: "https://supabase.test", serviceRoleKey: "service-key" };
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns was_duplicate=false when no task_id is supplied", async () => {
+    const mock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    mock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify([{ id: "run-fresh" }]),
+    });
+
+    const result = await createRun(config, {
+      targetUrl: "https://example.com",
+      actorUserId: "user-1",
+    });
+
+    expect(result.id).toBe("run-fresh");
+    expect(result.was_duplicate).toBe(false);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns was_duplicate=true when the same task_id collides with an existing row", async () => {
+    const taskId = "550e8400-e29b-51d4-a716-446655440000";
+    const mock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    mock
+      .mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        expect(body.task_id).toBe(taskId);
+        return {
+          ok: false,
+          status: 409,
+          text: async () =>
+            JSON.stringify({ code: "23505", message: "duplicate key value violates unique constraint" }),
+        };
+      })
+      .mockImplementationOnce(async (url: string) => {
+        expect(url).toContain(`task_id=eq.${taskId}`);
+        expect(url).toContain("actor_user_id=eq.user-1");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ id: "existing-run-id" }],
+        };
+      });
+
+    const result = await createRun(config, {
+      targetUrl: "https://example.com",
+      actorUserId: "user-1",
+      taskId,
+    });
+
+    expect(result.id).toBe("existing-run-id");
+    expect(result.was_duplicate).toBe(true);
+    expect(mock).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates two distinct rows when two different task_ids are submitted", async () => {
+    const mock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    mock
+      .mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        expect(body.task_id).toBe("aaaaaaaa-aaaa-5aaa-aaaa-aaaaaaaaaaaa");
+        return {
+          ok: true,
+          status: 201,
+          text: async () => JSON.stringify([{ id: "run-a" }]),
+        };
+      })
+      .mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        expect(body.task_id).toBe("bbbbbbbb-bbbb-5bbb-9bbb-bbbbbbbbbbbb");
+        return {
+          ok: true,
+          status: 201,
+          text: async () => JSON.stringify([{ id: "run-b" }]),
+        };
+      });
+
+    const a = await createRun(config, {
+      targetUrl: "https://example.com",
+      actorUserId: "user-1",
+      taskId: "aaaaaaaa-aaaa-5aaa-aaaa-aaaaaaaaaaaa",
+    });
+    const b = await createRun(config, {
+      targetUrl: "https://example.com",
+      actorUserId: "user-1",
+      taskId: "bbbbbbbb-bbbb-5bbb-9bbb-bbbbbbbbbbbb",
+    });
+
+    expect(a.id).toBe("run-a");
+    expect(a.was_duplicate).toBe(false);
+    expect(b.id).toBe("run-b");
+    expect(b.was_duplicate).toBe(false);
+    expect(mock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on non-23505 errors even when task_id is supplied", async () => {
+    const mock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    mock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "internal server error",
+    });
+
+    await expect(
+      createRun(config, {
+        targetUrl: "https://example.com",
+        actorUserId: "user-1",
+        taskId: "550e8400-e29b-51d4-a716-446655440000",
+      }),
+    ).rejects.toThrow(/500/);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/uxpass/src/run-manager.ts
+++ b/packages/uxpass/src/run-manager.ts
@@ -91,6 +91,9 @@ export async function createRun(
     return { id: rows[0].id, was_duplicate: false };
   }
   if (params.taskId && (res.status === 409 || res.status === 400) && /23505|duplicate key/.test(text)) {
+    // STALE_RUN check intentionally omitted — relies on synchronous handler invariant.
+    // If a runner is ever made async, add a `last_heartbeat`-based stale-run gate here
+    // before returning was_duplicate=true on a still-running task_id.
     const lookup = await fetch(
       `${config.supabaseUrl}/rest/v1/uxpass_runs?task_id=eq.${encodeURIComponent(params.taskId)}&actor_user_id=eq.${params.actorUserId}&select=id&limit=1`,
       {

--- a/packages/uxpass/src/run-manager.ts
+++ b/packages/uxpass/src/run-manager.ts
@@ -42,6 +42,11 @@ async function supaFetch(
   return text ? JSON.parse(text) : null;
 }
 
+export interface CreateRunResult {
+  id: string;
+  was_duplicate: boolean;
+}
+
 export async function createRun(
   config: RunManagerConfig,
   params: {
@@ -51,8 +56,9 @@ export async function createRun(
     viewports?: string[];
     themes?: string[];
     packId?: string | null;
+    taskId?: string;
   },
-): Promise<string> {
+): Promise<CreateRunResult> {
   const payload: Record<string, unknown> = {
     target_url: params.targetUrl,
     actor_user_id: params.actorUserId,
@@ -64,8 +70,47 @@ export async function createRun(
     breakdown: {},
   };
   if (params.packId) payload.pack_id = params.packId;
-  const rows = (await supaFetch(config, "uxpass_runs", "POST", payload)) as Array<{ id: string }>;
-  return rows[0].id;
+  if (params.taskId) payload.task_id = params.taskId;
+
+  // Insert. On unique-violation against the (actor_user_id, task_id) partial
+  // index, look up the existing row and surface it with was_duplicate=true so
+  // the caller can short-circuit work and avoid double-dispatch (MCP SEP-1686).
+  const res = await fetch(`${config.supabaseUrl}/rest/v1/uxpass_runs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: config.serviceRoleKey,
+      Authorization: `Bearer ${config.serviceRoleKey}`,
+      Prefer: "return=representation",
+    },
+    body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  if (res.ok) {
+    const rows = (text ? JSON.parse(text) : []) as Array<{ id: string }>;
+    return { id: rows[0].id, was_duplicate: false };
+  }
+  if (params.taskId && (res.status === 409 || res.status === 400) && /23505|duplicate key/.test(text)) {
+    const lookup = await fetch(
+      `${config.supabaseUrl}/rest/v1/uxpass_runs?task_id=eq.${encodeURIComponent(params.taskId)}&actor_user_id=eq.${params.actorUserId}&select=id&limit=1`,
+      {
+        headers: {
+          apikey: config.serviceRoleKey,
+          Authorization: `Bearer ${config.serviceRoleKey}`,
+        },
+      },
+    );
+    if (lookup.ok) {
+      const rows = (await lookup.json()) as Array<{ id: string }>;
+      if (rows[0]) {
+        console.log(
+          `[duplicate_dispatch_avoided] table=uxpass_runs task_id=${params.taskId} run_id=${rows[0].id}`,
+        );
+        return { id: rows[0].id, was_duplicate: true };
+      }
+    }
+  }
+  throw new Error(`Supabase POST uxpass_runs -> ${res.status}: ${text}`);
 }
 
 export async function updateRunStatus(

--- a/supabase/migrations/20260428200000_idempotent_task_ids.sql
+++ b/supabase/migrations/20260428200000_idempotent_task_ids.sql
@@ -6,13 +6,6 @@
 -- collide on a single NULL value. The index is compound (actor + task_id)
 -- so that a UUIDv5 collision across two different actors is treated as
 -- two distinct rows, not a 23505 leaked across tenants.
---
--- This file lives outside supabase/migrations/ on purpose. The repo's
--- apply-migrations workflow had a 4-day silent failure that PR #229 just
--- unblocked, so this migration is intended to be applied via Supabase
--- MCP `apply_migration` rather than the file-based workflow. After it
--- lands in production, the file may be moved into supabase/migrations/
--- (or deleted) at the maintainer's discretion.
 
 -- ── testpass_runs ───────────────────────────────────────────────────────────
 alter table testpass_runs add column if not exists task_id text;


### PR DESCRIPTION
## Summary

Adds an optional client-generated UUID `task_id` to `start_crew_run`, `testpass_run`, and `uxpass_run`, following the [MCP SEP-1686](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/1686) idempotency pattern + the WorkOS idempotency-keys playbook. Same `task_id` submitted twice (e.g. transport retry) returns the original `run_id` with `was_duplicate: true` instead of creating a second row. Eliminates the duplicate-session class of bug repro'd by Anthropic Issue #40177 for Cowork's `start_code_task`.

**Tier 1 / Chip 1** of the urgent fleet-efficiency build sequence (greenlit by Chris tonight). Two independent deep-research passes both flagged this as the smallest first step that empirically validates the rest of the 4-8 week roadmap.

## Migration

`supabase/migrations/20260428200000_idempotent_task_ids.sql` — auto-applies on merge to main via the standard `.github/scripts/apply_migrations.py` workflow (unblocked by #229). No manual Supabase MCP step needed.

```sql
alter table testpass_runs add column if not exists task_id text;
create unique index if not exists testpass_runs_task_id_actor_uniq
  on testpass_runs(actor_user_id, task_id)
  where task_id is not null;

alter table uxpass_runs add column if not exists task_id text;
create unique index if not exists uxpass_runs_task_id_actor_uniq
  on uxpass_runs(actor_user_id, task_id)
  where task_id is not null;

alter table mc_crew_runs add column if not exists task_id text;
create unique index if not exists mc_crew_runs_task_id_tenant_uniq
  on mc_crew_runs(api_key_hash, task_id)
  where task_id is not null;
```

Schema is purely additive. Column is nullable, no backfill, partial unique index ignores historical NULL rows.

**Deviation from the chip spec:** the unique index is **compound** `(actor_user_id, task_id)` (or `(api_key_hash, task_id)` for `mc_crew_runs`) rather than the single-column `(task_id)` you wrote up. Defense-in-depth: if a buggy client somehow reuses a UUID across tenants, neither tenant gets a confusing 23505 leaked from the other. Single-column would also have worked because UUIDv5 is collision-resistant by design; flag if you'd rather I revert.

## Code shape

- `createRun()` (testpass + uxpass run-manager) now accepts `taskId?: string`, returns `{ id, was_duplicate }`. On Postgres `23505` against the partial unique index it SELECTs the existing row scoped to the same actor and surfaces it, logging `[duplicate_dispatch_avoided] table=… task_id=… run_id=…`.
- `api/testpass.ts performStartRun` and `api/uxpass.ts start_run/run` short-circuit on duplicates: skip probe / seed / runner work, return the existing row's current state with `was_duplicate: true`.
- `api/memory-admin.ts start_crew_run` mirrors the pattern using the supabase-js error code `23505`. Card surfaces "Crews run already exists" when duplicate.
- `api/testpass-run.ts` and `api/uxpass-run.ts` (the cron / CI escape hatches) accept `task_id` from query string or body and short-circuit identically.
- MCP wrappers (`testpass-tool.ts`, `uxpass-tool.ts`, `crews-tool.ts`) thread `task_id` from `args` into the request body. Tool schemas in `tool-wiring.ts` advertise `task_id` with the canonical description: "Client-generated idempotency key (UUIDv5 from thread_id + prompt_hash + time_bucket recommended). Required for safe retry. If omitted…"
- UUID validation is **lenient**: any v1-v5 UUID format is accepted (regex `^[0-9a-f]{8}-...-[1-5]...-[89ab]...$`). UUIDv5 is recommended in the description but not enforced — strict v5-only would reject conformant clients picking a different deterministic scheme. Bad input gets `400 task_id must be a UUID`.

## Stale-run safety

Each of the three unique_violation catch sites (testpass run-manager, uxpass run-manager, memory-admin start_crew_run) carries an explicit comment:

```ts
// STALE_RUN check intentionally omitted — relies on synchronous handler invariant.
// If a runner is ever made async, add a `last_heartbeat`-based stale-run gate here
// before returning was_duplicate=true on a still-running task_id.
```

UnClick's runners are synchronous-within-the-handler today so the crashed-worker scenario doesn't really exist; the comment makes the omission self-documenting so async refactors trip on it.

## What is NOT included (deliberate scope cuts)

- **Heartbeat-based reclaim** for crashed workers (separate chip per spec).
- **Idempotency on non-run-creating tools** (`testpass_save_pack`, `uxpass_register_pack`, `create_todo`) — out of scope per spec, those are already pure idempotent inserts.
- **Backfill of existing rows** with synthesized task_ids — additive only, per spec.

## Reporting (per spec)

| Field | Value |
|---|---|
| Migration applied to production? | **Auto-applies on merge** via `.github/scripts/apply_migrations.py` (recorded in `_claude_migrations`). |
| Migration version | `20260428200000_idempotent_task_ids` (in canonical `supabase/migrations/`) |
| All 3 tools covered? | **Yes** — `start_crew_run`, `testpass_run`, `uxpass_run` all wired |
| Test pass count | **8** new idempotency tests pass (4 testpass jest + 4 uxpass vitest). Full testpass suite: 35/35 actual tests pass; 2 pre-existing test-suite failures (`auth-header.test.ts` and `deterministic.test.ts` use `jest` global without importing — exists on `main`, untouched by this PR). |
| Surprises in handler code | (1) The MCP `testpass_run` tool calls `/api/testpass?action=start_run`, NOT `/api/testpass-run` — the `*-run.ts` files are CI/cron escape hatches with separate handlers. Both code paths are covered. (2) The crew run row is created via the supabase-js client (PostgrestError surfaces `code: '23505'`) rather than the REST fetch pattern used by testpass/uxpass — needed a different error-detection branch. (3) UXPass had no run-manager test file before this PR; added one (vitest, mirrors testpass jest tests). |

## Test plan

- [x] Unit: same task_id twice → second response has `was_duplicate: true`, same row (testpass + uxpass)
- [x] Unit: different task_ids → two distinct rows (testpass + uxpass)
- [x] Unit: omit task_id → server-generated row, `was_duplicate: false` (testpass + uxpass)
- [x] Unit: non-23505 errors still throw even when task_id is supplied (uxpass)
- [x] Typecheck: testpass, uxpass, mcp-server clean (api/memory-admin.ts has 3 pre-existing TS errors, none in changed lines)
- [ ] Integration: hit live API with idempotency-key sequence, verify only one row created (post-merge, after migration auto-applies)

## Don't

- **Don't auto-merge** — Bailey reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)