### PR TITLE
fix(uxpass): wake scheduled run failures

### DIFF
--- a/api/lib/uxpass-run-handoff.ts
+++ b/api/lib/uxpass-run-handoff.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+
+export const UXPASS_RUN_HANDOFF_LEASE_SECONDS = 600;
+export const DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID = "chatgpt-55-plex-creativelead";
+
+export interface UxPassRunFailureHandoffInput {
+  runId: string;
+  targetUrl: string;
+  targetAgentId: string | null | undefined;
+  isScheduled: boolean;
+  status?: string | null;
+  errorMessage?: string | null;
+  taskId?: string | null;
+}
+
+export interface UxPassRunFailureHandoffPlan {
+  source: "uxpass";
+  targetAgentId: string;
+  taskRef: string;
+  payload: {
+    kind: "uxpass_run_failure";
+    run_id: string;
+    target_url: string;
+    status: "failed";
+    error_message: string;
+    task_id: string | null;
+    ack_required: true;
+  };
+  leaseSeconds: number;
+}
+
+export interface UxPassRunFailureDispatchRow {
+  api_key_hash: string;
+  dispatch_id: string;
+  source: "uxpass";
+  target_agent_id: string;
+  task_ref: string;
+  status: "leased";
+  lease_owner: string;
+  lease_expires_at: string;
+  payload: UxPassRunFailureHandoffPlan["payload"];
+  created_at: string;
+  updated_at: string;
+}
+
+function truncateMessage(value: string): string {
+  return value.length > 300 ? `${value.slice(0, 297)}...` : value;
+}
+
+export function uxPassRunFailureDispatchId(runId: string): string {
+  const digest = createHash("sha256")
+    .update(`uxpass-run-failure:${runId}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `dispatch_${digest}`;
+}
+
+export function planUxPassRunFailureHandoff(
+  input: UxPassRunFailureHandoffInput,
+): UxPassRunFailureHandoffPlan | null {
+  const targetAgentId = (input.targetAgentId ?? "").trim();
+  if (!input.isScheduled || !targetAgentId || !input.runId) return null;
+
+  const status = (input.status ?? "").trim();
+  const rawError = (input.errorMessage ?? "").trim();
+  if (status !== "failed" && !rawError) return null;
+
+  return {
+    source: "uxpass",
+    targetAgentId,
+    taskRef: `uxpass-run:${input.runId}`,
+    payload: {
+      kind: "uxpass_run_failure",
+      run_id: input.runId,
+      target_url: input.targetUrl,
+      status: "failed",
+      error_message: truncateMessage(rawError || "Scheduled UXPass run returned failed status"),
+      task_id: input.taskId ?? null,
+      ack_required: true,
+    },
+    leaseSeconds: UXPASS_RUN_HANDOFF_LEASE_SECONDS,
+  };
+}
+
+export function buildUxPassRunFailureDispatchRow(params: {
+  apiKeyHash: string;
+  dispatchId: string;
+  plan: UxPassRunFailureHandoffPlan;
+  now: Date;
+}): UxPassRunFailureDispatchRow {
+  const nowIso = params.now.toISOString();
+  return {
+    api_key_hash: params.apiKeyHash,
+    dispatch_id: params.dispatchId,
+    source: params.plan.source,
+    target_agent_id: params.plan.targetAgentId,
+    task_ref: params.plan.taskRef,
+    status: "leased",
+    lease_owner: params.plan.targetAgentId,
+    lease_expires_at: new Date(
+      params.now.getTime() + params.plan.leaseSeconds * 1000,
+    ).toISOString(),
+    payload: params.plan.payload,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+}

--- a/api/uxpass-run-handoff.test.ts
+++ b/api/uxpass-run-handoff.test.ts
@@ -1,0 +1,97 @@
+import {
+  buildUxPassRunFailureDispatchRow,
+  DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID,
+  planUxPassRunFailureHandoff,
+  UXPASS_RUN_HANDOFF_LEASE_SECONDS,
+  uxPassRunFailureDispatchId,
+} from "./lib/uxpass-run-handoff";
+
+describe("planUxPassRunFailureHandoff", () => {
+  const baseInput = {
+    runId: "ux-run-123",
+    targetUrl: "https://unclick.world",
+    targetAgentId: DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID,
+    isScheduled: true,
+    status: "failed",
+    errorMessage: "capture assertion failed",
+    taskId: "11111111-1111-4111-8111-111111111111",
+  };
+
+  it("creates ACK-required dispatch plans for scheduled UXPass failures", () => {
+    const plan = planUxPassRunFailureHandoff(baseInput);
+
+    expect(plan).toEqual({
+      source: "uxpass",
+      targetAgentId: DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID,
+      taskRef: "uxpass-run:ux-run-123",
+      leaseSeconds: UXPASS_RUN_HANDOFF_LEASE_SECONDS,
+      payload: {
+        kind: "uxpass_run_failure",
+        run_id: "ux-run-123",
+        target_url: "https://unclick.world",
+        status: "failed",
+        error_message: "capture assertion failed",
+        task_id: "11111111-1111-4111-8111-111111111111",
+        ack_required: true,
+      },
+    });
+  });
+
+  it("builds an already-leased row for missed-ACK reclaim", () => {
+    const plan = planUxPassRunFailureHandoff(baseInput);
+    expect(plan).not.toBeNull();
+
+    const row = buildUxPassRunFailureDispatchRow({
+      apiKeyHash: "hash-123",
+      dispatchId: "dispatch_123",
+      plan: plan!,
+      now: new Date("2026-05-01T00:00:00.000Z"),
+    });
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash-123",
+      dispatch_id: "dispatch_123",
+      source: "uxpass",
+      target_agent_id: DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID,
+      task_ref: "uxpass-run:ux-run-123",
+      status: "leased",
+      lease_owner: DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID,
+      lease_expires_at: "2026-05-01T00:10:00.000Z",
+      created_at: "2026-05-01T00:00:00.000Z",
+      updated_at: "2026-05-01T00:00:00.000Z",
+    });
+    expect(row.payload.ack_required).toBe(true);
+  });
+
+  it("uses stable dispatch ids so repeated failure paths do not duplicate work", () => {
+    expect(uxPassRunFailureDispatchId("ux-run-123")).toBe(
+      uxPassRunFailureDispatchId("ux-run-123"),
+    );
+    expect(uxPassRunFailureDispatchId("ux-run-123")).toMatch(/^dispatch_[a-f0-9]{32}$/);
+  });
+
+  it("stays silent for quiet, manual, or unowned paths", () => {
+    expect(planUxPassRunFailureHandoff({ ...baseInput, status: "complete", errorMessage: "" }))
+      .toBeNull();
+    expect(planUxPassRunFailureHandoff({ ...baseInput, isScheduled: false })).toBeNull();
+    expect(planUxPassRunFailureHandoff({ ...baseInput, targetAgentId: "" })).toBeNull();
+  });
+
+  it("keeps runner exceptions eligible for the same ACK path", () => {
+    const plan = planUxPassRunFailureHandoff({
+      ...baseInput,
+      status: "running",
+      errorMessage: "runner crashed after capture",
+      taskId: null,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan?.payload).toMatchObject({
+      kind: "uxpass_run_failure",
+      status: "failed",
+      error_message: "runner crashed after capture",
+      task_id: null,
+      ack_required: true,
+    });
+  });
+});

--- a/api/uxpass-run.ts
+++ b/api/uxpass-run.ts
@@ -16,9 +16,16 @@
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createHash } from "node:crypto";
 import { CORE_CHECKS } from "../packages/uxpass/src/checks.js";
 import { createRun } from "../packages/uxpass/src/run-manager.js";
 import { runDeterministicChecks } from "../packages/uxpass/src/runner.js";
+import {
+  buildUxPassRunFailureDispatchRow,
+  DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID,
+  planUxPassRunFailureHandoff,
+  uxPassRunFailureDispatchId,
+} from "./lib/uxpass-run-handoff.js";
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -47,6 +54,86 @@ async function getActorUserIdFromJwt(
   if (!r.ok) return null;
   const u = (await r.json()) as { id?: string };
   return u.id ?? null;
+}
+
+function sha256hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function getApiKeyHashForUser(
+  supabaseUrl: string,
+  serviceKey: string,
+  userId: string,
+): Promise<string | null> {
+  const r = await fetch(
+    `${supabaseUrl}/rest/v1/api_keys?user_id=eq.${encodeURIComponent(userId)}&is_active=eq.true&select=key_hash,api_key&order=last_used_at.desc.nullslast,created_at.desc&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } },
+  );
+  if (!r.ok) return null;
+  const rows = (await r.json().catch(() => [])) as Array<{
+    key_hash?: string | null;
+    api_key?: string | null;
+  }>;
+  const row = rows[0];
+  return row?.key_hash ?? (row?.api_key ? sha256hex(row.api_key) : null);
+}
+
+function shouldCreateScheduledFailureDispatch(params: {
+  isCron: boolean;
+  source?: string;
+}): boolean {
+  return params.isCron || params.source === "scheduled";
+}
+
+async function createUxPassRunFailureDispatch(params: {
+  supabaseUrl: string;
+  serviceKey: string;
+  apiKeyHash: string | null;
+  runId: string;
+  targetUrl: string;
+  isScheduled: boolean;
+  status?: string | null;
+  errorMessage?: string | null;
+  taskId?: string | null;
+}) {
+  if (!params.apiKeyHash) return;
+  const targetAgentId = process.env.UXPASS_WAKE_AGENT_ID ?? DEFAULT_UXPASS_RUN_HANDOFF_AGENT_ID;
+  const plan = planUxPassRunFailureHandoff({
+    runId: params.runId,
+    targetUrl: params.targetUrl,
+    targetAgentId,
+    isScheduled: params.isScheduled,
+    status: params.status,
+    errorMessage: params.errorMessage,
+    taskId: params.taskId,
+  });
+  if (!plan) return;
+
+  const row = buildUxPassRunFailureDispatchRow({
+    apiKeyHash: params.apiKeyHash,
+    dispatchId: uxPassRunFailureDispatchId(params.runId),
+    plan,
+    now: new Date(),
+  });
+
+  const response = await fetch(`${params.supabaseUrl}/rest/v1/mc_agent_dispatches`, {
+    method: "POST",
+    headers: {
+      apikey: params.serviceKey,
+      Authorization: `Bearer ${params.serviceKey}`,
+      "Content-Type": "application/json",
+      Prefer: "resolution=ignore-duplicates",
+    },
+    body: JSON.stringify(row),
+  });
+  if (!response.ok && response.status !== 409) {
+    const body = await response.text().catch(() => "");
+    console.error(
+      `uxpass-run failed to create failure dispatch for ${params.runId}:`,
+      response.status,
+      body,
+    );
+  }
 }
 
 function queryString(value: string | string[] | undefined): string | undefined {
@@ -88,8 +175,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     ? {
         url: queryString(req.query.url) ?? queryString(req.query.target_url),
         task_id: queryString(req.query.task_id),
+        source: queryString(req.query.source),
       }
-    : ((req.body ?? {}) as { url?: string; target_url?: string; task_id?: string });
+    : ((req.body ?? {}) as {
+        url?: string;
+        target_url?: string;
+        task_id?: string;
+        source?: string;
+      });
 
   const targetUrl = input.url ?? input.target_url ?? "";
   if (!targetUrl) return json(res, 400, { error: "url required" });
@@ -111,6 +204,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const taskId = input.task_id && input.task_id !== "" ? input.task_id.toLowerCase() : undefined;
 
   const config = { supabaseUrl, serviceRoleKey: serviceKey };
+  const isScheduledAction = shouldCreateScheduledFailureDispatch({
+    isCron,
+    source: input.source,
+  });
+  const apiKeyHash = isScheduledAction
+    ? await getApiKeyHashForUser(supabaseUrl, serviceKey, actorUserId)
+    : null;
   const { id: runId, was_duplicate } = await createRun(config, {
     targetUrl,
     actorUserId,
@@ -145,6 +245,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     const result = await runDeterministicChecks(config, runId, targetUrl);
+    if (result.status === "failed") {
+      await createUxPassRunFailureDispatch({
+        supabaseUrl,
+        serviceKey,
+        apiKeyHash,
+        runId,
+        targetUrl,
+        isScheduled: isScheduledAction,
+        status: result.status,
+        taskId: taskId ?? null,
+      });
+    }
     return json(res, 200, {
       run_id: runId,
       status: result.status,
@@ -155,6 +267,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       task_id: taskId ?? null,
     });
   } catch (err) {
+    await createUxPassRunFailureDispatch({
+      supabaseUrl,
+      serviceKey,
+      apiKeyHash,
+      runId,
+      targetUrl,
+      isScheduled: isScheduledAction,
+      status: "failed",
+      errorMessage: err instanceof Error ? err.message : String(err),
+      taskId: taskId ?? null,
+    });
     return json(res, 500, {
       run_id: runId,
       error: `runner failed: ${(err as Error).message}`,


### PR DESCRIPTION
## Summary
- Add UXPass scheduled failure WakePass handoff planning with 10-minute ACK leases
- Create ACK-required reliability dispatches when scheduled UXPass runs fail or throw
- Keep manual, successful, duplicate, and no-op UXPass paths silent

## Owned files
- api/uxpass-run.ts
- api/lib/uxpass-run-handoff.ts
- api/uxpass-run-handoff.test.ts

## Non-overlap
- No event-wake-router scripts (#369 / Forge)
- No #359 TestPass token/workflow files
- No #283 SecurityPass branch/files
- No packages/uxpass runner files
- No api/memory-admin.ts, secrets, auth, migrations, or broad UI

## Verification
- npm test -- api/uxpass-run-handoff.test.ts api/testpass-background-handoff.test.ts
- npx --no-install tsc --noEmit --pretty false
- npm run build
- git diff --check

## Ring-fence impact
Small positive move for overnight trust: scheduled UXPass failures now leave reclaimable ACK evidence instead of disappearing into a plain 500/failed status. Estimated +1-2% unattended coverage.
