### PR TITLE
docs: align memory tool surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,41 +16,36 @@ api/                            # Vercel serverless functions (REST API endpoint
 
 | File | Purpose |
 |------|---------|
-| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers meta-tools + 5 direct memory tools |
+| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and hidden internal meta-tools |
 | `packages/mcp-server/src/tool-wiring.ts` | Maps tool names to API calls |
 | `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (all 17 ops) |
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
-| `src/pages/tools/Tools.tsx` | Website tools grid, one tile per integration |
+| `src/pages/Tools.tsx` | Website tools grid, one tile per integration |
 
 ## Architecture
 
-**4 meta-tools** let agents discover and call anything dynamically:
+`CLAUDE.md` is the canonical source of truth for repo architecture and the MCP tool surface. Keep this section aligned with that file instead of expanding separate copies.
 
-- `unclick_search` - find tools by keyword
-- `unclick_browse` - list all tools, optionally by category
-- `unclick_tool_info` - get endpoints and params for a specific tool
-- `unclick_call` - execute any endpoint with parameters (including `memory.*`)
+Current summary:
 
-**5 direct memory tools** expose the session protocol agents should follow:
+- Hidden internal meta-tools: `unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call`
+- Direct memory tools: `load_memory`, `save_session`, `save_fact`, `search_memory`, `save_identity`
+- Old memory tool names still work as aliases: `get_startup_context`, `write_session_summary`, `add_fact`, `set_business_context`
+- Signals and Fishbowl coordination tools are visible first-party tools for worker operation
 
-- `get_startup_context` - call FIRST in every session
-- `write_session_summary` - call BEFORE session ends
-- `add_fact` - record preferences, decisions, important info
-- `search_memory` - recall anything from prior sessions
-- `set_business_context` - set standing rules (always loaded)
-
-The other 12 memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
+The other memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
 
 ## Adding a new tool
 
 1. Create `api/*-tool.ts` with the Vercel handler and endpoint logic
 2. Wire it in `packages/mcp-server/src/tool-wiring.ts` (add name, description, category, and endpoint mapping)
-3. Add a tile in `src/pages/tools/Tools.tsx`
+3. Add a tile in `src/pages/Tools.tsx`
+4. If it should appear in `ListTools`, add it intentionally to the first-party tool surface in `packages/mcp-server/src/server.ts`
 
 ## Style rules
 
 - No em dashes anywhere in code or content (use a regular dash or restructure the sentence)
-- No per-tool MCP registrations EXCEPT the 5 direct memory tools (everything else goes through the 4 meta-tools)
+- Do not add one-off MCP registrations casually. Catalog and integration tools should normally flow through `tool-wiring.ts` and the hidden internal meta-tools. Add visible first-party tools only when agents need a direct workflow surface.
 
 ## Operating rules for cloud-async coding agents
 
@@ -124,7 +119,7 @@ This is how we verify the work actually landed in the remote repository.
 
 ### 7. Brand voice rules (when writing user-facing copy or docs)
 
-- No em dashes (—). Use plain commas, full stops, or " - " hyphens instead.
+- No em dashes. Use plain commas, full stops, or " - " hyphens instead.
 - Plain English. Idiot-proof. Avoid jargon.
 - Short sentences.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,27 +16,34 @@ api/                            # Vercel serverless functions (REST API endpoint
 
 | File | Purpose |
 |------|---------|
-| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the 5 direct memory tools + unclick_search |
+| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and hidden internal meta-tools |
 | `packages/mcp-server/src/tool-wiring.ts` | Maps tool names to API calls |
 | `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (all 17 ops) |
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
-| `src/pages/tools/Tools.tsx` | Website tools grid, one tile per integration |
+| `src/pages/Tools.tsx` | Website tools grid, one tile per integration |
 
 ## Architecture
 
-**1 marketplace search tool** lets agents discover additional capabilities:
+This is the canonical tool-surface summary for this repo.
+
+**Hidden internal meta-tools** let agents discover and call catalog endpoints without crowding the default MCP tool list:
 
 - `unclick_search` - find tools by keyword
+- `unclick_browse` - list tools, optionally by category
+- `unclick_tool_info` - get endpoint and parameter details for a specific tool
+- `unclick_call` - execute any endpoint with parameters
 
-The raw meta-tools (`unclick_browse`, `unclick_tool_info`, `unclick_call`) remain callable but are hidden from the tool list to keep things clean for end users.
+These tools remain callable by name, but they are hidden from `ListTools` to keep the default surface clean.
 
-**5 direct memory tools** expose the session protocol agents should follow:
+**Visible first-party tools** expose the workflows agents should use directly. They include:
 
 - `load_memory` - call FIRST in every session (was `get_startup_context`)
 - `save_session` - call BEFORE session ends (was `write_session_summary`)
 - `save_fact` - record preferences, decisions, important info (was `add_fact`)
 - `search_memory` - recall anything from prior sessions
 - `save_identity` - set standing rules, always loaded (was `set_business_context`)
+- `check_signals` - check whether the agent should wake up or act
+- Fishbowl coordination tools such as `read_messages`, `post_message`, `create_todo`, `list_todos`, `update_todo`, `complete_todo`, `create_idea`, `list_ideas`, `vote_on_idea`, and `promote_idea_to_todo`
 
 The old tool names still work as aliases for backward compatibility. The other 12 memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
 
@@ -44,9 +51,10 @@ The old tool names still work as aliases for backward compatibility. The other 1
 
 1. Create `api/*-tool.ts` with the Vercel handler and endpoint logic
 2. Wire it in `packages/mcp-server/src/tool-wiring.ts` (add name, description, category, and endpoint mapping)
-3. Add a tile in `src/pages/tools/Tools.tsx`
+3. Add a tile in `src/pages/Tools.tsx`
+4. If it should appear in `ListTools`, add it intentionally to the first-party tool surface in `packages/mcp-server/src/server.ts`
 
 ## Style rules
 
 - No em dashes anywhere in code or content (use a regular dash or restructure the sentence)
-- No per-tool MCP registrations EXCEPT the 5 direct memory tools (everything else goes through the 4 meta-tools)
+- Do not add one-off MCP registrations casually. Catalog and integration tools should normally flow through `tool-wiring.ts` and the hidden internal meta-tools. Add visible first-party tools only when agents need a direct workflow surface.

--- a/README.md
+++ b/README.md
@@ -34,15 +34,17 @@ This repo follows the AGENTS.md fence rules for agent work.
 
 Gives your agent access to a growing catalog of tools across developer utilities, social media, e-commerce, finance, messaging, media, security, and more. You don't need to install separate packages for each integration. One server provides access to everything in the catalog.
 
-## The 3 tools
+## Tool Surface
 
-| Tool | What it does |
-|------|-------------|
-| `unclick_search` | Search the catalog by keyword or category |
-| `unclick_tool_info` | Get the full schema and parameters for a specific tool |
-| `unclick_call` | Call any tool in the catalog |
+UnClick exposes a small direct surface for daily agent workflows, plus hidden internal discovery tools for the full catalog.
 
-The agent searches for what it needs, checks the schema, and then calls the tool. Discovery is built into the workflow.
+| Tool group | Tools |
+|------------|-------|
+| Memory session protocol | `load_memory`, `save_fact`, `search_memory`, `save_identity`, `save_session` |
+| Signals and Fishbowl coordination | `check_signals`, `read_messages`, `post_message`, `create_todo`, `list_todos`, `update_todo`, `complete_todo`, `create_idea`, `list_ideas`, `vote_on_idea`, `promote_idea_to_todo` |
+| Hidden internal catalog tools | `unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call` |
+
+The agent starts with memory, uses direct Fishbowl tools for coordination, and can still call the hidden catalog tools by name when it needs dynamic endpoint discovery.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- make CLAUDE.md the canonical MCP tool-surface summary
- align AGENTS.md with current direct memory names, hidden internal meta-tools, and Fishbowl tools
- update README.md from the stale 3-tool summary to the current tool groups
- fix stale tools page path to src/pages/Tools.tsx

## Verification
- git diff --check
- checked CLAUDE.md, AGENTS.md, and README.md for forbidden unicode dash characters