### PR TITLE
feat(wakepass): ack fishbowl message handoffs

### DIFF
--- a/api/fishbowl-message-handoff.test.ts
+++ b/api/fishbowl-message-handoff.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFishbowlMessageHandoffDispatchRow,
+  FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS,
+  planFishbowlMessageHandoffs,
+} from "./lib/fishbowl-message-handoff";
+import { createReclaimSignal } from "../packages/mcp-server/src/reliability";
+
+const recipientProfiles = [
+  { agentId: "agent_builder", emoji: "B" },
+  { agentId: "agent_qc", emoji: "Q" },
+  { agentId: "human_chris", emoji: "C", userAgentHint: "admin-ui" },
+];
+
+const baseInput = {
+  messageId: "msg-abc",
+  text: "Please review this ready PR.",
+  tags: ["needs-doing"],
+  recipients: ["B"],
+  authorAgentId: "agent_author",
+  recipientProfiles,
+};
+
+describe("planFishbowlMessageHandoffs", () => {
+  it("produces ACK-required dispatch plans for direct worker action messages", () => {
+    const plans = planFishbowlMessageHandoffs(baseInput);
+
+    expect(plans).toHaveLength(1);
+    expect(plans[0]).toMatchObject({
+      source: "fishbowl",
+      targetAgentId: "agent_builder",
+      taskRef: "fishbowl-message:msg-abc",
+      leaseSeconds: FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS,
+      payload: {
+        kind: "message_handoff",
+        handoff_message_id: "msg-abc",
+        summary: "Please review this ready PR.",
+        tags: ["needs-doing"],
+        author_agent_id: "agent_author",
+        ack_required: true,
+      },
+    });
+  });
+
+  it("builds an already-leased dispatch row for reclaimable ACK tracking", () => {
+    const plan = planFishbowlMessageHandoffs(baseInput)[0];
+    const row = buildFishbowlMessageHandoffDispatchRow({
+      apiKeyHash: "hash_123",
+      dispatchId: "dispatch_123",
+      plan,
+      now: new Date("2026-05-01T03:00:00.000Z"),
+    });
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash_123",
+      dispatch_id: "dispatch_123",
+      source: "fishbowl",
+      target_agent_id: "agent_builder",
+      task_ref: "fishbowl-message:msg-abc",
+      status: "leased",
+      lease_owner: "agent_builder",
+      lease_expires_at: "2026-05-01T03:10:00.000Z",
+      created_at: "2026-05-01T03:00:00.000Z",
+      updated_at: "2026-05-01T03:00:00.000Z",
+    });
+    expect(row.payload.ack_required).toBe(true);
+  });
+
+  it("dispatch payload triggers handoff_ack_missing on stale reclaim", () => {
+    const plan = planFishbowlMessageHandoffs(baseInput)[0];
+    const signal = createReclaimSignal(
+      {
+        dispatchId: "dispatch_123",
+        source: plan.source,
+        targetAgentId: plan.targetAgentId,
+        taskRef: plan.taskRef,
+        payload: plan.payload,
+      },
+      900,
+    );
+
+    expect(signal.action).toBe("handoff_ack_missing");
+  });
+
+  it("stays silent for broadcasts, humans, self-handoffs, FYI, and ambiguous recipients", () => {
+    expect(planFishbowlMessageHandoffs({ ...baseInput, recipients: ["all"] })).toEqual([]);
+    expect(planFishbowlMessageHandoffs({ ...baseInput, recipients: ["C"] })).toEqual([]);
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        recipients: ["B"],
+        authorAgentId: "agent_builder",
+      }),
+    ).toEqual([]);
+    expect(planFishbowlMessageHandoffs({ ...baseInput, tags: ["status"] })).toEqual([]);
+    expect(planFishbowlMessageHandoffs({ ...baseInput, recipients: ["unknown"] })).toEqual([]);
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        recipientProfiles: [
+          ...recipientProfiles,
+          { agentId: "agent_duplicate", emoji: "B" },
+        ],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/api/lib/fishbowl-message-handoff.ts
+++ b/api/lib/fishbowl-message-handoff.ts
@@ -1,0 +1,119 @@
+// Universal ACK Handoff planner for action-needed Fishbowl messages.
+
+export const FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS = 600;
+
+const ACTION_TAGS = new Set(["needs-doing", "blocker", "tripwire"]);
+
+export interface FishbowlMessageRecipientProfile {
+  agentId: string;
+  emoji: string | null | undefined;
+  userAgentHint?: string | null | undefined;
+}
+
+export interface FishbowlMessageHandoffInput {
+  messageId: string;
+  text: string;
+  tags: string[];
+  recipients: string[];
+  authorAgentId: string;
+  recipientProfiles: FishbowlMessageRecipientProfile[];
+}
+
+export interface FishbowlMessageHandoffPlan {
+  source: "fishbowl";
+  targetAgentId: string;
+  taskRef: string;
+  payload: {
+    kind: "message_handoff";
+    handoff_message_id: string;
+    summary: string;
+    tags: string[];
+    author_agent_id: string;
+    ack_required: true;
+  };
+  leaseSeconds: number;
+}
+
+export interface FishbowlMessageHandoffDispatchRow {
+  api_key_hash: string;
+  dispatch_id: string;
+  source: "fishbowl";
+  target_agent_id: string;
+  task_ref: string;
+  status: "leased";
+  lease_owner: string;
+  lease_expires_at: string;
+  payload: FishbowlMessageHandoffPlan["payload"];
+  created_at: string;
+  updated_at: string;
+}
+
+export function planFishbowlMessageHandoffs(
+  input: FishbowlMessageHandoffInput,
+): FishbowlMessageHandoffPlan[] {
+  const tagSet = new Set(input.tags);
+  const hasActionTag = input.tags.some((tag) => ACTION_TAGS.has(tag));
+  if (!hasActionTag) return [];
+
+  const recipients = input.recipients.map((recipient) => recipient.trim()).filter(Boolean);
+  if (recipients.length === 0 || recipients.includes("all")) return [];
+
+  const summary = input.text.length > 200 ? `${input.text.slice(0, 197)}...` : input.text;
+  const plans: FishbowlMessageHandoffPlan[] = [];
+  const plannedTargets = new Set<string>();
+
+  for (const recipient of recipients) {
+    const matches = input.recipientProfiles.filter(
+      (profile) =>
+        profile.userAgentHint !== "admin-ui" &&
+        !profile.agentId.startsWith("human-") &&
+        (profile.agentId === recipient || profile.emoji === recipient),
+    );
+    if (matches.length !== 1) continue;
+
+    const targetAgentId = matches[0].agentId;
+    if (targetAgentId === input.authorAgentId || plannedTargets.has(targetAgentId)) continue;
+    plannedTargets.add(targetAgentId);
+
+    plans.push({
+      source: "fishbowl",
+      targetAgentId,
+      taskRef: `fishbowl-message:${input.messageId}`,
+      payload: {
+        kind: "message_handoff",
+        handoff_message_id: input.messageId,
+        summary,
+        tags: input.tags,
+        author_agent_id: input.authorAgentId,
+        ack_required: true,
+      },
+      leaseSeconds: FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS,
+    });
+  }
+
+  return plans;
+}
+
+export function buildFishbowlMessageHandoffDispatchRow(params: {
+  apiKeyHash: string;
+  dispatchId: string;
+  plan: FishbowlMessageHandoffPlan;
+  now: Date;
+}): FishbowlMessageHandoffDispatchRow {
+  const nowIso = params.now.toISOString();
+  return {
+    api_key_hash: params.apiKeyHash,
+    dispatch_id: params.dispatchId,
+    source: params.plan.source,
+    target_agent_id: params.plan.targetAgentId,
+    task_ref: params.plan.taskRef,
+    status: "leased",
+    lease_owner: params.plan.targetAgentId,
+    lease_expires_at: new Date(
+      params.now.getTime() + params.plan.leaseSeconds * 1000,
+    ).toISOString(),
+    payload: params.plan.payload,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -98,6 +98,10 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import {
+  buildFishbowlMessageHandoffDispatchRow,
+  planFishbowlMessageHandoffs,
+} from "./lib/fishbowl-message-handoff.js";
+import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
@@ -7139,16 +7143,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             // Discover this tenant's human admin profiles so we can match
             // recipients against the human's actual emoji and agent_id, not
             // just the canonical 😎 fallback.
-            const { data: humanRows } = await supabase
+            const { data: profileRows } = await supabase
               .from("mc_fishbowl_profiles")
-              .select("agent_id, emoji")
-              .eq("api_key_hash", apiKeyHash)
-              .eq("user_agent_hint", "admin-ui");
+              .select("agent_id, emoji, user_agent_hint")
+              .eq("api_key_hash", apiKeyHash);
             const humanEmojis = new Set<string>(["😎"]);
             const humanAgentIds = new Set<string>();
-            for (const h of humanRows ?? []) {
-              if (h?.emoji) humanEmojis.add(h.emoji);
-              if (h?.agent_id) humanAgentIds.add(h.agent_id);
+            for (const profileRow of profileRows ?? []) {
+              if (profileRow?.user_agent_hint !== "admin-ui") continue;
+              if (profileRow?.emoji) humanEmojis.add(profileRow.emoji);
+              if (profileRow?.agent_id) humanAgentIds.add(profileRow.agent_id);
             }
 
             const targetsHuman = recipientList.some(
@@ -7184,6 +7188,50 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 policy_label: needsDoing ? "warning" : severity,
               },
             });
+
+            const handoffPlans = planFishbowlMessageHandoffs({
+              messageId: inserted.id,
+              text: summarySource,
+              tags: tagList,
+              recipients: recipientList,
+              authorAgentId: agentId,
+              recipientProfiles: (profileRows ?? []).map((profileRow) => ({
+                agentId: profileRow.agent_id,
+                emoji: profileRow.emoji,
+                userAgentHint: profileRow.user_agent_hint,
+              })),
+            });
+            for (const handoffPlan of handoffPlans) {
+              const dispatchId = createDispatchId({
+                source: handoffPlan.source,
+                targetAgentId: handoffPlan.targetAgentId,
+                taskRef: handoffPlan.taskRef,
+              });
+              const now = new Date();
+              const { data: dispatchRows, error: upsertErr } = await supabase
+                .from("mc_agent_dispatches")
+                .upsert(
+                  buildFishbowlMessageHandoffDispatchRow({
+                    apiKeyHash,
+                    dispatchId,
+                    plan: handoffPlan,
+                    now,
+                  }),
+                  { onConflict: "api_key_hash,dispatch_id" },
+                )
+                .select("dispatch_id,status,lease_owner,lease_expires_at");
+              if (upsertErr) throw upsertErr;
+
+              const dispatchRow = dispatchRows?.[0];
+              if (
+                !dispatchRow ||
+                dispatchRow.status !== "leased" ||
+                dispatchRow.lease_owner !== handoffPlan.targetAgentId ||
+                !dispatchRow.lease_expires_at
+              ) {
+                throw new Error("message handoff dispatch lease was not persisted");
+              }
+            }
           } catch (publishErr) {
             console.error(
               "[fishbowl_post] signal publish failed:",


### PR DESCRIPTION
## Summary
- wraps action-needed worker-to-worker Fishbowl messages in ACK-required WakePass dispatches
- only direct, unambiguous worker recipients are eligible; `all`, humans, self-handoffs, FYI/status-only, unknown, and duplicate-recipient matches stay silent
- persists handoff dispatches as already-leased rows with the same verified 600s lease shape as todo handoffs

## Scope
- `api/memory-admin.ts`
- `api/lib/fishbowl-message-handoff.ts`
- `api/fishbowl-message-handoff.test.ts`

## Non-overlap
- separate PinballWake message-handoff planner
- no migrations, secrets, auth, billing, UI, workflow, Connections, or broad Fishbowl refactor
- follows the #349 atomic leased-upsert pattern

## Verification
- `npm run test -- api/fishbowl-message-handoff.test.ts api/fishbowl-todo-handoff.test.ts`
- `npm run test -- api/fishbowl-message-handoff.test.ts`
- `npm run test --workspace packages/mcp-server`
- `npm run build --workspace packages/mcp-server`
- `npm run build`
- `git diff --check`
- `npm run lint` still fails on pre-existing repo-wide lint debt unrelated to this PR

## Risk
Low-medium. The behavior is intentionally conservative to avoid waking the wrong worker: ambiguous recipient identity produces no ACK dispatch.

## Ring-fencing impact
Estimated +5-8% unattended coverage by giving explicit Fishbowl worker handoffs the same ACK/missed-ACK visibility as todo assignments and missed check-ins.
