### PR TITLE
test(rotatepass): add redaction guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Tests
         run: npm test --if-present
         continue-on-error: true
+      - name: RotatePass redaction guard
+        run: npm run test:rotatepass-redaction
 
   mcp-server:
     name: MCP server package

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:rotatepass-redaction": "node --test scripts/rotatepass-redaction-guard.test.mjs",
     "test:watch": "vitest",
     "test:api": "npm run test --workspace=apps/api"
   },

--- a/scripts/rotatepass-redaction-guard.test.mjs
+++ b/scripts/rotatepass-redaction-guard.test.mjs
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const scanPaths = [
+  "docs/rotatepass-chunk-2-prd.md",
+  "docs/rotatepass-connector-metadata.md",
+  "docs/rotatepass-local-phase0.md",
+  "docs/connectors/phase-1-plan.md",
+  "docs/connectors/spec.md",
+  "docs/connectors/system-credentials-health-panel.md",
+  "docs/prd/backstagepass.md",
+  "tests/rotatepass/fixtures/system-credentials.metadata.json",
+];
+
+const blockedPatterns = [
+  {
+    name: "openai-or-anthropic-key",
+    pattern: /\bsk-[A-Za-z0-9_-]{12,}\b/g,
+  },
+  {
+    name: "github-token",
+    pattern: /\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{20,}\b/g,
+  },
+  {
+    name: "slack-token",
+    pattern: /\bxox[baprs]-[A-Za-z0-9-]{12,}\b/g,
+  },
+  {
+    name: "stripe-secret",
+    pattern: /\b(?:sk_(?:live|test)_|whsec_)[A-Za-z0-9]{12,}\b/g,
+  },
+  {
+    name: "jwt-shaped-token",
+    pattern: /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g,
+  },
+  {
+    name: "unclick-api-key",
+    pattern: /\b(?:uc_|agt_)[A-Za-z0-9_-]{16,}\b/g,
+  },
+  {
+    name: "authorization-header",
+    pattern: /\bAuthorization:\s*(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/gi,
+  },
+  {
+    name: "private-key-block",
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/g,
+  },
+];
+
+function lineForOffset(content, offset) {
+  return content.slice(0, offset).split(/\r?\n/).length;
+}
+
+test("RotatePass and System Credentials public surfaces do not include secret-shaped values", () => {
+  const offenders = [];
+
+  for (const relativePath of scanPaths) {
+    const absolutePath = path.join(repoRoot, relativePath);
+    const content = fs.readFileSync(absolutePath, "utf8");
+
+    for (const { name, pattern } of blockedPatterns) {
+      pattern.lastIndex = 0;
+      for (const match of content.matchAll(pattern)) {
+        offenders.push(`${relativePath}:${lineForOffset(content, match.index ?? 0)} ${name}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Secret-shaped values found in public RotatePass/System Credentials surfaces:\n${offenders.join("\n")}`
+  );
+});

--- a/tests/rotatepass/fixtures/system-credentials.metadata.json
+++ b/tests/rotatepass/fixtures/system-credentials.metadata.json
@@ -1,0 +1,34 @@
+[
+  {
+    "provider": "github",
+    "credentialLabel": "TESTPASS_TOKEN",
+    "credentialType": "personal_access_token",
+    "ownerHint": "repo automation",
+    "usedBy": ["TestPass PR checks"],
+    "healthStatus": "healthy",
+    "rotationStatus": "healthy",
+    "lastCheckedAt": "2026-05-01T08:49:02Z",
+    "lastRotatedAt": null,
+    "safeProbeKind": "metadata_only",
+    "evidenceSource": "github_secret_inventory",
+    "redactedReason": null,
+    "verificationTarget": "TestPass smoke run",
+    "rotationNote": "Update the GitHub Actions secret, then rerun TestPass."
+  },
+  {
+    "provider": "vercel",
+    "credentialLabel": "SUPABASE_SERVICE_ROLE_KEY",
+    "credentialType": "service_role_key",
+    "ownerHint": "project runtime",
+    "usedBy": ["admin APIs", "Fishbowl"],
+    "healthStatus": "untested",
+    "rotationStatus": "unknown",
+    "lastCheckedAt": null,
+    "lastRotatedAt": null,
+    "safeProbeKind": "none",
+    "evidenceSource": "vercel_env_inventory",
+    "redactedReason": "metadata_only",
+    "verificationTarget": "manual admin smoke",
+    "rotationNote": "Rotate only with human approval and deploy coordination."
+  }
+]


### PR DESCRIPTION
## Summary
- Adds a CI-visible RotatePass/System Credentials redaction guard using `node:test`.
- Scans curated public docs and safe metadata fixtures for secret-shaped values: long API-key prefixes, GitHub/Slack/Stripe token shapes, JWTs, auth headers, and private key blocks.
- Reports only `path:line pattern-name`, never matched secret text.

## Safety / non-overlap
- Owned files: `.github/workflows/ci.yml`, `package.json`, `scripts/rotatepass-redaction-guard.test.mjs`, `tests/rotatepass/fixtures/system-credentials.metadata.json`.
- Does not touch #388 inventory files, BackstagePass, provider APIs, auth, billing, DNS/domains, migrations, or browser extension implementation.
- No secret values, no live provider reads, no provider writes.

## Tests
- `npm run test:rotatepass-redaction`
- `npm run build`
- `git diff --check`