### PR TITLE
fix(wakepass): register wake proof before routing

### DIFF
--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -118,6 +118,12 @@ status prose.
 Ready work should wake the right worker immediately instead of waiting for the
 next heartbeat. Cron remains the safety net, not the primary trigger.
 
+PinballWake should be called before the first delivery route for any event that
+expects a worker ACK. That gives the event an idempotent dispatch, lease, and
+reclaim path even if the first route fails. Do not wrap quiet health checks,
+dashboard reads, or zero-event heartbeats in PinballWake, because that creates
+alert noise without useful recovery.
+
 ## Scheduled TestPass Clock
 
 GitHub Actions `schedule` is a backup clock, not the primary TestPass cadence.

--- a/docs/prd/wakepass.md
+++ b/docs/prd/wakepass.md
@@ -133,6 +133,33 @@ Start with five routes:
 
 Browser extension routes come later through UnClick Local.
 
+## Where to call PinballWake
+
+PinballWake should sit at the start of any wake or handoff path that needs proof
+of delivery. Create the wake record before the first route is attempted, then let
+ACKs, heartbeats, leases, and reclaim decide whether the handoff landed.
+
+Use PinballWake for:
+
+- PR-ready, review-requested, green-check, and blocker-cleared events
+- direct Fishbowl handoffs that expect a worker response
+- scheduled TestPass, UXPass, FlowPass, SecurityPass, and rescan jobs
+- connector health failures that need an owner to refresh or reconnect
+- stale worker status, missed check-ins, and stuck Pass runs
+- manual `/wake` commands from GitHub, Fishbowl, or an operator surface
+
+Do not use PinballWake for:
+
+- zero-event heartbeat cycles
+- read-only status refreshes
+- dashboard page loads
+- duplicate comments on the same wake event
+- broad market or product research that does not hand work to a worker
+
+The risk of overuse is noisy alerts, duplicate leases, false missing-ACK signals,
+and worker fatigue. The rule is simple: if someone must ACK or take action, call
+PinballWake early. If nothing needs action, stay silent.
+
 ## ACK schema
 
 The first ACK object should include:

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -313,6 +313,7 @@ export function buildReliabilityDispatchRequest({
     payload: {
       ack_required: true,
       handoff_message_id: result?.message_id ?? null,
+      route_attempted: "fishbowl",
       wake_event_id: eventId,
       wake_reason: decision.reason,
       wake_urgency: decision.urgency,
@@ -497,14 +498,20 @@ async function main() {
     return;
   }
 
+  const reliability = await registerWakeDispatch({
+    eventId,
+    decision: finalDecision,
+    triage,
+    result: null,
+    event,
+  });
   const result = await postWake(finalDecision, triage, eventId, event);
-  const reliability =
-    result.posted || result.dry_run
-      ? await registerWakeDispatch({ eventId, decision: finalDecision, triage, result, event })
-      : null;
   const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
   writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, status });
-  if ((!result.posted && !result.dry_run) || (result.posted && !reliability?.registered)) {
+  if (
+    (!result.posted && !result.dry_run) ||
+    (!reliability?.registered && !reliability?.dry_run)
+  ) {
     process.exitCode = 1;
   }
 }

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -71,6 +71,7 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(request.task_ref, "wake-workflow_run-workflow-run-123-abc");
     assert.equal(request.payload.ack_required, true);
     assert.equal(request.payload.handoff_message_id, "msg-123");
+    assert.equal(request.payload.route_attempted, "fishbowl");
     assert.equal(request.payload.ack_fail_after_seconds, 600);
     assert.equal(request.payload.wake_owner, "🤖");
     assert.equal(request.payload.github_subject, "workflow-run-123");
@@ -91,6 +92,25 @@ describe("event wake router reliability dispatch", () => {
 
     assert.equal(request.time_bucket_seconds, 600);
     assert.equal(request.payload.ack_fail_after_seconds, 600);
+  });
+
+  it("can register PinballWake proof before the Fishbowl route returns", () => {
+    const request = buildReliabilityDispatchRequest({
+      eventId: "wake-workflow_run-workflow-run-789-ghi",
+      decision: {
+        owner: "🤖",
+        reason: "PR checks completed green",
+        urgency: "high",
+      },
+      triage: { used: false },
+      result: null,
+      event: { workflow_run: { id: 789 } },
+    });
+
+    assert.equal(request.source, "wakepass");
+    assert.equal(request.payload.ack_required, true);
+    assert.equal(request.payload.route_attempted, "fishbowl");
+    assert.equal(request.payload.handoff_message_id, null);
   });
 
   it("runs the wake path in dry-run mode without crashing", () => {
@@ -129,6 +149,11 @@ describe("event wake router reliability dispatch", () => {
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stdout, /reliability_dispatch_dry_run/);
+      assert.ok(
+        result.stdout.indexOf("reliability_dispatch_dry_run") <
+          result.stdout.indexOf('"text": "Wake event id:'),
+        "PinballWake reliability proof should be prepared before the Fishbowl route payload",
+      );
       assert.doesNotMatch(result.stderr, /ReferenceError/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Summary:
- Register WakePass/PinballWake reliability dispatch proof before the first Fishbowl route is attempted.
- Keep ACK-required metadata on the dispatch even when the Fishbowl route has not returned a message id yet.
- Document where PinballWake should and should not be called so it improves throughput without creating alert noise.

Scope:
- Wake router script and focused wake-router tests.
- WakePass PRD and Autopilot event-wakeup guidance.

Non-overlap:
- No connector schema changes.
- No scheduler cadence changes.
- No secrets, domains, billing, migrations, or workflow config changes.

Verification:
- node --test scripts/event-wake-router.test.mjs
- npm run build
- git diff --check

Risk:
- Low. Wake events now create the reliability record earlier; overuse is explicitly guarded in docs by limiting PinballWake to ACK/action-needed paths.