### PR TITLE
Harden no-ACK handoff planners for blank run IDs

### DIFF
--- a/api/lib/testpass-background-handoff.ts
+++ b/api/lib/testpass-background-handoff.ts
@@ -60,17 +60,18 @@ export function testPassBackgroundFailureDispatchId(runId: string): string {
 export function planTestPassBackgroundFailureHandoff(
   input: TestPassBackgroundFailureHandoffInput,
 ): TestPassBackgroundFailureHandoffPlan | null {
+  const runId = (input.runId ?? "").trim();
   const targetAgentId = (input.targetAgentId ?? "").trim();
   const errorMessage = (input.errorMessage ?? "").trim();
-  if (!targetAgentId || !input.runId || !errorMessage) return null;
+  if (!targetAgentId || !runId || !errorMessage) return null;
 
   return {
     source: "testpass",
     targetAgentId,
-    taskRef: `testpass-run:${input.runId}`,
+    taskRef: `testpass-run:${runId}`,
     payload: {
       kind: "testpass_background_failure",
-      run_id: input.runId,
+      run_id: runId,
       pack_slug: input.packSlug,
       pack_name: input.packName,
       profile: input.profile,

--- a/api/lib/uxpass-run-handoff.ts
+++ b/api/lib/uxpass-run-handoff.ts
@@ -58,8 +58,9 @@ export function uxPassRunFailureDispatchId(runId: string): string {
 export function planUxPassRunFailureHandoff(
   input: UxPassRunFailureHandoffInput,
 ): UxPassRunFailureHandoffPlan | null {
+  const runId = (input.runId ?? "").trim();
   const targetAgentId = (input.targetAgentId ?? "").trim();
-  if (!input.isScheduled || !targetAgentId || !input.runId) return null;
+  if (!input.isScheduled || !targetAgentId || !runId) return null;
 
   const status = (input.status ?? "").trim();
   const rawError = (input.errorMessage ?? "").trim();
@@ -68,10 +69,10 @@ export function planUxPassRunFailureHandoff(
   return {
     source: "uxpass",
     targetAgentId,
-    taskRef: `uxpass-run:${input.runId}`,
+    taskRef: `uxpass-run:${runId}`,
     payload: {
       kind: "uxpass_run_failure",
-      run_id: input.runId,
+      run_id: runId,
       target_url: input.targetUrl,
       status: "failed",
       error_message: truncateMessage(rawError || "Scheduled UXPass run returned failed status"),

--- a/api/testpass-background-handoff.test.ts
+++ b/api/testpass-background-handoff.test.ts
@@ -74,6 +74,7 @@ describe("planTestPassBackgroundFailureHandoff", () => {
   it("stays silent for normal accepted paths without an error", () => {
     expect(planTestPassBackgroundFailureHandoff({ ...baseInput, errorMessage: "" })).toBeNull();
     expect(planTestPassBackgroundFailureHandoff({ ...baseInput, targetAgentId: "" })).toBeNull();
+    expect(planTestPassBackgroundFailureHandoff({ ...baseInput, runId: "   " })).toBeNull();
   });
 
   it("keeps missed ACKs eligible for handoff_ack_missing reclaim signals", () => {

--- a/api/uxpass-run-handoff.test.ts
+++ b/api/uxpass-run-handoff.test.ts
@@ -75,6 +75,7 @@ describe("planUxPassRunFailureHandoff", () => {
       .toBeNull();
     expect(planUxPassRunFailureHandoff({ ...baseInput, isScheduled: false })).toBeNull();
     expect(planUxPassRunFailureHandoff({ ...baseInput, targetAgentId: "" })).toBeNull();
+    expect(planUxPassRunFailureHandoff({ ...baseInput, runId: "   " })).toBeNull();
   });
 
   it("keeps runner exceptions eligible for the same ACK path", () => {


### PR DESCRIPTION
## Summary
- reject whitespace-only run IDs in TestPass background failure handoff planner
- reject whitespace-only run IDs in UXPass scheduled failure handoff planner
- add regression tests for both planners

## Scope
Reliability hardening for no-ACK handoff plan generation only.

## Verification
- 
px vitest run api/testpass-background-handoff.test.ts api/uxpass-run-handoff.test.ts (fails in this environment due to missing vitest dependency)
