### PR TITLE
feat(wakepass): ask workers to review new ideas

### DIFF
--- a/api/fishbowl-idea-council.test.ts
+++ b/api/fishbowl-idea-council.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFishbowlIdeaCouncilDispatchRow,
+  FISHBOWL_IDEA_COUNCIL_LEASE_SECONDS,
+  planFishbowlIdeaCouncilHandoffs,
+} from "./lib/fishbowl-idea-council";
+import { createDispatchId, createReclaimSignal } from "../packages/mcp-server/src/reliability";
+
+const profiles = [
+  {
+    agentId: "agent_author",
+    emoji: "A",
+    lastSeenAt: "2026-05-01T01:00:00.000Z",
+  },
+  {
+    agentId: "agent_builder",
+    emoji: "B",
+    lastSeenAt: "2026-05-01T03:00:00.000Z",
+  },
+  {
+    agentId: "agent_qc",
+    emoji: "Q",
+    currentStatusUpdatedAt: "2026-05-01T02:30:00.000Z",
+  },
+  {
+    agentId: "human_chris",
+    emoji: "C",
+    userAgentHint: "admin-ui",
+    lastSeenAt: "2026-05-01T03:15:00.000Z",
+  },
+];
+
+const baseInput = {
+  ideaId: "idea-abc",
+  title: "Make Ideas ask the council",
+  description: "When a new idea arrives, ask a small AI quorum to comment or vote.",
+  createdByAgentId: "agent_author",
+  profiles,
+};
+
+describe("planFishbowlIdeaCouncilHandoffs", () => {
+  it("produces ACK-required dispatch plans for a new idea council review", () => {
+    const plans = planFishbowlIdeaCouncilHandoffs(baseInput);
+
+    expect(plans).toHaveLength(2);
+    expect(plans[0]).toMatchObject({
+      source: "fishbowl",
+      targetAgentId: "agent_builder",
+      taskRef: "fishbowl-idea:idea-abc",
+      leaseSeconds: FISHBOWL_IDEA_COUNCIL_LEASE_SECONDS,
+      payload: {
+        kind: "idea_council_review",
+        idea_id: "idea-abc",
+        title: "Make Ideas ask the council",
+        summary: "When a new idea arrives, ask a small AI quorum to comment or vote.",
+        deep_link: "/admin/fishbowl#idea-idea-abc",
+        created_by_agent_id: "agent_author",
+        requested_action: "comment_or_vote",
+        ack_required: true,
+      },
+    });
+    expect(plans[1].targetAgentId).toBe("agent_qc");
+  });
+
+  it("builds already-leased dispatch rows for reclaimable ACK tracking", () => {
+    const plan = planFishbowlIdeaCouncilHandoffs(baseInput)[0];
+    const row = buildFishbowlIdeaCouncilDispatchRow({
+      apiKeyHash: "hash_123",
+      dispatchId: "dispatch_123",
+      plan,
+      now: new Date("2026-05-01T03:20:00.000Z"),
+    });
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash_123",
+      dispatch_id: "dispatch_123",
+      source: "fishbowl",
+      target_agent_id: "agent_builder",
+      task_ref: "fishbowl-idea:idea-abc",
+      status: "leased",
+      lease_owner: "agent_builder",
+      lease_expires_at: "2026-05-01T03:30:00.000Z",
+      created_at: "2026-05-01T03:20:00.000Z",
+      updated_at: "2026-05-01T03:20:00.000Z",
+    });
+    expect(row.payload.ack_required).toBe(true);
+  });
+
+  it("dispatch payload triggers handoff_ack_missing on stale reclaim", () => {
+    const plan = planFishbowlIdeaCouncilHandoffs(baseInput)[0];
+    const signal = createReclaimSignal(
+      {
+        dispatchId: "dispatch_123",
+        source: plan.source,
+        targetAgentId: plan.targetAgentId,
+        taskRef: plan.taskRef,
+        payload: plan.payload,
+      },
+      900,
+    );
+
+    expect(signal.action).toBe("handoff_ack_missing");
+  });
+
+  it("keeps each worker ACK isolated with a target-specific dispatch id", () => {
+    const plans = planFishbowlIdeaCouncilHandoffs(baseInput);
+    const dispatchIds = plans.map((plan) =>
+      createDispatchId({
+        source: plan.source,
+        targetAgentId: plan.targetAgentId,
+        taskRef: plan.taskRef,
+      }),
+    );
+
+    expect(dispatchIds).toHaveLength(2);
+    expect(new Set(dispatchIds).size).toBe(2);
+    expect(plans[0].taskRef).toBe(plans[1].taskRef);
+  });
+
+  it("stays silent for human-only, self-only, missing-profile, and disabled quorum paths", () => {
+    expect(
+      planFishbowlIdeaCouncilHandoffs({
+        ...baseInput,
+        profiles: profiles.filter((profile) => profile.agentId === "agent_author"),
+      }),
+    ).toEqual([]);
+    expect(
+      planFishbowlIdeaCouncilHandoffs({
+        ...baseInput,
+        profiles: profiles.filter((profile) => profile.userAgentHint === "admin-ui"),
+      }),
+    ).toEqual([]);
+    expect(planFishbowlIdeaCouncilHandoffs({ ...baseInput, profiles: [] })).toEqual([]);
+    expect(planFishbowlIdeaCouncilHandoffs({ ...baseInput, maxReviewers: 0 })).toEqual([]);
+  });
+
+  it("deduplicates workers and respects the reviewer cap", () => {
+    const plans = planFishbowlIdeaCouncilHandoffs({
+      ...baseInput,
+      maxReviewers: 1,
+      profiles: [
+        ...profiles,
+        {
+          agentId: "agent_builder",
+          emoji: "B2",
+          lastSeenAt: "2026-05-01T03:30:00.000Z",
+        },
+      ],
+    });
+
+    expect(plans).toHaveLength(1);
+    expect(plans[0].targetAgentId).toBe("agent_builder");
+  });
+});

--- a/api/lib/fishbowl-idea-council.ts
+++ b/api/lib/fishbowl-idea-council.ts
@@ -1,0 +1,147 @@
+// Universal ACK Handoff planner for Fishbowl Ideas Council participation.
+//
+// A newly proposed idea should invite a small worker quorum to comment/vote.
+// The invite is action-needed enough to track with a 600-second ACK lease, but
+// only targets AI worker profiles. Humans, the author, and missing profiles stay
+// silent so Ideas does not become noisy.
+
+export const FISHBOWL_IDEA_COUNCIL_LEASE_SECONDS = 600;
+export const FISHBOWL_IDEA_COUNCIL_MAX_REVIEWERS = 2;
+
+export interface FishbowlIdeaCouncilProfile {
+  agentId: string;
+  emoji?: string | null | undefined;
+  displayName?: string | null | undefined;
+  userAgentHint?: string | null | undefined;
+  lastSeenAt?: string | null | undefined;
+  currentStatusUpdatedAt?: string | null | undefined;
+}
+
+export interface FishbowlIdeaCouncilInput {
+  ideaId: string;
+  title: string;
+  description?: string | null | undefined;
+  createdByAgentId: string;
+  profiles: FishbowlIdeaCouncilProfile[];
+  maxReviewers?: number;
+}
+
+export interface FishbowlIdeaCouncilPlan {
+  source: "fishbowl";
+  targetAgentId: string;
+  taskRef: string;
+  payload: {
+    kind: "idea_council_review";
+    idea_id: string;
+    title: string;
+    summary: string;
+    deep_link: string;
+    created_by_agent_id: string;
+    requested_action: "comment_or_vote";
+    ack_required: true;
+  };
+  leaseSeconds: number;
+}
+
+export interface FishbowlIdeaCouncilDispatchRow {
+  api_key_hash: string;
+  dispatch_id: string;
+  source: "fishbowl";
+  target_agent_id: string;
+  task_ref: string;
+  status: "leased";
+  lease_owner: string;
+  lease_expires_at: string;
+  payload: FishbowlIdeaCouncilPlan["payload"];
+  created_at: string;
+  updated_at: string;
+}
+
+function isHumanProfile(profile: FishbowlIdeaCouncilProfile): boolean {
+  return (
+    profile.userAgentHint === "admin-ui" ||
+    profile.agentId.startsWith("human-") ||
+    profile.agentId.startsWith("human_")
+  );
+}
+
+function recencyMillis(profile: FishbowlIdeaCouncilProfile): number {
+  const candidates = [profile.lastSeenAt, profile.currentStatusUpdatedAt]
+    .map((value) => (value ? Date.parse(value) : Number.NaN))
+    .filter((value) => Number.isFinite(value));
+  return candidates.length > 0 ? Math.max(...candidates) : 0;
+}
+
+function compactSummary(title: string, description: string | null | undefined): string {
+  const source = (description ?? "").trim() || title;
+  return source.length > 200 ? `${source.slice(0, 197)}...` : source;
+}
+
+export function planFishbowlIdeaCouncilHandoffs(
+  input: FishbowlIdeaCouncilInput,
+): FishbowlIdeaCouncilPlan[] {
+  const maxReviewers = Math.max(
+    0,
+    Math.min(input.maxReviewers ?? FISHBOWL_IDEA_COUNCIL_MAX_REVIEWERS, 5),
+  );
+  if (maxReviewers === 0) return [];
+
+  const plannedTargets = new Set<string>();
+  const eligibleProfiles = input.profiles
+    .filter((profile) => profile.agentId.trim())
+    .filter((profile) => profile.agentId !== input.createdByAgentId)
+    .filter((profile) => !isHumanProfile(profile))
+    .sort((a, b) => recencyMillis(b) - recencyMillis(a));
+
+  const summary = compactSummary(input.title, input.description);
+  const plans: FishbowlIdeaCouncilPlan[] = [];
+
+  for (const profile of eligibleProfiles) {
+    if (plannedTargets.has(profile.agentId)) continue;
+    plannedTargets.add(profile.agentId);
+    plans.push({
+      source: "fishbowl",
+      targetAgentId: profile.agentId,
+      taskRef: `fishbowl-idea:${input.ideaId}`,
+      payload: {
+        kind: "idea_council_review",
+        idea_id: input.ideaId,
+        title: input.title,
+        summary,
+        deep_link: `/admin/fishbowl#idea-${input.ideaId}`,
+        created_by_agent_id: input.createdByAgentId,
+        requested_action: "comment_or_vote",
+        ack_required: true,
+      },
+      leaseSeconds: FISHBOWL_IDEA_COUNCIL_LEASE_SECONDS,
+    });
+
+    if (plans.length >= maxReviewers) break;
+  }
+
+  return plans;
+}
+
+export function buildFishbowlIdeaCouncilDispatchRow(params: {
+  apiKeyHash: string;
+  dispatchId: string;
+  plan: FishbowlIdeaCouncilPlan;
+  now: Date;
+}): FishbowlIdeaCouncilDispatchRow {
+  const nowIso = params.now.toISOString();
+  return {
+    api_key_hash: params.apiKeyHash,
+    dispatch_id: params.dispatchId,
+    source: params.plan.source,
+    target_agent_id: params.plan.targetAgentId,
+    task_ref: params.plan.taskRef,
+    status: "leased",
+    lease_owner: params.plan.targetAgentId,
+    lease_expires_at: new Date(
+      params.now.getTime() + params.plan.leaseSeconds * 1000,
+    ).toISOString(),
+    payload: params.plan.payload,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -102,6 +102,10 @@ import {
   planFishbowlMessageHandoffs,
 } from "./lib/fishbowl-message-handoff.js";
 import {
+  buildFishbowlIdeaCouncilDispatchRow,
+  planFishbowlIdeaCouncilHandoffs,
+} from "./lib/fishbowl-idea-council.js";
+import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
@@ -7784,6 +7788,67 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             "idea-created",
             `New idea: ${titleRes}`,
           );
+
+          // Ideas Council: a fresh idea should invite a small worker quorum to
+          // comment/vote. Register ACK-required dispatches so stale participation
+          // becomes visible without waking humans or the idea author.
+          try {
+            const { data: profileRows, error: profileErr } = await supabase
+              .from("mc_fishbowl_profiles")
+              .select("agent_id, emoji, display_name, user_agent_hint, last_seen_at, current_status_updated_at")
+              .eq("api_key_hash", apiKeyHash);
+            if (profileErr) throw profileErr;
+
+            const councilPlans = planFishbowlIdeaCouncilHandoffs({
+              ideaId: data.id,
+              title: titleRes,
+              description: descRes,
+              createdByAgentId: agentId,
+              profiles: (profileRows ?? []).map((profileRow) => ({
+                agentId: profileRow.agent_id,
+                emoji: profileRow.emoji,
+                displayName: profileRow.display_name,
+                userAgentHint: profileRow.user_agent_hint,
+                lastSeenAt: profileRow.last_seen_at,
+                currentStatusUpdatedAt: profileRow.current_status_updated_at,
+              })),
+            });
+
+            for (const councilPlan of councilPlans) {
+              const dispatchId = createDispatchId({
+                source: councilPlan.source,
+                targetAgentId: councilPlan.targetAgentId,
+                taskRef: councilPlan.taskRef,
+              });
+              const now = new Date();
+              const { data: dispatchRows, error: upsertErr } = await supabase
+                .from("mc_agent_dispatches")
+                .upsert(
+                  buildFishbowlIdeaCouncilDispatchRow({
+                    apiKeyHash,
+                    dispatchId,
+                    plan: councilPlan,
+                    now,
+                  }),
+                  { onConflict: "api_key_hash,dispatch_id" },
+                )
+                .select("dispatch_id,status,lease_owner,lease_expires_at");
+              if (upsertErr) throw upsertErr;
+
+              const dispatchRow = dispatchRows?.[0];
+              if (
+                !dispatchRow ||
+                dispatchRow.status !== "leased" ||
+                dispatchRow.lease_owner !== councilPlan.targetAgentId ||
+                !dispatchRow.lease_expires_at
+              ) {
+                throw new Error("idea council dispatch lease was not persisted");
+              }
+            }
+          } catch (err) {
+            console.warn("[fishbowl_create_idea] council dispatch wrapping failed:", err);
+          }
+
           return res.status(200).json({ idea: data });
         }
 


### PR DESCRIPTION
## Summary
- Add an Ideas Council ACK handoff planner for newly proposed Fishbowl ideas.
- fishbowl_create_idea now asks up to two non-human, non-author worker profiles to comment/vote through ACK-required WakePass dispatches.
- Dispatches use the existing 10-minute lease pattern so missed participation becomes reclaimable as handoff_ack_missing.

## Scope
- api/lib/fishbowl-idea-council.ts
- api/fishbowl-idea-council.test.ts
- api/memory-admin.ts create-idea path only

## Non-overlap
- Does not touch Fishbowl message handoffs, todo handoffs, wake-router, Connections, TestPass, secrets, migrations, UI, DNS, billing, or auth.
- Stays out of the #350/#352/#353 worker-to-worker message handoff lane.

## Verification
- npm run test -- api/fishbowl-idea-council.test.ts api/fishbowl-message-handoff.test.ts api/fishbowl-todo-handoff.test.ts
- npm run build
- npm run build --workspace packages/mcp-server
- npm run test --workspace packages/mcp-server
- npx tsc --noEmit --skipLibCheck
- npx eslint api/lib/fishbowl-idea-council.ts api/fishbowl-idea-council.test.ts api/memory-admin.ts
- git diff --check

Note: full npm run lint still fails on pre-existing repo-wide lint debt unrelated to these files.

## Risk
Low. Best-effort dispatch wrapping logs and continues if profile lookup or dispatch upsert fails, so idea creation is not blocked.

## Ring-fencing Impact
Moves Ideas from passive/stale to active discussion requests. Rough estimate: +3-5% on Fishbowl collaboration ring-fencing by making new ideas visible to workers with ACK/missed-ACK proof.