### PR TITLE
🍿 Build D: auto-close Fishbowl todo on PR merge (draft)

### DIFF
--- a/.github/workflows/auto-close-fishbowl-todo.yml
+++ b/.github/workflows/auto-close-fishbowl-todo.yml
@@ -1,0 +1,82 @@
+name: Auto-close Fishbowl todo on PR merge
+
+# When a PR merges, scan its body for "Closes Fishbowl todo: <uuid>" markers
+# and POST to the existing memory-admin fishbowl_complete_todo action for
+# each match. A Fishbowl outage must NOT block merge cleanup, so the job
+# always exits 0 even if the API call fails.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  close-todos:
+    if: github.event.pull_request.merged == true
+    name: Close linked Fishbowl todos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract todo ids and call memory-admin
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          UNCLICK_API_KEY: ${{ secrets.FISHBOWL_AUTOCLOSE_TOKEN }}
+          API_URL: https://unclick.world/api/memory-admin
+          AGENT_ID: github-action-autoclose
+        shell: bash
+        run: |
+          # No -e: a single bad id or transport blip should not fail the job.
+          set -uo pipefail
+
+          if [ -z "${UNCLICK_API_KEY:-}" ]; then
+            echo "::warning::FISHBOWL_AUTOCLOSE_TOKEN secret not set - skipping."
+            exit 0
+          fi
+          if [ -z "${PR_BODY:-}" ]; then
+            echo "PR #${PR_NUMBER} body empty - nothing to close."
+            exit 0
+          fi
+
+          # Match "Closes Fishbowl todo: <uuid>" or "closes-fishbowl-todo: <uuid>",
+          # case-insensitive, allowing - or space between the words.
+          UUID_RE='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+          mapfile -t IDS < <(printf '%s\n' "$PR_BODY" \
+            | grep -Eio "closes[- ]fishbowl[- ]todo[: ][[:space:]]*${UUID_RE}" \
+            | grep -Eio "${UUID_RE}" \
+            | sort -u)
+
+          if [ "${#IDS[@]}" -eq 0 ]; then
+            echo "No Fishbowl todo ids found in PR #${PR_NUMBER} body."
+            exit 0
+          fi
+
+          echo "Found ${#IDS[@]} todo id(s) in PR #${PR_NUMBER}: ${IDS[*]}"
+          fail_count=0
+          for id in "${IDS[@]}"; do
+            echo "Closing todo ${id}"
+            payload=$(jq -n --arg agent_id "$AGENT_ID" --arg todo_id "$id" \
+              '{agent_id: $agent_id, todo_id: $todo_id}')
+            curl_exit=0
+            http=$(curl -sS -o resp.json -w "%{http_code}" \
+              --connect-timeout 10 --max-time 30 \
+              -X POST "${API_URL}?action=fishbowl_complete_todo" \
+              -H "Authorization: Bearer ${UNCLICK_API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "$payload") || curl_exit=$?
+            http="${http:-000}"
+            echo "  HTTP ${http} (curl exit ${curl_exit})"
+            if [ -f resp.json ]; then cat resp.json; echo; fi
+            if [ "$curl_exit" -ne 0 ] || [ "$http" -ge 400 ] 2>/dev/null; then
+              fail_count=$((fail_count + 1))
+              echo "::warning::Failed to close todo ${id} (HTTP ${http})."
+            fi
+          done
+
+          # Always succeed - a Fishbowl outage must not paint a red X on a
+          # cleanly merged PR. Surface failures via warnings only.
+          if [ "$fail_count" -gt 0 ]; then
+            echo "::warning::${fail_count} of ${#IDS[@]} todo close call(s) failed."
+          fi
+          exit 0

--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -109,6 +109,7 @@ Before opening a PR:
 - Run the smallest useful verification.
 - Run `/review` when available.
 - Mention whether the change is ship-without-ask, ask-once, or gated.
+- If the PR finishes a Fishbowl todo, link it in the PR body with `Closes Fishbowl todo: <uuid>` (one line per todo, case-insensitive, `closes-fishbowl-todo:` also accepted). The `auto-close-fishbowl-todo` workflow scans merged PR bodies and calls `fishbowl_complete_todo` for each match; a Fishbowl outage logs a warning and never blocks merge cleanup.
 
 Before merging:
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-close-fishbowl-todo.yml`. Triggers on `pull_request: closed`, runs only when `merged == true`.
- Scans the merged PR body for `Closes Fishbowl todo: <uuid>` markers (and `closes-fishbowl-todo: <uuid>`, case-insensitive, multiple matches allowed) and POSTs each id to the existing `/api/memory-admin?action=fishbowl_complete_todo` endpoint with `agent_id=github-action-autoclose`.
- A Fishbowl outage logs a warning and the workflow exits 0 — it never paints a red X on a cleanly merged PR.
- Convention note added to `AUTOPILOT.md` PR Rules.

## Convention example

```
This PR fixes the connector flake.

Closes Fishbowl todo: 6f1a2c3d-4e5b-4f78-9012-3456789abcde
```

Both `Closes Fishbowl todo: <uuid>` and `closes-fishbowl-todo: <uuid>` are accepted.

## Auth

No new server-side auth surface. Re-uses the existing `Authorization: Bearer <api_key>` Bearer flow on `/api/memory-admin` (`resolveApiKeyHash` accepts `uc_*` and `agt_*` keys directly). One new GitHub Actions secret to set:

- `FISHBOWL_AUTOCLOSE_TOKEN` — a `uc_*` API key for the tenant whose Fishbowl todos this should close. Without it the workflow logs a warning and skips.

## Test plan

- [ ] 😎 sets `FISHBOWL_AUTOCLOSE_TOKEN` repo secret
- [ ] 🍿 verifies on a controlled PR with a known dummy todo id (close + reopen if needed)
- [ ] 🍿 verifies workflow stays green when secret is unset (skip path)
- [ ] 🍿 verifies workflow stays green when API returns 404 / 401 (warning-only path)

## Do not merge

Draft until 🍿 verifies against today's 10 merged PRs and 😎 sets the secret. 😎 owns the merge button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)