### PR TITLE
fix(deps): unblock zod 4 Dependabot update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21225,7 +21225,7 @@
         "marked": "^17.0.6",
         "nodemailer": "^8.0.5",
         "turndown": "^7.2.4",
-        "zod": "^3.23.8"
+        "zod": "^4.4.1"
       },
       "bin": {
         "unclick-mcp": "dist/index.js"
@@ -21281,6 +21281,15 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/mcp-server/node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "packages/memory-mcp": {
       "name": "@unclick/memory-mcp",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -40,7 +40,7 @@
     "marked": "^17.0.6",
     "nodemailer": "^8.0.5",
     "turndown": "^7.2.4",
-    "zod": "^3.23.8"
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## Summary\n- sync root package-lock.json with the packages/mcp-server zod 4 dependency bump\n- keep scope to dependency unblock only\n- no product feature changes\n\n## Context\nDependabot PR #6 fails Website (root package) with 
pm ci lock mismatch (Missing: zod@4.4.1 from lock file).\n\n## Validation\n- 
pm ci --no-audit --no-fund\n- 
pm run build\n- 
pm run build --workspace=packages/mcp-server\n