### PR TITLE
copy(home): refresh Pass family positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
-    <title>UnClick - The Operating System for AI Agents</title>
+    <title>UnClick - Agent rails for tools, memory, and QC</title>
     <!-- Update counts from src/config/site-stats.ts -->
-    <meta name="description" content="UnClick is the AI agent marketplace where your AI finds and uses tools. 172+ verified tools, one API key. Works with Claude, ChatGPT, OpenClaw, and any MCP-compatible agent. All free." />
-    <meta name="keywords" content="AI agent marketplace, MCP tools, MCP marketplace, agent tools, AI tool store, AI app store, MCP server, agent-native API, AI tools for Claude, ChatGPT tools, OpenClaw tools, AI agent tools, tool marketplace for AI, MCP registry" />
+    <meta name="description" content="UnClick gives AI agents shared rails for callable tools, persistent memory, secure connections, crews, and Pass family QA checks. Works with Claude, ChatGPT, Cursor, and MCP-compatible agents." />
+    <meta name="keywords" content="AI agent rails, MCP tools, agent tools, persistent AI memory, AI agent credentials, AI agent QA, Pass family, TestPass, UXPass, SecurityPass, agent-native API, AI tools for Claude, ChatGPT tools, Cursor tools, MCP registry" />
     <meta name="author" content="UnClick" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://unclick.world/" />
@@ -20,20 +20,20 @@
     <!-- OpenGraph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="UnClick" />
-    <meta property="og:title" content="UnClick - The Operating System for AI Agents" />
-    <meta property="og:description" content="172+ verified tools for AI agents. One connection. Telegram, Slack, Shopify, Xero, games, security, science, and more. Works with Claude, ChatGPT, OpenClaw, and any MCP agent." />
+    <meta property="og:title" content="UnClick - Agent rails for tools, memory, and QC" />
+    <meta property="og:description" content="Shared agent rails for tools, memory, connections, crews, and Pass family checks. Works with Claude, ChatGPT, Cursor, and MCP-compatible agents." />
     <meta property="og:url" content="https://unclick.world/" />
     <meta property="og:image" content="https://unclick.world/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:alt" content="UnClick - the AI agent marketplace" />
+    <meta property="og:image:alt" content="UnClick - agent rails for AI agents" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@unclickworld" />
-    <meta name="twitter:title" content="UnClick - The Operating System for AI Agents" />
-    <meta name="twitter:description" content="172+ verified tools for AI agents. One API key, instant access. Works with Claude, ChatGPT, OpenClaw, and any MCP-compatible agent." />
+    <meta name="twitter:title" content="UnClick - Agent rails for tools, memory, and QC" />
+    <meta name="twitter:description" content="Tools, memory, connections, crews, and Pass family checks for AI agents. Works with Claude, ChatGPT, Cursor, and MCP-compatible agents." />
     <meta name="twitter:image" content="https://unclick.world/og-image.png" />
 
     <!-- Schema.org structured data -->
@@ -46,7 +46,7 @@
           "@id": "https://unclick.world/#org",
           "name": "UnClick",
           "url": "https://unclick.world",
-          "description": "AI agent marketplace providing verified tools for Claude, ChatGPT, OpenClaw, and MCP-compatible agents.",
+          "description": "Agent rails for tools, memory, connections, crews, and Pass family checks across Claude, ChatGPT, Cursor, and MCP-compatible agents.",
           "foundingLocation": "Melbourne, Australia",
           "contactPoint": {
             "@type": "ContactPoint",
@@ -58,7 +58,7 @@
           "@type": "WebSite",
           "@id": "https://unclick.world/#website",
           "url": "https://unclick.world",
-          "name": "UnClick - The Operating System for AI Agents",
+          "name": "UnClick - Agent rails for tools, memory, and QC",
           "publisher": { "@id": "https://unclick.world/#org" }
         },
         {
@@ -67,13 +67,13 @@
           "name": "UnClick",
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "Any",
-          "description": "An AI agent marketplace with 172+ verified tools accessible via one MCP connection or API key. Tools cover messaging (Telegram, Slack, Discord), social (Reddit, Bluesky, Mastodon), e-commerce (Shopify, Amazon), accounting (Xero), gaming (RAWG, Riot, Destiny 2), security (VirusTotal, Shodan, HaveIBeenPwned), science (USGS, OpenAQ, eBird), productivity (Notion, Readwise, Toggl), and more. Listed on the Official MCP Registry. Works with Claude, ChatGPT, OpenClaw, and any MCP-compatible AI agent.",
+          "description": "Agent rails with 172+ tool files and 450+ callable endpoints, persistent memory, secure connections, crews, and Pass family QA checks. Works with Claude, ChatGPT, Cursor, and MCP-compatible AI agents.",
           "url": "https://unclick.world",
           "offers": {
             "@type": "Offer",
             "price": "0",
             "priceCurrency": "USD",
-            "description": "Free - all 172+ tools included, no credit card required"
+            "description": "Free - agent tools, memory setup, and Pass family checks available without a credit card"
           },
           "featureList": [
             "Telegram, Slack, Discord messaging integrations",
@@ -89,6 +89,10 @@
             "JSON, CSV, and data utilities",
             "MCP server compatible with Claude Desktop and Cursor",
             "Listed on the Official MCP Registry",
+            "Persistent memory for agent sessions",
+            "Secure Connections for external services",
+            "Crews for multi-agent deliberation",
+            "Pass family QA checks before shipping",
             "One-time secret sharing",
             "Key-value storage for agents",
             "Webhook inspection tools"
@@ -98,8 +102,8 @@
         {
           "@type": "ItemList",
           "@id": "https://unclick.world/#tools",
-          "name": "UnClick AI Agent Tool Marketplace",
-          "description": "172+ verified tools available for AI agents via MCP or REST API",
+          "name": "UnClick Agent Tools",
+          "description": "172+ tool files and 450+ callable endpoints available for AI agents via MCP or REST API",
           "numberOfItems": 172,
           "itemListElement": [
             { "@type": "ListItem", "position": 1, "name": "URL Shortener", "description": "Shorten URLs with click tracking via POST /v1/shorten" },
@@ -132,10 +136,10 @@
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
-      "name": "UnClick MCP Server",
+      "name": "UnClick Agent Rails MCP Server",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Any (Node.js)",
-      "description": "AI agent tool marketplace with 450+ callable endpoints. Install once, discover tools dynamically via MCP protocol.",
+      "description": "Agent rails with 450+ callable endpoints, persistent memory, secure connections, crews, and Pass family checks. Install once and discover capabilities dynamically through MCP.",
       "url": "https://unclick.world",
       "downloadUrl": "https://www.npmjs.com/package/@unclick/mcp-server",
       "softwareVersion": "0.2.3",

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -1,6 +1,6 @@
 {
   "name": "UnClick",
-  "description": "AI agent tool marketplace. 450+ callable endpoints across 60+ integrations.",
+  "description": "Agent rails for tools, memory, connections, crews, and Pass family checks. 450+ callable endpoints across 60+ integrations.",
   "url": "https://unclick.world",
   "protocol": "mcp",
   "install": "npx @unclick/mcp-server",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,9 +1,9 @@
 # UnClick
 # Update counts from src/config/site-stats.ts
-> The app store for AI agents. 172+ tools across social, finance, dev, security, and more.
+> Agent rails for AI agents: tools, memory, connections, crews, and Pass family checks.
 
 ## What is UnClick
-UnClick is an MCP-compatible tool marketplace where AI agents discover and use tools through a single install. One npm package gives access to 450+ callable endpoints across 60+ integrations. No per-tool installs. No configuration per service.
+UnClick is an MCP-compatible agent-rails layer where AI agents discover tools, load memory, use secure connections, run crews, and verify work with the Pass family. One npm package gives access to 450+ callable endpoints across 60+ integrations. No per-tool installs. No configuration per service.
 
 ## How agents connect
 Install: npx @unclick/mcp-server

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -42,17 +42,17 @@
   <text x="80" y="260" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="96" font-weight="700" fill="#ffffff" letter-spacing="-3">UnClick</text>
 
   <!-- Tagline -->
-  <text x="82" y="320" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="32" font-weight="400" fill="#a0a0b0" letter-spacing="0">The App Store for AI Agents</text>
+  <text x="82" y="320" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="32" font-weight="400" fill="#a0a0b0" letter-spacing="0">Agent rails for tools, memory, and QC</text>
 
   <!-- Divider -->
   <rect x="80" y="360" width="1040" height="1" fill="#ffffff12"/>
 
   <!-- Stats row -->
-  <text x="80" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#6366f1" font-weight="600">59 tools</text>
-  <text x="220" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#ffffff30">|</text>
-  <text x="245" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#a0a0b0">One API key</text>
-  <text x="415" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#ffffff30">|</text>
-  <text x="440" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#a0a0b0">Works with Claude, ChatGPT &amp; more</text>
+  <text x="80" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#6366f1" font-weight="600">450+ endpoints</text>
+  <text x="280" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#ffffff30">|</text>
+  <text x="305" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#a0a0b0">Pass family checks</text>
+  <text x="560" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#ffffff30">|</text>
+  <text x="585" y="420" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" fill="#a0a0b0">Works with Claude, ChatGPT &amp; more</text>
 
   <!-- Domain -->
   <text x="80" y="530" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="20" fill="#6366f130" letter-spacing="2">unclick.world</text>

--- a/scripts/generate-og-image.cjs
+++ b/scripts/generate-og-image.cjs
@@ -57,7 +57,7 @@ ctx.fillText('UnClick', 80, 260);
 ctx.fillStyle = '#a0a0b0';
 ctx.font = '400 32px "Courier New", ui-monospace, monospace';
 ctx.letterSpacing = '0px';
-ctx.fillText('The App Store for AI Agents', 82, 320);
+ctx.fillText('Agent rails for tools, memory, and QC', 82, 320);
 
 // Divider line
 ctx.fillStyle = 'rgba(255,255,255,0.07)';
@@ -68,19 +68,19 @@ const statsY = 420;
 ctx.font = '600 22px "Courier New", ui-monospace, monospace';
 
 ctx.fillStyle = '#6366f1';
-ctx.fillText('48+ Tools', 80, statsY);
+ctx.fillText('450+ endpoints', 80, statsY);
 
 ctx.fillStyle = 'rgba(255,255,255,0.18)';
-ctx.fillText('|', 230, statsY);
+ctx.fillText('|', 270, statsY);
 
 ctx.fillStyle = '#a0a0b0';
-ctx.fillText('Arena', 255, statsY);
+ctx.fillText('Pass family checks', 295, statsY);
 
 ctx.fillStyle = 'rgba(255,255,255,0.18)';
-ctx.fillText('|', 340, statsY);
+ctx.fillText('|', 540, statsY);
 
 ctx.fillStyle = '#a0a0b0';
-ctx.fillText('API-First', 365, statsY);
+ctx.fillText('Claude, ChatGPT & more', 565, statsY);
 
 // Domain
 ctx.fillStyle = 'rgba(99,102,241,0.22)';

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -15,7 +15,7 @@ const faqData = [
     items: [
       {
         q: "What is UnClick?",
-        a: `UnClick is a managed MCP (Model Context Protocol) server that gives AI agents instant access to ${SITE_STATS.TOOLS_DISPLAY} real-world tools: web search, email, calendars, code execution, data lookups, and more. Instead of building and maintaining integrations yourself, you point your AI agent at UnClick and it handles everything with a single API key.`,
+        a: `UnClick is shared agent rails for tools, memory, connections, crews, and Pass family QA checks. Instead of building and maintaining integrations yourself, you point your AI agent at UnClick and it gets durable context, secure service access, and ${SITE_STATS.TOOLS_DISPLAY} real-world tools through one setup.`,
       },
       {
         q: "How does UnClick work?",
@@ -94,7 +94,7 @@ const faqData = [
       },
       {
         q: "What's the difference between UnClick and other MCP servers?",
-        a: `Most MCP servers focus on a single integration (e.g., one database, one API). UnClick is a unified MCP server covering ${SITE_STATS.TOOLS_DISPLAY} tools across dozens of categories, so you configure one server and get everything. It's also managed: no infrastructure to run, no credentials to rotate, no integrations to maintain.`,
+        a: `Most MCP servers focus on one integration, like one database or one API. UnClick is the shared layer behind your agent: ${SITE_STATS.TOOLS_DISPLAY} tools, persistent memory, secure connections, crews, and Pass family checks in one managed setup. No infrastructure to run, no credentials to hand-roll, no integrations to maintain.`,
       },
     ],
   },

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -26,7 +26,7 @@ const PRODUCTS = [
   },
   {
     title: "Pass family",
-    description: "TestPass, UXPass, SecurityPass, SEOPass",
+    description: "QA, UX, security, SEO, legal, and slop checks",
     href: "/admin/testpass",
     icon: BadgeCheck,
     color: "bg-red-500/10 text-red-500",
@@ -113,7 +113,7 @@ const Hero = () => {
               The rails your agent plugs into
             </h2>
             <p className="mt-3 text-center text-body max-w-2xl mx-auto">
-              UnClick sits behind Claude, ChatGPT, Cursor, and every MCP client as the shared layer for action, memory, credentials, teams, and QA.
+              UnClick sits behind Claude, ChatGPT, Cursor, and every MCP client as the shared layer for action, memory, credentials, crews, and Pass family verification.
             </p>
           </FadeIn>
 

--- a/src/components/Problem.tsx
+++ b/src/components/Problem.tsx
@@ -14,7 +14,7 @@ const Problem = () => (
       </FadeIn>
       <FadeIn delay={0.1}>
         <h2 className="mt-6 text-3xl font-semibold tracking-tight sm:text-4xl">
-          The web is built for humans. We built the agent version.
+          AI agents need rails, not another dashboard.
         </h2>
       </FadeIn>
       <FadeIn delay={0.2}>
@@ -25,8 +25,9 @@ const Problem = () => (
       </FadeIn>
       <FadeIn delay={0.3}>
         <p className="mt-4 text-body leading-relaxed">
-          UnClick builds proper APIs for the things AI agents constantly need to do. Link pages,
-          scheduling, forms, and more. Call an endpoint. Get JSON back. No browser involved.
+          UnClick gives them the shared pieces they keep reaching for: tools, memory,
+          connections, crews, and Pass family checks. Call an endpoint. Get JSON back.
+          Prove the work before it ships.
         </p>
       </FadeIn>
 

--- a/src/hooks/useMetaTags.ts
+++ b/src/hooks/useMetaTags.ts
@@ -19,7 +19,7 @@ function setMeta(property: string, content: string) {
   el.setAttribute("content", content);
 }
 
-const defaultTitle = "UnClick - The App Store for AI Agents";
+const defaultTitle = "UnClick - Agent rails for tools, memory, and QC";
 
 export function useMetaTags({ title, description, ogTitle, ogDescription, ogUrl }: MetaTagsOptions) {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove old Operating System/App Store/tool-marketplace phrasing from homepage SEO, social, FAQ, and AI-facing discovery copy
- introduce Pass family positioning across the public homepage and metadata surfaces
- keep the rails framing aligned with ADR-0003 / Stripe-model positioning

## Verification
- npm run build
- npx eslint src/components/Hero.tsx src/components/Problem.tsx src/components/FAQ.tsx src/hooks/useMetaTags.ts
- Select-String scan for old public homepage phrases: Operating System, App Store, tool marketplace, AI agent marketplace, unified MCP server, managed MCP