### PR TITLE
[codex] docs: add SecurityPass, CopyPass, and SlopPass scope contracts

### DIFF
--- a/docs/prd/copypass-chunk2.md
+++ b/docs/prd/copypass-chunk2.md
@@ -1,0 +1,178 @@
+# CopyPass Chunk 2
+**Status**: Draft
+**Last updated**: 2026-04-29
+**Owner**: `🦾`
+**Purpose**: Lock the CopyPass scope contract before implementation or packaging expands
+
+## Why this exists
+CopyPass needs a clear boundary before it ships as a product surface.
+This chunk defines:
+- what CopyPass is allowed to claim
+- what evidence a run must return
+- what it must explicitly decline to promise
+- what banner language should stay visible in product surfaces
+This is a doc-first scope lock, not an implementation PR.
+
+## One-sentence definition
+CopyPass is a scoped copy-quality verdict engine that reports evidence-based findings for the AI-generated copy it inspected.
+It is not a guarantee that the copy is correct, safe, lawful, or fit for every audience or use case.
+
+## Product posture
+CopyPass should feel:
+- concrete
+- evidence-led
+- conservative in claims
+- useful to an operator who needs next actions
+CopyPass should not feel:
+- like a creative-writing oracle
+- like a legal approval
+- like a brand-signoff substitute
+- like a blanket publish-safe stamp
+
+## Core promise
+CopyPass promises:
+1. it will inspect a defined body of AI-generated copy and review scope
+2. it will return findings tied to observable evidence in that copy
+3. it will distinguish observed issues from uncertainty, subjectivity, or missing context
+4. it will say what it did not evaluate
+CopyPass does not promise:
+1. that the copy is objectively good
+2. that no factual, legal, editorial, or brand issues remain
+3. that the result satisfies regulatory, platform, or client requirements
+4. that every audience, locale, or downstream channel interpretation was tested
+5. that the result remains valid after later prompt, model, policy, or copy changes
+
+## Disclaimer banner
+This should mirror the LegalPass pattern: plain language, always visible, hard to misread.
+
+### Banner headline
+`CopyPass is a scoped review, not a guarantee of copy quality or safety.`
+
+### Banner body
+`CopyPass reports evidence-based copy-quality findings it can observe in the AI-generated copy and scope for this run. It does not certify factual accuracy, legal compliance, brand approval, conversion performance, or fitness for every audience, channel, or future edit.`
+
+### Compact variant
+`Scoped review only. Not legal approval, brand sign-off, or a guarantee of quality, safety, or performance.`
+
+## Required run artifact
+Every CopyPass result must show four things:
+1. **Target**
+   - exact copy block, prompt output, asset, route, or campaign text under review
+2. **Scope performed**
+   - exact checks attempted
+3. **Findings**
+   - issues observed, with severity and evidence
+4. **Not checked**
+   - exclusions, blocked checks, and unknowns
+If any of those are missing, the run is incomplete as a product artifact.
+
+## In-scope review areas
+CopyPass may check:
+
+### 1. Claim clarity and support
+- unsupported product claims
+- vague superlatives presented as facts
+- copy that implies evidence it does not show
+- missing qualifiers where certainty is overstated
+
+### 2. Internal consistency
+- contradictions inside the same copy set
+- mismatched numbers, dates, or named entities
+- headline-to-body drift
+- CTA language that conflicts with the stated offer
+
+### 3. Audience and tone fit
+- tone that misses the intended audience
+- wording that creates unnecessary confusion
+- inconsistent voice across adjacent sections
+- phrasing that reads robotic, bloated, or unnatural
+
+### 4. Risky persuasion and trust signals
+- pressure language that overreaches
+- testimonials or authority cues with unclear support
+- misleading urgency or scarcity framing
+- trust language that implies guarantees not actually offered
+
+### 5. Product-surface honesty
+- UI copy that overclaims what the product or workflow can do
+- missing disclosure of meaningful uncertainty
+- hidden gaps between the evidence reviewed and the confidence presented
+
+## Evidence contract
+CopyPass should return evidence that is inspectable, not mystical.
+Acceptable evidence may include:
+- exact quoted spans from the inspected copy
+- location references for where the issue appears
+- comparison between conflicting statements in the same artifact
+- rationale for why a claim appears unsupported, overstated, or unclear
+- notes about missing context when a verdict cannot be made cleanly
+Evidence should avoid:
+- unexplained scores with no textual support
+- blanket judgments without quoted examples
+- simulated certainty where the issue is subjective
+- hidden chain-of-thought or private internal reasoning
+
+## Explicitly out of scope
+CopyPass should not claim to cover:
+
+### 1. Legal or regulatory approval
+- formal legal review
+- advertising-law sign-off
+- industry-specific regulatory certification
+- jurisdiction-by-jurisdiction compliance interpretation
+
+### 2. Full factual verification
+- source-checking every statement against external reality
+- validating future-looking claims
+- confirming customer outcomes or performance promises
+- proving that cited numbers remain current
+
+### 3. Full brand or editorial approval
+- final brand-team sign-off
+- creative-director preference arbitration
+- exhaustive style-guide enforcement unless the guide is explicitly in scope
+- perfect localization for every market
+
+### 4. Performance prediction
+- guaranteed conversion uplift
+- guaranteed engagement outcomes
+- guaranteed deliverability or platform acceptance
+- guaranteed protection from user complaints or moderation actions
+
+## Output contract
+Each finding should include:
+- title
+- severity
+- why it matters
+- evidence
+- suggested fix
+- confidence note when needed
+Each run summary should include:
+- one-sentence posture summary
+- counts by severity
+- a coverage or confidence note
+
+## Severity model
+- `critical`: severe overclaim, high-risk deception, or dangerous copy issue with immediate business or trust impact
+- `high`: serious clarity, support, or trust problem likely to mislead users or create material risk
+- `medium`: real quality weakness, but not clearly catastrophic alone
+- `low`: limited-impact clarity, tone, or polish issue
+- `info`: observation or improvement suggestion without current evidence of material harm
+
+## Failure modes to avoid
+CopyPass should not:
+- emit a green-sounding top-line summary when important scope was skipped
+- collapse subjective uncertainty into implied certainty
+- present style preference as a confirmed defect without saying so
+- hide blocked checks or missing context
+- describe copy as approved, compliant, or safe when the run only inspected text quality signals
+
+## UI and API acceptance bar
+Before implementation is called done:
+1. every result surface must show the disclaimer banner or compact equivalent
+2. every result payload must expose target, scope, findings, and not-checked sections
+3. every summary must preserve uncertainty and non-coverage instead of flattening them away
+4. no marketing or UI copy may describe CopyPass as approval, certification, or a guarantee of quality, legality, or performance
+
+## Recommended next step
+When Chunk 2 is approved, the next implementation slice should wire the disclaimer banner and output-shape requirements into the first CopyPass result surface before broader marketplace packaging or automation work proceeds.

--- a/docs/prd/securitypass-chunk2.md
+++ b/docs/prd/securitypass-chunk2.md
@@ -1,0 +1,206 @@
+# SecurityPass Chunk 2
+
+**Status**: Draft
+**Last updated**: 2026-04-29
+**Owner**: `🦾`
+**Purpose**: Lock the SecurityPass scope contract before implementation or packaging expands
+
+## Why this exists
+
+SecurityPass needs a clear boundary before it ships as a product surface.
+
+This chunk defines:
+
+- what SecurityPass is allowed to claim
+- what evidence a run must return
+- what it must explicitly decline to promise
+- what banner language should stay visible in product surfaces
+
+This is a doc-first scope lock, not an implementation PR.
+
+## One-sentence definition
+
+SecurityPass is a scoped security-hygiene review that reports evidence-based findings for the target it inspected.
+
+It is not a guarantee that the system is secure.
+
+## Product posture
+
+SecurityPass should feel:
+
+- concrete
+- evidence-led
+- conservative in claims
+- useful to an operator who needs next actions
+
+SecurityPass should not feel:
+
+- like a certification
+- like a penetration test
+- like a warranty
+- like a blanket approval stamp
+
+## Core promise
+
+SecurityPass promises:
+
+1. it will inspect a defined target and review scope
+2. it will return findings tied to observable evidence
+3. it will distinguish observed issues from unknown or untested areas
+4. it will say what it did not evaluate
+
+SecurityPass does not promise:
+
+1. that the target is secure
+2. that no vulnerabilities remain
+3. that the result satisfies compliance or legal requirements
+4. that every runtime path, dependency, or vendor surface was tested
+5. that the result remains valid after later code, env, or permission changes
+
+## Disclaimer banner
+
+This should mirror the LegalPass pattern: plain language, always visible, hard to misread.
+
+### Banner headline
+
+`SecurityPass is a scoped review, not a security guarantee.`
+
+### Banner body
+
+`SecurityPass reports evidence-based security risks it can observe in the target and scope for this run. It does not certify that the system is secure, replace a penetration test, or verify every dependency, provider, environment, or future change.`
+
+### Compact variant
+
+`Scoped review only. Not a pentest, certification, or guarantee of security.`
+
+## Required run artifact
+
+Every SecurityPass result must show four things:
+
+1. **Target**
+   - exact route, app, config, artifact, or environment under review
+2. **Scope performed**
+   - exact checks attempted
+3. **Findings**
+   - issues observed, with severity and evidence
+4. **Not checked**
+   - exclusions, blocked checks, and unknowns
+
+If any of those are missing, the run is incomplete as a product artifact.
+
+## In-scope review areas
+
+SecurityPass may check:
+
+### 1. Configuration hygiene
+
+- missing auth requirements
+- overly broad CORS
+- insecure defaults
+- missing security headers
+- unsafe public exposure of sensitive routes
+- weak environment or origin gating
+
+### 2. Permission and tenancy boundaries
+
+- obvious missing tenant filters
+- missing role checks
+- direct-access paths that bypass intended guards
+- unsafe admin-only access patterns
+
+### 3. Secret and credential handling
+
+- plaintext secret exposure in code or responses
+- unsafe reveal, update, or delete boundaries
+- missing audit trail on destructive secret operations
+- obviously weak secret storage or transport choices
+
+### 4. Dependency and release posture
+
+- stale lockfile or package drift with security impact
+- documented versus actual version mismatch in critical packages
+- re-opened exposure classes caused by dependency skew
+
+### 5. Product-surface honesty
+
+- UI copy that overclaims assurance
+- missing disclosure of important uncertainty
+- hidden gaps between executed checks and presented confidence
+
+## Explicitly out of scope
+
+SecurityPass should not claim to cover:
+
+### 1. Full penetration testing
+
+- exploit chaining
+- custom fuzzing
+- deep auth bypass research
+- red-team style adversarial simulation
+
+### 2. Full infrastructure assurance
+
+- cloud-account hardening
+- network perimeter validation
+- vendor-managed internals
+- WAF or registrar correctness unless directly targeted
+
+### 3. Full supply-chain assurance
+
+- exhaustive transitive dependency audit
+- provenance verification for every artifact
+- CI secret review unless the CI surface is itself in scope
+
+### 4. Compliance certification
+
+- SOC 2 or ISO sign-off
+- PCI, HIPAA, or GDPR legal certification
+- legal sufficiency of remediation advice
+
+## Output contract
+
+Each finding should include:
+
+- title
+- severity
+- why it matters
+- evidence
+- suggested fix
+- confidence note when needed
+
+Each run summary should include:
+
+- one-sentence posture summary
+- counts by severity
+- a coverage or confidence note
+
+## Severity model
+
+- `critical`: clear path to major compromise or severe tenant/security failure
+- `high`: serious exposure with meaningful exploit or impact potential
+- `medium`: real weakness, but not clearly catastrophic alone
+- `low`: limited impact, defense-in-depth, or cleanup issue
+- `info`: observation or hardening suggestion without current evidence of active risk
+
+## Failure modes to avoid
+
+SecurityPass should not:
+
+- emit a green-sounding top-line summary when important scope was skipped
+- collapse unknown coverage into implied safety
+- present hypothetical concerns as confirmed findings
+- hide blocked checks or tool limitations
+- use compliance-like language unless the run actually performed that mapping
+
+## UI and API acceptance bar
+
+Before implementation is called done:
+
+1. every result surface must show the disclaimer banner or compact equivalent
+2. every result payload must expose target, scope, findings, and not-checked sections
+3. every summary must preserve non-coverage instead of flattening it away
+4. no marketing or UI copy may describe SecurityPass as a certification, pentest, or guarantee
+
+## Recommended next step
+
+When Chunk 2 is approved, the next implementation slice should wire the disclaimer banner and output-shape requirements into the first SecurityPass result surface before broader marketplace packaging or automation work proceeds.

--- a/docs/prd/sloppass-chunk2.md
+++ b/docs/prd/sloppass-chunk2.md
@@ -1,0 +1,191 @@
+# SlopPass Chunk 2
+**Status**: Draft
+**Last updated**: 2026-04-29
+**Owner**: `🦾`
+**Purpose**: Lock the SlopPass scope contract before implementation or packaging expands
+## Why this exists
+SlopPass needs a clear boundary before it ships as a product surface.
+This chunk defines:
+- what SlopPass is allowed to claim
+- what evidence a run must return
+- what it must explicitly decline to promise
+- what banner language should stay visible in product surfaces
+This is a doc-first scope lock, not an implementation PR.
+
+## One-sentence definition
+SlopPass is a scoped code-quality verdict engine that reports evidence-based slop signals in the AI-generated code it inspected.
+It is not a guarantee that the code is good, correct, or production-ready.
+
+## Product posture
+SlopPass should feel:
+- concrete
+- evidence-led
+- conservative in claims
+- useful to an operator who needs next actions
+SlopPass should not feel:
+- like a style cop
+- like a taste-based code review
+- like a correctness certification
+- like a blanket approval stamp
+
+## Core promise
+SlopPass promises:
+1. it will inspect a defined target and review scope
+2. it will return slop findings tied to observable evidence
+3. it will distinguish observed quality failures from unknown or untested areas
+4. it will say what it did not evaluate
+SlopPass does not promise:
+1. that the code is bug-free
+2. that no hidden defects, regressions, or security issues remain
+3. that the result satisfies team style, architecture, or hiring standards
+4. that every runtime path, edge case, dependency, or framework interaction was validated
+5. that the result remains valid after later code, prompt, model, env, or dependency changes
+
+## Disclaimer banner
+This should mirror the LegalPass pattern: plain language, always visible, hard to misread.
+### Banner headline
+`SlopPass is a scoped quality review, not a guarantee that the code is good.`
+### Banner body
+`SlopPass reports evidence-based code quality risks it can observe in the target and scope for this run. It does not certify correctness, replace full testing or human review, or verify every runtime path, dependency, environment, or future change.`
+### Compact variant
+`Scoped review only. Not a correctness certification, full test suite, or quality guarantee.`
+
+## Required run artifact
+Every SlopPass result must show four things:
+1. **Target**
+   - exact repo, branch, diff, files, PR, or artifact under review
+2. **Scope performed**
+   - exact checks attempted
+3. **Findings**
+   - slop signals observed, with severity and evidence
+4. **Not checked**
+   - exclusions, blocked checks, and unknowns
+If any of those are missing, the run is incomplete as a product artifact.
+
+## In-scope review areas
+SlopPass may check:
+### 1. Grounding and API reality
+- invented framework APIs
+- wrong library methods or signatures
+- imports that do not exist
+- config keys copied from the wrong version or ecosystem
+- code paths that look plausible but are not wired to anything real
+### 2. Logic plausibility
+- conditionals that cannot produce the claimed outcome
+- unreachable branches
+- silent fall-through behaviour
+- broken async flow
+- missing awaits, swallowed promises, or unhandled error paths
+- state updates that appear cosmetically right but do not actually preserve invariants
+### 3. Scaffold-without-substance patterns
+- placeholder helpers presented as completed logic
+- TODO-shaped code wrapped in polished naming
+- dead abstractions added to look sophisticated
+- generic wrappers that increase indirection without adding working behaviour
+- copy-pasted modules with renamed nouns but unchanged semantics
+### 4. Test and proof theatre
+- tests that only snapshot happy-path output
+- mocks that prove the mock, not the feature
+- assertions too weak to catch the claimed behaviour
+- fixtures that bypass the risky path entirely
+- comments or PR copy that overstate what was verified
+### 5. Karpathy-style slopocalypse failure modes
+- verbose code that hides a simple missing constraint
+- pattern-matched architecture with no fit to the actual problem
+- fake robustness via retries, flags, or wrappers that do not solve the failure
+- cargo-cult security, performance, or accessibility changes
+- polished-looking structure pasted in ahead of basic correctness
+- confidence-heavy explanations that are not backed by executable reality
+### 6. Maintenance and change-risk signals
+- duplicated logic that will drift quickly
+- inconsistent naming across one generated slice
+- broad edits that touch many files without preserving local conventions
+- migrations, schema assumptions, or env dependencies not reflected in the surrounding code
+- code that future humans will not be able to reason about from the evidence present
+
+## Explicitly out of scope
+SlopPass should not claim to cover:
+### 1. Full correctness proof
+- formal verification
+- exhaustive path exploration
+- mathematical proof of business logic
+- guarantee of zero regressions
+### 2. Full testing
+- complete unit coverage
+- end-to-end environment validation
+- production load or concurrency behaviour
+- real-device or cross-browser confidence unless explicitly run
+### 3. Full security review
+- exploit research
+- auth bypass analysis
+- secret exposure hunting beyond what quality checks incidentally reveal
+- compliance mapping or secure-design sign-off
+### 4. Team-specific taste and architecture lawyering
+- preferred code style if the code is otherwise sound
+- framework ideology disputes
+- blanket bans on abstraction level without evidence of harm
+- hiring-quality judgments about the author
+
+## Output contract
+Each finding should include:
+- title
+- severity
+- why it matters
+- evidence
+- suggested fix
+- confidence note when needed
+Each run summary should include:
+- one-sentence posture summary
+- counts by severity
+- a coverage or confidence note
+
+## Evidence contract
+SlopPass should return evidence that lets a skeptical reviewer audit the verdict.
+That evidence may include:
+- file and line references
+- exact suspicious snippet or behaviour summary
+- failed or skipped checks
+- mismatch between claimed API and documented API
+- mismatch between tests and implementation
+- duplication or drift indicators across touched files
+- confidence notes when a signal is heuristic rather than definitive
+Evidence should prefer "here is the break or mismatch" over "this feels AI-generated."
+
+## Severity model
+- `critical`: the generated change creates a clear, high-impact break or false-safety condition likely to ship unnoticed
+- `high`: strong evidence of non-trivial wrongness, fake completeness, or major maintenance risk
+- `medium`: real weakness, likely bug source, or misleading scaffold that needs human cleanup
+- `low`: limited impact, local cleanup, or readability issue with some evidence of future drift
+- `info`: observation, smell, or recommendation without current evidence of concrete breakage
+
+## Failure modes to avoid
+SlopPass should not:
+- emit a green-sounding top-line summary when important scope was skipped
+- collapse unknown coverage into implied quality
+- present "AI-ish style" as a finding without a concrete code-quality consequence
+- punish unconventional but working code just because it is unfamiliar
+- hide blocked checks or tool limitations
+- use certification-like language unless the run actually performed that stronger review
+
+## What SlopPass can claim publicly
+Safe claims:
+- SlopPass reviewed the submitted code within a defined scope
+- SlopPass found evidence of specific slop risks
+- SlopPass found no major slop signals in the areas it evaluated
+- SlopPass reports what it checked and what it did not check
+Unsafe claims:
+- this code is production-ready
+- this PR is good
+- this feature is correct
+- this repository is free of AI slop
+- this result replaces tests, senior review, or real-world usage
+
+## UI and API acceptance bar
+Before implementation is called done:
+1. every result surface must show the disclaimer banner or compact equivalent
+2. every result payload must expose target, scope, findings, and not-checked sections
+3. every summary must preserve uncertainty and skipped coverage instead of flattening it away
+4. no marketing or UI copy may describe SlopPass as a certification, correctness proof, or guarantee
+
+## Recommended next step
+When Chunk 2 is approved, the next implementation slice should wire the disclaimer banner and output-shape requirements into the first SlopPass result surface before broader marketplace packaging or automation work proceeds.


### PR DESCRIPTION
## What changed
Added the pass-family scope contracts:
- `docs/prd/securitypass-chunk2.md`
- `docs/prd/copypass-chunk2.md`
- `docs/prd/sloppass-chunk2.md`

## Why
These docs lock what each verdict engine can claim, what evidence it must return, and what it explicitly does not promise before broader product packaging spreads.

## Notes
- Docs only
- All three docs follow the same SecurityPass-style contract shape
- No runtime tests were run
