### PR TITLE
Harden Fishbowl self-handoff suppression normalization

### DIFF
--- a/api/fishbowl-message-handoff.test.ts
+++ b/api/fishbowl-message-handoff.test.ts
@@ -135,6 +135,17 @@ describe("planFishbowlMessageHandoffs", () => {
       }),
     ).toEqual([]);
   });
+
+  it("normalizes author id when suppressing self-handoffs", () => {
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        authorAgentId: " AGENT_BUILDER ",
+        recipients: ["B"],
+      }),
+    ).toEqual([]);
+  });
+
   it("stays silent for wake-router posts that already registered dispatch proof", () => {
     expect(
       planFishbowlMessageHandoffs({

--- a/api/lib/fishbowl-message-handoff.ts
+++ b/api/lib/fishbowl-message-handoff.ts
@@ -96,7 +96,10 @@ export function planFishbowlMessageHandoffs(
     if (matches.length !== 1) continue;
 
     const targetAgentId = matches[0].agentId;
-    if (targetAgentId === input.authorAgentId || plannedTargets.has(targetAgentId)) continue;
+    if (
+      normalizeToken(targetAgentId) === normalizedAuthorAgentId ||
+      plannedTargets.has(targetAgentId)
+    ) continue;
     plannedTargets.add(targetAgentId);
 
     plans.push({


### PR DESCRIPTION
## Summary\n- normalize self-handoff suppression by comparing normalized target and author agent ids\n- prevent accidental ACK-required self-dispatch when author id casing or whitespace differs\n- add regression coverage in fishbowl message handoff tests\n\n## Scope\n- reliability hardening slice for Event Wake Router/Fishbowl handoff path only\n\n## Verification\n- npx vitest run api/fishbowl-message-handoff.test.ts *(fails in this worktree: missing local vitest dependencies)*\n