### PR TITLE
Harden no-ACK reclaim detection for WakePass handoffs

### DIFF
--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -253,6 +253,31 @@ describe("reliability helpers", () => {
     });
   });
 
+  it("treats string and numeric ACK flags as ACK-required handoffs", () => {
+    const stringAck = createReclaimSignal(
+      {
+        dispatchId: "dispatch_ack_string",
+        source: "wakepass",
+        targetAgentId: "coder",
+        payload: { require_ack: "true" },
+      },
+      61,
+    );
+
+    const numericAck = createReclaimSignal(
+      {
+        dispatchId: "dispatch_ack_numeric",
+        source: "wakepass",
+        targetAgentId: "coder",
+        payload: { ack_required: 1 },
+      },
+      61,
+    );
+
+    expect(stringAck.action).toBe("handoff_ack_missing");
+    expect(numericAck.action).toBe("handoff_ack_missing");
+  });
+
   it("marks non-ack reclaim as a generic stale dispatch", () => {
     const signal = createReclaimSignal(
       {

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -267,9 +267,18 @@ export function createReclaimSignal(
   staleSeconds: number,
 ): ReclaimSignalDescriptor {
   const payload = dispatch.payload ?? {};
+  const hasAckFlag = (value: unknown): boolean => {
+    if (value === true) return true;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      return normalized === "true" || normalized === "1" || normalized === "yes";
+    }
+    if (typeof value === "number") return value === 1;
+    return false;
+  };
   const expectsAck =
-    payload.ack_required === true ||
-    payload.require_ack === true ||
+    hasAckFlag(payload.ack_required) ||
+    hasAckFlag(payload.require_ack) ||
     typeof payload.handoff_message_id === "string" ||
     typeof payload.handoff_thread_id === "string";
 


### PR DESCRIPTION
## Summary
- harden ACK-required parsing in reclaim signal generation
- treat ack_required / require_ack values of true, "true", "1", "yes", and 1 as ACK-required
- add focused reliability tests for string and numeric ACK flag payloads

## Scope
Small reliability-only change in reclaim telemetry classification for no-ACK handoff detection.

## Verification
- attempted reliability test run in workspace

## Risk
Low; only broadens ACK-required detection and preserves existing behavior for boolean true.
