### PR TITLE
[codex] docs: add Connectors migration audit and Phase 1 plan

### DIFF
--- a/docs/connectors/migration-plan.md
+++ b/docs/connectors/migration-plan.md
@@ -1,8 +1,11 @@
 # BackstagePass to Connections Migration Plan
 
-**Status**: Audit complete  
+**Status**: Audit complete (Phase 0 baseline)  
 **Last updated**: 2026-04-29  
 **Owner**: `🦾`
+
+**Implementation note**: This document is a baseline audit captured before the full rename landed on `main`.
+Some user-facing copy changes identified here have already shipped, so this file should be read as migration grounding and wording history, not as a fresh unblock list.
 
 ## Goal
 

--- a/docs/connectors/migration-plan.md
+++ b/docs/connectors/migration-plan.md
@@ -1,0 +1,293 @@
+# BackstagePass to Connections Migration Plan
+
+**Status**: Audit complete  
+**Last updated**: 2026-04-29  
+**Owner**: `🦾`
+
+## Goal
+
+Audit every relevant `src/pages/admin/*` mention tied to the BackstagePass to Connections product-language migration, and separate:
+
+- copy that should change for operators
+- technical implementation terminology that should stay technical
+
+This document is intentionally limited to admin-surface wording.
+No code changes are included here.
+
+## Naming rule
+
+Use this split consistently:
+
+- `Connections` for the user-facing surface
+- `Connected services` for the catalog of available service integrations
+- `Connect a service` / `Reconnect` for user actions
+- `Credentials` for the stored secret material when user-facing copy needs precision
+- `connector` for internal platform definitions, IDs, and tool wiring
+- `BackstagePass` only when the storage subsystem itself is the subject
+
+## Audit result
+
+I verified all `BackstagePass`, `Keychain`, and adjacent `connector` / `connection` mentions under `src/pages/admin`.
+
+There are **6 user-facing copy changes** to make for Phase 0, plus **1 optional developer-comment cleanup**.
+
+## User-facing copy to change
+
+### 1. Admin nav label
+
+**File + line**
+
+`src/pages/admin/AdminShell.tsx:246`
+
+**Current**
+
+`Keychain (BackstagePass)`
+
+**Why this changes**
+
+This is the primary admin navigation label, so it should lead with the operator task, not the storage subsystem.
+
+**Recommended replacement**
+
+`Connections`
+
+### 2. Admin page title
+
+**File + line**
+
+`src/pages/admin/AdminKeychain.tsx:507`
+
+**Current**
+
+`BackstagePass`
+
+**Why this changes**
+
+This is the main page heading for `/admin/keychain`, so it currently presents the vault as the product surface.
+
+**Recommended replacement**
+
+`Connections`
+
+### 3. Admin page supporting copy
+
+**File + lines**
+
+`src/pages/admin/AdminKeychain.tsx:508-509`
+
+**Current**
+
+`Your encrypted credential vault. {credentials.length} credential{credentials.length === 1 ? "" : "s"} stored.`
+
+**Why this changes**
+
+The current helper text is accurate but vault-first. The operator-facing story should start with managing service connections, while still acknowledging credentials.
+
+**Recommended replacement**
+
+`Connect services, monitor connection health, and manage the credentials behind them. {credentials.length} credential{credentials.length === 1 ? "" : "s"} stored.`
+
+### 4. Tools page section label and helper copy
+
+**File + lines**
+
+`src/pages/admin/AdminTools.tsx:79-84`
+
+**Current heading**
+
+`Connected Services`
+
+**Current info-card title**
+
+`What are Connected Services?`
+
+**Current description**
+
+`Third-party platforms you've linked API keys for - like GitHub, Stripe, or Cloudflare. Your agent can use these on your behalf.`
+
+**Current learn-more**
+
+`Store credentials securely in Keychain, and your agent can interact with these services during conversations. Credentials are encrypted and only accessible to your agent.`
+
+**Why this changes**
+
+This section is already close, but still mixes old setup framing (`linked API keys`, `Keychain`) into a user-facing explainer.
+
+**Recommended replacements**
+
+- Heading: `Connections`
+- Info-card title: `What are Connections?`
+- Description: `Third-party services you've connected for your agent, like GitHub, Stripe, or Cloudflare. Your agent can use them on your behalf during conversations.`
+- Learn-more: `Connect services your agent can use during conversations. Connection state is managed here, and the underlying credentials stay encrypted behind the scenes.`
+
+### 5. Connected services empty state
+
+**File + lines**
+
+`src/pages/admin/tools/ConnectedServices.tsx:33-39`
+
+**Current body copy**
+
+`Third-party service integrations - connect your API keys in Keychain to enable these tools.`
+
+**Current CTA**
+
+`Go to Keychain`
+
+**Why this changes**
+
+This is direct setup copy shown when nothing is connected yet, so it needs to match the new model exactly.
+
+**Recommended replacements**
+
+- Body copy: `Connect the services your agent needs to use. Some connections use API keys, others use OAuth or bot tokens, but the setup starts here.`
+- CTA: `Go to Connections`
+
+### 6. API key reissue warning
+
+**File + line**
+
+`src/pages/admin/AdminYou.tsx:523`
+
+**Current**
+
+`Key not visible? Your browser may have cleared it. Re-issuing generates a new key and invalidates the old one - any BackstagePass encrypted credentials will need to be re-saved.`
+
+**Why this changes**
+
+This warning is user-visible and operationally important, but it currently names the storage layer instead of the product surface.
+
+**Recommended replacement**
+
+`Key not visible? Your browser may have cleared it. Re-issuing generates a new key and invalidates the old one - any saved Connections credentials will need to be re-saved.`
+
+**If implementation honesty is important here**
+
+`Key not visible? Your browser may have cleared it. Re-issuing generates a new key and invalidates the old one - any saved Connections credentials in BackstagePass will need to be re-saved.`
+
+## Optional developer-comment cleanup
+
+### 7. Top-of-file page comment
+
+**File + line**
+
+`src/pages/admin/AdminKeychain.tsx:2`
+
+**Current**
+
+`AdminKeychain — BackstagePass admin surface (/admin/keychain)`
+
+**Why this is optional**
+
+This is not user-visible, so it is not required for Phase 0. Still, it will keep the old product language alive in future edits if left alone.
+
+**Recommended replacement**
+
+`AdminKeychain — Connections admin surface (/admin/keychain)`
+
+Keep `AdminKeychain` and `/admin/keychain` unchanged for now; those are implementation names, not product copy.
+
+## Verified technical references to leave alone
+
+These mentions were checked and should **not** be blanket-renamed as part of this migration.
+
+### BackstagePass internals in `AdminKeychain`
+
+**Files + lines**
+
+- `src/pages/admin/AdminKeychain.tsx:21`
+- `src/pages/admin/AdminKeychain.tsx:23`
+- `src/pages/admin/AdminKeychain.tsx:234`
+- `src/pages/admin/AdminKeychain.tsx:276`
+- `src/pages/admin/AdminKeychain.tsx:332`
+- `src/pages/admin/AdminKeychain.tsx:377`
+- `src/pages/admin/AdminKeychain.tsx:431`
+- `src/pages/admin/AdminKeychain.tsx:456`
+- `src/pages/admin/AdminKeychain.tsx:1082`
+- `src/pages/admin/AdminKeychain.tsx:1160`
+- `src/pages/admin/AdminKeychain.tsx:1231`
+
+These refer to the backend subsystem, audit table, and API endpoints:
+
+- `backstagepass_audit`
+- `/api/backstagepass?...`
+
+Those should remain technical unless the backend itself is renamed later.
+
+### Internal connector terminology
+
+**Files + lines**
+
+- `src/pages/admin/AdminAgents.tsx:48`
+- `src/pages/admin/AdminAgents.tsx:58`
+- `src/pages/admin/AdminAgents.tsx:108`
+- `src/pages/admin/AdminAgents.tsx:128`
+- `src/pages/admin/AdminAgents.tsx:179`
+- `src/pages/admin/AdminAgents.tsx:769`
+- `src/pages/admin/agentTemplates.ts:5-6`
+- `src/pages/admin/Fishbowl.tsx:144-145`
+- `src/pages/admin/Fishbowl.tsx:158-159`
+- `src/pages/admin/AdminSettings.tsx:636`
+
+These are describing one of:
+
+- connector records / IDs
+- tool-assignment wiring
+- the MCP connector as a technical integration mechanism
+- generic database or service connectors
+
+Do not convert these to `Connections` unless the sentence is explicitly about the operator-facing product surface.
+
+### Existing connection wording that is already correct
+
+**Files + lines**
+
+- `src/pages/admin/AdminSettings.tsx:447-450`
+- `src/pages/admin/AdminOrchestrator.tsx:6`
+- `src/pages/admin/BrainMap.tsx:114`
+
+These already use `Connection` in the literal sense of live connectivity or setup state, which matches the intended Phase 0 language.
+
+### Internal comment in `AdminYou`
+
+**File + lines**
+
+`src/pages/admin/AdminYou.tsx:31-32`
+
+`BackstagePass` appears in a developer comment about masking values. This is not a product-surface issue and does not need migration work unless the broader implementation vocabulary is cleaned up later.
+
+## Surfaces checked
+
+Reviewed mentions across:
+
+- `src/pages/admin/AdminShell.tsx`
+- `src/pages/admin/AdminKeychain.tsx`
+- `src/pages/admin/AdminTools.tsx`
+- `src/pages/admin/tools/ConnectedServices.tsx`
+- `src/pages/admin/AdminYou.tsx`
+- `src/pages/admin/AdminSettings.tsx`
+- `src/pages/admin/AdminAgents.tsx`
+- `src/pages/admin/AdminOrchestrator.tsx`
+- `src/pages/admin/BrainMap.tsx`
+- `src/pages/admin/Fishbowl.tsx`
+- `src/pages/admin/agentTemplates.ts`
+
+## Rollout recommendation
+
+### Phase 0
+
+Apply only the six user-facing copy changes above.
+
+### Phase 0.5
+
+Optionally update the `AdminKeychain.tsx:2` comment so future edits follow the new language.
+
+### Later, only if desired
+
+Evaluate route and symbol renames such as:
+
+- `/admin/keychain`
+- `AdminKeychain`
+- backend `backstagepass` endpoint naming
+
+Those are implementation changes and are explicitly out of scope for this wording migration.

--- a/docs/connectors/phase-1-plan.md
+++ b/docs/connectors/phase-1-plan.md
@@ -1,0 +1,336 @@
+# Connectors Phase 1 Plan
+
+**Status**: Draft
+**Last updated**: 2026-04-29
+**Owner**: `🦾`
+**Purpose**: Define the first implementation slice after Connectors Phase 0
+
+## Goal
+
+Phase 1 ships the first real user-facing Connections surface without attempting a backend rename or vault rewrite.
+
+It should make three things true:
+
+1. operators see `Connections`, not `BackstagePass`, in the main admin story
+2. connection state is driven from the existing `platform_connectors` + `user_credentials` substrate
+3. proof-of-possession and API key reset consequences are surfaced honestly
+
+This is still an incremental implementation phase.
+It is not the final architecture.
+
+## What ships in Phase 1
+
+Phase 1 should ship:
+
+- user-facing copy migration from Keychain or BackstagePass to Connections
+- a clearer connection status model on top of existing `user_credentials` state
+- catalog and setup metadata that lets the UI explain how a connector is configured
+- consistent admin entry points for browsing, testing, reconnecting, and managing credentials
+- a single product story across frontend, admin API, and MCP-adjacent connector metadata
+
+Phase 1 should not ship:
+
+- a route rename away from `/admin/keychain`
+- an `/api/backstagepass` endpoint rename
+- a crypto redesign
+- team/shared vault semantics
+- full OAuth broker orchestration for every provider
+- connector auto-refresh or automatic token rotation
+
+## Product outcome
+
+At the end of Phase 1, an operator should be able to:
+
+1. open `Connections` from admin navigation
+2. understand which third-party services are available
+3. see whether each service is connected, broken, or needs reconnection
+4. complete API key or bot token setup from the Connections surface
+5. understand when an API key reset invalidates saved credentials
+
+## Existing source of truth to preserve
+
+Phase 1 should continue to treat:
+
+- `platform_connectors` as the connector catalog layer
+- `user_credentials` as the live secret and connection-state substrate
+- `backstagepass_audit` as the sensitive action audit log
+- `api/backstagepass.ts` as the proof-of-possession admin API
+
+Phase 1 may improve naming and metadata around these layers, but should not fork them into a second competing source of truth.
+
+## Files that should change
+
+### Frontend admin surfaces
+
+These are the Phase 1 user-facing copy and UX surfaces:
+
+- `src/pages/admin/AdminShell.tsx`
+- `src/pages/admin/AdminKeychain.tsx`
+- `src/pages/admin/AdminTools.tsx`
+- `src/pages/admin/tools/ConnectedServices.tsx`
+- `src/pages/admin/AdminYou.tsx`
+
+Expected changes:
+
+- rename visible nav and headings to `Connections`
+- update helper copy using the migration plan wording
+- surface status labels that match the Phase 0 spec
+- make reissue warning speak in connection lifecycle language
+
+### Frontend connector metadata
+
+- `src/lib/connectors.ts`
+
+Expected changes:
+
+- extend connector metadata beyond `authType` alone
+- add setup-oriented fields that the UI can render honestly
+- keep browser-safe shape aligned with server registry
+
+Recommended additive fields:
+
+- `setupFlow`: `oauth_redirect` | `manual_token` | `manual_api_key` | `hybrid`
+- `supportsConnectionTest`: boolean
+- `capabilitySummary`: short operator-facing text
+- optional `docsUrl` normalization if currently uneven
+
+### MCP and server connector registry
+
+- `packages/mcp-server/src/connectors/index.ts`
+- per-connector config files under `packages/mcp-server/src/connectors/*`
+
+Expected changes:
+
+- keep the registry structurally aligned with the frontend connector metadata
+- add the same setup-flow semantics so admin UI and MCP do not drift
+- avoid expanding auth promises beyond what the current broker can really do
+
+### Admin APIs
+
+- `api/backstagepass.ts`
+- `api/credentials.ts`
+- `api/oauth-callback.ts`
+- `api/memory-admin.ts`
+
+Expected changes:
+
+#### `api/backstagepass.ts`
+
+- keep endpoint name for now
+- return or derive status information in the Phase 1 connection vocabulary
+- make `testConnection` support visible in metadata
+- keep proof-of-possession boundary intact for reveal, values update, export, and delete
+
+#### `api/credentials.ts`
+
+- align credential-upsert behavior with the Connections story
+- stay as the manual credential write path for API key and bot token connectors
+- do not become a parallel connection-state system
+
+#### `api/oauth-callback.ts`
+
+- ensure OAuth-backed connectors that are already partially supported can write into `user_credentials` consistently
+- keep honest distinction between “OAuth-capable in theory” and “fully redirect-wired in Phase 1”
+
+#### `api/memory-admin.ts`
+
+- continue powering `admin_tools` and related admin read surfaces
+- update any response shaping needed so Connections cards can render catalog + credential state consistently
+
+## Database and migration work
+
+Phase 1 should prefer additive migrations over table replacement.
+
+### 1. `platform_connectors` metadata expansion
+
+Current repo reality already stores:
+
+- `id`
+- `name`
+- `category`
+- `auth_type`
+- `description`
+- `setup_url`
+- `test_endpoint`
+- `sort_order`
+
+Phase 1 should add enough metadata to tell the truth about setup:
+
+- `setup_flow` text
+- `docs_url` text if not already present in DB
+- `capability_summary` text
+- `supports_connection_test` boolean default false
+
+Why:
+
+- `auth_type` alone is not enough to explain the real operator path
+- many connectors are effectively manual even if the long-term direction is OAuth
+
+### 2. `user_credentials` connection-state expansion
+
+Current repo already has:
+
+- `is_valid`
+- `last_tested_at`
+- `last_used_at`
+- `last_rotated_at`
+- `expires_at`
+
+Phase 1 should add only the fields needed to support honest user-facing states:
+
+- `setup_completed_at` timestamptz nullable
+- `status_reason` text nullable
+- `connected_via` text nullable, for example `oauth_redirect`, `manual_api_key`, `manual_token`
+
+Why:
+
+- `is_valid` alone cannot distinguish broken, incomplete, and reconnect-required states
+- the UI needs to explain why a row is not healthy without overloading one boolean
+
+### 3. No table split
+
+Phase 1 should not create a new `connections` table unless a later phase proves it necessary.
+
+The existing `user_credentials` table is already the live encrypted substrate and should stay the operational source of truth for this slice.
+
+## Status model to ship
+
+Phase 1 should render the following states:
+
+- `Not connected`
+- `Connected`
+- `Needs reconnection`
+- `Connection error`
+- `Setup incomplete`
+
+Recommended initial mapping:
+
+- no row in `user_credentials` -> `Not connected`
+- row exists, `is_valid = true`, not expired, setup complete -> `Connected`
+- row exists, expired or invalidated by lifecycle reset -> `Needs reconnection`
+- row exists, `is_valid = false`, `status_reason` present -> `Connection error`
+- row exists, missing setup completion or required fields -> `Setup incomplete`
+
+## UI surfaces to ship
+
+### Admin navigation
+
+Change:
+
+- `AdminShell.tsx` nav label to `Connections`
+
+Do not change yet:
+
+- route path `/admin/keychain`
+- component symbol `AdminKeychain`
+
+### Connections page
+
+Primary file:
+
+- `src/pages/admin/AdminKeychain.tsx`
+
+Phase 1 additions:
+
+- new page heading and helper copy from the migration plan
+- clearer grouping between catalog browsing and saved credentials
+- setup-flow-aware CTAs
+- visible health/status pills based on the new mapping
+- reconnect wording where credentials have expired or gone invalid
+
+### Tools page
+
+Primary files:
+
+- `src/pages/admin/AdminTools.tsx`
+- `src/pages/admin/tools/ConnectedServices.tsx`
+
+Phase 1 additions:
+
+- `Connections` naming parity
+- empty state that explains setup honestly
+- cards that show connection state, not just valid versus invalid
+
+### Identity page
+
+Primary file:
+
+- `src/pages/admin/AdminYou.tsx`
+
+Phase 1 additions:
+
+- API key reset warning rewritten in connection lifecycle language
+- explicit note that saved Connections credentials may need re-save after key reset
+
+## API behavior to preserve
+
+Phase 1 must preserve these guardrails:
+
+- session JWT required for admin access
+- proof-of-possession for decrypt, rotate-values, export, and delete flows
+- no plaintext credential material in audit rows
+- no hidden claim that API key reset keeps credentials readable
+
+## Test and verification plan
+
+Phase 1 should include:
+
+### Unit or integration coverage
+
+- connector registry shape parity between frontend and server
+- status mapping from `user_credentials` row state to UI label
+- proof-of-possession flows still reject mismatched keys
+
+### UI verification
+
+- admin nav shows `Connections`
+- Connections page copy reflects the migration plan
+- Tools page empty state says `Go to Connections`
+- API key reissue warning reflects re-save requirement
+
+### Manual smoke
+
+1. create one manual API key connection
+2. create one bot-token connection
+3. verify they appear as `Connected`
+4. force one failed test and verify `Connection error`
+5. rotate or invalidate one key and verify `Needs reconnection`
+
+## Recommended rollout order
+
+### Step 1
+
+Ship schema additions for `platform_connectors` and `user_credentials`.
+
+### Step 2
+
+Update admin APIs to emit or derive the new setup and status semantics.
+
+### Step 3
+
+Update frontend admin surfaces to use `Connections` language and new status mapping.
+
+### Step 4
+
+Run a manual smoke across one API key, one bot token, and one partial or broken setup.
+
+## Non-goals to defend
+
+Avoid these in Phase 1:
+
+- renaming every legacy `backstagepass` symbol
+- introducing a second connection-state table
+- claiming all OAuth connectors are fully redirect-complete
+- broadening proof-of-possession exemptions for convenience
+
+## Deliverable summary
+
+If Phase 1 lands cleanly, the product story becomes:
+
+- `Connections` is what the operator sees
+- `platform_connectors` describes what can be connected
+- `user_credentials` stores what is connected
+- `backstagepass_audit` records what sensitive actions happened
+- `/api/backstagepass` remains the secure admin substrate until a later rename phase
+
+That is enough to make Connectors feel like a product, not just a vault wrapper.


### PR DESCRIPTION
## What changed
Added the Connectors follow-on planning docs:
- `docs/connectors/migration-plan.md`
- `docs/connectors/phase-1-plan.md`

## Why
Phase 0 already locked the product contract. This PR turns the next slice into an implementation-facing plan with exact frontend/admin surfaces, API endpoints, additive migrations, and rollout order.

## Notes
- Docs only
- Pairs the wording migration audit with the Phase 1 implementation kickoff plan
- No runtime tests were run
