### PR TITLE
test(rotatepass): avoid logging secret-shaped matches

### DIFF
--- a/src/__tests__/rotatepass-doc-redaction.test.ts
+++ b/src/__tests__/rotatepass-doc-redaction.test.ts
@@ -33,7 +33,8 @@ describe("RotatePass public docs redaction", () => {
       const content = withoutAllowedPrefixReferenceLines(readFileSync(file, "utf8"));
       for (const { name, pattern } of SECRET_PATTERNS) {
         for (const match of content.matchAll(pattern)) {
-          findings.push(`${file}: ${name} near ${match[0].slice(0, 12)}...`);
+          const line = content.slice(0, match.index ?? 0).split(/\r?\n/).length;
+          findings.push(`${file}:${line}: ${name}`);
         }
       }
     }


### PR DESCRIPTION
## Summary
- removes matched-text snippets from the merged RotatePass public docs redaction test
- reports only file, line, and pattern name when the guard fails
- keeps scope test-only with no provider calls, secret reads, auth, migrations, billing, DNS, or browser extension work

## Tests
- npx vitest run src/__tests__/rotatepass-doc-redaction.test.ts
- npm run test:rotatepass-redaction
- git diff --check