### PR TITLE
fix(analytics): initialize posthog on startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,8 +164,6 @@
     <!-- AI agent discovery -->
     <link rel="alternate" type="text/plain" href="/llms.txt" title="UnClick for AI agents" />
 
-    <!-- Umami Analytics -->
-    <script async src="https://analytics.unclick.world/script.js" data-website-id="724975a0-999c-4006-b238-19ee7182c25b"></script>
   </head>
 
   <body>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,19 +1,10 @@
+import { posthog } from "./posthog";
+
 /**
- * Analytics helper — thin wrapper around Umami's window.umami.track().
- *
- * The Umami snippet is loaded async in index.html with data-website-id
- * 724975a0-999c-4006-b238-19ee7182c25b, pointed at
- * https://analytics.unclick.world. It attaches window.umami with a
- * .track(eventName, eventData?) function once it finishes loading.
- *
- * This helper is safe to call before the script has loaded, in dev
- * environments without the script, and in tests — it no-ops instead
- * of throwing. Every failure mode is swallowed so analytics can never
- * break the app.
- *
- * Usage:
- *   track("signup_started", { method: "magic" });
- *   track("auth_success",   { new_user: true, provider: "google" });
+ * Analytics helper. PostHog is the primary client-side analytics path.
+ * Umami is kept as an optional compatibility fallback in case the old
+ * self-hosted script is restored later. Every failure mode is swallowed so
+ * analytics can never break the app.
  */
 
 type EventData = Record<string, string | number | boolean | null | undefined>;
@@ -27,6 +18,7 @@ interface UmamiWindow {
 export function track(event: string, data?: EventData): void {
   if (typeof window === "undefined") return;
   try {
+    posthog.capture(event, data);
     const umami = (window as unknown as UmamiWindow).umami;
     if (umami && typeof umami.track === "function") {
       umami.track(event, data);

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -9,8 +9,9 @@ export function initPostHog(): void {
   if (initialized || !key) return;
   posthog.init(key, {
     api_host: host,
+    defaults: "2026-01-30",
     autocapture: true,
-    capture_pageview: true,
+    capture_pageview: "history_change",
     persistence: "localStorage",
     respect_dnt: true,
   });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,7 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { initPostHog } from "./lib/posthog";
 
+initPostHog();
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- Initialize PostHog at app startup so client-side pageviews/events actually start flowing.
- Use PostHog history-change pageview tracking for the Vite SPA.
- Route the shared analytics helper through PostHog, while keeping Umami as optional fallback.
- Remove the broken Umami script tag that currently requests https://analytics.unclick.world/script.js, which returns 404 live.

## Scope
- index.html
- src/main.tsx
- src/lib/posthog.ts
- src/lib/analytics.ts

## Non-overlap
No secrets, DNS, billing, auth flows, migrations, backend wake reliability, Fishbowl, Connections, or Pass logic touched.

## Verification
- Live check before patch: https://analytics.unclick.world/script.js returned 404; live HTML loaded that script; live bundle contained PostHog config but app did not call initPostHog().
- npm run build
- npx tsc --noEmit --skipLibCheck
- npx eslint src/lib/posthog.ts src/lib/analytics.ts src/main.tsx
- git diff --check

## Risk
Low. If VITE_POSTHOG_KEY is missing in an environment, initPostHog still no-ops. If PostHog is blocked by browser/adblocker, the app continues normally.

## Follow-up
Consider a tiny first-party analytics receipt endpoint as a backup ledger, not a full PostHog replacement.