### PR TITLE
Harden reliability heartbeat publish token validation

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -103,6 +103,7 @@ import {
   createHeartbeat,
   parseHeartbeatEtaMinutes,
   parseOptionalFilterToken,
+  parseRequiredToken,
   createReclaimSignal,
   createTimeBucket,
   decideStaleLease,
@@ -5059,14 +5060,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           case "publish": {
             if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
             const body = (req.body ?? {}) as Record<string, unknown>;
-            const agentId = String(body.agent_id ?? "").trim();
             const state = body.state;
-            if (!agentId) return res.status(400).json({ error: "agent_id required" });
+            const agentIdResult = parseRequiredToken(body.agent_id, "agent_id", 128);
+            if (agentIdResult.error) return res.status(400).json({ error: agentIdResult.error });
+            const agentId = agentIdResult.value!;
             if (!isReliabilityHeartbeatState(state)) {
               return res.status(400).json({ error: "valid state required" });
             }
 
-            const dispatchId = String(body.dispatch_id ?? "").trim() || undefined;
+            const dispatchIdResult = parseOptionalFilterToken(body.dispatch_id, "dispatch_id", 256);
+            if (dispatchIdResult.error) {
+              return res.status(400).json({ error: dispatchIdResult.error });
+            }
+            const dispatchId = dispatchIdResult.value;
             let dispatchForHeartbeat: ReliabilityDispatchRow | null = null;
             if (dispatchId) {
               const { data: dispatchData, error: dispatchError } = await supabase

--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -4,6 +4,7 @@ import {
   createHeartbeat,
   createOperatorTelemetry,
   parseOptionalFilterToken,
+  parseRequiredToken,
   createQueuedDispatch,
   createReclaimSignal,
   createTimeBucket,
@@ -339,6 +340,21 @@ describe("reliability helpers", () => {
     );
     expect(parseOptionalFilterToken("x".repeat(257), "dispatch_id", 256).error).toBe(
       "dispatch_id must be at most 256 characters",
+    );
+  });
+
+  it("parses required publish tokens safely", () => {
+    expect(parseRequiredToken(" worker-1 ", "agent_id")).toEqual({ value: "worker-1" });
+    expect(parseRequiredToken(undefined, "agent_id")).toEqual({ error: "agent_id required" });
+    expect(parseRequiredToken("  ", "agent_id")).toEqual({ error: "agent_id required" });
+  });
+
+  it("rejects malformed required publish tokens", () => {
+    expect(parseRequiredToken("bad id", "agent_id").error).toBe(
+      "agent_id must not contain whitespace",
+    );
+    expect(parseRequiredToken("x".repeat(129), "agent_id", 128).error).toBe(
+      "agent_id must be at most 128 characters",
     );
   });
 });

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -119,6 +119,11 @@ export interface OptionalFilterTokenResult {
   error?: string;
 }
 
+export interface RequiredTokenResult {
+  value?: string;
+  error?: string;
+}
+
 export function createDispatchId(input: DispatchIdInput): string {
   const hash = createHash("sha256")
     .update(stableStringify(input))
@@ -357,6 +362,17 @@ export function parseOptionalFilterToken(
   }
 
   return { value };
+}
+
+export function parseRequiredToken(
+  input: unknown,
+  fieldName: string,
+  maxLength = 128,
+): RequiredTokenResult {
+  const parsed = parseOptionalFilterToken(input, fieldName, maxLength);
+  if (parsed.error) return parsed;
+  if (!parsed.value) return { error: `${fieldName} required` };
+  return { value: parsed.value };
 }
 
 function stableStringify(value: unknown): string {


### PR DESCRIPTION
## Summary\n- harden eliability_heartbeats publish input validation for gent_id and dispatch_id\n- reuse shared reliability token parsing rules so publish and list paths enforce the same constraints\n- add focused reliability helper tests for required-token behavior\n\n## Scope\n- reliability heartbeat publish path only\n- reliability helper parsing utilities and tests only\n\n## Verification\n- 
pm --prefix packages/mcp-server run test -- src/__tests__/reliability.test.ts *(fails in this environment: 	sx not found)*