### PR TITLE
fix(backstagepass): log audit insert failures

### DIFF
--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -268,16 +268,36 @@ async function writeAudit(params: {
       success:       params.success ?? true,
       metadata:      params.metadata ?? {},
     };
-    await supaFetch(
+    const { ok, status, data } = await supaFetch(
       `${params.supabaseUrl}/rest/v1/backstagepass_audit`,
       "POST",
       supaHeaders(params.serviceRoleKey),
       row,
     );
-  } catch {
+    if (!ok) {
+      // Audit failures must stay non-blocking, but they must be visible.
+      // Never log credential values. Supabase error payloads include only
+      // database error metadata such as message, details, hint, and code.
+      // eslint-disable-next-line no-console
+      console.error("backstagepass_audit write failed", {
+        status,
+        action: params.action,
+        credential_id: params.credentialId ?? null,
+        platform_slug: params.platformSlug ?? null,
+        success: params.success ?? true,
+        error: data,
+      });
+    }
+  } catch (err) {
     // Audit must never break the caller's request. Log and move on.
     // eslint-disable-next-line no-console
-    console.error("backstagepass_audit write failed");
+    console.error("backstagepass_audit write threw", {
+      action: params.action,
+      credential_id: params.credentialId ?? null,
+      platform_slug: params.platformSlug ?? null,
+      success: params.success ?? true,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Make BackstagePass audit insert failures visible instead of silently swallowing Supabase HTTP errors.
- Keep audit writes non-blocking for the user action, but log status, action, credential id, platform, success flag, and Supabase error metadata.
- Avoid logging credential values or API keys.

## Diagnosis
The audit writer only caught thrown network errors. `supaFetch()` returns `{ ok: false, status, data }` for Supabase/PostgREST failures, and the old code ignored that return value. That means a 400/401/404 insert could produce zero `backstagepass_audit` rows with no useful runtime clue.

## Verification
- Ran `git diff --check -- api/backstagepass.ts` successfully.
- Ran `npm run build` successfully.

## Follow-up
After deploy, rotate or update one BackstagePass credential again and inspect Vercel logs. If audit rows still stay at 0, the log should now show the Supabase failure reason.

## Proof of delivery
- Branch: fix/backstagepass-audit-diagnostics
- Commit: 633f248