### PR TITLE
docs(marketing): align stale tool count copy

### DIFF
--- a/src/pages/Crews.tsx
+++ b/src/pages/Crews.tsx
@@ -134,7 +134,7 @@ const Crews = () => {
             <p className="mt-4 text-lg text-body max-w-2xl mx-auto leading-relaxed">
               UnClick Crews lets you define AI agent personas - each with their own tools, memory context, and expertise.
               A developer, a researcher, a writer, an organiser. They collaborate through Claude's Agent Teams, powered by
-              UnClick's 172+ MCP tools.
+              UnClick's 178+ MCP tools.
             </p>
           </FadeIn>
 
@@ -250,7 +250,7 @@ const Crews = () => {
                   <h3 className="text-sm font-semibold text-heading">Tools</h3>
                 </div>
                 <p className="text-xs text-body leading-relaxed">
-                  Each agent gets a curated subset of 172+ MCP tools. Developer gets GitHub and build tools. Writer gets CMS and formatting tools. No tool bloat, maximum focus.
+                  Each agent gets a curated subset of 178+ MCP tools. Developer gets GitHub and build tools. Writer gets CMS and formatting tools. No tool bloat, maximum focus.
                 </p>
               </div>
             </FadeIn>

--- a/src/pages/Dispatch.tsx
+++ b/src/pages/Dispatch.tsx
@@ -7,7 +7,7 @@ import { GitBranch, Zap, Brain, Lock, ArrowRight, Network, CheckCircle2, Termina
 
 const DISPATCH_FEATURES = [
   {
-    title: "172+ MCP Tools",
+    title: "178+ MCP Tools",
     desc: "Every tool available in both Cowork and Claude Code",
     icon: Network,
   },

--- a/src/pages/NewToAI.tsx
+++ b/src/pages/NewToAI.tsx
@@ -24,7 +24,7 @@ const FEATURES = [
     title: "Tools",
     subtitle: "The toolbox",
     icon: Wrench,
-    analogy: "Like giving your assistant access to email, calendar, weather, news, and 172 other services. They can check the weather, search Amazon, look up stocks, and more - without you doing it manually.",
+    analogy: "Like giving your assistant access to email, calendar, weather, news, and 178 other services. They can check the weather, search Amazon, look up stocks, and more - without you doing it manually.",
   },
   {
     id: "memory",
@@ -65,7 +65,7 @@ const FAQ = [
   },
   {
     q: "Is it free?",
-    a: "Yes! The free plan gives you 172+ tools. Pro is $29/month for unlimited access and advanced features.",
+    a: "Yes! The free plan gives you 178+ tools. Pro is $29/month for unlimited access and advanced features.",
   },
   {
     q: "What AI does it work with?",
@@ -105,7 +105,7 @@ const HowItWorks = [
 const PRODUCTS = [
   {
     name: "Tools",
-    desc: "172+ integrations: email, weather, finance, social media, and more.",
+    desc: "178+ integrations: email, weather, finance, social media, and more.",
     link: "/tools",
     icon: Wrench,
   },

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -16,7 +16,7 @@ const TIERS = [
     ctaHref: "#install",
     highlight: false,
     features: [
-      "172+ tools (100 calls/day)",
+      "178+ tools (100 calls/day)",
       "Arena browsing",
       "Memory (self-hosted, direct mode)",
       "BackstagePass (5 credentials)",


### PR DESCRIPTION
## Summary
- Align stale marketing-page copy from \172+\/\172\ tool references to \178+\/\178\.
- Keep claims consistent with current published tool-count messaging.

## Scope
- Updated copy only in:
  - \src/pages/Crews.tsx\
  - \src/pages/Dispatch.tsx\
  - \src/pages/NewToAI.tsx\
  - \src/pages/Pricing.tsx\
- No behavior, API, schema, auth, or workflow changes.

## Non-overlap
- Does not modify open feature branches, backend endpoints, CI config, or migrations.
- Isolated docs/UX copy drift fix for low-risk maintenance.

## Verification
- \
ode --test scripts/event-wake-router.test.mjs\ (pass, 16/16)

## Risk
- Low. String-only updates in user-facing marketing content.

## Follow-up
- Optionally centralize tool-count copy in one shared constant to prevent future drift.