### PR TITLE
chore(connectors): stale/untested metadata-only connection status

### DIFF
--- a/src/pages/admin/tools/ConnectedServices.tsx
+++ b/src/pages/admin/tools/ConnectedServices.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { Plug, ExternalLink } from "lucide-react";
+import { getConnectedServiceStatus } from "./connectedServiceStatus";
 
 interface Connector {
   id: string;
@@ -19,18 +20,6 @@ interface ConnectedServicesProps {
 }
 
 export default function ConnectedServices({ connectors, loading }: ConnectedServicesProps) {
-  function formatLastTested(value: string | null): string {
-    if (!value) return "not tested yet";
-
-    const testedAt = new Date(value);
-    if (Number.isNaN(testedAt.getTime())) return "test time unknown";
-
-    return new Intl.DateTimeFormat(undefined, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(testedAt);
-  }
-
   function getSetupLabel(authType?: Connector["auth_type"]): string {
     switch (authType) {
       case "oauth2":
@@ -41,48 +30,6 @@ export default function ConnectedServices({ connectors, loading }: ConnectedServ
       default:
         return "API key";
     }
-  }
-
-  function getStatus(connector: Connector): {
-    dot: string;
-    pillClass: string;
-    pill: string;
-    note: string;
-  } {
-    const credential = connector.credential;
-    if (!credential) {
-      return {
-        dot: "bg-white/20",
-        pillClass: "border border-white/[0.08] bg-white/[0.04] text-white/75",
-        pill: "Setup required",
-        note: "No saved connection yet.",
-      };
-    }
-
-    if (!credential.is_valid) {
-      return {
-        dot: "bg-amber-400",
-        pillClass: "bg-amber-400/10 text-amber-200",
-        pill: "Needs reconnection",
-        note: `Reconnect or retest this service in Connections. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
-      };
-    }
-
-    if (!credential.last_tested_at) {
-      return {
-        dot: "bg-sky-400",
-        pillClass: "bg-sky-400/10 text-sky-200",
-        pill: "Setup incomplete",
-        note: "Saved, but not validated with a connection test yet.",
-      };
-    }
-
-    return {
-      dot: "bg-green-500",
-      pillClass: "bg-green-500/10 text-green-200",
-      pill: "Connected",
-      note: `Ready for approved agent workflows. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
-    };
   }
 
   if (loading) {
@@ -116,7 +63,7 @@ export default function ConnectedServices({ connectors, loading }: ConnectedServ
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {connectors.map((c) => {
-        const status = getStatus(c);
+        const status = getConnectedServiceStatus(c);
         const setupLabel = getSetupLabel(c.auth_type);
         const hasTest = Boolean(c.test_endpoint);
 

--- a/src/pages/admin/tools/connectedServiceStatus.test.ts
+++ b/src/pages/admin/tools/connectedServiceStatus.test.ts
@@ -1,0 +1,45 @@
+import { getConnectedServiceStatus } from "./connectedServiceStatus";
+
+describe("getConnectedServiceStatus", () => {
+  const NOW = Date.parse("2026-05-02T00:00:00.000Z");
+
+  it("marks missing credentials as setup required", () => {
+    const status = getConnectedServiceStatus({ credential: null }, NOW);
+    expect(status.pill).toBe("Setup required");
+  });
+
+  it("marks invalid credentials as needing reconnection", () => {
+    const status = getConnectedServiceStatus({
+      credential: { is_valid: false, last_tested_at: "2026-05-01T00:00:00.000Z" },
+    }, NOW);
+
+    expect(status.pill).toBe("Needs reconnection");
+  });
+
+  it("marks never-tested credentials as setup incomplete", () => {
+    const status = getConnectedServiceStatus({
+      credential: { is_valid: true, last_tested_at: null },
+    }, NOW);
+
+    expect(status.pill).toBe("Setup incomplete");
+    expect(status.note.toLowerCase()).toContain("not validated");
+  });
+
+  it("marks old test evidence as stale", () => {
+    const status = getConnectedServiceStatus({
+      credential: { is_valid: true, last_tested_at: "2026-03-01T00:00:00.000Z" },
+    }, NOW);
+
+    expect(status.pill).toBe("Check stale");
+    expect(status.note.toLowerCase()).toContain("stale");
+  });
+
+  it("uses metadata-only wording for recent test evidence", () => {
+    const status = getConnectedServiceStatus({
+      credential: { is_valid: true, last_tested_at: "2026-04-30T00:00:00.000Z" },
+    }, NOW);
+
+    expect(status.pill).toBe("Check recent");
+    expect(status.note.toLowerCase()).toContain("metadata-only");
+  });
+});

--- a/src/pages/admin/tools/connectedServiceStatus.ts
+++ b/src/pages/admin/tools/connectedServiceStatus.ts
@@ -1,0 +1,80 @@
+export interface ConnectedServiceCredential {
+  is_valid: boolean;
+  last_tested_at: string | null;
+}
+
+export interface ConnectedService {
+  credential: ConnectedServiceCredential | null;
+}
+
+export interface ConnectedServiceStatus {
+  dot: string;
+  pillClass: string;
+  pill: string;
+  note: string;
+}
+
+const STALE_CHECK_MS = 1000 * 60 * 60 * 24 * 30;
+
+function parseTestedAt(value: string | null): Date | null {
+  if (!value) return null;
+  const testedAt = new Date(value);
+  return Number.isNaN(testedAt.getTime()) ? null : testedAt;
+}
+
+export function formatLastTested(value: string | null): string {
+  const testedAt = parseTestedAt(value);
+  if (!testedAt) return value ? "test time unknown" : "not tested yet";
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(testedAt);
+}
+
+export function getConnectedServiceStatus(connector: ConnectedService, now = Date.now()): ConnectedServiceStatus {
+  const credential = connector.credential;
+  if (!credential) {
+    return {
+      dot: "bg-white/20",
+      pillClass: "border border-white/[0.08] bg-white/[0.04] text-white/75",
+      pill: "Setup required",
+      note: "No saved connection yet.",
+    };
+  }
+
+  if (!credential.is_valid) {
+    return {
+      dot: "bg-amber-400",
+      pillClass: "bg-amber-400/10 text-amber-200",
+      pill: "Needs reconnection",
+      note: `Reconnect or retest this service in Connections. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+    };
+  }
+
+  const testedAt = parseTestedAt(credential.last_tested_at);
+  if (!testedAt) {
+    return {
+      dot: "bg-sky-400",
+      pillClass: "bg-sky-400/10 text-sky-200",
+      pill: "Setup incomplete",
+      note: "Saved, but not validated with a connection test yet.",
+    };
+  }
+
+  if (now - testedAt.getTime() > STALE_CHECK_MS) {
+    return {
+      dot: "bg-yellow-400",
+      pillClass: "bg-yellow-400/10 text-yellow-200",
+      pill: "Check stale",
+      note: `Credential exists, but test evidence is stale. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+    };
+  }
+
+  return {
+    dot: "bg-green-500",
+    pillClass: "bg-green-500/10 text-green-200",
+    pill: "Check recent",
+    note: `Metadata-only check passed recently. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+  };
+}


### PR DESCRIPTION
## Summary
- extract Connected Services status logic into a small helper
- mark stale test evidence explicitly instead of implying active health
- use metadata-only wording for recent checks to avoid health claims from presence alone
- add focused unit tests for setup, invalid, untested, stale, and recent states

## Safety
- no secret values, token prefixes, headers, cookies, or provider payloads exposed
- no provider write calls or rotation logic added

## Testing
- 
pm run test -- src/pages/admin/tools/connectedServiceStatus.test.ts src/pages/admin/systemCredentialInventory.test.ts *(fails in this worktree: itest binary/deps not installed)*
- 
px vitest run src/pages/admin/tools/connectedServiceStatus.test.ts src/pages/admin/systemCredentialInventory.test.ts *(fails: local itest package missing in this environment)*