### PR TITLE
fix(wakepass): wake on scheduled testpass failures

### DIFF
--- a/.github/workflows/event-wake-router.yml
+++ b/.github/workflows/event-wake-router.yml
@@ -6,6 +6,7 @@ on:
       - Website
       - MCP server package
       - TestPass PR Check
+      - TestPass Scheduled Smoke
     types: [completed]
   pull_request:
     types: [ready_for_review, review_requested, reopened]

--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -124,6 +124,9 @@ reclaim path even if the first route fails. Do not wrap quiet health checks,
 dashboard reads, or zero-event heartbeats in PinballWake, because that creates
 alert noise without useful recovery.
 
+Scheduled TestPass success is a receipt, not a wake. Scheduled TestPass failure
+is action-needed and should wake through PinballWake immediately.
+
 ## Scheduled TestPass Clock
 
 GitHub Actions `schedule` is a backup clock, not the primary TestPass cadence.

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -90,6 +90,22 @@ function baseDecision(event) {
   if (eventName === "workflow_run") {
     const run = event.workflow_run || {};
     const prs = Array.isArray(run.pull_requests) ? run.pull_requests : [];
+    if (
+      run.status === "completed" &&
+      run.name === "TestPass Scheduled Smoke" &&
+      run.conclusion &&
+      run.conclusion !== "success"
+    ) {
+      return {
+        wake: true,
+        owner: "🤖",
+        urgency: "urgent",
+        reason: `Scheduled TestPass smoke ${run.conclusion}`,
+        eventCreatedAt: run.updated_at || run.created_at,
+        needsTriage: false,
+      };
+    }
+
     if (run.status === "completed" && run.conclusion === "success" && prs.length > 0) {
       return {
         wake: true,

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -160,6 +160,48 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("wakes urgently when scheduled TestPass smoke fails", () => {
+    const result = runDryWake("workflow_run", {
+      action: "completed",
+      workflow_run: {
+        id: 456,
+        name: "TestPass Scheduled Smoke",
+        status: "completed",
+        conclusion: "failure",
+        html_url: "https://github.com/acme/repo/actions/runs/456",
+        created_at: "2026-04-30T15:00:00Z",
+        updated_at: "2026-04-30T15:04:00Z",
+        pull_requests: [],
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Scheduled TestPass smoke failure/);
+    assert.match(result.stdout, /"wake_urgency": "urgent"/);
+    assert.match(result.stdout, /reliability_dispatch_dry_run/);
+    assert.match(result.stdout, /"ack_required": true/);
+  });
+
+  it("keeps successful scheduled TestPass smoke runs silent", () => {
+    const result = runDryWake("workflow_run", {
+      action: "completed",
+      workflow_run: {
+        id: 457,
+        name: "TestPass Scheduled Smoke",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://github.com/acme/repo/actions/runs/457",
+        created_at: "2026-04-30T15:00:00Z",
+        updated_at: "2026-04-30T15:04:00Z",
+        pull_requests: [],
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /No wake needed/);
+    assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
+  });
+
   it("dogfoods issue comments with /wake into ACK-required dispatches", () => {
     const result = runDryWake("issue_comment", {
       action: "created",


### PR DESCRIPTION
Summary:
- Add TestPass Scheduled Smoke to the wake-router workflow_run trigger list.
- Wake urgently when a scheduled TestPass smoke workflow completes with a non-success conclusion.
- Keep successful scheduled TestPass smoke runs silent so healthy receipts do not create worker noise.

Scope:
- Event wake router rules and focused tests.
- Event wake router workflow trigger list.
- Autopilot guidance for scheduled TestPass success vs failure.

Non-overlap:
- No connector schema changes.
- No cron cadence changes.
- No secrets, billing, domains, migrations, or Pass runner behavior changes.

Verification:
- node --test scripts/event-wake-router.test.mjs
- npm run build
- git diff --check

Risk:
- Low-medium because this touches a workflow trigger, but the behavior is scoped to scheduled TestPass workflow_run completion. Success stays quiet; failure becomes ACK-required WakePass/PinballWake work.