### PR TITLE
fix(testpass): send MCP Accept header and parse SSE

### DIFF
--- a/packages/testpass/src/__tests__/deterministic.test.ts
+++ b/packages/testpass/src/__tests__/deterministic.test.ts
@@ -61,6 +61,41 @@ function makeMockMcpServer(): Promise<{ url: string; close: () => void }> {
   });
 }
 
+function makeStrictSseMcpServer(): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const accept = req.headers.accept ?? "";
+      if (!accept.includes("application/json") || !accept.includes("text/event-stream")) {
+        res.writeHead(406, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32000, message: "Not Acceptable" } }));
+        return;
+      }
+
+      let raw = "";
+      req.on("data", (c: Buffer) => (raw += c.toString()));
+      req.on("end", () => {
+        const rpc = JSON.parse(raw) as { id?: number; method: string };
+        if (rpc.id === undefined) {
+          res.writeHead(204).end();
+          return;
+        }
+
+        const result = rpc.method === "ping" ? {} : mockResult(rpc.method);
+        const payload = result === "__ERROR__"
+          ? { jsonrpc: "2.0", id: rpc.id, error: { code: -32601, message: "Method not found" } }
+          : { jsonrpc: "2.0", id: rpc.id, result };
+
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.end(`event: message\ndata: ${JSON.stringify(payload)}\n\n`);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() });
+    });
+  });
+}
+
 function mockResult(method: string): unknown {
   if (method === "initialize") {
     return {
@@ -268,5 +303,18 @@ items:
     const smokePack = loadPackFromYaml(smokeOnlyYaml);
     await runDeterministicChecks(config, "run-2", srv.url, smokePack, "deep");
     expect(mockUpdateItem).toHaveBeenCalledTimes(0);
+  });
+
+  it("sends MCP Accept header and parses SSE JSON-RPC responses", async () => {
+    const strictSrv = await makeStrictSseMcpServer();
+    try {
+      await runDeterministicChecks(config, "run-sse", strictSrv.url, pack, "standard");
+      const rpc001 = mockUpdateItem.mock.calls.find((c) => c[2] === "RPC-001");
+      const mcp005 = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-005");
+      expect(rpc001?.[3].verdict).toBe("check");
+      expect(mcp005?.[3].verdict).toBe("check");
+    } finally {
+      strictSrv.close();
+    }
   });
 });

--- a/packages/testpass/src/__tests__/mcp-http.test.ts
+++ b/packages/testpass/src/__tests__/mcp-http.test.ts
@@ -1,0 +1,17 @@
+import { MCP_ACCEPT_HEADER, readMcpResponseBody } from "../mcp-http.js";
+
+describe("mcp-http helpers", () => {
+  it("requests both JSON and SSE MCP response formats", () => {
+    expect(MCP_ACCEPT_HEADER).toContain("application/json");
+    expect(MCP_ACCEPT_HEADER).toContain("text/event-stream");
+  });
+
+  it("parses JSON-RPC payloads from SSE message frames", async () => {
+    const payload = { jsonrpc: "2.0", id: 1, result: { ok: true } };
+    const res = new Response(`event: message\ndata: ${JSON.stringify(payload)}\n\n`, {
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+    await expect(readMcpResponseBody(res)).resolves.toEqual(payload);
+  });
+});

--- a/packages/testpass/src/__tests__/probe.test.ts
+++ b/packages/testpass/src/__tests__/probe.test.ts
@@ -26,6 +26,45 @@ function makeJsonRpcServer(
   });
 }
 
+function makeStrictSseMcpServer(): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const accept = req.headers.accept ?? "";
+      if (!accept.includes("application/json") || !accept.includes("text/event-stream")) {
+        res.writeHead(406, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32000, message: "Not Acceptable" } }));
+        return;
+      }
+
+      let body = "";
+      req.on("data", (c: Buffer) => (body += c.toString()));
+      req.on("end", () => {
+        const rpc = JSON.parse(body) as { id?: number; method: string };
+        if (rpc.id === undefined) {
+          res.writeHead(204).end();
+          return;
+        }
+
+        const result = rpc.method === "tools/list"
+          ? { tools: [{ name: "echo", description: "Echoes input" }] }
+          : {
+              protocolVersion: "2024-11-05",
+              serverInfo: { name: "sse-test-server", version: "1.0.0" },
+              capabilities: { tools: {} },
+              instructions: "Test MCP server",
+            };
+
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.end(`event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result })}\n\n`);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() });
+    });
+  });
+}
+
 describe("probeServer", () => {
   let srv: { url: string; close: () => void };
 
@@ -67,5 +106,16 @@ describe("probeServer", () => {
 
   it("throws on unreachable server", async () => {
     await expect(probeServer("http://127.0.0.1:1", { timeoutMs: 500 })).rejects.toThrow();
+  });
+
+  it("sends MCP Accept header and parses SSE JSON-RPC responses", async () => {
+    const strictSrv = await makeStrictSseMcpServer();
+    try {
+      const result = await probeServer(strictSrv.url);
+      expect(result.serverInfo.name).toBe("sse-test-server");
+      expect(result.tools[0].name).toBe("echo");
+    } finally {
+      strictSrv.close();
+    }
   });
 });

--- a/packages/testpass/src/mcp-http.ts
+++ b/packages/testpass/src/mcp-http.ts
@@ -1,0 +1,50 @@
+export const MCP_ACCEPT_HEADER = "application/json, text/event-stream";
+
+export function buildMcpHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: MCP_ACCEPT_HEADER,
+  };
+  if (process.env.TESTPASS_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.TESTPASS_TOKEN}`;
+  }
+  return headers;
+}
+
+export async function readMcpResponseBody(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (!text) return null;
+
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.toLowerCase().includes("text/event-stream")) {
+    return parseSseJson(text);
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function parseSseJson(text: string): unknown {
+  const events = text.split(/\r?\n\r?\n/);
+  for (const event of events) {
+    const data = event
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trimStart())
+      .join("\n")
+      .trim();
+
+    if (!data || data === "[DONE]") continue;
+
+    try {
+      return JSON.parse(data);
+    } catch {
+      return data;
+    }
+  }
+
+  return text;
+}

--- a/packages/testpass/src/probe.ts
+++ b/packages/testpass/src/probe.ts
@@ -1,9 +1,10 @@
 /**
  * MCP probe - connects to an MCP server over HTTP and reads its tool list.
  *
- * Transport: HTTP POST to a single endpoint (simple JSON-RPC over HTTP).
- * SSE transport is out of scope for Chunk 2.
+ * Transport: MCP Streamable HTTP. Servers may answer with JSON or SSE.
  */
+
+import { buildMcpHeaders, readMcpResponseBody } from "./mcp-http.js";
 
 export interface ProbeResult {
   protocolVersion: string;
@@ -47,13 +48,7 @@ async function rpc(
 
   const controller = new AbortController();
   const tid = setTimeout(() => controller.abort(), timeoutMs);
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept: "application/json",
-  };
-  if (process.env.TESTPASS_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.TESTPASS_TOKEN}`;
-  }
+  const headers = buildMcpHeaders();
   try {
     const res = await fetch(url, {
       method: "POST",
@@ -65,7 +60,7 @@ async function rpc(
       throw new Error(`HTTP ${res.status} from MCP server`);
     }
     if (id === null) return null; // notification - no response expected
-    const data = (await res.json()) as {
+    const data = (await readMcpResponseBody(res)) as {
       result?: unknown;
       error?: { code: number; message: string };
     };

--- a/packages/testpass/src/runner/deterministic.ts
+++ b/packages/testpass/src/runner/deterministic.ts
@@ -13,6 +13,7 @@ import type { Pack, RunProfile } from "../types.js";
 import type { RunManagerConfig } from "../run-manager.js";
 import { updateItem, createEvidence } from "../run-manager.js";
 import { createHash } from "node:crypto";
+import { buildMcpHeaders, readMcpResponseBody } from "../mcp-http.js";
 
 // ─── Internal types ────────────────────────────────────────────────
 
@@ -42,13 +43,7 @@ async function send(
   const start      = Date.now();
   const controller = new AbortController();
   const tid        = setTimeout(() => controller.abort(), timeoutMs);
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept:         "application/json",
-  };
-  if (process.env.TESTPASS_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.TESTPASS_TOKEN}`;
-  }
+  const headers = buildMcpHeaders();
   try {
     const res = await fetch(url, {
       method:  "POST",
@@ -56,11 +51,7 @@ async function send(
       body:    JSON.stringify(reqBody),
       signal:  controller.signal,
     });
-    let body: unknown = null;
-    const text = await res.text();
-    if (text) {
-      try { body = JSON.parse(text); } catch { body = text; }
-    }
+    const body = await readMcpResponseBody(res);
     return { status: res.status, body, latency_ms: Date.now() - start };
   } finally {
     clearTimeout(tid);


### PR DESCRIPTION
## Summary
- send the MCP Streamable HTTP Accept header from TestPass probe and deterministic runner
- parse JSON-RPC payloads returned as text/event-stream SSE frames
- add regression coverage for strict Accept handling and SSE parsing

## Tests
- npm run build --workspace=@unclick/testpass
- node --experimental-vm-modules ..\\..\\node_modules\\jest\\bin\\jest.js --runInBand src/__tests__/mcp-http.test.ts src/__tests__/probe.test.ts

Note: src/__tests__/deterministic.test.ts still fails before running tests with ReferenceError: jest is not defined under the current ESM Jest invocation; this appears to be pre-existing harness wiring.