### PR TITLE
feat(reliability): wake on dogfood report failures

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -106,6 +106,22 @@ function baseDecision(event) {
       };
     }
 
+    if (
+      run.status === "completed" &&
+      run.name === "Dogfood Report" &&
+      run.conclusion &&
+      run.conclusion !== "success"
+    ) {
+      return {
+        wake: true,
+        owner: "🦾",
+        urgency: "urgent",
+        reason: `Dogfood Report workflow ${run.conclusion}`,
+        eventCreatedAt: run.updated_at || run.created_at,
+        needsTriage: false,
+      };
+    }
+
     if (run.status === "completed" && run.conclusion === "success" && prs.length > 0) {
       return {
         wake: true,

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -202,6 +202,49 @@ describe("event wake router reliability dispatch", () => {
     assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
   });
 
+  it("wakes the builder when the Dogfood Report workflow fails", () => {
+    const result = runDryWake("workflow_run", {
+      action: "completed",
+      workflow_run: {
+        id: 458,
+        name: "Dogfood Report",
+        status: "completed",
+        conclusion: "failure",
+        html_url: "https://github.com/acme/repo/actions/runs/458",
+        created_at: "2026-04-30T16:00:00Z",
+        updated_at: "2026-04-30T16:05:00Z",
+        pull_requests: [],
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Dogfood Report workflow failure/);
+    assert.match(result.stdout, /"wake_owner": "🦾"/);
+    assert.match(result.stdout, /"wake_urgency": "urgent"/);
+    assert.match(result.stdout, /reliability_dispatch_dry_run/);
+    assert.match(result.stdout, /"ack_required": true/);
+  });
+
+  it("keeps successful Dogfood Report workflow runs silent", () => {
+    const result = runDryWake("workflow_run", {
+      action: "completed",
+      workflow_run: {
+        id: 459,
+        name: "Dogfood Report",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://github.com/acme/repo/actions/runs/459",
+        created_at: "2026-04-30T16:00:00Z",
+        updated_at: "2026-04-30T16:05:00Z",
+        pull_requests: [],
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /No wake needed/);
+    assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
+  });
+
   it("dogfoods issue comments with /wake into ACK-required dispatches", () => {
     const result = runDryWake("issue_comment", {
       action: "created",


### PR DESCRIPTION
## PinballWake v0.1 chip - failed Dogfood Report workflow

### Chosen call point
`workflow_run` events for the `Dogfood Report` GitHub Actions workflow inside `scripts/event-wake-router.mjs`.

A failed scheduled dogfood receipt run is action-needed because overnight public proof can silently stop refreshing. This PR routes that failure to the builder lane as an ACK-required WakePass dispatch. Successful Dogfood Report runs remain silent.

### Files owned
- `scripts/event-wake-router.mjs`
- `scripts/event-wake-router.test.mjs`

### Non-overlap statement
This PR does not touch #345 files, `api/memory-admin.ts`, migrations, secrets, Connections, TestPass internals, Pass APIs, or workflow definitions. It only adds one event-router decision and matching tests.

### Acceptance
- action-needed path: `Dogfood Report` workflow failure creates a wake with `owner: "🦾"`, `urgency: "urgent"`, and the existing ACK-required reliability dispatch dry-run proof.
- quiet path: successful `Dogfood Report` workflow runs stay silent and do not emit reliability dispatch proof.
- missed ACK flow: this reuses the existing event-wake-router dispatch path, which creates `ack_required: true` WakePass dispatches with the standard 600s lease/reclaim behavior.

### Verification
- `node --test scripts/event-wake-router.test.mjs` - 14/14 passed
- `git diff --check` - passed

### Ring-fencing impact
Estimated +2-4% unattended coverage. It closes a specific overnight proof gap: failed public dogfood receipt runs now wake a builder with ACK/reclaim coverage instead of relying on someone noticing the failed scheduled job.

Draft until CI confirms the branch is clean.
