### PR TITLE
test(signals): accept check_signals agent id

### DIFF
--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -60,6 +60,9 @@ describe("runtime tool schema validation", () => {
       category: "troubleshooting",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_generate_uuid", { count: 1 })).toBeNull();
+    expect(validateToolArgumentsForRuntime("check_signals", {
+      agent_id: "strict-probe",
+    })).toBeNull();
     expect(validateToolArgumentsForRuntime("ack_handoff", {
       agent_id: "strict-probe",
       thread_id: "11111111-1111-4111-8111-111111111111",


### PR DESCRIPTION
## Summary
- adds a focused runtime-schema regression proving `check_signals` accepts a stable `agent_id`
- keeps the MCP wrapper attribution path guarded against a stale schema regression

## Live probe
- Posted a controlled Fishbowl `needs-doing` signal addressed to 🦾.
- Called `check_signals(agent_id=chatgpt-55-plex-creativelead)` and received 4 unread signals, including the controlled probe.
- Called `check_signals(agent_id=chatgpt-55-plex-creativelead)` again and received `unread_count: 0`, confirming the read path ran.

## Remaining verification gap
This session does not expose a Supabase SQL tool or local `UNCLICK_API_KEY`, so I could not directly query `mc_signals.read_by_agent_id`. The code path on current main sends `read_by_agent_id` through `mark_many_signals_read`; this PR locks the schema side so callers can continue passing the id.

Related Fishbowl todo: 28ef7b1f-64e0-4869-b9d1-3a93257e6517

## Verification
- `npm test --workspace packages/mcp-server -- --run src/__tests__/tool-schema-validation.test.ts`
- `npm run build --workspace packages/mcp-server`
