### PR TITLE
feat(dogfood): add nightly receipt runner

### DIFF
--- a/.github/workflows/dogfood-report.yml
+++ b/.github/workflows/dogfood-report.yml
@@ -1,0 +1,72 @@
+name: Dogfood Report
+
+on:
+  schedule:
+    - cron: "17 16 * * *"
+  workflow_dispatch:
+    inputs:
+      public_url:
+        description: Public UnClick URL for UXPass.
+        required: false
+        default: https://unclick.world
+      mcp_url:
+        description: MCP endpoint URL for TestPass.
+        required: false
+        default: https://unclick.world/api/mcp
+
+permissions:
+  contents: write
+
+jobs:
+  dogfood-report:
+    name: Build public dogfood receipt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Build receipt
+        env:
+          DOGFOOD_API_BASE: https://unclick.world
+          DOGFOOD_PUBLIC_URL: ${{ inputs.public_url || 'https://unclick.world' }}
+          DOGFOOD_MCP_URL: ${{ inputs.mcp_url || 'https://unclick.world/api/mcp' }}
+          DOGFOOD_TESTPASS_TOKEN: ${{ secrets.TESTPASS_TOKEN }}
+          DOGFOOD_UXPASS_TOKEN: ${{ secrets.UXPASS_TOKEN || secrets.CRON_SECRET }}
+        run: node scripts/build-dogfood-report.mjs
+
+      - name: Upload receipt artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dogfood-latest
+          path: public/dogfood/latest.json
+
+      - name: Summarize receipt
+        shell: bash
+        run: |
+          {
+            echo "### Public dogfood receipt"
+            echo ""
+            echo "- Output: \`public/dogfood/latest.json\`"
+            echo "- Public URL: \`${{ inputs.public_url || 'https://unclick.world' }}\`"
+            echo "- MCP URL: \`${{ inputs.mcp_url || 'https://unclick.world/api/mcp' }}\`"
+            echo ""
+            jq -r '.results[] | "- \(.name): \(.status) - \(.summary)"' public/dogfood/latest.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit public receipt
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/dogfood/latest.json
+          if git diff --cached --quiet; then
+            echo "Dogfood receipt unchanged."
+            exit 0
+          fi
+          git commit -m "chore(dogfood): update public receipt"
+          git push

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run") || process.env.DOGFOOD_DRY_RUN === "1";
+const outputIndex = process.argv.indexOf("--output");
+const outputPath =
+  outputIndex >= 0 && process.argv[outputIndex + 1]
+    ? process.argv[outputIndex + 1]
+    : "public/dogfood/latest.json";
+
+const apiBase = trimTrailingSlash(process.env.DOGFOOD_API_BASE || "https://unclick.world");
+const publicUrl = process.env.DOGFOOD_PUBLIC_URL || "https://unclick.world";
+const mcpUrl = process.env.DOGFOOD_MCP_URL || "https://unclick.world/api/mcp";
+const generatedAt = new Date().toISOString();
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, "");
+}
+
+function statusFromFailureKind(failureKind) {
+  if (failureKind === "missing_secret") return "failing";
+  if (failureKind === "network" || failureKind === "http" || failureKind === "parse") return "failing";
+  return "pending";
+}
+
+function pendingResult(id, name, summary, evidence) {
+  return { id, name, status: "pending", summary, evidence };
+}
+
+function failureResult(id, name, summary, evidence) {
+  return { id, name, status: "failing", summary, evidence };
+}
+
+function passResult(id, name, summary, evidence) {
+  return { id, name, status: "passing", summary, evidence };
+}
+
+async function postJson(url, token, body) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  let json = {};
+  try {
+    json = await res.json();
+  } catch {
+    json = {};
+  }
+
+  return { ok: res.ok, status: res.status, json };
+}
+
+async function runTestPass() {
+  const token = process.env.DOGFOOD_TESTPASS_TOKEN || process.env.TESTPASS_TOKEN || "";
+  if (dryRun) {
+    return passResult(
+      "testpass",
+      "TestPass",
+      "Dry-run receipt builder validated the TestPass result shape.",
+      "Dry run only. Live workflow calls /api/testpass-run with source=scheduled.",
+    );
+  }
+  if (!token) {
+    return failureResult(
+      "testpass",
+      "TestPass",
+      "Scheduled TestPass could not run because DOGFOOD_TESTPASS_TOKEN or TESTPASS_TOKEN is missing.",
+      "Set the GitHub secret so the nightly dogfood workflow can create a fresh testpass_runs row.",
+    );
+  }
+
+  try {
+    const { ok, status, json } = await postJson(`${apiBase}/api/testpass-run`, token, {
+      pack_id: "testpass-core",
+      profile: "smoke",
+      server_url: mcpUrl,
+      source: "scheduled",
+    });
+
+    if (!ok) {
+      return failureResult(
+        "testpass",
+        "TestPass",
+        `Scheduled TestPass API call returned HTTP ${status}.`,
+        json.error ? `API error: ${json.error}` : "The API did not return an error body.",
+      );
+    }
+
+    const summary = json.verdict_summary || {};
+    const failCount = Number(summary.fail || 0);
+    const total = Number(summary.total || 0);
+    const runId = json.run_id || "unknown";
+    if (json.status === "complete" && failCount === 0) {
+      return passResult(
+        "testpass",
+        "TestPass",
+        `Scheduled TestPass completed with ${total} checks and 0 failures.`,
+        `Run ${runId} checked ${mcpUrl}.`,
+      );
+    }
+
+    const statusLabel = json.status || "unknown";
+    return {
+      id: "testpass",
+      name: "TestPass",
+      status: statusFromFailureKind(statusLabel === "running" ? "pending" : "http"),
+      summary: `Scheduled TestPass returned status ${statusLabel} with ${failCount} failures.`,
+      evidence: `Run ${runId} checked ${mcpUrl}.`,
+    };
+  } catch (err) {
+    return failureResult(
+      "testpass",
+      "TestPass",
+      "Scheduled TestPass could not reach the API.",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+async function runUXPass() {
+  const token = process.env.DOGFOOD_UXPASS_TOKEN || process.env.UXPASS_TOKEN || process.env.CRON_SECRET || "";
+  if (dryRun) {
+    return passResult(
+      "uxpass",
+      "UXPass",
+      "Dry-run receipt builder validated the UXPass result shape.",
+      "Dry run only. Live workflow calls /api/uxpass-run against the public URL.",
+    );
+  }
+  if (!token) {
+    return failureResult(
+      "uxpass",
+      "UXPass",
+      "Scheduled UXPass could not run because DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET is missing.",
+      "Set one workflow secret so the nightly dogfood workflow can create a fresh uxpass_runs row.",
+    );
+  }
+
+  try {
+    const { ok, status, json } = await postJson(`${apiBase}/api/uxpass-run`, token, {
+      url: publicUrl,
+      target_url: publicUrl,
+    });
+
+    if (!ok) {
+      return failureResult(
+        "uxpass",
+        "UXPass",
+        `Scheduled UXPass API call returned HTTP ${status}.`,
+        json.error ? `API error: ${json.error}` : "The API did not return an error body.",
+      );
+    }
+
+    const runId = json.run_id || "unknown";
+    const uxScore = typeof json.ux_score === "number" ? json.ux_score : null;
+    if (json.status === "complete" && (uxScore === null || uxScore >= 80)) {
+      return passResult(
+        "uxpass",
+        "UXPass",
+        `Scheduled UXPass completed${uxScore === null ? "" : ` with UX score ${uxScore}`}.`,
+        `Run ${runId} checked ${publicUrl}.`,
+      );
+    }
+
+    return failureResult(
+      "uxpass",
+      "UXPass",
+      `Scheduled UXPass returned status ${json.status || "unknown"}${uxScore === null ? "" : ` with UX score ${uxScore}`}.`,
+      `Run ${runId} checked ${publicUrl}.`,
+    );
+  } catch (err) {
+    return failureResult(
+      "uxpass",
+      "UXPass",
+      "Scheduled UXPass could not reach the API.",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+function buildTrend(results) {
+  const today = generatedAt.slice(0, 10);
+  return [{
+    date: today,
+    passing: results.filter((result) => result.status === "passing").length,
+    failing: results.filter((result) => result.status === "failing").length,
+    pending: results.filter((result) => result.status === "pending").length,
+  }];
+}
+
+function buildLastActionableFailure(results) {
+  const failing = results.find((result) => result.status === "failing");
+  if (!failing) {
+    return {
+      title: "No actionable dogfood failure in the latest receipt",
+      detail: "The live checks that ran in this receipt did not report a blocking failure.",
+      owner: "Dogfood automation",
+    };
+  }
+
+  return {
+    title: `${failing.name} needs attention`,
+    detail: failing.summary,
+    owner: "Dogfood automation",
+  };
+}
+
+const results = [
+  await runTestPass(),
+  await runUXPass(),
+  pendingResult(
+    "seopass",
+    "SEOPass",
+    "Queued for recurring search and metadata review.",
+    "SEOPass is still scaffold-only for public dogfood receipts.",
+  ),
+  pendingResult(
+    "copypass",
+    "CopyPass",
+    "Queued for recurring copy quality review.",
+    "CopyPass recurring public receipts will land after the runner surface is available.",
+  ),
+  pendingResult(
+    "legalpass",
+    "LegalPass",
+    "Queued for recurring policy and claims review.",
+    "LegalPass recurring public receipts will land after the runner surface is available.",
+  ),
+];
+
+const report = {
+  generatedAt,
+  source: dryRun ? "dogfood receipt dry run" : "nightly dogfood workflow",
+  headline: "We dogfood UnClick on UnClick.",
+  target: "UnClick public and agent-facing product surfaces",
+  nextAutomation: "Nightly dogfood receipts refresh this board with live scheduled evidence.",
+  results,
+  trend: buildTrend(results),
+  lastActionableFailure: buildLastActionableFailure(results),
+};
+
+await fs.mkdir(path.dirname(outputPath), { recursive: true });
+await fs.writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+
+console.log(`Wrote dogfood report to ${outputPath}`);
+console.log(JSON.stringify({
+  generatedAt: report.generatedAt,
+  passing: report.trend[0].passing,
+  failing: report.trend[0].failing,
+  pending: report.trend[0].pending,
+}, null, 2));


### PR DESCRIPTION
## Summary
- add a scheduled/manual Dogfood Report workflow that builds the public dogfood receipt
- add a dependency-free Node receipt builder that calls the existing TestPass and UXPass run endpoints
- upload the generated receipt as an artifact and commit `public/dogfood/latest.json` back to main when the live receipt changes

## Scope guard
- no Pass runner internals changed
- no TestPass/UXPass API changes
- no Connections/WakePass/security/migration changes
- SEOPass/CopyPass/LegalPass stay pending until their recurring runner surfaces are available

## Verification
- `DOGFOOD_DRY_RUN=1 node scripts/build-dogfood-report.mjs --output %TEMP%\\dogfood-latest-test.json`
- `node -e "import fs from 'node:fs'; import yaml from 'js-yaml'; yaml.load(fs.readFileSync('.github/workflows/dogfood-report.yml','utf8')); console.log('workflow yaml ok')"`
- `npm run build`

## Live blockers
- live nightly TestPass requires `TESTPASS_TOKEN`
- live nightly UXPass requires `UXPASS_TOKEN` or `CRON_SECRET`
- public target defaults are `https://unclick.world` and `https://unclick.world/api/mcp`, overrideable in manual dispatch