### PR TITLE
feat(admin): add System Credentials health panel

### DIFF
--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -152,6 +152,18 @@ const PLATFORM_PROBES: Record<string, {
       Authorization: `Bearer ${v.api_key ?? ""}`,
     }),
   },
+  openrouter: {
+    url: "https://openrouter.ai/api/v1/models",
+    buildHeaders: (v) => ({
+      Authorization: `Bearer ${v.api_key ?? v.token ?? ""}`,
+    }),
+  },
+  vercel: {
+    url: "https://api.vercel.com/v2/user",
+    buildHeaders: (v) => ({
+      Authorization: `Bearer ${v.api_key ?? v.token ?? ""}`,
+    }),
+  },
 };
 
 // ─── Supabase REST helper ────────────────────────────────────────
@@ -377,6 +389,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         is_valid:        r.is_valid !== false,
         last_tested_at:  r.last_tested_at ?? null,
         last_used_at:    r.last_used_at ?? null,
+        last_rotated_at: r.last_rotated_at ?? null,
         expires_at:      r.expires_at ?? null,
         created_at:      r.created_at,
         updated_at:      r.updated_at,
@@ -570,7 +583,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const testedAt = new Date().toISOString();
     let ok = false;
     let status = 0;
-    let message = "";
+    let message: string;
     try {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 5_000);

--- a/src/lib/systemCredentialsHealth.test.ts
+++ b/src/lib/systemCredentialsHealth.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSystemCredentialHealthRows,
+  deriveSystemCredentialStatus,
+  type CredentialHealthInput,
+} from "./systemCredentialsHealth";
+
+const NOW = new Date("2026-05-01T00:00:00.000Z");
+
+function credential(overrides: Partial<CredentialHealthInput>): CredentialHealthInput {
+  return {
+    platform: "github",
+    label: "main",
+    is_valid: true,
+    last_tested_at: "2026-04-30T00:00:00.000Z",
+    last_used_at: null,
+    last_rotated_at: "2026-04-01T00:00:00.000Z",
+    connector: { name: "GitHub", category: "Dev Tools" },
+    ...overrides,
+  };
+}
+
+describe("system credential health", () => {
+  it("derives failing before freshness or rotation warnings", () => {
+    expect(deriveSystemCredentialStatus([
+      credential({
+        is_valid: false,
+        last_tested_at: "2026-04-30T00:00:00.000Z",
+        last_rotated_at: "2025-01-01T00:00:00.000Z",
+      }),
+    ], NOW)).toBe("failing");
+  });
+
+  it("marks healthy credentials with recent checks as healthy", () => {
+    expect(deriveSystemCredentialStatus([
+      credential({ last_tested_at: "2026-04-30T00:00:00.000Z" }),
+    ], NOW)).toBe("healthy");
+  });
+
+  it("distinguishes untested, stale, and rotation-due credentials", () => {
+    expect(deriveSystemCredentialStatus([], NOW)).toBe("untested");
+    expect(deriveSystemCredentialStatus([
+      credential({ last_tested_at: null, last_rotated_at: "2026-04-01T00:00:00.000Z" }),
+    ], NOW)).toBe("untested");
+    expect(deriveSystemCredentialStatus([
+      credential({ last_tested_at: "2026-03-01T00:00:00.000Z", last_rotated_at: "2026-04-01T00:00:00.000Z" }),
+    ], NOW)).toBe("stale");
+    expect(deriveSystemCredentialStatus([
+      credential({ last_tested_at: "2026-04-30T00:00:00.000Z", last_rotated_at: "2026-01-01T00:00:00.000Z" }),
+    ], NOW)).toBe("needs_rotation");
+  });
+
+  it("builds metadata-only rows without secret values", () => {
+    const rows = buildSystemCredentialHealthRows([
+      credential({ platform: "github", label: "ci" }),
+      credential({ platform: "openrouter", label: "models", last_tested_at: null }),
+    ], "chris@example.com", NOW);
+
+    const github = rows.find((row) => row.id === "github");
+    const openrouter = rows.find((row) => row.id === "openrouter");
+
+    expect(github).toMatchObject({
+      owner: "chris@example.com",
+      status: "healthy",
+      matchedCredentialCount: 1,
+      matchedCredentialLabels: ["ci"],
+    });
+    expect(github?.expectedFields).toEqual(["api_key", "token"]);
+    expect(github?.usedBy).toContain("CI inspection");
+    expect(openrouter?.status).toBe("untested");
+    expect(JSON.stringify(rows)).not.toContain("sk-");
+  });
+});

--- a/src/lib/systemCredentialsHealth.ts
+++ b/src/lib/systemCredentialsHealth.ts
@@ -1,0 +1,212 @@
+export type SystemCredentialStatus =
+  | "healthy"
+  | "untested"
+  | "failing"
+  | "stale"
+  | "needs_rotation";
+
+export interface CredentialHealthInput {
+  platform: string;
+  label: string | null;
+  is_valid: boolean;
+  last_tested_at: string | null;
+  last_used_at: string | null;
+  last_rotated_at: string | null;
+  connector: {
+    name: string;
+    category: string;
+  } | null;
+}
+
+export interface SystemCredentialCatalogItem {
+  id: string;
+  name: string;
+  platformSlugs: string[];
+  expectedFields: string[];
+  usedBy: string[];
+  rotationNote: string;
+  probeSupported: boolean;
+}
+
+export interface SystemCredentialHealthRow extends SystemCredentialCatalogItem {
+  owner: string;
+  status: SystemCredentialStatus;
+  statusLabel: string;
+  lastCheckedAt: string | null;
+  lastRotatedAt: string | null;
+  matchedCredentialCount: number;
+  matchedCredentialLabels: string[];
+}
+
+export const SYSTEM_CREDENTIAL_STALE_DAYS = 30;
+export const SYSTEM_CREDENTIAL_ROTATION_DAYS = 90;
+
+export const SYSTEM_CREDENTIAL_CATALOG: SystemCredentialCatalogItem[] = [
+  {
+    id: "testpass",
+    name: "TestPass API key",
+    platformSlugs: ["testpass", "unclick"],
+    expectedFields: ["api_key", "token"],
+    usedBy: ["TestPass PR checks", "scheduled TestPass", "Dogfood receipt runner"],
+    rotationNote: "Rotate the repo secret, rerun TestPass PR Check, then rerun the nightly dogfood receipt.",
+    probeSupported: false,
+  },
+  {
+    id: "fishbowl",
+    name: "Fishbowl admin key",
+    platformSlugs: ["fishbowl", "unclick", "supabase"],
+    expectedFields: ["api_key", "service_role_key"],
+    usedBy: ["Fishbowl posts", "Now Playing status", "todo reconciliation"],
+    rotationNote: "Rotate during a quiet window, then verify Fishbowl post, read, and status updates.",
+    probeSupported: false,
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter API key",
+    platformSlugs: ["openrouter"],
+    expectedFields: ["api_key"],
+    usedBy: ["model routing", "agent fallback models"],
+    rotationNote: "Rotate in BackstagePass, retest the connection, then run one model route smoke test.",
+    probeSupported: true,
+  },
+  {
+    id: "vercel",
+    name: "Vercel token",
+    platformSlugs: ["vercel"],
+    expectedFields: ["api_key", "token"],
+    usedBy: ["preview deployments", "deployment status", "project automation"],
+    rotationNote: "Rotate in Vercel, update BackstagePass, then verify the next preview deployment.",
+    probeSupported: true,
+  },
+  {
+    id: "supabase",
+    name: "Supabase service key",
+    platformSlugs: ["supabase"],
+    expectedFields: ["url", "service_role_key", "anon_key"],
+    usedBy: ["BackstagePass", "memory admin", "Pass run storage"],
+    rotationNote: "Rotate carefully. BackstagePass, Fishbowl, and Pass run APIs depend on this project key.",
+    probeSupported: false,
+  },
+  {
+    id: "github",
+    name: "GitHub token",
+    platformSlugs: ["github"],
+    expectedFields: ["api_key", "token"],
+    usedBy: ["PR triage", "CI inspection", "repo automation"],
+    rotationNote: "Rotate in GitHub, retest the connection, then verify PR list and workflow read access.",
+    probeSupported: true,
+  },
+  {
+    id: "posthog",
+    name: "PostHog project key",
+    platformSlugs: ["posthog"],
+    expectedFields: ["api_key", "project_key"],
+    usedBy: ["analytics events", "explicit pageviews"],
+    rotationNote: "Rotate in PostHog, update BackstagePass, then verify one pageview reaches the project.",
+    probeSupported: false,
+  },
+];
+
+function parseTime(value: string | null): number | null {
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function newestIso(values: Array<string | null>): string | null {
+  let newest: string | null = null;
+  let newestTime = -Infinity;
+  for (const value of values) {
+    const time = parseTime(value);
+    if (time !== null && time > newestTime) {
+      newest = value;
+      newestTime = time;
+    }
+  }
+  return newest;
+}
+
+function oldestIso(values: Array<string | null>): string | null {
+  let oldest: string | null = null;
+  let oldestTime = Infinity;
+  for (const value of values) {
+    const time = parseTime(value);
+    if (time !== null && time < oldestTime) {
+      oldest = value;
+      oldestTime = time;
+    }
+  }
+  return oldest;
+}
+
+function daysSince(value: string | null, now: Date): number | null {
+  const time = parseTime(value);
+  if (time === null) return null;
+  return Math.floor((now.getTime() - time) / 86_400_000);
+}
+
+function statusLabel(status: SystemCredentialStatus): string {
+  switch (status) {
+    case "healthy":
+      return "Healthy";
+    case "failing":
+      return "Failing";
+    case "stale":
+      return "Stale";
+    case "needs_rotation":
+      return "Needs rotation";
+    case "untested":
+    default:
+      return "Untested";
+  }
+}
+
+export function deriveSystemCredentialStatus(
+  credentials: CredentialHealthInput[],
+  now = new Date(),
+): SystemCredentialStatus {
+  if (credentials.length === 0) return "untested";
+  if (credentials.some((credential) => !credential.is_valid)) return "failing";
+
+  const oldestRotation = oldestIso(credentials.map((credential) => credential.last_rotated_at));
+  const rotationAge = daysSince(oldestRotation, now);
+  if (rotationAge !== null && rotationAge >= SYSTEM_CREDENTIAL_ROTATION_DAYS) {
+    return "needs_rotation";
+  }
+
+  const lastCheckedAt = newestIso(credentials.map((credential) => credential.last_tested_at));
+  if (!lastCheckedAt) return "untested";
+
+  const checkedAge = daysSince(lastCheckedAt, now);
+  if (checkedAge !== null && checkedAge >= SYSTEM_CREDENTIAL_STALE_DAYS) return "stale";
+
+  return "healthy";
+}
+
+export function buildSystemCredentialHealthRows(
+  credentials: CredentialHealthInput[],
+  ownerEmail: string | null | undefined,
+  now = new Date(),
+): SystemCredentialHealthRow[] {
+  const normalizedOwner = ownerEmail?.trim() || "Current signed-in user";
+
+  return SYSTEM_CREDENTIAL_CATALOG.map((item) => {
+    const matches = credentials.filter((credential) =>
+      item.platformSlugs.includes(credential.platform),
+    );
+    const status = deriveSystemCredentialStatus(matches, now);
+
+    return {
+      ...item,
+      owner: normalizedOwner,
+      status,
+      statusLabel: statusLabel(status),
+      lastCheckedAt: newestIso(matches.map((credential) => credential.last_tested_at)),
+      lastRotatedAt: oldestIso(matches.map((credential) => credential.last_rotated_at)),
+      matchedCredentialCount: matches.length,
+      matchedCredentialLabels: matches.map((credential) =>
+        credential.label || credential.connector?.name || credential.platform,
+      ),
+    };
+  });
+}

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -27,6 +27,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useSession } from "@/lib/auth";
 import {
+  buildSystemCredentialHealthRows,
+  type SystemCredentialHealthRow,
+  type SystemCredentialStatus,
+} from "@/lib/systemCredentialsHealth";
+import {
   AlertTriangle,
   CheckCircle2,
   Clipboard,
@@ -53,6 +58,7 @@ const PLATFORMS = [
   // AI / LLM
   { slug: "anthropic",  name: "Anthropic",   category: "AI",           desc: "Claude models" },
   { slug: "openai",     name: "OpenAI",       category: "AI",           desc: "GPT and Assistants" },
+  { slug: "openrouter", name: "OpenRouter",   category: "AI",           desc: "Model routing" },
   { slug: "google-ai",  name: "Google AI",    category: "AI",           desc: "Gemini models" },
   { slug: "cohere",     name: "Cohere",       category: "AI",           desc: "Command models" },
   { slug: "mistral",    name: "Mistral",      category: "AI",           desc: "Mistral models" },
@@ -170,10 +176,32 @@ function maskValue(v: string): string {
   return `${v.slice(0, 4)}${"•".repeat(8)}${v.slice(-4)}`;
 }
 
+function healthStatusClasses(status: SystemCredentialStatus): string {
+  switch (status) {
+    case "healthy":
+      return "border-green-500/20 bg-green-500/10 text-green-300";
+    case "failing":
+      return "border-red-500/20 bg-red-500/10 text-red-300";
+    case "stale":
+      return "border-amber-500/20 bg-amber-500/10 text-amber-300";
+    case "needs_rotation":
+      return "border-orange-500/20 bg-orange-500/10 text-orange-300";
+    case "untested":
+    default:
+      return "border-sky-500/20 bg-sky-500/10 text-sky-300";
+  }
+}
+
+function healthStatusIcon(status: SystemCredentialStatus) {
+  if (status === "healthy") return <CheckCircle2 className="h-3 w-3" />;
+  if (status === "failing") return <XCircle className="h-3 w-3" />;
+  return <AlertTriangle className="h-3 w-3" />;
+}
+
 // ─── Component ──────────────────────────────────────────────────
 
 export default function AdminKeychain() {
-  const { session } = useSession();
+  const { session, user } = useSession();
 
   const [credentials, setCredentials] = useState<Credential[]>([]);
   const [loading, setLoading]         = useState(true);
@@ -499,6 +527,14 @@ export default function AdminKeychain() {
     acc[cat].push(cred);
     return acc;
   }, {});
+  const healthRows = useMemo(
+    () => buildSystemCredentialHealthRows(credentials, user?.email ?? null),
+    [credentials, user?.email],
+  );
+  const healthCounts = healthRows.reduce<Record<SystemCredentialStatus, number>>((acc, row) => {
+    acc[row.status] += 1;
+    return acc;
+  }, { healthy: 0, untested: 0, failing: 0, stale: 0, needs_rotation: 0 });
 
   return (
     <div>
@@ -544,6 +580,12 @@ export default function AdminKeychain() {
           </p>
         </div>
       </div>
+
+      <SystemCredentialsHealthPanel
+        rows={healthRows}
+        counts={healthCounts}
+        formatLastTested={timeAgo}
+      />
 
       {/* List */}
       {error && (
@@ -1026,6 +1068,98 @@ export default function AdminKeychain() {
   );
 }
 
+function SystemCredentialsHealthPanel({
+  rows,
+  counts,
+  formatLastTested,
+}: {
+  rows: SystemCredentialHealthRow[];
+  counts: Record<SystemCredentialStatus, number>;
+  formatLastTested: (iso: string | null) => string;
+}) {
+  const attentionCount = counts.failing + counts.stale + counts.needs_rotation + counts.untested;
+
+  return (
+    <section className="mb-6 rounded-xl border border-white/[0.06] bg-[#111111]">
+      <div className="flex flex-col gap-3 border-b border-white/[0.06] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-white">System credentials health</h2>
+          <p className="mt-0.5 text-[11px] text-[#777]">
+            Metadata only. Secret values stay encrypted in BackstagePass.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <span className="rounded-full border border-green-500/20 bg-green-500/10 px-2 py-0.5 text-[10px] text-green-300">
+            {counts.healthy} healthy
+          </span>
+          <span className="rounded-full border border-white/[0.08] bg-white/[0.04] px-2 py-0.5 text-[10px] text-[#aaa]">
+            {attentionCount} need attention
+          </span>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-white/[0.06] text-left">
+          <thead className="bg-black/20">
+            <tr className="text-[10px] uppercase tracking-wider text-[#666]">
+              <th className="px-4 py-2 font-semibold">Credential</th>
+              <th className="px-4 py-2 font-semibold">Owner</th>
+              <th className="px-4 py-2 font-semibold">Used by</th>
+              <th className="px-4 py-2 font-semibold">Status</th>
+              <th className="px-4 py-2 font-semibold">Last checked</th>
+              <th className="px-4 py-2 font-semibold">Rotation note</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/[0.04]">
+            {rows.map((row) => (
+              <tr key={row.id} className="align-top">
+                <td className="px-4 py-3">
+                  <p className="text-xs font-medium text-white">{row.name}</p>
+                  <p className="mt-0.5 text-[10px] text-[#666]">
+                    {row.matchedCredentialCount > 0
+                      ? row.matchedCredentialLabels.join(", ")
+                      : `Expected fields: ${row.expectedFields.join(", ")}`}
+                  </p>
+                  {row.probeSupported ? (
+                    <span className="mt-1 inline-flex rounded-full border border-[#61C1C4]/20 bg-[#61C1C4]/10 px-2 py-0.5 text-[10px] text-[#61C1C4]">
+                      Probe supported
+                    </span>
+                  ) : null}
+                </td>
+                <td className="px-4 py-3 text-[11px] text-[#aaa]">{row.owner}</td>
+                <td className="px-4 py-3">
+                  <div className="flex max-w-xs flex-wrap gap-1">
+                    {row.usedBy.map((use) => (
+                      <span
+                        key={use}
+                        className="rounded-full border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[10px] text-[#999]"
+                      >
+                        {use}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${healthStatusClasses(row.status)}`}>
+                    {healthStatusIcon(row.status)}
+                    {row.statusLabel}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-[11px] text-[#aaa]">
+                  {row.lastCheckedAt ? formatLastTested(row.lastCheckedAt) : "not checked"}
+                </td>
+                <td className="px-4 py-3 text-[11px] text-[#888]">
+                  {row.rotationNote}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
 // ─── Modals ───────────────────────────────────────────────────────
 
 function ModalShell({
@@ -1151,7 +1285,8 @@ function RotateValuesModal({
           throw new Error("Values must be a JSON object of string fields.");
         }
       } catch (e) {
-        throw new Error(e instanceof Error ? e.message : "Invalid JSON");
+        setErr(e instanceof Error ? e.message : "Invalid JSON");
+        return;
       }
 
       const apiKey = readLocalApiKey();


### PR DESCRIPTION
## Summary
- add a metadata-only System Credentials health panel to the Connections admin page
- show credential name, safe owner identity, used-by labels, derived health status, last checked, expected fields, and rotation notes without revealing secret values
- add OpenRouter and Vercel to the safe BackstagePass connection probe map
- return `last_rotated_at` from the BackstagePass list response so rotation health can be derived from existing metadata

## Non-overlap
- no secret values displayed or logged
- no migrations, auth-provider changes, billing, DNS/domains, or broad vault rebuild
- keeps BackstagePass as the secure substrate
- does not touch #375 package files, #377/#378 drafts, or old conflicted PR branches

## Validation
- `npm test -- src/lib/systemCredentialsHealth.test.ts`
- `npx eslint src/lib/systemCredentialsHealth.ts src/lib/systemCredentialsHealth.test.ts src/pages/admin/AdminKeychain.tsx api/backstagepass.ts --quiet`
- `npm run build`
- `git diff --check`

## Known baseline
- `npm exec tsc -- --noEmit --pretty false -p tsconfig.app.json` still fails on existing `src/components/ArenaNav.tsx` `.soon` type errors unrelated to this PR.