### PR TITLE
chore(testpass): remove em dashes in anti-stomp copy

### DIFF
--- a/packages/testpass/packs/anti-stomp-v0.yaml
+++ b/packages/testpass/packs/anti-stomp-v0.yaml
@@ -166,7 +166,7 @@ items:
     check_type: deterministic
     description: >
       If the PR title contains any of: restore, reorg, refactor, fix nav,
-      fix sidebar — the PR body must contain a section titled "## Archaeology"
+      fix sidebar - the PR body must contain a section titled "## Archaeology"
       or "## Pre-restore audit" with git log output and a disposition per
       item found. This check is a no-op for unmatched PR titles.
     expected:
@@ -190,7 +190,7 @@ items:
     check_type: deterministic
     description: >
       For any row in mc_extracted_facts where category is one of "built",
-      "shipped", or "change" — at least one of commit_sha or pr_number must
+      "shipped", or "change" - at least one of commit_sha or pr_number must
       be non-null. Facts without linkage cannot be audited or attributed.
       This check is a no-op for other categories.
     expected:


### PR DESCRIPTION
## Summary
- Remove remaining em dash punctuation from anti-stomp pack copy.
- Keep wording and behavior unchanged.

## Scope
- One file: packages/testpass/packs/anti-stomp-v0.yaml.
- Two copy-only line edits in AUDIT-001 and GIT-LINK-001 descriptions.

## Non-overlap
- No workflow, auth, secrets, migrations, or runtime logic touched.
- No dependency or lockfile changes.

## Verification
- `Select-String -Path "packages/testpass/packs/anti-stomp-v0.yaml" -Pattern "—"` -> no matches.
- `npm run --workspace @unclick/testpass test` -> fails in this worktree because `packages/testpass/node_modules/.bin/jest` is missing.

## Risk
- Very low. Text-only normalization in a TestPass pack description.

## Follow-up
- Optionally run workspace install in CI/local dev image and re-run `@unclick/testpass` tests.