### PR TITLE
Harden reliability heartbeat list filter parsing

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -101,6 +101,7 @@ import {
   createDispatchId,
   createHeartbeat,
   parseHeartbeatEtaMinutes,
+  parseOptionalFilterToken,
   createReclaimSignal,
   createTimeBucket,
   decideStaleLease,
@@ -5020,8 +5021,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         switch (method) {
           case "list": {
             const limit = getClampedLimit(req.query.limit ?? req.body?.limit, 50, 200);
-            const agentId = String(req.query.agent_id ?? req.body?.agent_id ?? "").trim();
-            const dispatchId = String(req.query.dispatch_id ?? req.body?.dispatch_id ?? "").trim();
+            const agentIdFilter = parseOptionalFilterToken(
+              req.query.agent_id ?? req.body?.agent_id,
+              "agent_id",
+              128,
+            );
+            if (agentIdFilter.error) {
+              return res.status(400).json({ error: agentIdFilter.error });
+            }
+
+            const dispatchIdFilter = parseOptionalFilterToken(
+              req.query.dispatch_id ?? req.body?.dispatch_id,
+              "dispatch_id",
+              256,
+            );
+            if (dispatchIdFilter.error) {
+              return res.status(400).json({ error: dispatchIdFilter.error });
+            }
             let query = supabase
               .from("mc_agent_heartbeats")
               .select(
@@ -5031,8 +5047,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               .order("created_at", { ascending: false })
               .limit(limit);
 
-            if (agentId) query = query.eq("agent_id", agentId);
-            if (dispatchId) query = query.eq("dispatch_id", dispatchId);
+            if (agentIdFilter.value) query = query.eq("agent_id", agentIdFilter.value);
+            if (dispatchIdFilter.value) query = query.eq("dispatch_id", dispatchIdFilter.value);
 
             const { data, error } = await query;
             if (error) throw error;

--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -3,6 +3,7 @@ import {
   createDispatchId,
   createHeartbeat,
   createOperatorTelemetry,
+  parseOptionalFilterToken,
   createQueuedDispatch,
   createReclaimSignal,
   createTimeBucket,
@@ -314,5 +315,30 @@ describe("reliability helpers", () => {
       stale_seconds: 12,
       route: "oauth-health",
     });
+  });
+
+  it("parses optional heartbeat list filters safely", () => {
+    expect(parseOptionalFilterToken(undefined, "agent_id")).toEqual({});
+    expect(parseOptionalFilterToken("  ", "agent_id")).toEqual({});
+    expect(parseOptionalFilterToken("worker_1", "agent_id")).toEqual({ value: "worker_1" });
+    expect(parseOptionalFilterToken("dispatch_abc", "dispatch_id", 256)).toEqual({
+      value: "dispatch_abc",
+    });
+  });
+
+  it("rejects malformed heartbeat list filters", () => {
+    expect(parseOptionalFilterToken(["bad"], "agent_id").error).toBe("agent_id must be a string");
+    expect(parseOptionalFilterToken("bad id", "agent_id").error).toBe(
+      "agent_id must not contain whitespace",
+    );
+    expect(parseOptionalFilterToken("bad\tid", "dispatch_id", 256).error).toBe(
+      "dispatch_id must not contain whitespace",
+    );
+    expect(parseOptionalFilterToken(`a${"\u0001"}b`, "agent_id").error).toBe(
+      "agent_id contains invalid control characters",
+    );
+    expect(parseOptionalFilterToken("x".repeat(257), "dispatch_id", 256).error).toBe(
+      "dispatch_id must be at most 256 characters",
+    );
   });
 });

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -114,6 +114,11 @@ export interface OperatorTelemetry {
 
 const MAX_HEARTBEAT_ETA_MINUTES = 7 * 24 * 60;
 
+export interface OptionalFilterTokenResult {
+  value?: string;
+  error?: string;
+}
+
 export function createDispatchId(input: DispatchIdInput): string {
   const hash = createHash("sha256")
     .update(stableStringify(input))
@@ -327,6 +332,31 @@ export function createReclaimSignal(
       ...payload,
     },
   };
+}
+
+export function parseOptionalFilterToken(
+  input: unknown,
+  fieldName: string,
+  maxLength = 128,
+): OptionalFilterTokenResult {
+  if (input == null) return {};
+  if (typeof input !== "string") {
+    return { error: `${fieldName} must be a string` };
+  }
+
+  const value = input.trim();
+  if (!value) return {};
+  if (value.length > maxLength) {
+    return { error: `${fieldName} must be at most ${maxLength} characters` };
+  }
+  if (/\s/.test(value)) {
+    return { error: `${fieldName} must not contain whitespace` };
+  }
+  if (/[\u0000-\u001F\u007F]/.test(value)) {
+    return { error: `${fieldName} contains invalid control characters` };
+  }
+
+  return { value };
 }
 
 function stableStringify(value: unknown): string {


### PR DESCRIPTION
## Summary
- harden reliability_heartbeats list filter parsing for optional agent_id and dispatch_id
- reject malformed non-string, whitespace-bearing, control-character, and overlong values with 400
- add focused reliability helper tests for valid and malformed filter token inputs

## Verification
- pnpm vitest packages/mcp-server/src/__tests__/reliability.test.ts *(fails in this environment: pnpm not installed)*
