### PR TITLE
fix(mcp): reject extra tool arguments at runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21212,6 +21212,7 @@
         "@supabase/supabase-js": "^2.103.0",
         "@types/imap": "^0.8.43",
         "@types/nodemailer": "^8.0.0",
+        "ajv": "^8.20.0",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "fast-xml-parser": "^5.5.10",
@@ -21247,6 +21248,28 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "packages/mcp-server/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/mcp-server/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "packages/mcp-server/node_modules/undici-types": {
       "version": "7.19.2",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -31,6 +31,7 @@
     "@supabase/supabase-js": "^2.103.0",
     "@types/imap": "^0.8.43",
     "@types/nodemailer": "^8.0.0",
+    "ajv": "^8.20.0",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
     "fast-xml-parser": "^5.5.10",

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { validateToolArgumentsForRuntime } from "../server.js";
+
+describe("runtime tool schema validation", () => {
+  const probes: Array<{ name: string; args: Record<string, unknown> }> = [
+    { name: "load_memory", args: { num_sessions: 1, bogus_field: "should reject" } },
+    { name: "search_memory", args: { query: "strict schema probe", bogus_field: "should reject" } },
+    { name: "check_signals", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
+    { name: "stripe_customers", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
+    { name: "stripe_charges", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
+    {
+      name: "paypal_orders",
+      args: {
+        client_id: "dummy",
+        client_secret: "dummy",
+        action: "X",
+        order_id: "ORDER",
+        bogus_field: "should reject",
+      },
+    },
+    { name: "square_payments", args: { access_token: "dummy", action: "X", bogus_field: "should reject" } },
+    {
+      name: "unclick_call",
+      args: {
+        endpoint_id: "memory.search_memory",
+        params: { query: "strict schema probe" },
+        bogus_field: "should reject",
+      },
+    },
+    { name: "unclick_generate_uuid", args: { count: 1, bogus_field: "should reject" } },
+    { name: "unclick_random_password", args: { length: 8, bogus_field: "should reject" } },
+  ];
+
+  it("rejects extra fields before handlers can run", () => {
+    for (const probe of probes) {
+      const result = validateToolArgumentsForRuntime(probe.name, probe.args);
+      expect(result, probe.name).not.toBeNull();
+      expect(result?.code).toBe("validation_error");
+      expect(result?.details.some((detail) => detail.keyword === "additionalProperties")).toBe(true);
+      expect(JSON.stringify(result)).toContain("bogus_field");
+    }
+  });
+
+  it("allows valid arguments for the same tool family", () => {
+    expect(validateToolArgumentsForRuntime("load_memory", { num_sessions: 1 })).toBeNull();
+    expect(validateToolArgumentsForRuntime("unclick_generate_uuid", { count: 1 })).toBeNull();
+    expect(validateToolArgumentsForRuntime("unclick_call", {
+      endpoint_id: "memory.search_memory",
+      params: { query: "strict schema probe" },
+    })).toBeNull();
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,5 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import * as AjvModule from "ajv";
+import type { ValidateFunction } from "ajv";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -1164,6 +1166,98 @@ const DIRECT_TOOLS = [
   },
 ] as const;
 
+type RuntimeToolSchema = {
+  name: string;
+  inputSchema?: unknown;
+};
+
+type RuntimeValidationError = {
+  code: "validation_error";
+  tool: string;
+  message: string;
+  details: Array<{
+    path: string;
+    message: string;
+    keyword: string;
+  }>;
+};
+
+type RuntimeAjvError = {
+  keyword: string;
+  message?: string;
+  instancePath?: string;
+  dataPath?: string;
+  params?: unknown;
+};
+
+type AjvRuntime = {
+  compile(schema: unknown): ValidateFunction;
+};
+
+const AjvCtor = ((AjvModule as { default?: unknown }).default ?? AjvModule) as new (
+  options: { allErrors: boolean }
+) => AjvRuntime;
+
+const ajv = new AjvCtor({
+  allErrors: true,
+});
+
+const TOOL_INPUT_SCHEMAS = new Map<string, unknown>();
+const TOOL_VALIDATORS = new Map<string, ValidateFunction>();
+
+function registerToolInputSchema(tool: RuntimeToolSchema): void {
+  if (tool.inputSchema) TOOL_INPUT_SCHEMAS.set(tool.name, tool.inputSchema);
+}
+
+for (const tool of [...INTERNAL_TOOLS, ...VISIBLE_TOOLS, ...DIRECT_TOOLS, ...ADDITIONAL_TOOLS]) {
+  registerToolInputSchema(tool);
+}
+
+// Backwards-compatible memory tool names still dispatch directly, so they need
+// the same runtime guard as the newer visible names.
+for (const [alias, canonical] of Object.entries(MEMORY_TOOL_ALIASES)) {
+  const schema = TOOL_INPUT_SCHEMAS.get(alias);
+  if (schema) TOOL_INPUT_SCHEMAS.set(canonical, schema);
+}
+
+function formatAjvError(error: RuntimeAjvError): RuntimeValidationError["details"][number] {
+  const additionalProperty =
+    error.keyword === "additionalProperties" &&
+    error.params &&
+    typeof (error.params as { additionalProperty?: unknown }).additionalProperty === "string"
+      ? ` '${(error.params as { additionalProperty: string }).additionalProperty}'`
+      : "";
+  return {
+    path: error.instancePath || error.dataPath || "/",
+    message: `${error.message ?? "invalid input"}${additionalProperty}`,
+    keyword: error.keyword,
+  };
+}
+
+export function validateToolArgumentsForRuntime(
+  toolName: string,
+  args: Record<string, unknown>
+): RuntimeValidationError | null {
+  const schema = TOOL_INPUT_SCHEMAS.get(toolName);
+  if (!schema) return null;
+
+  let validate = TOOL_VALIDATORS.get(toolName);
+  if (!validate) {
+    const compiled = ajv.compile(schema);
+    TOOL_VALIDATORS.set(toolName, compiled);
+    validate = compiled;
+  }
+
+  const validator = validate as ValidateFunction;
+  if (validator(args)) return null;
+  return {
+    code: "validation_error",
+    tool: toolName,
+    message: `Invalid arguments for ${toolName}`,
+    details: ((validator.errors ?? []) as RuntimeAjvError[]).map(formatAjvError),
+  };
+}
+
 // ─── Handler map for direct tools ───────────────────────────────────────────
 
 type DirectHandler = (
@@ -1312,6 +1406,13 @@ export function createServer(): Server {
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: rawArgs } = request.params;
     const args = (rawArgs ?? {}) as Record<string, unknown>;
+    const validationError = validateToolArgumentsForRuntime(name, args);
+    if (validationError) {
+      return {
+        content: [{ type: "text", text: JSON.stringify(validationError, null, 2) }],
+        isError: true,
+      };
+    }
 
     // Fire-and-forget Umami event for tool-usage stats. Never awaited.
     trackToolCall(name);


### PR DESCRIPTION
Recreated from closed stacked PR #272 after #265 merged to main.\n\n## Summary\n- adds runtime Ajv validation at the MCP tools/call boundary\n- rejects undeclared extra fields before handlers run\n- adds regression coverage for extra-field rejection\n\n## Verification\n- npm run build --workspace=@unclick/mcp-server\n- npm test --workspace=@unclick/mcp-server