### PR TITLE
fix(analytics): remove future PostHog defaults

### DIFF
--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -9,7 +9,6 @@ export function initPostHog(): void {
   if (initialized || !key) return;
   posthog.init(key, {
     api_host: host,
-    defaults: "2026-01-30",
     autocapture: true,
     capture_pageview: true,
     persistence: "localStorage",


### PR DESCRIPTION
## Summary\n- removes the future-dated PostHog defaults value from client init\n- leaves token/host env handling, autocapture, pageview capture, and localStorage persistence unchanged\n\n## Verification\n- npm run build\n\nRuntime follow-up after merge/deploy: force a Vercel no-cache redeploy, then verify window.posthog exists and Live events receives a $pageview.