### PR TITLE
feat(wakepass): register wake dispatch leases

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -4850,7 +4850,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               return res.status(400).json({ error: "dispatch_id and agent_id required" });
             }
 
-            const leaseSeconds = getClampedLimit(body.lease_seconds, 900, 86400);
+            const leaseSeconds = getClampedLimit(body.lease_seconds, 60, 86400);
             const { data, error } = await supabase
               .from("mc_agent_dispatches")
               .select(

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -3,6 +3,7 @@
 import { createHash } from "node:crypto";
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const eventName = process.env.GITHUB_EVENT_NAME || "manual";
 const eventPath = process.env.GITHUB_EVENT_PATH || "";
@@ -12,9 +13,15 @@ const runId = process.env.GITHUB_RUN_ID || "";
 const apiUrl = process.env.UNCLICK_API_URL || "https://unclick.world/api/memory-admin";
 const unclickApiKey = process.env.FISHBOWL_WAKE_TOKEN || process.env.FISHBOWL_AUTOCLOSE_TOKEN || "";
 const dryRun = process.env.WAKE_ROUTER_DRY_RUN === "1" || process.env.WAKE_ROUTER_DRY_RUN === "true";
+const ackFailSeconds = parsePositiveInt(process.env.WAKE_ACK_FAIL_SECONDS, 960);
 const receivedAt = new Date().toISOString();
 const ledgerDir = process.env.WAKE_LEDGER_DIR || ".wake-ledger";
 const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY || "";
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 function readEvent() {
   if (!eventPath) return {};
@@ -70,6 +77,11 @@ function wakeEventId(event, decision) {
   ].join("|");
   const digest = createHash("sha256").update(basis).digest("hex").slice(0, 12);
   return `wake-${eventName}-${eventSubject(event)}-${digest}`.replace(/[^a-zA-Z0-9_.-]/g, "-");
+}
+
+export function wakeDispatchId(eventId) {
+  const digest = createHash("sha256").update(eventId).digest("hex").slice(0, 32);
+  return `dispatch_${digest}`;
 }
 
 function baseDecision(event) {
@@ -284,7 +296,116 @@ async function postWake(decision, triage, eventId) {
   return { posted: response.ok, status: response.status, message_id: messageId };
 }
 
-function writeLedger({ eventId, event, decision, triage, result, status }) {
+export function buildReliabilityDispatchRequest({
+  eventId,
+  decision,
+  triage,
+  result,
+  event,
+  ackSeconds = 960,
+}) {
+  return {
+    dispatch_id: wakeDispatchId(eventId),
+    source: "wakepass",
+    target_agent_id: decision.owner,
+    task_ref: eventId,
+    time_bucket_seconds: ackSeconds,
+    payload: {
+      ack_required: true,
+      handoff_message_id: result?.message_id ?? null,
+      wake_event_id: eventId,
+      wake_reason: decision.reason,
+      wake_urgency: decision.urgency,
+      wake_owner: decision.owner,
+      source_url: sourceUrl(event),
+      github_event_name: eventName,
+      github_event_action: event.action || null,
+      github_subject: eventSubject(event),
+      cheap_triage_used: Boolean(triage.used),
+      ack_fail_after_seconds: ackSeconds,
+    },
+  };
+}
+
+async function registerWakeDispatch({ eventId, decision, triage, result, event }) {
+  const dispatchRequest = buildReliabilityDispatchRequest({
+    eventId,
+    decision,
+    triage,
+    result,
+    event,
+    ackSeconds: ackFailSeconds,
+  });
+
+  const claimRequest = {
+    dispatch_id: dispatchRequest.dispatch_id,
+    agent_id: decision.owner,
+    lease_seconds: ackFailSeconds,
+  };
+
+  if (dryRun || !unclickApiKey) {
+    console.log(
+      JSON.stringify(
+        {
+          reliability_dispatch_dry_run: true,
+          missing_key: !unclickApiKey,
+          upsert: dispatchRequest,
+          claim: claimRequest,
+        },
+        null,
+        2,
+      ),
+    );
+    return {
+      registered: false,
+      dry_run: true,
+      dispatch_id: dispatchRequest.dispatch_id,
+      upsert: dispatchRequest,
+      claim: claimRequest,
+    };
+  }
+
+  const upsertResponse = await fetch(`${apiUrl}?action=reliability_dispatches&method=upsert`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${unclickApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(dispatchRequest),
+  });
+  const upsertBody = await upsertResponse.text();
+  console.log(`Reliability dispatch upsert HTTP ${upsertResponse.status}`);
+  console.log(upsertBody);
+  if (!upsertResponse.ok) {
+    return {
+      registered: false,
+      status: upsertResponse.status,
+      dispatch_id: dispatchRequest.dispatch_id,
+      error: compactText(upsertBody, 500),
+    };
+  }
+
+  const claimResponse = await fetch(`${apiUrl}?action=reliability_dispatches&method=claim`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${unclickApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(claimRequest),
+  });
+  const claimBody = await claimResponse.text();
+  console.log(`Reliability dispatch claim HTTP ${claimResponse.status}`);
+  console.log(claimBody);
+
+  return {
+    registered: claimResponse.ok,
+    status: claimResponse.status,
+    dispatch_id: dispatchRequest.dispatch_id,
+    error: claimResponse.ok ? null : compactText(claimBody, 500),
+  };
+}
+
+function writeLedger({ eventId, event, decision, triage, result, reliability, status }) {
   const eventSeconds = secondsSince(decision.eventCreatedAt);
   const ledger = {
     event_id: eventId,
@@ -313,11 +434,18 @@ function writeLedger({ eventId, event, decision, triage, result, status }) {
       status: result?.status || null,
       message_id: result?.message_id || null,
     },
+    reliability_dispatch: {
+      registered: Boolean(reliability?.registered),
+      dry_run: Boolean(reliability?.dry_run),
+      status: reliability?.status || null,
+      dispatch_id: reliability?.dispatch_id || null,
+      error: reliability?.error || null,
+    },
     ack: {
       requested: status === "wake_posted" || status === "wake_dry_run",
-      expected_within_seconds: 120,
-      warning_after_seconds: 300,
-      fail_after_seconds: 960,
+      expected_within_seconds: Math.min(120, ackFailSeconds),
+      warning_after_seconds: Math.min(300, ackFailSeconds),
+      fail_after_seconds: ackFailSeconds,
       observed_at: null,
     },
   };
@@ -336,6 +464,7 @@ function writeLedger({ eventId, event, decision, triage, result, status }) {
     `- Source: ${sourceUrl(event)}`,
     `- Event-to-router: ${eventSeconds === null ? "unknown" : `${eventSeconds}s`}`,
     `- Fishbowl posted: ${result?.posted ? "yes" : result?.dry_run ? "dry run" : "no"}`,
+    `- Reliability dispatch: ${reliability?.registered ? reliability.dispatch_id : reliability?.dry_run ? "dry run" : "not registered"}`,
     `- Cheap triage: ${triage.used ? triage.error ? `error (${triage.error})` : "used" : "skipped"}`,
     "",
   ].join("\n");
@@ -344,22 +473,42 @@ function writeLedger({ eventId, event, decision, triage, result, status }) {
   return ledger;
 }
 
-const event = readEvent();
-const initialDecision = baseDecision(event);
-const brief = eventBrief(event, initialDecision);
-const triage = await cheapTriage(brief, initialDecision);
-const finalDecision = triage.decision;
-const eventId = wakeEventId(event, finalDecision);
+async function main() {
+  const event = readEvent();
+  const initialDecision = baseDecision(event);
+  const brief = eventBrief(event, initialDecision);
+  const triage = await cheapTriage(brief, initialDecision);
+  const finalDecision = triage.decision;
+  const eventId = wakeEventId(event, finalDecision);
 
-console.log(JSON.stringify({ eventId, brief, finalDecision, triage }, null, 2));
+  console.log(JSON.stringify({ eventId, brief, finalDecision, triage }, null, 2));
 
-if (!finalDecision.wake) {
-  console.log("No wake needed.");
-  writeLedger({ eventId, event, decision: finalDecision, triage, result: null, status: "no_wake" });
-  process.exit(0);
+  if (!finalDecision.wake) {
+    console.log("No wake needed.");
+    writeLedger({
+      eventId,
+      event,
+      decision: finalDecision,
+      triage,
+      result: null,
+      reliability: null,
+      status: "no_wake",
+    });
+    return;
+  }
+
+  const result = await postWake(finalDecision, triage, eventId);
+  const reliability =
+    result.posted || result.dry_run
+      ? await registerWakeDispatch({ eventId, decision: finalDecision, triage, result, event })
+      : null;
+  const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
+  writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, status });
+  if ((!result.posted && !result.dry_run) || (result.posted && !reliability?.registered)) {
+    process.exitCode = 1;
+  }
 }
 
-const result = await postWake(finalDecision, triage, eventId);
-const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
-writeLedger({ eventId, event, decision: finalDecision, triage, result, status });
-if (!result.posted && !result.dry_run) process.exitCode = 1;
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -13,7 +13,7 @@ const runId = process.env.GITHUB_RUN_ID || "";
 const apiUrl = process.env.UNCLICK_API_URL || "https://unclick.world/api/memory-admin";
 const unclickApiKey = process.env.FISHBOWL_WAKE_TOKEN || process.env.FISHBOWL_AUTOCLOSE_TOKEN || "";
 const dryRun = process.env.WAKE_ROUTER_DRY_RUN === "1" || process.env.WAKE_ROUTER_DRY_RUN === "true";
-const ackFailSeconds = parsePositiveInt(process.env.WAKE_ACK_FAIL_SECONDS, 960);
+const ackFailSeconds = parsePositiveInt(process.env.WAKE_ACK_FAIL_SECONDS, 600);
 const receivedAt = new Date().toISOString();
 const ledgerDir = process.env.WAKE_LEDGER_DIR || ".wake-ledger";
 const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY || "";
@@ -302,7 +302,7 @@ export function buildReliabilityDispatchRequest({
   triage,
   result,
   event,
-  ackSeconds = 960,
+  ackSeconds = 600,
 }) {
   return {
     dispatch_id: wakeDispatchId(eventId),

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -250,7 +250,7 @@ async function cheapTriage(brief, decision) {
   }
 }
 
-async function postWake(decision, triage, eventId) {
+async function postWake(decision, triage, eventId, event) {
   const eventSeconds = secondsSince(decision.eventCreatedAt);
   const wakeSecondsLabel = eventSeconds === null ? "unknown" : `${eventSeconds}s`;
   const recipients = decision.owner === "all" ? ["all"] : [decision.owner];
@@ -497,7 +497,7 @@ async function main() {
     return;
   }
 
-  const result = await postWake(finalDecision, triage, eventId);
+  const result = await postWake(finalDecision, triage, eventId, event);
   const reliability =
     result.posted || result.dry_run
       ? await registerWakeDispatch({ eventId, decision: finalDecision, triage, result, event })

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -44,4 +44,21 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(request.payload.wake_owner, "🤖");
     assert.equal(request.payload.github_subject, "workflow-run-123");
   });
+
+  it("defaults missed-ACK handoff leases to ten minutes", () => {
+    const request = buildReliabilityDispatchRequest({
+      eventId: "wake-workflow_run-workflow-run-456-def",
+      decision: {
+        owner: "🤖",
+        reason: "PR checks completed green",
+        urgency: "high",
+      },
+      triage: { used: false },
+      result: { message_id: "msg-456" },
+      event: { workflow_run: { id: 456 } },
+    });
+
+    assert.equal(request.time_bucket_seconds, 600);
+    assert.equal(request.payload.ack_fail_after_seconds, 600);
+  });
 });

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildReliabilityDispatchRequest,
+  wakeDispatchId,
+} from "./event-wake-router.mjs";
+
+describe("event wake router reliability dispatch", () => {
+  it("creates stable dispatch IDs from wake event IDs", () => {
+    const first = wakeDispatchId("wake-workflow_run-workflow-run-123-abc");
+    const second = wakeDispatchId("wake-workflow_run-workflow-run-123-abc");
+
+    assert.equal(first, second);
+    assert.match(first, /^dispatch_[a-f0-9]{32}$/);
+  });
+
+  it("marks wake handoffs as ACK-required WakePass dispatches", () => {
+    const request = buildReliabilityDispatchRequest({
+      eventId: "wake-workflow_run-workflow-run-123-abc",
+      decision: {
+        owner: "🤖",
+        reason: "PR checks completed green for TestPass PR Check on PR #310",
+        urgency: "high",
+      },
+      triage: { used: false },
+      result: { message_id: "msg-123" },
+      event: {
+        action: "completed",
+        workflow_run: {
+          id: 123,
+          html_url: "https://github.com/acme/repo/actions/runs/123",
+        },
+      },
+      ackSeconds: 600,
+    });
+
+    assert.equal(request.source, "wakepass");
+    assert.equal(request.target_agent_id, "🤖");
+    assert.equal(request.task_ref, "wake-workflow_run-workflow-run-123-abc");
+    assert.equal(request.payload.ack_required, true);
+    assert.equal(request.payload.handoff_message_id, "msg-123");
+    assert.equal(request.payload.ack_fail_after_seconds, 600);
+    assert.equal(request.payload.wake_owner, "🤖");
+    assert.equal(request.payload.github_subject, "workflow-run-123");
+  });
+});

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -1,10 +1,19 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   buildReliabilityDispatchRequest,
   wakeDispatchId,
 } from "./event-wake-router.mjs";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const scriptPath = join(scriptDir, "event-wake-router.mjs");
+const repoRoot = dirname(scriptDir);
 
 describe("event wake router reliability dispatch", () => {
   it("creates stable dispatch IDs from wake event IDs", () => {
@@ -60,5 +69,47 @@ describe("event wake router reliability dispatch", () => {
 
     assert.equal(request.time_bucket_seconds, 600);
     assert.equal(request.payload.ack_fail_after_seconds, 600);
+  });
+
+  it("runs the wake path in dry-run mode without crashing", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        action: "completed",
+        workflow_run: {
+          id: 123,
+          name: "TestPass PR Check",
+          status: "completed",
+          conclusion: "success",
+          html_url: "https://github.com/acme/repo/actions/runs/123",
+          created_at: "2026-04-30T14:00:00Z",
+          updated_at: "2026-04-30T14:05:00Z",
+          pull_requests: [{ number: 316 }],
+        },
+      }),
+    );
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /reliability_dispatch_dry_run/);
+      assert.doesNotMatch(result.stderr, /ReferenceError/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Registers each posted wake-router event as an ACK-required `wakepass` reliability dispatch.
- Immediately claims the dispatch for the routed owner with a configurable `WAKE_ACK_FAIL_SECONDS` lease.
- Adds dispatch metadata to the wake ledger so stale reclaim can emit `handoff_ack_missing` instead of losing the no-ACK case.
- Adds a small script-level test for stable wake dispatch IDs and ACK-required dispatch payloads.

## Linked Todo
- Fishbowl todo `fe443a8a`: WakePass wake-router auto-handoff after no-ACK threshold

## Verification
- `node --test scripts/event-wake-router.test.mjs`
- `npm run build --workspace packages/mcp-server`
- `npm run build`

Note: this worktree uses a local ignored `node_modules` junction to the already-installed dependency tree; no package or lockfile changes are included.