### PR TITLE
feat(sloppass): scaffold chunk one package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7863,6 +7863,10 @@
       "resolved": "packages/securitypass",
       "link": true
     },
+    "node_modules/@unclick/sloppass": {
+      "resolved": "packages/sloppass",
+      "link": true
+    },
     "node_modules/@unclick/testpass": {
       "resolved": "packages/testpass",
       "link": true
@@ -21319,6 +21323,32 @@
       }
     },
     "packages/securitypass/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/sloppass": {
+      "name": "@unclick/sloppass",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.4.0",
+        "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/sloppass/node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",

--- a/packages/sloppass/README.md
+++ b/packages/sloppass/README.md
@@ -1,0 +1,15 @@
+# SlopPass
+
+SlopPass is a scoped code-quality verdict engine for AI-generated code. It reports evidence-based slop signals in the target and scope for a run. It is not a correctness certification, full test suite, or quality guarantee.
+
+This package is a deliberately stripped promptfoo-derived scaffold. It keeps the useful 80/20 primitives:
+
+- eval runner
+- provider abstraction
+- test schema
+- report surface
+- a small provider set
+
+It drops red-team and jailbreak modules, enterprise auth, plugin ecosystem, complex CLI flags, and the wide provider zoo.
+
+See `docs/prd/sloppass-chunk2.md` for the locked scope contract.

--- a/packages/sloppass/package.json
+++ b/packages/sloppass/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@unclick/sloppass",
+  "version": "0.1.0",
+  "description": "SlopPass - scoped AI-code quality review with evidence, scope, and not-checked boundaries.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./types": "./dist/types.js",
+    "./runner": "./dist/runner/index.js",
+    "./reporter": "./dist/reporter.js",
+    "./vendor/promptfoo-lite": "./dist/vendor/promptfoo-lite/index.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "upstream:fetch": "git fetch promptfoo",
+    "upstream:log": "git log --oneline --decorate --max-count=20 promptfoo/main"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/packages/sloppass/src/__tests__/disclaimer.test.ts
+++ b/packages/sloppass/src/__tests__/disclaimer.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { renderDisclaimer, SLOPPASS_DISCLAIMER } from "../disclaimer.js";
+
+describe("SlopPass disclaimer", () => {
+  it("matches the locked scope banner", () => {
+    expect(SLOPPASS_DISCLAIMER.headline).toBe(
+      "SlopPass is a scoped quality review, not a guarantee that the code is good."
+    );
+    expect(SLOPPASS_DISCLAIMER.body).toContain("It does not certify correctness");
+    expect(SLOPPASS_DISCLAIMER.compact).toContain("Scoped review only");
+  });
+
+  it("renders each variant", () => {
+    expect(renderDisclaimer("headline")).toBe(SLOPPASS_DISCLAIMER.headline);
+    expect(renderDisclaimer("body")).toBe(SLOPPASS_DISCLAIMER.body);
+    expect(renderDisclaimer("compact")).toBe(SLOPPASS_DISCLAIMER.compact);
+  });
+});

--- a/packages/sloppass/src/__tests__/dogfood.test.ts
+++ b/packages/sloppass/src/__tests__/dogfood.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runSlopPass } from "../runner/index.js";
+
+function collectSourceFiles(dir: string): Array<{ path: string; content: string }> {
+  const files: Array<{ path: string; content: string }> = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      if (entry === "__tests__") continue;
+      files.push(...collectSourceFiles(full));
+    } else if (entry.endsWith(".ts")) {
+      files.push({
+        path: relative(process.cwd(), full).replace(/\\/g, "/"),
+        content: readFileSync(full, "utf8"),
+      });
+    }
+  }
+  return files;
+}
+
+describe("SlopPass dogfoods on itself", () => {
+  it("can inspect its own source and return a scoped artifact", async () => {
+    const root = join(fileURLToPath(new URL("..", import.meta.url)));
+    const files = collectSourceFiles(root);
+    const result = await runSlopPass({
+      target: { kind: "files", label: "@unclick/sloppass self-check", files: files.map((file) => file.path) },
+      files,
+    });
+
+    expect(result.target.label).toBe("@unclick/sloppass self-check");
+    expect(result.scope.files_reviewed.length).toBeGreaterThan(0);
+    expect(result.summary.coverage_note).toContain("Unknown runtime paths stay unknown");
+    expect(result.disclaimer.headline).toContain("not a guarantee");
+  });
+});

--- a/packages/sloppass/src/__tests__/reporter.test.ts
+++ b/packages/sloppass/src/__tests__/reporter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { generateHtmlReport, generateJsonReport, generateMarkdownReport } from "../reporter.js";
+import { runSlopPass } from "../runner/index.js";
+
+describe("SlopPass reporter", () => {
+  it("keeps the disclaimer visible in markdown and HTML reports", async () => {
+    const result = await runSlopPass({
+      target: { kind: "files", label: "report", files: ["src/report.ts"] },
+      files: [{ path: "src/report.ts", content: "export const placeholder = true;" }],
+    });
+
+    const markdown = generateMarkdownReport(result);
+    const html = generateHtmlReport(result);
+
+    expect(markdown).toContain("Scoped review only");
+    expect(html).toContain("SlopPass is a scoped quality review");
+  });
+
+  it("emits JSON with the canonical result shape", async () => {
+    const result = await runSlopPass({
+      target: { kind: "files", label: "json", files: ["src/json.ts"] },
+      files: [{ path: "src/json.ts", content: "export const value = 1;" }],
+    });
+    const report = generateJsonReport(result) as Record<string, unknown>;
+
+    expect(report.target).toBeDefined();
+    expect(report.scope).toBeDefined();
+    expect(report.findings).toBeDefined();
+    expect(report.not_checked).toBeDefined();
+    expect(report.generated_at).toEqual(expect.any(String));
+  });
+});

--- a/packages/sloppass/src/__tests__/runner.test.ts
+++ b/packages/sloppass/src/__tests__/runner.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { runSlopPass } from "../runner/index.js";
+
+describe("SlopPass runner", () => {
+  it("returns the canonical target, scope, findings, and not_checked sections", async () => {
+    const result = await runSlopPass({
+      target: { kind: "files", label: "fixture", files: ["src/generated.ts"] },
+      files: [
+        {
+          path: "src/generated.ts",
+          content: "export function run() { try { return true; } catch {} }",
+        },
+      ],
+      checks: ["logic_plausibility"],
+    });
+
+    expect(result.target.label).toBe("fixture");
+    expect(result.scope.checks_attempted).toEqual(["logic_plausibility"]);
+    expect(result.findings.some((finding) => finding.category === "logic_plausibility")).toBe(true);
+    expect(result.not_checked.length).toBeGreaterThan(0);
+    expect(result.disclaimer.compact).toContain("Scoped review only");
+  });
+
+  it("treats Slopocalypse as a first-class check category", async () => {
+    const result = await runSlopPass({
+      target: { kind: "files", label: "wrapper", files: ["src/wrapper.ts"] },
+      files: [{ path: "src/wrapper.ts", content: "export const retryWrapper = true;" }],
+      checks: ["slopocalypse_failure_mode"],
+    });
+
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        category: "slopocalypse_failure_mode",
+        title: "Robustness wording needs evidence",
+      })
+    );
+  });
+
+  it("supports a stripped promptfoo-style model provider scaffold", async () => {
+    const result = await runSlopPass({
+      target: { kind: "files", label: "echo", files: ["src/a.ts"] },
+      files: [{ path: "src/a.ts", content: "export const a = 1;" }],
+      provider: "openai",
+      checks: ["maintenance_change_risk"],
+    });
+
+    expect(result.scope.provider).toBe("openai");
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        title: "OpenAI provider scaffold is wired",
+      })
+    );
+  });
+});

--- a/packages/sloppass/src/__tests__/schema.test.ts
+++ b/packages/sloppass/src/__tests__/schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CHECKS } from "../categories.js";
+import { SlopPassRunInputSchema } from "../schema.js";
+
+describe("SlopPass run schema", () => {
+  it("accepts the canonical target, files, and provider shape", () => {
+    const parsed = SlopPassRunInputSchema.parse({
+      target: { kind: "files", label: "fixture", files: ["src/example.ts"] },
+      files: [{ path: "src/example.ts", content: "export const ok = true;" }],
+    });
+
+    expect(parsed.provider).toBe("http");
+    expect(parsed.target.label).toBe("fixture");
+  });
+
+  it("keeps the six PRD categories as built-in checks", () => {
+    expect(DEFAULT_CHECKS).toEqual([
+      "grounding_api_reality",
+      "logic_plausibility",
+      "scaffold_without_substance",
+      "test_proof_theatre",
+      "slopocalypse_failure_mode",
+      "maintenance_change_risk",
+    ]);
+  });
+
+  it("rejects a run without files", () => {
+    expect(() =>
+      SlopPassRunInputSchema.parse({
+        target: { kind: "files", label: "empty" },
+        files: [],
+      })
+    ).toThrow();
+  });
+});

--- a/packages/sloppass/src/categories.ts
+++ b/packages/sloppass/src/categories.ts
@@ -1,0 +1,12 @@
+import type { SlopPassCategory } from "./types.js";
+
+export const SLOPPASS_CATEGORIES: Record<SlopPassCategory, string> = {
+  grounding_api_reality: "Grounding and API reality",
+  logic_plausibility: "Logic plausibility",
+  scaffold_without_substance: "Scaffold-without-substance patterns",
+  test_proof_theatre: "Test and proof theatre",
+  slopocalypse_failure_mode: "Karpathy-style slopocalypse failure modes",
+  maintenance_change_risk: "Maintenance and change-risk signals",
+};
+
+export const DEFAULT_CHECKS = Object.keys(SLOPPASS_CATEGORIES) as SlopPassCategory[];

--- a/packages/sloppass/src/disclaimer.ts
+++ b/packages/sloppass/src/disclaimer.ts
@@ -1,0 +1,12 @@
+import type { SlopPassDisclaimer } from "./types.js";
+
+export const SLOPPASS_DISCLAIMER: SlopPassDisclaimer = {
+  headline: "SlopPass is a scoped quality review, not a guarantee that the code is good.",
+  body:
+    "SlopPass reports evidence-based code quality risks it can observe in the target and scope for this run. It does not certify correctness, replace full testing or human review, or verify every runtime path, dependency, environment, or future change.",
+  compact: "Scoped review only. Not a correctness certification, full test suite, or quality guarantee.",
+};
+
+export function renderDisclaimer(mode: "headline" | "body" | "compact" = "body"): string {
+  return SLOPPASS_DISCLAIMER[mode];
+}

--- a/packages/sloppass/src/index.ts
+++ b/packages/sloppass/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./categories.js";
+export * from "./disclaimer.js";
+export * from "./reporter.js";
+export * from "./runner/index.js";
+export * from "./schema.js";
+export type * from "./types.js";
+export * from "./vendor/promptfoo-lite/index.js";

--- a/packages/sloppass/src/reporter.ts
+++ b/packages/sloppass/src/reporter.ts
@@ -1,0 +1,96 @@
+import type { SlopPassResult } from "./types.js";
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function generateJsonReport(result: SlopPassResult): object {
+  return {
+    ...result,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+export function generateMarkdownReport(result: SlopPassResult): string {
+  const lines: string[] = [
+    `# SlopPass Report - ${result.target.label}`,
+    "",
+    `> ${result.disclaimer.compact}`,
+    "",
+    `Posture: ${result.summary.posture}`,
+    "",
+    "## Scope performed",
+    "",
+    ...result.scope.checks_attempted.map((check) => `- ${check}`),
+    "",
+    "## Findings",
+    "",
+  ];
+
+  if (result.findings.length === 0) {
+    lines.push("No findings in the inspected scope.", "");
+  } else {
+    for (const finding of result.findings) {
+      const location = finding.file ? ` (${finding.file}${finding.line ? `:${finding.line}` : ""})` : "";
+      lines.push(`- **${finding.severity}** ${finding.title}${location}`);
+      lines.push(`  - Why it matters: ${finding.why_it_matters}`);
+      lines.push(`  - Evidence: ${finding.evidence}`);
+      lines.push(`  - Suggested fix: ${finding.suggested_fix}`);
+      if (finding.confidence_note) lines.push(`  - Confidence: ${finding.confidence_note}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Not checked", "");
+  if (result.not_checked.length === 0) {
+    lines.push("All built-in SlopPass check categories were attempted.", "");
+  } else {
+    for (const item of result.not_checked) lines.push(`- ${item.label}: ${item.reason}`);
+    lines.push("");
+  }
+
+  lines.push("## Disclaimer", "", result.disclaimer.body, "");
+  return lines.join("\n");
+}
+
+export function generateHtmlReport(result: SlopPassResult): string {
+  const findings = result.findings
+    .map(
+      (finding) => `<li>
+        <strong>${escapeHtml(finding.severity)}: ${escapeHtml(finding.title)}</strong>
+        <p>${escapeHtml(finding.why_it_matters)}</p>
+        <p><strong>Evidence:</strong> ${escapeHtml(finding.evidence)}</p>
+        <p><strong>Suggested fix:</strong> ${escapeHtml(finding.suggested_fix)}</p>
+      </li>`
+    )
+    .join("");
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SlopPass Report - ${escapeHtml(result.target.label)}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 32px; color: #111827; }
+    .banner { border: 1px solid #f59e0b; background: #fffbeb; padding: 16px; border-radius: 8px; }
+    li { margin-bottom: 16px; }
+  </style>
+</head>
+<body>
+  <div class="banner">
+    <strong>${escapeHtml(result.disclaimer.headline)}</strong>
+    <p>${escapeHtml(result.disclaimer.body)}</p>
+  </div>
+  <h1>SlopPass Report</h1>
+  <p>${escapeHtml(result.summary.posture)}</p>
+  <h2>Findings</h2>
+  <ul>${findings || "<li>No findings in the inspected scope.</li>"}</ul>
+  <h2>Not checked</h2>
+  <ul>${result.not_checked.map((item) => `<li>${escapeHtml(item.label)}: ${escapeHtml(item.reason)}</li>`).join("") || "<li>All built-in SlopPass check categories were attempted.</li>"}</ul>
+</body>
+</html>`;
+}

--- a/packages/sloppass/src/runner/detectors.ts
+++ b/packages/sloppass/src/runner/detectors.ts
@@ -1,0 +1,122 @@
+import type { SlopPassCategory, SlopPassFinding } from "../types.js";
+
+interface SourceFile {
+  path: string;
+  content: string;
+}
+
+function lineOf(content: string, index: number): number {
+  return content.slice(0, index).split(/\r?\n/).length;
+}
+
+function finding(
+  file: SourceFile,
+  title: string,
+  category: SlopPassCategory,
+  severity: SlopPassFinding["severity"],
+  evidence: string,
+  why_it_matters: string,
+  suggested_fix: string,
+  index = 0,
+  confidence_note?: string
+): SlopPassFinding {
+  return {
+    title,
+    category,
+    severity,
+    why_it_matters,
+    evidence,
+    suggested_fix,
+    file: file.path,
+    line: lineOf(file.content, index),
+    confidence_note,
+  };
+}
+
+export function detectSlopSignals(files: SourceFile[]): SlopPassFinding[] {
+  const findings: SlopPassFinding[] = [];
+
+  for (const file of files) {
+    const checks: Array<{
+      pattern: RegExp;
+      category: SlopPassCategory;
+      severity: SlopPassFinding["severity"];
+      title: string;
+      why: string;
+      fix: string;
+      confidence?: string;
+    }> = [
+      {
+        pattern: /\bTODO\b|throw new Error\(["']not implemented|placeholder|stubbed?/i,
+        category: "scaffold_without_substance",
+        severity: "medium",
+        title: "Placeholder logic is still present",
+        why: "Placeholder code can look complete in a generated scaffold while the risky path is not implemented.",
+        fix: "Replace the placeholder with working logic or move it into the not-checked section of the run.",
+      },
+      {
+        pattern: /\bas\s+any\b|@ts-ignore|@ts-expect-error/i,
+        category: "maintenance_change_risk",
+        severity: "low",
+        title: "Type safety was bypassed",
+        why: "Type bypasses are often generated to make a scaffold compile without proving the data shape.",
+        fix: "Model the real type or isolate the unsafe boundary with a narrow parser.",
+      },
+      {
+        pattern: /catch\s*\([^)]*\)\s*\{\s*\}|catch\s*\{\s*\}/,
+        category: "logic_plausibility",
+        severity: "high",
+        title: "Error path is silently swallowed",
+        why: "A silent catch can make a feature appear robust while failures disappear from the operator.",
+        fix: "Return a visible error, log structured context, or add an explicit not-checked result.",
+      },
+      {
+        pattern: /expect\([^)]*\)\.toBeTruthy\(\)|expect\([^)]*\)\.toBeDefined\(\)/,
+        category: "test_proof_theatre",
+        severity: "medium",
+        title: "Assertion may only prove that something exists",
+        why: "Weak assertions can pass while missing the behaviour the test claims to protect.",
+        fix: "Assert the specific output, side effect, or failure mode the feature promises.",
+        confidence: "Heuristic signal. Some existence assertions are valid as setup checks.",
+      },
+      {
+        pattern: /retry|fallback|wrapper|orchestrat/i,
+        category: "slopocalypse_failure_mode",
+        severity: "info",
+        title: "Robustness wording needs evidence",
+        why: "Generated code often adds reliability-sounding wrappers before proving the original failure is handled.",
+        fix: "Tie the wrapper to a concrete failure case and add a test that fails without it.",
+        confidence: "First-class Slopocalypse detector: this is a smell unless paired with executable evidence.",
+      },
+      {
+        pattern: /from\s+["'][^"']+["'];?|require\(["'][^"']+["']\)/,
+        category: "grounding_api_reality",
+        severity: "info",
+        title: "Imported API should be grounded",
+        why: "SlopPass flags API reality as a review area so reviewers confirm imports and methods exist in the installed version.",
+        fix: "Verify the import against the installed package version or mark the check as not run.",
+        confidence: "Inventory signal only. It is not a finding of wrongness by itself.",
+      },
+    ];
+
+    for (const check of checks) {
+      const match = check.pattern.exec(file.content);
+      if (!match) continue;
+      findings.push(
+        finding(
+          file,
+          check.title,
+          check.category,
+          check.severity,
+          match[0],
+          check.why,
+          check.fix,
+          match.index,
+          check.confidence
+        )
+      );
+    }
+  }
+
+  return findings;
+}

--- a/packages/sloppass/src/runner/index.ts
+++ b/packages/sloppass/src/runner/index.ts
@@ -1,0 +1,52 @@
+import { DEFAULT_CHECKS } from "../categories.js";
+import { SLOPPASS_DISCLAIMER } from "../disclaimer.js";
+import { SlopPassRunInputSchema, type SlopPassRunInput } from "../schema.js";
+import type { SlopPassResult, SlopPassSeverity } from "../types.js";
+import { detectSlopSignals } from "./detectors.js";
+import { getProvider } from "../vendor/promptfoo-lite/index.js";
+
+const SEVERITIES: SlopPassSeverity[] = ["critical", "high", "medium", "low", "info"];
+
+function emptyCounts(): Record<SlopPassSeverity, number> {
+  return { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+}
+
+export async function runSlopPass(input: SlopPassRunInput): Promise<SlopPassResult> {
+  const parsed = SlopPassRunInputSchema.parse(input);
+  const checks = parsed.checks ?? DEFAULT_CHECKS;
+  const provider = getProvider(parsed.provider);
+  const providerFindings = await provider.evaluate(parsed.files, checks);
+  const heuristicFindings = detectSlopSignals(parsed.files).filter((finding) =>
+    checks.includes(finding.category)
+  );
+  const findings = [...providerFindings, ...heuristicFindings];
+  const counts = emptyCounts();
+  for (const finding of findings) counts[finding.severity]++;
+
+  const checkedLabels = new Set(checks);
+  const notChecked = DEFAULT_CHECKS.filter((category) => !checkedLabels.has(category)).map((category) => ({
+    label: category,
+    reason: "Check was not requested for this scoped run.",
+  }));
+
+  const hasSerious = SEVERITIES.slice(0, 3).some((severity) => counts[severity] > 0);
+  return {
+    target: parsed.target,
+    scope: {
+      checks_attempted: checks,
+      files_reviewed: parsed.files.map((file) => file.path),
+      provider: provider.id,
+    },
+    findings,
+    not_checked: notChecked,
+    summary: {
+      posture: hasSerious
+        ? "SlopPass found evidence-backed risks in the inspected scope."
+        : "SlopPass found no major slop signals in the inspected scope.",
+      counts_by_severity: counts,
+      coverage_note:
+        "This result only covers the target, files, and checks listed in the scope. Unknown runtime paths stay unknown.",
+    },
+    disclaimer: SLOPPASS_DISCLAIMER,
+  };
+}

--- a/packages/sloppass/src/schema.ts
+++ b/packages/sloppass/src/schema.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+export const SlopPassSeveritySchema = z.enum(["critical", "high", "medium", "low", "info"]);
+
+export const SlopPassCategorySchema = z.enum([
+  "grounding_api_reality",
+  "logic_plausibility",
+  "scaffold_without_substance",
+  "test_proof_theatre",
+  "slopocalypse_failure_mode",
+  "maintenance_change_risk",
+]);
+
+export const SlopPassTargetSchema = z.object({
+  kind: z.enum(["repo", "branch", "diff", "files", "pr", "artifact"]),
+  label: z.string().min(1),
+  files: z.array(z.string()).optional(),
+  ref: z.string().optional(),
+});
+
+export const SlopPassFindingSchema = z.object({
+  title: z.string().min(1),
+  category: SlopPassCategorySchema,
+  severity: SlopPassSeveritySchema,
+  why_it_matters: z.string().min(1),
+  evidence: z.string().min(1),
+  suggested_fix: z.string().min(1),
+  confidence_note: z.string().optional(),
+  file: z.string().optional(),
+  line: z.number().int().positive().optional(),
+});
+
+export const SlopPassRunInputSchema = z.object({
+  target: SlopPassTargetSchema,
+  files: z
+    .array(
+      z.object({
+        path: z.string().min(1),
+        content: z.string(),
+      })
+    )
+    .min(1),
+  checks: z.array(SlopPassCategorySchema).optional(),
+  provider: z.enum(["openai", "anthropic", "google", "ollama", "http"]).default("http"),
+});
+
+export type SlopPassRunInput = z.input<typeof SlopPassRunInputSchema>;
+export type SlopPassParsedRunInput = z.output<typeof SlopPassRunInputSchema>;

--- a/packages/sloppass/src/types.ts
+++ b/packages/sloppass/src/types.ts
@@ -1,0 +1,60 @@
+export type SlopPassSeverity = "critical" | "high" | "medium" | "low" | "info";
+
+export type SlopPassCategory =
+  | "grounding_api_reality"
+  | "logic_plausibility"
+  | "scaffold_without_substance"
+  | "test_proof_theatre"
+  | "slopocalypse_failure_mode"
+  | "maintenance_change_risk";
+
+export interface SlopPassTarget {
+  kind: "repo" | "branch" | "diff" | "files" | "pr" | "artifact";
+  label: string;
+  files?: string[];
+  ref?: string;
+}
+
+export interface SlopPassScope {
+  checks_attempted: SlopPassCategory[];
+  files_reviewed: string[];
+  provider: string;
+}
+
+export interface SlopPassFinding {
+  title: string;
+  category: SlopPassCategory;
+  severity: SlopPassSeverity;
+  why_it_matters: string;
+  evidence: string;
+  suggested_fix: string;
+  confidence_note?: string;
+  file?: string;
+  line?: number;
+}
+
+export interface SlopPassNotChecked {
+  label: string;
+  reason: string;
+}
+
+export interface SlopPassSummary {
+  posture: string;
+  counts_by_severity: Record<SlopPassSeverity, number>;
+  coverage_note: string;
+}
+
+export interface SlopPassResult {
+  target: SlopPassTarget;
+  scope: SlopPassScope;
+  findings: SlopPassFinding[];
+  not_checked: SlopPassNotChecked[];
+  summary: SlopPassSummary;
+  disclaimer: SlopPassDisclaimer;
+}
+
+export interface SlopPassDisclaimer {
+  headline: string;
+  body: string;
+  compact: string;
+}

--- a/packages/sloppass/src/vendor/promptfoo-lite/UPSTREAM.md
+++ b/packages/sloppass/src/vendor/promptfoo-lite/UPSTREAM.md
@@ -1,0 +1,21 @@
+# promptfoo upstream tracking
+
+This folder is the deliberately stripped promptfoo-derived vendor surface for SlopPass.
+
+Upstream:
+
+- Repository: https://github.com/promptfoo/promptfoo
+- Baseline release: `promptfoo@0.121.9`
+- Baseline commit: `195df77800b749679f73ed3f258d858d33d55b48`
+- Import style: vendored snapshot, not a submodule
+- Sync policy: no automatic sync
+
+Selective upstream updates should use a temporary remote:
+
+```bash
+git remote add promptfoo https://github.com/promptfoo/promptfoo.git
+npm run upstream:fetch --workspace=@unclick/sloppass
+npm run upstream:log --workspace=@unclick/sloppass
+```
+
+Cherry-pick only the small primitives SlopPass keeps: eval runner concepts, provider abstraction, test schema, and report surface. Do not import promptfoo red-team or jailbreak modules, enterprise auth, plugin ecosystem, complex CLI flags, or the provider zoo.

--- a/packages/sloppass/src/vendor/promptfoo-lite/index.ts
+++ b/packages/sloppass/src/vendor/promptfoo-lite/index.ts
@@ -1,0 +1,22 @@
+import type { PromptfooLiteProvider } from "./provider.js";
+import {
+  anthropicProvider,
+  googleProvider,
+  httpProvider,
+  ollamaProvider,
+  openaiProvider,
+} from "./providers.js";
+
+export type { PromptfooLiteFile, PromptfooLiteProvider } from "./provider.js";
+
+const PROVIDERS: Record<PromptfooLiteProvider["id"], PromptfooLiteProvider> = {
+  openai: openaiProvider,
+  anthropic: anthropicProvider,
+  google: googleProvider,
+  ollama: ollamaProvider,
+  http: httpProvider,
+};
+
+export function getProvider(id: PromptfooLiteProvider["id"]): PromptfooLiteProvider {
+  return PROVIDERS[id];
+}

--- a/packages/sloppass/src/vendor/promptfoo-lite/provider.ts
+++ b/packages/sloppass/src/vendor/promptfoo-lite/provider.ts
@@ -1,0 +1,11 @@
+import type { SlopPassCategory, SlopPassFinding } from "../../types.js";
+
+export interface PromptfooLiteFile {
+  path: string;
+  content: string;
+}
+
+export interface PromptfooLiteProvider {
+  id: "openai" | "anthropic" | "google" | "ollama" | "http";
+  evaluate(files: PromptfooLiteFile[], checks: SlopPassCategory[]): Promise<SlopPassFinding[]>;
+}

--- a/packages/sloppass/src/vendor/promptfoo-lite/providers.ts
+++ b/packages/sloppass/src/vendor/promptfoo-lite/providers.ts
@@ -1,0 +1,34 @@
+import type { PromptfooLiteProvider } from "./provider.js";
+
+function scaffoldProvider(id: PromptfooLiteProvider["id"], label: string): PromptfooLiteProvider {
+  return {
+    id,
+    async evaluate(files, checks) {
+      if (files.length === 0 || checks.length === 0) return [];
+      return [
+        {
+          title: `${label} provider scaffold is wired`,
+          category: checks[0],
+          severity: "info",
+          why_it_matters:
+            "SlopPass keeps provider plumbing explicit while the first scaffold avoids making live model calls.",
+          evidence: `${id}: ${files.length} file(s), ${checks.length} check category/categories`,
+          suggested_fix: "Add the provider call adapter in a later implementation chip before operator-facing model review.",
+          confidence_note: "Provider scaffold only. No model call was made.",
+        },
+      ];
+    },
+  };
+}
+
+export const openaiProvider = scaffoldProvider("openai", "OpenAI");
+export const anthropicProvider = scaffoldProvider("anthropic", "Anthropic");
+export const googleProvider = scaffoldProvider("google", "Google");
+export const ollamaProvider = scaffoldProvider("ollama", "Ollama");
+
+export const httpProvider: PromptfooLiteProvider = {
+  id: "http",
+  async evaluate() {
+    return [];
+  },
+};

--- a/packages/sloppass/tsconfig.json
+++ b/packages/sloppass/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sloppass/vendor/sloppass-upstream.json
+++ b/packages/sloppass/vendor/sloppass-upstream.json
@@ -1,0 +1,18 @@
+{
+  "upstream": "https://github.com/promptfoo/promptfoo",
+  "package": "promptfoo",
+  "version": "0.121.9",
+  "tag": "0.121.9",
+  "commit": "195df77800b749679f73ed3f258d858d33d55b48",
+  "license": "MIT",
+  "trackedPaths": [
+    "src/evaluator.ts",
+    "src/configTypes.ts",
+    "src/types/index.ts",
+    "src/types/providers.ts",
+    "src/providers/registry.ts",
+    "src/assertions/index.ts"
+  ],
+  "localImplementation": "packages/sloppass/src",
+  "notes": "Hand-curated vendored snapshot of the small promptfoo primitives SlopPass keeps; aggressively stripped, not a wholesale fork."
+}

--- a/packages/sloppass/vitest.config.ts
+++ b/packages/sloppass/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- adds a new `@unclick/sloppass` workspace package with the scoped target/scope/findings/not-checked result contract
- adds the LegalPass-style disclaimer banner to JSON, Markdown, and HTML report surfaces
- includes the six locked SlopPass review categories, severity model, and a first-class Slopocalypse detector
- vendors a stripped promptfoo-lite provider surface with upstream tracking metadata for selective cherry-picks
- adds package tests, including a dogfood test that runs SlopPass against its own source

## Proof of delivery
- Commit: d88c626
- Diff stat: 23 files changed, 797 insertions
- Tests: `npm run build --workspace=@unclick/sloppass` PASS
- Tests: `npm test --workspace=@unclick/sloppass` PASS (5 files, 11 tests)

## Notes
- No generated `dist/` or package `node_modules/` are committed.
- The lockfile change is limited to registering the new workspace package.