### PR TITLE
chore(backstagepass): redirect marketing route to /admin/keychain

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,7 @@ const App = () => (
           <Route path="/developers/vibe-coding" element={<VibeCodingPage />} />
           <Route path="/terms" element={<TermsPage />} />
           <Route path="/privacy" element={<PrivacyPage />} />
-          <Route path="/backstagepass" element={<BackstagePassPage />} />
+          <Route path="/backstagepass" element={<Navigate to="/admin/keychain" replace />} />
           {/* Core product pages */}
           <Route path="/tools" element={<ToolsPage />} />
           <Route path="/memory" element={<MemoryPage />} />


### PR DESCRIPTION
## Summary
- Redirect `/backstagepass` marketing page to `/admin/keychain` (the live credential management UI)
- - One-line route swap in App.tsx. File stays in repo per never-delete policy.
- - BackstagePass backend (api/backstagepass.ts, audit table, user_credentials) is unaffected.
## Test plan
- [ ] Visit unclick.world/backstagepass → should redirect to /admin/keychain
- [ ] - [ ] Verify /admin/keychain loads normally
- [ ] - [ ] Verify no other routes affected
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>