### PR TITLE
test(reliability): guard TestPass packs against em dash drift

### DIFF
--- a/scripts/no-emdash-docs.test.mjs
+++ b/scripts/no-emdash-docs.test.mjs
@@ -14,9 +14,12 @@ const docPaths = [
   "CLAUDE.md",
   "README.md",
   ".github/OPERATIONS.md",
+  "packages/testpass/packs/anti-stomp-v0.yaml",
+  "packages/testpass/packs/testpass-core.yaml",
+  "packages/testpass/packs/testpass-fishbowl-v0.yaml",
 ];
 
-test("core docs do not contain em dashes", () => {
+test("core docs and TestPass packs do not contain em dashes", () => {
   const offenders = [];
 
   for (const relativePath of docPaths) {


### PR DESCRIPTION
## Summary
- Extend the existing em-dash hygiene test to also scan TestPass pack YAML files.
- Prevent regressions in worker-facing automation copy where em-dash drift already occurred.

## Scope
- Updated only `scripts/no-emdash-docs.test.mjs`.
- Added three `packages/testpass/packs/*.yaml` paths to the scan list.
- Renamed the test title to reflect expanded coverage.

## Non-overlap
- No runtime logic changes.
- No workflow, dependency, auth, migrations, or secrets changes.
- No overlap with open feature PRs; this is a narrow reliability guardrail.

## Verification
- `node --test scripts/no-emdash-docs.test.mjs` (pass)
- `node --test scripts/event-wake-router.test.mjs` (pass)

## Risk
- Low. Read-only test coverage expansion with no production code impact.

## Follow-up
- Optional: fold this check into any broader docs lint suite if one is added later.