### PR TITLE
fix(memory): mark startup fact kind on writes

### DIFF
--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -120,6 +120,7 @@ interface FactRow {
   confidence: number;
   source_session_id?: string;
   source_type: string;
+  startup_fact_kind: "durable" | "operational" | "excluded" | "legacy_unspecified";
   status: string;
   superseded_by?: string;
   access_count: number;
@@ -284,6 +285,7 @@ export class LocalBackend implements MemoryBackend {
       confidence: data.confidence,
       source_session_id: data.source_session_id,
       source_type: "manual",
+      startup_fact_kind: data.startup_fact_kind ?? "durable",
       status: "active",
       superseded_by: undefined,
       access_count: 0,
@@ -315,6 +317,7 @@ export class LocalBackend implements MemoryBackend {
       confidence: confidence ?? 1.0,
       source_session_id: undefined,
       source_type: "manual",
+      startup_fact_kind: "durable",
       status: "active",
       superseded_by: undefined,
       access_count: 0,

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -490,6 +490,7 @@ export class SupabaseBackend implements MemoryBackend {
           confidence: data.confidence,
           source_session_id: data.source_session_id ?? null,
           source_type: "manual",
+          startup_fact_kind: data.startup_fact_kind ?? "durable",
           status: "active",
           decay_tier: "hot",
           last_accessed: now(),
@@ -592,6 +593,7 @@ export class SupabaseBackend implements MemoryBackend {
             confidence: Math.max(0, data.confidence - 0.05), // slight confidence discount
             source_session_id: data.source_session_id ?? null,
             source_type: "auto_extract",
+            startup_fact_kind: data.startup_fact_kind ?? "durable",
             status: "active",
             decay_tier: "hot",
             last_accessed: now(),

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -17,6 +17,7 @@ export interface FactInput {
   category: string;
   confidence: number;
   source_session_id?: string;
+  startup_fact_kind?: StartupFactKind;
   // Bi-temporal + provenance (Chunk 2)
   valid_from?: string;
   extractor_id?: string;
@@ -27,6 +28,8 @@ export interface FactInput {
   commit_sha?: string;
   pr_number?: number;
 }
+
+export type StartupFactKind = "durable" | "operational" | "excluded" | "legacy_unspecified";
 
 export interface InvalidateFactInput {
   fact_id: string;

--- a/supabase/migrations/20260429070000_startup_fact_kind_marker.sql
+++ b/supabase/migrations/20260429070000_startup_fact_kind_marker.sql
@@ -1,0 +1,49 @@
+-- W2: add startup-context eligibility marker for managed and BYOD facts.
+-- This chip only adds/write-enables the marker. Read-time filtering and
+-- startup view switches stay in the follow-up R3 chip.
+
+ALTER TABLE IF EXISTS mc_extracted_facts
+  ADD COLUMN IF NOT EXISTS startup_fact_kind TEXT NOT NULL DEFAULT 'legacy_unspecified';
+
+ALTER TABLE IF EXISTS extracted_facts
+  ADD COLUMN IF NOT EXISTS startup_fact_kind TEXT NOT NULL DEFAULT 'legacy_unspecified';
+
+DO $$
+BEGIN
+  IF to_regclass('public.mc_extracted_facts') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conname = 'mc_extracted_facts_startup_fact_kind_check'
+         AND conrelid = 'public.mc_extracted_facts'::regclass
+     ) THEN
+    ALTER TABLE mc_extracted_facts
+      ADD CONSTRAINT mc_extracted_facts_startup_fact_kind_check
+      CHECK (startup_fact_kind IN ('durable', 'operational', 'excluded', 'legacy_unspecified'));
+  END IF;
+
+  IF to_regclass('public.extracted_facts') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conname = 'extracted_facts_startup_fact_kind_check'
+         AND conrelid = 'public.extracted_facts'::regclass
+     ) THEN
+    ALTER TABLE extracted_facts
+      ADD CONSTRAINT extracted_facts_startup_fact_kind_check
+      CHECK (startup_fact_kind IN ('durable', 'operational', 'excluded', 'legacy_unspecified'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.mc_extracted_facts') IS NOT NULL THEN
+    COMMENT ON COLUMN mc_extracted_facts.startup_fact_kind IS
+      'Startup-context eligibility marker: durable, operational, excluded, or legacy_unspecified.';
+  END IF;
+
+  IF to_regclass('public.extracted_facts') IS NOT NULL THEN
+    COMMENT ON COLUMN extracted_facts.startup_fact_kind IS
+      'Startup-context eligibility marker: durable, operational, excluded, or legacy_unspecified.';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add `startup_fact_kind` to managed `mc_extracted_facts` and BYOD `extracted_facts`
- constrain marker values to `durable`, `operational`, `excluded`, and `legacy_unspecified`
- write `durable` explicitly from current durable fact paths in Supabase and local backends

## Pollution trace for R3
The existing polluted startup rows came from operational/cron self-reports being saved through the ordinary memory fact path with no startup eligibility marker. The trace is `packages/mcp-server/src/memory/handlers.ts` `add_fact` -> `SupabaseBackend.addFact()` -> `mc_extracted_facts` / `extracted_facts`, where rows were stamped only as `source_type: "manual"`. Blob extraction also routes through `SupabaseBackend.saveBlob()` with `source_type: "auto_extract"`. Because startup reads had no separate eligibility field, these operational narration rows could masquerade as durable facts and occupy `active_facts` slots. R3 should target those operational writer paths and classify them as `startup_fact_kind = "operational"`, then switch startup views to durable-only.

## Scope boundary
No read behavior changes in this PR. R3/view switches and metric-bump narrowing remain separate chips.

## Verification
- `npm run build --workspace=@unclick/mcp-server`
- `npm test --workspace=@unclick/mcp-server`