### PR TITLE
fix(wakepass): persist todo handoff leases atomically

### DIFF
--- a/api/fishbowl-todo-handoff.test.ts
+++ b/api/fishbowl-todo-handoff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildFishbowlTodoHandoffDispatchRow,
   FISHBOWL_TODO_HANDOFF_LEASE_SECONDS,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff";
@@ -30,6 +31,30 @@ describe("planFishbowlTodoHandoff", () => {
       },
     });
     expect(plan?.leaseSeconds).toBe(FISHBOWL_TODO_HANDOFF_LEASE_SECONDS);
+  });
+
+  it("builds an already-leased dispatch row for reclaimable ACK tracking", () => {
+    const plan = planFishbowlTodoHandoff({ ...baseInput, assignedToAgentId: "agent_owner" })!;
+    const row = buildFishbowlTodoHandoffDispatchRow({
+      apiKeyHash: "hash_123",
+      dispatchId: "dispatch_123",
+      plan,
+      now: new Date("2026-05-01T02:00:00.000Z"),
+    });
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash_123",
+      dispatch_id: "dispatch_123",
+      source: "fishbowl",
+      target_agent_id: "agent_owner",
+      task_ref: "todo-abc",
+      status: "leased",
+      lease_owner: "agent_owner",
+      lease_expires_at: "2026-05-01T02:10:00.000Z",
+      created_at: "2026-05-01T02:00:00.000Z",
+      updated_at: "2026-05-01T02:00:00.000Z",
+    });
+    expect(row.payload.ack_required).toBe(true);
   });
 
   it("dispatch payload triggers handoff_ack_missing on stale reclaim", () => {

--- a/api/lib/fishbowl-todo-handoff.ts
+++ b/api/lib/fishbowl-todo-handoff.ts
@@ -30,6 +30,20 @@ export interface FishbowlTodoHandoffPlan {
   leaseSeconds: number;
 }
 
+export interface FishbowlTodoHandoffDispatchRow {
+  api_key_hash: string;
+  dispatch_id: string;
+  source: "fishbowl";
+  target_agent_id: string;
+  task_ref: string;
+  status: "leased";
+  lease_owner: string;
+  lease_expires_at: string;
+  payload: FishbowlTodoHandoffPlan["payload"];
+  created_at: string;
+  updated_at: string;
+}
+
 export function planFishbowlTodoHandoff(
   input: FishbowlTodoHandoffInput,
 ): FishbowlTodoHandoffPlan | null {
@@ -50,5 +64,29 @@ export function planFishbowlTodoHandoff(
       ack_required: true,
     },
     leaseSeconds: FISHBOWL_TODO_HANDOFF_LEASE_SECONDS,
+  };
+}
+
+export function buildFishbowlTodoHandoffDispatchRow(params: {
+  apiKeyHash: string;
+  dispatchId: string;
+  plan: FishbowlTodoHandoffPlan;
+  now: Date;
+}): FishbowlTodoHandoffDispatchRow {
+  const nowIso = params.now.toISOString();
+  return {
+    api_key_hash: params.apiKeyHash,
+    dispatch_id: params.dispatchId,
+    source: params.plan.source,
+    target_agent_id: params.plan.targetAgentId,
+    task_ref: params.plan.taskRef,
+    status: "leased",
+    lease_owner: params.plan.targetAgentId,
+    lease_expires_at: new Date(
+      params.now.getTime() + params.plan.leaseSeconds * 1000,
+    ).toISOString(),
+    payload: params.plan.payload,
+    created_at: nowIso,
+    updated_at: nowIso,
   };
 }

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -97,7 +97,10 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
-import { planFishbowlTodoHandoff } from "./lib/fishbowl-todo-handoff.js";
+import {
+  buildFishbowlTodoHandoffDispatchRow,
+  planFishbowlTodoHandoff,
+} from "./lib/fishbowl-todo-handoff.js";
 import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
 import {
   createDispatchId,
@@ -7391,34 +7394,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 taskRef: handoffPlan.taskRef,
               });
               const now = new Date();
-              const leaseExpiresAt = new Date(
-                now.getTime() + handoffPlan.leaseSeconds * 1000,
-              ).toISOString();
-              const { error: upsertErr } = await supabase
+              const { data: dispatchRows, error: upsertErr } = await supabase
                 .from("mc_agent_dispatches")
-                .insert({
-                  api_key_hash: apiKeyHash,
-                  dispatch_id: dispatchId,
-                  source: handoffPlan.source,
-                  target_agent_id: handoffPlan.targetAgentId,
-                  task_ref: handoffPlan.taskRef,
-                  status: "queued",
-                  payload: handoffPlan.payload,
-                });
-              if (upsertErr && (upsertErr as { code?: string }).code !== "23505") {
+                .upsert(
+                  buildFishbowlTodoHandoffDispatchRow({
+                    apiKeyHash,
+                    dispatchId,
+                    plan: handoffPlan,
+                    now,
+                  }),
+                  { onConflict: "api_key_hash,dispatch_id" },
+                )
+                .select("dispatch_id,status,lease_owner,lease_expires_at");
+              if (upsertErr) {
                 throw upsertErr;
               }
-              await supabase
-                .from("mc_agent_dispatches")
-                .update({
-                  status: "leased",
-                  lease_owner: handoffPlan.targetAgentId,
-                  lease_expires_at: leaseExpiresAt,
-                  updated_at: now.toISOString(),
-                })
-                .eq("api_key_hash", apiKeyHash)
-                .eq("dispatch_id", dispatchId)
-                .eq("status", "queued");
+              const dispatchRow = dispatchRows?.[0];
+              if (
+                !dispatchRow ||
+                dispatchRow.status !== "leased" ||
+                dispatchRow.lease_owner !== handoffPlan.targetAgentId ||
+                !dispatchRow.lease_expires_at
+              ) {
+                throw new Error("handoff dispatch lease was not persisted");
+              }
             } catch (err) {
               console.warn("[fishbowl_create_todo] dispatch wrapping failed:", err);
             }


### PR DESCRIPTION
## Summary
- fixes the merged Fishbowl todo ACK handoff path so dispatch rows are persisted as leased in one upsert
- verifies the returned dispatch row is leased and reclaimable before treating the WakePass bookkeeping as successful
- adds focused planner coverage for the already-leased row shape

## Scope
- `api/memory-admin.ts`
- `api/lib/fishbowl-todo-handoff.ts`
- `api/fishbowl-todo-handoff.test.ts`

## Non-overlap
- follow-up to #345 only
- no migrations, secrets, auth, billing, UI, or unrelated reliability paths

## Verification
- `npm run test -- api/fishbowl-todo-handoff.test.ts packages/mcp-server/src/__tests__/reliability.test.ts` (root config only picked up the API test: 4/4 pass)
- `npm run test --workspace packages/mcp-server`
- `npm run build --workspace packages/mcp-server`
- `npm run build`
- `git diff --check`

## Risk
Low. This keeps todo creation best-effort if WakePass bookkeeping fails, but removes the silent queued-not-leased gap so ACK reclaim can work.
