### PR TITLE
fix(testpass): align cron cadence

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "/api/testpass-run?pack_id=testpass-core&profile=smoke&server_url=https%3A%2F%2Funclick.world%2Fapi%2Fmcp",
-      "schedule": "0 */6 * * *"
+      "schedule": "*/15 * * * *"
     },
     {
       "path": "/api/uxpass-run?url=https%3A%2F%2Funclick.world&pack_slug=uxpass-core",


### PR DESCRIPTION
## Summary
- changes the existing TestPass smoke Vercel cron from every 6 hours to every 15 minutes
- keeps the existing `/api/testpass-run` endpoint and smoke query params unchanged
- mirrors the fishbowl-watcher cadence so TestPass cron verification has a regular dispatch window

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json ok')"`

## Notes
- This touches `vercel.json`, same file as PR #254. Merge order may require a simple rebase if both land close together.
- Follow-up after deploy: confirm `CRON_SECRET` and `TESTPASS_CRON_USER_ID` in Vercel, then verify a fresh `testpass_runs` row.
