### PR TITLE
docs(testpass): clarify CI bearer token

### DIFF
--- a/.github/actions/testpass/action.yml
+++ b/.github/actions/testpass/action.yml
@@ -3,7 +3,7 @@ description: Run a TestPass pack against an MCP server and surface verdict outpu
 
 inputs:
   token:
-    description: Supabase JWT used as Bearer token against /api/testpass-run.
+    description: Bearer token for TestPass; use a Supabase JWT for session calls or a uc_ UnClick API key for CI.
     required: true
   pack_id:
     description: Slug of the TestPass pack to run (e.g. testpass-core).
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   api_url:
-    description: TestPass API endpoint.
+    description: TestPass run API endpoint; this action calls it and passes server_url as the MCP target under test.
     required: false
     default: https://unclick.world/api/testpass-run
   source:

--- a/.github/workflows/testpass-pr-check.yml
+++ b/.github/workflows/testpass-pr-check.yml
@@ -68,9 +68,14 @@ jobs:
             const failureKind = process.env.FAILURE_KIND || 'unknown';
             const httpCode = process.env.HTTP_CODE || '000';
 
-            let summary = {};
-            try { summary = JSON.parse(process.env.RESPONSE || '{}').verdict_summary || {}; }
-            catch { summary = {}; }
+            let responseJson = {};
+            try { responseJson = JSON.parse(process.env.RESPONSE || '{}'); }
+            catch { responseJson = {}; }
+            const summary = responseJson.verdict_summary || {};
+            const authReason =
+              typeof responseJson.auth_reason === 'string' ? responseJson.auth_reason : '';
+            const howToFix =
+              typeof responseJson.how_to_fix === 'string' ? responseJson.how_to_fix : '';
 
             const isInfra = failureKind && failureKind.startsWith('infra_');
 
@@ -83,12 +88,14 @@ jobs:
                 infra_http:      ':warning: TestPass: infra issue (API error)',
                 infra_transport: ':warning: TestPass: infra issue (transport)',
               };
+              const authReasonSuffix = authReason ? ` (${authReason})` : '';
               const explanations = {
                 infra_auth:
-                  `The TestPass API rejected our token (HTTP ${httpCode}). ` +
-                  `This is almost always a stale \`TESTPASS_TOKEN\` secret, ` +
-                  `**not** a problem with this PR. Refresh the secret in repo ` +
-                  `settings and re-run the workflow.`,
+                  `The TestPass API rejected the provided bearer token${authReasonSuffix} ` +
+                  `(HTTP ${httpCode}). ` +
+                  (howToFix ||
+                    `Use a valid Supabase JWT or uc_ UnClick API key in ` +
+                    `\`TESTPASS_TOKEN\`, then re-run the workflow.`),
                 infra_http:
                   `The TestPass API returned HTTP ${httpCode}. This is a ` +
                   `service-side issue, **not** a problem with this PR. ` +


### PR DESCRIPTION
## Summary
Clarifies TestPass CI bearer-token wording now that the PR check accepts both Supabase JWTs and `uc_` UnClick API keys.

## Scope
- Owned files: `.github/actions/testpass/action.yml`, `.github/workflows/testpass-pr-check.yml`
- Product lane: System Credentials / TestPass trust copy

## Non-overlap
- Does not change auth-provider behavior, secret handling, billing, domains, migrations, or any Pass runtime logic.
- Does not touch #370, #371, #372, #374, #375, #377, or #378 files.
- No secret values are logged or exposed.

## Verification
- `git diff --check`
- Wording grep for stale Supabase-only/stale-token phrasing and em dashes

## Risk
Low. This changes action metadata and PR comment text only. TestPass behavior remains fail-closed.

## Follow-up
The larger Connections UI status slice can still map `user_credentials` metadata into Connected Services without exposing encrypted fields.
