### PR TITLE
chore(dogfood): list SecurityPass receipt placeholder

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -24,6 +24,14 @@
       "checkedAt": "2026-05-01T00:50:00Z"
     },
     {
+      "id": "securitypass",
+      "name": "SecurityPass",
+      "status": "pending",
+      "summary": "Queued for recurring security review.",
+      "evidence": "SecurityPass remains scope-gated until a small recurring runner proof is ready.",
+      "checkedAt": "2026-05-01T00:50:00Z"
+    },
+    {
       "id": "seopass",
       "name": "SEOPass",
       "status": "pending",
@@ -49,9 +57,9 @@
     }
   ],
   "trend": [
-    { "date": "2026-04-29", "passing": 0, "failing": 0, "pending": 5 },
-    { "date": "2026-04-30", "passing": 1, "failing": 0, "pending": 4 },
-    { "date": "2026-05-01", "passing": 1, "failing": 0, "pending": 4 }
+    { "date": "2026-04-29", "passing": 0, "failing": 0, "pending": 6 },
+    { "date": "2026-04-30", "passing": 1, "failing": 0, "pending": 5 },
+    { "date": "2026-05-01", "passing": 1, "failing": 0, "pending": 5 }
   ],
   "lastActionableFailure": {
     "title": "Canonical public check target needs confirmation",

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -235,6 +235,12 @@ const results = [
   await runTestPass(),
   await runUXPass(),
   pendingResult(
+    "securitypass",
+    "SecurityPass",
+    "Queued for recurring security review.",
+    "SecurityPass remains scope-gated until a small recurring runner proof is ready.",
+  ),
+  pendingResult(
     "seopass",
     "SEOPass",
     "Queued for recurring search and metadata review.",

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -44,6 +44,14 @@ export const dogfoodReport = {
       checkedAt: "2026-05-01T00:50:00Z",
     },
     {
+      id: "securitypass",
+      name: "SecurityPass",
+      status: "pending",
+      summary: "Queued for recurring security review.",
+      evidence: "SecurityPass remains scope-gated until a small recurring runner proof is ready.",
+      checkedAt: "2026-05-01T00:50:00Z",
+    },
+    {
       id: "seopass",
       name: "SEOPass",
       status: "pending",
@@ -69,9 +77,9 @@ export const dogfoodReport = {
     },
   ] satisfies DogfoodPassResult[],
   trend: [
-    { date: "2026-04-29", passing: 0, failing: 0, pending: 5 },
-    { date: "2026-04-30", passing: 1, failing: 0, pending: 4 },
-    { date: "2026-05-01", passing: 1, failing: 0, pending: 4 },
+    { date: "2026-04-29", passing: 0, failing: 0, pending: 6 },
+    { date: "2026-04-30", passing: 1, failing: 0, pending: 5 },
+    { date: "2026-05-01", passing: 1, failing: 0, pending: 5 },
   ] satisfies DogfoodTrendPoint[],
   lastActionableFailure: {
     title: "Canonical public check target needs confirmation",


### PR DESCRIPTION
## Summary
- add SecurityPass as a pending row in the public dogfood receipt seed
- include the same SecurityPass placeholder in the dogfood receipt builder
- keep SecurityPass visible without touching the stale phase-2 implementation PR

## Non-overlap
- no TestPass #359 files
- no SecurityPass implementation, MCP, admin, or migration files from #283
- no analytics, Fishbowl handoff, wake-router, auth, secrets, billing, DNS, or dependency changes

## Validation
- dogfood dry-run proof: 6 results, SecurityPass pending, no missing checkedAt values
- `npm exec tsc -- --noEmit --pretty false`
- `npm run build`
- `npm test`
- `npx eslint src/data/dogfoodReport.ts`
- `node --check scripts/build-dogfood-report.mjs`
- `git diff --check`