### PR TITLE
feat(reliability): ACK direct Fishbowl worker handoffs

### DIFF
--- a/api/fishbowl-message-handoff.test.ts
+++ b/api/fishbowl-message-handoff.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFishbowlMessageHandoffDispatchRow,
+  FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS,
+  planFishbowlMessageHandoff,
+  type FishbowlRecipientProfile,
+} from "./lib/fishbowl-message-handoff";
+import { createReclaimSignal } from "../packages/mcp-server/src/reliability";
+
+const workerProfile: FishbowlRecipientProfile = {
+  agent_id: "chatgpt-codex-worker",
+  emoji: "🤖",
+  user_agent_hint: "codex-desktop",
+};
+
+const authorProfile: FishbowlRecipientProfile = {
+  agent_id: "chatgpt-55-plex-creativelead",
+  emoji: "🦾",
+  user_agent_hint: "chatgpt-plex",
+};
+
+const humanProfile: FishbowlRecipientProfile = {
+  agent_id: "human-123",
+  emoji: "😎",
+  user_agent_hint: "admin-ui",
+};
+
+const baseInput = {
+  messageId: "msg-abc",
+  text: "Please pick up the stale worker handoff.",
+  tags: ["needs-doing"],
+  recipients: ["🤖"],
+  authorAgentId: "chatgpt-55-plex-creativelead",
+  authorEmoji: "🦾",
+  recipientProfiles: [authorProfile, workerProfile, humanProfile],
+};
+
+describe("planFishbowlMessageHandoff", () => {
+  it("produces an ACK-required dispatch with a 600s lease for direct worker action handoffs", () => {
+    const plan = planFishbowlMessageHandoff(baseInput);
+    expect(plan).toMatchObject({
+      source: "fishbowl",
+      targetAgentId: "chatgpt-codex-worker",
+      taskRef: "msg-abc",
+      leaseSeconds: 600,
+      payload: {
+        kind: "fishbowl_worker_handoff",
+        message_id: "msg-abc",
+        recipients: ["🤖"],
+        tags: ["needs-doing"],
+        action_tags: ["needs-doing"],
+        created_by_agent_id: "chatgpt-55-plex-creativelead",
+        author_emoji: "🦾",
+        ack_required: true,
+      },
+    });
+    expect(plan?.leaseSeconds).toBe(FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS);
+
+    const row = buildFishbowlMessageHandoffDispatchRow({
+      apiKeyHash: "hash",
+      dispatchId: "dispatch_123",
+      plan: plan!,
+      now: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    expect(row).toMatchObject({
+      status: "leased",
+      lease_owner: "chatgpt-codex-worker",
+      lease_expires_at: "2026-05-01T00:10:00.000Z",
+    });
+  });
+
+  it("dispatch payload triggers handoff_ack_missing on stale reclaim", () => {
+    const plan = planFishbowlMessageHandoff(baseInput)!;
+    const signal = createReclaimSignal(
+      {
+        dispatchId: "x",
+        source: plan.source,
+        targetAgentId: plan.targetAgentId,
+        taskRef: plan.taskRef,
+        payload: plan.payload,
+      },
+      900,
+    );
+    expect(signal.action).toBe("handoff_ack_missing");
+  });
+
+  it("returns null for quiet paths", () => {
+    expect(planFishbowlMessageHandoff({ ...baseInput, tags: ["fyi"] })).toBeNull();
+    expect(planFishbowlMessageHandoff({ ...baseInput, recipients: ["all"] })).toBeNull();
+    expect(planFishbowlMessageHandoff({ ...baseInput, recipients: ["🤖", "🍿"] })).toBeNull();
+    expect(planFishbowlMessageHandoff({ ...baseInput, recipients: ["😎"] })).toBeNull();
+    expect(planFishbowlMessageHandoff({ ...baseInput, recipients: ["unknown-worker"] })).toBeNull();
+    expect(planFishbowlMessageHandoff({ ...baseInput, authorAgentId: "human-123" })).toBeNull();
+    expect(
+      planFishbowlMessageHandoff({
+        ...baseInput,
+        authorAgentId: "chatgpt-codex-worker",
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts blocker and tripwire action tags for direct worker recipients", () => {
+    expect(planFishbowlMessageHandoff({ ...baseInput, tags: ["blocker"] })).not.toBeNull();
+    expect(planFishbowlMessageHandoff({ ...baseInput, tags: ["tripwire"] })).not.toBeNull();
+  });
+});

--- a/api/lib/fishbowl-message-handoff.ts
+++ b/api/lib/fishbowl-message-handoff.ts
@@ -1,0 +1,130 @@
+// Universal ACK Handoff planner for direct worker-to-worker Fishbowl posts.
+//
+// Only direct action-needed handoffs are wrapped:
+// one known non-human worker recipient plus an action tag. Room chatter,
+// human escalations, self-handoffs, and no-op posts stay silent.
+
+export const FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS = 600;
+const ACTION_TAGS = new Set(["needs-doing", "blocker", "tripwire"]);
+
+export interface FishbowlRecipientProfile {
+  agent_id: string;
+  emoji: string | null;
+  user_agent_hint: string | null;
+}
+
+export interface FishbowlMessageHandoffInput {
+  messageId: string;
+  text: string;
+  tags: readonly string[] | null | undefined;
+  recipients: readonly string[];
+  authorAgentId: string;
+  authorEmoji: string | null | undefined;
+  recipientProfiles: readonly FishbowlRecipientProfile[];
+}
+
+export interface FishbowlMessageHandoffPlan {
+  source: "fishbowl";
+  targetAgentId: string;
+  taskRef: string;
+  payload: {
+    kind: "fishbowl_worker_handoff";
+    message_id: string;
+    text_preview: string;
+    recipients: string[];
+    tags: string[];
+    action_tags: string[];
+    created_by_agent_id: string;
+    author_emoji: string | null;
+    ack_required: true;
+  };
+  leaseSeconds: number;
+}
+
+export interface FishbowlMessageHandoffDispatchRow {
+  api_key_hash: string;
+  dispatch_id: string;
+  source: "fishbowl";
+  target_agent_id: string;
+  task_ref: string;
+  status: "leased";
+  lease_owner: string;
+  lease_expires_at: string;
+  payload: FishbowlMessageHandoffPlan["payload"];
+  created_at: string;
+  updated_at: string;
+}
+
+export function planFishbowlMessageHandoff(
+  input: FishbowlMessageHandoffInput,
+): FishbowlMessageHandoffPlan | null {
+  const tags = [...(input.tags ?? [])];
+  const actionTags = tags.filter((tag) => ACTION_TAGS.has(tag));
+  if (actionTags.length === 0) return null;
+
+  const authorProfile = input.recipientProfiles.find(
+    (profile) => profile.agent_id === input.authorAgentId,
+  );
+  if (!authorProfile) return null;
+  if (authorProfile.user_agent_hint === "admin-ui") return null;
+  if (authorProfile.agent_id.startsWith("human-")) return null;
+
+  const recipientTokens = input.recipients.map((recipient) => recipient.trim()).filter(Boolean);
+  if (recipientTokens.length !== 1) return null;
+  if (recipientTokens[0] === "all") return null;
+
+  const targetProfile = input.recipientProfiles.find(
+    (profile) => profile.agent_id === recipientTokens[0] || profile.emoji === recipientTokens[0],
+  );
+  if (!targetProfile) return null;
+  if (targetProfile.user_agent_hint === "admin-ui") return null;
+  if (targetProfile.agent_id.startsWith("human-")) return null;
+  if (targetProfile.agent_id === input.authorAgentId) return null;
+
+  return {
+    source: "fishbowl",
+    targetAgentId: targetProfile.agent_id,
+    taskRef: input.messageId,
+    payload: {
+      kind: "fishbowl_worker_handoff",
+      message_id: input.messageId,
+      text_preview: compactPreview(input.text),
+      recipients: recipientTokens,
+      tags,
+      action_tags: actionTags,
+      created_by_agent_id: input.authorAgentId,
+      author_emoji: input.authorEmoji ?? null,
+      ack_required: true,
+    },
+    leaseSeconds: FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS,
+  };
+}
+
+export function buildFishbowlMessageHandoffDispatchRow(params: {
+  apiKeyHash: string;
+  dispatchId: string;
+  plan: FishbowlMessageHandoffPlan;
+  now: Date;
+}): FishbowlMessageHandoffDispatchRow {
+  const nowIso = params.now.toISOString();
+  return {
+    api_key_hash: params.apiKeyHash,
+    dispatch_id: params.dispatchId,
+    source: params.plan.source,
+    target_agent_id: params.plan.targetAgentId,
+    task_ref: params.plan.taskRef,
+    status: "leased",
+    lease_owner: params.plan.targetAgentId,
+    lease_expires_at: new Date(
+      params.now.getTime() + params.plan.leaseSeconds * 1000,
+    ).toISOString(),
+    payload: params.plan.payload,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+}
+
+function compactPreview(value: string): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  return text.length > 220 ? `${text.slice(0, 217)}...` : text;
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -101,6 +101,10 @@ import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
+import {
+  buildFishbowlMessageHandoffDispatchRow,
+  planFishbowlMessageHandoff,
+} from "./lib/fishbowl-message-handoff.js";
 import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
 import {
   createDispatchId,
@@ -7136,17 +7140,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             const needsDoing = tagSet.has("needs-doing");
             const broadcastsAll = recipientList.includes("all");
 
-            // Discover this tenant's human admin profiles so we can match
-            // recipients against the human's actual emoji and agent_id, not
-            // just the canonical 😎 fallback.
-            const { data: humanRows } = await supabase
+            // Discover this tenant's profiles so human wake policy and worker
+            // handoff dispatches can resolve emoji recipients consistently.
+            const { data: recipientProfiles } = await supabase
               .from("mc_fishbowl_profiles")
-              .select("agent_id, emoji")
-              .eq("api_key_hash", apiKeyHash)
-              .eq("user_agent_hint", "admin-ui");
+              .select("agent_id, emoji, user_agent_hint")
+              .eq("api_key_hash", apiKeyHash);
             const humanEmojis = new Set<string>(["😎"]);
             const humanAgentIds = new Set<string>();
-            for (const h of humanRows ?? []) {
+            for (const h of recipientProfiles ?? []) {
+              if (h?.user_agent_hint !== "admin-ui") continue;
               if (h?.emoji) humanEmojis.add(h.emoji);
               if (h?.agent_id) humanAgentIds.add(h.agent_id);
             }
@@ -7163,6 +7166,45 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             else if (needsDoing) severity = "action_needed";
             else if (broadcastsAll && isBlocker) severity = "action_needed";
             else if (isBlocker) severity = "action_needed";
+
+            const handoffPlan = planFishbowlMessageHandoff({
+              messageId: inserted.id,
+              text: inserted.text ?? text,
+              tags: tagList,
+              recipients: recipientList,
+              authorAgentId: inserted.author_agent_id,
+              authorEmoji: inserted.author_emoji,
+              recipientProfiles: recipientProfiles ?? [],
+            });
+            if (handoffPlan) {
+              const dispatchId = createDispatchId({
+                source: handoffPlan.source,
+                targetAgentId: handoffPlan.targetAgentId,
+                taskRef: handoffPlan.taskRef,
+              });
+              const { data: dispatchRows, error: dispatchErr } = await supabase
+                .from("mc_agent_dispatches")
+                .upsert(
+                  buildFishbowlMessageHandoffDispatchRow({
+                    apiKeyHash,
+                    dispatchId,
+                    plan: handoffPlan,
+                    now: new Date(),
+                  }),
+                  { onConflict: "api_key_hash,dispatch_id" },
+                )
+                .select("dispatch_id,status,lease_owner,lease_expires_at");
+              if (dispatchErr) throw dispatchErr;
+              const dispatchRow = dispatchRows?.[0];
+              if (
+                !dispatchRow ||
+                dispatchRow.status !== "leased" ||
+                dispatchRow.lease_owner !== handoffPlan.targetAgentId ||
+                !dispatchRow.lease_expires_at
+              ) {
+                throw new Error("message handoff dispatch lease was not persisted");
+              }
+            }
 
             const summarySource = inserted.text ?? text;
             const summary =
@@ -7186,7 +7228,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             });
           } catch (publishErr) {
             console.error(
-              "[fishbowl_post] signal publish failed:",
+              "[fishbowl_post] async wake plumbing failed:",
               (publishErr as Error).message,
             );
           }


### PR DESCRIPTION
## PinballWake v0.1 chip - direct Fishbowl worker handoffs

### Chosen call point
`fishbowl_post` in `api/memory-admin.ts`.

Direct worker-to-worker Fishbowl messages with action tags are action-needed handoffs. This PR registers an ACK-required reliability dispatch with a 600s lease for those posts only.

### Files owned
- `api/lib/fishbowl-message-handoff.ts` - pure planner and dispatch row builder
- `api/fishbowl-message-handoff.test.ts` - focused planner/reclaim tests
- `api/memory-admin.ts` - wraps the existing `fishbowl_post` async wake plumbing

### Non-overlap statement
This PR is based on current main after #345/#342/#347/#348/#349 merged. It does not touch event-router files, workflows, secrets, migrations, Connections, Pass internals, or another worker branch.

### Acceptance
- action-needed path: one known worker posts to one different known worker with `needs-doing`, `blocker`, or `tripwire` and gets an ACK-required `fishbowl` dispatch leased to the target for 600s.
- quiet paths: no action tag, `all`, multiple recipients, human recipient, human author, unknown recipient, and self-handoff return no dispatch.
- missed ACK flow: planner payload has `ack_required: true`; the test verifies `createReclaimSignal` maps it to `handoff_ack_missing`.

### Verification
- `npm run test -- api/fishbowl-message-handoff.test.ts` - 4/4 passed
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck --strict api/lib/fishbowl-message-handoff.ts api/fishbowl-message-handoff.test.ts` - passed
- `npm run build` - passed
- `git diff --cached --check` - passed before commit

### Ring-fencing impact
Estimated +5-7% unattended coverage. This covers the highest-value remaining Fishbowl action path: direct worker handoff messages that would otherwise rely on social memory instead of a leased, reclaimable ACK.

Draft until CI is green.
