### PR TITLE
fix(uxpass): return failed status for capture failures

### DIFF
--- a/api/uxpass-run.ts
+++ b/api/uxpass-run.ts
@@ -147,7 +147,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const result = await runDeterministicChecks(config, runId, targetUrl);
     return json(res, 200, {
       run_id: runId,
-      status: "complete",
+      status: result.status,
       ux_score: result.uxScore,
       target_url: targetUrl,
       stats: result.stats,

--- a/api/uxpass.ts
+++ b/api/uxpass.ts
@@ -236,7 +236,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const result = await runDeterministicChecks(config, runId, targetUrl);
       return json(res, 201, {
         run_id: runId,
-        status: "complete",
+        status: result.status,
         ux_score: result.uxScore,
         target_url: targetUrl,
         stats: result.stats,

--- a/packages/uxpass/src/__tests__/runner.test.ts
+++ b/packages/uxpass/src/__tests__/runner.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { captureContext, evaluateUrl, summariseStats } from "../runner.js";
+import { captureContext, evaluateUrl, runDeterministicChecks, summariseStats } from "../runner.js";
 
 interface MockServer {
   url: string;
@@ -129,6 +129,51 @@ describe("evaluateUrl - integration with live HTTP server", () => {
       });
     } finally {
       server.close();
+    }
+  });
+});
+
+describe("runDeterministicChecks", () => {
+  it("returns failed and persists failed status when capture fails", async () => {
+    const updateBodies: unknown[] = [];
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        updateBodies.push(init?.body ? JSON.parse(String(init.body)) : null);
+        return new Response("[]", { status: 200 });
+      }),
+    );
+
+    try {
+      const result = await runDeterministicChecks(
+        {
+          supabaseUrl: "https://example.supabase.co",
+          serviceRoleKey: "service-role",
+        },
+        "run-fail",
+        "https://broken.example",
+        {
+          fetch: async () => {
+            throw new Error("network boom");
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        status: "failed",
+        uxScore: 0,
+        checkCount: 0,
+        stats: { total: 0, pass: 0, fail: 0, na: 0, pass_rate: 0 },
+      });
+      expect(updateBodies[0]).toMatchObject({
+        status: "failed",
+        ux_score: null,
+        summary: "Capture failed: network boom",
+        error: "network boom",
+      });
+    } finally {
+      vi.stubGlobal("fetch", originalFetch);
     }
   });
 });

--- a/packages/uxpass/src/runner.ts
+++ b/packages/uxpass/src/runner.ts
@@ -136,7 +136,13 @@ export async function runDeterministicChecks(
   runId: string,
   targetUrl: string,
   opts: CaptureOptions = {},
-): Promise<{ stats: RunSummaryStats; uxScore: number; checkCount: number; hats: string[] }> {
+): Promise<{
+  status: "complete" | "failed";
+  stats: RunSummaryStats;
+  uxScore: number;
+  checkCount: number;
+  hats: string[];
+}> {
   let evaluations: CheckEvaluation[];
   try {
     const context = await captureContext(targetUrl, opts);
@@ -150,6 +156,7 @@ export async function runDeterministicChecks(
       error: message,
     });
     return {
+      status: "failed",
       stats: { total: 0, pass: 0, fail: 0, na: 0, pass_rate: 0 },
       uxScore: 0,
       checkCount: 0,
@@ -173,6 +180,7 @@ export async function runDeterministicChecks(
   });
 
   return {
+    status: "complete",
     stats,
     uxScore,
     checkCount: evaluations.length,


### PR DESCRIPTION
## Summary
- Return the real UXPass runner status from both UXPass API entrypoints.
- Capture failures now surface as `failed` instead of `complete` while keeping successful runs unchanged.
- Add a regression test proving capture failure persists `failed` and returns zeroed run stats.

## Scope
- api/uxpass.ts
- api/uxpass-run.ts
- packages/uxpass/src/runner.ts
- packages/uxpass/src/__tests__/runner.test.ts

## Non-overlap
- Does not touch TestPass PRs #357/#359 files.
- Does not touch Dogfood #360 files, SecurityPass #283, wake-router, Fishbowl, analytics, secrets, auth, billing, DNS, or migrations.

## Verification
- npm run test --workspace packages/uxpass
- npm run build
- npx tsc --ignoreConfig --noEmit --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck --strict --jsx react-jsx --types vitest/globals,node packages/uxpass/src/runner.ts packages/uxpass/src/__tests__/runner.test.ts api/uxpass.ts api/uxpass-run.ts
- git diff --check

Notes:
- `npm run build --workspace packages/uxpass` still fails on existing package tsconfig/node-types issues (`node:http`, `Buffer`) that predate this patch.
- Targeted lint of touched files still reports existing repo lint debt in api/uxpass-run.ts and packages/uxpass/src/runner.ts unrelated to this status fix.

## Risk
Low. Response correctness only: persisted failed runs now agree with API responses. Successful UXPass runs still return `complete`.