### PR TITLE
Harden reclaim ACK classification for empty handoff IDs

### DIFF
--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -294,6 +294,31 @@ describe("reliability helpers", () => {
     expect(numericAck.action).toBe("handoff_ack_missing");
   });
 
+  it("requires non-empty handoff IDs before classifying as missing ACK", () => {
+    const emptyHandoff = createReclaimSignal(
+      {
+        dispatchId: "dispatch_empty_handoff",
+        source: "wakepass",
+        targetAgentId: "coder",
+        payload: { handoff_message_id: "   " },
+      },
+      61,
+    );
+
+    const validHandoff = createReclaimSignal(
+      {
+        dispatchId: "dispatch_valid_handoff",
+        source: "wakepass",
+        targetAgentId: "coder",
+        payload: { handoff_thread_id: "thread-123" },
+      },
+      61,
+    );
+
+    expect(emptyHandoff.action).toBe("stale_dispatch_reclaimed");
+    expect(validHandoff.action).toBe("handoff_ack_missing");
+  });
+
   it("marks non-ack reclaim as a generic stale dispatch", () => {
     const signal = createReclaimSignal(
       {

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -295,6 +295,8 @@ export function createReclaimSignal(
   staleSeconds: number,
 ): ReclaimSignalDescriptor {
   const payload = dispatch.payload ?? {};
+  const hasNonEmptyString = (value: unknown): boolean =>
+    typeof value === "string" && value.trim().length > 0;
   const hasAckFlag = (value: unknown): boolean => {
     if (value === true) return true;
     if (typeof value === "string") {
@@ -307,8 +309,8 @@ export function createReclaimSignal(
   const expectsAck =
     hasAckFlag(payload.ack_required) ||
     hasAckFlag(payload.require_ack) ||
-    typeof payload.handoff_message_id === "string" ||
-    typeof payload.handoff_thread_id === "string";
+    hasNonEmptyString(payload.handoff_message_id) ||
+    hasNonEmptyString(payload.handoff_thread_id);
 
   if (expectsAck) {
     return {


### PR DESCRIPTION
## Summary\n- treat handoff_message_id and handoff_thread_id as ACK indicators only when non-empty trimmed strings\n- avoid false handoff_ack_missing signals for empty handoff ID payloads\n- add focused reliability helper tests for empty vs valid handoff IDs\n\n## Verification\n- npx vitest run packages/mcp-server/src/__tests__/reliability.test.ts *(fails in this environment: missing vitest/tooling dependencies)*\n