### PR TITLE
docs(memory): fix remaining operation count in tool-surface docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Current summary:
 - Old memory tool names still work as aliases: `get_startup_context`, `write_session_summary`, `add_fact`, `set_business_context`
 - Signals and Fishbowl coordination tools are visible first-party tools for worker operation
 
-The other memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
+The other 13 memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
 
 ## Adding a new tool
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ These tools remain callable by name, but they are hidden from `ListTools` to kee
 - `check_signals` - check whether the agent should wake up or act
 - Fishbowl coordination tools such as `read_messages`, `post_message`, `create_todo`, `list_todos`, `update_todo`, `complete_todo`, `create_idea`, `list_ideas`, `vote_on_idea`, and `promote_idea_to_todo`
 
-The old tool names still work as aliases for backward compatibility. The other 12 memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
+The old tool names still work as aliases for backward compatibility. The other 13 memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
 
 ## Adding a new tool
 


### PR DESCRIPTION
## Summary
- Corrected memory operation count in canonical architecture docs.
- Updated both CLAUDE and AGENTS to state that 13 operations remain behind `unclick_call` after the 5 direct memory tools.

## Scope
- Docs-only change in two files:
  - `CLAUDE.md`
  - `AGENTS.md`

## Non-overlap
- No behavior, API, schema, workflow, or dependency changes.
- No changes to migrations, secrets, auth policy, payments, analytics, or CI config.

## Verification
- `node --test scripts/event-wake-router.test.mjs`
  - Pass: 9 passed, 0 failed.

## Risk
- Low. Copy correction only.

## Follow-up
- Optional: add an automated docs consistency check for memory operation counts to avoid future drift.