### PR TITLE
fix(testpass): make Vercel cron primary smoke clock

### DIFF
--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -118,6 +118,19 @@ status prose.
 Ready work should wake the right worker immediately instead of waiting for the
 next heartbeat. Cron remains the safety net, not the primary trigger.
 
+## Scheduled TestPass Clock
+
+GitHub Actions `schedule` is a backup clock, not the primary TestPass cadence.
+On 2026-05-01, the workflow was configured for every 5 minutes but natural
+GitHub runs arrived about 70 minutes apart during the first overnight proof
+window. Treat GitHub schedule events as useful receipts, not precise timing.
+
+Use Vercel Cron as the primary scheduled TestPass clock when the project plan
+supports minute-level cron. Keep the cron request authenticated with
+`CRON_SECRET`, include `source=scheduled`, and leave a TestPass run plus signal
+receipt so the fleet can prove unattended execution without reading provider
+logs.
+
 Wake targets:
 
 - Target: event-to-visible-worker-action under 2 minutes.

--- a/vercel.json
+++ b/vercel.json
@@ -42,8 +42,8 @@
       "schedule": "*/15 * * * *"
     },
     {
-      "path": "/api/testpass-run?pack_id=testpass-core&profile=smoke&server_url=https%3A%2F%2Funclick.world%2Fapi%2Fmcp",
-      "schedule": "*/15 * * * *"
+      "path": "/api/testpass-run?pack_id=testpass-core&profile=smoke&server_url=https%3A%2F%2Funclick.world%2Fapi%2Fmcp&source=scheduled",
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/uxpass-run?url=https%3A%2F%2Funclick.world&pack_slug=uxpass-core",


### PR DESCRIPTION
Summary: Document the observed GitHub Actions schedule drift and promote Vercel Cron as the primary TestPass clock. The Vercel TestPass cron now runs every 5 minutes and includes source=scheduled so runs leave clearer scheduled receipts/signals.

Scope: AUTOPILOT.md and vercel.json only.

Non-overlap: No TestPass runner logic, auth policy, database migrations, WakePass, Fishbowl UI, or dependencies.

Verification: Parsed vercel.json with Node and ran git diff --check. Researched Vercel, Cloudflare, cron-job.org, and UptimeRobot options against official docs/help pages.

Risk: Increased Vercel TestPass cron cadence from 15 minutes to 5 minutes. This uses Vercel Function/Supabase/MCP requests, not AI tokens. Requires a Vercel plan that supports minute-level cron; existing vercel.json already uses minute-level cron, so this appears compatible.

Follow-up: After merge/deploy, watch Vercel cron receipts/signals and compare against the flaky GitHub schedule backup.