### PR TITLE
feat(dogfood): add public report shell

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -1,0 +1,54 @@
+{
+  "generatedAt": "2026-05-01T00:50:00Z",
+  "source": "public seed receipt",
+  "headline": "We dogfood UnClick on UnClick.",
+  "target": "UnClick public and agent-facing product surfaces",
+  "nextAutomation": "Automated receipts will replace this seed as the dogfood loop expands.",
+  "results": [
+    {
+      "id": "testpass",
+      "name": "TestPass",
+      "status": "passing",
+      "summary": "PR smoke checks are producing green receipts.",
+      "evidence": "Recent TestPass PR checks completed successfully on UnClick PRs."
+    },
+    {
+      "id": "uxpass",
+      "name": "UXPass",
+      "status": "pending",
+      "summary": "Queued for recurring UX review.",
+      "evidence": "Public UX receipts will appear here once recurring checks begin."
+    },
+    {
+      "id": "seopass",
+      "name": "SEOPass",
+      "status": "pending",
+      "summary": "Queued for recurring search and metadata review.",
+      "evidence": "Public SEO receipts will appear here once recurring checks begin."
+    },
+    {
+      "id": "copypass",
+      "name": "CopyPass",
+      "status": "pending",
+      "summary": "Queued for recurring copy quality review.",
+      "evidence": "Public copy-quality receipts will appear here once recurring checks begin."
+    },
+    {
+      "id": "legalpass",
+      "name": "LegalPass",
+      "status": "pending",
+      "summary": "Queued for recurring policy and claims review.",
+      "evidence": "Public legal-quality receipts will appear here once recurring checks begin."
+    }
+  ],
+  "trend": [
+    { "date": "2026-04-29", "passing": 0, "failing": 0, "pending": 5 },
+    { "date": "2026-04-30", "passing": 1, "failing": 0, "pending": 4 },
+    { "date": "2026-05-01", "passing": 1, "failing": 0, "pending": 4 }
+  ],
+  "lastActionableFailure": {
+    "title": "Canonical public check target needs confirmation",
+    "detail": "The next automated receipt should lock the exact public URL set that represents UnClick's production experience.",
+    "owner": "Dogfood automation follow-up"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import ToolsPage from "./pages/Tools.tsx";
 import NewToAIPage from "./pages/NewToAI.tsx";
 import SmartHomePage from "./pages/SmartHome.tsx";
 import InstallRecoverPage from "./pages/InstallRecover.tsx";
+import DogfoodReportPage from "./pages/DogfoodReport.tsx";
 import LoginPage from "./pages/Login.tsx";
 import SignupPage from "./pages/Signup.tsx";
 import AuthCallbackPage from "./pages/AuthCallback.tsx";
@@ -169,6 +170,7 @@ const App = () => (
           <Route path="/organiser" element={<OrganiserPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />
           <Route path="/crews" element={<CrewsPage />} />
+          <Route path="/dogfood" element={<DogfoodReportPage />} />
           <Route path="/build" element={<BuildDeskPage />} />
           <Route path="/new-to-ai" element={<NewToAIPage />} />
           <Route path="/smarthome" element={<SmartHomePage />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,6 +5,7 @@ const PRODUCT_LINKS = [
   { label: "Memory", href: "/memory" },
   { label: "Connections", href: "/admin/keychain" },
   { label: "TestPass", href: "/admin/testpass" },
+  { label: "Dogfood Report", href: "/dogfood" },
 ];
 
 const RESOURCES_LINKS = [

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -1,0 +1,71 @@
+export type DogfoodStatus = "passing" | "failing" | "pending";
+
+export interface DogfoodPassResult {
+  id: string;
+  name: string;
+  status: DogfoodStatus;
+  summary: string;
+  evidence: string;
+}
+
+export interface DogfoodTrendPoint {
+  date: string;
+  passing: number;
+  failing: number;
+  pending: number;
+}
+
+export const dogfoodReport = {
+  generatedAt: "2026-05-01T00:50:00Z",
+  source: "public seed receipt",
+  headline: "We dogfood UnClick on UnClick.",
+  target: "UnClick public and agent-facing product surfaces",
+  nextAutomation: "Automated receipts will replace this seed as the dogfood loop expands.",
+  results: [
+    {
+      id: "testpass",
+      name: "TestPass",
+      status: "passing",
+      summary: "PR smoke checks are producing green receipts.",
+      evidence: "Recent TestPass PR checks completed successfully on UnClick PRs.",
+    },
+    {
+      id: "uxpass",
+      name: "UXPass",
+      status: "pending",
+      summary: "Queued for recurring UX review.",
+      evidence: "Public UX receipts will appear here once recurring checks begin.",
+    },
+    {
+      id: "seopass",
+      name: "SEOPass",
+      status: "pending",
+      summary: "Queued for recurring search and metadata review.",
+      evidence: "Public SEO receipts will appear here once recurring checks begin.",
+    },
+    {
+      id: "copypass",
+      name: "CopyPass",
+      status: "pending",
+      summary: "Queued for recurring copy quality review.",
+      evidence: "Public copy-quality receipts will appear here once recurring checks begin.",
+    },
+    {
+      id: "legalpass",
+      name: "LegalPass",
+      status: "pending",
+      summary: "Queued for recurring policy and claims review.",
+      evidence: "Public legal-quality receipts will appear here once recurring checks begin.",
+    },
+  ] satisfies DogfoodPassResult[],
+  trend: [
+    { date: "2026-04-29", passing: 0, failing: 0, pending: 5 },
+    { date: "2026-04-30", passing: 1, failing: 0, pending: 4 },
+    { date: "2026-05-01", passing: 1, failing: 0, pending: 4 },
+  ] satisfies DogfoodTrendPoint[],
+  lastActionableFailure: {
+    title: "Canonical public check target needs confirmation",
+    detail: "The next automated receipt should lock the exact public URL set that represents UnClick's production experience.",
+    owner: "Dogfood automation follow-up",
+  },
+};

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useMemo, useState } from "react";
+import { Activity, AlertTriangle, CheckCircle2, Clock3, ExternalLink } from "lucide-react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import FadeIn from "@/components/FadeIn";
+import { useCanonical } from "@/hooks/use-canonical";
+import { useMetaTags } from "@/hooks/useMetaTags";
+import { dogfoodReport as fallbackReport, type DogfoodPassResult, type DogfoodStatus } from "@/data/dogfoodReport";
+
+type DogfoodReportData = typeof fallbackReport;
+
+const STATUS_STYLES: Record<DogfoodStatus, { label: string; badge: string; icon: typeof CheckCircle2 }> = {
+  passing: {
+    label: "Passing",
+    badge: "border-emerald-400/20 bg-emerald-400/10 text-emerald-200",
+    icon: CheckCircle2,
+  },
+  failing: {
+    label: "Needs action",
+    badge: "border-red-400/20 bg-red-400/10 text-red-200",
+    icon: AlertTriangle,
+  },
+  pending: {
+    label: "Pending",
+    badge: "border-amber-400/20 bg-amber-400/10 text-amber-200",
+    icon: Clock3,
+  },
+};
+
+function countByStatus(results: DogfoodPassResult[], status: DogfoodStatus): number {
+  return results.filter((result) => result.status === status).length;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export default function DogfoodReportPage() {
+  const [report, setReport] = useState<DogfoodReportData>(fallbackReport);
+
+  useCanonical("/dogfood");
+  useMetaTags({
+    title: "UnClick Dogfood Report - We Run UnClick on UnClick",
+    description: "Public dogfood receipt for UnClick Pass-family checks running against UnClick itself.",
+    ogTitle: "UnClick Dogfood Report",
+    ogDescription: "We dogfood UnClick on UnClick. Public Pass-family quality receipts.",
+    ogUrl: "https://unclick.world/dogfood",
+  });
+
+  useEffect(() => {
+    fetch("/dogfood/latest.json", { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : fallbackReport))
+      .then((data: DogfoodReportData) => setReport(data))
+      .catch(() => setReport(fallbackReport));
+  }, []);
+
+  const counts = useMemo(() => ({
+    passing: countByStatus(report.results, "passing"),
+    failing: countByStatus(report.results, "failing"),
+    pending: countByStatus(report.results, "pending"),
+  }), [report.results]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar />
+
+      <main className="px-6 pt-28 pb-16">
+        <section className="mx-auto max-w-5xl">
+          <FadeIn>
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-1.5 text-xs font-medium text-primary">
+              <Activity className="h-3.5 w-3.5" />
+              Public dogfood receipt
+            </div>
+          </FadeIn>
+
+          <FadeIn delay={0.05}>
+            <div className="mt-6 grid gap-8 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
+              <div>
+                <h1 className="text-4xl font-semibold tracking-tight text-heading sm:text-5xl">
+                  {report.headline}
+                </h1>
+                <p className="mt-4 max-w-2xl text-lg leading-relaxed text-body">
+                  This is the public receipt board for UnClick's own Pass-family checks. Today it
+                  shows the first receipt contract; future receipts will update it with fresh
+                  automated evidence.
+                </p>
+              </div>
+
+              <div className="rounded-2xl border border-border/70 bg-card/60 p-5 shadow-lg shadow-black/10">
+                <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">
+                  Latest receipt
+                </p>
+                <p className="mt-2 text-sm text-heading">{formatDate(report.generatedAt)}</p>
+                <p className="mt-3 text-xs leading-relaxed text-body">{report.nextAutomation}</p>
+              </div>
+            </div>
+          </FadeIn>
+        </section>
+
+        <section className="mx-auto mt-10 grid max-w-5xl gap-4 sm:grid-cols-3">
+          {([
+            ["Passing", counts.passing, "text-emerald-200"],
+            ["Needs action", counts.failing, "text-red-200"],
+            ["Pending automation", counts.pending, "text-amber-200"],
+          ] as const).map(([label, value, className]) => (
+            <FadeIn key={label} delay={0.08}>
+              <div className="rounded-2xl border border-border/70 bg-card/40 p-5">
+                <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">{label}</p>
+                <p className={`mt-2 text-4xl font-semibold ${className}`}>{value}</p>
+              </div>
+            </FadeIn>
+          ))}
+        </section>
+
+        <section className="mx-auto mt-10 max-w-5xl">
+          <div className="grid gap-4 md:grid-cols-2">
+            {report.results.map((result, index) => {
+              const status = STATUS_STYLES[result.status];
+              const Icon = status.icon;
+
+              return (
+                <FadeIn key={result.id} delay={0.04 * index}>
+                  <article className="h-full rounded-2xl border border-border/70 bg-card/40 p-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h2 className="text-lg font-semibold text-heading">{result.name}</h2>
+                        <p className="mt-2 text-sm leading-relaxed text-body">{result.summary}</p>
+                      </div>
+                      <span className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium ${status.badge}`}>
+                        <Icon className="h-3.5 w-3.5" />
+                        {status.label}
+                      </span>
+                    </div>
+                    <p className="mt-4 rounded-xl border border-border/50 bg-background/40 p-3 text-xs leading-relaxed text-muted-custom">
+                      {result.evidence}
+                    </p>
+                  </article>
+                </FadeIn>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="mx-auto mt-10 grid max-w-5xl gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+          <FadeIn>
+            <div className="rounded-2xl border border-border/70 bg-card/40 p-5">
+              <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">
+                Last actionable failure
+              </p>
+              <h2 className="mt-3 text-lg font-semibold text-heading">{report.lastActionableFailure.title}</h2>
+              <p className="mt-2 text-sm leading-relaxed text-body">{report.lastActionableFailure.detail}</p>
+              <p className="mt-4 text-xs text-muted-custom">Owner: {report.lastActionableFailure.owner}</p>
+            </div>
+          </FadeIn>
+
+          <FadeIn delay={0.05}>
+            <div className="rounded-2xl border border-border/70 bg-card/40 p-5">
+              <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">7-day trend seed</p>
+              <div className="mt-4 overflow-hidden rounded-xl border border-border/60">
+                {report.trend.map((point) => (
+                  <div key={point.date} className="grid grid-cols-4 gap-2 border-b border-border/50 px-4 py-3 text-xs last:border-b-0">
+                    <span className="text-heading">{point.date}</span>
+                    <span className="text-emerald-200">Pass {point.passing}</span>
+                    <span className="text-red-200">Fail {point.failing}</span>
+                    <span className="text-amber-200">Pending {point.pending}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </FadeIn>
+        </section>
+
+        <section className="mx-auto mt-10 max-w-5xl">
+          <a
+            href="/dogfood/latest.json"
+            className="inline-flex items-center gap-2 text-sm font-medium text-primary transition-opacity hover:opacity-80"
+          >
+            View public JSON receipt
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add public `/dogfood` report page for the first UnClick-on-UnClick receipt surface
- add `/dogfood/latest.json` public receipt seed plus typed fallback data
- link Dogfood Report from the public footer

## Owned files
- `src/pages/DogfoodReport.tsx`
- `src/data/dogfoodReport.ts`
- `public/dogfood/latest.json`
- `src/App.tsx`
- `src/components/Footer.tsx`

## Scope guard
- No Pass runner internals changed
- No cron/workflow changes in this slice
- No secrets or live credentials required
- No admin report/API expansion

## Verification
- `npm run build`
- sidecar review caught public-copy leakage; fixed before PR

## Follow-up blocker
- Nightly all-Pass execution still needs a separate runner PR plus confirmation of the public target URL set and required cron secrets.

Todo: 006f6fa7-07be-4080-9e99-8c168cc7cd00