### PR TITLE
feat(spec): Connectors Phase 0 spec + Crews eval seed

### DIFF
--- a/docs/connectors/spec.md
+++ b/docs/connectors/spec.md
@@ -1,0 +1,319 @@
+# Connectors Phase 0
+
+**Status**: Draft  
+**Last updated**: 2026-04-29  
+**Owner**: `🦾`
+
+## Purpose
+
+Phase 0 locks the product and architecture contract for Connectors so later UI and implementation work stops drifting between:
+
+- connector catalog
+- live tenant connection state
+- encrypted secret storage
+- legacy BackstagePass language
+
+This is a doc-first phase.
+It does not replace the vault, introduce server-side inference, or redesign provider integrations.
+
+## Architecture lock
+
+Phase 0 assumes the current platform direction:
+
+- the user's chat model does the cognition
+- UnClick owns orchestration, prompts, schemas, memory boundaries, audit trail, and connection state
+- Connectors are a platform capability, not an LLM capability
+- no server-side model routing is added for connector setup in v1
+
+## Noun lock
+
+Phase 0 locks four terms:
+
+- **Connector**: the static platform definition for a service integration such as Slack, Xero, Shopify, or Figma
+- **Connection**: a tenant's live configured relationship to one connector
+- **Credential**: the secret material or OAuth token set that powers a connection
+- **BackstagePass**: the encrypted storage and audit subsystem behind the scenes, not the primary user-facing noun
+
+User-facing surfaces should prefer:
+
+- Connections
+- Connect a service
+- Reconnect
+- Connection health
+
+BackstagePass can stay visible as an advanced or legacy surface during transition, but it should not be the main product story.
+
+## Current repo reality
+
+The repo already has most of the building blocks, but not one coherent contract:
+
+- frontend connector registry in `src/lib/connectors.ts`
+- MCP/server connector registry in `packages/mcp-server/src/connectors/index.ts`
+- connector catalog data in `platform_connectors`
+- encrypted credential storage in `user_credentials`
+- connection-adjacent admin UI in `src/pages/admin/tools/ConnectedServices.tsx`
+- vault API and audit writes in `api/backstagepass.ts`
+
+Today those surfaces drift in wording, source-of-truth assumptions, and auth/setup behavior.
+Phase 0 exists to stop that drift before a larger Connections or Plugboard surface lands.
+
+## In-scope decisions
+
+### 1. Product boundary
+
+The user-facing story is:
+
+- browse available connectors
+- see what is connected
+- see whether a connection is healthy
+- reconnect, remove, or finish setup
+- understand what capability a connection unlocks
+
+The user should not need to think about salts, IVs, auth tags, or vault internals unless they intentionally open an advanced surface.
+
+### 2. Connector definition versus connection state
+
+Phase 0 separates:
+
+- **public connector metadata**
+- **tenant-scoped connection metadata**
+- **secret credential material**
+
+These must not be blurred together in UI or API shape.
+
+Minimum distinction:
+
+- connector catalog can be public or metadata-only
+- connection rows must always be tenant-scoped by `api_key_hash`
+- plaintext secret access must stay behind explicit sensitive flows
+
+### 3. Source of truth
+
+Phase 0 locks these current truths:
+
+- `platform_connectors` is the connector catalog surface
+- `user_credentials` is the live secret substrate for connection state
+- `platform_credentials` is legacy or compatibility-only and should not become the primary live connection store
+
+The product may still have duplicated connector definitions during Phase 0, but the contract should assume the system is moving toward one canonical connector definition source that generates or feeds the others.
+
+## Auth and permission boundaries
+
+Phase 0 locks three auth surfaces:
+
+### Browser session JWT
+
+Used for signed-in admin and operator flows.
+
+Appropriate for:
+
+- browsing connector catalog
+- listing connection metadata
+- viewing status
+- editing non-secret metadata
+
+### Agent or MCP API-key bearer
+
+Used by agent clients through `UNCLICK_API_KEY` or bearer auth.
+
+Appropriate for:
+
+- tenant-scoped agent operations
+- MCP tool access
+- connection-aware tooling that never exposes plaintext secrets to the browser
+
+### Proof-of-possession
+
+Sensitive connection actions require dual proof:
+
+- signed-in session context
+- plaintext UnClick API key
+
+Phase 0 should treat the following as proof-of-possession actions:
+
+- reveal secret values
+- add credential values
+- rotate or replace credential values
+- validate or test live credentials
+- export credential material
+- remove a live connection
+
+This is stricter than some current legacy behavior, but it is the cleaner Phase 0 security boundary.
+
+## Auth type versus setup flow
+
+Phase 0 explicitly separates:
+
+- `auth_type`
+- `setup_flow`
+
+Current `auth_type` values in code are:
+
+- `oauth2`
+- `api_key`
+- `bot_token`
+
+That is not enough on its own.
+
+An `oauth2` connector must also declare whether Phase 0 supports:
+
+- real OAuth redirect and token exchange
+- manual token paste only
+- hybrid or partial setup
+
+This matters because several connectors are labeled `oauth2` while the real operator experience is still closer to manual token entry.
+
+## Storage and encryption contract
+
+Phase 0 preserves the current storage model.
+
+### Credential substrate
+
+The real secret store remains `user_credentials`.
+
+Minimum row shape Phase 0 assumes:
+
+- `api_key_hash`
+- `platform_slug`
+- nullable `label`
+- `encrypted_data`
+- `encryption_iv`
+- `encryption_tag`
+- `encryption_salt`
+- `expires_at`
+- `is_valid`
+- `last_tested_at`
+- `last_used_at`
+- `last_rotated_at`
+- timestamps
+
+Connection views derive from this substrate plus catalog metadata.
+
+### Encryption stance
+
+Credential material remains:
+
+- encrypted per row
+- AES-256-GCM at rest
+- derived from the user's plaintext UnClick API key via PBKDF2
+- unique salt and IV per row
+- no server-side master decryption key
+
+Phase 0 does not introduce:
+
+- KMS migration
+- shared team vaults
+- plaintext-at-rest mode
+
+### API key rotation rule
+
+Current repo behavior means resetting the UnClick API key makes existing credentials unreadable until re-saved.
+
+Phase 0 locks the honest rule:
+
+- **API key reset invalidates existing live connections unless or until a future re-wrap path exists**
+
+That means the product must surface reset as a connection lifecycle event, not pretend the old connections remain healthy.
+
+## Audit contract
+
+Phase 0 preserves append-only audit semantics.
+
+At minimum, sensitive connection actions should produce an audit row with:
+
+- `actor_user_id`
+- `api_key_hash`
+- `credential_id`
+- `platform_slug`
+- nullable `label`
+- `action`
+- `success`
+- `metadata`
+- `created_at`
+
+Audit metadata must never contain plaintext secret values.
+
+Phase 0 also calls out the current split:
+
+- `api/backstagepass.ts` is the audited admin surface
+- legacy `/api/credentials` uses the same crypto model but does not currently provide the same audit behavior
+
+Phase 0 should not create a second divergent secret contract.
+Any broader audit unification is later work.
+
+## Connection status model
+
+Phase 0 keeps the user-facing status model intentionally small:
+
+- **Not connected**
+- **Connected**
+- **Needs reconnection**
+- **Connection error**
+- **Setup incomplete**
+
+Recommended mapping:
+
+| Status | Meaning |
+| --- | --- |
+| `Not connected` | No usable credential row exists for this tenant and connector |
+| `Connected` | Credential exists, latest validation is healthy, and expiry or scope state is acceptable |
+| `Needs reconnection` | Credential exists but has expired, lost required scopes, or was invalidated by lifecycle changes such as API-key reset |
+| `Connection error` | Validation or usage failed for a reason not yet resolved by simple reconnect |
+| `Setup incomplete` | The connector has been started but required fields or setup steps are missing |
+
+Important honesty note:
+
+The current repo does not fully encode every one of these states yet.
+In particular, `Needs reconnection` and `Setup incomplete` need either explicit state mapping rules or extra persisted fields beyond today's simple `is_valid` and timestamp set.
+
+That gap should be treated as implementation work, not hidden by the spec.
+
+## Capability unlock contract
+
+A connection is valuable because it unlocks actions.
+
+Every connector surface should leave room for:
+
+- a short "what this unlocks" summary
+- a future "used by these tools" mapping
+
+Phase 0 does not require a full dependency graph yet.
+It only locks the expectation that connections are described in capability language, not vault language.
+
+## Out of scope
+
+Phase 0 does not include:
+
+- replacing BackstagePass crypto
+- KMS adoption
+- automatic credential rotation
+- provider token refresh orchestration
+- outbound API call brokering
+- shared team vaults
+- a full marketplace app model
+- a full rename of every legacy BackstagePass symbol
+- server-side inference for connection help
+
+## Immediate implementation follow-up
+
+After this spec is accepted, the next implementation slice should:
+
+1. move the user-facing narrative from Keychain or BackstagePass to Connections
+2. reuse `user_credentials` as the live connection substrate
+3. keep `platform_connectors` as the catalog layer
+4. make proof-of-possession boundaries explicit in the UI and API contract
+5. expose connection state honestly, including reconnect and invalidation cases
+
+## Summary
+
+Phase 0 locks this direction:
+
+- **Connections** is the user-facing product concept
+- **Connector** is the static definition
+- **BackstagePass** remains the encrypted credential substrate
+- **user_credentials** remains the live secret store
+- **api_key_hash** remains the tenant boundary
+- sensitive actions use **proof-of-possession**
+- API key reset is a **connection lifecycle event**, not a hidden internal detail
+
+That is enough to keep later UI, MCP, and storage work moving in one direction.

--- a/tests/crews-eval/seed.json
+++ b/tests/crews-eval/seed.json
@@ -1,0 +1,162 @@
+[
+  {
+    "crew_id": "business-council",
+    "prompt": "A retainer client wants a 3-month commitment at 50 percent of my usual rate. Cash flow is light this quarter, but I worry the discount will anchor future pricing and crowd out better work. Should I take it, counter it, or walk away?",
+    "expected_traits": [
+      "Makes a clear call between taking it, countering, or walking away instead of staying purely conditional",
+      "Weighs short-term cash flow against long-term price anchoring and opportunity cost",
+      "Includes downside protection such as tighter scope, time limits, prepayment, or reset terms",
+      "Shows how to negotiate the next step in a practical, low-drama way"
+    ],
+    "anti_patterns": [
+      "Vague 'it depends' framing with no recommendation",
+      "Ignoring the future pricing anchor risk",
+      "Treating any revenue as automatically good because the quarter is slow",
+      "Offering generic sales advice without concrete protections"
+    ]
+  },
+  {
+    "crew_id": "business-council",
+    "prompt": "A mid-sized client wants to start a 6-week enterprise pilot, but they are asking for a custom security review, weekly stakeholder calls, and a price below our normal floor. Should we accept, counter, or decline? I want the answer to weigh revenue, distraction cost, precedent risk, and what would make the pilot worth it.",
+    "expected_traits": [
+      "Makes a clear accept, counter, or decline recommendation",
+      "Balances revenue upside against delivery drag, stakeholder overhead, and precedent risk",
+      "Defines the guardrails that would make the pilot acceptable if the answer is yes or counter",
+      "Treats security review and custom process demands as real scope, not background noise"
+    ],
+    "anti_patterns": [
+      "Seeing the enterprise logo as sufficient reason to say yes",
+      "Ignoring internal distraction cost",
+      "No clear counter structure or guardrails",
+      "Treating the security review as trivial admin work"
+    ]
+  },
+  {
+    "crew_id": "business-council",
+    "prompt": "Design the onboarding flow for the first 10 pilot customers using UnClick crews and memory. They are technical enough to follow instructions but not patient enough to debug MCP setup for an hour. What is the minimum path that gets them to first value fast without creating a support nightmare for us?",
+    "expected_traits": [
+      "Designs a minimum path to first value with as little setup friction as possible",
+      "Reduces MCP and debug burden through defaults, preflight checks, or guided setup",
+      "Defines a clear first milestone that proves the product is working for the pilot customer",
+      "Balances customer success with support scalability so the team does not create a manual ops trap"
+    ],
+    "anti_patterns": [
+      "Expecting pilots to troubleshoot setup for long periods",
+      "Creating an overly elaborate onboarding process before first value",
+      "No explicit first-value milestone or success checkpoint",
+      "Unlimited white-glove support with no containment"
+    ]
+  },
+  {
+    "crew_id": "launch-stress-test",
+    "prompt": "Stress test this launch plan for June: soft announce UnClick Pro to the waitlist on June 3, publish the public landing page on June 10, run founder-led outreach for two weeks, and open paid signup on June 24. Attack the sequencing, risk points, and weak assumptions, then tell me what to change before I commit.",
+    "expected_traits": [
+      "Identifies the biggest sequencing risks and weak assumptions in the current launch order",
+      "Prioritizes fixes instead of producing an undifferentiated list of concerns",
+      "Distinguishes what must change before commitment from what can be monitored later",
+      "Ends with a revised plan, timeline, or gating logic that is more robust than the original"
+    ],
+    "anti_patterns": [
+      "Generic launch advice that could apply to any product",
+      "Listing risks without ranking or recommending changes",
+      "Failing to challenge the current dates or sequence",
+      "Ending without a clearer revised plan"
+    ]
+  },
+  {
+    "crew_id": "launch-stress-test",
+    "prompt": "Build the rollback and comms plan for this same June launch if paid signup opens and one of three things goes wrong in the first 48 hours: conversion is near zero, support tickets spike, or the MCP install path breaks for a meaningful share of users. What should trigger rollback, who gets told what, and what should stay live versus get paused?",
+    "expected_traits": [
+      "Defines explicit failure triggers rather than vague concern levels",
+      "Separates internal escalation, public comms, and customer-facing messaging cleanly",
+      "Distinguishes what to pause, what to keep live, and what to monitor through the incident",
+      "Optimizes for trust preservation as well as operational recovery"
+    ],
+    "anti_patterns": [
+      "No rollback thresholds or ownership",
+      "Treating all failures as equal severity",
+      "Only focusing on engineering steps and forgetting comms",
+      "Panic advice that shuts everything down without triage"
+    ]
+  },
+  {
+    "crew_id": "creative-studio",
+    "prompt": "Write three homepage headline and subhead options for unclick.world aimed at technical operators evaluating MCP tooling. Make them feel credible, specific, and high-agency. Avoid generic AI automation language, hype, or sounding like a consumer productivity app.",
+    "expected_traits": [
+      "Produces strong headline and subhead options rather than only abstract positioning commentary",
+      "Keeps the voice sharp, credible, and high-agency instead of futuristic or fluffy",
+      "Translates the product's capabilities into clear user value without drowning in jargon",
+      "Pressure-tests wording for vagueness, overclaiming, and credibility gaps"
+    ],
+    "anti_patterns": [
+      "Generic AI-marketing copy full of buzzwords",
+      "Feature-dumping without a crisp positioning angle",
+      "Using jargon like MCP or crews without making the benefit legible",
+      "Ignoring the requested tone"
+    ]
+  },
+  {
+    "crew_id": "creative-studio",
+    "prompt": "Draft the hero copy, supporting bullets, and primary CTA for a pricing page that introduces UnClick Pro. The reader is a technical founder or operator who wants leverage, not a beginner looking for general AI advice. Make the copy specific enough to convert, but still clean and uncluttered.",
+    "expected_traits": [
+      "Produces usable pricing-page copy instead of only positioning notes",
+      "Matches the audience of technical founders and operators with concrete language",
+      "Creates a clear primary CTA and supporting bullets that reduce hesitation",
+      "Balances specificity with restraint so the page does not feel cluttered"
+    ],
+    "anti_patterns": [
+      "Generic SaaS pricing copy that could fit any tool",
+      "No real CTA or next step",
+      "Too much abstraction about leverage with no concrete product value",
+      "Crowded messaging that tries to explain everything at once"
+    ]
+  },
+  {
+    "crew_id": "decision-desk",
+    "prompt": "Should UnClick Pro launch at 19, 29, or 39 AUD per month? Assume the early product has strong utility for technical operators, weak mainstream awareness, and a support burden that will be real for the first 60 days. Recommend one launch price, what to include, and what objection I should expect first.",
+    "expected_traits": [
+      "Chooses one launch price and commits to it clearly",
+      "Justifies the choice using target user utility, weak awareness, and early support burden",
+      "Defines a sensible package for launch rather than treating price in isolation",
+      "Anticipates the first likely objection and addresses it realistically"
+    ],
+    "anti_patterns": [
+      "Comparing prices without making a decision",
+      "Ignoring support costs during the first 60 days",
+      "Vague packaging with no clear inclusions or limits",
+      "Assuming mainstream demand dynamics instead of niche technical adoption"
+    ]
+  },
+  {
+    "crew_id": "decision-desk",
+    "prompt": "We currently have two overlapping ways to handle third-party credentials and connection state. Should we consolidate on one model now or keep both for 6 months to avoid migration pain? Weigh product clarity, migration cost, security risk, and user confusion, then recommend the timing and shape of the move.",
+    "expected_traits": [
+      "Provides strategic clarity on the primary direction rather than preserving ambiguity",
+      "Weighs product clarity, migration cost, security posture, and operator confusion together",
+      "Treats transition risk realistically, including bridge or compatibility considerations",
+      "Explains the operational implications of the chosen path, not just the architectural story"
+    ],
+    "anti_patterns": [
+      "Hand-wavy architecture talk with no recommendation",
+      "Ignoring migration pain or adoption friction",
+      "Reducing the decision to security alone",
+      "Missing the operator-confusion dimension"
+    ]
+  },
+  {
+    "crew_id": "decision-desk",
+    "prompt": "I have too many plausible priorities at once: ship the crews engine, clean up Fishbowl reliability, close the memory startup-context noise bug, fix the TestPass scheduler path, and keep the merge queue moving. Assume I only get one focused week and I will lose part of two days to support interruptions. Build me a brutally honest one-week priority stack that protects momentum instead of making me feel busy.",
+    "expected_traits": [
+      "Produces a hard one-week priority stack with explicit deprioritization",
+      "Sequences work to protect momentum and avoid thrash across too many fronts",
+      "Recognizes which tasks unblock reliability or execution for everything else",
+      "Keeps the plan bounded and practical for a single week rather than aspirational"
+    ],
+    "anti_patterns": [
+      "A long task list masquerading as prioritization",
+      "Treating every item as equally urgent",
+      "Ignoring dependencies and blocker-clearing logic",
+      "Using motivational or productivity language instead of making tradeoffs"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add the Connectors Phase 0 architecture and product contract spec
- add a 10-item Crews eval seed with expected traits and anti-patterns
- keep the change scoped to docs/data only

## Testing
- JSON parse check for `tests/crews-eval/seed.json`
- no runtime or unit tests run (docs/data only)
