### PR TITLE
fix: accept wake alias and upload ledgers

### DIFF
--- a/.github/workflows/event-wake-router.yml
+++ b/.github/workflows/event-wake-router.yml
@@ -48,3 +48,4 @@ jobs:
           path: .wake-ledger/*.json
           if-no-files-found: ignore
           retention-days: 14
+          include-hidden-files: true

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -119,7 +119,7 @@ function baseDecision(event) {
   if (eventName === "issue_comment") {
     const comment = event.comment || {};
     const body = String(comment.body || "").toLowerCase();
-    if (body.includes("/wake") || body.includes("wake worker")) {
+    if (body.includes("/wake") || body.includes("wake worker") || body.trim().startsWith("wake:")) {
       return {
         wake: true,
         owner: "🤖",


### PR DESCRIPTION
## Summary
- accepts `wake:` as a manual wake command alias alongside `/wake` and `wake worker`
- allows the wake-ledger artifact upload to include the hidden `.wake-ledger` directory

## Why
A no-spend regression probe showed `wake:` did not route and the workflow wrote a ledger but uploaded no artifact because hidden paths were excluded.

## Test plan
- `git diff --check` passed
- local dry-run with a fake issue_comment body `wake: manual no-spend test` routed to 🤖, skipped OpenRouter, and wrote a ledger