### PR TITLE
fix(testpass): run scheduled smoke every 5 minutes

### DIFF
--- a/.github/workflows/testpass-scheduled-smoke.yml
+++ b/.github/workflows/testpass-scheduled-smoke.yml
@@ -2,7 +2,7 @@ name: TestPass Scheduled Smoke
 
 on:
   schedule:
-    - cron: "7,22,37,52 * * * *"
+    - cron: "*/5 * * * *"
   workflow_dispatch:
     inputs:
       pack_id:


### PR DESCRIPTION
Summary: Increase TestPass scheduled smoke cadence from every 15 minutes to every 5 minutes so unattended proof arrives quickly.

Scope: .github/workflows/testpass-scheduled-smoke.yml only.

Non-overlap: No TestPass API logic, WakePass, Fishbowl, Connections, or secrets changes.

Verification: Earlier cron-secret manual scheduled-smoke runs passed on main. This PR only changes the cron expression.

Risk: More frequent lightweight smoke runs. Reduce cadence later if it becomes noisy.

Follow-up: After merge, watch for the next natural schedule event at the next 5-minute mark.