### PR TITLE
scaffold(geopass): add chunk 1

### DIFF
--- a/docs/geopass-product-brief.md
+++ b/docs/geopass-product-brief.md
@@ -1,0 +1,59 @@
+# GEOPass Chunk 1 Product Brief
+
+GEOPass is the Pass family product for AI-search readiness. SEOPass checks classic search visibility; GEOPass checks whether a product, brand, or page can be found, understood, cited, and safely summarized by answer engines.
+
+## Positioning
+
+GEOPass answers one question: when a user asks ChatGPT, Claude, Gemini, Perplexity, or another answer engine about this product or category, does the brand show up correctly?
+
+It focuses on:
+
+- entity clarity
+- citation readiness
+- source attribution
+- AI crawler accessibility
+- structured facts
+- answer-engine prompt coverage
+- competitor comparison visibility
+
+## Chunk 1 Scope
+
+This first chunk is a scaffold only. It ships:
+
+- a GEOPass pack shape
+- a core example pack
+- four MCP tool stubs
+- a crawler execution-plan scaffold
+- a brief product direction document
+
+It does not yet execute live crawls, call external answer engines, persist runs, or score results.
+
+## MCP Tools
+
+- `geopass_run`: plan a GEOPass run for a URL or registered pack
+- `geopass_status`: reserve the status lookup shape
+- `geopass_register_pack`: store a YAML pack for later runs
+- `geopass_crawl_plan`: build the crawler and extraction plan for a URL
+
+## First Real Checks
+
+The first executable GEOPass checks should be:
+
+- crawler access: robots, sitemap, and AI crawler policy
+- extractable facts: title, description, schema, headings, canonical URL
+- entity consistency: brand, product, founder, location, pricing, category
+- citation targets: stable source pages answer engines can cite
+- answer prompts: small prompt set that tests whether the brand appears in generated answers
+
+## Relationship To SEOPass
+
+SEOPass checks if search engines can crawl and rank the site. GEOPass checks if AI answer engines can understand and cite it.
+
+The two products should share URL, crawl, metadata, and report primitives later, but remain separate user-facing passes because the jobs are different:
+
+- SEOPass: "Can Google and search engines find me?"
+- GEOPass: "Can AI answers explain and recommend me accurately?"
+
+## Product Notes
+
+GEOPass should be careful not to promise control over AI answers. The pitch is visibility and readiness, not guaranteed ranking. The safest language is: "find and fix the signals answer engines rely on."

--- a/packages/geopass/packs/geopass-core.yaml
+++ b/packages/geopass/packs/geopass-core.yaml
@@ -1,0 +1,42 @@
+name: GEOPass Core
+url: https://unclick.world
+description: Core AI-search readiness, citation, and entity clarity checks.
+checks:
+  - ai-crawler-access
+  - entity-consistency
+  - citation-readiness
+  - source-attribution
+  - structured-facts
+  - answer-engine-prompts
+  - competitor-comparison
+  - content-extractability
+ai_surfaces:
+  - chatgpt
+  - claude
+  - gemini
+  - perplexity
+crawl:
+  max_pages: 25
+  respect_robots: true
+  include_sitemap: true
+entities:
+  brand: UnClick
+  product: UnClick
+  category: AI tool marketplace and MCP server
+  competitors:
+    - Zapier
+    - Gumloop
+    - Cursor
+prompts:
+  - What is UnClick?
+  - What tools can help me test an MCP server?
+  - Compare UnClick with other AI tool automation platforms.
+budgets:
+  entity_confidence: ">= 80"
+  citation_targets: ">= 3"
+  crawler_blockers: "0"
+  prompt_coverage: ">= 60"
+tags:
+  - geo
+  - ai-search
+  - citations

--- a/packages/geopass/src/crawler.ts
+++ b/packages/geopass/src/crawler.ts
@@ -1,0 +1,34 @@
+import type { GeoPassPack } from "./schema.js";
+
+export interface GeoPassCrawlerPlan {
+  runner: "geopass-crawler";
+  target_url: string;
+  max_pages: number;
+  respect_robots: boolean;
+  include_sitemap: boolean;
+  extractors: string[];
+  notes: string[];
+}
+
+export function buildCrawlerPlan(pack: GeoPassPack): GeoPassCrawlerPlan {
+  return {
+    runner: "geopass-crawler",
+    target_url: pack.url,
+    max_pages: pack.crawl.max_pages,
+    respect_robots: pack.crawl.respect_robots,
+    include_sitemap: pack.crawl.include_sitemap,
+    extractors: [
+      "robots-policy",
+      "sitemap-urls",
+      "canonical-url",
+      "metadata",
+      "schema-json-ld",
+      "heading-facts",
+      "citation-targets",
+    ],
+    notes: [
+      "Chunk 1 scaffold only: this builds the crawl and extraction plan.",
+      "A later chip will execute crawls, persist runs, and compare answer-engine visibility.",
+    ],
+  };
+}

--- a/packages/geopass/src/index.ts
+++ b/packages/geopass/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./schema.js";
+export * from "./crawler.js";

--- a/packages/geopass/src/schema.ts
+++ b/packages/geopass/src/schema.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+export const GeoPassCheckIdSchema = z.enum([
+  "ai-crawler-access",
+  "entity-consistency",
+  "citation-readiness",
+  "source-attribution",
+  "structured-facts",
+  "answer-engine-prompts",
+  "competitor-comparison",
+  "content-extractability",
+]);
+
+export const GeoPassSurfaceSchema = z.enum([
+  "chatgpt",
+  "claude",
+  "gemini",
+  "perplexity",
+  "google-ai-overviews",
+  "bing-copilot",
+]);
+
+export const GeoPassBudgetSchema = z
+  .object({
+    entity_confidence: z.string().optional(),
+    citation_targets: z.string().optional(),
+    crawler_blockers: z.string().optional(),
+    prompt_coverage: z.string().optional(),
+  })
+  .catchall(z.string());
+
+export const GeoPassPackSchema = z.object({
+  name: z.string().min(1),
+  url: z.string().url(),
+  checks: z.array(GeoPassCheckIdSchema).min(1),
+  ai_surfaces: z.array(GeoPassSurfaceSchema).default(["chatgpt", "claude", "perplexity"]),
+  crawl: z
+    .object({
+      max_pages: z.number().int().positive().max(500).default(25),
+      respect_robots: z.boolean().default(true),
+      include_sitemap: z.boolean().default(true),
+    })
+    .default({ max_pages: 25, respect_robots: true, include_sitemap: true }),
+  entities: z
+    .object({
+      brand: z.string().optional(),
+      product: z.string().optional(),
+      category: z.string().optional(),
+      competitors: z.array(z.string()).optional(),
+    })
+    .default({}),
+  prompts: z.array(z.string()).default([]),
+  budgets: GeoPassBudgetSchema.default({
+    entity_confidence: ">= 80",
+    citation_targets: ">= 3",
+    crawler_blockers: "0",
+  }),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export type GeoPassPack = z.infer<typeof GeoPassPackSchema>;
+export type GeoPassCheckId = z.infer<typeof GeoPassCheckIdSchema>;
+export type GeoPassSurface = z.infer<typeof GeoPassSurfaceSchema>;

--- a/packages/mcp-server/src/geopass-tool.ts
+++ b/packages/mcp-server/src/geopass-tool.ts
@@ -1,0 +1,133 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import yaml from "js-yaml";
+
+const PACKS_DIR = path.resolve(
+  process.env.GEOPASS_PACKS_DIR ??
+    path.join(process.cwd(), "packages", "geopass", "packs", "registered"),
+);
+
+const REQUIRED_PACK_KEYS = ["name", "url", "checks", "ai_surfaces", "crawl", "entities", "budgets"] as const;
+
+function ensurePacksDir(): void {
+  fs.mkdirSync(PACKS_DIR, { recursive: true });
+}
+
+function safeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 120);
+}
+
+function loadRegisteredPack(name: string): Record<string, unknown> | null {
+  ensurePacksDir();
+  const candidate = fs.readdirSync(PACKS_DIR).find((file) => file.startsWith(`${safeFilename(name)}-`));
+  if (!candidate) return null;
+  return yaml.load(fs.readFileSync(path.join(PACKS_DIR, candidate), "utf8")) as Record<string, unknown>;
+}
+
+function normaliseCrawl(crawl: unknown): Record<string, unknown> {
+  return crawl && typeof crawl === "object" && !Array.isArray(crawl) ? (crawl as Record<string, unknown>) : {};
+}
+
+function crawlerPlan(pack: Record<string, unknown>): Record<string, unknown> {
+  const crawl = normaliseCrawl(pack.crawl);
+  return {
+    runner: "geopass-crawler",
+    target_url: pack.url,
+    max_pages: typeof crawl.max_pages === "number" ? crawl.max_pages : 25,
+    respect_robots: typeof crawl.respect_robots === "boolean" ? crawl.respect_robots : true,
+    include_sitemap: typeof crawl.include_sitemap === "boolean" ? crawl.include_sitemap : true,
+    extractors: [
+      "robots-policy",
+      "sitemap-urls",
+      "canonical-url",
+      "metadata",
+      "schema-json-ld",
+      "heading-facts",
+      "citation-targets",
+    ],
+    notes: [
+      "Chunk 1 scaffold only: this builds the crawl and extraction plan.",
+      "A later chip will execute crawls, persist runs, and compare answer-engine visibility.",
+    ],
+  };
+}
+
+export async function geopassRun(args: Record<string, unknown>): Promise<unknown> {
+  const url = typeof args.url === "string" ? args.url : undefined;
+  const packName = typeof args.pack_name === "string" ? args.pack_name : undefined;
+  if (!url && !packName) return { error: "Either url or pack_name is required" };
+
+  const pack = packName ? loadRegisteredPack(packName) : null;
+  const targetUrl = url ?? (typeof pack?.url === "string" ? pack.url : undefined);
+  if (!targetUrl) return { error: `No registered GEOPass pack found for '${packName}'` };
+
+  const plannedPack = { ...(pack ?? {}), url: targetUrl };
+  return {
+    status: "planned",
+    pass: "geopass",
+    target_url: targetUrl,
+    checks: pack?.checks ?? [
+      "ai-crawler-access",
+      "entity-consistency",
+      "citation-readiness",
+      "source-attribution",
+      "structured-facts",
+      "answer-engine-prompts",
+    ],
+    ai_surfaces: pack?.ai_surfaces ?? ["chatgpt", "claude", "perplexity"],
+    crawler_plan: crawlerPlan(plannedPack),
+    note: "GEOPass Chunk 1 is scaffold-only. Execution and persistence land in a later chip.",
+  };
+}
+
+export async function geopassStatus(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id : "";
+  if (!runId) return { error: "run_id is required" };
+  return {
+    run_id: runId,
+    status: "not_implemented",
+    note: "GEOPass run persistence lands in a later chip.",
+  };
+}
+
+export async function geopassRegisterPack(args: Record<string, unknown>): Promise<unknown> {
+  const packYaml = typeof args.pack_yaml === "string" ? args.pack_yaml : "";
+  if (!packYaml) return { error: "pack_yaml is required" };
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(packYaml);
+  } catch (err) {
+    return { error: `pack_yaml is not valid YAML: ${(err as Error).message}` };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { error: "pack_yaml must be a YAML object at the top level" };
+  }
+
+  const pack = parsed as Record<string, unknown>;
+  const missing = REQUIRED_PACK_KEYS.filter((key) => pack[key] === undefined);
+  if (missing.length > 0) return { error: "pack is missing required keys", missing };
+
+  const name = typeof pack.name === "string" ? pack.name : "";
+  if (!name) return { error: "pack name must be a non-empty string" };
+
+  ensurePacksDir();
+  const packId = `${safeFilename(name)}-${crypto.randomBytes(4).toString("hex")}`;
+  const filePath = path.join(PACKS_DIR, `${packId}.yaml`);
+  fs.writeFileSync(filePath, packYaml, "utf8");
+  return { pack_id: packId, name, file: filePath };
+}
+
+export async function geopassCrawlPlan(args: Record<string, unknown>): Promise<unknown> {
+  const url = typeof args.url === "string" ? args.url : "";
+  if (!url) return { error: "url is required" };
+  return crawlerPlan({
+    url,
+    crawl: {
+      max_pages: typeof args.max_pages === "number" ? args.max_pages : 25,
+      respect_robots: args.respect_robots !== false,
+      include_sitemap: args.include_sitemap !== false,
+    },
+  });
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -776,6 +776,14 @@ import {
   seopassLighthousePlan,
 } from "./seopass-tool.js";
 
+// --- GEOPass (AI search readiness QC, sister to UXPass) ----------------------
+import {
+  geopassRun,
+  geopassStatus,
+  geopassRegisterPack,
+  geopassCrawlPlan,
+} from "./geopass-tool.js";
+
 // ─── Crews (Orchestrator Wizard) ──────────────────────────────────────────────
 import { crewsStartRun, crewsGetRun, crewsListRuns } from "./crews-tool.js";
 
@@ -11304,6 +11312,55 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // --- geopass-tool.ts (AI search readiness QC) ------------------------------
+  {
+    name: "geopass_run",
+    description: "Plan a GEOPass run against a URL or registered pack. Chunk 1 returns the AI-search crawl, entity, and citation-readiness plan without persisting results.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: { type: "string", description: "Target URL for a one-off GEOPass plan" },
+        pack_name: { type: "string", description: "Name of a registered GEOPass pack; the pack URL is used as the target" },
+      },
+    },
+  },
+  {
+    name: "geopass_status",
+    description: "Fetch the status for a GEOPass run. Chunk 1 reserves the tool shape; persistence lands later.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        run_id: { type: "string", description: "The GEOPass run id returned by a future geopass_run execution path" },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: "geopass_register_pack",
+    description: "Register a GEOPass pack from a YAML string. Validates required keys and stores the pack locally for geopass_run.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        pack_yaml: { type: "string", description: "Full GEOPass pack definition as a YAML string" },
+      },
+      required: ["pack_yaml"],
+    },
+  },
+  {
+    name: "geopass_crawl_plan",
+    description: "Build the crawler and extraction plan for a GEOPass target URL. Execution and persistence land in a later chunk.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: { type: "string", description: "Target URL for the crawl plan" },
+        max_pages: { type: "number", description: "Maximum pages to plan for crawling (default: 25)" },
+        respect_robots: { type: "boolean", description: "Whether the crawl should respect robots.txt (default: true)" },
+        include_sitemap: { type: "boolean", description: "Whether the crawler should inspect sitemap URLs (default: true)" },
+      },
+      required: ["url"],
+    },
+  },
+
   // ── crews-tool.ts (Orchestrator Wizard) ──────────────────────────────────────
   {
     name: "start_crew_run",
@@ -12475,6 +12532,12 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   seopass_status:          (args) => seopassStatus(args),
   seopass_register_pack:   (args) => seopassRegisterPack(args),
   seopass_lighthouse_plan: (args) => seopassLighthousePlan(args),
+
+  // geopass-tool.ts
+  geopass_run:           (args) => geopassRun(args),
+  geopass_status:        (args) => geopassStatus(args),
+  geopass_register_pack: (args) => geopassRegisterPack(args),
+  geopass_crawl_plan:    (args) => geopassCrawlPlan(args),
 
   // crews-tool.ts
   start_crew_run: (args) => crewsStartRun(args),


### PR DESCRIPTION
## Summary
- add GEOPass Chunk 1 product brief, core pack, schema, and crawler plan scaffold
- add four MCP tools: geopass_run, geopass_status, geopass_register_pack, geopass_crawl_plan
- wire GEOPass into the MCP server tool registry

## Verification
- git diff --check
- npm run build --workspace packages/mcp-server

## Notes
- This branch is based on origin/main and does not include SEOPass PR #260.
- If #260 merges first, this PR may need a small tool-wiring.ts rebase because both add Pass-family MCP tool wiring.

Fishbowl: b6a16f33-ce0d-40f9-a042-15907124d885