### PR TITLE
docs(memory): align handler ops count to 18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ api/                            # Vercel serverless functions (REST API endpoint
 |------|---------|
 | `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and hidden internal meta-tools |
 | `packages/mcp-server/src/tool-wiring.ts` | Maps tool names to API calls |
-| `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (all 17 ops) |
+| `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (all 18 ops) |
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
 | `src/pages/Tools.tsx` | Website tools grid, one tile per integration |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ api/                            # Vercel serverless functions (REST API endpoint
 |------|---------|
 | `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and hidden internal meta-tools |
 | `packages/mcp-server/src/tool-wiring.ts` | Maps tool names to API calls |
-| `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (all 17 ops) |
+| `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (all 18 ops) |
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
 | `src/pages/Tools.tsx` | Website tools grid, one tile per integration |
 

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -1,7 +1,7 @@
 /**
  * Memory operation handlers for @unclick/mcp-server.
  *
- * Wraps the 17 memory operations (get_startup_context, search_memory, add_fact,
+ * Wraps the 18 memory operations (get_startup_context, search_memory, add_fact,
  * write_session_summary, etc.) as plain async functions that take a single
  * params object. Used by both direct MCP tools and the unclick_call meta-tool.
  */


### PR DESCRIPTION
## Summary
- align memory operation count in architecture docs and handler header comment from 17 to 18
- keep AGENTS and CLAUDE in sync with the current MEMORY_HANDLERS surface

## Scope
- AGENTS.md
- CLAUDE.md
- packages/mcp-server/src/memory/handlers.ts comment only

## Non-overlap
- docs/comment-only update, no runtime logic or API behavior changes
- no lockfiles, migrations, auth, secrets, analytics, workflows, or product UI touched

## Verification
- counted async handlers in MEMORY_HANDLERS and confirmed total is 18
- inspected git diff to ensure exactly three one-line edits

## Risk
- very low, documentation accuracy correction only

## Follow-up
- optional: add a tiny unit guard that asserts documented op count if the team wants drift prevention