### PR TITLE
docs(reliability): align admin plan tool count

### DIFF
--- a/docs/UNCLICK_ADMIN_BUILD_PLAN.md
+++ b/docs/UNCLICK_ADMIN_BUILD_PLAN.md
@@ -302,7 +302,7 @@ Each phase has a goal, concrete work, acceptance criteria, and a verification st
 
 1. **Category browser.** Use the existing 20 categories from `tool-wiring.ts`. Each category is a collapsible section.
 
-2. **Tool cards.** For each of the 172+ tools: name, one-line description, "enabled for my agent" toggle (default on), "prefer this for category X" button.
+2. **Tool cards.** For each of the 178+ tools: name, one-line description, "enabled for my agent" toggle (default on), "prefer this for category X" button.
 
 3. **Preference storage.** When the user sets a preference, store in the memory business_context layer under `tool_preference` category. The agent's tool resolution order picks these up automatically (preference wins over defaults).
 


### PR DESCRIPTION
## Summary
- Fix one stale docs reference in the admin build plan from `172+ tools` to `178+ tools`.

## Scope
- Updated one line in `docs/UNCLICK_ADMIN_BUILD_PLAN.md`.
- No runtime code, API, auth, payments, migrations, or workflow config changes.

## Non-overlap
- Narrow docs-only drift fix in admin planning docs.
- Does not modify user-owned branches or in-flight reliability code paths.

## Verification
- `node --test scripts/event-wake-router.test.mjs` (pass, 16/16)

## Risk
- Low. Copy-only documentation correction.

## Follow-up
- Optional: continue sweeping stale `172+` marketing copy once current open PRs land.