### PR TITLE
fix(testpass): accept API keys in CI runner

### DIFF
--- a/.github/actions/testpass/action.yml
+++ b/.github/actions/testpass/action.yml
@@ -106,7 +106,9 @@ runs:
           status="infra_transport_error"
           failure_kind="infra_transport"
         elif [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
-          echo "::warning::TestPass auth failure (HTTP $http_code) - TESTPASS_TOKEN is likely stale. Refresh the secret and retry." >&2
+          auth_reason=$(jq -r '.auth_reason // "unknown"' response.json 2>/dev/null || echo "unknown")
+          how_to_fix=$(jq -r '.how_to_fix // "Refresh TESTPASS_TOKEN and retry."' response.json 2>/dev/null || echo "Refresh TESTPASS_TOKEN and retry.")
+          echo "::warning::TestPass auth failure (HTTP $http_code, $auth_reason) - $how_to_fix" >&2
           status="infra_auth_error"
           failure_kind="infra_auth"
           response=$(jq -c '.' response.json 2>/dev/null || echo "{}")

--- a/api/testpass-run-auth.test.ts
+++ b/api/testpass-run-auth.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveTestPassRunActor } from "./testpass-run";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function mockJsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("resolveTestPassRunActor", () => {
+  it("accepts active UnClick API keys linked to a user", async () => {
+    const fetchMock = vi.fn(async () => mockJsonResponse(200, [
+      { user_id: "user-123", is_active: true },
+    ]));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await resolveTestPassRunActor(
+      "https://example.supabase.co",
+      "service-role",
+      "uc_test_key",
+    );
+
+    expect(result).toEqual({ ok: true, actorUserId: "user-123", tokenKind: "api_key" });
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/rest/v1/api_keys?");
+    expect(String(fetchMock.mock.calls[0][0])).toContain("key_hash=eq.");
+  });
+
+  it("explains inactive API keys", async () => {
+    globalThis.fetch = vi.fn(async () => mockJsonResponse(200, [
+      { user_id: "user-123", is_active: false },
+    ])) as typeof fetch;
+
+    const result = await resolveTestPassRunActor(
+      "https://example.supabase.co",
+      "service-role",
+      "uc_inactive_key",
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 401,
+      auth_reason: "api_key_inactive",
+    });
+  });
+
+  it("explains unlinked API keys", async () => {
+    globalThis.fetch = vi.fn(async () => mockJsonResponse(200, [
+      { user_id: null, is_active: true },
+    ])) as typeof fetch;
+
+    const result = await resolveTestPassRunActor(
+      "https://example.supabase.co",
+      "service-role",
+      "uc_unlinked_key",
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 401,
+      auth_reason: "api_key_unlinked",
+    });
+  });
+
+  it("still accepts Supabase session tokens", async () => {
+    globalThis.fetch = vi.fn(async () => mockJsonResponse(200, { id: "session-user" })) as typeof fetch;
+
+    const result = await resolveTestPassRunActor(
+      "https://example.supabase.co",
+      "service-role",
+      "jwt-token",
+    );
+
+    expect(result).toEqual({ ok: true, actorUserId: "session-user", tokenKind: "session" });
+  });
+});

--- a/api/testpass-run.ts
+++ b/api/testpass-run.ts
@@ -1,8 +1,9 @@
 /**
  * TestPass CI escape hatch - POST /api/testpass-run
  *
- * Bearer-auth (Supabase JWT) entry point for CI pipelines. Runs a named
- * pack against a target MCP server without going through MCP.
+ * Bearer-auth entry point for CI pipelines. Accepts either a Supabase JWT
+ * or an UnClick API key (uc_...). Runs a named pack against a target MCP
+ * server without going through MCP.
  *
  * Body/query: { pack_id: string, pack_name?: string, profile?: "smoke"|"standard"|"deep", server_url?: string }
  * Returns: { run_id: string, status: RunStatus, verdict_summary?: VerdictSummary }
@@ -62,6 +63,94 @@ async function getActorUserId(
   if (!r.ok) return null;
   const u = (await r.json()) as { id?: string };
   return u.id ?? null;
+}
+
+type ActorAuthResult =
+  | { ok: true; actorUserId: string; tokenKind: "api_key" | "session" }
+  | {
+      ok: false;
+      status: 401 | 500;
+      auth_reason: string;
+      error: string;
+      how_to_fix: string;
+    };
+
+async function getActorUserIdFromApiKey(
+  supabaseUrl: string,
+  serviceKey: string,
+  apiKey: string,
+): Promise<ActorAuthResult> {
+  const keyHash = sha256hex(apiKey);
+  const r = await fetch(
+    `${supabaseUrl}/rest/v1/api_keys?key_hash=eq.${encodeURIComponent(keyHash)}&select=user_id,is_active&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } },
+  );
+  if (!r.ok) {
+    return {
+      ok: false,
+      status: 500,
+      auth_reason: "api_key_lookup_failed",
+      error: "Could not verify UnClick API key",
+      how_to_fix: "Retry the workflow. If this repeats, check Supabase service-role access for api_keys.",
+    };
+  }
+
+  const rows = (await r.json().catch(() => [])) as Array<{
+    user_id?: string | null;
+    is_active?: boolean | null;
+  }>;
+  const row = rows[0];
+  if (!row) {
+    return {
+      ok: false,
+      status: 401,
+      auth_reason: "api_key_not_found",
+      error: "UnClick API key not found",
+      how_to_fix: "Update TESTPASS_TOKEN to an active key from /admin/you and rerun the workflow.",
+    };
+  }
+  if (row.is_active === false) {
+    return {
+      ok: false,
+      status: 401,
+      auth_reason: "api_key_inactive",
+      error: "UnClick API key is inactive",
+      how_to_fix: "Reissue or choose an active UnClick API key, update TESTPASS_TOKEN, and rerun the workflow.",
+    };
+  }
+  if (!row.user_id) {
+    return {
+      ok: false,
+      status: 401,
+      auth_reason: "api_key_unlinked",
+      error: "UnClick API key is not linked to a user",
+      how_to_fix: "Use an API key from a signed-in account on /admin/you, or link this key to a user before using it for TestPass.",
+    };
+  }
+
+  return { ok: true, actorUserId: row.user_id, tokenKind: "api_key" };
+}
+
+export async function resolveTestPassRunActor(
+  supabaseUrl: string,
+  serviceKey: string,
+  token: string,
+): Promise<ActorAuthResult> {
+  if (token.startsWith("uc_")) {
+    return getActorUserIdFromApiKey(supabaseUrl, serviceKey, token);
+  }
+
+  const actorUserId = await getActorUserId(supabaseUrl, token);
+  if (!actorUserId) {
+    return {
+      ok: false,
+      status: 401,
+      auth_reason: "session_invalid",
+      error: "Invalid session",
+      how_to_fix: "Use a valid Supabase session token or an active UnClick API key.",
+    };
+  }
+  return { ok: true, actorUserId, tokenKind: "session" };
 }
 
 async function getPackIdBySlug(
@@ -254,8 +343,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
   } else {
-    actorUserId = await getActorUserId(supabaseUrl, token);
-    if (!actorUserId) return json(res, 401, { error: "Invalid session" });
+    const actor = await resolveTestPassRunActor(supabaseUrl, serviceKey, token);
+    if (!actor.ok) {
+      return json(res, actor.status, {
+        error: actor.error,
+        auth_reason: actor.auth_reason,
+        how_to_fix: actor.how_to_fix,
+      });
+    }
+    actorUserId = actor.actorUserId;
   }
   const apiKeyHash = shouldEmitScheduledSignal(input.source) || profile !== "smoke"
     ? await getApiKeyHashForUser(supabaseUrl, serviceKey, actorUserId)


### PR DESCRIPTION
Summary:
- Fixes the TestPass CI auth path so /api/testpass-run accepts UnClick uc_ API keys as well as Supabase session tokens.
- Adds clear auth_reason/how_to_fix responses for not found, inactive, unlinked, lookup-failed, and invalid-session cases.
- Updates the composite GitHub Action warning to surface that auth_reason instead of only saying the token is stale.

Scope:
- TestPass CI endpoint and focused auth tests.
- Small GitHub Action log-message improvement.

Non-overlap:
- Does not touch analytics, Connectors UI, Fishbowl handoff, WakePass routing, migrations, secrets, auth provider config, billing, or domains.
- Intentionally should land before #359 so that #359 can rerun the fail-closed gate with a token the endpoint actually understands.

Verification:
- npx vitest run api/testpass-run-auth.test.ts
- git diff --check
- npm run build

Risk:
- Low. This widens the existing TestPass CI endpoint to support the documented/keyed automation path without exposing key material.
- If a key still fails, the API now reports a safe reason instead of a generic 401.

Follow-up:
- After merge, rerun #359 TestPass workflow. If it still fails, the new auth_reason should identify the exact credential problem.