### PR TITLE
fix(wakepass): suppress green check echoes

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -124,10 +124,10 @@ function baseDecision(event) {
 
     if (run.status === "completed" && run.conclusion === "success" && prs.length > 0) {
       return {
-        wake: true,
-        owner: "🍿",
-        urgency: "high",
-        reason: `PR checks completed green for ${run.name || "workflow"} on PR #${prs[0].number}`,
+        wake: false,
+        owner: "none",
+        urgency: "low",
+        reason: `PR checks completed green for ${run.name || "workflow"} on PR #${prs[0].number}; no action needed`,
         eventCreatedAt: run.updated_at || run.created_at,
         needsTriage: false,
       };

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -113,7 +113,7 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(request.payload.handoff_message_id, null);
   });
 
-  it("runs the wake path in dry-run mode without crashing", () => {
+  it("keeps successful PR workflow green echoes silent", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");
     const ledgerDir = join(tempDir, "ledger");
@@ -148,14 +148,12 @@ describe("event wake router reliability dispatch", () => {
       });
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /reliability_dispatch_dry_run/);
-      assert.match(result.stdout, /"wake_owner": "🍿"/);
-      assert.match(result.stdout, /"ack_required": true/);
-      assert.ok(
-        result.stdout.indexOf("reliability_dispatch_dry_run") <
-          result.stdout.indexOf('"text": "Wake event id:'),
-        "PinballWake reliability proof should be prepared before the Fishbowl route payload",
-      );
+      assert.match(result.stdout, /PR checks completed green for TestPass PR Check on PR #316; no action needed/);
+      assert.match(result.stdout, /No wake needed/);
+      assert.doesNotMatch(result.stdout, /reliability_dispatch_dry_run/);
+      assert.doesNotMatch(result.stdout, /"ack_required": true/);
+      assert.doesNotMatch(result.stdout, /"wake_owner": "🍿"/);
+      assert.doesNotMatch(result.stdout, /ACK requested: reply ACK/);
       assert.doesNotMatch(result.stderr, /ReferenceError/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -321,6 +319,7 @@ describe("event wake router reliability dispatch", () => {
     assert.match(result.stdout, /"wake_urgency": "high"/);
     assert.match(result.stdout, /reliability_dispatch_dry_run/);
     assert.match(result.stdout, /"ack_required": true/);
+    assert.match(result.stdout, /ACK requested: reply ACK/);
   });
 
   it("keeps ordinary PR updates silent", () => {


### PR DESCRIPTION
## Summary
Suppress successful PR workflow-run green-check echoes in the event wake router so they do not create Fishbowl WakePass ACK work.

## Scope
- Owned files: `scripts/event-wake-router.mjs`, `scripts/event-wake-router.test.mjs`
- Product lane: WakePass / PinballWake router noise reduction

## Non-overlap
- Does not touch #359 TestPass fail-closed credentials, #72 dependency policy, Pass product files, Ideas, analytics, secrets, auth, migrations, or stale/conflicted PR branches.
- Keeps action-needed routes as ACK-required handoffs.

## Verification
- `node --test scripts/event-wake-router.test.mjs` (16/16)
- `git diff --check` (clean; Git emitted CRLF warnings for touched files)

## Risk
Low. Narrows only the successful PR workflow-run route; failed scheduled jobs, manual wakes, issue assignment/label routes, and ready-review PR wakes still dispatch with ACK required.

## Follow-up
If the team wants non-blocking green visibility later, add an explicit FYI-only route without `needs-doing` or WakePass reliability dispatch.
