### PR TITLE
fix(testpass): wake on background failures

### DIFF
--- a/api/lib/testpass-background-handoff.ts
+++ b/api/lib/testpass-background-handoff.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import type { RunProfile, RunTarget } from "../../packages/testpass/src/types.js";
+
+export const TESTPASS_BACKGROUND_HANDOFF_LEASE_SECONDS = 600;
+export const DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID = "chatgpt-55-plex-creativelead";
+
+export interface TestPassBackgroundFailureHandoffInput {
+  runId: string;
+  packSlug: string;
+  packName: string;
+  profile: RunProfile;
+  target: RunTarget;
+  targetAgentId: string | null | undefined;
+  errorMessage: string | null | undefined;
+}
+
+export interface TestPassBackgroundFailureHandoffPlan {
+  source: "testpass";
+  targetAgentId: string;
+  taskRef: string;
+  payload: {
+    kind: "testpass_background_failure";
+    run_id: string;
+    pack_slug: string;
+    pack_name: string;
+    profile: RunProfile;
+    target_url: string;
+    error_message: string;
+    ack_required: true;
+  };
+  leaseSeconds: number;
+}
+
+export interface TestPassBackgroundFailureDispatchRow {
+  api_key_hash: string;
+  dispatch_id: string;
+  source: "testpass";
+  target_agent_id: string;
+  task_ref: string;
+  status: "leased";
+  lease_owner: string;
+  lease_expires_at: string;
+  payload: TestPassBackgroundFailureHandoffPlan["payload"];
+  created_at: string;
+  updated_at: string;
+}
+
+function truncateError(value: string): string {
+  return value.length > 300 ? `${value.slice(0, 297)}...` : value;
+}
+
+export function testPassBackgroundFailureDispatchId(runId: string): string {
+  const digest = createHash("sha256")
+    .update(`testpass-background-failure:${runId}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `dispatch_${digest}`;
+}
+
+export function planTestPassBackgroundFailureHandoff(
+  input: TestPassBackgroundFailureHandoffInput,
+): TestPassBackgroundFailureHandoffPlan | null {
+  const targetAgentId = (input.targetAgentId ?? "").trim();
+  const errorMessage = (input.errorMessage ?? "").trim();
+  if (!targetAgentId || !input.runId || !errorMessage) return null;
+
+  return {
+    source: "testpass",
+    targetAgentId,
+    taskRef: `testpass-run:${input.runId}`,
+    payload: {
+      kind: "testpass_background_failure",
+      run_id: input.runId,
+      pack_slug: input.packSlug,
+      pack_name: input.packName,
+      profile: input.profile,
+      target_url: input.target.url ?? "",
+      error_message: truncateError(errorMessage),
+      ack_required: true,
+    },
+    leaseSeconds: TESTPASS_BACKGROUND_HANDOFF_LEASE_SECONDS,
+  };
+}
+
+export function buildTestPassBackgroundFailureDispatchRow(params: {
+  apiKeyHash: string;
+  dispatchId: string;
+  plan: TestPassBackgroundFailureHandoffPlan;
+  now: Date;
+}): TestPassBackgroundFailureDispatchRow {
+  const nowIso = params.now.toISOString();
+  return {
+    api_key_hash: params.apiKeyHash,
+    dispatch_id: params.dispatchId,
+    source: params.plan.source,
+    target_agent_id: params.plan.targetAgentId,
+    task_ref: params.plan.taskRef,
+    status: "leased",
+    lease_owner: params.plan.targetAgentId,
+    lease_expires_at: new Date(
+      params.now.getTime() + params.plan.leaseSeconds * 1000,
+    ).toISOString(),
+    payload: params.plan.payload,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+}

--- a/api/testpass-background-handoff.test.ts
+++ b/api/testpass-background-handoff.test.ts
@@ -1,0 +1,96 @@
+import {
+  buildTestPassBackgroundFailureDispatchRow,
+  DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID,
+  planTestPassBackgroundFailureHandoff,
+  TESTPASS_BACKGROUND_HANDOFF_LEASE_SECONDS,
+  testPassBackgroundFailureDispatchId,
+} from "./lib/testpass-background-handoff";
+
+describe("planTestPassBackgroundFailureHandoff", () => {
+  const baseInput = {
+    runId: "run-123",
+    packSlug: "unclick-smoke",
+    packName: "UnClick Smoke",
+    profile: "standard" as const,
+    target: { type: "url" as const, url: "https://unclick.world" },
+    targetAgentId: DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID,
+    errorMessage: "database write failed",
+  };
+
+  it("creates ACK-required dispatch plans for background failures", () => {
+    const plan = planTestPassBackgroundFailureHandoff(baseInput);
+
+    expect(plan).toEqual({
+      source: "testpass",
+      targetAgentId: DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID,
+      taskRef: "testpass-run:run-123",
+      leaseSeconds: TESTPASS_BACKGROUND_HANDOFF_LEASE_SECONDS,
+      payload: {
+        kind: "testpass_background_failure",
+        run_id: "run-123",
+        pack_slug: "unclick-smoke",
+        pack_name: "UnClick Smoke",
+        profile: "standard",
+        target_url: "https://unclick.world",
+        error_message: "database write failed",
+        ack_required: true,
+      },
+    });
+  });
+
+  it("builds an already-leased dispatch row for reclaimable ACK tracking", () => {
+    const plan = planTestPassBackgroundFailureHandoff(baseInput);
+    expect(plan).not.toBeNull();
+
+    const row = buildTestPassBackgroundFailureDispatchRow({
+      apiKeyHash: "hash-123",
+      dispatchId: "dispatch_123",
+      plan: plan!,
+      now: new Date("2026-05-01T00:00:00.000Z"),
+    });
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash-123",
+      dispatch_id: "dispatch_123",
+      source: "testpass",
+      target_agent_id: DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID,
+      task_ref: "testpass-run:run-123",
+      status: "leased",
+      lease_owner: DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID,
+      lease_expires_at: "2026-05-01T00:10:00.000Z",
+      created_at: "2026-05-01T00:00:00.000Z",
+      updated_at: "2026-05-01T00:00:00.000Z",
+    });
+    expect(row.payload.ack_required).toBe(true);
+  });
+
+  it("uses stable dispatch ids so repeated catch paths do not duplicate work", () => {
+    expect(testPassBackgroundFailureDispatchId("run-123")).toBe(
+      testPassBackgroundFailureDispatchId("run-123"),
+    );
+    expect(testPassBackgroundFailureDispatchId("run-123")).toMatch(/^dispatch_[a-f0-9]{32}$/);
+  });
+
+  it("stays silent for normal accepted paths without an error", () => {
+    expect(planTestPassBackgroundFailureHandoff({ ...baseInput, errorMessage: "" })).toBeNull();
+    expect(planTestPassBackgroundFailureHandoff({ ...baseInput, targetAgentId: "" })).toBeNull();
+  });
+
+  it("keeps missed ACKs eligible for handoff_ack_missing reclaim signals", () => {
+    const plan = planTestPassBackgroundFailureHandoff(baseInput);
+    expect(plan).not.toBeNull();
+
+    const row = buildTestPassBackgroundFailureDispatchRow({
+      apiKeyHash: "hash-123",
+      dispatchId: "dispatch_123",
+      plan: plan!,
+      now: new Date("2026-05-01T00:00:00.000Z"),
+    });
+
+    expect(row.status).toBe("leased");
+    expect(row.lease_owner).toBe(DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID);
+    expect(row.lease_expires_at).toBe("2026-05-01T00:10:00.000Z");
+    expect(row.payload.kind).toBe("testpass_background_failure");
+    expect(row.payload.ack_required).toBe(true);
+  });
+});

--- a/api/testpass-run.ts
+++ b/api/testpass-run.ts
@@ -28,6 +28,12 @@ import * as path from "node:path";
 import * as url from "node:url";
 import { createHash } from "node:crypto";
 import type { RunProfile, RunTarget } from "../packages/testpass/src/types.js";
+import {
+  buildTestPassBackgroundFailureDispatchRow,
+  DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID,
+  planTestPassBackgroundFailureHandoff,
+  testPassBackgroundFailureDispatchId,
+} from "./lib/testpass-background-handoff.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -128,6 +134,58 @@ function emitScheduledRunSignal(params: {
   });
 }
 
+async function createBackgroundFailureDispatch(params: {
+  supabaseUrl: string;
+  serviceKey: string;
+  apiKeyHash: string | null;
+  runId: string;
+  packSlug: string;
+  packName: string;
+  profile: RunProfile;
+  target: RunTarget;
+  error: unknown;
+}) {
+  if (!params.apiKeyHash) return;
+  const targetAgentId =
+    process.env.TESTPASS_WAKE_AGENT_ID ?? DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID;
+  const plan = planTestPassBackgroundFailureHandoff({
+    runId: params.runId,
+    packSlug: params.packSlug,
+    packName: params.packName,
+    profile: params.profile,
+    target: params.target,
+    targetAgentId,
+    errorMessage: params.error instanceof Error ? params.error.message : String(params.error),
+  });
+  if (!plan) return;
+
+  const row = buildTestPassBackgroundFailureDispatchRow({
+    apiKeyHash: params.apiKeyHash,
+    dispatchId: testPassBackgroundFailureDispatchId(params.runId),
+    plan,
+    now: new Date(),
+  });
+
+  const response = await fetch(`${params.supabaseUrl}/rest/v1/mc_agent_dispatches`, {
+    method: "POST",
+    headers: {
+      apikey: params.serviceKey,
+      Authorization: `Bearer ${params.serviceKey}`,
+      "Content-Type": "application/json",
+      Prefer: "resolution=ignore-duplicates",
+    },
+    body: JSON.stringify(row),
+  });
+  if (!response.ok && response.status !== 409) {
+    const body = await response.text().catch(() => "");
+    console.error(
+      `testpass-run failed to create background failure dispatch for ${params.runId}:`,
+      response.status,
+      body,
+    );
+  }
+}
+
 function queryString(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
@@ -199,7 +257,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     actorUserId = await getActorUserId(supabaseUrl, token);
     if (!actorUserId) return json(res, 401, { error: "Invalid session" });
   }
-  const apiKeyHash = shouldEmitScheduledSignal(input.source)
+  const apiKeyHash = shouldEmitScheduledSignal(input.source) || profile !== "smoke"
     ? await getApiKeyHashForUser(supabaseUrl, serviceKey, actorUserId)
     : null;
 
@@ -297,8 +355,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
   }
 
-  runWork().catch((err) => {
+  runWork().catch(async (err) => {
     console.error(`testpass-run background work failed for ${runId}:`, (err as Error).message);
+    try {
+      await createBackgroundFailureDispatch({
+        supabaseUrl,
+        serviceKey,
+        apiKeyHash,
+        runId,
+        packSlug,
+        packName,
+        profile,
+        target,
+        error: err,
+      });
+    } catch (dispatchErr) {
+      console.error(
+        `testpass-run background failure dispatch errored for ${runId}:`,
+        (dispatchErr as Error).message,
+      );
+    }
   });
   return json(res, 202, {
     run_id: runId,


### PR DESCRIPTION
## Summary
- Create an ACK-required WakePass dispatch when a non-smoke TestPass background run throws after returning 202.
- Keep normal accepted/background-start paths silent unless an actual background failure occurs.
- Add focused planner tests for 600s lease, stable dispatch ID, quiet path, and reclaim eligibility.

## Files owned
- api/testpass-run.ts
- api/lib/testpass-background-handoff.ts
- api/testpass-background-handoff.test.ts

## Non-overlap
- Does not touch api/memory-admin.ts, create_idea, Fishbowl message/todo handoff files, event-wake-router files, Connections, migrations, secrets, auth, billing, or UI.
- Built from a fresh worktree on origin/main after #352 merged.

## Verification
- npx vitest run api/testpass-background-handoff.test.ts
- npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck --strict api/lib/testpass-background-handoff.ts api/testpass-background-handoff.test.ts api/testpass-run.ts
- npm run build
- git diff --cached --check

## Ring-fencing impact
Estimated +1% unattended automation coverage. A TestPass run that fails after the request returns no longer dies as a console-only event; it creates a leased ACK-required dispatch that can flow into stale reclaim / handoff_ack_missing.

Draft until CI is green and scope stays clean.