### PR TITLE
fix(testpass): use cron secret for scheduled smoke

### DIFF
--- a/.github/workflows/testpass-scheduled-smoke.yml
+++ b/.github/workflows/testpass-scheduled-smoke.yml
@@ -33,7 +33,7 @@ jobs:
         id: testpass
         uses: ./.github/actions/testpass
         with:
-          token: ${{ secrets.TESTPASS_TOKEN }}
+          token: ${{ secrets.TESTPASS_CRON_SECRET || secrets.CRON_SECRET || secrets.TESTPASS_TOKEN }}
           pack_id: ${{ inputs.pack_id || 'testpass-core' }}
           profile: ${{ inputs.profile || 'smoke' }}
           server_url: ${{ inputs.server_url || 'https://unclick.world/api/mcp' }}


### PR DESCRIPTION
Summary: Scheduled TestPass smoke now prefers a durable cron secret instead of relying on the short-lived TESTPASS_TOKEN session secret. It falls back to CRON_SECRET and then TESTPASS_TOKEN so existing manual runs do not break while the repo secret is being wired.

Scope: .github/workflows/testpass-scheduled-smoke.yml only.

Non-overlap: No TestPass API code, PR check workflow, WakePass, Fishbowl, or Connections changes.

Verification: Triggered TestPass Scheduled Smoke manually before this patch; it failed with HTTP 401 Invalid session, proving TESTPASS_TOKEN is stale/short-lived. Ran git diff --check locally.

Risk: Requires GitHub secret TESTPASS_CRON_SECRET, or CRON_SECRET, to match the production Vercel CRON_SECRET for durable scheduled runs. Until that secret exists, fallback to TESTPASS_TOKEN may still fail after session expiry.

Follow-up: Set TESTPASS_CRON_SECRET in GitHub repo secrets to the same value as Vercel CRON_SECRET, then re-run TestPass Scheduled Smoke and wait for a natural schedule event.