### PR TITLE
feat(reliability): add operator telemetry helpers

### DIFF
--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   createDispatchId,
   createHeartbeat,
+  createOperatorTelemetry,
+  createQueuedDispatch,
   createReclaimSignal,
   createTimeBucket,
   decideStaleLease,
@@ -43,6 +45,36 @@ describe("reliability helpers", () => {
     });
 
     expect(first).not.toBe(second);
+  });
+
+  it("creates a queued dispatch from stable inputs", () => {
+    const dispatch = createQueuedDispatch({
+      apiKeyHash: "hash_123",
+      source: "wakepass",
+      targetAgentId: "coder",
+      taskRef: "pr-314",
+      timeBucket: "2026-04-30T13:40:00.000Z",
+      payload: { b: 2, a: 1 },
+      createdAt: new Date("2026-04-30T13:41:00.000Z"),
+    });
+
+    expect(dispatch).toEqual({
+      apiKeyHash: "hash_123",
+      dispatchId: createDispatchId({
+        source: "wakepass",
+        targetAgentId: "coder",
+        taskRef: "pr-314",
+        timeBucket: "2026-04-30T13:40:00.000Z",
+        payload: { a: 1, b: 2 },
+      }),
+      source: "wakepass",
+      targetAgentId: "coder",
+      taskRef: "pr-314",
+      status: "queued",
+      createdAt: "2026-04-30T13:41:00.000Z",
+      updatedAt: "2026-04-30T13:41:00.000Z",
+      payload: { b: 2, a: 1 },
+    });
   });
 
   it("buckets dispatch time into stable windows", () => {
@@ -92,6 +124,28 @@ describe("reliability helpers", () => {
     ).toMatchObject({ isStale: false, reason: "not_leased" });
   });
 
+  it("treats missing or invalid lease expiry as not reclaimable", () => {
+    expect(
+      decideStaleLease(
+        {
+          status: "leased",
+          leaseExpiresAt: null,
+        },
+        new Date("2026-04-30T11:00:10.000Z"),
+      ),
+    ).toEqual({ isStale: false, reason: "missing_lease_expiry", staleSeconds: 0 });
+
+    expect(
+      decideStaleLease(
+        {
+          status: "leased",
+          leaseExpiresAt: "not-a-date",
+        },
+        new Date("2026-04-30T11:00:10.000Z"),
+      ),
+    ).toEqual({ isStale: false, reason: "missing_lease_expiry", staleSeconds: 0 });
+  });
+
   it("creates compact heartbeat metadata", () => {
     const heartbeat = createHeartbeat({
       apiKeyHash: "hash_123",
@@ -116,6 +170,60 @@ describe("reliability helpers", () => {
       createdAt: "2026-04-30T11:00:00.000Z",
       lastRealActionAt: "2026-04-30T10:59:30.000Z",
     });
+  });
+
+  it("creates operator-safe telemetry without tenant hash or payload", () => {
+    const dispatch = createQueuedDispatch({
+      apiKeyHash: "hash_secret",
+      source: "fishbowl",
+      targetAgentId: "plex",
+      taskRef: "handoff-1",
+      payload: { private_note: "do not surface" },
+      createdAt: new Date("2026-04-30T13:00:00.000Z"),
+    });
+
+    const heartbeat = createHeartbeat({
+      apiKeyHash: "hash_secret",
+      agentId: "plex",
+      dispatchId: dispatch.dispatchId,
+      state: "blocked",
+      currentTask: "resolve conflict",
+      nextAction: "post blocker",
+      blocker: "merge conflict",
+      etaMinutes: 15,
+      createdAt: new Date("2026-04-30T13:02:00.000Z"),
+      lastRealActionAt: new Date("2026-04-30T13:01:00.000Z"),
+    });
+
+    const telemetry = createOperatorTelemetry({
+      dispatch,
+      heartbeat,
+      staleDecision: {
+        isStale: false,
+        reason: "lease_active",
+        staleSeconds: 0,
+      },
+    });
+
+    expect(telemetry).toEqual({
+      dispatchId: dispatch.dispatchId,
+      source: "fishbowl",
+      targetAgentId: "plex",
+      status: "queued",
+      updatedAt: "2026-04-30T13:00:00.000Z",
+      agentId: "plex",
+      heartbeatState: "blocked",
+      currentTask: "resolve conflict",
+      nextAction: "post blocker",
+      blocker: "merge conflict",
+      etaMinutes: 15,
+      lastRealActionAt: "2026-04-30T13:01:00.000Z",
+      stale: false,
+      staleReason: "lease_active",
+      staleSeconds: 0,
+    });
+    expect(JSON.stringify(telemetry)).not.toContain("hash_secret");
+    expect(JSON.stringify(telemetry)).not.toContain("private_note");
   });
 
   it("marks missing-ack handoffs as a WakePass reliability miss", () => {

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -81,6 +81,37 @@ export interface StaleLeaseDecision {
   staleSeconds: number;
 }
 
+export interface QueuedDispatchParams {
+  apiKeyHash: string;
+  source: DispatchSource;
+  targetAgentId: string;
+  taskRef?: string;
+  promptHash?: string;
+  timeBucket?: string;
+  payload?: Record<string, unknown>;
+  createdAt?: Date;
+}
+
+export interface OperatorTelemetry {
+  dispatchId?: string;
+  source?: DispatchSource;
+  targetAgentId?: string;
+  status?: DispatchStatus;
+  leaseOwner?: string;
+  leaseExpiresAt?: string;
+  updatedAt?: string;
+  agentId?: string;
+  heartbeatState?: HeartbeatState;
+  currentTask?: string;
+  nextAction?: string;
+  etaMinutes?: number;
+  blocker?: string;
+  lastRealActionAt?: string;
+  stale?: boolean;
+  staleReason?: StaleLeaseDecision["reason"];
+  staleSeconds?: number;
+}
+
 export function createDispatchId(input: DispatchIdInput): string {
   const hash = createHash("sha256")
     .update(stableStringify(input))
@@ -88,6 +119,34 @@ export function createDispatchId(input: DispatchIdInput): string {
     .slice(0, 32);
 
   return `dispatch_${hash}`;
+}
+
+export function createQueuedDispatch(params: QueuedDispatchParams): AgentDispatch {
+  const createdAt = (params.createdAt ?? new Date()).toISOString();
+  const idInput: DispatchIdInput = {
+    source: params.source,
+    targetAgentId: params.targetAgentId,
+  };
+
+  if (params.taskRef) idInput.taskRef = params.taskRef;
+  if (params.promptHash) idInput.promptHash = params.promptHash;
+  if (params.timeBucket) idInput.timeBucket = params.timeBucket;
+  if (params.payload) idInput.payload = params.payload;
+
+  const dispatch: AgentDispatch = {
+    apiKeyHash: params.apiKeyHash,
+    dispatchId: createDispatchId(idInput),
+    source: params.source,
+    targetAgentId: params.targetAgentId,
+    status: "queued",
+    createdAt,
+    updatedAt: createdAt,
+  };
+
+  if (params.taskRef) dispatch.taskRef = params.taskRef;
+  if (params.payload) dispatch.payload = params.payload;
+
+  return dispatch;
 }
 
 export function createTimeBucket(date: Date, bucketSeconds = 5): string {
@@ -158,6 +217,49 @@ export function createHeartbeat(params: {
   }
 
   return heartbeat;
+}
+
+export function createOperatorTelemetry(input: {
+  dispatch?: AgentDispatch;
+  heartbeat?: AgentHeartbeat;
+  staleDecision?: StaleLeaseDecision;
+}): OperatorTelemetry {
+  const telemetry: OperatorTelemetry = {};
+
+  if (input.dispatch) {
+    telemetry.dispatchId = input.dispatch.dispatchId;
+    telemetry.source = input.dispatch.source;
+    telemetry.targetAgentId = input.dispatch.targetAgentId;
+    telemetry.status = input.dispatch.status;
+    telemetry.updatedAt = input.dispatch.updatedAt;
+    if (input.dispatch.leaseOwner) telemetry.leaseOwner = input.dispatch.leaseOwner;
+    if (input.dispatch.leaseExpiresAt) {
+      telemetry.leaseExpiresAt = input.dispatch.leaseExpiresAt;
+    }
+    if (input.dispatch.lastRealActionAt) {
+      telemetry.lastRealActionAt = input.dispatch.lastRealActionAt;
+    }
+  }
+
+  if (input.heartbeat) {
+    telemetry.dispatchId = input.heartbeat.dispatchId ?? telemetry.dispatchId;
+    telemetry.agentId = input.heartbeat.agentId;
+    telemetry.heartbeatState = input.heartbeat.state;
+    telemetry.currentTask = input.heartbeat.currentTask;
+    telemetry.nextAction = input.heartbeat.nextAction;
+    telemetry.etaMinutes = input.heartbeat.etaMinutes;
+    telemetry.blocker = input.heartbeat.blocker;
+    telemetry.lastRealActionAt =
+      input.heartbeat.lastRealActionAt ?? telemetry.lastRealActionAt;
+  }
+
+  if (input.staleDecision) {
+    telemetry.stale = input.staleDecision.isStale;
+    telemetry.staleReason = input.staleDecision.reason;
+    telemetry.staleSeconds = input.staleDecision.staleSeconds;
+  }
+
+  return telemetry;
 }
 
 export function createReclaimSignal(


### PR DESCRIPTION
## Summary
- add a pure helper for building queued reliability dispatch records from stable inputs
- add operator-safe telemetry shaping for dispatch, heartbeat, and stale lease state
- extend reliability helper tests for queued dispatch creation, invalid lease expiry, and redacted telemetry

## Validation
- npm exec --workspace packages/mcp-server vitest run src/__tests__/reliability.test.ts
- npm run build --workspace packages/mcp-server

## Notes
- No API, migration, UI, or smoke-doc changes.
- This keeps the slice separate from PR #310 and PR #314.
