### PR TITLE
fix(uxpass): close failed runner persistence

### DIFF
--- a/packages/uxpass/src/__tests__/runner.test.ts
+++ b/packages/uxpass/src/__tests__/runner.test.ts
@@ -176,6 +176,63 @@ describe("runDeterministicChecks", () => {
       vi.stubGlobal("fetch", originalFetch);
     }
   });
+
+  it("returns failed and closes the run when finding persistence fails", async () => {
+    const updateBodies: unknown[] = [];
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const urlString = String(url);
+        if (urlString.includes("uxpass_findings")) {
+          return new Response("insert failed", { status: 500 });
+        }
+        if (urlString.includes("uxpass_runs")) {
+          updateBodies.push(init?.body ? JSON.parse(String(init.body)) : null);
+          return new Response("[]", { status: 200 });
+        }
+        throw new Error(`unexpected fetch: ${urlString}`);
+      }),
+    );
+
+    try {
+      const result = await runDeterministicChecks(
+        {
+          supabaseUrl: "https://example.supabase.co",
+          serviceRoleKey: "service-role",
+        },
+        "run-stuck",
+        "http://example.test",
+        {
+          fetch: async (url) => {
+            const urlString = String(url);
+            if (urlString.endsWith("/llms.txt")) {
+              return new Response("# llms", { status: 200 });
+            }
+            return new Response(goodHtml, {
+              status: 200,
+              headers: { "Strict-Transport-Security": "max-age=63072000; includeSubDomains" },
+            });
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        status: "failed",
+        uxScore: 0,
+        checkCount: 0,
+        stats: { total: 0, pass: 0, fail: 0, na: 0, pass_rate: 0 },
+      });
+      expect(updateBodies[0]).toMatchObject({
+        status: "failed",
+        ux_score: null,
+        summary: expect.stringContaining("Persistence failed: Supabase POST uxpass_findings -> 500"),
+        error: expect.stringContaining("Supabase POST uxpass_findings -> 500"),
+      });
+    } finally {
+      vi.stubGlobal("fetch", originalFetch);
+    }
+  });
 });
 
 describe("summariseStats", () => {

--- a/packages/uxpass/src/runner.ts
+++ b/packages/uxpass/src/runner.ts
@@ -101,6 +101,22 @@ function uniqueHats(evaluations: CheckEvaluation[]): string[] {
   return Array.from(new Set(evaluations.map((e) => e.hat))).sort();
 }
 
+function failedResult(): {
+  status: "failed";
+  stats: RunSummaryStats;
+  uxScore: number;
+  checkCount: number;
+  hats: string[];
+} {
+  return {
+    status: "failed",
+    stats: { total: 0, pass: 0, fail: 0, na: 0, pass_rate: 0 },
+    uxScore: 0,
+    checkCount: 0,
+    hats: uniqueHats(CORE_CHECKS as unknown as CheckEvaluation[]),
+  };
+}
+
 /**
  * Capture + evaluate without touching the database. Used by tests and any
  * caller that wants the raw evaluations (e.g. the local CLI when offline).
@@ -143,47 +159,43 @@ export async function runDeterministicChecks(
   checkCount: number;
   hats: string[];
 }> {
-  let evaluations: CheckEvaluation[];
+  let failureSummaryPrefix = "Capture failed";
   try {
     const context = await captureContext(targetUrl, opts);
-    evaluations = evaluateAllChecks(context);
+    const evaluations = evaluateAllChecks(context);
+
+    const findings = failingFindings(evaluations);
+    failureSummaryPrefix = "Persistence failed";
+    await createFindings(config, runId, findings);
+
+    const stats = summariseStats(evaluations);
+    const uxScore = computeUxScore(evaluations);
+    const breakdown = buildBreakdown(evaluations);
+    const summary = buildSummaryText(stats, uxScore);
+
+    failureSummaryPrefix = "Completion failed";
+    await updateRunStatus(config, runId, {
+      status: "complete",
+      ux_score: uxScore,
+      breakdown,
+      summary,
+    });
+
+    return {
+      status: "complete",
+      stats,
+      uxScore,
+      checkCount: evaluations.length,
+      hats: uniqueHats(evaluations),
+    };
   } catch (err) {
     const message = (err as Error).message;
     await updateRunStatus(config, runId, {
       status: "failed",
       ux_score: null,
-      summary: `Capture failed: ${message}`,
+      summary: `${failureSummaryPrefix}: ${message}`,
       error: message,
     });
-    return {
-      status: "failed",
-      stats: { total: 0, pass: 0, fail: 0, na: 0, pass_rate: 0 },
-      uxScore: 0,
-      checkCount: 0,
-      hats: uniqueHats(CORE_CHECKS as unknown as CheckEvaluation[]),
-    };
+    return failedResult();
   }
-
-  const findings = failingFindings(evaluations);
-  await createFindings(config, runId, findings);
-
-  const stats = summariseStats(evaluations);
-  const uxScore = computeUxScore(evaluations);
-  const breakdown = buildBreakdown(evaluations);
-  const summary = buildSummaryText(stats, uxScore);
-
-  await updateRunStatus(config, runId, {
-    status: "complete",
-    ux_score: uxScore,
-    breakdown,
-    summary,
-  });
-
-  return {
-    status: "complete",
-    stats,
-    uxScore,
-    checkCount: evaluations.length,
-    hats: uniqueHats(evaluations),
-  };
 }


### PR DESCRIPTION
Summary:
- Closes UXPass deterministic runner failures by writing a failed run status when post-capture persistence fails.
- Preserves the existing capture-failure behavior and adds a regression test for a failed findings insert.

Scope:
- UXPass runner failure handling only.
- Owned files: packages/uxpass/src/runner.ts and packages/uxpass/src/__tests__/runner.test.ts.

Non-overlap:
- Does not touch #365 Fishbowl UI, #366 dogfood receipt files, #359 TestPass auth, #283 SecurityPass, api/memory-admin.ts, wake routing, secrets, or migrations.

Verification:
- PASS: npm test --workspace @unclick/uxpass
- PASS: npm run build --workspace @unclick/uxpass
- PASS: git diff --check

Risk:
- Low. This only changes UXPass run closure semantics on failures. If the final failed-status write also cannot reach Supabase, the failure still surfaces to the caller.

Follow-up:
- Add stale duplicate task recovery later if UXPass moves from synchronous execution to async workers.