### PR TITLE
feat(mcp): expose LegalPass tools

### DIFF
--- a/packages/mcp-server/src/__tests__/legalpass-tool.test.ts
+++ b/packages/mcp-server/src/__tests__/legalpass-tool.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { ADDITIONAL_HANDLERS, ADDITIONAL_TOOLS } from "../tool-wiring.js";
+import { legalpassRun, legalpassVerdict, lintLegalPassVerdict } from "../legalpass-tool.js";
+
+describe("LegalPass MCP exposure", () => {
+  it("registers legalpass_run and legalpass_verdict", () => {
+    const names = ADDITIONAL_TOOLS.map((tool) => tool.name);
+    expect(names).toContain("legalpass_run");
+    expect(names).toContain("legalpass_verdict");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("legalpass_run");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("legalpass_verdict");
+  });
+
+  it("plans LegalPass runs with the issue-spotter guardrail", async () => {
+    const result = await legalpassRun({
+      target: { kind: "url", url: "https://example.com/terms" },
+      jurisdictions: ["AU"],
+    }) as Record<string, unknown>;
+
+    expect(result.status).toBe("planned");
+    expect(result.pack_id).toBe("legalpass-mvp-v0");
+    expect(String(result.disclaimer)).toContain("issue-spotter");
+    expect(result.safety).toMatchObject({
+      issue_spotter_only: true,
+      no_legal_advice: true,
+      no_transactional_instrument: true,
+    });
+  });
+
+  it("returns a validation-style error when target.kind is missing", async () => {
+    await expect(legalpassRun({ target: {} })).resolves.toMatchObject({
+      error: "target.kind is required",
+    });
+  });
+
+  it("lints directive LegalPass verdict language", async () => {
+    expect(lintLegalPassVerdict("This clause may warrant review.")).toEqual([]);
+
+    const result = await legalpassVerdict({
+      verdict_text: "You should file this now because this is illegal.",
+      disclaimer_length: "chat",
+    }) as Record<string, unknown>;
+
+    expect(result.ok).toBe(false);
+    expect(result.safe_to_emit).toBe(false);
+    expect(JSON.stringify(result.issues)).toContain("should");
+    expect(JSON.stringify(result.issues)).toContain("this is illegal");
+    expect(String(result.disclaimer)).toContain("not a lawyer");
+  });
+});

--- a/packages/mcp-server/src/legalpass-tool.ts
+++ b/packages/mcp-server/src/legalpass-tool.ts
@@ -1,0 +1,136 @@
+/**
+ * legalpass-tool - MCP exposure for LegalPass.
+ *
+ * LegalPass is an issue-spotter only. These handlers expose the existing
+ * LegalPass guardrails to MCP callers without pretending a full legal review
+ * engine exists yet.
+ */
+
+type DisclaimerLength = "chat" | "results" | "tos";
+
+const DISCLAIMERS: Record<DisclaimerLength, string> = {
+  chat:
+    "LegalPass is an issue-spotter, not a lawyer. It surfaces risks in plain " +
+    "English and does not give legal advice, take legal action on your behalf, " +
+    "or replace counsel. For action on a specific matter, engage a qualified " +
+    "human practitioner in your jurisdiction.",
+  results:
+    "These findings are issue-spotting output only. LegalPass is not a lawyer, " +
+    "law firm, or substitute for one, and nothing here is legal advice or a " +
+    "legal opinion about your situation. No solicitor-client or attorney-client " +
+    "relationship is created. Items are flagged using a twelve-hat panel, with " +
+    "every claim traced to a primary source by the Citation Verifier. " +
+    "Jurisdictions named are routing hints, not warranties of coverage. Before " +
+    "acting on any item, consult a qualified practitioner admitted in the " +
+    "relevant jurisdiction. You can engage one through the LegalPass " +
+    "marketplace bolt-on or any provider of your choice. LegalPass disclaims " +
+    "liability for action or inaction taken on the basis of this report.",
+  tos:
+    "LegalPass is an automated issue-spotting service operated by UnClick. It " +
+    "is not a lawyer, attorney, solicitor, barrister, law firm, or licensed " +
+    "provider of legal services in any jurisdiction. Use of LegalPass does " +
+    "not create a solicitor-client, attorney-client, or fiduciary relationship " +
+    "between you and UnClick. Output is provided for informational purposes " +
+    "only. It is not legal advice, a legal opinion, legal representation, " +
+    "certification of compliance, or a guarantee that any document is " +
+    "lawful. LegalPass does not draft, execute, file, or serve " +
+    "any transactional legal instrument and does not recommend that you take " +
+    "or refrain from any specific legal action. Findings reference primary " +
+    "sources via the Citation Verifier hard-veto, but those references may " +
+    "be incomplete or out of date. Jurisdictional routing is best-effort and " +
+    "may be wrong; you are responsible for confirming jurisdiction with a " +
+    "qualified practitioner. Where LegalPass surfaces an option to engage a " +
+    "practitioner through the marketplace bolt-on, that practitioner contracts " +
+    "with you directly and is solely responsible for services they provide. " +
+    "To the fullest extent permitted by law, UnClick disclaims all liability " +
+    "for loss, damage, or cost arising from action or inaction taken on the " +
+    "basis of LegalPass output. Always consult a qualified practitioner " +
+    "before acting on any finding, and treat the report as a starting point. " +
+    "Rubrics are updated periodically; an item rated as a check today may be " +
+    "rated otherwise tomorrow, and you should not rely on a stale report. " +
+    "LegalPass does not retain privilege over uploads and does not assert " +
+    "work-product protection. Where you face dispute resolution, statutes of " +
+    "limitation, or any other deadline, LegalPass does not track or warn " +
+    "you, and a missed deadline remains your responsibility. If a finding " +
+    "conflicts with advice from a practitioner you have engaged, defer to " +
+    "the practitioner. UnClick may update these terms, the rubrics, the hat " +
+    "roster, and the routing logic at any time without notice, and continued " +
+    "use constitutes acceptance.",
+};
+
+const FORBIDDEN_PHRASES: ReadonlyArray<{ phrase: string; reason: string }> = [
+  { phrase: "should", reason: "directive verb - implies a recommendation" },
+  { phrase: "must", reason: "directive verb - implies an obligation" },
+  { phrase: "you need to", reason: "directive phrasing - implies an instruction" },
+  { phrase: "you have to", reason: "directive phrasing - implies an instruction" },
+  { phrase: "we recommend", reason: "first-person recommendation - prohibited" },
+  { phrase: "this is illegal", reason: "definitive legal conclusion - prohibited" },
+  { phrase: "you will win", reason: "outcome prediction - prohibited" },
+  { phrase: "you will lose", reason: "outcome prediction - prohibited" },
+];
+
+const ALLOWED_PHRASES = ["appears", "may", "consider", "in similar contracts", "warrants review"];
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function disclaimerLength(value: unknown): DisclaimerLength {
+  return value === "chat" || value === "tos" ? value : "results";
+}
+
+export function lintLegalPassVerdict(text: string): Array<{ phrase: string; index: number; reason: string }> {
+  const issues: Array<{ phrase: string; index: number; reason: string }> = [];
+  for (const { phrase, reason } of FORBIDDEN_PHRASES) {
+    const pattern = new RegExp(`\\b${escapeRegex(phrase)}\\b`, "gi");
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      issues.push({ phrase, index: match.index, reason });
+    }
+  }
+  return issues.sort((a, b) => a.index - b.index);
+}
+
+export async function legalpassRun(args: Record<string, unknown>): Promise<unknown> {
+  const packId = typeof args.pack_id === "string" && args.pack_id ? args.pack_id : "legalpass-mvp-v0";
+  const target = args.target && typeof args.target === "object" && !Array.isArray(args.target)
+    ? args.target as Record<string, unknown>
+    : null;
+  const profile = typeof args.profile === "string" ? args.profile : "smoke";
+  const jurisdictions = Array.isArray(args.jurisdictions) ? args.jurisdictions.filter((item) => typeof item === "string") : [];
+
+  if (!target || typeof target.kind !== "string") {
+    return { error: "target.kind is required" };
+  }
+
+  return {
+    status: "planned",
+    pass: "legalpass",
+    pack_id: packId,
+    target,
+    profile,
+    jurisdictions,
+    disclaimer: DISCLAIMERS.chat,
+    note:
+      "LegalPass MCP exposure is scaffold-only. It returns the guarded run plan now; full 12-hat execution lands in a later LegalPass engine chip.",
+    safety: {
+      issue_spotter_only: true,
+      no_legal_advice: true,
+      no_transactional_instrument: true,
+    },
+  };
+}
+
+export async function legalpassVerdict(args: Record<string, unknown>): Promise<unknown> {
+  const verdictText = typeof args.verdict_text === "string" ? args.verdict_text : "";
+  const length = disclaimerLength(args.disclaimer_length);
+  const issues = verdictText ? lintLegalPassVerdict(verdictText) : [];
+  return {
+    ok: issues.length === 0,
+    safe_to_emit: issues.length === 0,
+    issues,
+    allowed_framing: ALLOWED_PHRASES,
+    disclaimer_length: length,
+    disclaimer: DISCLAIMERS[length],
+  };
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -758,6 +758,12 @@ import {
   testpassReportMd,
 } from "./testpass-tool.js";
 
+// ─── LegalPass (issue-spotting guardrails) ───────────────────────────────────
+import {
+  legalpassRun,
+  legalpassVerdict,
+} from "./legalpass-tool.js";
+
 // ─── UXPass (sister to TestPass, UI/UX QC) ───────────────────────────────────
 import {
   uxpassRun,
@@ -11934,6 +11940,47 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── legalpass-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "legalpass_run",
+    description: "Plan a LegalPass issue-spotting run against a URL, contract upload, or repo. Scaffold-only: exposes LegalPass guardrails and the safe run envelope while full 12-hat execution lands in a later engine chip.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        pack_id: { type: "string", description: "LegalPass pack slug (default: legalpass-mvp-v0)" },
+        target: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            kind: { type: "string", enum: ["url", "contract_upload", "repo"] },
+            url: { type: "string", description: "Target URL for url runs" },
+            upload_ref: { type: "string", description: "Upload reference for contract_upload runs" },
+            repo: { type: "string", description: "Repository identifier for repo runs" },
+            branch: { type: "string", description: "Optional branch name for repo runs" },
+            commit: { type: "string", description: "Optional commit SHA for repo runs" },
+          },
+          required: ["kind"],
+        },
+        profile: { type: "string", enum: ["smoke", "standard", "deep"], description: "Run profile (default: smoke)" },
+        jurisdictions: { type: "array", items: { type: "string" }, description: "Optional jurisdiction routing hints" },
+      },
+      required: ["target"],
+    },
+  },
+  {
+    name: "legalpass_verdict",
+    description: "Lint LegalPass-style verdict text against the issue-spotter guardrail and return the legally reviewed disclaimer banner for Pass-family outputs.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        verdict_text: { type: "string", description: "Verdict or finding text to check before display" },
+        disclaimer_length: { type: "string", enum: ["chat", "results", "tos"], description: "Disclaimer length to return (default: results)" },
+      },
+    },
+  },
+
   // ── uxpass-tool.ts (UI/UX QC, sister to TestPass) ──────────────────────────
   {
     name: "uxpass_run",
@@ -13229,6 +13276,10 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   testpass_report_html: (args) => testpassReportHtml(args),
   testpass_report_json: (args) => testpassReportJson(args),
   testpass_report_md:   (args) => testpassReportMd(args),
+
+  // legalpass-tool.ts
+  legalpass_run:     (args) => legalpassRun(args),
+  legalpass_verdict: (args) => legalpassVerdict(args),
 
   // uxpass-tool.ts
   uxpass_run:           (args) => uxpassRun(args),


### PR DESCRIPTION
## Summary
- exposes `legalpass_run` and `legalpass_verdict` through the MCP server tool registry
- adds a scaffold-only LegalPass run handler that returns the guarded run envelope and issue-spotter disclaimer
- adds a verdict/disclaimer handler so Pass-family outputs can reuse the LegalPass guardrail banner
- adds MCP server tests for registration, scaffold run behavior, missing target handling, and directive-language linting

## Proof of delivery
- Commit: 69d9b60
- Diff stat: 3 files changed, 238 insertions
- Tests: `npm run build --workspace=@unclick/mcp-server` PASS
- Tests: `npm test --workspace=@unclick/mcp-server` PASS (node tests 29 pass, vitest 5 files / 16 tests pass)

## Notes
- `legalpass_run` is intentionally scaffold-only. It exposes the safe envelope now; full 12-hat LegalPass execution stays for the later engine chip.