### PR TITLE
Harden heartbeat ETA sanitization in createHeartbeat

### DIFF
--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -175,6 +175,27 @@ describe("reliability helpers", () => {
     });
   });
 
+  it("sanitizes heartbeat ETA values in createHeartbeat", () => {
+    const invalid = createHeartbeat({
+      apiKeyHash: "hash_123",
+      agentId: "bailey",
+      state: "working",
+      etaMinutes: Number.NaN,
+      createdAt: new Date("2026-04-30T11:00:00.000Z"),
+    });
+
+    const clamped = createHeartbeat({
+      apiKeyHash: "hash_123",
+      agentId: "bailey",
+      state: "working",
+      etaMinutes: 20000,
+      createdAt: new Date("2026-04-30T11:00:00.000Z"),
+    });
+
+    expect(invalid.etaMinutes).toBeUndefined();
+    expect(clamped.etaMinutes).toBe(10080);
+  });
+
   it("parses heartbeat ETA from number and numeric string inputs", () => {
     expect(parseHeartbeatEtaMinutes(4.8)).toBe(4);
     expect(parseHeartbeatEtaMinutes("12")).toBe(12);

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -222,7 +222,10 @@ export function createHeartbeat(params: {
   if (params.dispatchId) heartbeat.dispatchId = params.dispatchId;
   if (params.currentTask) heartbeat.currentTask = params.currentTask;
   if (params.nextAction) heartbeat.nextAction = params.nextAction;
-  if (typeof params.etaMinutes === "number") heartbeat.etaMinutes = params.etaMinutes;
+  const parsedEtaMinutes = parseHeartbeatEtaMinutes(params.etaMinutes);
+  if (typeof parsedEtaMinutes === "number") {
+    heartbeat.etaMinutes = parsedEtaMinutes;
+  }
   if (params.blocker) heartbeat.blocker = params.blocker;
   if (params.lastRealActionAt) {
     heartbeat.lastRealActionAt = params.lastRealActionAt.toISOString();


### PR DESCRIPTION
## Summary
- sanitize taMinutes inside createHeartbeat using shared parseHeartbeatEtaMinutes
- prevent invalid numeric values (for example NaN) from being emitted in heartbeat telemetry
- add focused test coverage for invalid and clamped ETA behavior

## Scope
- reliability helper and its unit tests only

## Verification
- pnpm vitest packages/mcp-server/src/__tests__/reliability.test.ts (fails in this environment: pnpm not found)
