### PR TITLE
chore(reliability): guard wake ACK timeout parsing

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -13,14 +13,22 @@ const runId = process.env.GITHUB_RUN_ID || "";
 const apiUrl = process.env.UNCLICK_API_URL || "https://unclick.world/api/memory-admin";
 const unclickApiKey = process.env.FISHBOWL_WAKE_TOKEN || process.env.FISHBOWL_AUTOCLOSE_TOKEN || "";
 const dryRun = process.env.WAKE_ROUTER_DRY_RUN === "1" || process.env.WAKE_ROUTER_DRY_RUN === "true";
-const ackFailSeconds = parsePositiveInt(process.env.WAKE_ACK_FAIL_SECONDS, 600);
+const ACK_FAIL_SECONDS_MAX = 86_400;
+const ackFailSeconds = parsePositiveInt(
+  process.env.WAKE_ACK_FAIL_SECONDS,
+  600,
+  ACK_FAIL_SECONDS_MAX,
+);
 const receivedAt = new Date().toISOString();
 const ledgerDir = process.env.WAKE_LEDGER_DIR || ".wake-ledger";
 const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY || "";
 
-function parsePositiveInt(value, fallback) {
-  const parsed = Number.parseInt(String(value || ""), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+function parsePositiveInt(value, fallback, max = Number.POSITIVE_INFINITY) {
+  const text = String(value ?? "").trim();
+  if (!/^\d+$/.test(text)) return fallback;
+  const parsed = Number(text);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
 }
 
 function readEvent() {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -406,4 +406,89 @@ describe("event wake router reliability dispatch", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("falls back to default ACK timeout when WAKE_ACK_FAIL_SECONDS is malformed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        action: "completed",
+        workflow_run: {
+          id: 461,
+          name: "TestPass Scheduled Smoke",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/acme/repo/actions/runs/461",
+          created_at: "2026-04-30T17:00:00Z",
+          updated_at: "2026-04-30T17:05:00Z",
+          pull_requests: [],
+        },
+      }),
+    );
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+          WAKE_ACK_FAIL_SECONDS: "600s",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /"ack_fail_after_seconds": 600/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clamps WAKE_ACK_FAIL_SECONDS to one day for lease safety", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        action: "completed",
+        workflow_run: {
+          id: 462,
+          name: "TestPass Scheduled Smoke",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/acme/repo/actions/runs/462",
+          created_at: "2026-04-30T17:00:00Z",
+          updated_at: "2026-04-30T17:05:00Z",
+          pull_requests: [],
+        },
+      }),
+    );
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+          WAKE_ACK_FAIL_SECONDS: "999999",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /"ack_fail_after_seconds": 86400/);
+      assert.match(result.stdout, /"lease_seconds": 86400/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- harden WAKE_ACK_FAIL_SECONDS parsing to accept only digit-only positive integers
- cap ACK fail timeout at 86400s to prevent accidental multi-day leases
- add regression tests for malformed and oversized timeout env values

## Testing
- node --test scripts/event-wake-router.test.mjs