### PR TITLE
fix(dogfood): add live Pass proof fields

### DIFF
--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -30,20 +30,20 @@ function result(id, name, status, summary, evidence, details = {}) {
   return { id, name, status, summary, evidence, checkedAt: generatedAt, ...details };
 }
 
-function pendingResult(id, name, summary, evidence) {
-  return result(id, name, "pending", summary, evidence);
+function pendingResult(id, name, summary, evidence, details = {}) {
+  return result(id, name, "pending", summary, evidence, details);
 }
 
 function blockedResult(id, name, summary, evidence, blockedReason) {
   return result(id, name, "blocked", summary, evidence, { blockedReason });
 }
 
-function failureResult(id, name, summary, evidence) {
-  return result(id, name, "failing", summary, evidence);
+function failureResult(id, name, summary, evidence, details = {}) {
+  return result(id, name, "failing", summary, evidence, details);
 }
 
-function passResult(id, name, summary, evidence) {
-  return result(id, name, "passing", summary, evidence);
+function passResult(id, name, summary, evidence, details = {}) {
+  return result(id, name, "passing", summary, evidence, details);
 }
 
 async function postJson(url, token, body) {
@@ -113,6 +113,11 @@ async function runTestPass() {
         "TestPass",
         `Scheduled TestPass completed with ${total} checks and 0 failures.`,
         `Run ${runId} checked ${mcpUrl}.`,
+        {
+          runId,
+          targetUrl: mcpUrl,
+          proof: { kind: "testpass_run", runId, targetUrl: mcpUrl },
+        },
       );
     }
 
@@ -123,6 +128,11 @@ async function runTestPass() {
       statusFromFailureKind(statusLabel === "running" ? "pending" : "http"),
       `Scheduled TestPass returned status ${statusLabel} with ${failCount} failures.`,
       `Run ${runId} checked ${mcpUrl}.`,
+      {
+        runId,
+        targetUrl: mcpUrl,
+        proof: { kind: "testpass_run", runId, targetUrl: mcpUrl },
+      },
     );
   } catch (err) {
     return failureResult(
@@ -177,6 +187,11 @@ async function runUXPass() {
         "UXPass",
         `Scheduled UXPass completed${uxScore === null ? "" : ` with UX score ${uxScore}`}.`,
         `Run ${runId} checked ${publicUrl}.`,
+        {
+          runId,
+          targetUrl: publicUrl,
+          proof: { kind: "uxpass_run", runId, targetUrl: publicUrl },
+        },
       );
     }
 
@@ -185,6 +200,11 @@ async function runUXPass() {
       "UXPass",
       `Scheduled UXPass returned status ${json.status || "unknown"}${uxScore === null ? "" : ` with UX score ${uxScore}`}.`,
       `Run ${runId} checked ${publicUrl}.`,
+      {
+        runId,
+        targetUrl: publicUrl,
+        proof: { kind: "uxpass_run", runId, targetUrl: publicUrl },
+      },
     );
   } catch (err) {
     return failureResult(

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -168,6 +168,7 @@ async function runUXPass() {
     const { ok, status, json } = await postJson(`${apiBase}/api/uxpass-run`, token, {
       url: publicUrl,
       target_url: publicUrl,
+      source: "scheduled",
     });
 
     if (!ok) {

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -28,6 +29,76 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
     assert.equal(report.status, "blocked");
     assert.match(report.lastActionableFailure.detail, /Blocked reason:/);
   } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("dogfood receipt includes structured proof for live TestPass and UXPass runs", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
+  const output = path.join(dir, "latest.json");
+  const server = http.createServer((req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    if (req.url === "/api/testpass-run") {
+      res.end(JSON.stringify({
+        run_id: "testpass-run-123",
+        status: "complete",
+        verdict_summary: { total: 12, fail: 0 },
+      }));
+      return;
+    }
+    if (req.url === "/api/uxpass-run") {
+      res.end(JSON.stringify({
+        run_id: "uxpass-run-456",
+        status: "complete",
+        ux_score: 91,
+      }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: "not found" }));
+  });
+
+  try {
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    await execFileAsync(process.execPath, [
+      "scripts/build-dogfood-report.mjs",
+      "--output",
+      output,
+    ], {
+      env: {
+        ...process.env,
+        DOGFOOD_API_BASE: `http://127.0.0.1:${address.port}`,
+        DOGFOOD_PUBLIC_URL: "https://unclick.world",
+        DOGFOOD_MCP_URL: "https://unclick.world/api/mcp",
+        DOGFOOD_TESTPASS_TOKEN: "test-token",
+        DOGFOOD_UXPASS_TOKEN: "ux-token",
+      },
+    });
+
+    const report = JSON.parse(await fs.readFile(output, "utf8"));
+    const testpass = report.results.find((result) => result.id === "testpass");
+    const uxpass = report.results.find((result) => result.id === "uxpass");
+
+    assert.equal(testpass.runId, "testpass-run-123");
+    assert.equal(testpass.targetUrl, "https://unclick.world/api/mcp");
+    assert.deepEqual(testpass.proof, {
+      kind: "testpass_run",
+      runId: "testpass-run-123",
+      targetUrl: "https://unclick.world/api/mcp",
+    });
+
+    assert.equal(uxpass.runId, "uxpass-run-456");
+    assert.equal(uxpass.targetUrl, "https://unclick.world");
+    assert.deepEqual(uxpass.proof, {
+      kind: "uxpass_run",
+      runId: "uxpass-run-456",
+      targetUrl: "https://unclick.world",
+    });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
     await fs.rm(dir, { recursive: true, force: true });
   }
 });

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -36,7 +36,16 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
 test("dogfood receipt includes structured proof for live TestPass and UXPass runs", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
   const output = path.join(dir, "latest.json");
-  const server = http.createServer((req, res) => {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+    const bodyText = Buffer.concat(chunks).toString("utf8");
+    const body = bodyText ? JSON.parse(bodyText) : {};
+    requests.push({ url: req.url, body });
+
     res.setHeader("Content-Type", "application/json");
     if (req.url === "/api/testpass-run") {
       res.end(JSON.stringify({
@@ -81,7 +90,10 @@ test("dogfood receipt includes structured proof for live TestPass and UXPass run
     const report = JSON.parse(await fs.readFile(output, "utf8"));
     const testpass = report.results.find((result) => result.id === "testpass");
     const uxpass = report.results.find((result) => result.id === "uxpass");
+    const testpassRequest = requests.find((request) => request.url === "/api/testpass-run");
+    const uxpassRequest = requests.find((request) => request.url === "/api/uxpass-run");
 
+    assert.equal(testpassRequest.body.source, "scheduled");
     assert.equal(testpass.runId, "testpass-run-123");
     assert.equal(testpass.targetUrl, "https://unclick.world/api/mcp");
     assert.deepEqual(testpass.proof, {
@@ -90,6 +102,7 @@ test("dogfood receipt includes structured proof for live TestPass and UXPass run
       targetUrl: "https://unclick.world/api/mcp",
     });
 
+    assert.equal(uxpassRequest.body.source, "scheduled");
     assert.equal(uxpass.runId, "uxpass-run-456");
     assert.equal(uxpass.targetUrl, "https://unclick.world");
     assert.deepEqual(uxpass.proof, {

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -8,6 +8,13 @@ export interface DogfoodPassResult {
   evidence: string;
   checkedAt?: string;
   blockedReason?: string;
+  runId?: string;
+  targetUrl?: string;
+  proof?: {
+    kind: "testpass_run" | "uxpass_run" | "planned";
+    runId?: string;
+    targetUrl?: string;
+  };
 }
 
 export interface DogfoodTrendPoint {

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -5,9 +5,17 @@ import Footer from "@/components/Footer";
 import FadeIn from "@/components/FadeIn";
 import { useCanonical } from "@/hooks/use-canonical";
 import { useMetaTags } from "@/hooks/useMetaTags";
-import { dogfoodReport as fallbackReport, type DogfoodPassResult, type DogfoodStatus } from "@/data/dogfoodReport";
+import {
+  dogfoodReport as fallbackReport,
+  type DogfoodPassResult,
+  type DogfoodStatus,
+  type DogfoodTrendPoint,
+} from "@/data/dogfoodReport";
 
-type DogfoodReportData = typeof fallbackReport;
+type DogfoodReportData = Omit<typeof fallbackReport, "results" | "trend"> & {
+  results: DogfoodPassResult[];
+  trend: DogfoodTrendPoint[];
+};
 
 const STATUS_STYLES: Record<DogfoodStatus, { label: string; badge: string; icon: typeof CheckCircle2 }> = {
   passing: {
@@ -161,6 +169,12 @@ export default function DogfoodReportPage() {
                     ) : null}
                     {result.checkedAt ? (
                       <p className="mt-3 text-[11px] text-muted-custom">Checked: {formatDate(result.checkedAt)}</p>
+                    ) : null}
+                    {result.runId || result.targetUrl ? (
+                      <div className="mt-3 space-y-1 text-[11px] text-muted-custom">
+                        {result.runId ? <p>Run: {result.runId}</p> : null}
+                        {result.targetUrl ? <p className="break-all">Target: {result.targetUrl}</p> : null}
+                      </div>
                     ) : null}
                   </article>
                 </FadeIn>


### PR DESCRIPTION
## Summary
- add structured `runId`, `targetUrl`, and `proof` metadata to live TestPass and UXPass dogfood receipt rows
- show Run and Target metadata on the public Dogfood Report when present
- cover the receipt builder with a fake local TestPass/UXPass API test so no real tokens or services are needed

## Non-overlap
- does not touch #359 TestPass fail-closed workflow or token/auth handling
- does not touch #72 dependency policy, #283 SecurityPass implementation, UXPass runner code, migrations, secrets, billing, DNS/domains, or workflow files

## Validation
- `node --test scripts/build-dogfood-report.test.mjs`
- `npm test`
- `npm run build`
- `node --check scripts/build-dogfood-report.mjs`
- `npx eslint src/data/dogfoodReport.ts src/pages/DogfoodReport.tsx`
- `git diff --check`

## Known baseline
- `npm exec tsc -- --noEmit --pretty false -p tsconfig.app.json` still reports unrelated existing `src/components/ArenaNav.tsx` `.soon` type errors; this PR did not touch that file or add Dogfood type errors.