### PR TITLE
fix(oauth): verify connector state server-side

### DIFF
--- a/api/oauth-callback.ts
+++ b/api/oauth-callback.ts
@@ -22,6 +22,7 @@
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { verifyOAuthStateToken } from "./oauth-state";
 
 // ─── Platform OAuth configs ────────────────────────────────────────────────────
 
@@ -182,16 +183,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === "OPTIONS") return res.status(204).end();
   if (req.method !== "POST")    return res.status(405).json({ error: "Method not allowed." });
 
-  const { platform, code, api_key, store } = (req.body ?? {}) as {
+  const { platform, code, api_key, state, store } = (req.body ?? {}) as {
     platform?: string;
     code?:     string;
     api_key?:  string;
+    state?:    string;
     store?:    string; // Shopify only
   };
 
   if (!platform) return res.status(400).json({ error: "platform is required." });
   if (!code)     return res.status(400).json({ error: "code is required." });
   if (!api_key)  return res.status(400).json({ error: "api_key is required." });
+  if (!state)    return res.status(400).json({ error: "state is required." });
 
   if (!api_key.startsWith("uc_") && !api_key.startsWith("agt_")) {
     return res.status(400).json({ error: "Invalid api_key format." });
@@ -202,11 +205,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     : "https://unclick.world";
 
   try {
+    const statePayload = verifyOAuthStateToken(state, process.env);
+    if (statePayload.platform !== platform) {
+      return res.status(400).json({ error: "OAuth state platform mismatch." });
+    }
+    if (statePayload.redirectPath !== `/connect/${platform}`) {
+      return res.status(400).json({ error: "OAuth state redirect mismatch." });
+    }
+
     let credentials: Record<string, string>;
 
     if (platform === "shopify") {
-      if (!store) return res.status(400).json({ error: "store is required for Shopify." });
-      credentials = await exchangeShopify(code, store, process.env);
+      const verifiedStore = statePayload.store ?? store;
+      if (!verifiedStore) return res.status(400).json({ error: "store is required for Shopify." });
+      credentials = await exchangeShopify(code, verifiedStore, process.env);
     } else {
       const config = PLATFORM_CONFIGS[platform];
       if (!config) {

--- a/api/oauth-init.ts
+++ b/api/oauth-init.ts
@@ -1,0 +1,45 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createOAuthStateToken } from "./oauth-state";
+
+const ALLOWED_PLATFORMS = new Set(["xero", "reddit", "shopify"]);
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "https://unclick.world");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed." });
+
+  const { platform, store } = (req.body ?? {}) as {
+    platform?: string;
+    store?: string;
+  };
+
+  if (!platform || !ALLOWED_PLATFORMS.has(platform)) {
+    return res.status(400).json({ error: "Unsupported OAuth platform." });
+  }
+
+  const normalizedStore =
+    platform === "shopify" && typeof store === "string"
+      ? store.trim().replace(/\.myshopify\.com$/i, "")
+      : undefined;
+
+  if (platform === "shopify" && !normalizedStore) {
+    return res.status(400).json({ error: "store is required for Shopify." });
+  }
+
+  try {
+    const state = createOAuthStateToken({
+      platform,
+      redirectPath: `/connect/${platform}`,
+      env: process.env,
+      ...(normalizedStore ? { store: normalizedStore } : {}),
+    });
+
+    return res.status(200).json({ success: true, state });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to initialize OAuth.";
+    return res.status(500).json({ error: message });
+  }
+}

--- a/api/oauth-state.test.ts
+++ b/api/oauth-state.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createOAuthStateToken, verifyOAuthStateToken } from "./oauth-state";
+
+const env = {
+  XERO_CLIENT_SECRET: "xero-secret",
+  REDDIT_CLIENT_SECRET: "reddit-secret",
+  SHOPIFY_CLIENT_SECRET: "shopify-secret",
+} as NodeJS.ProcessEnv;
+
+describe("oauth state token", () => {
+  it("round-trips a valid token", () => {
+    const token = createOAuthStateToken({
+      platform: "xero",
+      redirectPath: "/connect/xero",
+      env,
+      nowSeconds: 1_000,
+    });
+
+    expect(verifyOAuthStateToken(token, env, 1_100)).toMatchObject({
+      platform: "xero",
+      redirectPath: "/connect/xero",
+      v: 1,
+    });
+  });
+
+  it("rejects tampered payloads", () => {
+    const token = createOAuthStateToken({
+      platform: "shopify",
+      redirectPath: "/connect/shopify",
+      store: "demo-store",
+      env,
+      nowSeconds: 1_000,
+    });
+
+    const [payload, signature] = token.split(".");
+    const tampered = `${Buffer.from(
+      JSON.stringify({
+        ...JSON.parse(Buffer.from(payload, "base64url").toString("utf8")),
+        store: "evil-store",
+      }),
+      "utf8"
+    ).toString("base64url")}.${signature}`;
+
+    expect(() => verifyOAuthStateToken(tampered, env, 1_100)).toThrow(
+      "OAuth state signature mismatch."
+    );
+  });
+
+  it("rejects expired tokens", () => {
+    const token = createOAuthStateToken({
+      platform: "reddit",
+      redirectPath: "/connect/reddit",
+      env,
+      nowSeconds: 1_000,
+    });
+
+    expect(() => verifyOAuthStateToken(token, env, 2_000)).toThrow(
+      "OAuth state token expired."
+    );
+  });
+});

--- a/api/oauth-state.ts
+++ b/api/oauth-state.ts
@@ -1,0 +1,106 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export interface OAuthStatePayload {
+  platform: string;
+  redirectPath: string;
+  exp: number;
+  store?: string;
+  v: 1;
+}
+
+const STATE_TTL_SECONDS = 10 * 60;
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function base64UrlDecode(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function getPlatformSecret(platform: string, env: NodeJS.ProcessEnv): string {
+  switch (platform) {
+    case "xero":
+      return env.XERO_CLIENT_SECRET ?? "";
+    case "reddit":
+      return env.REDDIT_CLIENT_SECRET ?? "";
+    case "shopify":
+      return env.SHOPIFY_CLIENT_SECRET ?? "";
+    default:
+      return "";
+  }
+}
+
+function signPayload(encodedPayload: string, secret: string): string {
+  return createHmac("sha256", secret).update(encodedPayload, "utf8").digest("base64url");
+}
+
+export function createOAuthStateToken(args: {
+  platform: string;
+  redirectPath: string;
+  env: NodeJS.ProcessEnv;
+  nowSeconds?: number;
+  store?: string;
+}): string {
+  const secret = getPlatformSecret(args.platform, args.env);
+  if (!secret) {
+    throw new Error(`OAuth client secret missing for platform "${args.platform}".`);
+  }
+
+  const payload: OAuthStatePayload = {
+    platform: args.platform,
+    redirectPath: args.redirectPath,
+    exp: (args.nowSeconds ?? Math.floor(Date.now() / 1000)) + STATE_TTL_SECONDS,
+    ...(args.store ? { store: args.store } : {}),
+    v: 1,
+  };
+
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = signPayload(encodedPayload, secret);
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyOAuthStateToken(
+  token: string,
+  env: NodeJS.ProcessEnv,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): OAuthStatePayload {
+  const [encodedPayload, signature] = token.split(".");
+  if (!encodedPayload || !signature) {
+    throw new Error("Invalid OAuth state token.");
+  }
+
+  let payload: OAuthStatePayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encodedPayload)) as OAuthStatePayload;
+  } catch {
+    throw new Error("Invalid OAuth state token.");
+  }
+
+  if (
+    payload.v !== 1 ||
+    typeof payload.platform !== "string" ||
+    typeof payload.redirectPath !== "string" ||
+    typeof payload.exp !== "number"
+  ) {
+    throw new Error("Invalid OAuth state token.");
+  }
+
+  const secret = getPlatformSecret(payload.platform, env);
+  if (!secret) {
+    throw new Error(`OAuth client secret missing for platform "${payload.platform}".`);
+  }
+
+  const expectedSignature = signPayload(encodedPayload, secret);
+  const actual = Buffer.from(signature, "utf8");
+  const expected = Buffer.from(expectedSignature, "utf8");
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    throw new Error("OAuth state signature mismatch.");
+  }
+
+  if (payload.exp < nowSeconds) {
+    throw new Error("OAuth state token expired.");
+  }
+
+  return payload;
+}

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -20,16 +20,17 @@ type PageState =
 const VITE_ENV = import.meta.env as Record<string, string>;
 
 /** Returns the OAuth2 authorization URL for a platform, or null if client_id not configured. */
-function buildOAuthUrl(connector: ConnectorConfig, redirectOrigin: string): string | null {
+function buildOAuthUrl(
+  connector: ConnectorConfig,
+  redirectOrigin: string,
+  state: string
+): string | null {
   if (connector.authType !== "oauth2") return null;
 
   // Platform-specific client IDs come from Vite public env vars
   const clientIdKey = `VITE_${connector.slug.toUpperCase()}_CLIENT_ID`;
   const clientId    = VITE_ENV[clientIdKey];
   if (!clientId) return null;
-
-  const state       = crypto.randomUUID();
-  sessionStorage.setItem(`oauth_state_${connector.slug}`, state);
 
   let authUrl = connector.authUrl ?? "";
 
@@ -158,13 +159,10 @@ export default function ConnectPage() {
     if (!code || !connector || callbackFired.current) return;
     callbackFired.current = true;
 
-    // CSRF state validation
-    const storedState = sessionStorage.getItem(`oauth_state_${connector.slug}`);
-    if (storedState && stateParam && storedState !== stateParam) {
-      setPageState({ kind: "error", message: "OAuth state mismatch. Please try again." });
+    if (!stateParam) {
+      setPageState({ kind: "error", message: "Missing OAuth state. Please try again." });
       return;
     }
-    sessionStorage.removeItem(`oauth_state_${connector.slug}`);
 
     const currentApiKey = apiKey || getApiKey();
     if (!currentApiKey) {
@@ -180,6 +178,7 @@ export default function ConnectPage() {
     const body: Record<string, string> = {
       platform: connector.slug,
       code,
+      state: stateParam,
       api_key:  currentApiKey,
     };
     const storedStore = sessionStorage.getItem("shopify_store");
@@ -311,8 +310,8 @@ export default function ConnectPage() {
 
   const isOAuth2          = connector.authType === "oauth2";
   const origin            = window.location.origin;
-  const oauthUrl          = isOAuth2 ? buildOAuthUrl(connector, origin) : null;
-  const oauthNotConfigured = isOAuth2 && !oauthUrl && connector.slug !== "shopify";
+  const oauthClientKey     = isOAuth2 ? VITE_ENV[`VITE_${connector.slug.toUpperCase()}_CLIENT_ID`] : "";
+  const oauthNotConfigured = isOAuth2 && !oauthClientKey && connector.slug !== "shopify";
 
   function handleFieldChange(key: string, value: string) {
     setFieldValues((prev) => ({ ...prev, [key]: value }));
@@ -350,14 +349,45 @@ export default function ConnectPage() {
     }
   }
 
-  function handleOAuthConnect() {
-    if (connector.slug === "shopify") {
-      const store = shopifyStore.trim().replace(".myshopify.com", "");
-      if (!store) return;
-      sessionStorage.setItem("shopify_store", store);
+  async function handleOAuthConnect() {
+    const normalizedStore =
+      connector.slug === "shopify"
+        ? shopifyStore.trim().replace(/\.myshopify\.com$/i, "")
+        : "";
+
+    if (connector.slug === "shopify" && !normalizedStore) return;
+
+    try {
+      const res = await fetch("/api/oauth-init", {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({
+          platform: connector.slug,
+          ...(normalizedStore ? { store: normalizedStore } : {}),
+        }),
+      });
+
+      const data = (await res.json()) as { state?: string; error?: string };
+      if (!res.ok || !data.state) {
+        setPageState({ kind: "error", message: data.error ?? "Failed to initialize OAuth." });
+        return;
+      }
+
+      if (normalizedStore) {
+        sessionStorage.setItem("shopify_store", normalizedStore);
+      }
+
+      const url = buildOAuthUrl(connector, origin, data.state);
+      if (!url) {
+        setPageState({ kind: "error", message: `OAuth2 setup pending for ${connector.name}.` });
+        return;
+      }
+
+      window.location.href = url;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Network error.";
+      setPageState({ kind: "error", message });
     }
-    const url = buildOAuthUrl(connector, origin);
-    if (url) window.location.href = url;
   }
 
   const allFieldsFilled = connector.credentialFields.every(
@@ -424,7 +454,7 @@ export default function ConnectPage() {
             ) : (
               <Button
                 className="w-full bg-[#E2B93B] hover:bg-[#E2B93B]/90 text-black font-semibold"
-                onClick={handleOAuthConnect}
+                onClick={() => void handleOAuthConnect()}
                 disabled={!apiKey.trim() || (connector.slug === "shopify" && !shopifyStore.trim())}
               >
                 Connect with {connector.name}

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,7 @@
     { "source": "/v1/arena/(.*)", "destination": "/api/arena" },
     { "source": "/v1/arena",      "destination": "/api/arena" },
     { "source": "/v1/report-bug",          "destination": "/api/report-bug" },
+    { "source": "/api/oauth-init",         "destination": "/api/oauth-init" },
     { "source": "/api/oauth-callback",     "destination": "/api/oauth-callback" },
     { "source": "/api/credentials",        "destination": "/api/credentials" },
     { "source": "/api/mcp",               "destination": "/api/mcp" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}", "api/**/*.{test,spec}.{ts,tsx}"],
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },


### PR DESCRIPTION
## Summary
- add a server-issued signed OAuth state token and init endpoint
- verify state server-side in the OAuth callback before token exchange
- bind Shopify store selection to the signed state payload instead of trusting the callback body
- add focused OAuth state tests and include API tests in the root Vitest config

## Verification
- 
pm exec vitest run api/oauth-state.test.ts
- 
pm run build

## Notes
- scoped in a clean worktree to avoid unrelated local docs/admin changes
