### PR TITLE
Harden channel heartbeat overlap handling

### DIFF
--- a/packages/channel-plugin/heartbeat-gate.js
+++ b/packages/channel-plugin/heartbeat-gate.js
@@ -1,0 +1,14 @@
+export function createHeartbeatGate() {
+  let inFlight = false;
+
+  return {
+    tryAcquire() {
+      if (inFlight) return false;
+      inFlight = true;
+      return true;
+    },
+    release() {
+      inFlight = false;
+    },
+  };
+}

--- a/packages/channel-plugin/heartbeat-gate.test.js
+++ b/packages/channel-plugin/heartbeat-gate.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHeartbeatGate } from "./heartbeat-gate.js";
+
+test("heartbeat gate blocks overlapping requests", () => {
+  const gate = createHeartbeatGate();
+
+  assert.equal(gate.tryAcquire(), true);
+  assert.equal(gate.tryAcquire(), false);
+
+  gate.release();
+
+  assert.equal(gate.tryAcquire(), true);
+});

--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -33,6 +33,7 @@ import os from "node:os";
 import process from "node:process";
 import readline from "node:readline";
 import { apiFetchJson } from "./http.js";
+import { createHeartbeatGate } from "./heartbeat-gate.js";
 
 const API_BASE       = process.env.UNCLICK_API_BASE     || "https://unclick.world";
 const API_KEY        = process.env.UNCLICK_API_KEY      || "";
@@ -42,6 +43,7 @@ const POLL_INTERVAL  = parseInt(process.env.UNCLICK_CHANNEL_POLL || "5000", 10);
 const HEARTBEAT_MS   = 30_000;
 const API_TIMEOUT_MS = parseInt(process.env.UNCLICK_API_TIMEOUT_MS || "10000", 10);
 const RESPONSE_TIMEOUT_MS = 5 * 60_000;
+const heartbeatGate = createHeartbeatGate();
 
 function log(...args) {
   // Channel hosts use stdio for JSON-RPC, so keep human logs on stderr.
@@ -198,6 +200,11 @@ async function apiFetch(action, { method = "GET", body, query = {} } = {}) {
 }
 
 async function sendHeartbeat() {
+  if (!heartbeatGate.tryAcquire()) {
+    log("heartbeat skipped: previous request still in flight");
+    return;
+  }
+
   try {
     await apiFetch("admin_channel_heartbeat", {
       method: "POST",
@@ -207,6 +214,8 @@ async function sendHeartbeat() {
     });
   } catch (err) {
     log("heartbeat failed:", err.message);
+  } finally {
+    heartbeatGate.release();
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent overlapping admin heartbeat requests in the channel plugin
- add a tiny heartbeat gate helper and unit test

## Verification
- node --test packages/channel-plugin/*.test.js