### PR TITLE
test(rotatepass): guard public docs against secret-like values

### DIFF
--- a/src/__tests__/rotatepass-doc-redaction.test.ts
+++ b/src/__tests__/rotatepass-doc-redaction.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const SCANNED_FILES = [
+  "docs/rotatepass-connector-metadata.md",
+  "docs/connectors/system-credentials-health-panel.md",
+  "docs/rotatepass-local-phase0.md",
+] as const;
+
+const SECRET_PATTERNS = [
+  { name: "UnClick API key", pattern: /\buc_[A-Za-z0-9]{16,}\b/g },
+  { name: "OpenAI-style API key", pattern: /\bsk[-_][A-Za-z0-9_-]{16,}\b/g },
+  { name: "Slack bot token", pattern: /\bxoxb-[A-Za-z0-9-]{16,}\b/g },
+  { name: "GitHub token", pattern: /\b(?:gh[pous]|ghs|pat)_[A-Za-z0-9_]{16,}\b/g },
+  { name: "Stripe webhook secret", pattern: /\bwhsec_[A-Za-z0-9_]{16,}\b/g },
+  { name: "Authorization bearer example", pattern: /\bAuthorization:\s*Bearer\s+[A-Za-z0-9._~+/=-]{16,}\b/g },
+];
+
+function withoutAllowedPrefixReferenceLines(content: string): string {
+  return content
+    .split(/\r?\n/)
+    .filter((line) => !line.includes("common secret prefixes"))
+    .filter((line) => !line.includes("approved redacted example"))
+    .filter((line) => !line.includes("such as `sk-`"))
+    .join("\n");
+}
+
+describe("RotatePass public docs redaction", () => {
+  it("does not include unredacted secret-shaped examples", () => {
+    const findings: string[] = [];
+
+    for (const file of SCANNED_FILES) {
+      const content = withoutAllowedPrefixReferenceLines(readFileSync(file, "utf8"));
+      for (const { name, pattern } of SECRET_PATTERNS) {
+        for (const match of content.matchAll(pattern)) {
+          findings.push(`${file}: ${name} near ${match[0].slice(0, 12)}...`);
+        }
+      }
+    }
+
+    expect(findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
Summary:
- Adds a Vitest public redaction guard for RotatePass/System Credentials docs.
- Scans the public-facing RotatePass/Connectors docs for actual-looking secret-shaped examples.
- Allows short prefix references like `sk-`, but catches realistic-looking UnClick, OpenAI-style, Slack, GitHub, Stripe webhook, and Authorization Bearer examples.

Scope:
- src/__tests__/rotatepass-doc-redaction.test.ts

Non-overlap:
- Test-only.
- Does not touch #388 inventory implementation files.
- No Connections/Admin UI, BackstagePass API, auth, secrets, billing, DNS/domains, migrations, provider writes, or browser extension implementation.

Verification:
- npx vitest run src/__tests__/rotatepass-doc-redaction.test.ts
- npx eslint src/__tests__/rotatepass-doc-redaction.test.ts
- git diff --check
- npm run build

Risk:
- Low. This is a guardrail test only. It may need allowlist tuning later if docs intentionally add longer redacted examples.

Follow-up:
- Extend the scan list if future public credential docs are added.