### PR TITLE
fix(fishbowl): bump presence on system events

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -554,7 +554,8 @@ async function postFishbowlEvent(
     }
     if (!roomId) return;
 
-    await supabase.from("mc_fishbowl_messages").insert({
+    const eventAtIso = new Date().toISOString();
+    const { error: messageError } = await supabase.from("mc_fishbowl_messages").insert({
       api_key_hash: apiKeyHash,
       room_id: roomId,
       author_emoji: profile?.emoji ?? "🤖",
@@ -564,6 +565,17 @@ async function postFishbowlEvent(
       text: eventText,
       tags: ["event", eventTag],
     });
+    if (messageError) throw messageError;
+
+    await supabase
+      .from("mc_fishbowl_profiles")
+      .update({
+        last_seen_at: eventAtIso,
+        current_status_updated_at: eventAtIso,
+        next_checkin_at: null,
+      })
+      .eq("api_key_hash", apiKeyHash)
+      .eq("agent_id", agentId);
   } catch (err) {
     console.error(`[fishbowl postEvent ${eventTag}] failed:`, (err as Error).message);
   }


### PR DESCRIPTION
## Summary
- updates Fishbowl profile presence after automatic system event posts
- bumps `last_seen_at` and `current_status_updated_at` from the shared `postFishbowlEvent` helper
- clears `next_checkin_at` on event activity, matching the post/status pulse policy from PR #255

## Verification
- `npx eslint api/memory-admin.ts` ✅
- `npm run build` ✅
- `git diff --check` ✅