### PR TITLE
fix(fishbowl): add manual todo reconciliation

### DIFF
--- a/.github/workflows/auto-close-fishbowl-todo.yml
+++ b/.github/workflows/auto-close-fishbowl-todo.yml
@@ -2,24 +2,36 @@ name: Auto-close Fishbowl todo on PR merge
 
 # When a PR merges, scan its body for "Closes Fishbowl todo: <uuid>" markers
 # and POST to the existing memory-admin fishbowl_complete_todo action for
-# each match. A Fishbowl outage must NOT block merge cleanup, so the job
+# each match. Manual dispatch accepts explicit merged PR numbers for bounded
+# reconciliation. A Fishbowl outage must NOT block merge cleanup, so the job
 # always exits 0 even if the API call fails.
 
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: Comma or space separated merged PR numbers to reconcile.
+        required: false
+        default: ""
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   close-todos:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     name: Close linked Fishbowl todos
     runs-on: ubuntu-latest
     steps:
       - name: Extract todo ids and call memory-admin
         env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          MANUAL_PR_NUMBERS: ${{ github.event.inputs.pr_numbers || '' }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           UNCLICK_API_KEY: ${{ secrets.FISHBOWL_AUTOCLOSE_TOKEN }}
@@ -34,49 +46,89 @@ jobs:
             echo "::warning::FISHBOWL_AUTOCLOSE_TOKEN secret not set - skipping."
             exit 0
           fi
-          if [ -z "${PR_BODY:-}" ]; then
-            echo "PR #${PR_NUMBER} body empty - nothing to close."
+
+          PR_NUMBERS=()
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            mapfile -t PR_NUMBERS < <(printf '%s\n' "${MANUAL_PR_NUMBERS:-}" \
+              | tr ',;' '  ' \
+              | grep -Eo '[0-9]+' \
+              | sort -n -u)
+
+            if [ "${#PR_NUMBERS[@]}" -eq 0 ]; then
+              echo "::warning::No PR numbers supplied for manual reconciliation."
+              exit 0
+            fi
+          else
+            PR_NUMBERS=("${PR_NUMBER}")
+          fi
+
+          if [ "${#PR_NUMBERS[@]}" -eq 0 ]; then
+            echo "No PRs to inspect."
             exit 0
           fi
 
           # Match "Closes Fishbowl todo: <uuid>" or "closes-fishbowl-todo: <uuid>",
           # case-insensitive, allowing - or space between the words.
           UUID_RE='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
-          mapfile -t IDS < <(printf '%s\n' "$PR_BODY" \
-            | grep -Eio "closes[- ]fishbowl[- ]todo[: ][[:space:]]*${UUID_RE}" \
-            | grep -Eio "${UUID_RE}" \
-            | sort -u)
-
-          if [ "${#IDS[@]}" -eq 0 ]; then
-            echo "No Fishbowl todo ids found in PR #${PR_NUMBER} body."
-            exit 0
-          fi
-
-          echo "Found ${#IDS[@]} todo id(s) in PR #${PR_NUMBER}: ${IDS[*]}"
           fail_count=0
-          for id in "${IDS[@]}"; do
-            echo "Closing todo ${id}"
-            payload=$(jq -n --arg agent_id "$AGENT_ID" --arg todo_id "$id" \
-              '{agent_id: $agent_id, todo_id: $todo_id}')
-            curl_exit=0
-            http=$(curl -sS -o resp.json -w "%{http_code}" \
-              --connect-timeout 10 --max-time 30 \
-              -X POST "${API_URL}?action=fishbowl_complete_todo" \
-              -H "Authorization: Bearer ${UNCLICK_API_KEY}" \
-              -H "Content-Type: application/json" \
-              -d "$payload") || curl_exit=$?
-            http="${http:-000}"
-            echo "  HTTP ${http} (curl exit ${curl_exit})"
-            if [ -f resp.json ]; then cat resp.json; echo; fi
-            if [ "$curl_exit" -ne 0 ] || [ "$http" -ge 400 ] 2>/dev/null; then
-              fail_count=$((fail_count + 1))
-              echo "::warning::Failed to close todo ${id} (HTTP ${http})."
+          close_count=0
+
+          for pr_number in "${PR_NUMBERS[@]}"; do
+            pr_body="${PR_BODY:-}"
+            if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+              pr_body=$(gh pr view "${pr_number}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json body,mergedAt \
+                --jq 'if .mergedAt == null then "" else (.body // "") end' 2>/tmp/gh-pr-view.err) || {
+                  echo "::warning::Could not read PR #${pr_number}: $(cat /tmp/gh-pr-view.err)"
+                  fail_count=$((fail_count + 1))
+                  continue
+                }
             fi
+
+            if [ -z "${pr_body:-}" ]; then
+              echo "PR #${pr_number} body empty or PR is not merged - nothing to close."
+              continue
+            fi
+
+            mapfile -t IDS < <(printf '%s\n' "$pr_body" \
+              | grep -Eio "closes[- ]fishbowl[- ]todo[: ][[:space:]]*${UUID_RE}" \
+              | grep -Eio "${UUID_RE}" \
+              | sort -u)
+
+            if [ "${#IDS[@]}" -eq 0 ]; then
+              echo "No Fishbowl todo ids found in PR #${pr_number} body."
+              continue
+            fi
+
+            echo "Found ${#IDS[@]} todo id(s) in PR #${pr_number}: ${IDS[*]}"
+            for id in "${IDS[@]}"; do
+              echo "Closing todo ${id}"
+              payload=$(jq -n --arg agent_id "$AGENT_ID" --arg todo_id "$id" \
+                '{agent_id: $agent_id, todo_id: $todo_id}')
+              curl_exit=0
+              http=$(curl -sS -o resp.json -w "%{http_code}" \
+                --connect-timeout 10 --max-time 30 \
+                -X POST "${API_URL}?action=fishbowl_complete_todo" \
+                -H "Authorization: Bearer ${UNCLICK_API_KEY}" \
+                -H "Content-Type: application/json" \
+                -d "$payload") || curl_exit=$?
+              http="${http:-000}"
+              echo "  HTTP ${http} (curl exit ${curl_exit})"
+              if [ -f resp.json ]; then cat resp.json; echo; fi
+              if [ "$curl_exit" -ne 0 ] || [ "$http" -ge 400 ] 2>/dev/null; then
+                fail_count=$((fail_count + 1))
+                echo "::warning::Failed to close todo ${id} (HTTP ${http})."
+              else
+                close_count=$((close_count + 1))
+              fi
+            done
           done
 
           # Always succeed - a Fishbowl outage must not paint a red X on a
           # cleanly merged PR. Surface failures via warnings only.
+          echo "Closed ${close_count} Fishbowl todo(s)."
           if [ "$fail_count" -gt 0 ]; then
-            echo "::warning::${fail_count} of ${#IDS[@]} todo close call(s) failed."
+            echo "::warning::${fail_count} reconciliation call(s) failed."
           fi
           exit 0


### PR DESCRIPTION
Summary:
- Adds a bounded manual reconciliation mode to the Fishbowl todo auto-close workflow.
- Manual dispatch accepts explicit merged PR numbers, reads each PR body with `gh pr view`, reuses the existing `Closes Fishbowl todo: <uuid>` parser, and calls the existing `fishbowl_complete_todo` endpoint.
- Keeps Fishbowl/API failures warning-only so cleanup outages do not turn unrelated merges red.

Scope:
- Owned file: `.github/workflows/auto-close-fishbowl-todo.yml`.
- Lane: Fishbowl todo completion reconciliation / board hygiene.

Non-overlap:
- Did not touch `api/memory-admin.ts`, Ideas Council, analytics/PostHog, Pass product files, TestPass PR workflow, wake-router scripts, secrets, auth, billing, domains, or migrations.
- No schedule was added; manual runs are explicit and bounded by provided PR numbers.

Verification:
- `git diff --check`
- Parsed workflow YAML with `js-yaml`
- Extracted embedded Bash and ran `bash -n`
- Local no-secret manual no-input path exits warning-only
- Local PR-merge no-marker path exits cleanly with zero closes
- Static parser proof for comma/semicolon/space PR-number input and `Closes Fishbowl todo: <uuid>` marker extraction

Risk:
- Low. Workflow-only change, manual dispatch only, and parser remains the existing explicit marker format.
- Requires `FISHBOWL_AUTOCLOSE_TOKEN` to actually close todos, matching the existing merge-trigger behavior.

Follow-up:
- Use manual workflow dispatch with exact merged PR numbers when stale Fishbowl todos need reconciliation.