### PR TITLE
fix(analytics): capture explicit PostHog pageviews

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { useEffect } from "react";
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { Toaster } from "@/components/ui/toaster";
@@ -73,11 +74,20 @@ import SignalsCatalog from "./pages/admin/signals/SignalsCatalog.tsx";
 import SignalsSettings from "./pages/admin/signals/SignalsSettings.tsx";
 import Fishbowl from "./pages/admin/Fishbowl.tsx";
 import BuildDeskPage from "./pages/BuildDesk.tsx";
-import { initPostHog } from "./lib/posthog.ts";
-
-initPostHog();
+import { trackPageView } from "./lib/analytics.ts";
 
 const queryClient = new QueryClient();
+
+function AnalyticsPageviewTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const path = `${location.pathname}${location.search}${location.hash}`;
+    trackPageView(path);
+  }, [location.hash, location.pathname, location.search]);
+
+  return null;
+}
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
@@ -86,6 +96,7 @@ const App = () => (
       <Sonner />
       <Analytics />
       <BrowserRouter>
+        <AnalyticsPageviewTracker />
         <BetaBanner />
         <Routes>
           <Route path="/" element={<Index />} />

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -27,3 +27,22 @@ export function track(event: string, data?: EventData): void {
     // Never let analytics break the app.
   }
 }
+
+export function trackPageView(path: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const properties = {
+      path,
+      title: document.title || undefined,
+      $current_url: window.location.href,
+      $pathname: path,
+    };
+    posthog.capture("$pageview", properties);
+    const umami = (window as unknown as UmamiWindow).umami;
+    if (umami && typeof umami.track === "function") {
+      umami.track("pageview", properties);
+    }
+  } catch {
+    // Never let analytics break the app.
+  }
+}

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -11,7 +11,8 @@ export function initPostHog(): void {
     api_host: host,
     defaults: "2026-01-30",
     autocapture: true,
-    capture_pageview: "history_change",
+    capture_pageview: false,
+    capture_pageleave: false,
     persistence: "localStorage",
     respect_dnt: true,
   });


### PR DESCRIPTION
Summary:
- Replaces PostHog's automatic history-change pageview mode with explicit UnClick-controlled pageview captures.
- Sends a \$pageview\ on initial load and every React Router path/search/hash change.
- Keeps Vercel Analytics and optional Umami fallback intact.

Scope:
- src/App.tsx
- src/lib/analytics.ts
- src/lib/posthog.ts

Non-overlap:
- No auth, secrets, billing, DNS/domains, migrations, Pass runners, Fishbowl, wake-router, or dependency changes.

Verification:
- npm run build
- npx eslint src/App.tsx src/lib/analytics.ts src/lib/posthog.ts --max-warnings=0
- git diff --check

Risk:
- Low. This only changes browser analytics event capture. It should increase pageview reliability and reduce dependence on third-party automatic SPA behavior.

Follow-up:
- After deploy, visit 2-3 public routes and confirm fresh \$pageview\ events in PostHog Live Events/Web Analytics.
- If PostHog remains unreliable after this, build a tiny first-party UnClick analytics collector as a fallback.