### PR TITLE
fix(fishbowl): trim stale board noise

### DIFF
--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -186,7 +186,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     .from("mc_fishbowl_profiles")
     .select("api_key_hash, agent_id, emoji, display_name, last_seen_at, current_status, current_status_updated_at, next_checkin_at")
     .not("current_status", "is", null)
-    .lt("current_status_updated_at", staleStatusCutoff);
+    .or(`current_status_updated_at.is.null,current_status_updated_at.lt.${staleStatusCutoff}`);
 
   if (staleStatusErr) {
     console.error("[fishbowl-watcher] stale status fetch error:", staleStatusErr.message);
@@ -194,21 +194,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const staleStatusCandidates = ((staleStatusProfiles ?? []) as ProfileRow[]).filter((p) => {
-    if (!p.current_status || !p.current_status_updated_at) return false;
+    if (!p.current_status) return false;
+    if (!p.current_status_updated_at) return true;
     const statusMs = new Date(p.current_status_updated_at).getTime();
     if (Number.isNaN(statusMs) || nowMs - statusMs < STATUS_STALE_WINDOW_MS) return false;
-    if (!p.next_checkin_at) return true;
-    const checkinMs = new Date(p.next_checkin_at).getTime();
-    return Number.isNaN(checkinMs) || checkinMs <= nowMs;
+    return true;
   });
 
   for (const profile of staleStatusCandidates) {
-    const { error: clearErr } = await supabase
+    let clearQuery = supabase
       .from("mc_fishbowl_profiles")
       .update({ current_status: null, current_status_updated_at: nowIso })
       .eq("api_key_hash", profile.api_key_hash)
-      .eq("agent_id", profile.agent_id)
-      .eq("current_status_updated_at", profile.current_status_updated_at);
+      .eq("agent_id", profile.agent_id);
+    clearQuery = profile.current_status_updated_at
+      ? clearQuery.eq("current_status_updated_at", profile.current_status_updated_at)
+      : clearQuery.is("current_status_updated_at", null);
+    const { error: clearErr } = await clearQuery;
 
     if (clearErr) {
       console.error("[fishbowl-watcher] stale status clear error:", clearErr.message);

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7299,6 +7299,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           normal: 1,
           low: 0,
         };
+        const DONE_TODO_ARCHIVE_WINDOW_MS = 12 * 60 * 60 * 1000;
 
         // ── Todos ──────────────────────────────────────────────────────────
 
@@ -7457,6 +7458,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (action === "fishbowl_list_todos") {
           const limit = Math.min(Math.max(Number(body.limit ?? 50) || 50, 1), 200);
           const includeDescription = body.include_description === true || body.full_content === true;
+          const includeArchivedDone =
+            body.include_archived_done === true ||
+            body.include_archived === true ||
+            body.show_archived === true;
+          const doneArchiveCutoff = new Date(Date.now() - DONE_TODO_ARCHIVE_WINDOW_MS).toISOString();
           let q = supabase
             .from("mc_fishbowl_todos")
             .select("*")
@@ -7473,6 +7479,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           if (body.assigned_to_agent_id != null) {
             const a = String(body.assigned_to_agent_id);
             q = q.eq("assigned_to_agent_id", a);
+          }
+          if (!includeArchivedDone && body.status == null) {
+            q = q.or(`status.neq.done,completed_at.is.null,completed_at.gte.${doneArchiveCutoff}`);
           }
           const { data, error } = await q;
           if (error) throw error;
@@ -7512,6 +7521,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             response_bounds: {
               compact: !includeDescription,
               descriptions_included: includeDescription,
+              archived_done_hidden: !includeArchivedDone && body.status == null,
+              done_archive_cutoff: !includeArchivedDone && body.status == null ? doneArchiveCutoff : null,
               todos_returned: decorated.length,
             },
           });


### PR DESCRIPTION
## Summary
- clear stale Fishbowl current_status text after the stale window even when a future check-in exists
- handle legacy/null current_status_updated_at values in the stale-status cleanup sweep
- hide completed todos older than 12 hours from the default todo list response while keeping explicit done/history queries available

## Verification
- npm run build --workspace packages/mcp-server
- npm run build

## Notes
- No rows are deleted. Old completed todos remain queryable with status: "done" or include_archived_done/include_archived/show_archived.
- This is meant to reduce overnight board noise, not change ownership or todo lifecycle semantics.