### PR TITLE
fix(dogfood): clarify public receipt proof

### DIFF
--- a/.github/workflows/dogfood-report.yml
+++ b/.github/workflows/dogfood-report.yml
@@ -51,11 +51,14 @@ jobs:
           {
             echo "### Public dogfood receipt"
             echo ""
+            echo "- Last run: \`$(jq -r '.lastRunAt // .generatedAt' public/dogfood/latest.json)\`"
+            echo "- Status: \`$(jq -r '.status // \"unknown\"' public/dogfood/latest.json)\`"
+            echo "- Source: \`$(jq -r '.source // \"unknown\"' public/dogfood/latest.json)\`"
             echo "- Output: \`public/dogfood/latest.json\`"
             echo "- Public URL: \`${{ inputs.public_url || 'https://unclick.world' }}\`"
             echo "- MCP URL: \`${{ inputs.mcp_url || 'https://unclick.world/api/mcp' }}\`"
             echo ""
-            jq -r '.results[] | "- \(.name): \(.status) - \(.summary)"' public/dogfood/latest.json
+            jq -r '.results[] | "- \(.name): \(.status) - \(.summary)\(if .blockedReason then " Blocked reason: \(.blockedReason)" else "" end)"' public/dogfood/latest.json
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit public receipt

--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -1,5 +1,7 @@
 {
   "generatedAt": "2026-05-01T00:50:00Z",
+  "lastRunAt": "2026-05-01T00:50:00Z",
+  "status": "pending",
   "source": "public seed receipt",
   "headline": "We dogfood UnClick on UnClick.",
   "target": "UnClick public and agent-facing product surfaces",
@@ -10,35 +12,40 @@
       "name": "TestPass",
       "status": "passing",
       "summary": "PR smoke checks are producing green receipts.",
-      "evidence": "Recent TestPass PR checks completed successfully on UnClick PRs."
+      "evidence": "Recent TestPass PR checks completed successfully on UnClick PRs.",
+      "checkedAt": "2026-05-01T00:50:00Z"
     },
     {
       "id": "uxpass",
       "name": "UXPass",
       "status": "pending",
       "summary": "Queued for recurring UX review.",
-      "evidence": "Public UX receipts will appear here once recurring checks begin."
+      "evidence": "Public UX receipts will appear here once recurring checks begin.",
+      "checkedAt": "2026-05-01T00:50:00Z"
     },
     {
       "id": "seopass",
       "name": "SEOPass",
       "status": "pending",
       "summary": "Queued for recurring search and metadata review.",
-      "evidence": "Public SEO receipts will appear here once recurring checks begin."
+      "evidence": "Public SEO receipts will appear here once recurring checks begin.",
+      "checkedAt": "2026-05-01T00:50:00Z"
     },
     {
       "id": "copypass",
       "name": "CopyPass",
       "status": "pending",
       "summary": "Queued for recurring copy quality review.",
-      "evidence": "Public copy-quality receipts will appear here once recurring checks begin."
+      "evidence": "Public copy-quality receipts will appear here once recurring checks begin.",
+      "checkedAt": "2026-05-01T00:50:00Z"
     },
     {
       "id": "legalpass",
       "name": "LegalPass",
       "status": "pending",
       "summary": "Queued for recurring policy and claims review.",
-      "evidence": "Public legal-quality receipts will appear here once recurring checks begin."
+      "evidence": "Public legal-quality receipts will appear here once recurring checks begin.",
+      "checkedAt": "2026-05-01T00:50:00Z"
     }
   ],
   "trend": [

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -21,21 +21,29 @@ function trimTrailingSlash(value) {
 }
 
 function statusFromFailureKind(failureKind) {
-  if (failureKind === "missing_secret") return "failing";
+  if (failureKind === "missing_secret") return "blocked";
   if (failureKind === "network" || failureKind === "http" || failureKind === "parse") return "failing";
   return "pending";
 }
 
+function result(id, name, status, summary, evidence, details = {}) {
+  return { id, name, status, summary, evidence, checkedAt: generatedAt, ...details };
+}
+
 function pendingResult(id, name, summary, evidence) {
-  return { id, name, status: "pending", summary, evidence };
+  return result(id, name, "pending", summary, evidence);
+}
+
+function blockedResult(id, name, summary, evidence, blockedReason) {
+  return result(id, name, "blocked", summary, evidence, { blockedReason });
 }
 
 function failureResult(id, name, summary, evidence) {
-  return { id, name, status: "failing", summary, evidence };
+  return result(id, name, "failing", summary, evidence);
 }
 
 function passResult(id, name, summary, evidence) {
-  return { id, name, status: "passing", summary, evidence };
+  return result(id, name, "passing", summary, evidence);
 }
 
 async function postJson(url, token, body) {
@@ -69,11 +77,12 @@ async function runTestPass() {
     );
   }
   if (!token) {
-    return failureResult(
+    return blockedResult(
       "testpass",
       "TestPass",
       "Scheduled TestPass could not run because DOGFOOD_TESTPASS_TOKEN or TESTPASS_TOKEN is missing.",
       "Set the GitHub secret so the nightly dogfood workflow can create a fresh testpass_runs row.",
+      "Missing DOGFOOD_TESTPASS_TOKEN or TESTPASS_TOKEN.",
     );
   }
 
@@ -108,13 +117,13 @@ async function runTestPass() {
     }
 
     const statusLabel = json.status || "unknown";
-    return {
-      id: "testpass",
-      name: "TestPass",
-      status: statusFromFailureKind(statusLabel === "running" ? "pending" : "http"),
-      summary: `Scheduled TestPass returned status ${statusLabel} with ${failCount} failures.`,
-      evidence: `Run ${runId} checked ${mcpUrl}.`,
-    };
+    return result(
+      "testpass",
+      "TestPass",
+      statusFromFailureKind(statusLabel === "running" ? "pending" : "http"),
+      `Scheduled TestPass returned status ${statusLabel} with ${failCount} failures.`,
+      `Run ${runId} checked ${mcpUrl}.`,
+    );
   } catch (err) {
     return failureResult(
       "testpass",
@@ -136,11 +145,12 @@ async function runUXPass() {
     );
   }
   if (!token) {
-    return failureResult(
+    return blockedResult(
       "uxpass",
       "UXPass",
       "Scheduled UXPass could not run because DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET is missing.",
       "Set one workflow secret so the nightly dogfood workflow can create a fresh uxpass_runs row.",
+      "Missing DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
     );
   }
 
@@ -192,12 +202,20 @@ function buildTrend(results) {
     date: today,
     passing: results.filter((result) => result.status === "passing").length,
     failing: results.filter((result) => result.status === "failing").length,
+    blocked: results.filter((result) => result.status === "blocked").length,
     pending: results.filter((result) => result.status === "pending").length,
   }];
 }
 
+function buildStatus(results) {
+  if (results.some((result) => result.status === "failing")) return "failing";
+  if (results.some((result) => result.status === "blocked")) return "blocked";
+  if (results.some((result) => result.status === "pending")) return "pending";
+  return "passing";
+}
+
 function buildLastActionableFailure(results) {
-  const failing = results.find((result) => result.status === "failing");
+  const failing = results.find((result) => result.status === "failing" || result.status === "blocked");
   if (!failing) {
     return {
       title: "No actionable dogfood failure in the latest receipt",
@@ -208,7 +226,7 @@ function buildLastActionableFailure(results) {
 
   return {
     title: `${failing.name} needs attention`,
-    detail: failing.summary,
+    detail: failing.blockedReason ? `${failing.summary} Blocked reason: ${failing.blockedReason}` : failing.summary,
     owner: "Dogfood automation",
   };
 }
@@ -238,6 +256,8 @@ const results = [
 
 const report = {
   generatedAt,
+  lastRunAt: generatedAt,
+  status: buildStatus(results),
   source: dryRun ? "dogfood receipt dry run" : "nightly dogfood workflow",
   headline: "We dogfood UnClick on UnClick.",
   target: "UnClick public and agent-facing product surfaces",
@@ -253,7 +273,9 @@ await fs.writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
 console.log(`Wrote dogfood report to ${outputPath}`);
 console.log(JSON.stringify({
   generatedAt: report.generatedAt,
+  status: report.status,
   passing: report.trend[0].passing,
   failing: report.trend[0].failing,
+  blocked: report.trend[0].blocked,
   pending: report.trend[0].pending,
 }, null, 2));

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -1,4 +1,4 @@
-export type DogfoodStatus = "passing" | "failing" | "pending";
+export type DogfoodStatus = "passing" | "failing" | "pending" | "blocked";
 
 export interface DogfoodPassResult {
   id: string;
@@ -6,17 +6,22 @@ export interface DogfoodPassResult {
   status: DogfoodStatus;
   summary: string;
   evidence: string;
+  checkedAt?: string;
+  blockedReason?: string;
 }
 
 export interface DogfoodTrendPoint {
   date: string;
   passing: number;
   failing: number;
+  blocked?: number;
   pending: number;
 }
 
 export const dogfoodReport = {
   generatedAt: "2026-05-01T00:50:00Z",
+  lastRunAt: "2026-05-01T00:50:00Z",
+  status: "pending",
   source: "public seed receipt",
   headline: "We dogfood UnClick on UnClick.",
   target: "UnClick public and agent-facing product surfaces",
@@ -28,6 +33,7 @@ export const dogfoodReport = {
       status: "passing",
       summary: "PR smoke checks are producing green receipts.",
       evidence: "Recent TestPass PR checks completed successfully on UnClick PRs.",
+      checkedAt: "2026-05-01T00:50:00Z",
     },
     {
       id: "uxpass",
@@ -35,6 +41,7 @@ export const dogfoodReport = {
       status: "pending",
       summary: "Queued for recurring UX review.",
       evidence: "Public UX receipts will appear here once recurring checks begin.",
+      checkedAt: "2026-05-01T00:50:00Z",
     },
     {
       id: "seopass",
@@ -42,6 +49,7 @@ export const dogfoodReport = {
       status: "pending",
       summary: "Queued for recurring search and metadata review.",
       evidence: "Public SEO receipts will appear here once recurring checks begin.",
+      checkedAt: "2026-05-01T00:50:00Z",
     },
     {
       id: "copypass",
@@ -49,6 +57,7 @@ export const dogfoodReport = {
       status: "pending",
       summary: "Queued for recurring copy quality review.",
       evidence: "Public copy-quality receipts will appear here once recurring checks begin.",
+      checkedAt: "2026-05-01T00:50:00Z",
     },
     {
       id: "legalpass",
@@ -56,6 +65,7 @@ export const dogfoodReport = {
       status: "pending",
       summary: "Queued for recurring policy and claims review.",
       evidence: "Public legal-quality receipts will appear here once recurring checks begin.",
+      checkedAt: "2026-05-01T00:50:00Z",
     },
   ] satisfies DogfoodPassResult[],
   trend: [

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -25,6 +25,11 @@ const STATUS_STYLES: Record<DogfoodStatus, { label: string; badge: string; icon:
     badge: "border-amber-400/20 bg-amber-400/10 text-amber-200",
     icon: Clock3,
   },
+  blocked: {
+    label: "Blocked",
+    badge: "border-sky-400/25 bg-sky-400/10 text-sky-200",
+    icon: AlertTriangle,
+  },
 };
 
 function countByStatus(results: DogfoodPassResult[], status: DogfoodStatus): number {
@@ -62,8 +67,11 @@ export default function DogfoodReportPage() {
   const counts = useMemo(() => ({
     passing: countByStatus(report.results, "passing"),
     failing: countByStatus(report.results, "failing"),
+    blocked: countByStatus(report.results, "blocked"),
     pending: countByStatus(report.results, "pending"),
   }), [report.results]);
+  const receiptStatus = STATUS_STYLES[(report.status || "pending") as DogfoodStatus] || STATUS_STYLES.pending;
+  const ReceiptIcon = receiptStatus.icon;
 
   return (
     <div className="min-h-screen bg-background">
@@ -85,9 +93,8 @@ export default function DogfoodReportPage() {
                   {report.headline}
                 </h1>
                 <p className="mt-4 max-w-2xl text-lg leading-relaxed text-body">
-                  This is the public receipt board for UnClick's own Pass-family checks. Today it
-                  shows the first receipt contract; future receipts will update it with fresh
-                  automated evidence.
+                  This page shows the latest Pass-family receipt evidence from checks running
+                  against UnClick itself.
                 </p>
               </div>
 
@@ -95,17 +102,25 @@ export default function DogfoodReportPage() {
                 <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">
                   Latest receipt
                 </p>
-                <p className="mt-2 text-sm text-heading">{formatDate(report.generatedAt)}</p>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium ${receiptStatus.badge}`}>
+                    <ReceiptIcon className="h-3.5 w-3.5" />
+                    {receiptStatus.label}
+                  </span>
+                  <span className="text-xs text-muted-custom">{report.source}</span>
+                </div>
+                <p className="mt-3 text-sm text-heading">Last run: {formatDate(report.lastRunAt || report.generatedAt)}</p>
                 <p className="mt-3 text-xs leading-relaxed text-body">{report.nextAutomation}</p>
               </div>
             </div>
           </FadeIn>
         </section>
 
-        <section className="mx-auto mt-10 grid max-w-5xl gap-4 sm:grid-cols-3">
+        <section className="mx-auto mt-10 grid max-w-5xl gap-4 sm:grid-cols-4">
           {([
             ["Passing", counts.passing, "text-emerald-200"],
             ["Needs action", counts.failing, "text-red-200"],
+            ["Blocked", counts.blocked, "text-sky-200"],
             ["Pending automation", counts.pending, "text-amber-200"],
           ] as const).map(([label, value, className]) => (
             <FadeIn key={label} delay={0.08}>
@@ -139,6 +154,14 @@ export default function DogfoodReportPage() {
                     <p className="mt-4 rounded-xl border border-border/50 bg-background/40 p-3 text-xs leading-relaxed text-muted-custom">
                       {result.evidence}
                     </p>
+                    {result.blockedReason ? (
+                      <p className="mt-3 text-xs leading-relaxed text-sky-200">
+                        Blocked reason: {result.blockedReason}
+                      </p>
+                    ) : null}
+                    {result.checkedAt ? (
+                      <p className="mt-3 text-[11px] text-muted-custom">Checked: {formatDate(result.checkedAt)}</p>
+                    ) : null}
                   </article>
                 </FadeIn>
               );
@@ -160,13 +183,14 @@ export default function DogfoodReportPage() {
 
           <FadeIn delay={0.05}>
             <div className="rounded-2xl border border-border/70 bg-card/40 p-5">
-              <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">7-day trend seed</p>
-              <div className="mt-4 overflow-hidden rounded-xl border border-border/60">
+              <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">Receipt trend</p>
+              <div className="mt-4 overflow-x-auto rounded-xl border border-border/60">
                 {report.trend.map((point) => (
-                  <div key={point.date} className="grid grid-cols-4 gap-2 border-b border-border/50 px-4 py-3 text-xs last:border-b-0">
+                  <div key={point.date} className="grid min-w-[460px] grid-cols-5 gap-2 border-b border-border/50 px-4 py-3 text-xs last:border-b-0">
                     <span className="text-heading">{point.date}</span>
                     <span className="text-emerald-200">Pass {point.passing}</span>
                     <span className="text-red-200">Fail {point.failing}</span>
+                    <span className="text-sky-200">Blocked {point.blocked || 0}</span>
                     <span className="text-amber-200">Pending {point.pending}</span>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- add explicit dogfood receipt `status` and `lastRunAt` fields
- distinguish missing-token blocks from live pass failures with per-result `blockedReason`
- surface latest status, source, checked time, and blocked reason on the public Dogfood Report and workflow summary

## Non-overlap
- does not touch #357/#359 TestPass implementation files
- does not touch analytics from #358
- does not touch wake-router files owned by #355/#353
- does not touch stale SecurityPass implementation in #283

## Validation
- dogfood builder no-token proof: emits `status=blocked`, `blocked=2`, `missingCheckedAt=0`
- `npm exec tsc -- --noEmit --pretty false`
- `npm run build`
- `npm test`
- `node --check scripts/build-dogfood-report.mjs`
- `npx eslint src/pages/DogfoodReport.tsx src/data/dogfoodReport.ts`
- `git diff --check`

Note: full `npm run lint` still fails on existing repo-wide findings unrelated to this diff; the changed TS/TSX files lint clean.