### PR TITLE
fix(seo): redirect www host to apex

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,14 @@
       ]
     }
   ],
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.unclick.world" }],
+      "destination": "https://unclick.world/:path*",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     { "source": "/sitemap.xml",   "destination": "/api/sitemap" },
     { "source": "/v1/arena/(.*)", "destination": "/api/arena" },


### PR DESCRIPTION
## Summary
- Add a Vercel host redirect so requests for www.unclick.world canonicalize to https://unclick.world while preserving the path.
- Keep the change limited to vercel.json.

## Verification
- Parsed vercel.json successfully with Node.
- Ran npm run build successfully.

## Follow-up
- Vercel/DNS still needs www.unclick.world configured so Vercel can issue a TLS certificate. Until that is done, https://www.unclick.world/ can fail before this app-level redirect runs.

## Proof of delivery
- Branch: fix/www-apex-redirect
- Commit: 18afafc