### PR TITLE
Harden channel plugin invalid JSON telemetry

### DIFF
--- a/packages/channel-plugin/http.js
+++ b/packages/channel-plugin/http.js
@@ -24,7 +24,15 @@ export async function apiFetchJson({
       const text = await res.text().catch(() => "");
       throw new Error(`api ${action} -> ${res.status} ${text.slice(0, 200)}`);
     }
-    return res.json();
+    try {
+      return await res.json();
+    } catch (err) {
+      const text = await res.text().catch(() => "");
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `api ${action} invalid json response: ${reason}${text ? ` body=${text.slice(0, 200)}` : ""}`
+      );
+    }
   } catch (err) {
     if (err && typeof err === "object" && err.name === "AbortError") {
       throw new Error(`api ${action} timeout after ${timeoutMs}ms`);

--- a/packages/channel-plugin/http.test.js
+++ b/packages/channel-plugin/http.test.js
@@ -50,3 +50,29 @@ test("apiFetchJson throws timeout error when request hangs", async () => {
     global.fetch = originalFetch;
   }
 });
+
+test("apiFetchJson throws useful error when JSON decoding fails", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON");
+    },
+    text: async () => "<html>upstream proxy error</html>",
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        apiFetchJson({
+          apiBase: "https://unclick.world",
+          apiKey: "k",
+          action: "admin_channel_heartbeat",
+          timeoutMs: 50,
+        }),
+      /api admin_channel_heartbeat invalid json response:.*body=<html>upstream proxy error<\/html>/
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- improve piFetchJson error diagnostics when 200 OK response is invalid JSON
- include decode reason and short body snippet to aid reliability triage
- add unit test for invalid JSON response path

## Verification
- node --test packages/channel-plugin/*.test.js

## Scope
- channel-plugin reliability hardening only