### PR TITLE
fix(dogfood): block SecurityPass receipt clearly

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "2026-05-01T00:50:00Z",
   "lastRunAt": "2026-05-01T00:50:00Z",
-  "status": "pending",
+  "status": "blocked",
   "source": "public seed receipt",
   "headline": "We dogfood UnClick on UnClick.",
   "target": "UnClick public and agent-facing product surfaces",
@@ -26,10 +26,11 @@
     {
       "id": "securitypass",
       "name": "SecurityPass",
-      "status": "pending",
-      "summary": "Queued for recurring security review.",
-      "evidence": "SecurityPass remains scope-gated until a small recurring runner proof is ready.",
-      "checkedAt": "2026-05-01T00:50:00Z"
+      "status": "blocked",
+      "summary": "SecurityPass is blocked until the recurring runner proof is ready.",
+      "evidence": "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
+      "checkedAt": "2026-05-01T00:50:00Z",
+      "blockedReason": "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands."
     },
     {
       "id": "seopass",
@@ -59,11 +60,11 @@
   "trend": [
     { "date": "2026-04-29", "passing": 0, "failing": 0, "pending": 6 },
     { "date": "2026-04-30", "passing": 1, "failing": 0, "pending": 5 },
-    { "date": "2026-05-01", "passing": 1, "failing": 0, "pending": 5 }
+    { "date": "2026-05-01", "passing": 1, "failing": 0, "blocked": 1, "pending": 4 }
   ],
   "lastActionableFailure": {
-    "title": "Canonical public check target needs confirmation",
-    "detail": "The next automated receipt should lock the exact public URL set that represents UnClick's production experience.",
-    "owner": "Dogfood automation follow-up"
+    "title": "SecurityPass needs attention",
+    "detail": "SecurityPass is blocked until the recurring runner proof is ready. Blocked reason: SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
+    "owner": "Dogfood automation"
   }
 }

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -234,11 +234,12 @@ function buildLastActionableFailure(results) {
 const results = [
   await runTestPass(),
   await runUXPass(),
-  pendingResult(
+  blockedResult(
     "securitypass",
     "SecurityPass",
-    "Queued for recurring security review.",
-    "SecurityPass remains scope-gated until a small recurring runner proof is ready.",
+    "SecurityPass is blocked until the recurring runner proof is ready.",
+    "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
+    "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
   ),
   pendingResult(
     "seopass",

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+test("dogfood receipt marks SecurityPass as blocked with a reason", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
+  const output = path.join(dir, "latest.json");
+
+  try {
+    await execFileAsync(process.execPath, [
+      "scripts/build-dogfood-report.mjs",
+      "--dry-run",
+      "--output",
+      output,
+    ]);
+
+    const report = JSON.parse(await fs.readFile(output, "utf8"));
+    const securitypass = report.results.find((result) => result.id === "securitypass");
+
+    assert.equal(securitypass?.status, "blocked");
+    assert.match(securitypass?.blockedReason ?? "", /scope-gated/i);
+    assert.equal(report.status, "blocked");
+    assert.match(report.lastActionableFailure.detail, /Blocked reason:/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -21,7 +21,7 @@ export interface DogfoodTrendPoint {
 export const dogfoodReport = {
   generatedAt: "2026-05-01T00:50:00Z",
   lastRunAt: "2026-05-01T00:50:00Z",
-  status: "pending",
+  status: "blocked",
   source: "public seed receipt",
   headline: "We dogfood UnClick on UnClick.",
   target: "UnClick public and agent-facing product surfaces",
@@ -46,10 +46,11 @@ export const dogfoodReport = {
     {
       id: "securitypass",
       name: "SecurityPass",
-      status: "pending",
-      summary: "Queued for recurring security review.",
-      evidence: "SecurityPass remains scope-gated until a small recurring runner proof is ready.",
+      status: "blocked",
+      summary: "SecurityPass is blocked until the recurring runner proof is ready.",
+      evidence: "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
       checkedAt: "2026-05-01T00:50:00Z",
+      blockedReason: "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
     },
     {
       id: "seopass",
@@ -79,11 +80,11 @@ export const dogfoodReport = {
   trend: [
     { date: "2026-04-29", passing: 0, failing: 0, pending: 6 },
     { date: "2026-04-30", passing: 1, failing: 0, pending: 5 },
-    { date: "2026-05-01", passing: 1, failing: 0, pending: 5 },
+    { date: "2026-05-01", passing: 1, failing: 0, blocked: 1, pending: 4 },
   ] satisfies DogfoodTrendPoint[],
   lastActionableFailure: {
-    title: "Canonical public check target needs confirmation",
-    detail: "The next automated receipt should lock the exact public URL set that represents UnClick's production experience.",
-    owner: "Dogfood automation follow-up",
+    title: "SecurityPass needs attention",
+    detail: "SecurityPass is blocked until the recurring runner proof is ready. Blocked reason: SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
+    owner: "Dogfood automation",
   },
 };


### PR DESCRIPTION
Summary:
- Marks the SecurityPass dogfood receipt as blocked, with an explicit blockedReason, instead of generic pending.
- Keeps the static public/fallback receipt aligned with the clearer blocked state.
- Adds a focused Node test for the receipt builder regression.

Scope:
- Dogfood receipt generation and public fallback data only.
- Owned files: scripts/build-dogfood-report.mjs, scripts/build-dogfood-report.test.mjs, public/dogfood/latest.json, src/data/dogfoodReport.ts.

Non-overlap:
- Does not touch SecurityPass runner implementation, PR #283, TestPass auth/#359, Fishbowl Now Playing/#365, api/memory-admin.ts, secrets, migrations, or wake routing.

Verification:
- PASS: node --test scripts/build-dogfood-report.test.mjs
- PASS: git diff --check
- NOT RUN: npm run build could not start in this fresh worktree because vite is not installed.

Risk:
- Low. Public dogfood status semantics change from pending to blocked for SecurityPass only; no auth, secrets, billing, DNS, migrations, or runner behavior changed.

Follow-up:
- Wire a safe recurring SecurityPass runner proof later, then flip this receipt from blocked to live evidence.