### PR TITLE
fix: harden wake-router dispatch-proof gating

### DIFF
--- a/api/fishbowl-message-handoff.test.ts
+++ b/api/fishbowl-message-handoff.test.ts
@@ -146,6 +146,13 @@ describe("planFishbowlMessageHandoffs", () => {
     expect(
       planFishbowlMessageHandoffs({
         ...baseInput,
+        authorAgentId: "  GITHUB-ACTION-WAKE-ROUTER ",
+        tags: ["needs-doing"],
+      }),
+    ).toEqual([]);
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
         tags: ["needs-doing", "wake"],
       }),
     ).toEqual([]);

--- a/api/lib/fishbowl-message-handoff.ts
+++ b/api/lib/fishbowl-message-handoff.ts
@@ -64,7 +64,8 @@ export interface FishbowlMessageHandoffDispatchRow {
 export function planFishbowlMessageHandoffs(
   input: FishbowlMessageHandoffInput,
 ): FishbowlMessageHandoffPlan[] {
-  if (PRE_DISPATCHED_AUTHORS.has(input.authorAgentId)) return [];
+  const normalizedAuthorAgentId = normalizeToken(input.authorAgentId);
+  if (PRE_DISPATCHED_AUTHORS.has(normalizedAuthorAgentId)) return [];
   const normalizedTags = input.tags.map(normalizeToken).filter(Boolean);
   const tagSet = new Set(normalizedTags);
   if (tagSet.has("wake")) return [];
@@ -74,7 +75,7 @@ export function planFishbowlMessageHandoffs(
   const authorProfile = input.recipientProfiles.find(
     (profile) =>
       !isHumanProfile(profile) &&
-      profile.agentId === input.authorAgentId,
+      normalizeToken(profile.agentId) === normalizedAuthorAgentId,
   );
   if (!authorProfile) return [];
 


### PR DESCRIPTION
## Summary
- normalize authorAgentId before wake-router pre-dispatch suppression checks
- compare author profile ids using normalized tokens for consistency
- add regression coverage for uppercase/whitespace wake-router author ids

## Why
Wake-router posts that include case or whitespace drift in authorAgentId could bypass suppression and generate duplicate ACK-required handoffs.

## Testing
- pnpm vitest api/fishbowl-message-handoff.test.ts (fails locally: pnpm not installed in this workspace)