### PR TITLE
chore(connectors): sanitize RotatePass metadata copy fields

### DIFF
--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -102,4 +102,24 @@ describe("system credential inventory", () => {
       rotationImpact: "PR checks may fail until the replacement is wired.",
     });
   });
+
+  it("drops unsafe metadata copy from docs hint and rotation impact", () => {
+    expect(sanitizeInventoryRecord({
+      provider: "github",
+      source: "github_actions_secret",
+      name: "TESTPASS_TOKEN",
+      docsHint: "Authorization: Bearer sk-secret-never-show",
+      rotationImpact: "Provider body contained set-cookie: session=123",
+    })).toEqual({
+      provider: "github",
+      source: "github_actions_secret",
+      name: "TESTPASS_TOKEN",
+      scope: "unknown",
+      workload: "unknown",
+      risk: "normal",
+      expected: false,
+      docsHint: "Metadata only; no secret value is available.",
+      rotationImpact: undefined,
+    });
+  });
 });

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -31,6 +31,8 @@ const EXCLUDED_NAMES = new Set([
 ]);
 
 const NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const UNSAFE_METADATA_COPY_PATTERN =
+  /(authorization:|bearer\s+[a-z0-9._-]{8,}|x-api-key|apikey|api[_ -]?key|refresh[_ -]?token|set-cookie:|cookie:|sk-[a-z0-9_-]{8,}|ghp_[a-z0-9]{8,}|xox[baprs]-[a-z0-9-]{8,})/i;
 
 export const SYSTEM_CREDENTIAL_INVENTORY: readonly SystemCredentialInventoryEntry[] = Object.freeze([
   {
@@ -369,11 +371,19 @@ export function sanitizeInventoryRecord(record: Record<string, unknown>): System
     workload: typeof record.workload === "string" ? record.workload : "unknown",
     risk: record.risk === "critical" || record.risk === "high" ? record.risk : "normal",
     expected: record.expected === true,
-    docsHint: typeof record.docsHint === "string" ? record.docsHint : "Metadata only; no secret value is available.",
-    rotationImpact: typeof record.rotationImpact === "string" ? record.rotationImpact : undefined,
+    docsHint: sanitizeMetadataCopy(record.docsHint, "Metadata only; no secret value is available."),
+    rotationImpact: sanitizeMetadataCopy(record.rotationImpact),
   };
 }
 
 export function listSystemCredentialInventory(): readonly SystemCredentialInventoryEntry[] {
   return SYSTEM_CREDENTIAL_INVENTORY;
+}
+
+function sanitizeMetadataCopy(value: unknown, fallback?: string): string | undefined {
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  if (!trimmed) return fallback;
+  if (UNSAFE_METADATA_COPY_PATTERN.test(trimmed)) return fallback;
+  return trimmed;
 }


### PR DESCRIPTION
## Summary\n- add guardrails so sanitizeInventoryRecord strips unsafe secret-like patterns from docsHint and otationImpact\n- keep metadata-only fallback wording when unsafe content is detected\n- add focused test coverage for auth header, cookie, and token-prefix style leak patterns\n\n## Scope\nTiny non-overlapping RotatePass slice: metadata copy safety only.\n\n## Testing\n- 
px vitest run src/pages/admin/systemCredentialInventory.test.ts *(fails in this runner because vitest dependencies are not installed)*