### PR TITLE
[codex] feat: scaffold CopyPass MCP and admin surfaces

### DIFF
--- a/packages/mcp-server/src/copypass-tool.test.ts
+++ b/packages/mcp-server/src/copypass-tool.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { copypassRun, copypassStatus } from "./copypass-tool.js";
+
+describe("copypass-tool", () => {
+  it("requires copy_text", async () => {
+    const result = (await copypassRun({})) as { error?: string };
+    expect(result.error).toMatch(/copy_text is required/);
+  });
+
+  it("rejects invalid profiles", async () => {
+    const result = (await copypassRun({
+      copy_text: "Try the new operator stack.",
+      profile: "turbo",
+    })) as { error?: string };
+    expect(result.error).toMatch(/profile must be one of/);
+  });
+
+  it("stores an in-memory scaffold run and exposes status", async () => {
+    const run = (await copypassRun({
+      copy_text: "Ship the fastest way to turn your chat model into a useful operator.",
+      channel: "homepage_hero",
+      audience: "technical founders",
+      goal: "clarity and conversion",
+      profile: "smoke",
+    })) as { run_id?: string; status?: string; finding_count?: number; verdict_summary?: { na?: number } };
+
+    expect(run.status).toBe("complete");
+    expect(run.finding_count).toBe(1);
+    expect(run.verdict_summary?.na).toBe(1);
+    expect(run.run_id).toBeTruthy();
+
+    const status = (await copypassStatus({
+      run_id: run.run_id,
+    })) as { run_id?: string; status?: string; target?: { channel?: string } };
+
+    expect(status.run_id).toBe(run.run_id);
+    expect(status.status).toBe("complete");
+    expect(status.target?.channel).toBe("homepage_hero");
+  });
+
+  it("returns a clear error for missing run ids", async () => {
+    const status = (await copypassStatus({
+      run_id: "missing-run-id",
+    })) as { error?: string };
+    expect(status.error).toMatch(/was not found in this MCP session/);
+  });
+});

--- a/packages/mcp-server/src/copypass-tool.ts
+++ b/packages/mcp-server/src/copypass-tool.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+
+type Verdict = "check" | "na" | "fail" | "other" | "pending";
+type Severity = "critical" | "high" | "medium" | "low";
+type RunStatus = "queued" | "running" | "complete" | "failed";
+type RunProfile = "smoke" | "standard" | "deep";
+
+interface VerdictSummary {
+  total: number;
+  check: number;
+  na: number;
+  fail: number;
+  other: number;
+  pending: number;
+  pass_rate: number;
+}
+
+interface CopyFinding {
+  id: string;
+  check_id: string;
+  title: string;
+  severity: Severity;
+  verdict: Verdict;
+  category: string;
+  description?: string;
+  remediation?: string;
+  evidence: Record<string, unknown>;
+  created_at: string;
+}
+
+interface CopyRunRecord {
+  id: string;
+  profile: RunProfile;
+  status: RunStatus;
+  target: {
+    type: "copy";
+    copy_text_preview: string;
+    channel?: string;
+    audience?: string;
+    goal?: string;
+  };
+  verdict_summary: VerdictSummary;
+  created_at: string;
+  completed_at: string | null;
+  findings: CopyFinding[];
+  notes: string[];
+  error?: string;
+}
+
+const RUNS = new Map<string, CopyRunRecord>();
+
+function emptySummary(): VerdictSummary {
+  return { total: 0, check: 0, na: 0, fail: 0, other: 0, pending: 0, pass_rate: 0 };
+}
+
+function parseProfile(raw: unknown): RunProfile | null {
+  if (raw === undefined || raw === null || raw === "") return "smoke";
+  return raw === "smoke" || raw === "standard" || raw === "deep" ? raw : null;
+}
+
+function previewCopy(text: string): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length > 160 ? `${oneLine.slice(0, 157)}...` : oneLine;
+}
+
+function summarize(findings: CopyFinding[]): VerdictSummary {
+  const summary = emptySummary();
+  summary.total = findings.length;
+  for (const finding of findings) {
+    summary[finding.verdict] += 1;
+  }
+  const decided = summary.check + summary.na + summary.fail + summary.other;
+  summary.pass_rate = decided > 0 ? summary.check / decided : 0;
+  return summary;
+}
+
+function createRunRecord(copyText: string, profile: RunProfile, args: Record<string, unknown>): CopyRunRecord {
+  const record: CopyRunRecord = {
+    id: randomUUID(),
+    profile,
+    status: "queued",
+    target: {
+      type: "copy",
+      copy_text_preview: previewCopy(copyText),
+      channel: typeof args.channel === "string" ? args.channel : undefined,
+      audience: typeof args.audience === "string" ? args.audience : undefined,
+      goal: typeof args.goal === "string" ? args.goal : undefined,
+    },
+    verdict_summary: emptySummary(),
+    created_at: new Date().toISOString(),
+    completed_at: null,
+    findings: [],
+    notes: [],
+  };
+  RUNS.set(record.id, record);
+  return record;
+}
+
+function appendScaffoldFinding(runId: string, copyText: string): void {
+  const current = RUNS.get(runId);
+  if (!current) return;
+  current.findings.push({
+    id: randomUUID(),
+    check_id: "copypass.scaffold.placeholder",
+    title: "CopyPass scaffold is wired, but automated copy checks have not landed yet",
+    severity: "low",
+    verdict: "na",
+    category: "scaffold",
+    description:
+      "This run proves the CopyPass MCP and admin surface are connected. Evidence-led copy checks land in a later chunk.",
+    remediation:
+      "Use this scaffold to test routing, entitlement, and UI placement now. Add deterministic copy checks before calling the result a real verdict.",
+    evidence: {
+      copy_length: copyText.length,
+      preview: previewCopy(copyText),
+      channel: current.target.channel ?? null,
+      audience: current.target.audience ?? null,
+      goal: current.target.goal ?? null,
+    },
+    created_at: new Date().toISOString(),
+  });
+  current.verdict_summary = summarize(current.findings);
+  RUNS.set(runId, current);
+}
+
+function appendNote(runId: string, note: string): void {
+  const current = RUNS.get(runId);
+  if (!current) return;
+  current.notes.push(note);
+  RUNS.set(runId, current);
+}
+
+export async function copypassRun(args: Record<string, unknown>): Promise<unknown> {
+  const copyText = typeof args.copy_text === "string" ? args.copy_text.trim() : "";
+  if (!copyText) return { error: "copy_text is required" };
+  const profile = parseProfile(args.profile);
+  if (!profile) return { error: "profile must be one of: smoke, standard, deep" };
+
+  const run = createRunRecord(copyText, profile, args);
+  RUNS.set(run.id, { ...run, status: "running" });
+  appendScaffoldFinding(run.id, copyText);
+  appendNote(run.id, "Chunk 1 scaffold only: CopyPass surface is live, but deterministic copy-quality checks land in a later chunk.");
+  appendNote(run.id, "Use channel, audience, and goal fields now so later evaluator passes inherit realistic operator context.");
+
+  const completed = RUNS.get(run.id);
+  if (!completed) return { error: "run disappeared before completion" };
+  completed.status = "complete";
+  completed.completed_at = new Date().toISOString();
+  RUNS.set(run.id, completed);
+
+  return {
+    run_id: completed.id,
+    status: completed.status,
+    finding_count: completed.findings.length,
+    verdict_summary: completed.verdict_summary,
+    notes: completed.notes,
+    preview: completed.target.copy_text_preview,
+  };
+}
+
+export async function copypassStatus(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id : "";
+  if (!runId) return { error: "run_id is required" };
+  const run = RUNS.get(runId);
+  if (!run) return { error: `CopyPass run '${runId}' was not found in this MCP session` };
+  return {
+    run_id: run.id,
+    status: run.status,
+    profile: run.profile,
+    finding_count: run.findings.length,
+    verdict_summary: run.verdict_summary,
+    target: run.target,
+    notes: run.notes,
+    completed_at: run.completed_at,
+  };
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -776,6 +776,12 @@ import {
   seopassLighthousePlan,
 } from "./seopass-tool.js";
 
+// ─── CopyPass (copy quality QC, sister to SecurityPass) ─────────────────────
+import {
+  copypassRun,
+  copypassStatus,
+} from "./copypass-tool.js";
+
 // ─── Crews (Orchestrator Wizard) ──────────────────────────────────────────────
 import { crewsStartRun, crewsGetRun, crewsListRuns } from "./crews-tool.js";
 
@@ -12069,6 +12075,36 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── copypass-tool.ts (copy quality QC, scaffold-only for Chunk 1) ────────
+  {
+    name: "copypass_run",
+    description: "Start a scaffold CopyPass run for AI-generated copy. Chunk 1 stores an in-session run record and echoes operator context so later evidence-led copy checks can plug into a stable shape.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        copy_text: { type: "string", description: "The AI-generated copy to review." },
+        channel: { type: "string", description: "Optional surface label such as homepage_hero, pricing_section, or onboarding_email." },
+        audience: { type: "string", description: "Optional intended audience for the copy." },
+        goal: { type: "string", description: "Optional goal for the copy, such as clarity, conversion, or trust." },
+        profile: { type: "string", enum: ["smoke", "standard", "deep"], description: "Reserved for later evaluator depth. Defaults to smoke." },
+      },
+      required: ["copy_text"],
+    },
+  },
+  {
+    name: "copypass_status",
+    description: "Fetch the current status, notes, and scaffold finding count for a CopyPass run started in this MCP session.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string", description: "The run id returned by copypass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+
   // ── crews-tool.ts (Orchestrator Wizard) ──────────────────────────────────────
   {
     name: "start_crew_run",
@@ -13243,6 +13279,10 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   seopass_status:          (args) => seopassStatus(args),
   seopass_register_pack:   (args) => seopassRegisterPack(args),
   seopass_lighthouse_plan: (args) => seopassLighthousePlan(args),
+
+  // copypass-tool.ts
+  copypass_run:            (args) => copypassRun(args),
+  copypass_status:         (args) => copypassStatus(args),
 
   // crews-tool.ts
   start_crew_run: (args) => crewsStartRun(args),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import TestPassCatalog from "./pages/admin/testpass/TestPassCatalog.tsx";
 import NewRunWizard from "./pages/admin/testpass/NewRunWizard.tsx";
 import RunDetail from "./pages/admin/testpass/RunDetail.tsx";
 import ReportDetail from "./pages/admin/testpass/ReportDetail.tsx";
+import CopyPassCatalog from "./pages/admin/copypass/CopyPassCatalog.tsx";
 import CrewsCatalog from "./pages/admin/crews/CrewsCatalog.tsx";
 import CrewComposer from "./pages/admin/crews/CrewComposer.tsx";
 import CrewsRuns from "./pages/admin/crews/CrewsRuns.tsx";
@@ -141,6 +142,7 @@ const App = () => (
             <Route path="testpass/packs/:id/edit" element={<AdminTestPass />} />
             <Route path="testpass/reports"      element={<Navigate to="/admin/testpass" replace />} />
             <Route path="testpass/reports/:id"  element={<ReportDetail />} />
+            <Route path="copypass"              element={<CopyPassCatalog />} />
             <Route path="crews"          element={<CrewsCatalog />} />
             <Route path="crews/new"      element={<CrewComposer />} />
             <Route path="crews/:id/edit" element={<CrewComposer />} />

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -38,6 +38,7 @@ import {
   Sparkles,
   BookOpen,
   FlaskConical,
+  PenSquare,
   ShieldAlert,
   Users as UsersIcon,
   HeartPulse,
@@ -249,6 +250,7 @@ export default function AdminShell() {
         <SurfaceLink path="/admin/agents"       label="Agents"        icon={Bot}          onClick={onLinkClick} />
         <SurfaceLink path="/admin/crews"        label="Crews"         icon={UsersIcon}    onClick={onLinkClick} />
         <SurfaceLink path="/admin/testpass"     label="TestPass"      icon={FlaskConical} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/copypass"     label="CopyPass"      icon={PenSquare}    onClick={onLinkClick} />
         <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />
         {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}
         <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Wrench, Rocket } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Wrench, Rocket, PenSquare } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import { InfoCard } from "./memory/InfoCard";
 import UnClickTools from "./tools/UnClickTools";
@@ -86,17 +87,38 @@ export default function AdminToolsPage() {
           <ConnectedServices connectors={connectors} loading={loading} />
         </section>
 
-        {/* Section 3 - Marketplace placeholder */}
+        {/* Section 3 - Marketplace */}
         <section>
           <h2 className="mb-4 text-lg font-semibold text-white">Marketplace</h2>
-          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-8 text-center">
-            <Rocket className="mx-auto h-8 w-8 text-white/20 mb-3" />
-            <p className="text-sm text-white/50">
-              Community tools and custom integrations - coming soon.
-            </p>
-            <p className="mt-1 text-xs text-white/30">
-              Build your own MCP tools or install from the UnClick marketplace.
-            </p>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Link
+              to="/admin/copypass"
+              className="rounded-xl border border-white/[0.06] bg-[#111] p-5 transition-colors hover:border-fuchsia-400/30 hover:bg-white/[0.04]"
+            >
+              <div className="flex items-center gap-2">
+                <PenSquare className="h-4 w-4 text-fuchsia-300" />
+                <h3 className="text-sm font-semibold text-white">CopyPass</h3>
+                <span className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-fuchsia-500/10 text-fuchsia-300">
+                  Pass family
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-white/50">
+                Scaffold-only MCP and admin surface for AI-generated copy review. Deterministic checks land in a later chunk.
+              </p>
+              <p className="mt-3 text-[11px] font-medium text-fuchsia-300">
+                Open CopyPass →
+              </p>
+            </Link>
+
+            <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-8 text-center">
+              <Rocket className="mx-auto h-8 w-8 text-white/20 mb-3" />
+              <p className="text-sm text-white/50">
+                Community tools and custom integrations - coming soon.
+              </p>
+              <p className="mt-1 text-xs text-white/30">
+                Build your own MCP tools or install from the UnClick marketplace.
+              </p>
+            </div>
           </div>
         </section>
     </>

--- a/src/pages/admin/copypass/CopyPassCatalog.tsx
+++ b/src/pages/admin/copypass/CopyPassCatalog.tsx
@@ -1,0 +1,142 @@
+import { PenSquare, FileText, MessagesSquare, TriangleAlert, Sparkles } from "lucide-react";
+
+const STARTER_PACKS = [
+  {
+    id: "copypass-homepage-hero",
+    name: "Homepage Hero",
+    category: "Landing page",
+    useWhen: "Use this when you want to pressure-test a headline, subhead, and CTA before shipping a homepage change.",
+    checks: "clarity, overclaim risk, audience fit, CTA specificity",
+    cta: "Run from MCP",
+  },
+  {
+    id: "copypass-pricing-section",
+    name: "Pricing Section",
+    category: "Commercial copy",
+    useWhen: "Use this when pricing copy needs to stay specific, honest, and usable for technical buyers.",
+    checks: "claim support, trust signals, internal consistency, tone drift",
+    cta: "Scaffold only",
+  },
+];
+
+function DisclaimerBanner() {
+  return (
+    <div className="rounded-xl border border-[#E2B93B]/25 bg-[#E2B93B]/10 p-4">
+      <div className="flex items-start gap-3">
+        <TriangleAlert className="mt-0.5 h-5 w-5 shrink-0 text-[#E2B93B]" />
+        <div>
+          <h2 className="text-sm font-semibold text-[#E2B93B]">CopyPass scaffold disclaimer</h2>
+          <p className="mt-1 text-sm text-[#d9d0a8]">
+            CopyPass is a scoped copy-quality review surface, not final brand approval, legal review, or a guarantee of
+            performance. This first scaffold wires the MCP and admin surfaces. Evidence-led copy checks land in a later chunk.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PackTile({
+  name,
+  category,
+  useWhen,
+  checks,
+  cta,
+}: {
+  name: string;
+  category: string;
+  useWhen: string;
+  checks: string;
+  cta: string;
+}) {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-[#111] p-5 flex flex-col gap-3">
+      <div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <h3 className="text-sm font-semibold text-white">{name}</h3>
+          <span className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-fuchsia-500/10 text-fuchsia-300">
+            {category}
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-[#888]">{useWhen}</p>
+        <p className="mt-2 text-[11px] text-[#666]">{checks}</p>
+      </div>
+      <button
+        disabled
+        className="mt-auto flex items-center justify-center gap-1.5 rounded-md border border-white/[0.08] bg-black/30 px-3 py-2 text-xs font-medium text-[#777]"
+      >
+        {cta}
+      </button>
+    </div>
+  );
+}
+
+export default function CopyPassCatalog() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <PenSquare className="h-6 w-6 text-fuchsia-300" />
+          <div>
+            <h1 className="text-2xl font-semibold text-white">CopyPass</h1>
+            <p className="mt-0.5 text-sm text-[#888]">
+              A scaffolded review surface for AI-generated copy. Start with routing and operator context, then layer in deeper verdict logic later.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        <DisclaimerBanner />
+
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <div className="flex items-start gap-3">
+            <FileText className="mt-0.5 h-5 w-5 shrink-0 text-fuchsia-300" />
+            <div>
+              <h2 className="text-sm font-semibold text-white">Available now through MCP scaffold</h2>
+              <p className="mt-1 text-sm text-[#888]">
+                `copypass_run` accepts `copy_text` plus optional `channel`, `audience`, and `goal` fields today.
+                `copypass_status` polls the in-session scaffold run record.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <div className="flex items-start gap-3">
+            <MessagesSquare className="mt-0.5 h-5 w-5 shrink-0 text-[#61C1C4]" />
+            <div>
+              <h2 className="text-sm font-semibold text-white">What lands next</h2>
+              <p className="mt-1 text-sm text-[#888]">
+                Claim support, clarity, trust-signal, and tone-fit checks land next. This first scaffold is for tool
+                routing, admin placement, and later evaluator integration.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-4 flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-fuchsia-300" />
+            <h2 className="text-lg font-semibold text-white">Starter packs</h2>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {STARTER_PACKS.map((pack) => (
+              <PackTile
+                key={pack.id}
+                name={pack.name}
+                category={pack.category}
+                useWhen={pack.useWhen}
+                checks={pack.checks}
+                cta={pack.cta}
+              />
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-[#666]">
+            Starter packs are planning prompts for MCP-triggered runs today. In-product launch controls land in a later chunk.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold CopyPass MCP tools with in-session run/status storage
- add admin route, sidebar entry, marketplace card, and catalog surface
- keep the surface explicitly scaffold-only while deeper copy checks land later

## Testing
- npm exec --workspace packages/mcp-server vitest run src/copypass-tool.test.ts
- npm run build --workspace packages/mcp-server
- npm run build
