### PR TITLE
scaffold(securitypass): add scanner probe adapters

### DIFF
--- a/packages/securitypass/src/__tests__/gitleaks-probe.test.ts
+++ b/packages/securitypass/src/__tests__/gitleaks-probe.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildGitleaksCommand, gitleaksResultFromCommand, parseGitleaksJson } from "../probes/gitleaks.js";
+
+describe("Gitleaks probe scaffold", () => {
+  it("builds an inert JSON command spec", () => {
+    const spec = buildGitleaksCommand("/repo");
+    expect(spec.command).toBe("gitleaks");
+    expect(spec.args).toContain("detect");
+    expect(spec.args).toContain("--report-format");
+    expect(spec.args).toContain("json");
+  });
+
+  it("redacts secret evidence from parsed findings", () => {
+    const findings = parseGitleaksJson(JSON.stringify([{
+      RuleID: "generic-api-key",
+      Description: "Generic API Key",
+      File: ".env",
+      StartLine: 2,
+      Secret: "sk_live_secret",
+    }]));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("critical");
+    expect(findings[0].evidence.secret_redacted).toBe("[redacted]");
+    expect(JSON.stringify(findings)).not.toContain("sk_live_secret");
+  });
+
+  it("wraps command output without executing anything", () => {
+    const command = buildGitleaksCommand("/repo");
+    const result = gitleaksResultFromCommand(
+      { type: "git", url: "https://github.com/example/repo" },
+      command,
+      { exitCode: 1, stdout: "[]", stderr: "scan complete" },
+    );
+    expect(result.probe).toBe("gitleaks");
+    expect(result.findings).toEqual([]);
+    expect(result.raw).toEqual({ exitCode: 1, stderr: "scan complete" });
+  });
+});
+

--- a/packages/securitypass/src/__tests__/osv-scanner-probe.test.ts
+++ b/packages/securitypass/src/__tests__/osv-scanner-probe.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildOsvScannerCommand, osvResultFromCommand, parseOsvScannerJson } from "../probes/osv-scanner.js";
+
+describe("OSV-Scanner probe scaffold", () => {
+  it("builds a recursive JSON command spec", () => {
+    const spec = buildOsvScannerCommand("/repo");
+    expect(spec.command).toBe("osv-scanner");
+    expect(spec.args).toEqual(["--format", "json", "--recursive", "/repo"]);
+  });
+
+  it("parses vulnerability findings from OSV JSON", () => {
+    const findings = parseOsvScannerJson(JSON.stringify({
+      results: [{
+        packages: [{
+          package: { name: "left-pad", version: "1.0.0" },
+          vulnerabilities: [{
+            id: "GHSA-test",
+            summary: "Prototype pollution",
+            severity: [{ type: "CVSS_V3", score: "HIGH" }],
+          }],
+        }],
+      }],
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].check_id).toBe("securitypass.osv.GHSA-test");
+    expect(findings[0].severity).toBe("high");
+    expect(findings[0].evidence.package).toBe("left-pad");
+  });
+
+  it("wraps command output with target metadata", () => {
+    const result = osvResultFromCommand(
+      { type: "git", url: "https://github.com/example/repo" },
+      buildOsvScannerCommand("/repo"),
+      { exitCode: 0, stdout: "{\"results\":[]}", stderr: "" },
+    );
+    expect(result.probe).toBe("osv-scanner");
+    expect(result.findings).toEqual([]);
+  });
+});
+

--- a/packages/securitypass/src/__tests__/stagehand-probe.test.ts
+++ b/packages/securitypass/src/__tests__/stagehand-probe.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { runStagehandProbe, type StagehandLike } from "../probes/stagehand.js";
+
+describe("Stagehand probe scaffold", () => {
+  it("maps injected browser observations to findings", async () => {
+    const fakeStagehand: StagehandLike = {
+      async observeSecurity() {
+        return [{
+          check_id: "securitypass.stagehand.login-csrf",
+          title: "Login flow resists CSRF replay",
+          ok: false,
+          evidence: { step: "submit-login" },
+          remediation: "Add a verified CSRF token to the login form.",
+        }];
+      },
+    };
+    const result = await runStagehandProbe(
+      { type: "url", url: "https://example.com" },
+      fakeStagehand,
+    );
+    expect(result.probe).toBe("stagehand");
+    expect(result.findings[0].verdict).toBe("fail");
+    expect(result.findings[0].severity).toBe("medium");
+  });
+
+  it("returns not-applicable when no URL is present", async () => {
+    const fakeStagehand: StagehandLike = {
+      async observeSecurity() {
+        throw new Error("should not run without a URL");
+      },
+    };
+    const result = await runStagehandProbe({ type: "git", url: undefined }, fakeStagehand);
+    expect(result.findings[0].verdict).toBe("na");
+    expect(result.findings[0].check_id).toBe("securitypass.stagehand.target-url");
+  });
+});
+

--- a/packages/securitypass/src/probes/command-runner.ts
+++ b/packages/securitypass/src/probes/command-runner.ts
@@ -1,0 +1,26 @@
+import { spawn } from "node:child_process";
+import type { CommandExecutionResult, CommandSpec } from "./types.js";
+
+export type CommandRunner = (spec: CommandSpec) => Promise<CommandExecutionResult>;
+
+export const runCommand: CommandRunner = (spec) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(spec.command, spec.args, {
+      cwd: spec.cwd,
+      shell: false,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+

--- a/packages/securitypass/src/probes/gitleaks.ts
+++ b/packages/securitypass/src/probes/gitleaks.ts
@@ -1,0 +1,55 @@
+import type { SecurityRunTarget } from "../types/index.js";
+import type { CommandExecutionResult, CommandSpec, SecurityProbeFinding, SecurityProbeResult } from "./types.js";
+
+interface GitleaksLeak {
+  RuleID?: string;
+  Description?: string;
+  File?: string;
+  StartLine?: number;
+  Secret?: string;
+  Commit?: string;
+}
+
+export function buildGitleaksCommand(repoPath: string): CommandSpec {
+  return {
+    command: "gitleaks",
+    args: ["detect", "--source", repoPath, "--report-format", "json", "--no-banner"],
+    cwd: repoPath,
+  };
+}
+
+export function parseGitleaksJson(stdout: string): SecurityProbeFinding[] {
+  if (!stdout.trim()) return [];
+  const leaks = JSON.parse(stdout) as GitleaksLeak[];
+  return leaks.map((leak) => ({
+    check_id: `securitypass.gitleaks.${leak.RuleID ?? "secret"}`,
+    title: leak.Description ?? "Potential secret detected",
+    severity: "critical",
+    verdict: "fail",
+    category: "secrets",
+    description: `Gitleaks reported a potential secret in ${leak.File ?? "an unknown file"}.`,
+    remediation: "Rotate the exposed credential, remove it from history, and replace it with a managed secret.",
+    evidence: {
+      rule_id: leak.RuleID ?? null,
+      file: leak.File ?? null,
+      start_line: leak.StartLine ?? null,
+      commit: leak.Commit ?? null,
+      secret_redacted: leak.Secret ? "[redacted]" : null,
+    },
+  }));
+}
+
+export function gitleaksResultFromCommand(
+  target: SecurityRunTarget,
+  command: CommandSpec,
+  result: CommandExecutionResult,
+): SecurityProbeResult {
+  return {
+    probe: "gitleaks",
+    target,
+    command,
+    findings: parseGitleaksJson(result.stdout),
+    raw: { exitCode: result.exitCode, stderr: result.stderr },
+  };
+}
+

--- a/packages/securitypass/src/probes/index.ts
+++ b/packages/securitypass/src/probes/index.ts
@@ -1,0 +1,6 @@
+export * from "./types.js";
+export * from "./command-runner.js";
+export * from "./gitleaks.js";
+export * from "./osv-scanner.js";
+export * from "./stagehand.js";
+

--- a/packages/securitypass/src/probes/osv-scanner.ts
+++ b/packages/securitypass/src/probes/osv-scanner.ts
@@ -1,0 +1,80 @@
+import type { SecurityRunTarget } from "../types/index.js";
+import type { CommandExecutionResult, CommandSpec, SecurityProbeFinding, SecurityProbeResult } from "./types.js";
+
+interface OsvPackage {
+  name?: string;
+  version?: string;
+}
+
+interface OsvVulnerability {
+  id?: string;
+  summary?: string;
+  details?: string;
+  severity?: Array<{ type?: string; score?: string }>;
+}
+
+interface OsvResult {
+  packages?: Array<{
+    package?: OsvPackage;
+    vulnerabilities?: OsvVulnerability[];
+  }>;
+}
+
+export function buildOsvScannerCommand(path: string): CommandSpec {
+  return {
+    command: "osv-scanner",
+    args: ["--format", "json", "--recursive", path],
+    cwd: path,
+  };
+}
+
+function severityFromOsv(vuln: OsvVulnerability): SecurityProbeFinding["severity"] {
+  const score = vuln.severity?.find((s) => s.score)?.score?.toUpperCase() ?? "";
+  if (score.includes("CRITICAL")) return "critical";
+  if (score.includes("HIGH")) return "high";
+  if (score.includes("MEDIUM")) return "medium";
+  return "low";
+}
+
+export function parseOsvScannerJson(stdout: string): SecurityProbeFinding[] {
+  if (!stdout.trim()) return [];
+  const body = JSON.parse(stdout) as { results?: OsvResult[] };
+  const findings: SecurityProbeFinding[] = [];
+  for (const result of body.results ?? []) {
+    for (const pkg of result.packages ?? []) {
+      for (const vuln of pkg.vulnerabilities ?? []) {
+        findings.push({
+          check_id: `securitypass.osv.${vuln.id ?? "vulnerability"}`,
+          title: vuln.summary ?? "Open source vulnerability detected",
+          severity: severityFromOsv(vuln),
+          verdict: "fail",
+          category: "supply-chain",
+          description: vuln.details,
+          remediation: "Upgrade the affected package, apply a vendor patch, or document an accepted risk.",
+          evidence: {
+            id: vuln.id ?? null,
+            package: pkg.package?.name ?? null,
+            version: pkg.package?.version ?? null,
+            severity: vuln.severity ?? [],
+          },
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export function osvResultFromCommand(
+  target: SecurityRunTarget,
+  command: CommandSpec,
+  result: CommandExecutionResult,
+): SecurityProbeResult {
+  return {
+    probe: "osv-scanner",
+    target,
+    command,
+    findings: parseOsvScannerJson(result.stdout),
+    raw: { exitCode: result.exitCode, stderr: result.stderr },
+  };
+}
+

--- a/packages/securitypass/src/probes/stagehand.ts
+++ b/packages/securitypass/src/probes/stagehand.ts
@@ -1,0 +1,47 @@
+import type { SecurityRunTarget } from "../types/index.js";
+import type { SecurityProbeFinding, SecurityProbeResult } from "./types.js";
+
+export interface StagehandObservation {
+  check_id: string;
+  title: string;
+  ok: boolean;
+  evidence: Record<string, unknown>;
+  remediation?: string;
+}
+
+export interface StagehandLike {
+  observeSecurity(targetUrl: string): Promise<StagehandObservation[]>;
+}
+
+export async function runStagehandProbe(
+  target: SecurityRunTarget,
+  stagehand: StagehandLike,
+): Promise<SecurityProbeResult> {
+  if (!target.url) {
+    return {
+      probe: "stagehand",
+      target,
+      findings: [{
+        check_id: "securitypass.stagehand.target-url",
+        title: "Stagehand probe requires a URL target",
+        severity: "low",
+        verdict: "na",
+        category: "browser",
+        evidence: { target },
+      }],
+    };
+  }
+
+  const observations = await stagehand.observeSecurity(target.url);
+  const findings: SecurityProbeFinding[] = observations.map((obs) => ({
+    check_id: obs.check_id,
+    title: obs.title,
+    severity: obs.ok ? "low" : "medium",
+    verdict: obs.ok ? "check" : "fail",
+    category: "browser",
+    remediation: obs.remediation,
+    evidence: obs.evidence,
+  }));
+  return { probe: "stagehand", target, findings, raw: observations };
+}
+

--- a/packages/securitypass/src/probes/types.ts
+++ b/packages/securitypass/src/probes/types.ts
@@ -1,0 +1,35 @@
+import type { SecurityRunTarget, Severity, Verdict } from "../types/index.js";
+
+export type ProbeKind = "gitleaks" | "osv-scanner" | "stagehand";
+
+export interface CommandSpec {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+export interface CommandExecutionResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SecurityProbeFinding {
+  check_id: string;
+  title: string;
+  severity: Severity;
+  verdict: Verdict;
+  category: string;
+  description?: string;
+  remediation?: string;
+  evidence: Record<string, unknown>;
+}
+
+export interface SecurityProbeResult {
+  probe: ProbeKind;
+  target: SecurityRunTarget;
+  command?: CommandSpec;
+  findings: SecurityProbeFinding[];
+  raw?: unknown;
+}
+


### PR DESCRIPTION
## Summary
- adds internal SecurityPass probe scaffolds for Gitleaks, OSV-Scanner, and Stagehand-style browser checks
- keeps probes inert and injectable so tests do not execute external scanners or browser automation
- adds deterministic tests for command specs, JSON parsing, secret redaction, and Stagehand observation mapping

## Scope note
- New files only under `packages/securitypass/src/probes` and `packages/securitypass/src/__tests__`
- No package exports, dependency edits, runner wiring, or existing SecurityPass behavior changes

## Verification
- `npm run test --workspace=@unclick/securitypass` ✅
- `npm run build --workspace=@unclick/securitypass` ✅
- `npx eslint <new SecurityPass probe files>` ✅
- `git diff --check` ✅