### PR TITLE
fix(memory): filter invalidated active facts in load_memory

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   compactSearchMemoryForStrictClients,
   compactStartupContextForStrictClients,
+  filterInvalidatedActiveFactsForLoadMemory,
 } from "../handlers.js";
 
 const long = (prefix: string, size: number) => `${prefix} ${"x".repeat(size)}`;
@@ -56,6 +57,43 @@ describe("strict-client memory response bounds", () => {
     assert.equal(compact.recent_sessions.length, 1);
     assert.ok(compact.recent_sessions[0].summary.length < 500);
     assert.match(compact.recent_sessions[0].summary, /truncated/);
+  });
+
+  test("load_memory filters invalidated active facts before compact ranking", () => {
+    const compact = compactStartupContextForStrictClients({
+      active_facts: [
+        {
+          fact: "invalidated-high-rank",
+          category: "general",
+          confidence: 1,
+          created_at: "2026-04-28T00:00:00Z",
+          invalidated_at: "2026-04-29T00:00:00Z",
+        },
+        ...Array.from({ length: 12 }, (_, i) => ({
+          fact: `live-${i}`,
+          category: "general",
+          confidence: 0.9,
+          created_at: "2026-04-28T00:00:00Z",
+          invalidated_at: null,
+        })),
+      ],
+    }) as { active_facts: Array<{ fact: string }>; response_bounds: { active_facts_available_in_loaded_window: number } };
+
+    const facts = compact.active_facts.map((row) => row.fact);
+    assert.equal(facts.includes("invalidated-high-rank"), false);
+    assert.equal(facts.length, 12);
+    assert.equal(compact.response_bounds.active_facts_available_in_loaded_window, 12);
+  });
+
+  test("load_memory full-content path filters invalidated active facts", () => {
+    const filtered = filterInvalidatedActiveFactsForLoadMemory({
+      active_facts: [
+        { fact: "live", invalidated_at: null, extra: "kept" },
+        { fact: "stale", invalidated_at: "2026-04-29T00:00:00Z" },
+      ],
+    }) as { active_facts: Array<{ fact: string; invalidated_at: string | null; extra?: string }> };
+
+    assert.deepEqual(filtered.active_facts, [{ fact: "live", invalidated_at: null, extra: "kept" }]);
   });
 
   test("search_memory caps content previews by default", () => {

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -62,11 +62,26 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function hasInvalidatedAtSet(value: unknown): boolean {
+  const row = asRecord(value);
+  if (!row || !("invalidated_at" in row)) return false;
+  return row.invalidated_at !== null && row.invalidated_at !== undefined && row.invalidated_at !== "";
+}
+
+export function filterInvalidatedActiveFactsForLoadMemory(value: unknown): unknown {
+  const context = asRecord(value);
+  if (!context || !Array.isArray(context.active_facts)) return value;
+
+  const activeFacts = context.active_facts.filter((row) => !hasInvalidatedAtSet(row));
+  if (activeFacts.length === context.active_facts.length) return value;
+  return { ...context, active_facts: activeFacts };
+}
+
 export function compactStartupContextForStrictClients(
   value: unknown,
   includeSessionSummaries = false
 ): unknown {
-  const context = asRecord(value);
+  const context = asRecord(filterInvalidatedActiveFactsForLoadMemory(value));
   if (!context) return value;
 
   const out: Record<string, unknown> = { ...context };
@@ -139,9 +154,10 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       db.getStartupContext(sessionCount),
       resolveAgent({ agent_slug: slug, agent_id: id }),
     ]);
+    const safeBaseContext = filterInvalidatedActiveFactsForLoadMemory(baseContext);
     const boundedContext = fullContent
-      ? baseContext
-      : compactStartupContextForStrictClients(baseContext, !lite);
+      ? safeBaseContext
+      : compactStartupContextForStrictClients(safeBaseContext, !lite);
 
     // Optional: if the client passed the list of other tools in this session,
     // classify them and attach tool_guidance so the agent can nudge the user.


### PR DESCRIPTION
## Summary
- filters load_memory active_facts rows with invalidated_at set before compact ranking/truncation
- applies the same read-path guard to full_content responses
- adds regression tests for compact and full-content paths

## Tests
- npm run build --workspace=@unclick/mcp-server
- npm test --workspace=@unclick/mcp-server

🤖 → 🐺