### PR TITLE
test(reliability): guard core docs against em dashes

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -52,7 +52,7 @@ error. Fix the migration, push again. The CLI is idempotent about already
 applied migrations.
 
 As a belt-and-braces safety net, `api/install-ticket.ts` also self-heals its
-table via `ensureSchema()` on cold start — so even a missed migration won't
+table via `ensureSchema()` on cold start, so even a missed migration won't
 break install-ticket issuance.
 
 ## Publishing the MCP server
@@ -68,7 +68,7 @@ workflow:
 5. Polls `npm view` to confirm propagation.
 
 To cut a minor or major release, bump manually in `packages/mcp-server/package.json`
-and push — the workflow will still publish (its `npm version patch` becomes a
+and push, the workflow will still publish (its `npm version patch` becomes a
 no-op if the working tree is dirty, but simpler: just skip the workflow by
 including `[skip ci]` in your message and running `npm publish` locally).
 
@@ -82,7 +82,7 @@ including `[skip ci]` in your message and running `npm publish` locally).
    Generate a new **Automation** token (not Classic) and update the secret.
 3. **`apply-migrations.yml` link failure** - the access token may have been
    rotated. Regenerate at https://supabase.com/dashboard/account/tokens.
-4. **`apply-migrations.yml` migration error** — open the run logs. If it's a
+4. **`apply-migrations.yml` migration error** - open the run logs. If it's a
    destructive change we don't want automated, revert the migration commit
    and apply it manually via the SQL editor instead.
 

--- a/scripts/no-emdash-docs.test.mjs
+++ b/scripts/no-emdash-docs.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const docPaths = [
+  "AGENTS.md",
+  "AUTOPILOT.md",
+  "CLAUDE.md",
+  "README.md",
+  ".github/OPERATIONS.md",
+];
+
+test("core docs do not contain em dashes", () => {
+  const offenders = [];
+
+  for (const relativePath of docPaths) {
+    const absolutePath = path.join(repoRoot, relativePath);
+    const content = fs.readFileSync(absolutePath, "utf8");
+    if (content.includes("—")) {
+      offenders.push(relativePath);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Found em dashes in: ${offenders.join(", ")}`
+  );
+});


### PR DESCRIPTION
## Summary
- add a small node test that fails when core operator docs include em dashes
- replace three remaining em dashes in operations guidance so the new guard passes

## Scope
- touched only docs hygiene and a single test file
- no runtime code paths, API handlers, workflows, or package manifests changed

## Non-overlap
- independent from currently open wake/testpass PRs
- no edits to secrets, auth policy, payments, migrations, or user-owned branches

## Verification
- `node --test scripts/no-emdash-docs.test.mjs` (pass)
- `node --test scripts/event-wake-router.test.mjs` (pass, 16/16)

## Risk
- low; change is documentation text plus a read-only style guard test

## Follow-up
- optional: extend the em-dash guard to additional docs once desired coverage is agreed