### PR TITLE
feat(connections): add system credential health panel

### DIFF
--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -377,6 +377,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         is_valid:        r.is_valid !== false,
         last_tested_at:  r.last_tested_at ?? null,
         last_used_at:    r.last_used_at ?? null,
+        last_rotated_at: r.last_rotated_at ?? null,
         expires_at:      r.expires_at ?? null,
         created_at:      r.created_at,
         updated_at:      r.updated_at,
@@ -570,7 +571,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const testedAt = new Date().toISOString();
     let ok = false;
     let status = 0;
-    let message = "";
+    let message: string;
     try {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 5_000);

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -26,6 +26,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useSession } from "@/lib/auth";
+import { buildSystemCredentialRows, type SystemCredentialRow } from "./systemCredentials";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -168,6 +169,80 @@ function readLocalApiKey(): string | null {
 function maskValue(v: string): string {
   if (v.length <= 8) return "•".repeat(Math.max(v.length, 4));
   return `${v.slice(0, 4)}${"•".repeat(8)}${v.slice(-4)}`;
+}
+
+function SystemCredentialsPanel({ rows }: { rows: SystemCredentialRow[] }) {
+  const needsAction = rows.filter((row) => row.rotationRisk !== "low" || row.status !== "healthy").length;
+  const healthy = rows.length - needsAction;
+  const statusClass: Record<SystemCredentialRow["status"], string> = {
+    healthy:  "border-green-500/20 bg-green-500/10 text-green-400",
+    untested: "border-[#E2B93B]/20 bg-[#E2B93B]/10 text-[#E2B93B]",
+    stale:    "border-amber-500/20 bg-amber-500/10 text-amber-400",
+    failing:  "border-red-500/20 bg-red-500/10 text-red-400",
+  };
+  const riskClass: Record<SystemCredentialRow["rotationRisk"], string> = {
+    low:    "text-green-400",
+    medium: "text-[#E2B93B]",
+    high:   "text-red-400",
+  };
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-[#101010] p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <Shield className="h-4 w-4 text-[#E2B93B]" />
+            <h2 className="text-sm font-semibold text-white">System Credentials</h2>
+          </div>
+          <p className="mt-1 text-[11px] text-[#777]">
+            Metadata-only view for what each connection powers, when it was checked, and what rotation might affect.
+          </p>
+        </div>
+        <div className="flex gap-2 text-[10px]">
+          <span className="rounded-full border border-green-500/20 bg-green-500/10 px-2 py-1 text-green-400">
+            {healthy} healthy
+          </span>
+          <span className="rounded-full border border-[#E2B93B]/20 bg-[#E2B93B]/10 px-2 py-1 text-[#E2B93B]">
+            {needsAction} review
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-4 overflow-hidden rounded-lg border border-white/[0.04]">
+        <div className="grid grid-cols-[minmax(160px,1.15fr)_minmax(140px,1fr)_120px_120px] gap-3 border-b border-white/[0.04] bg-white/[0.02] px-3 py-2 text-[10px] uppercase tracking-wide text-[#555] max-lg:hidden">
+          <span>Credential</span>
+          <span>Used by</span>
+          <span>Status</span>
+          <span>Rotation</span>
+        </div>
+        <div className="divide-y divide-white/[0.04]">
+          {rows.slice(0, 8).map((row) => (
+            <div
+              key={row.id}
+              className="grid gap-3 px-3 py-3 text-xs max-lg:grid-cols-1 lg:grid-cols-[minmax(160px,1.15fr)_minmax(140px,1fr)_120px_120px] lg:items-center"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium text-white">{row.displayName}</p>
+                <p className="mt-0.5 truncate text-[10px] text-[#666]">Owner: {row.ownerHint}</p>
+              </div>
+              <p className="min-w-0 truncate text-[11px] text-[#aaa]">{row.usedBy.join(", ")}</p>
+              <span className={`w-fit rounded-full border px-2 py-0.5 text-[10px] font-medium ${statusClass[row.status]}`}>
+                {row.statusLabel}
+              </span>
+              <div>
+                <p className={`text-[11px] font-medium ${riskClass[row.rotationRisk]}`}>{row.rotationLabel}</p>
+                <p className="mt-0.5 text-[10px] text-[#555]">Last check {timeAgo(row.lastChecked)}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p className="mt-3 text-[10px] text-[#555]">
+        This panel never displays raw keys, tokens, cookies, passkeys, or MFA secrets.
+      </p>
+    </section>
+  );
 }
 
 // ─── Component ──────────────────────────────────────────────────
@@ -499,6 +574,10 @@ export default function AdminKeychain() {
     acc[cat].push(cred);
     return acc;
   }, {});
+  const systemCredentialRows = useMemo(
+    () => buildSystemCredentialRows(credentials),
+    [credentials],
+  );
 
   return (
     <div>
@@ -537,10 +616,10 @@ export default function AdminKeychain() {
       <div className="mb-6 flex items-start gap-3 rounded-xl border border-[#E2B93B]/20 bg-[#E2B93B]/5 px-4 py-3">
         <Shield className="mt-0.5 h-4 w-4 shrink-0 text-[#E2B93B]" />
         <div>
-          <p className="text-xs font-medium text-[#E2B93B]">Encrypted connection secrets</p>
+          <p className="text-xs font-medium text-[#E2B93B]">Connections track health first</p>
           <p className="mt-0.5 text-[11px] text-[#888]">
-            Connection secrets are AES-256-GCM encrypted with a key derived from your UnClick API key.
-            UnClick staff cannot decrypt them — even revealing a value requires your API key to be present in this browser.
+            System Credentials shows ownership, usage, test freshness, and rotation risk from metadata only.
+            Raw secret values stay hidden unless you explicitly reveal one with your UnClick API key in this browser.
           </p>
         </div>
       </div>
@@ -574,6 +653,8 @@ export default function AdminKeychain() {
         </div>
       ) : (
         <div className="space-y-6">
+          <SystemCredentialsPanel rows={systemCredentialRows} />
+
           {Object.entries(grouped).map(([category, creds]) => (
             <div key={category}>
               <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[#666]">
@@ -1151,7 +1232,7 @@ function RotateValuesModal({
           throw new Error("Values must be a JSON object of string fields.");
         }
       } catch (e) {
-        throw new Error(e instanceof Error ? e.message : "Invalid JSON");
+        throw new Error(e instanceof Error ? e.message : "Invalid JSON", { cause: e });
       }
 
       const apiKey = readLocalApiKey();

--- a/src/pages/admin/systemCredentials.test.ts
+++ b/src/pages/admin/systemCredentials.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemCredentialRows, type SystemCredentialSource } from "./systemCredentials";
+
+const NOW = new Date("2026-05-01T08:00:00Z").getTime();
+
+function cred(overrides: Partial<SystemCredentialSource>): SystemCredentialSource {
+  return {
+    id:              "cred-1",
+    platform:        "github",
+    label:           "TESTPASS_TOKEN byrneck",
+    is_valid:        true,
+    last_tested_at:  "2026-05-01T07:00:00Z",
+    last_used_at:    null,
+    last_rotated_at: "2026-04-15T00:00:00Z",
+    expires_at:      null,
+    created_at:      "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("buildSystemCredentialRows", () => {
+  it("infers TestPass/GitHub usage and owner without exposing values", () => {
+    const rows = buildSystemCredentialRows([cred({})], NOW);
+    expect(rows[0]).toMatchObject({
+      displayName:   "github / TESTPASS_TOKEN byrneck",
+      ownerHint:     "byrneck",
+      status:        "healthy",
+      rotationRisk:  "low",
+    });
+    expect(rows[0].usedBy).toContain("TestPass PR checks");
+    expect(rows[0].usedBy).toContain("GitHub workflows");
+    expect(rows[0].safeNote).toContain("metadata only");
+  });
+
+  it("marks scheduled cron keys as medium risk when never tested", () => {
+    const rows = buildSystemCredentialRows([
+      cred({
+        id:             "cron",
+        platform:       "unclick",
+        label:          "TESTPASS_CRON_SECRET creativelead scheduled",
+        last_tested_at: null,
+      }),
+    ], NOW);
+    expect(rows[0].usedBy).toContain("TestPass PR checks");
+    expect(rows[0].usedBy).toContain("scheduled smoke receipts");
+    expect(rows[0].ownerHint).toBe("creativelead");
+    expect(rows[0].status).toBe("untested");
+    expect(rows[0].rotationRisk).toBe("medium");
+  });
+
+  it("sorts failing or old-rotation credentials before healthy ones", () => {
+    const rows = buildSystemCredentialRows([
+      cred({ id: "good", label: "OpenRouter", platform: "openrouter" }),
+      cred({
+        id:              "old",
+        label:           "Supabase production",
+        platform:        "supabase",
+        last_rotated_at: "2025-12-01T00:00:00Z",
+      }),
+      cred({
+        id:       "bad",
+        label:    "PostHog analytics",
+        platform: "posthog",
+        is_valid: false,
+      }),
+    ], NOW);
+
+    expect(rows.map((row) => row.id)).toEqual(["bad", "old", "good"]);
+    expect(rows[0].status).toBe("failing");
+    expect(rows[1].rotationRisk).toBe("high");
+  });
+});

--- a/src/pages/admin/systemCredentials.ts
+++ b/src/pages/admin/systemCredentials.ts
@@ -1,0 +1,123 @@
+export type SystemCredentialStatus = "healthy" | "untested" | "stale" | "failing";
+export type SystemCredentialRisk = "low" | "medium" | "high";
+
+export interface SystemCredentialSource {
+  id:              string;
+  platform:        string;
+  label:           string | null;
+  is_valid:        boolean;
+  last_tested_at:  string | null;
+  last_used_at:    string | null;
+  last_rotated_at: string | null;
+  expires_at:      string | null;
+  created_at:      string;
+}
+
+export interface SystemCredentialRow {
+  id:             string;
+  displayName:    string;
+  platform:       string;
+  ownerHint:      string;
+  usedBy:         string[];
+  status:         SystemCredentialStatus;
+  statusLabel:    string;
+  rotationRisk:   SystemCredentialRisk;
+  rotationLabel:  string;
+  lastChecked:    string | null;
+  safeNote:       string;
+}
+
+const STALE_TEST_DAYS = 7;
+const ROTATION_DAYS = 90;
+
+function daysSince(iso: string | null, nowMs: number): number | null {
+  if (!iso) return null;
+  const time = new Date(iso).getTime();
+  if (Number.isNaN(time)) return null;
+  return Math.floor((nowMs - time) / 86_400_000);
+}
+
+function hasAny(haystack: string, needles: string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function inferUsedBy(source: SystemCredentialSource): string[] {
+  const text = `${source.platform} ${source.label ?? ""}`.toLowerCase();
+  const uses: string[] = [];
+
+  if (hasAny(text, ["testpass", "test-pass", "test pass"])) uses.push("TestPass PR checks");
+  if (hasAny(text, ["cron", "scheduled", "dogfood"])) uses.push("scheduled smoke receipts");
+  if (hasAny(text, ["fishbowl", "wake", "wakepass", "pinball"])) uses.push("Fishbowl/WakePass routing");
+  if (hasAny(text, ["openrouter", "router"])) uses.push("wake classifier");
+  if (hasAny(text, ["github", "gh_"])) uses.push("GitHub workflows");
+  if (hasAny(text, ["vercel"])) uses.push("Vercel deploys and cron");
+  if (hasAny(text, ["supabase"])) uses.push("database and auth");
+  if (hasAny(text, ["posthog", "analytics"])) uses.push("analytics");
+  if (hasAny(text, ["slack", "discord", "telegram"])) uses.push("agent notifications");
+
+  return Array.from(new Set(uses.length > 0 ? uses : ["manual agent connection"]));
+}
+
+function inferOwnerHint(source: SystemCredentialSource): string {
+  const text = `${source.platform} ${source.label ?? ""}`.toLowerCase();
+  if (text.includes("creativelead")) return "creativelead";
+  if (text.includes("byrneck")) return "byrneck";
+  if (text.includes("prod") || text.includes("production")) return "production";
+  if (text.includes("staging") || text.includes("preview")) return "preview";
+  return "not recorded";
+}
+
+function inferStatus(source: SystemCredentialSource, nowMs: number): Pick<SystemCredentialRow, "status" | "statusLabel"> {
+  if (!source.is_valid) return { status: "failing", statusLabel: "failing" };
+  const testedAge = daysSince(source.last_tested_at, nowMs);
+  if (testedAge === null) return { status: "untested", statusLabel: "untested" };
+  if (testedAge > STALE_TEST_DAYS) return { status: "stale", statusLabel: `stale (${testedAge}d)` };
+  return { status: "healthy", statusLabel: "healthy" };
+}
+
+function inferRotation(source: SystemCredentialSource, status: SystemCredentialStatus, nowMs: number): Pick<SystemCredentialRow, "rotationRisk" | "rotationLabel"> {
+  const expiryAge = daysSince(source.expires_at, nowMs);
+  if (expiryAge !== null && expiryAge >= 0) {
+    return { rotationRisk: "high", rotationLabel: "expired" };
+  }
+
+  const rotatedAge = daysSince(source.last_rotated_at, nowMs);
+  if (status === "failing") return { rotationRisk: "high", rotationLabel: "check before reuse" };
+  if (rotatedAge !== null && rotatedAge >= ROTATION_DAYS) {
+    return { rotationRisk: "high", rotationLabel: `rotate (${rotatedAge}d)` };
+  }
+  if (status === "untested" || status === "stale") {
+    return { rotationRisk: "medium", rotationLabel: "test before rotate" };
+  }
+  if (rotatedAge === null) {
+    return { rotationRisk: "medium", rotationLabel: "rotation date unknown" };
+  }
+  return { rotationRisk: "low", rotationLabel: "low" };
+}
+
+export function buildSystemCredentialRows(
+  credentials: SystemCredentialSource[],
+  nowMs = Date.now(),
+): SystemCredentialRow[] {
+  return credentials.map((source) => {
+    const status = inferStatus(source, nowMs);
+    const rotation = inferRotation(source, status.status, nowMs);
+    const label = source.label?.trim();
+    const displayName = label ? `${source.platform} / ${label}` : source.platform;
+
+    return {
+      id:             source.id,
+      displayName,
+      platform:       source.platform,
+      ownerHint:      inferOwnerHint(source),
+      usedBy:         inferUsedBy(source),
+      ...status,
+      ...rotation,
+      lastChecked:    source.last_tested_at,
+      safeNote:       "Tracks metadata only. Raw secret values are not shown in this view.",
+    };
+  }).sort((a, b) => {
+    const rank: Record<SystemCredentialRisk, number> = { high: 0, medium: 1, low: 2 };
+    return rank[a.rotationRisk] - rank[b.rotationRisk] || a.displayName.localeCompare(b.displayName);
+  });
+}


### PR DESCRIPTION
Summary:
- Adds a metadata-only System Credentials panel to the Connections admin surface.
- Classifies stored connection metadata by likely usage, owner hint, test freshness, and rotation risk.
- Keeps raw secret values out of the panel and keeps reveal/rotate behind the existing BackstagePass proof-of-possession flow.

Scope:
- Connections/Admin UI: src/pages/admin/AdminKeychain.tsx
- Metadata classifier + tests: src/pages/admin/systemCredentials.ts, src/pages/admin/systemCredentials.test.ts
- BackstagePass list metadata: api/backstagepass.ts now returns last_rotated_at so rotation warnings can work.

Non-overlap:
- No secrets, auth policy, billing, DNS/domains, migrations, browser extension implementation, or broad vault rewrite.
- Does not touch TestPass token handling, WakePass routing, analytics, UXPass runner, or SecurityPass implementation.

Verification:
- npx vitest run src/pages/admin/systemCredentials.test.ts
- npx eslint src/pages/admin/systemCredentials.ts src/pages/admin/systemCredentials.test.ts src/pages/admin/AdminKeychain.tsx api/backstagepass.ts
- git diff --check
- npm run build

Risk:
- UI/metadata-only. The panel infers owner/usage from platform and label text, so hints are advisory until a future metadata source is added.
- Existing full-repo lint/typecheck still fail on unrelated pre-existing files; touched-file lint is clean except existing backstagepass warnings.

Follow-up:
- Add first-class system credential metadata source for GitHub/Vercel secrets so TESTPASS_TOKEN and TESTPASS_CRON_SECRET can be shown even when they are not stored as Connections credentials.
- Later: UnClick Local/browser extension Phase 0 spec only, no implementation yet.