### PR TITLE
scaffold(seopass): add chunk 1

### DIFF
--- a/docs/seopass-product-brief.md
+++ b/docs/seopass-product-brief.md
@@ -1,0 +1,29 @@
+# SEOPass product brief and build plan
+
+SEOPass is the search visibility sibling to TestPass and UXPass. It gives agents a repeatable way to inspect whether a site can be crawled, understood, ranked, and cited by search engines and AI answer systems.
+
+## Wedge
+
+Most SEO tooling is built for specialists and dashboards. SEOPass is built for agents. The first version should answer four questions quickly: can crawlers reach the site, can search engines understand the page, does Lighthouse show obvious quality gaps, and is the content structured enough for AI search surfaces.
+
+## Chunk 1 scope
+
+This chip is a scaffold only. It adds the SEOPass pack schema, a core pack, a Lighthouse execution-plan helper, four MCP tools, and this product brief. It does not run Lighthouse, write database rows, or create UI.
+
+## MCP tools
+
+- `seopass_run` returns a planned run for a URL or registered pack.
+- `seopass_status` reserves the status shape for the later persistence chip.
+- `seopass_register_pack` validates and stores a YAML pack locally.
+- `seopass_lighthouse_plan` builds the Lighthouse plan that later execution will consume.
+
+## Build sequence
+
+1. Chunk 1: schema, pack, MCP tools, Lighthouse plan, brief.
+2. Chunk 2: execute Lighthouse and persist SEOPass runs/findings.
+3. Chunk 3: crawler checks for robots, sitemap, canonical, redirects, and internal links.
+4. Chunk 4: admin UI, reports, and Fishbowl/Signals routing.
+
+## Positioning
+
+TestPass checks agent tools. UXPass checks user experience. SEOPass checks whether the public web can find and trust the page.

--- a/packages/mcp-server/src/seopass-tool.ts
+++ b/packages/mcp-server/src/seopass-tool.ts
@@ -1,0 +1,109 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import yaml from "js-yaml";
+
+const PACKS_DIR = path.resolve(
+  process.env.SEOPASS_PACKS_DIR ??
+    path.join(process.cwd(), "packages", "seopass", "packs", "registered"),
+);
+
+const REQUIRED_PACK_KEYS = ["name", "url", "checks", "lighthouse", "crawl", "budgets"] as const;
+
+function ensurePacksDir(): void {
+  fs.mkdirSync(PACKS_DIR, { recursive: true });
+}
+
+function safeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 120);
+}
+
+function loadRegisteredPack(name: string): Record<string, unknown> | null {
+  ensurePacksDir();
+  const candidate = fs.readdirSync(PACKS_DIR).find((file) => file.startsWith(`${safeFilename(name)}-`));
+  if (!candidate) return null;
+  return yaml.load(fs.readFileSync(path.join(PACKS_DIR, candidate), "utf8")) as Record<string, unknown>;
+}
+
+function lighthousePlan(pack: Record<string, unknown>): Record<string, unknown> {
+  const lighthouse = (pack.lighthouse ?? {}) as Record<string, unknown>;
+  return {
+    runner: "lighthouse",
+    target_url: pack.url,
+    strategy: lighthouse.strategy ?? "mobile",
+    categories: lighthouse.categories ?? ["seo"],
+    output: ["json"],
+    notes: [
+      "Chunk 1 scaffold only: this builds the Lighthouse execution plan.",
+      "A later chip will execute Lighthouse, persist runs, and emit findings.",
+    ],
+  };
+}
+
+export async function seopassRun(args: Record<string, unknown>): Promise<unknown> {
+  const url = typeof args.url === "string" ? args.url : undefined;
+  const packName = typeof args.pack_name === "string" ? args.pack_name : undefined;
+  if (!url && !packName) return { error: "Either url or pack_name is required" };
+
+  const pack = packName ? loadRegisteredPack(packName) : null;
+  const targetUrl = url ?? (typeof pack?.url === "string" ? pack.url : undefined);
+  if (!targetUrl) return { error: `No registered SEOPass pack found for '${packName}'` };
+
+  return {
+    status: "planned",
+    pass: "seopass",
+    target_url: targetUrl,
+    checks: pack?.checks ?? ["lighthouse-performance", "crawlability", "metadata", "structured-data"],
+    lighthouse_plan: lighthousePlan({ ...(pack ?? {}), url: targetUrl }),
+    note: "SEOPass Chunk 1 is scaffold-only. Execution and persistence land in a later chip.",
+  };
+}
+
+export async function seopassStatus(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id : "";
+  if (!runId) return { error: "run_id is required" };
+  return {
+    run_id: runId,
+    status: "not_implemented",
+    note: "SEOPass run persistence lands in a later chip.",
+  };
+}
+
+export async function seopassRegisterPack(args: Record<string, unknown>): Promise<unknown> {
+  const packYaml = typeof args.pack_yaml === "string" ? args.pack_yaml : "";
+  if (!packYaml) return { error: "pack_yaml is required" };
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(packYaml);
+  } catch (err) {
+    return { error: `pack_yaml is not valid YAML: ${(err as Error).message}` };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { error: "pack_yaml must be a YAML object at the top level" };
+  }
+  const pack = parsed as Record<string, unknown>;
+  const missing = REQUIRED_PACK_KEYS.filter((key) => pack[key] === undefined);
+  if (missing.length > 0) return { error: "pack is missing required keys", missing };
+
+  const name = typeof pack.name === "string" ? pack.name : "";
+  if (!name) return { error: "pack name must be a non-empty string" };
+
+  ensurePacksDir();
+  const packId = `${safeFilename(name)}-${crypto.randomBytes(4).toString("hex")}`;
+  const filePath = path.join(PACKS_DIR, `${packId}.yaml`);
+  fs.writeFileSync(filePath, packYaml, "utf8");
+  return { pack_id: packId, name, file: filePath };
+}
+
+export async function seopassLighthousePlan(args: Record<string, unknown>): Promise<unknown> {
+  const url = typeof args.url === "string" ? args.url : "";
+  if (!url) return { error: "url is required" };
+  return lighthousePlan({
+    url,
+    lighthouse: {
+      strategy: args.strategy === "desktop" ? "desktop" : "mobile",
+      categories: Array.isArray(args.categories) ? args.categories : ["performance", "accessibility", "best-practices", "seo"],
+    },
+  });
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -760,6 +760,14 @@ import {
   uxpassRegisterPack,
 } from "./uxpass-tool.js";
 
+// ─── SEOPass (search visibility QC, sister to UXPass) ───────────────────────
+import {
+  seopassRun,
+  seopassStatus,
+  seopassRegisterPack,
+  seopassLighthousePlan,
+} from "./seopass-tool.js";
+
 // ─── Crews (Orchestrator Wizard) ──────────────────────────────────────────────
 import { crewsStartRun, crewsGetRun, crewsListRuns } from "./crews-tool.js";
 
@@ -11207,6 +11215,54 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── seopass-tool.ts (search visibility QC, sister to UXPass) ────────────────
+  {
+    name: "seopass_run",
+    description: "Plan a SEOPass run against a URL or registered pack. Chunk 1 returns the crawl and Lighthouse execution plan without persisting results.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: { type: "string", description: "Target URL for a one-off SEOPass plan" },
+        pack_name: { type: "string", description: "Name of a registered SEOPass pack; the pack URL is used as the target" },
+      },
+    },
+  },
+  {
+    name: "seopass_status",
+    description: "Fetch the status for a SEOPass run. Chunk 1 reserves the tool shape; persistence lands later.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        run_id: { type: "string", description: "The SEOPass run id returned by a future seopass_run execution path" },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: "seopass_register_pack",
+    description: "Register a SEOPass pack from a YAML string. Validates required keys and stores the pack locally for seopass_run.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        pack_yaml: { type: "string", description: "Full SEOPass pack definition as a YAML string" },
+      },
+      required: ["pack_yaml"],
+    },
+  },
+  {
+    name: "seopass_lighthouse_plan",
+    description: "Build the Lighthouse execution plan for a SEOPass target URL. Execution and persistence land in a later chunk.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: { type: "string", description: "Target URL to audit with Lighthouse" },
+        strategy: { type: "string", enum: ["mobile", "desktop"], description: "Lighthouse strategy (default: mobile)" },
+        categories: { type: "array", items: { type: "string" }, description: "Lighthouse categories to request" },
+      },
+      required: ["url"],
+    },
+  },
+
   // ── crews-tool.ts (Orchestrator Wizard) ──────────────────────────────────────
   {
     name: "start_crew_run",
@@ -12369,6 +12425,12 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   uxpass_report_json:   (args) => uxpassReportJson(args),
   uxpass_report_md:     (args) => uxpassReportMd(args),
   uxpass_register_pack: (args) => uxpassRegisterPack(args),
+
+  // seopass-tool.ts
+  seopass_run:             (args) => seopassRun(args),
+  seopass_status:          (args) => seopassStatus(args),
+  seopass_register_pack:   (args) => seopassRegisterPack(args),
+  seopass_lighthouse_plan: (args) => seopassLighthousePlan(args),
 
   // crews-tool.ts
   start_crew_run: (args) => crewsStartRun(args),

--- a/packages/seopass/packs/seopass-core.yaml
+++ b/packages/seopass/packs/seopass-core.yaml
@@ -1,0 +1,32 @@
+name: SEOPass Core
+url: https://unclick.world
+description: Core SEO, crawlability, and AI search readiness checks.
+checks:
+  - lighthouse-performance
+  - crawlability
+  - metadata
+  - structured-data
+  - indexability
+  - canonical-signals
+  - internal-links
+  - ai-overview-readiness
+lighthouse:
+  strategy: mobile
+  categories:
+    - performance
+    - accessibility
+    - best-practices
+    - seo
+crawl:
+  max_pages: 25
+  respect_robots: true
+budgets:
+  performance: ">= 75"
+  accessibility: ">= 90"
+  best_practices: ">= 90"
+  seo: ">= 90"
+  crawl_errors: "0"
+tags:
+  - seo
+  - lighthouse
+  - ai-search

--- a/packages/seopass/src/index.ts
+++ b/packages/seopass/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./schema.js";
+export * from "./lighthouse.js";

--- a/packages/seopass/src/lighthouse.ts
+++ b/packages/seopass/src/lighthouse.ts
@@ -1,0 +1,24 @@
+import type { SeoPassPack } from "./schema.js";
+
+export interface LighthousePluginPlan {
+  runner: "lighthouse";
+  target_url: string;
+  strategy: "mobile" | "desktop";
+  categories: string[];
+  output: ["json"];
+  notes: string[];
+}
+
+export function buildLighthousePlan(pack: SeoPassPack): LighthousePluginPlan {
+  return {
+    runner: "lighthouse",
+    target_url: pack.url,
+    strategy: pack.lighthouse.strategy,
+    categories: pack.lighthouse.categories,
+    output: ["json"],
+    notes: [
+      "Chunk 1 scaffold only: this builds the Lighthouse execution plan.",
+      "A later chip will execute Lighthouse, persist runs, and emit findings.",
+    ],
+  };
+}

--- a/packages/seopass/src/schema.ts
+++ b/packages/seopass/src/schema.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+export const SeoPassCheckIdSchema = z.enum([
+  "lighthouse-performance",
+  "crawlability",
+  "metadata",
+  "structured-data",
+  "indexability",
+  "canonical-signals",
+  "internal-links",
+  "ai-overview-readiness",
+]);
+
+export const SeoPassBudgetSchema = z
+  .object({
+    performance: z.string().optional(),
+    accessibility: z.string().optional(),
+    best_practices: z.string().optional(),
+    seo: z.string().optional(),
+    crawl_errors: z.string().optional(),
+  })
+  .catchall(z.string());
+
+export const SeoPassPackSchema = z.object({
+  name: z.string().min(1),
+  url: z.string().url(),
+  checks: z.array(SeoPassCheckIdSchema).min(1),
+  lighthouse: z
+    .object({
+      strategy: z.enum(["mobile", "desktop"]).default("mobile"),
+      categories: z.array(z.enum(["performance", "accessibility", "best-practices", "seo"])).default(["seo"]),
+    })
+    .default({ strategy: "mobile", categories: ["seo"] }),
+  crawl: z
+    .object({
+      max_pages: z.number().int().positive().max(500).default(25),
+      respect_robots: z.boolean().default(true),
+    })
+    .default({ max_pages: 25, respect_robots: true }),
+  budgets: SeoPassBudgetSchema.default({ seo: ">= 90" }),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export type SeoPassPack = z.infer<typeof SeoPassPackSchema>;
+export type SeoPassCheckId = z.infer<typeof SeoPassCheckIdSchema>;


### PR DESCRIPTION
## Summary
- add SEOPass Chunk 1 schema, core pack, and Lighthouse plan scaffold
- expose four MCP tools: seopass_run, seopass_status, seopass_register_pack, seopass_lighthouse_plan
- add a short SEOPass product brief for the first launch slice

## Verification
- npm run build --workspace packages/mcp-server
- git diff --check

## Notes
- scaffold only: no execution persistence or Lighthouse runner yet
- no package or lockfile changes