### PR TITLE
fix(reliability): narrow Fishbowl handoff ACKs

### DIFF
--- a/api/fishbowl-message-handoff.test.ts
+++ b/api/fishbowl-message-handoff.test.ts
@@ -7,6 +7,7 @@ import {
 import { createReclaimSignal } from "../packages/mcp-server/src/reliability";
 
 const recipientProfiles = [
+  { agentId: "agent_author", emoji: "A" },
   { agentId: "agent_builder", emoji: "B" },
   { agentId: "agent_qc", emoji: "Q" },
   { agentId: "human_chris", emoji: "C", userAgentHint: "admin-ui" },
@@ -84,7 +85,14 @@ describe("planFishbowlMessageHandoffs", () => {
 
   it("stays silent for broadcasts, humans, self-handoffs, FYI, and ambiguous recipients", () => {
     expect(planFishbowlMessageHandoffs({ ...baseInput, recipients: ["all"] })).toEqual([]);
+    expect(planFishbowlMessageHandoffs({ ...baseInput, recipients: ["B", "Q"] })).toEqual([]);
     expect(planFishbowlMessageHandoffs({ ...baseInput, recipients: ["C"] })).toEqual([]);
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        authorAgentId: "human_chris",
+      }),
+    ).toEqual([]);
     expect(
       planFishbowlMessageHandoffs({
         ...baseInput,

--- a/api/lib/fishbowl-message-handoff.ts
+++ b/api/lib/fishbowl-message-handoff.ts
@@ -51,12 +51,19 @@ export interface FishbowlMessageHandoffDispatchRow {
 export function planFishbowlMessageHandoffs(
   input: FishbowlMessageHandoffInput,
 ): FishbowlMessageHandoffPlan[] {
-  const tagSet = new Set(input.tags);
   const hasActionTag = input.tags.some((tag) => ACTION_TAGS.has(tag));
   if (!hasActionTag) return [];
 
+  const authorProfile = input.recipientProfiles.find(
+    (profile) =>
+      profile.userAgentHint !== "admin-ui" &&
+      !profile.agentId.startsWith("human-") &&
+      profile.agentId === input.authorAgentId,
+  );
+  if (!authorProfile) return [];
+
   const recipients = input.recipients.map((recipient) => recipient.trim()).filter(Boolean);
-  if (recipients.length === 0 || recipients.includes("all")) return [];
+  if (recipients.length !== 1 || recipients[0] === "all") return [];
 
   const summary = input.text.length > 200 ? `${input.text.slice(0, 197)}...` : input.text;
   const plans: FishbowlMessageHandoffPlan[] = [];

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7172,23 +7172,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             const summary =
               summarySource.length > 200 ? `${summarySource.slice(0, 197)}...` : summarySource;
 
-            await supabase.from("mc_signals").insert({
-              api_key_hash: apiKeyHash,
-              tool: "fishbowl",
-              action: "message_posted",
-              severity,
-              summary,
-              deep_link: `/admin/fishbowl#msg-${inserted.id}`,
-              payload: {
-                author_emoji: inserted.author_emoji,
-                author_agent_id: inserted.author_agent_id,
-                recipients: recipientList,
-                tags: tagList,
-                message_id: inserted.id,
-                policy_label: needsDoing ? "warning" : severity,
-              },
-            });
-
             const handoffPlans = planFishbowlMessageHandoffs({
               messageId: inserted.id,
               text: summarySource,
@@ -7232,9 +7215,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 throw new Error("message handoff dispatch lease was not persisted");
               }
             }
+
+            await supabase.from("mc_signals").insert({
+              api_key_hash: apiKeyHash,
+              tool: "fishbowl",
+              action: "message_posted",
+              severity,
+              summary,
+              deep_link: `/admin/fishbowl#msg-${inserted.id}`,
+              payload: {
+                author_emoji: inserted.author_emoji,
+                author_agent_id: inserted.author_agent_id,
+                recipients: recipientList,
+                tags: tagList,
+                message_id: inserted.id,
+                policy_label: needsDoing ? "warning" : severity,
+              },
+            });
           } catch (publishErr) {
             console.error(
-              "[fishbowl_post] signal publish failed:",
+              "[fishbowl_post] async wake plumbing failed:",
               (publishErr as Error).message,
             );
           }


### PR DESCRIPTION
## PinballWake v0.1 hardening - direct Fishbowl worker handoffs

### Summary
PR #350 landed the Fishbowl message ACK handoff path first. This follow-up narrows it to the exact direct-worker-only contract from 😎's push.

### Files owned
- `api/lib/fishbowl-message-handoff.ts`
- `api/fishbowl-message-handoff.test.ts`
- `api/memory-admin.ts`

### Non-overlap statement
This is a follow-up on current main after #350 merged. Closed duplicate #351 instead of force-pushing over the same work. This PR does not touch event-router files, workflows, secrets, migrations, Connections, Pass internals, or another worker branch.

### What changed
- Requires the author to resolve to a known non-human worker profile.
- Requires exactly one recipient and rejects `all` or multi-recipient posts.
- Keeps human recipients, human authors, unknown recipients, no-action tags, and self-handoffs silent.
- Moves ACK dispatch persistence before the best-effort `mc_signals` insert so a signal write failure does not prevent dispatch proof.

### Verification
- `npm run test -- api/fishbowl-message-handoff.test.ts` - 4/4 passed
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck --strict api/lib/fishbowl-message-handoff.ts api/fishbowl-message-handoff.test.ts` - passed
- `npm run build` - passed
- `git diff --cached --check` - passed before commit

### Ring-fencing impact
Estimated +1-2% quality hardening on top of #350. The coverage already landed; this reduces false-positive WakePass traffic and makes the dispatch proof more reliable.

Draft until CI is green.
