### PR TITLE
Reliability substrate: deeper README + runnable smoke (slice 1 follow-up)

### DIFF
--- a/docs/reliability-substrate.md
+++ b/docs/reliability-substrate.md
@@ -1,0 +1,135 @@
+# Reliability Substrate
+
+The reliability substrate gives the 🤖 fleet a durable way to hand work between agents without relying on chat alone. It lives behind `/api/memory-admin` and is keyed by your tenant's `UNCLICK_API_KEY`.
+
+## Concepts
+
+- **Dispatch.** A unit of work directed at a target agent. It carries `source` (which tool created it), `target_agent_id`, optional `task_ref`, and a free-form `payload`. A dispatch lives in `mc_agent_dispatches` with a deterministic `dispatch_id` so two callers with the same input idempotently create the same row.
+- **Heartbeat.** A periodic note from the working agent that records `state` (`idle | received | accepted | working | blocked | completed`), the current task, next action, ETA, and any blocker. Heartbeats land in `mc_agent_heartbeats` and double as the dispatch's `last_real_action_at` timestamp.
+- **Lease.** When an agent claims a dispatch it becomes the `lease_owner` until `lease_expires_at`. Only the lease owner can publish heartbeats against the dispatch or release it. Leases default to 900s and clamp to 86400s.
+- **Stale reclaim.** A janitor sweeps leases whose `lease_expires_at` is in the past, flips the dispatch to `status=stale`, clears the owner, and emits a WakePass signal so a human or watchdog can pick it back up.
+
+## Action map
+
+The substrate is exposed as URL-routed actions on `POST /api/memory-admin?action=...&method=...`. The friendly names below are how the fleet talks about them; the API column is what you actually call.
+
+| Friendly name | API call | What it does |
+|---|---|---|
+| `dispatch_create` | `reliability_dispatches&method=upsert` | Creates a queued dispatch (idempotent on `dispatch_id`). |
+| `dispatch_ack` | `reliability_dispatches&method=claim` | Claims the lease for an `agent_id`. |
+| `dispatch_heartbeat` | `reliability_heartbeats&method=publish` | Publishes a state update from the lease owner. |
+| `dispatch_complete` | `reliability_heartbeats&method=publish` with `state=completed` | Publishes a terminal heartbeat and marks the dispatch completed. |
+| `dispatch_fail` | `reliability_dispatches&method=release` with `status=failed` | Releases the lease and marks the dispatch failed. |
+| `dispatch_reclaim_stale` | `reliability_reclaim_stale` | Sweeps expired leases; emits WakePass signals. |
+
+All requests need `Authorization: Bearer $UNCLICK_API_KEY`. Responses are JSON; errors return `{ "error": "..." }` with a 4xx status.
+
+### `dispatch_create`
+
+Request:
+```json
+{
+  "source": "wakepass",
+  "target_agent_id": "agent_qa_1",
+  "task_ref": "ticket-1234",
+  "payload": { "note": "validate substrate" }
+}
+```
+Response: `{ "data": <dispatch row>, "was_duplicate": false }`. Returns `400` if `source` is invalid or `target_agent_id` is missing. Duplicate `dispatch_id` returns `200` with `was_duplicate: true`.
+
+### `dispatch_ack`
+
+Request:
+```json
+{ "dispatch_id": "dispatch_...", "agent_id": "agent_qa_1", "lease_seconds": 900 }
+```
+Response: `{ "data": <dispatch row>, "reclaimed_stale_lease": false }`. Rejection codes:
+- `400` if `dispatch_id` or `agent_id` is missing.
+- `404` if the dispatch does not exist.
+- `409` if the dispatch is already `completed | failed | cancelled`, already actively leased by someone else, or another writer raced ahead.
+
+### `dispatch_heartbeat`
+
+Request:
+```json
+{
+  "dispatch_id": "dispatch_...",
+  "agent_id": "agent_qa_1",
+  "state": "working",
+  "current_task": "running smokes",
+  "next_action": "post results",
+  "eta_minutes": 5
+}
+```
+Response: `{ "data": <heartbeat row> }`.
+
+**Strict ownership rule.** Heartbeat publish always returns `409` if `dispatch.status === "leased"` AND `dispatch.lease_owner` is set AND `dispatch.lease_owner !== agent_id`, regardless of whether the lease has expired. Stale handling lives in `dispatch_reclaim_stale` only — heartbeat publish never reclaims, so a paused agent can not silently overwrite another agent's lease.
+
+Other rejection codes: `400` (missing `agent_id` or invalid `state`), `404` (unknown `dispatch_id`), `409` (dispatch row changed between read and write).
+
+### `dispatch_complete`
+
+Same shape as `dispatch_heartbeat` with `state: "completed"`. The dispatch row is updated to `status=completed` with `lease_owner=null` and `lease_expires_at=null` in the same transaction as the heartbeat insert.
+
+### `dispatch_fail`
+
+Request:
+```json
+{ "dispatch_id": "dispatch_...", "agent_id": "agent_qa_1", "status": "failed" }
+```
+Response: `{ "data": <dispatch row> }`. Status defaults to `queued` if omitted; `leased` is rejected with `400`. Returns `409` if another agent owns the lease.
+
+### `dispatch_reclaim_stale`
+
+Request:
+```json
+{ "limit": 25, "dry_run": false }
+```
+Response: `{ "reclaimed_count": N, "reclaimed": [...], "dry_run": false }`. Each reclaim emits a WakePass signal — `handoff_ack_missing` when the dispatch payload expected an ACK, otherwise `stale_dispatch_reclaimed`.
+
+## Curl examples
+
+```bash
+BASE=https://unclick.world/api/memory-admin
+TOK="Authorization: Bearer $UNCLICK_API_KEY"
+
+# create
+curl -sS -X POST "$BASE?action=reliability_dispatches&method=upsert" \
+  -H "$TOK" -H 'content-type: application/json' \
+  -d '{"source":"manual","target_agent_id":"agent_qa_1","task_ref":"smoke-1"}'
+
+# ack
+curl -sS -X POST "$BASE?action=reliability_dispatches&method=claim" \
+  -H "$TOK" -H 'content-type: application/json' \
+  -d '{"dispatch_id":"dispatch_...","agent_id":"agent_qa_1"}'
+
+# heartbeat
+curl -sS -X POST "$BASE?action=reliability_heartbeats&method=publish" \
+  -H "$TOK" -H 'content-type: application/json' \
+  -d '{"dispatch_id":"dispatch_...","agent_id":"agent_qa_1","state":"working"}'
+
+# complete
+curl -sS -X POST "$BASE?action=reliability_heartbeats&method=publish" \
+  -H "$TOK" -H 'content-type: application/json' \
+  -d '{"dispatch_id":"dispatch_...","agent_id":"agent_qa_1","state":"completed"}'
+
+# fail (alternative terminal state)
+curl -sS -X POST "$BASE?action=reliability_dispatches&method=release" \
+  -H "$TOK" -H 'content-type: application/json' \
+  -d '{"dispatch_id":"dispatch_...","agent_id":"agent_qa_1","status":"failed"}'
+
+# reclaim stale
+curl -sS -X POST "$BASE?action=reliability_reclaim_stale" \
+  -H "$TOK" -H 'content-type: application/json' \
+  -d '{"limit":25,"dry_run":true}'
+```
+
+## Running the smoke script
+
+```bash
+export UNCLICK_API_URL=https://unclick.world/api/memory-admin   # defaults to this
+export UNCLICK_API_KEY=uc_...                                   # tenant key
+bash scripts/smoke-reliability.sh
+```
+
+The script generates a fresh idempotency key per run, walks the happy path (`create → ack → heartbeat → complete`) plus an optional `fail` and `reclaim_stale` pass, prints PASS/FAIL with the HTTP status per action, and exits `0` only if every action passes. See `scripts/smoke-reliability.sh` for the source.

--- a/docs/reliability-substrate.md
+++ b/docs/reliability-substrate.md
@@ -1,6 +1,8 @@
 # Reliability Substrate
 
-The reliability substrate gives the 🤖 fleet a durable way to hand work between agents without relying on chat alone. It lives behind `/api/memory-admin` and is keyed by your tenant's `UNCLICK_API_KEY`.
+The reliability substrate gives the agent fleet a durable way to hand work between agents without relying on chat alone. It lives behind `/api/memory-admin` and is keyed by your tenant's `UNCLICK_API_KEY`.
+
+For the operator-facing validation runbook (curl + per-step assertions), see `docs/reliability-substrate-smoke.md`. This document is the developer reference: concepts, action map, request/response shapes, error codes, and the runnable smoke script.
 
 ## Concepts
 
@@ -63,7 +65,7 @@ Request:
 ```
 Response: `{ "data": <heartbeat row> }`.
 
-**Strict ownership rule.** Heartbeat publish always returns `409` if `dispatch.status === "leased"` AND `dispatch.lease_owner` is set AND `dispatch.lease_owner !== agent_id`, regardless of whether the lease has expired. Stale handling lives in `dispatch_reclaim_stale` only — heartbeat publish never reclaims, so a paused agent can not silently overwrite another agent's lease.
+**Strict ownership rule.** Heartbeat publish always returns `409` if `dispatch.status === "leased"` AND `dispatch.lease_owner` is set AND `dispatch.lease_owner !== agent_id`, regardless of whether the lease has expired. Stale handling lives in `dispatch_reclaim_stale` only - heartbeat publish never reclaims, so a paused agent can not silently overwrite another agent's lease.
 
 Other rejection codes: `400` (missing `agent_id` or invalid `state`), `404` (unknown `dispatch_id`), `409` (dispatch row changed between read and write).
 
@@ -85,7 +87,7 @@ Request:
 ```json
 { "limit": 25, "dry_run": false }
 ```
-Response: `{ "reclaimed_count": N, "reclaimed": [...], "dry_run": false }`. Each reclaim emits a WakePass signal — `handoff_ack_missing` when the dispatch payload expected an ACK, otherwise `stale_dispatch_reclaimed`.
+Response: `{ "reclaimed_count": N, "reclaimed": [...], "dry_run": false }`. Each reclaim emits a WakePass signal - `handoff_ack_missing` when the dispatch payload expected an ACK, otherwise `stale_dispatch_reclaimed`.
 
 ## Curl examples
 
@@ -132,4 +134,4 @@ export UNCLICK_API_KEY=uc_...                                   # tenant key
 bash scripts/smoke-reliability.sh
 ```
 
-The script generates a fresh idempotency key per run, walks the happy path (`create → ack → heartbeat → complete`) plus an optional `fail` and `reclaim_stale` pass, prints PASS/FAIL with the HTTP status per action, and exits `0` only if every action passes. See `scripts/smoke-reliability.sh` for the source.
+The script generates a fresh idempotency key per run, walks the happy path (`create -> ack -> heartbeat -> complete`) plus an optional `fail` and `reclaim_stale` pass, prints PASS/FAIL with the HTTP status per action, and exits `0` only if every action passes. See `scripts/smoke-reliability.sh` for the source.

--- a/scripts/smoke-reliability.sh
+++ b/scripts/smoke-reliability.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Smoke-test the reliability substrate (dispatch_create -> ack -> heartbeat ->
+# complete, plus optional fail + reclaim_stale). Reads UNCLICK_API_URL and
+# UNCLICK_API_KEY from env. Exits 0 on full pass, 1 on any failure.
+set -uo pipefail
+
+BASE="${UNCLICK_API_URL:-https://unclick.world/api/memory-admin}"
+TOKEN="${UNCLICK_API_KEY:-}"
+if [[ -z "$TOKEN" ]]; then
+  echo "FAIL setup: UNCLICK_API_KEY not set" >&2
+  exit 1
+fi
+
+if command -v uuidgen >/dev/null 2>&1; then
+  RUN_ID="$(uuidgen | tr 'A-Z' 'a-z')"
+else
+  RUN_ID="$(date +%s)-$RANDOM"
+fi
+AGENT_ID="agent_smoke_${RUN_ID:0:8}"
+TASK_REF="smoke-${RUN_ID}"
+
+FAILS=0
+DISPATCH_ID=""
+
+call() {
+  local label="$1" method_q="$2" body="$3"
+  local url="${BASE}?action=${method_q}"
+  local out status
+  out="$(curl -sS -o /tmp/smoke_body.$$ -w '%{http_code}' -X POST "$url" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'content-type: application/json' \
+    --data "$body")" || { echo "FAIL $label: curl error"; FAILS=$((FAILS+1)); return 1; }
+  status="$out"
+  local payload; payload="$(cat /tmp/smoke_body.$$)"; rm -f /tmp/smoke_body.$$
+  if [[ "$status" =~ ^2 ]]; then
+    echo "PASS $label ($status)"
+    printf '%s\n' "$payload"
+    return 0
+  fi
+  echo "FAIL $label ($status): $payload" >&2
+  FAILS=$((FAILS+1))
+  return 1
+}
+
+# 1. create
+CREATE_BODY="{\"source\":\"manual\",\"target_agent_id\":\"$AGENT_ID\",\"task_ref\":\"$TASK_REF\",\"payload\":{\"smoke_run_id\":\"$RUN_ID\"}}"
+if RESP="$(call dispatch_create 'reliability_dispatches&method=upsert' "$CREATE_BODY")"; then
+  DISPATCH_ID="$(printf '%s' "$RESP" | sed -n 's/.*"dispatch_id":"\([^"]*\)".*/\1/p' | head -n1)"
+fi
+if [[ -z "$DISPATCH_ID" ]]; then
+  echo "FAIL dispatch_create: no dispatch_id in response" >&2
+  exit 1
+fi
+echo "  dispatch_id=$DISPATCH_ID"
+
+# 2. ack
+call dispatch_ack 'reliability_dispatches&method=claim' \
+  "{\"dispatch_id\":\"$DISPATCH_ID\",\"agent_id\":\"$AGENT_ID\",\"lease_seconds\":900}" >/dev/null
+
+# 3. heartbeat
+call dispatch_heartbeat 'reliability_heartbeats&method=publish' \
+  "{\"dispatch_id\":\"$DISPATCH_ID\",\"agent_id\":\"$AGENT_ID\",\"state\":\"working\",\"current_task\":\"smoke\",\"next_action\":\"complete\",\"eta_minutes\":1}" >/dev/null
+
+# 4. complete
+call dispatch_complete 'reliability_heartbeats&method=publish' \
+  "{\"dispatch_id\":\"$DISPATCH_ID\",\"agent_id\":\"$AGENT_ID\",\"state\":\"completed\"}" >/dev/null
+
+# 5. fail path (separate dispatch so we don't fight the completed one)
+FAIL_BODY="{\"source\":\"manual\",\"target_agent_id\":\"$AGENT_ID\",\"task_ref\":\"${TASK_REF}-fail\",\"payload\":{\"smoke_run_id\":\"$RUN_ID\"}}"
+FAIL_DID=""
+if RESP2="$(call dispatch_create_fail 'reliability_dispatches&method=upsert' "$FAIL_BODY")"; then
+  FAIL_DID="$(printf '%s' "$RESP2" | sed -n 's/.*"dispatch_id":"\([^"]*\)".*/\1/p' | head -n1)"
+fi
+if [[ -n "$FAIL_DID" ]]; then
+  call dispatch_ack_fail 'reliability_dispatches&method=claim' \
+    "{\"dispatch_id\":\"$FAIL_DID\",\"agent_id\":\"$AGENT_ID\"}" >/dev/null
+  call dispatch_fail 'reliability_dispatches&method=release' \
+    "{\"dispatch_id\":\"$FAIL_DID\",\"agent_id\":\"$AGENT_ID\",\"status\":\"failed\"}" >/dev/null
+fi
+
+# 6. reclaim_stale (dry-run is non-destructive, safe to always run)
+call dispatch_reclaim_stale 'reliability_reclaim_stale' \
+  '{"limit":25,"dry_run":true}' >/dev/null
+
+if (( FAILS == 0 )); then
+  echo "OK reliability substrate smoke passed (run_id=$RUN_ID)"
+  exit 0
+fi
+echo "$FAILS action(s) failed (run_id=$RUN_ID)" >&2
+exit 1


### PR DESCRIPTION
## Summary
- Adds `docs/reliability-substrate.md`: concept refresher (dispatches, heartbeats, leases, stale reclaim), action map (friendly name -> API call), request/response shapes per action, rejection codes, and the strict ownership rule.
- Adds `scripts/smoke-reliability.sh` (90 LOC): exercises `dispatch_create -> ack -> heartbeat -> complete` plus a `fail` and a dry-run `reclaim_stale` against `UNCLICK_API_URL` / `UNCLICK_API_KEY`.
- Validates the substrate that landed in #312. No source/migration/package changes.

## What this validates
- Happy path round-trip: queue a dispatch, claim a lease, publish a working heartbeat, complete it via terminal heartbeat.
- Fail path on a separate dispatch: claim then `release` with `status=failed`.
- Reclaim janitor wiring: `reliability_reclaim_stale` returns a well-formed envelope under `dry_run`.
- Documents the strict ownership rule on `dispatch_heartbeat`: always 409 if `status=leased` and `lease_owner` is set and `lease_owner !== agent_id`, regardless of staleness. Stale reclaim lives in `dispatch_reclaim_stale` only.

## How to run
```bash
export UNCLICK_API_URL=https://unclick.world/api/memory-admin   # default
export UNCLICK_API_KEY=uc_...                                    # tenant key
bash scripts/smoke-reliability.sh
```
Exits 0 on full pass, 1 on any fail. Each run uses a fresh idempotency key so reruns don't collide.

## Parent
Substrate slice landed in #312 (head `b6d331b` on main). This PR is QC fold-in only — no implementation changes to `api/memory-admin.ts`.