### PR TITLE
docs(memory): add troubleshooting fact lane

### DIFF
--- a/docs/prd/memory.md
+++ b/docs/prd/memory.md
@@ -21,6 +21,7 @@ Memory belongs to the user, not the harness. It should survive model upgrades, h
    - Business context: standing rules the agent loads on every turn.
    - Sessions: summaries of prior conversations.
    - Facts: atomic statements with confidence, category, and supersede chain.
+     Troubleshooting facts use category `troubleshooting` and the shape `Issue: <symptom>. Solution: <fix>` so solved client, browser, connector, or tool problems can be found again.
    - Library: canonical documents with provenance and history.
    - Conversations: raw conversation log for replay and debugging.
    - Code: code dumps and architecture snapshots.

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -44,6 +44,10 @@ describe("runtime tool schema validation", () => {
 
   it("allows valid arguments for the same tool family", () => {
     expect(validateToolArgumentsForRuntime("load_memory", { num_sessions: 1 })).toBeNull();
+    expect(validateToolArgumentsForRuntime("save_fact", {
+      fact: "Issue: Claude tool-result submission fails in Brave. Solution: disable Brave Shields for claude.ai.",
+      category: "troubleshooting",
+    })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_generate_uuid", { count: 1 })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_call", {
       endpoint_id: "memory.search_memory",

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -278,7 +278,9 @@ const VISIBLE_TOOLS = [
       "Saves a new persistent fact about the user that will be available in all future sessions across every AI tool. " +
       "Use whenever the user shares anything worth keeping -- even if they don't explicitly ask: 'capture', 'noted', " +
       "'remember this', 'log', 'store', 'don't forget', or any preference, decision, correction, contact, project detail, " +
-      "technical choice, or personal detail the user mentions. " +
+      "technical choice, troubleshooting fix, or personal detail the user mentions. " +
+      "When the user reports a solved client/tool issue, save it as category 'troubleshooting' using the shape " +
+      "'Issue: <symptom>. Solution: <fix>'. " +
       "Also trigger proactively when the user corrects you (save the correction immediately), " +
       "reveals a preference by rejecting something, or names a person/tool/project for the first time. " +
       "Do NOT trigger for transient values (today's weather, one-off calculations, temporary state that won't matter next session). " +
@@ -290,8 +292,8 @@ const VISIBLE_TOOLS = [
         fact: { type: "string", description: "The fact -- a single atomic statement" },
         category: {
           type: "string",
-          enum: ["preference", "decision", "technical", "contact", "project", "general"],
-          description: "Category: preference, decision, technical, contact, project, general",
+          enum: ["preference", "decision", "technical", "contact", "project", "troubleshooting", "general"],
+          description: "Category: preference, decision, technical, contact, project, troubleshooting, general",
           default: "general",
         },
         confidence: { type: "number", minimum: 0, maximum: 1, default: 0.9 },
@@ -1380,6 +1382,8 @@ export function createServer(): Server {
         "               'facts about me', 'who am I', or references any past work.",
         "  3. SAVE   -- call `save_fact` the moment the user shares anything",
         "               worth keeping: name, preferences, decisions, corrections.",
+        "               For solved client/tool issues, use category `troubleshooting`",
+        "               and write `Issue: <symptom>. Solution: <fix>`.",
         "               Use `save_identity` for standing rules that apply every",
         "               session (role, timezone, stack, workflow).",
         "  4. END    -- call `save_session` before closing. Record decisions made,",


### PR DESCRIPTION
## Summary
- add 	roubleshooting as an accepted save_fact category
- document the Issue: ... Solution: ... convention for solved client/tool problems
- add a runtime schema test proving troubleshooting facts pass validation

## Verification
- npm run build --workspace=@unclick/mcp-server
- npx vitest run src/__tests__/tool-schema-validation.test.ts (from packages/mcp-server)
- npx eslint packages/mcp-server/src/server.ts packages/mcp-server/src/__tests__/tool-schema-validation.test.ts