### PR TITLE
docs(seo): sync index JSON-LD tool count to 178+

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           "name": "UnClick",
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "Any",
-          "description": "Agent rails with 172+ tool files and 450+ callable endpoints, persistent memory, secure connections, crews, and Pass family QA checks. Works with Claude, ChatGPT, Cursor, and MCP-compatible AI agents.",
+          "description": "Agent rails with 178+ tool files and 450+ callable endpoints, persistent memory, secure connections, crews, and Pass family QA checks. Works with Claude, ChatGPT, Cursor, and MCP-compatible AI agents.",
           "url": "https://unclick.world",
           "offers": {
             "@type": "Offer",
@@ -103,8 +103,8 @@
           "@type": "ItemList",
           "@id": "https://unclick.world/#tools",
           "name": "UnClick Agent Tools",
-          "description": "172+ tool files and 450+ callable endpoints available for AI agents via MCP or REST API",
-          "numberOfItems": 172,
+          "description": "178+ tool files and 450+ callable endpoints available for AI agents via MCP or REST API",
+          "numberOfItems": 178,
           "itemListElement": [
             { "@type": "ListItem", "position": 1, "name": "URL Shortener", "description": "Shorten URLs with click tracking via POST /v1/shorten" },
             { "@type": "ListItem", "position": 2, "name": "Image Processing", "description": "Resize, convert, and compress images via POST /v1/image" },


### PR DESCRIPTION
## Summary
- Sync stale JSON-LD tool-count metadata in `index.html` from `172+` to `178+`.
- Update `numberOfItems` from `172` to `178` for the ItemList schema block.

## Scope
- Single-file docs/SEO metadata change in `index.html`.
- No runtime logic, API wiring, auth, payments, migrations, or workflow config touched.

## Non-overlap
- Complements prior docs drift PRs by covering remaining homepage structured-data count drift only.
- Does not modify user-owned feature branches or broad UI copy surfaces.

## Verification
- `node --test scripts/event-wake-router.test.mjs` (pass: 12/12)

## Risk
- Low. Static metadata-only edits.

## Follow-up
- Remaining `172+` references still exist in other pages/docs and can be handled in separate scoped PRs.