### PR TITLE
fix(wakepass): route PR review wakes to QC

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -125,7 +125,7 @@ function baseDecision(event) {
     if (run.status === "completed" && run.conclusion === "success" && prs.length > 0) {
       return {
         wake: true,
-        owner: "🤖",
+        owner: "🍿",
         urgency: "high",
         reason: `PR checks completed green for ${run.name || "workflow"} on PR #${prs[0].number}`,
         eventCreatedAt: run.updated_at || run.created_at,
@@ -139,7 +139,7 @@ function baseDecision(event) {
     if (["ready_for_review", "review_requested", "reopened"].includes(action)) {
       return {
         wake: true,
-        owner: "🤖",
+        owner: "🍿",
         urgency: "high",
         reason: `PR #${pr.number || event.number} is ${action.replaceAll("_", " ")}`,
         eventCreatedAt: pr.updated_at || pr.created_at,

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -149,6 +149,8 @@ describe("event wake router reliability dispatch", () => {
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stdout, /reliability_dispatch_dry_run/);
+      assert.match(result.stdout, /"wake_owner": "🍿"/);
+      assert.match(result.stdout, /"ack_required": true/);
       assert.ok(
         result.stdout.indexOf("reliability_dispatch_dry_run") <
           result.stdout.indexOf('"text": "Wake event id:'),
@@ -315,7 +317,29 @@ describe("event wake router reliability dispatch", () => {
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.match(result.stdout, /PR #330 is ready for review/);
+    assert.match(result.stdout, /"wake_owner": "🍿"/);
     assert.match(result.stdout, /"wake_urgency": "high"/);
+    assert.match(result.stdout, /reliability_dispatch_dry_run/);
+    assert.match(result.stdout, /"ack_required": true/);
+  });
+
+  it("keeps ordinary PR updates silent", () => {
+    const result = runDryWake("pull_request", {
+      action: "synchronize",
+      number: 331,
+      pull_request: {
+        number: 331,
+        title: "Refresh implementation branch",
+        draft: false,
+        state: "open",
+        html_url: "https://github.com/acme/repo/pull/331",
+        updated_at: "2026-04-30T15:10:00Z",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /No wake needed/);
+    assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
   });
 
   it("keeps non-wake issue comments silent", () => {


### PR DESCRIPTION
## Summary
- route PR-ready/review and green-check wake events to 🍿 QC lane instead of the generic 🤖 leader route
- keep existing WakePass ACK dispatch proof and 10-minute lease behavior intact
- add coverage proving action-needed PR review wakes create ACK-required dispatches while ordinary PR updates stay silent

## Owned files
- scripts/event-wake-router.mjs
- scripts/event-wake-router.test.mjs

## Non-overlap
- no #359 TestPass workflow/auth changes
- no #363 dogfood docs changes
- no SecurityPass, secrets, auth, migrations, or broad UI work

## Tests
- `node --test scripts/event-wake-router.test.mjs`
- `git diff --check`

## Ring-fence impact
Small but concrete: moves PR review wakeups to the QC owner and keeps missed ACKs visible/reclaimable; estimated +1-2% unattended routing reliability.