### PR TITLE
Harden channel heartbeat API timeout handling

### DIFF
--- a/packages/channel-plugin/http.js
+++ b/packages/channel-plugin/http.js
@@ -1,0 +1,36 @@
+export async function apiFetchJson({
+  apiBase,
+  apiKey,
+  action,
+  method = "GET",
+  body,
+  query = {},
+  timeoutMs = 10_000,
+}) {
+  const qs = new URLSearchParams({ action, ...query }).toString();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${apiBase}/api/memory-admin?${qs}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`api ${action} -> ${res.status} ${text.slice(0, 200)}`);
+    }
+    return res.json();
+  } catch (err) {
+    if (err && typeof err === "object" && err.name === "AbortError") {
+      throw new Error(`api ${action} timeout after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/channel-plugin/http.test.js
+++ b/packages/channel-plugin/http.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { apiFetchJson } from "./http.js";
+
+test("apiFetchJson returns parsed JSON on success", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ ok: true }),
+  });
+
+  try {
+    const result = await apiFetchJson({
+      apiBase: "https://unclick.world",
+      apiKey: "k",
+      action: "admin_channel_heartbeat",
+      method: "POST",
+      body: { client_info: "test" },
+      timeoutMs: 50,
+    });
+    assert.deepEqual(result, { ok: true });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("apiFetchJson throws timeout error when request hangs", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async (_url, { signal }) =>
+    new Promise((_resolve, reject) => {
+      signal.addEventListener("abort", () => {
+        const err = new Error("aborted");
+        err.name = "AbortError";
+        reject(err);
+      });
+    });
+
+  try {
+    await assert.rejects(
+      () =>
+        apiFetchJson({
+          apiBase: "https://unclick.world",
+          apiKey: "k",
+          action: "admin_channel_heartbeat",
+          timeoutMs: 10,
+        }),
+      /timeout after 10ms/
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -32,6 +32,7 @@ import crypto from "node:crypto";
 import os from "node:os";
 import process from "node:process";
 import readline from "node:readline";
+import { apiFetchJson } from "./http.js";
 
 const API_BASE       = process.env.UNCLICK_API_BASE     || "https://unclick.world";
 const API_KEY        = process.env.UNCLICK_API_KEY      || "";
@@ -39,6 +40,7 @@ const SUPABASE_URL   = process.env.UNCLICK_SUPABASE_URL || "";
 const SUPABASE_ANON  = process.env.UNCLICK_SUPABASE_ANON || "";
 const POLL_INTERVAL  = parseInt(process.env.UNCLICK_CHANNEL_POLL || "5000", 10);
 const HEARTBEAT_MS   = 30_000;
+const API_TIMEOUT_MS = parseInt(process.env.UNCLICK_API_TIMEOUT_MS || "10000", 10);
 const RESPONSE_TIMEOUT_MS = 5 * 60_000;
 
 function log(...args) {
@@ -184,20 +186,15 @@ function startStdioLoop() {
 // ─── Admin API calls ────────────────────────────────────────────────────────
 
 async function apiFetch(action, { method = "GET", body, query = {} } = {}) {
-  const qs = new URLSearchParams({ action, ...query }).toString();
-  const res = await fetch(`${API_BASE}/api/memory-admin?${qs}`, {
+  return apiFetchJson({
+    apiBase: API_BASE,
+    apiKey: API_KEY,
+    action,
     method,
-    headers: {
-      Authorization: `Bearer ${API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: body ? JSON.stringify(body) : undefined,
+    body,
+    query,
+    timeoutMs: API_TIMEOUT_MS,
   });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`api ${action} -> ${res.status} ${text.slice(0, 200)}`);
-  }
-  return res.json();
 }
 
 async function sendHeartbeat() {


### PR DESCRIPTION
## Summary
- add a shared channel-plugin API helper with explicit request timeout + abort handling
- route channel heartbeat/admin API calls through the timeout-enabled helper
- add focused tests for success path and timeout path

## Scope
- reliability hardening slice: heartbeat robustness only
- no UI, dependency, migration, auth, secret, or payment changes

## Verification
- node --test packages/channel-plugin/http.test.js