### PR TITLE
docs(readme): clarify memory aliases and hidden ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ UnClick exposes a small direct surface for daily agent workflows, plus hidden in
 
 The agent starts with memory, uses direct Fishbowl tools for coordination, and can still call the hidden catalog tools by name when it needs dynamic endpoint discovery.
 
+### Compatibility and advanced memory operations
+
+- Legacy memory names still work as aliases: `get_startup_context` -> `load_memory`, `write_session_summary` -> `save_session`, `add_fact` -> `save_fact`, `set_business_context` -> `save_identity`.
+- The remaining memory operations are intentionally not listed in `ListTools` and are called through `unclick_call` with `endpoint_id: "memory.<op>"` (for example `memory.manage_decay`, `memory.store_code`, `memory.log_conversation`, `memory.supersede_fact`, `memory.upsert_library_doc`).
+
 ## Requirements
 
 - Node.js 18+


### PR DESCRIPTION
## Summary
Clarifies README guidance for memory tool aliases and advanced memory operations so automation workers use the intended tool surface.

## Scope
- Update `README.md` only
- Add alias mapping examples for old memory names
- Document how to call non-listed memory operations through `unclick_call`

## Non-overlap
- No workflow, auth, secrets, payments, migration, or UI logic changes
- No package or lockfile changes

## Verification
- Command: `npm run lint --if-present`
- Result: failed locally because dependencies are not installed in this worktree (`eslint` command not found)
- Sanity: `git diff --name-only main...HEAD` shows README-only change

## Risk
Low. Documentation-only clarification with no runtime behavior changes.

## Follow-up
If desired, mirror this wording into any worker prompt templates that currently mention only canonical memory tool names.
