### PR TITLE
feat(mcp): testpass_report_html/json/md tools (parity with uxpass)

### DIFF
--- a/packages/mcp-server/src/testpass-tool.ts
+++ b/packages/mcp-server/src/testpass-tool.ts
@@ -1,7 +1,8 @@
 /**
- * testpass-tool - MCP handlers for starting TestPass runs and polling status.
+ * testpass-tool - MCP handlers for starting TestPass runs, polling status,
+ * and fetching reports in HTML, JSON, or Markdown.
  *
- * Both handlers call back into the UnClick Vercel API (/api/testpass) using
+ * All handlers call back into the UnClick Vercel API (/api/testpass) using
  * the caller's UNCLICK_API_KEY as the Bearer token. The API resolves the
  * caller's user id from that token and enforces actor_user_id scoping.
  */
@@ -58,6 +59,59 @@ export async function testpassStatus(args: Record<string, unknown>): Promise<unk
   let body: unknown = text;
   try { body = text ? JSON.parse(text) : null; } catch { /* keep text */ }
   if (!res.ok) return { error: `testpass status failed (HTTP ${res.status})`, body };
+  return body;
+}
+
+export async function testpassReportHtml(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id : "";
+  if (!runId) return { error: "run_id is required" };
+
+  const apiKey = getApiKey();
+  const res = await fetch(
+    `${API_BASE}/api/testpass?action=report_html&run_id=${encodeURIComponent(runId)}`,
+    { headers: { Authorization: `Bearer ${apiKey}` } },
+  );
+  const text = await res.text();
+  if (!res.ok) {
+    let body: unknown = text;
+    try { body = text ? JSON.parse(text) : null; } catch { /* keep text */ }
+    return { error: `testpass report_html failed (HTTP ${res.status})`, body };
+  }
+  return { run_id: runId, format: "html", body: text };
+}
+
+export async function testpassReportJson(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id : "";
+  if (!runId) return { error: "run_id is required" };
+
+  const apiKey = getApiKey();
+  const res = await fetch(
+    `${API_BASE}/api/testpass?action=report_json&run_id=${encodeURIComponent(runId)}`,
+    { headers: { Authorization: `Bearer ${apiKey}` } },
+  );
+  const text = await res.text();
+  let body: unknown = text;
+  try { body = text ? JSON.parse(text) : null; } catch { /* keep text */ }
+  if (!res.ok) return { error: `testpass report_json failed (HTTP ${res.status})`, body };
+  return { run_id: runId, format: "json", body };
+}
+
+export async function testpassReportMd(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id : "";
+  if (!runId) return { error: "run_id is required" };
+
+  const apiKey = getApiKey();
+  const res = await fetch(
+    `${API_BASE}/api/testpass?action=report_md&run_id=${encodeURIComponent(runId)}`,
+    { headers: { Authorization: `Bearer ${apiKey}` } },
+  );
+  const text = await res.text();
+  let body: unknown = text;
+  try { body = text ? JSON.parse(text) : null; } catch { /* keep text */ }
+  if (!res.ok) return { error: `testpass report_md failed (HTTP ${res.status})`, body };
+  if (body && typeof body === "object" && "markdown" in body) {
+    return { run_id: runId, format: "md", body: (body as { markdown: string }).markdown };
+  }
   return body;
 }
 

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -748,7 +748,15 @@ import {
 } from "./convertkit-tool.js";
 
 // ─── TestPass ─────────────────────────────────────────────────────────────────
-import { testpassRun, testpassStatus, testpassSavePack, testpassEditItem } from "./testpass-tool.js";
+import {
+  testpassRun,
+  testpassStatus,
+  testpassSavePack,
+  testpassEditItem,
+  testpassReportHtml,
+  testpassReportJson,
+  testpassReportMd,
+} from "./testpass-tool.js";
 
 // ─── UXPass (sister to TestPass, UI/UX QC) ───────────────────────────────────
 import {
@@ -11129,6 +11137,39 @@ export const ADDITIONAL_TOOLS = [
       required: ["run_id", "item_id", "verdict"],
     },
   },
+  {
+    name: "testpass_report_html",
+    description: "Get the HTML report for a TestPass run.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        run_id: { type: "string", description: "The run id returned by testpass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: "testpass_report_json",
+    description: "Get the JSON report for a TestPass run.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        run_id: { type: "string", description: "The run id returned by testpass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: "testpass_report_md",
+    description: "Get the Markdown report for a TestPass run.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        run_id: { type: "string", description: "The run id returned by testpass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
 
   // ── uxpass-tool.ts (UI/UX QC, sister to TestPass) ──────────────────────────
   {
@@ -12357,10 +12398,13 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   togetherai_list_models:     (args) => togetherai_list_models(args),
 
   // testpass-tool.ts
-  testpass_run:       (args) => testpassRun(args),
-  testpass_status:    (args) => testpassStatus(args),
-  testpass_save_pack: (args) => testpassSavePack(args),
-  testpass_edit_item: (args) => testpassEditItem(args),
+  testpass_run:         (args) => testpassRun(args),
+  testpass_status:      (args) => testpassStatus(args),
+  testpass_save_pack:   (args) => testpassSavePack(args),
+  testpass_edit_item:   (args) => testpassEditItem(args),
+  testpass_report_html: (args) => testpassReportHtml(args),
+  testpass_report_json: (args) => testpassReportJson(args),
+  testpass_report_md:   (args) => testpassReportMd(args),
 
   // uxpass-tool.ts
   uxpass_run:           (args) => uxpassRun(args),


### PR DESCRIPTION
## Summary
- Expose three new direct MCP tools — `testpass_report_html`, `testpass_report_json`, `testpass_report_md` — mirroring the existing `uxpass_report_*` shape.
- Wiring only. The HTTP endpoints (`/api/testpass?action=report_html|report_json|report_md`) and renderers (`generateHtmlReport`, `generateJsonReport`, `buildFixListMarkdown`) already exist; no new rendering logic is introduced.
- Closes Fishbowl todo `01eaf4af-040d-4275-8d33-4ed254bcc557`.

## Changes
- `packages/mcp-server/src/testpass-tool.ts` — add `testpassReportHtml`, `testpassReportJson`, `testpassReportMd` handlers (use the same `UNCLICK_API_KEY` Bearer pattern and return `{ run_id, format, body }` like the uxpass equivalents).
- `packages/mcp-server/src/tool-wiring.ts` — add three tool schemas (input: `{ run_id: string }`, required) and three dispatcher entries; extend the import from `./testpass-tool.js`.

## Test plan
- [x] `npm run --workspace=@unclick/mcp-server build` (tsc passes)
- [x] `npm run --workspace=@unclick/mcp-server test` — 21 pass, 0 fail (node:test) + 10 pass, 0 fail (vitest)
- [x] `npx eslint packages/mcp-server/src/testpass-tool.ts packages/mcp-server/src/tool-wiring.ts` — clean
- [ ] Smoke: `testpass_report_json` against a real run should return the same JSON the website's report viewer consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)