### PR TITLE
feat(securitypass): wire phase 2 MCP and admin surfaces

### DIFF
--- a/packages/mcp-server/src/securitypass-tool.test.ts
+++ b/packages/mcp-server/src/securitypass-tool.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetSecuritypassToolForTests,
+  __setSecuritypassCommandRunnerForTests,
+  securitypassRun,
+  securitypassStatus,
+} from "./securitypass-tool.js";
+
+describe("securitypass-tool", () => {
+  afterEach(() => {
+    __resetSecuritypassToolForTests();
+  });
+
+  it("requires repo_path or target_url", async () => {
+    const result = (await securitypassRun({})) as { error?: string };
+    expect(result.error).toMatch(/repo_path or target_url is required/);
+  });
+
+  it("keeps URL targets gated behind scope verification", async () => {
+    const result = (await securitypassRun({
+      target_url: "https://example.com",
+    })) as { error?: string; next_step?: string };
+    expect(result.error).toBe("scope_unverified");
+    expect(result.next_step).toMatch(/repo_path/i);
+  });
+
+  it("stores an in-memory run for repo scans and exposes status", async () => {
+    __setSecuritypassCommandRunnerForTests(async (spec) => {
+      if (spec.command === "gitleaks") {
+        return {
+          exitCode: 1,
+          stdout: JSON.stringify([
+            {
+              RuleID: "generic-api-key",
+              Description: "Generic API key",
+              File: "src/config.ts",
+              StartLine: 12,
+              Secret: "sk_live_123",
+            },
+          ]),
+          stderr: "",
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          results: [
+            {
+              packages: [
+                {
+                  package: { name: "vite", version: "1.0.0" },
+                  vulnerabilities: [
+                    {
+                      id: "OSV-2026-1",
+                      summary: "Example vulnerability",
+                      severity: [{ score: "HIGH" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    });
+
+    const run = (await securitypassRun({
+      repo_path: process.cwd(),
+      profile: "smoke",
+    })) as { run_id?: string; status?: string; finding_count?: number; verdict_summary?: { fail?: number } };
+
+    expect(run.status).toBe("complete");
+    expect(run.finding_count).toBe(2);
+    expect(run.verdict_summary?.fail).toBe(2);
+    expect(run.run_id).toBeTruthy();
+
+    const status = (await securitypassStatus({
+      run_id: run.run_id,
+    })) as { run_id?: string; status?: string; finding_count?: number };
+
+    expect(status.run_id).toBe(run.run_id);
+    expect(status.status).toBe("complete");
+    expect(status.finding_count).toBe(2);
+  });
+});

--- a/packages/mcp-server/src/securitypass-tool.ts
+++ b/packages/mcp-server/src/securitypass-tool.ts
@@ -1,0 +1,390 @@
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+type Verdict = "check" | "na" | "fail" | "other" | "pending";
+type Severity = "critical" | "high" | "medium" | "low";
+type RunStatus = "queued" | "running" | "complete" | "failed";
+type RunProfile = "smoke" | "standard" | "deep";
+
+interface VerdictSummary {
+  total: number;
+  check: number;
+  na: number;
+  fail: number;
+  other: number;
+  pending: number;
+  pass_rate: number;
+}
+
+interface SecurityFinding {
+  id: string;
+  check_id: string;
+  title: string;
+  severity: Severity;
+  verdict: Verdict;
+  category: string;
+  description?: string;
+  remediation?: string;
+  evidence: Record<string, unknown>;
+  created_at: string;
+}
+
+interface SecurityRunRecord {
+  id: string;
+  profile: RunProfile;
+  status: RunStatus;
+  target: {
+    type: "git" | "url";
+    repo_path?: string;
+    target_url?: string;
+  };
+  verdict_summary: VerdictSummary;
+  created_at: string;
+  completed_at: string | null;
+  findings: SecurityFinding[];
+  notes: string[];
+  error?: string;
+}
+
+interface CommandSpec {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+interface CommandExecutionResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface GitleaksLeak {
+  RuleID?: string;
+  Description?: string;
+  File?: string;
+  StartLine?: number;
+  Secret?: string;
+  Commit?: string;
+}
+
+interface OsvPackage {
+  name?: string;
+  version?: string;
+}
+
+interface OsvVulnerability {
+  id?: string;
+  summary?: string;
+  details?: string;
+  severity?: Array<{ type?: string; score?: string }>;
+}
+
+interface OsvResult {
+  packages?: Array<{
+    package?: OsvPackage;
+    vulnerabilities?: OsvVulnerability[];
+  }>;
+}
+
+type CommandRunner = (spec: CommandSpec) => Promise<CommandExecutionResult>;
+
+const RUNS = new Map<string, SecurityRunRecord>();
+
+function emptySummary(): VerdictSummary {
+  return { total: 0, check: 0, na: 0, fail: 0, other: 0, pending: 0, pass_rate: 0 };
+}
+
+function defaultCommandRunner(spec: CommandSpec): Promise<CommandExecutionResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(spec.command, spec.args, {
+      cwd: spec.cwd,
+      shell: false,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+let runCommand: CommandRunner = defaultCommandRunner;
+
+function normalizeProfile(raw: unknown): RunProfile {
+  return raw === "standard" || raw === "deep" ? raw : "smoke";
+}
+
+function buildGitleaksCommand(repoPath: string): CommandSpec {
+  return {
+    command: "gitleaks",
+    args: ["detect", "--source", repoPath, "--report-format", "json", "--no-banner"],
+    cwd: repoPath,
+  };
+}
+
+function buildOsvScannerCommand(repoPath: string): CommandSpec {
+  return {
+    command: "osv-scanner",
+    args: ["--format", "json", "--recursive", repoPath],
+    cwd: repoPath,
+  };
+}
+
+function parseGitleaksJson(stdout: string): Omit<SecurityFinding, "id" | "created_at">[] {
+  if (!stdout.trim()) return [];
+  const leaks = JSON.parse(stdout) as GitleaksLeak[];
+  return leaks.map((leak) => ({
+    check_id: `securitypass.gitleaks.${leak.RuleID ?? "secret"}`,
+    title: leak.Description ?? "Potential secret detected",
+    severity: "critical",
+    verdict: "fail",
+    category: "secrets",
+    description: `Gitleaks reported a potential secret in ${leak.File ?? "an unknown file"}.`,
+    remediation: "Rotate the exposed credential, remove it from history, and replace it with a managed secret.",
+    evidence: {
+      rule_id: leak.RuleID ?? null,
+      file: leak.File ?? null,
+      start_line: leak.StartLine ?? null,
+      commit: leak.Commit ?? null,
+      secret_redacted: leak.Secret ? "[redacted]" : null,
+    },
+  }));
+}
+
+function severityFromOsv(vuln: OsvVulnerability): Severity {
+  const score = vuln.severity?.find((s) => s.score)?.score?.toUpperCase() ?? "";
+  if (score.includes("CRITICAL")) return "critical";
+  if (score.includes("HIGH")) return "high";
+  if (score.includes("MEDIUM")) return "medium";
+  return "low";
+}
+
+function parseOsvScannerJson(stdout: string): Omit<SecurityFinding, "id" | "created_at">[] {
+  if (!stdout.trim()) return [];
+  const body = JSON.parse(stdout) as { results?: OsvResult[] };
+  const findings: Array<Omit<SecurityFinding, "id" | "created_at">> = [];
+  for (const result of body.results ?? []) {
+    for (const pkg of result.packages ?? []) {
+      for (const vuln of pkg.vulnerabilities ?? []) {
+        findings.push({
+          check_id: `securitypass.osv.${vuln.id ?? "vulnerability"}`,
+          title: vuln.summary ?? "Open source vulnerability detected",
+          severity: severityFromOsv(vuln),
+          verdict: "fail",
+          category: "supply-chain",
+          description: vuln.details,
+          remediation: "Upgrade the affected package, apply a vendor patch, or document an accepted risk.",
+          evidence: {
+            id: vuln.id ?? null,
+            package: pkg.package?.name ?? null,
+            version: pkg.package?.version ?? null,
+            severity: vuln.severity ?? [],
+          },
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+function createRunRecord(target: SecurityRunRecord["target"], profile: RunProfile): SecurityRunRecord {
+  const record: SecurityRunRecord = {
+    id: randomUUID(),
+    target,
+    profile,
+    status: "queued",
+    verdict_summary: emptySummary(),
+    created_at: new Date().toISOString(),
+    completed_at: null,
+    findings: [],
+    notes: [],
+  };
+  RUNS.set(record.id, record);
+  return record;
+}
+
+function updateRun(runId: string, patch: Partial<SecurityRunRecord>): SecurityRunRecord | undefined {
+  const current = RUNS.get(runId);
+  if (!current) return undefined;
+  const next = { ...current, ...patch };
+  RUNS.set(runId, next);
+  return next;
+}
+
+function appendFindings(runId: string, findings: Array<Omit<SecurityFinding, "id" | "created_at">>): void {
+  const current = RUNS.get(runId);
+  if (!current || findings.length === 0) return;
+  current.findings.push(
+    ...findings.map((finding) => ({
+      ...finding,
+      id: randomUUID(),
+      created_at: new Date().toISOString(),
+    })),
+  );
+  current.verdict_summary = summarize(current.findings);
+  RUNS.set(runId, current);
+}
+
+function appendNote(runId: string, note: string): void {
+  const current = RUNS.get(runId);
+  if (!current) return;
+  current.notes.push(note);
+  RUNS.set(runId, current);
+}
+
+function summarize(findings: SecurityFinding[]): VerdictSummary {
+  const summary = emptySummary();
+  summary.total = findings.length;
+  for (const finding of findings) {
+    summary[finding.verdict] += 1;
+  }
+  const decided = summary.check + summary.na + summary.fail + summary.other;
+  summary.pass_rate = decided > 0 ? summary.check / decided : 0;
+  return summary;
+}
+
+function dependencyNoticeFinding(command: string, repoPath: string, detail: string): Omit<SecurityFinding, "id" | "created_at"> {
+  return {
+    check_id: `securitypass.runner.${command}.missing`,
+    title: `${command} is not installed on this MCP host`,
+    severity: "low",
+    verdict: "other",
+    category: "runner.dependencies",
+    description: `SecurityPass could not execute ${command} for ${repoPath}.`,
+    remediation: `Install ${command} on the machine hosting the MCP server, then rerun the scan.`,
+    evidence: { command, repo_path: repoPath, detail },
+  };
+}
+
+function probeFailureFinding(command: string, repoPath: string, detail: string): Omit<SecurityFinding, "id" | "created_at"> {
+  return {
+    check_id: `securitypass.runner.${command}.error`,
+    title: `${command} could not complete the scan`,
+    severity: "medium",
+    verdict: "other",
+    category: "runner.execution",
+    description: detail,
+    remediation: "Inspect the scanner stderr output and fix the invocation or project state before rerunning.",
+    evidence: { command, repo_path: repoPath, detail },
+  };
+}
+
+async function executeRepoProbe(
+  runId: string,
+  probeName: "gitleaks" | "osv-scanner",
+  repoPath: string,
+): Promise<void> {
+  const command = probeName === "gitleaks"
+    ? buildGitleaksCommand(repoPath)
+    : buildOsvScannerCommand(repoPath);
+  let result: CommandExecutionResult;
+  try {
+    result = await runCommand(command);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    appendFindings(runId, [dependencyNoticeFinding(probeName, repoPath, detail)]);
+    return;
+  }
+
+  try {
+    const findings = probeName === "gitleaks"
+      ? parseGitleaksJson(result.stdout)
+      : parseOsvScannerJson(result.stdout);
+    if (findings.length > 0) {
+      appendFindings(runId, findings);
+    }
+    if (!result.stdout.trim() && result.exitCode !== 0 && result.stderr.trim()) {
+      appendFindings(runId, [probeFailureFinding(probeName, repoPath, result.stderr.trim())]);
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    appendFindings(runId, [probeFailureFinding(probeName, repoPath, detail)]);
+  }
+}
+
+function getRunOutput(record: SecurityRunRecord): Record<string, unknown> {
+  return {
+    run_id: record.id,
+    status: record.status,
+    profile: record.profile,
+    target: record.target,
+    verdict_summary: record.verdict_summary,
+    finding_count: record.findings.length,
+    notes: record.notes,
+    completed_at: record.completed_at,
+    error: record.error ?? null,
+  };
+}
+
+export async function securitypassRun(args: Record<string, unknown>): Promise<unknown> {
+  const repoPathRaw = typeof args.repo_path === "string" ? args.repo_path.trim() : "";
+  const targetUrl = typeof args.target_url === "string" ? args.target_url.trim() : "";
+  const profile = normalizeProfile(args.profile);
+
+  if (!repoPathRaw && !targetUrl) {
+    return { error: "repo_path or target_url is required" };
+  }
+
+  if (targetUrl) {
+    return {
+      error: "scope_unverified",
+      detail:
+        "Active URL probing is still gated until scope verification ships. Phase 2 wires repo-local scanners first.",
+      next_step:
+        "Use repo_path for local secrets and supply-chain scans now. URL targets stay blocked until the scope verifier lands.",
+    };
+  }
+
+  const repoPath = path.resolve(repoPathRaw);
+  if (!fs.existsSync(repoPath)) return { error: `repo_path does not exist: ${repoPath}` };
+  if (!fs.statSync(repoPath).isDirectory()) return { error: `repo_path must be a directory: ${repoPath}` };
+
+  const record = createRunRecord({ type: "git", repo_path: repoPath }, profile);
+  updateRun(record.id, { status: "running" });
+  appendNote(record.id, "Phase 2 wires repo-local gitleaks and osv-scanner probes.");
+  appendNote(record.id, "Active URL probing remains blocked until scope verification lands.");
+
+  try {
+    await executeRepoProbe(record.id, "gitleaks", repoPath);
+    await executeRepoProbe(record.id, "osv-scanner", repoPath);
+    const completed = updateRun(record.id, {
+      status: "complete",
+      completed_at: new Date().toISOString(),
+    });
+    return getRunOutput(completed ?? RUNS.get(record.id)!);
+  } catch (err) {
+    const failed = updateRun(record.id, {
+      status: "failed",
+      completed_at: new Date().toISOString(),
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return getRunOutput(failed ?? RUNS.get(record.id)!);
+  }
+}
+
+export async function securitypassStatus(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id.trim() : "";
+  if (!runId) return { error: "run_id is required" };
+  const record = RUNS.get(runId);
+  if (!record) return { error: "run not found", run_id: runId };
+  return getRunOutput(record);
+}
+
+export function __setSecuritypassCommandRunnerForTests(next: CommandRunner): void {
+  runCommand = next;
+}
+
+export function __resetSecuritypassToolForTests(): void {
+  runCommand = defaultCommandRunner;
+  RUNS.clear();
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -776,6 +776,12 @@ import {
   seopassLighthousePlan,
 } from "./seopass-tool.js";
 
+// ─── SecurityPass (security posture QC, sister to TestPass) ─────────────────
+import {
+  securitypassRun,
+  securitypassStatus,
+} from "./securitypass-tool.js";
+
 // ─── Crews (Orchestrator Wizard) ──────────────────────────────────────────────
 import { crewsStartRun, crewsGetRun, crewsListRuns } from "./crews-tool.js";
 
@@ -12069,6 +12075,49 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── securitypass-tool.ts (security posture QC, repo-local today) ──────────
+  {
+    name: "securitypass_run",
+    description:
+      "Run SecurityPass against a local repo path or prepare a future scoped URL scan. Phase 2 wires gitleaks and osv-scanner for repo_path now; target_url stays gated until scope verification lands.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      anyOf: [
+        { required: ["repo_path"] },
+        { required: ["target_url"] },
+      ],
+      properties: {
+        repo_path: {
+          type: "string",
+          description: "Absolute or relative path to a local repository for secrets and supply-chain scanning.",
+        },
+        target_url: {
+          type: "string",
+          description: "Reserved for active web probing. Currently returns scope_unverified until the scope verifier lands.",
+        },
+        profile: {
+          type: "string",
+          enum: ["smoke", "standard", "deep"],
+          description: "Run depth hint. Phase 2 treats all profiles the same for repo-local scans.",
+        },
+      },
+    },
+  },
+  {
+    name: "securitypass_status",
+    description:
+      "Fetch the current status, verdict summary, and finding count for a SecurityPass run started in this MCP session.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string", description: "The run id returned by securitypass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+
   // ── crews-tool.ts (Orchestrator Wizard) ──────────────────────────────────────
   {
     name: "start_crew_run",
@@ -13243,6 +13292,10 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   seopass_status:          (args) => seopassStatus(args),
   seopass_register_pack:   (args) => seopassRegisterPack(args),
   seopass_lighthouse_plan: (args) => seopassLighthousePlan(args),
+
+  // securitypass-tool.ts
+  securitypass_run:        (args) => securitypassRun(args),
+  securitypass_status:     (args) => securitypassStatus(args),
 
   // crews-tool.ts
   start_crew_run: (args) => crewsStartRun(args),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import TestPassCatalog from "./pages/admin/testpass/TestPassCatalog.tsx";
 import NewRunWizard from "./pages/admin/testpass/NewRunWizard.tsx";
 import RunDetail from "./pages/admin/testpass/RunDetail.tsx";
 import ReportDetail from "./pages/admin/testpass/ReportDetail.tsx";
+import SecurityPassCatalog from "./pages/admin/securitypass/SecurityPassCatalog.tsx";
 import CrewsCatalog from "./pages/admin/crews/CrewsCatalog.tsx";
 import CrewComposer from "./pages/admin/crews/CrewComposer.tsx";
 import CrewsRuns from "./pages/admin/crews/CrewsRuns.tsx";
@@ -141,6 +142,7 @@ const App = () => (
             <Route path="testpass/packs/:id/edit" element={<AdminTestPass />} />
             <Route path="testpass/reports"      element={<Navigate to="/admin/testpass" replace />} />
             <Route path="testpass/reports/:id"  element={<ReportDetail />} />
+            <Route path="securitypass"          element={<SecurityPassCatalog />} />
             <Route path="crews"          element={<CrewsCatalog />} />
             <Route path="crews/new"      element={<CrewComposer />} />
             <Route path="crews/:id/edit" element={<CrewComposer />} />

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -249,6 +249,7 @@ export default function AdminShell() {
         <SurfaceLink path="/admin/agents"       label="Agents"        icon={Bot}          onClick={onLinkClick} />
         <SurfaceLink path="/admin/crews"        label="Crews"         icon={UsersIcon}    onClick={onLinkClick} />
         <SurfaceLink path="/admin/testpass"     label="TestPass"      icon={FlaskConical} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/securitypass" label="SecurityPass"  icon={ShieldAlert}  onClick={onLinkClick} />
         <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />
         {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}
         <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Wrench, Rocket } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import { InfoCard } from "./memory/InfoCard";
@@ -89,14 +90,36 @@ export default function AdminToolsPage() {
         {/* Section 3 - Marketplace placeholder */}
         <section>
           <h2 className="mb-4 text-lg font-semibold text-white">Marketplace</h2>
-          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-8 text-center">
-            <Rocket className="mx-auto h-8 w-8 text-white/20 mb-3" />
-            <p className="text-sm text-white/50">
-              Community tools and custom integrations - coming soon.
-            </p>
-            <p className="mt-1 text-xs text-white/30">
-              Build your own MCP tools or install from the UnClick marketplace.
-            </p>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Link
+              to="/admin/securitypass"
+              className="rounded-xl border border-white/[0.06] bg-[#111] p-5 transition-colors hover:border-red-400/30 hover:bg-white/[0.04]"
+            >
+              <div className="flex items-center gap-2">
+                <Rocket className="h-4 w-4 text-red-300" />
+                <h3 className="text-sm font-semibold text-white">SecurityPass</h3>
+                <span className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-red-500/10 text-red-300">
+                  Pass family
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-white/50">
+                Repo-local secrets and supply-chain scans are live through MCP today. Scoped active probing is scaffolded
+                behind the disclaimer banner until verification lands.
+              </p>
+              <p className="mt-3 text-[11px] font-medium text-red-300">
+                Open SecurityPass →
+              </p>
+            </Link>
+
+            <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-8 text-center">
+              <Rocket className="mx-auto h-8 w-8 text-white/20 mb-3" />
+              <p className="text-sm text-white/50">
+                Community tools and custom integrations - coming soon.
+              </p>
+              <p className="mt-1 text-xs text-white/30">
+                Build your own MCP tools or install from the UnClick marketplace.
+              </p>
+            </div>
           </div>
         </section>
     </>

--- a/src/pages/admin/securitypass/SecurityPassCatalog.tsx
+++ b/src/pages/admin/securitypass/SecurityPassCatalog.tsx
@@ -1,0 +1,146 @@
+import { ShieldAlert, ShieldCheck, TerminalSquare, LockKeyhole, TriangleAlert } from "lucide-react";
+
+const STARTER_PACKS = [
+  {
+    id: "securitypass-repo-baseline",
+    name: "Repo Baseline",
+    category: "Repo scan",
+    useWhen: "Use this when you want a quick secrets + supply-chain sweep against a local repository path.",
+    checks: "gitleaks, osv-scanner",
+    cta: "Run from MCP",
+  },
+  {
+    id: "securitypass-web-baseline",
+    name: "Scoped Web Baseline",
+    category: "Active probe",
+    useWhen: "Use this when you have explicit authorization to probe a live URL and want header + browser checks.",
+    checks: "security headers, stagehand",
+    cta: "Scope gate pending",
+  },
+];
+
+function DisclaimerBanner() {
+  return (
+    <div className="rounded-xl border border-[#E2B93B]/25 bg-[#E2B93B]/10 p-4">
+      <div className="flex items-start gap-3">
+        <TriangleAlert className="mt-0.5 h-5 w-5 shrink-0 text-[#E2B93B]" />
+        <div>
+          <h2 className="text-sm font-semibold text-[#E2B93B]">SecurityPass disclaimer placeholder</h2>
+          <p className="mt-1 text-sm text-[#d9d0a8]">
+            SecurityPass is an evidence-led QA surface, not blanket authorization to scan. Repo-local checks are live in
+            Phase 2. Active URL probing remains blocked until scope verification and disclosure plumbing land.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PackTile({
+  name,
+  category,
+  useWhen,
+  checks,
+  cta,
+  disabled = false,
+}: {
+  name: string;
+  category: string;
+  useWhen: string;
+  checks: string;
+  cta: string;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-[#111] p-5 flex flex-col gap-3">
+      <div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <h3 className="text-sm font-semibold text-white">{name}</h3>
+          <span className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-red-500/10 text-red-300">
+            {category}
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-[#888]">{useWhen}</p>
+        <p className="mt-2 text-[11px] text-[#666]">{checks}</p>
+      </div>
+      <button
+        disabled
+        className={`mt-auto flex items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium ${
+          disabled
+            ? "border-white/[0.08] bg-black/30 text-[#777]"
+            : "border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#E2B93B] hover:bg-[#E2B93B]/20"
+        }`}
+      >
+        {cta}
+      </button>
+    </div>
+  );
+}
+
+export default function SecurityPassCatalog() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <ShieldCheck className="h-6 w-6 text-red-300" />
+          <div>
+            <h1 className="text-2xl font-semibold text-white">SecurityPass</h1>
+            <p className="mt-0.5 text-sm text-[#888]">
+              The quality gate for security. Start with repo-local evidence, then step into scoped active probing.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        <DisclaimerBanner />
+
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <div className="flex items-start gap-3">
+            <TerminalSquare className="mt-0.5 h-5 w-5 shrink-0 text-[#61C1C4]" />
+            <div>
+              <h2 className="text-sm font-semibold text-white">Live now through MCP</h2>
+              <p className="mt-1 text-sm text-[#888]">
+                `securitypass_run` accepts a local `repo_path` today and executes gitleaks plus osv-scanner inside the
+                connected MCP host. `securitypass_status` polls the in-session run record.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <div className="flex items-start gap-3">
+            <LockKeyhole className="mt-0.5 h-5 w-5 shrink-0 text-[#E2B93B]" />
+            <div>
+              <h2 className="text-sm font-semibold text-white">Next up</h2>
+              <p className="mt-1 text-sm text-[#888]">
+                Scope verification, disclosure timers, and persistent reports land next. Until then, live URL scans stay
+                blocked by design.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-4 flex items-center gap-2">
+            <ShieldAlert className="h-4 w-4 text-red-300" />
+            <h2 className="text-lg font-semibold text-white">Starter packs</h2>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {STARTER_PACKS.map((pack) => (
+              <PackTile
+                key={pack.id}
+                name={pack.name}
+                category={pack.category}
+                useWhen={pack.useWhen}
+                checks={pack.checks}
+                cta={pack.cta}
+                disabled
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SecurityPass MCP run/status wiring with repo-local gitleaks and osv-scanner execution
- register the new tools in the MCP server and add focused unit coverage
- add an admin SecurityPass surface with a placeholder disclaimer banner and marketplace entry

## Verification
- 
pm exec --workspace packages/mcp-server vitest run src/securitypass-tool.test.ts
- 
pm run build --workspace packages/mcp-server
- 
pm run build

## Notes
- active URL probing still returns scope_unverified until scope verification lands
- left unrelated packages/channel-plugin/index.js worktree change untouched