### PR TITLE
Harden reliability heartbeat ETA parsing

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -100,6 +100,7 @@ import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/c
 import {
   createDispatchId,
   createHeartbeat,
+  parseHeartbeatEtaMinutes,
   createReclaimSignal,
   createTimeBucket,
   decideStaleLease,
@@ -5077,11 +5078,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 });
               }
             }
-            const etaMinutesRaw = body.eta_minutes;
-            const etaMinutes =
-              typeof etaMinutesRaw === "number" && Number.isFinite(etaMinutesRaw)
-                ? Math.max(0, Math.floor(etaMinutesRaw))
-                : undefined;
+            const etaMinutes = parseHeartbeatEtaMinutes(body.eta_minutes);
             const lastRealActionAt = body.last_real_action_at
               ? new Date(String(body.last_real_action_at))
               : new Date();

--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -7,6 +7,7 @@ import {
   createReclaimSignal,
   createTimeBucket,
   decideStaleLease,
+  parseHeartbeatEtaMinutes,
 } from "../reliability.js";
 
 describe("reliability helpers", () => {
@@ -170,6 +171,19 @@ describe("reliability helpers", () => {
       createdAt: "2026-04-30T11:00:00.000Z",
       lastRealActionAt: "2026-04-30T10:59:30.000Z",
     });
+  });
+
+  it("parses heartbeat ETA from number and numeric string inputs", () => {
+    expect(parseHeartbeatEtaMinutes(4.8)).toBe(4);
+    expect(parseHeartbeatEtaMinutes("12")).toBe(12);
+    expect(parseHeartbeatEtaMinutes(" 0 ")).toBe(0);
+  });
+
+  it("clamps invalid or extreme heartbeat ETA values safely", () => {
+    expect(parseHeartbeatEtaMinutes(-8)).toBe(0);
+    expect(parseHeartbeatEtaMinutes(20000)).toBe(10080);
+    expect(parseHeartbeatEtaMinutes("not-a-number")).toBeUndefined();
+    expect(parseHeartbeatEtaMinutes(null)).toBeUndefined();
   });
 
   it("creates operator-safe telemetry without tenant hash or payload", () => {

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -112,6 +112,8 @@ export interface OperatorTelemetry {
   staleSeconds?: number;
 }
 
+const MAX_HEARTBEAT_ETA_MINUTES = 7 * 24 * 60;
+
 export function createDispatchId(input: DispatchIdInput): string {
   const hash = createHash("sha256")
     .update(stableStringify(input))
@@ -217,6 +219,22 @@ export function createHeartbeat(params: {
   }
 
   return heartbeat;
+}
+
+export function parseHeartbeatEtaMinutes(value: unknown): number | undefined {
+  let parsed: number | null = null;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    parsed = value;
+  } else if (typeof value === "string" && value.trim()) {
+    const parsedString = Number(value);
+    if (Number.isFinite(parsedString)) {
+      parsed = parsedString;
+    }
+  }
+
+  if (parsed === null) return undefined;
+  const clamped = Math.max(0, Math.floor(parsed));
+  return Math.min(clamped, MAX_HEARTBEAT_ETA_MINUTES);
 }
 
 export function createOperatorTelemetry(input: {


### PR DESCRIPTION
## Summary\n- parse ta_minutes in reliability heartbeat publish path using a shared helper\n- accept numeric string ETA values for cross-client compatibility\n- clamp heartbeat ETA to safe bounds (0..10080 minutes)\n- add unit coverage for numeric, string, invalid, and extreme ETA inputs\n\n## Scope\n- reliability heartbeat robustness only\n\n## Verification\n- 
pm run test -- packages/mcp-server/src/__tests__/reliability.test.ts *(fails in this environment: itest not found on PATH)*\n