### PR TITLE
Harden wake router missing-token failure path

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -303,9 +303,13 @@ async function postWake(decision, triage, eventId, event) {
     text,
   };
 
-  if (dryRun || !unclickApiKey) {
+  if (dryRun) {
     console.log(JSON.stringify({ dry_run: true, missing_key: !unclickApiKey, payload }, null, 2));
     return { posted: false, dry_run: true, payload };
+  }
+  if (!unclickApiKey) {
+    console.error("FISHBOWL_WAKE_TOKEN or FISHBOWL_AUTOCLOSE_TOKEN is required for wake posting.");
+    return { posted: false, dry_run: false, missing_key: true, payload };
   }
 
   const response = await fetch(`${apiUrl}?action=fishbowl_post`, {
@@ -376,7 +380,7 @@ async function registerWakeDispatch({ eventId, decision, triage, result, event }
     lease_seconds: ackFailSeconds,
   };
 
-  if (dryRun || !unclickApiKey) {
+  if (dryRun) {
     console.log(
       JSON.stringify(
         {
@@ -395,6 +399,15 @@ async function registerWakeDispatch({ eventId, decision, triage, result, event }
       dispatch_id: dispatchRequest.dispatch_id,
       upsert: dispatchRequest,
       claim: claimRequest,
+    };
+  }
+  if (!unclickApiKey) {
+    console.error("FISHBOWL_WAKE_TOKEN or FISHBOWL_AUTOCLOSE_TOKEN is required for reliability dispatch.");
+    return {
+      registered: false,
+      dry_run: false,
+      dispatch_id: dispatchRequest.dispatch_id,
+      error: "missing_wake_token",
     };
   }
 

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -337,4 +337,49 @@ describe("event wake router reliability dispatch", () => {
     assert.match(result.stdout, /No wake needed/);
     assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
   });
+
+  it("fails closed when wake is required but wake token is missing", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        action: "completed",
+        workflow_run: {
+          id: 460,
+          name: "TestPass Scheduled Smoke",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/acme/repo/actions/runs/460",
+          created_at: "2026-04-30T17:00:00Z",
+          updated_at: "2026-04-30T17:05:00Z",
+          pull_requests: [],
+        },
+      }),
+    );
+
+    try {
+      const env = { ...process.env };
+      delete env.FISHBOWL_WAKE_TOKEN;
+      delete env.FISHBOWL_AUTOCLOSE_TOKEN;
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "false",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /required for reliability dispatch|required for wake posting/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary\n- fail closed when a wake is required but Fishbowl token is missing\n- keep true dry-run behavior unchanged\n- add regression test for missing-token non-dry wake\n\n## Verification\n- node --test scripts/event-wake-router.test.mjs