### PR TITLE
fix(wakepass): keep wake-router posts out of handoff ACKs

### DIFF
--- a/api/fishbowl-message-handoff.test.ts
+++ b/api/fishbowl-message-handoff.test.ts
@@ -104,4 +104,20 @@ describe("planFishbowlMessageHandoffs", () => {
       }),
     ).toEqual([]);
   });
+
+  it("stays silent for wake-router posts that already registered dispatch proof", () => {
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        authorAgentId: "github-action-wake-router",
+        tags: ["needs-doing"],
+      }),
+    ).toEqual([]);
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        tags: ["needs-doing", "wake"],
+      }),
+    ).toEqual([]);
+  });
 });

--- a/api/lib/fishbowl-message-handoff.ts
+++ b/api/lib/fishbowl-message-handoff.ts
@@ -3,6 +3,7 @@
 export const FISHBOWL_MESSAGE_HANDOFF_LEASE_SECONDS = 600;
 
 const ACTION_TAGS = new Set(["needs-doing", "blocker", "tripwire"]);
+const PRE_DISPATCHED_AUTHORS = new Set(["github-action-wake-router"]);
 
 export interface FishbowlMessageRecipientProfile {
   agentId: string;
@@ -51,7 +52,9 @@ export interface FishbowlMessageHandoffDispatchRow {
 export function planFishbowlMessageHandoffs(
   input: FishbowlMessageHandoffInput,
 ): FishbowlMessageHandoffPlan[] {
+  if (PRE_DISPATCHED_AUTHORS.has(input.authorAgentId)) return [];
   const tagSet = new Set(input.tags);
+  if (tagSet.has("wake")) return [];
   const hasActionTag = input.tags.some((tag) => ACTION_TAGS.has(tag));
   if (!hasActionTag) return [];
 


### PR DESCRIPTION
Summary:
Keeps Fishbowl wake-router messages out of the message-handoff ACK planner so already-dispatched wake events do not get a second ACK lease.

Scope:
Owned files: api/lib/fishbowl-message-handoff.ts, api/fishbowl-message-handoff.test.ts.
Lane: WakePass / PinballWake reliability hardening.

Non-overlap:
Does not touch memory-admin integration code, event-wake-router, workflows, migrations, auth, secrets, billing, UI, or PR #351.

Verification:
- npx vitest run api/fishbowl-message-handoff.test.ts api/fishbowl-todo-handoff.test.ts
- npx tsc --noEmit --pretty false --skipLibCheck --moduleResolution bundler --module esnext --target es2022 --jsx react-jsx --types vitest/globals,node api/lib/fishbowl-message-handoff.ts api/fishbowl-message-handoff.test.ts
- npm run build
- git diff --check

Risk:
Low. This only narrows dispatch creation for pre-dispatched wake-router posts and messages tagged wake; normal direct worker handoffs still create ACK-required leases.

Follow-up:
Watch CI and lift from draft only if green and scope stays clean.