### PR TITLE
feat: add structured Fishbowl handoff ACK tool

### DIFF
--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -100,6 +100,11 @@ Every handoff should include:
 
 Every worker should acknowledge a direct handoff within the next expected cycle. If there is no ack after two cycles, Bailey may reassign or return the card to the pool.
 
+When the MCP `ack_handoff` tool is available, use it instead of a free-form
+reply. It posts a standard ACK card with current chip, next action, ETA, and
+blocker so the fleet can measure handoff latency without the human translating
+status prose.
+
 ## Event Wakeups
 
 Ready work should wake the right worker immediately instead of waiting for the

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -7,6 +7,17 @@ describe("runtime tool schema validation", () => {
     { name: "load_memory", args: { num_sessions: 1, bogus_field: "should reject" } },
     { name: "search_memory", args: { query: "strict schema probe", bogus_field: "should reject" } },
     { name: "check_signals", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
+    {
+      name: "ack_handoff",
+      args: {
+        agent_id: "strict-probe",
+        thread_id: "11111111-1111-4111-8111-111111111111",
+        current_chip: "Build B probe",
+        next_action: "ack the handoff",
+        eta: "next cycle",
+        bogus_field: "should reject",
+      },
+    },
     { name: "stripe_customers", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     { name: "stripe_charges", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     {
@@ -49,6 +60,14 @@ describe("runtime tool schema validation", () => {
       category: "troubleshooting",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_generate_uuid", { count: 1 })).toBeNull();
+    expect(validateToolArgumentsForRuntime("ack_handoff", {
+      agent_id: "strict-probe",
+      thread_id: "11111111-1111-4111-8111-111111111111",
+      current_chip: "Build B probe",
+      next_action: "ack the handoff",
+      eta: "next cycle",
+      blocker: "none",
+    })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_call", {
       endpoint_id: "memory.search_memory",
       params: { query: "strict schema probe" },

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -521,6 +521,51 @@ const VISIBLE_TOOLS = [
     },
   },
   {
+    name: "ack_handoff",
+    title: "Acknowledge a Fishbowl handoff",
+    description:
+      "Replies to a Fishbowl handoff with a structured ACK card so the sender and the human can see ownership, next action, ETA, and blockers without parsing free-form chat. " +
+      "Use when a message is directly addressed to you, tagged handoff, or asks you to confirm receipt. " +
+      "This posts a short reply in the original thread using the existing Fishbowl post path; it does not claim a todo or change code by itself.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        agent_id: {
+          type: "string",
+          description:
+            "Stable identifier for yourself, e.g. 'claude-desktop-bailey-lenovo' or 'chatgpt-codex-creativelead'. Use the same value across Fishbowl calls.",
+        },
+        thread_id: {
+          type: "string",
+          description: "Fishbowl message id of the handoff you are acknowledging.",
+        },
+        current_chip: {
+          type: "string",
+          description: "The work you are taking or watching, in one short phrase.",
+        },
+        next_action: {
+          type: "string",
+          description: "The next concrete action you will take.",
+        },
+        eta: {
+          type: "string",
+          description: "Expected next check-in or completion time, e.g. '15m', 'next cycle', or 'blocked until CI finishes'.",
+        },
+        blocker: {
+          type: "string",
+          description: "Blocker if any. Use 'none' when clear.",
+        },
+        recipients: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional recipients for the ACK reply. Defaults to ['all'].",
+        },
+      },
+      required: ["agent_id", "thread_id", "current_chip", "next_action", "eta"],
+    },
+  },
+  {
     name: "set_my_status",
     title: "Update my Now Playing status",
     description:
@@ -1504,6 +1549,54 @@ export function createServer(): Server {
       // All routes go through /api/memory-admin?action=<fishbowl_*> so the
       // backend stays the single source of truth for validation, anti-spoof,
       // and side effects (event posts, score updates).
+      if (name === "ack_handoff") {
+        const apiKey = process.env.UNCLICK_API_KEY;
+        const base =
+          process.env.UNCLICK_MEMORY_BASE_URL ||
+          process.env.UNCLICK_SITE_URL ||
+          "https://unclick.world";
+        if (!apiKey) {
+          return {
+            content: [
+              { type: "text", text: "Fishbowl unavailable: no UNCLICK_API_KEY configured. Run the UnClick setup wizard." },
+            ],
+            isError: true,
+          };
+        }
+        const blocker = typeof args.blocker === "string" && args.blocker.trim() ? args.blocker.trim() : "none";
+        const text = [
+          "ACK",
+          `Current chip: ${String(args.current_chip).trim()}`,
+          `Next action: ${String(args.next_action).trim()}`,
+          `ETA: ${String(args.eta).trim()}`,
+          `Blocker: ${blocker}`,
+        ].join("\n");
+        const userAgentHint =
+          (args.user_agent_hint as string | undefined) ||
+          process.env.UNCLICK_CLIENT_USER_AGENT ||
+          "unclick-mcp-server";
+        const resp = await fetch(`${base}/api/memory-admin?action=fishbowl_post`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            agent_id: args.agent_id,
+            thread_id: args.thread_id,
+            recipients: args.recipients ?? ["all"],
+            tags: ["answer", "handoff"],
+            text,
+            user_agent_hint: userAgentHint,
+          }),
+        });
+        const respBody = await resp.json().catch(() => ({}));
+        return {
+          content: [{ type: "text", text: JSON.stringify(respBody, null, 2) }],
+          isError: !resp.ok,
+        };
+      }
+
       const FISHBOWL_TOOL_ACTIONS: Record<string, string> = {
         set_my_emoji: "fishbowl_set_emoji",
         post_message: "fishbowl_post",


### PR DESCRIPTION
## Summary
- add an `ack_handoff` MCP tool that replies to a Fishbowl handoff with a standard ACK card
- route ACKs through the existing Fishbowl post API with `answer` + `handoff` tags
- document the ACK convention in `AUTOPILOT.md`

Closes Fishbowl todo: 2c5bfa04-faa4-4fa9-8217-dff3dd9dbab4

## Verification
- `npm --workspace packages/mcp-server run build`
- `npx vitest run src/__tests__/tool-schema-validation.test.ts` from `packages/mcp-server`
- `npm run build`
