### PR TITLE
docs(stats): sync tool count to 178

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The app store for AI agents.** [unclick.world](https://unclick.world)
 
-450+ callable endpoints across 172+ tools, available to any MCP-compatible AI client. New tools ship to the API continuously. Your agent picks them up automatically; no package update is needed.
+450+ callable endpoints across 178+ tools, available to any MCP-compatible AI client. New tools ship to the API continuously. Your agent picks them up automatically; no package update is needed.
 <!-- Update counts from src/config/site-stats.ts -->
 
 ## Install

--- a/src/config/site-stats.ts
+++ b/src/config/site-stats.ts
@@ -1,11 +1,11 @@
 // SINGLE SOURCE OF TRUTH for all site-wide statistics
 // Update these numbers here and they propagate everywhere
-// Last updated: 2026-04-11
+// Last updated: 2026-05-01
 
 export const SITE_STATS = {
   // Tool counts
   TOOL_GROUPS: 21,           // Number of tool groups in the hosted API catalog
-  TOOL_FILES: 172,           // Number of tool files in the repo
+  TOOL_FILES: 178,           // Number of tool files in the repo
   CALLABLE_ENDPOINTS: 450,   // Total callable endpoints across all tools
 
   // BackstagePass


### PR DESCRIPTION
## Summary
- sync public tool-count claims from 172 to 178
- update single source of truth in `src/config/site-stats.ts`
- align README headline count with the updated stat

## Scope
- docs/stats only (`README.md`, `src/config/site-stats.ts`)
- no runtime logic changes

## Non-overlap
- does not touch prior overnight PR #332 (memory operation count fix)
- does not modify workflows, auth, secrets, migrations, or lockfiles

## Verification
- `node --test scripts/event-wake-router.test.mjs` (pass, 9/9)
- counted current tool files with PowerShell: `Get-ChildItem packages/mcp-server/src -Filter *-tool.ts -File | Measure-Object`

## Risk
- low: string/count update only

## Follow-up
- optional: add a CI drift check to compare README/site stats against generated tool counts