### PR TITLE
feat(rotatepass): add safe credential name inventory

### DIFF
--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -1,0 +1,84 @@
+import {
+  hasSecretValueField,
+  listSystemCredentialInventory,
+  sanitizeInventoryRecord,
+  shouldTrackCredentialName,
+} from "./systemCredentialInventory";
+
+describe("system credential inventory", () => {
+  it("tracks critical GitHub Actions names without values", () => {
+    const names = listSystemCredentialInventory()
+      .filter((entry) => entry.provider === "github")
+      .map((entry) => entry.name);
+
+    expect(names).toContain("TESTPASS_TOKEN");
+    expect(names).toContain("TESTPASS_CRON_SECRET");
+    expect(names).toContain("OPENROUTER_API_KEY");
+    expect(names).toContain("FISHBOWL_WAKE_TOKEN");
+    expect(names).not.toContain("GITHUB_TOKEN");
+  });
+
+  it("tracks Vercel environment names without touching secret values", () => {
+    const entries = listSystemCredentialInventory().filter((entry) => entry.provider === "vercel");
+    const names = entries.map((entry) => entry.name);
+
+    expect(names).toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(names).toContain("CRON_SECRET");
+    expect(names).toContain("POSTHOG_API_KEY");
+    expect(names).toContain("STRIPE_SECRET_KEY");
+    expect(names).not.toContain("VERCEL_URL");
+    expect(entries.every((entry) => "value" in entry === false)).toBe(true);
+  });
+
+  it("requires all seeded entries to carry purpose and rotation guidance", () => {
+    for (const entry of listSystemCredentialInventory()) {
+      expect(entry.name).toMatch(/^[A-Z][A-Z0-9_]*$/);
+      expect(entry.scope.length).toBeGreaterThan(0);
+      expect(entry.workload.length).toBeGreaterThan(0);
+      expect(entry.docsHint.toLowerCase()).not.toContain("secret value:");
+    }
+  });
+
+  it("filters built-in or public runtime names that are not credential inventory", () => {
+    expect(shouldTrackCredentialName("TESTPASS_TOKEN")).toBe(true);
+    expect(shouldTrackCredentialName("GITHUB_TOKEN")).toBe(false);
+    expect(shouldTrackCredentialName("VERCEL_URL")).toBe(false);
+    expect(shouldTrackCredentialName("lowercase-token")).toBe(false);
+  });
+
+  it("rejects records that include value-shaped fields", () => {
+    expect(hasSecretValueField({ name: "TESTPASS_TOKEN", value: "never-print-me" })).toBe(true);
+    expect(hasSecretValueField({ name: "TESTPASS_TOKEN", encrypted_value: "ciphertext" })).toBe(true);
+    expect(hasSecretValueField({ name: "TESTPASS_TOKEN", vsmValue: "opaque" })).toBe(true);
+    expect(hasSecretValueField({ name: "TESTPASS_TOKEN", legacyValue: "old" })).toBe(true);
+
+    expect(sanitizeInventoryRecord({
+      provider: "vercel",
+      source: "vercel_env",
+      name: "TESTPASS_TOKEN",
+      value: "never-print-me",
+    })).toBeNull();
+  });
+
+  it("sanitizes metadata-only records into the safe display shape", () => {
+    expect(sanitizeInventoryRecord({
+      provider: "github",
+      source: "github_actions_secret",
+      name: " testpass_token ",
+      scope: "repository actions secret",
+      workload: "TestPass PR checks",
+      risk: "critical",
+      expected: true,
+      docsHint: "Name and timestamps only.",
+    })).toEqual({
+      provider: "github",
+      source: "github_actions_secret",
+      name: "TESTPASS_TOKEN",
+      scope: "repository actions secret",
+      workload: "TestPass PR checks",
+      risk: "critical",
+      expected: true,
+      docsHint: "Name and timestamps only.",
+    });
+  });
+});

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -1,0 +1,367 @@
+export type SystemCredentialProvider = "github" | "vercel";
+export type SystemCredentialSource = "github_actions_secret" | "vercel_env";
+export type SystemCredentialRisk = "critical" | "high" | "normal";
+
+export interface SystemCredentialInventoryEntry {
+  provider: SystemCredentialProvider;
+  source: SystemCredentialSource;
+  name: string;
+  scope: string;
+  workload: string;
+  risk: SystemCredentialRisk;
+  expected: boolean;
+  docsHint: string;
+}
+
+const BLOCKED_VALUE_FIELDS = new Set([
+  "value",
+  "encrypted_value",
+  "encryptedValue",
+  "vsmValue",
+  "legacyValue",
+  "secret",
+  "token",
+  "raw",
+]);
+
+const EXCLUDED_NAMES = new Set([
+  "GITHUB_TOKEN",
+  "VERCEL_URL",
+]);
+
+const NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+export const SYSTEM_CREDENTIAL_INVENTORY: readonly SystemCredentialInventoryEntry[] = Object.freeze([
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "TESTPASS_TOKEN",
+    scope: "repository actions secret",
+    workload: "TestPass PR checks",
+    risk: "critical",
+    expected: true,
+    docsHint: "GitHub Actions secret metadata can confirm name and timestamps without returning the value.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "TESTPASS_CRON_SECRET",
+    scope: "repository actions secret",
+    workload: "scheduled TestPass smoke",
+    risk: "critical",
+    expected: true,
+    docsHint: "Track by secret name only; scheduled proof should verify the cron gate.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "CRON_SECRET",
+    scope: "repository actions secret",
+    workload: "scheduled job gates",
+    risk: "high",
+    expected: true,
+    docsHint: "Shared cron gates need rotation notes before any key swap.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "UXPASS_TOKEN",
+    scope: "repository actions secret",
+    workload: "UXPass dogfood and scheduled captures",
+    risk: "high",
+    expected: true,
+    docsHint: "Use dogfood receipts for health evidence; never show the token value.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "FISHBOWL_WAKE_TOKEN",
+    scope: "repository actions secret",
+    workload: "Event Wake Router and WakePass handoffs",
+    risk: "critical",
+    expected: true,
+    docsHint: "Wake dispatch proof is the safe health signal.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "FISHBOWL_AUTOCLOSE_TOKEN",
+    scope: "repository actions secret",
+    workload: "Fishbowl todo auto-close on PR merge",
+    risk: "high",
+    expected: true,
+    docsHint: "Auto-close workflow success proves the credential path without exposing it.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "OPENROUTER_API_KEY",
+    scope: "repository actions secret",
+    workload: "wake/no-wake classifier and model routing",
+    risk: "high",
+    expected: true,
+    docsHint: "Only static dry-run prompts should be used for future health probes.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "ANTHROPIC_API_KEY",
+    scope: "repository actions secret",
+    workload: "Claude model workflows",
+    risk: "normal",
+    expected: false,
+    docsHint: "Optional model key; track presence by metadata only.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "SUPABASE_ACCESS_TOKEN",
+    scope: "repository actions secret",
+    workload: "Supabase CLI automation",
+    risk: "high",
+    expected: false,
+    docsHint: "Supabase automation should use metadata and successful job evidence only.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "SUPABASE_PROJECT_REF",
+    scope: "repository actions secret",
+    workload: "Supabase CLI project targeting",
+    risk: "normal",
+    expected: false,
+    docsHint: "Project references are identifiers, but still useful for ownership mapping.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "SUPABASE_DB_PASSWORD",
+    scope: "repository actions secret",
+    workload: "Supabase database automation",
+    risk: "critical",
+    expected: false,
+    docsHint: "Database password rotation needs explicit human approval.",
+  },
+  {
+    provider: "github",
+    source: "github_actions_secret",
+    name: "VAULT_PLAN_JSON",
+    scope: "repository actions secret",
+    workload: "vault planning workflows",
+    risk: "high",
+    expected: false,
+    docsHint: "Treat as sensitive structured payload; inventory must never copy the contents.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "SUPABASE_URL",
+    scope: "project environment variable",
+    workload: "admin APIs and runtime Supabase access",
+    risk: "normal",
+    expected: true,
+    docsHint: "Vercel metadata may include value-shaped fields; sanitize before display.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "SUPABASE_SERVICE_ROLE_KEY",
+    scope: "project environment variable",
+    workload: "privileged admin/server operations",
+    risk: "critical",
+    expected: true,
+    docsHint: "Service-role rotation needs human review and deploy coordination.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "VITE_SUPABASE_URL",
+    scope: "project environment variable",
+    workload: "browser Supabase configuration",
+    risk: "normal",
+    expected: true,
+    docsHint: "Public runtime names can still help explain which app surface depends on them.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "VITE_SUPABASE_ANON_KEY",
+    scope: "project environment variable",
+    workload: "browser Supabase anon access",
+    risk: "normal",
+    expected: true,
+    docsHint: "Anon keys are not service-role secrets, but rotation can still break login flows.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "OPENAI_API_KEY",
+    scope: "project environment variable",
+    workload: "OpenAI model calls",
+    risk: "high",
+    expected: false,
+    docsHint: "Future probes should use read-only model metadata, not user prompts.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "ANTHROPIC_API_KEY",
+    scope: "project environment variable",
+    workload: "Claude model calls",
+    risk: "high",
+    expected: false,
+    docsHint: "Track project ownership and last successful model metadata check.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "OPENROUTER_API_KEY",
+    scope: "project environment variable",
+    workload: "model routing",
+    risk: "high",
+    expected: false,
+    docsHint: "Inventory by name only; never copy Vercel env values into RotatePass.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "CRON_SECRET",
+    scope: "project environment variable",
+    workload: "scheduled route gates",
+    risk: "critical",
+    expected: true,
+    docsHint: "Cron gate changes can break scheduled Pass receipts.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "TESTPASS_CRON_USER_ID",
+    scope: "project environment variable",
+    workload: "scheduled TestPass identity",
+    risk: "normal",
+    expected: false,
+    docsHint: "Identifier only; useful for ownership and blast-radius notes.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "UXPASS_CRON_USER_ID",
+    scope: "project environment variable",
+    workload: "scheduled UXPass identity",
+    risk: "normal",
+    expected: false,
+    docsHint: "Identifier only; pair with scheduled receipt status.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "POSTHOG_API_KEY",
+    scope: "project environment variable",
+    workload: "analytics capture",
+    risk: "normal",
+    expected: false,
+    docsHint: "Prefer existing analytics receipt evidence over synthetic events.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "POSTHOG_HOST",
+    scope: "project environment variable",
+    workload: "analytics host routing",
+    risk: "normal",
+    expected: false,
+    docsHint: "Host metadata is safe to show when known.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "STRIPE_SECRET_KEY",
+    scope: "project environment variable",
+    workload: "payments",
+    risk: "critical",
+    expected: false,
+    docsHint: "Payments credentials require explicit human approval before any rotation work.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "STRIPE_WEBHOOK_SECRET",
+    scope: "project environment variable",
+    workload: "payment webhooks",
+    risk: "critical",
+    expected: false,
+    docsHint: "Webhook secret rotation can break payment event verification.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "RESEND_API_KEY",
+    scope: "project environment variable",
+    workload: "email delivery",
+    risk: "high",
+    expected: false,
+    docsHint: "Email credential health should use delivery metadata only.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "ADMIN_NOTIFICATION_EMAIL",
+    scope: "project environment variable",
+    workload: "admin notifications",
+    risk: "normal",
+    expected: false,
+    docsHint: "Email addresses are metadata, but still avoid broad public display.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "UMAMI_WEBSITE_ID",
+    scope: "project environment variable",
+    workload: "analytics",
+    risk: "normal",
+    expected: false,
+    docsHint: "Identifier only; track with analytics health evidence if used.",
+  },
+  {
+    provider: "vercel",
+    source: "vercel_env",
+    name: "UMAMI_URL",
+    scope: "project environment variable",
+    workload: "analytics",
+    risk: "normal",
+    expected: false,
+    docsHint: "Host metadata is safe to show when known.",
+  },
+]);
+
+export function shouldTrackCredentialName(name: string): boolean {
+  const normalized = name.trim().toUpperCase();
+  return NAME_PATTERN.test(normalized) && !EXCLUDED_NAMES.has(normalized);
+}
+
+export function hasSecretValueField(record: Record<string, unknown>): boolean {
+  return Object.keys(record).some((key) => BLOCKED_VALUE_FIELDS.has(key));
+}
+
+export function sanitizeInventoryRecord(record: Record<string, unknown>): SystemCredentialInventoryEntry | null {
+  if (hasSecretValueField(record)) return null;
+  const name = typeof record.name === "string" ? record.name.trim().toUpperCase() : "";
+  if (!shouldTrackCredentialName(name)) return null;
+  if (record.provider !== "github" && record.provider !== "vercel") return null;
+  if (record.source !== "github_actions_secret" && record.source !== "vercel_env") return null;
+
+  return {
+    provider: record.provider,
+    source: record.source,
+    name,
+    scope: typeof record.scope === "string" ? record.scope : "unknown",
+    workload: typeof record.workload === "string" ? record.workload : "unknown",
+    risk: record.risk === "critical" || record.risk === "high" ? record.risk : "normal",
+    expected: record.expected === true,
+    docsHint: typeof record.docsHint === "string" ? record.docsHint : "Metadata only; no secret value is available.",
+  };
+}
+
+export function listSystemCredentialInventory(): readonly SystemCredentialInventoryEntry[] {
+  return SYSTEM_CREDENTIAL_INVENTORY;
+}


### PR DESCRIPTION
## Summary
- Adds a metadata-only RotatePass inventory for GitHub Actions secrets and Vercel env var names.
- Captures provider, source, name, scope, workload, risk, expected flag, and safe docs hint only.
- Adds sanitizer helpers that reject value-shaped payload fields such as `value`, `encrypted_value`, `vsmValue`, and `legacyValue`.

## Safety / non-overlap
- Owned files: `src/pages/admin/systemCredentialInventory.ts`, `src/pages/admin/systemCredentialInventory.test.ts`.
- No secret values, no prefixes, no live GitHub/Vercel calls, no BackstagePass changes, no UI wiring, no migrations.
- Does not touch #384 panel files beyond adding a future inventory vocabulary next to admin code.

## Tests
- `npx vitest run src/pages/admin/systemCredentialInventory.test.ts`
- `npm run build`
- `git diff --check`