### PR TITLE
fix(fishbowl): clear check-in timer on activity

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -6183,7 +6183,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         // Updates the agent's free-form Now Playing line. The row must already
         // exist (set_my_emoji creates it). An empty string clears the status
         // back to idle. Always bumps last_seen_at so the status timestamp and
-        // the activity timestamp stay coherent.
+        // the activity timestamp stay coherent. A status pulse also clears any
+        // prior dead-man timer unless the caller sets next_checkin_at again.
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) {
@@ -6263,23 +6264,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           current_status_updated_at: nowIso,
           last_seen_at: nowIso,
         };
-        if (nextCheckinUpdate.apply) {
-          updatePayload.next_checkin_at = nextCheckinUpdate.iso;
-        } else {
-          const { data: existingProfile, error: existingProfileErr } = await supabase
-            .from("mc_fishbowl_profiles")
-            .select("next_checkin_at")
-            .eq("api_key_hash", apiKeyHash)
-            .eq("agent_id", agentId)
-            .maybeSingle();
-          if (existingProfileErr) throw existingProfileErr;
-          const existingNextCheckin = existingProfile?.next_checkin_at;
-          const existingNextCheckinMs =
-            typeof existingNextCheckin === "string" ? Date.parse(existingNextCheckin) : Number.NaN;
-          if (!Number.isNaN(existingNextCheckinMs) && existingNextCheckinMs < now.getTime()) {
-            updatePayload.next_checkin_at = new Date(now.getTime() + 30 * 60_000).toISOString();
-          }
-        }
+        updatePayload.next_checkin_at = nextCheckinUpdate.apply ? nextCheckinUpdate.iso : null;
         const { data, error } = await supabase
           .from("mc_fishbowl_profiles")
           .update(updatePayload)
@@ -6441,10 +6426,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (insertErr) throw insertErr;
 
         // Bump post-side presence so active authors do not look stale on Now Playing.
+        // Posting is a live pulse, so it clears any prior dead-man timer.
         const postedAtIso = new Date().toISOString();
         await supabase
           .from("mc_fishbowl_profiles")
-          .update({ last_seen_at: postedAtIso, current_status_updated_at: postedAtIso })
+          .update({ last_seen_at: postedAtIso, current_status_updated_at: postedAtIso, next_checkin_at: null })
           .eq("api_key_hash", apiKeyHash)
           .eq("agent_id", agentId);
 

--- a/packages/testpass/packs/testpass-fishbowl-v0.yaml
+++ b/packages/testpass/packs/testpass-fishbowl-v0.yaml
@@ -177,23 +177,24 @@ items:
     profiles: [smoke, standard, deep]
 
   - id: FB-011
-    title: post_message refreshes profile presence without rewriting status
+    title: post_message refreshes profile presence and clears dead-man timer
     category: fishbowl-validation
     severity: high
     check_type: agent
     description: |
       After set_my_status seeds current_status and next_checkin_at, posting a
       message with the same agent_id must advance current_status_updated_at on
-      the profile while preserving current_status text and next_checkin_at.
-      This guards the PR 221 fix for post-side Now Playing freshness.
+      the profile while preserving current_status text and clearing
+      next_checkin_at. A post is a live pulse, so it should retire the old
+      dead-man timer instead of leaving the agent looking scheduled or MIA.
     expected:
       current_status_updated_at: advances after post_message
       current_status: unchanged
-      next_checkin_at: unchanged
+      next_checkin_at: null
     on_fail: |
       Check api/memory-admin.ts fishbowl_post. The handler should update
       current_status_updated_at with last_seen_at after a successful insert,
-      but must not rewrite the status text or extend the dead-man timer.
+      clear next_checkin_at, and not rewrite the status text.
     tags: [fishbowl, presence, regression-check]
     profiles: [smoke, standard, deep]
 


### PR DESCRIPTION
## Summary
- Clear `next_checkin_at` when `set_my_status` is called without a new timer.
- Clear `next_checkin_at` after a successful `post_message` pulse.
- Update the Fishbowl TestPass expectation so posts retire the old dead-man timer while preserving status text.

## Verification
- Ran `npm run build` successfully.
- Ran `git diff --check` successfully for the touched files.

## Proof of delivery
- Branch: fix/fishbowl-presence-clears-checkin
- Commit: b3d8dd8