### PR TITLE
fix(wakepass): suppress wake-router self echoes

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -122,6 +122,22 @@ function baseDecision(event) {
       };
     }
 
+    if (
+      run.status === "completed" &&
+      run.conclusion === "success" &&
+      run.name === "Event Wake Router" &&
+      prs.length > 0
+    ) {
+      return {
+        wake: false,
+        owner: "none",
+        urgency: "low",
+        reason: `Wake router self-check completed green on PR #${prs[0].number}`,
+        eventCreatedAt: run.updated_at || run.created_at,
+        needsTriage: false,
+      };
+    }
+
     if (run.status === "completed" && run.conclusion === "success" && prs.length > 0) {
       return {
         wake: true,

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -342,6 +342,27 @@ describe("event wake router reliability dispatch", () => {
     assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
   });
 
+  it("keeps wake-router green-check self-echoes silent", () => {
+    const result = runDryWake("workflow_run", {
+      action: "completed",
+      workflow_run: {
+        id: 461,
+        name: "Event Wake Router",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://github.com/acme/repo/actions/runs/461",
+        created_at: "2026-04-30T17:00:00Z",
+        updated_at: "2026-04-30T17:05:00Z",
+        pull_requests: [{ number: 368 }],
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Wake router self-check completed green on PR #368/);
+    assert.match(result.stdout, /No wake needed/);
+    assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
+  });
+
   it("keeps non-wake issue comments silent", () => {
     const result = runDryWake("issue_comment", {
       action: "created",


### PR DESCRIPTION
Summary:
- Keeps successful Event Wake Router workflow_run events on PRs silent so the router does not create dead-letter ACK noise from its own green checks.
- Leaves normal PR green-check wakeups routed to QC, and failed scheduled/workflow paths unchanged.

Scope:
- scripts/event-wake-router.mjs
- scripts/event-wake-router.test.mjs

Non-overlap:
- No Fishbowl UI, Pass runner, dogfood report, docs, auth/secrets, migrations, DNS/domains, or dependency changes.

Verification:
- node --test scripts/event-wake-router.test.mjs
- git diff --check

Risk:
- Low. This only suppresses the wake-router workflow's own successful PR check echo; real action-needed handoffs still request ACK.

Follow-up:
- Watch the dead-letter audit to confirm green-check self-echo noise drops.