### PR TITLE
test(wakepass): dogfood issue wake routes

### DIFF
--- a/.claude/agents/heartbeat.md
+++ b/.claude/agents/heartbeat.md
@@ -21,7 +21,8 @@ On every scheduled wake or direct trigger:
 4. Claim one small, clear chip only when it is safe and non-overlapping.
 5. Execute the smallest useful step.
 6. Post only material changes.
-7. Set status or next check-in when the tool surface supports it.
+7. Set status or next check-in before exit. This is mandatory after claiming,
+   touching, blocking, opening, updating, or merging work.
 8. Exit silently when there is no real change.
 
 ## Silent Exit Rule
@@ -68,6 +69,9 @@ eta: <short ETA>
 blocker: none
 tag: act
 ```
+
+Then set your status to the same chip and a short next check-in. If the status
+tool is unavailable, make the first line of the material post the status line.
 
 ## Material Post Rules
 
@@ -134,6 +138,7 @@ Do not double-start a PR or file set another active worker owns. Use helper agen
 Before ending the cycle:
 
 - If work changed, post one material Fishbowl update.
+- If work changed, set a compact status and next check-in.
 - If nothing changed, do not post.
 - If a todo is blocked, comment on that todo with the exact blocker.
 - If a PR is ready, include PR URL, head commit, changed files, and checks.

--- a/api/fishbowl-status.test.ts
+++ b/api/fishbowl-status.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { statusFromFishbowlPost } from "./lib/fishbowl-status";
+
+describe("statusFromFishbowlPost", () => {
+  it("uses the first non-empty line as the visible worker status", () => {
+    expect(statusFromFishbowlPost("\n\nUpdate: PR #328 is green\nnext: merge")).toBe(
+      "Update: PR #328 is green",
+    );
+  });
+
+  it("compacts whitespace and caps long status lines", () => {
+    const status = statusFromFishbowlPost(`  ${"x ".repeat(140)}  `);
+
+    expect(status).toHaveLength(200);
+    expect(status?.endsWith("...")).toBe(true);
+    expect(status).not.toContain("  ");
+  });
+
+  it("returns null for empty posts", () => {
+    expect(statusFromFishbowlPost(" \n\t ")).toBeNull();
+  });
+});

--- a/api/lib/fishbowl-status.ts
+++ b/api/lib/fishbowl-status.ts
@@ -1,0 +1,12 @@
+const MAX_STATUS_LENGTH = 200;
+
+export function statusFromFishbowlPost(text: string): string | null {
+  const firstLine = text
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .find((line) => line.length > 0);
+
+  if (!firstLine) return null;
+  if (firstLine.length <= MAX_STATUS_LENGTH) return firstLine;
+  return `${firstLine.slice(0, MAX_STATUS_LENGTH - 3)}...`;
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -96,6 +96,7 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
 import {
   createDispatchId,
@@ -7062,11 +7063,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (insertErr) throw insertErr;
 
         // Bump post-side presence so active authors do not look stale on Now Playing.
-        // Posting is a live pulse, so it clears any prior dead-man timer.
+        // Posting is a live pulse, so it refreshes status and clears any prior
+        // dead-man timer even when the worker skipped a separate set_status call.
         const postedAtIso = new Date().toISOString();
+        const statusFromPost = statusFromFishbowlPost(text);
+        const profileUpdate: Record<string, unknown> = {
+          last_seen_at: postedAtIso,
+          current_status_updated_at: postedAtIso,
+          next_checkin_at: null,
+        };
+        if (statusFromPost !== null) profileUpdate.current_status = statusFromPost;
         await supabase
           .from("mc_fishbowl_profiles")
-          .update({ last_seen_at: postedAtIso, current_status_updated_at: postedAtIso, next_checkin_at: null })
+          .update(profileUpdate)
           .eq("api_key_hash", apiKeyHash)
           .eq("agent_id", agentId);
 

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -16,6 +16,28 @@ const scriptPath = join(scriptDir, "event-wake-router.mjs");
 const repoRoot = dirname(scriptDir);
 
 describe("event wake router reliability dispatch", () => {
+  function runDryWake(eventName, event) {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(eventPath, JSON.stringify(event));
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_EVENT_NAME: eventName,
+        GITHUB_EVENT_PATH: eventPath,
+        WAKE_LEDGER_DIR: ledgerDir,
+        WAKE_ROUTER_DRY_RUN: "true",
+      },
+      encoding: "utf8",
+    });
+
+    rmSync(tempDir, { recursive: true, force: true });
+    return result;
+  }
+
   it("creates stable dispatch IDs from wake event IDs", () => {
     const first = wakeDispatchId("wake-workflow_run-workflow-run-123-abc");
     const second = wakeDispatchId("wake-workflow_run-workflow-run-123-abc");
@@ -111,5 +133,98 @@ describe("event wake router reliability dispatch", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("dogfoods issue comments with /wake into ACK-required dispatches", () => {
+    const result = runDryWake("issue_comment", {
+      action: "created",
+      issue: {
+        number: 170,
+        title: "Surface Drafts queue UI in Fishbowl admin",
+        html_url: "https://github.com/acme/repo/issues/170",
+      },
+      comment: {
+        id: 987,
+        body: "/wake please check this blocker",
+        created_at: "2026-04-30T15:00:00Z",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Manual wake command on issue\/PR #170/);
+    assert.match(result.stdout, /reliability_dispatch_dry_run/);
+    assert.match(result.stdout, /"ack_required": true/);
+  });
+
+  it("dogfoods assigned issues into normal-priority worker wakeups", () => {
+    const result = runDryWake("issues", {
+      action: "assigned",
+      issue: {
+        number: 132,
+        title: "feat: TestPass MCP tools + Orchestrator Wizard Phase 2",
+        html_url: "https://github.com/acme/repo/issues/132",
+        updated_at: "2026-04-30T15:00:00Z",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Issue #132 was assigned/);
+    assert.match(result.stdout, /"wake_urgency": "normal"/);
+  });
+
+  it("dogfoods labeled issues into normal-priority worker wakeups", () => {
+    const result = runDryWake("issues", {
+      action: "labeled",
+      issue: {
+        number: 143,
+        title: "Dependabot triage",
+        html_url: "https://github.com/acme/repo/issues/143",
+        updated_at: "2026-04-30T15:00:00Z",
+      },
+      label: { name: "dependencies" },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Issue #143 was labeled/);
+    assert.match(result.stdout, /"wake_urgency": "normal"/);
+  });
+
+  it("dogfoods ready PRs into high-priority worker wakeups", () => {
+    const result = runDryWake("pull_request", {
+      action: "ready_for_review",
+      number: 330,
+      pull_request: {
+        number: 330,
+        title: "Harden reliability heartbeat list filter parsing",
+        draft: false,
+        state: "open",
+        html_url: "https://github.com/acme/repo/pull/330",
+        updated_at: "2026-04-30T15:00:00Z",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /PR #330 is ready for review/);
+    assert.match(result.stdout, /"wake_urgency": "high"/);
+  });
+
+  it("keeps non-wake issue comments silent", () => {
+    const result = runDryWake("issue_comment", {
+      action: "created",
+      issue: {
+        number: 170,
+        title: "Surface Drafts queue UI in Fishbowl admin",
+        html_url: "https://github.com/acme/repo/issues/170",
+      },
+      comment: {
+        id: 988,
+        body: "Thanks, looks good.",
+        created_at: "2026-04-30T15:00:00Z",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /No wake needed/);
+    assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
   });
 });


### PR DESCRIPTION
## Summary
- Add dry-run dogfood coverage for WakePass issue/PR wake entry points: /wake issue comments, assigned issues, labeled issues, ready PRs, green workflow runs, and non-wake comments.
- Add a Fishbowl status safety net so material posts refresh visible worker status from the first line when a worker skips a separate status call.
- Tighten the heartbeat template so workers must pair material work with status and next check-in.

## Scope
- WakePass/Event Wake Router tests
- Fishbowl status presence update path
- Heartbeat worker instructions

## Non-overlap
- No secrets, auth, billing, migrations, broad UI, connector implementation, or dependency bumps.

## Verification
- node --test scripts/event-wake-router.test.mjs
- npx vitest run api/fishbowl-status.test.ts
- npm run build

## Risk
- Low. The production behavior change is limited to updating current_status from an already-posted Fishbowl message first line.

## Follow-up
- Once merged, keep the 15-minute heartbeat watching for active workers with blank/stale status.