### PR TITLE
Harden channel invalid JSON telemetry

### DIFF
--- a/packages/channel-plugin/http.js
+++ b/packages/channel-plugin/http.js
@@ -7,6 +7,12 @@ export async function apiFetchJson({
   query = {},
   timeoutMs = 10_000,
 }) {
+  const describeBody = (value) => {
+    if (typeof value !== "string") return "";
+    const compact = value.replace(/\s+/g, " ").trim();
+    return compact ? ` body="${compact.slice(0, 160)}"` : "";
+  };
+
   const qs = new URLSearchParams({ action, ...query }).toString();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -22,9 +28,20 @@ export async function apiFetchJson({
     });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      throw new Error(`api ${action} -> ${res.status} ${text.slice(0, 200)}`);
+      throw new Error(`api ${action} -> ${res.status}${describeBody(text)}`);
     }
-    return res.json();
+    try {
+      return await res.json();
+    } catch (err) {
+      const text = await res.text().catch(() => "");
+      const reason =
+        err && typeof err === "object" && "message" in err
+          ? String(err.message)
+          : "unknown parse error";
+      throw new Error(
+        `api ${action} -> invalid json (${reason})${describeBody(text)}`
+      );
+    }
   } catch (err) {
     if (err && typeof err === "object" && err.name === "AbortError") {
       throw new Error(`api ${action} timeout after ${timeoutMs}ms`);

--- a/packages/channel-plugin/http.test.js
+++ b/packages/channel-plugin/http.test.js
@@ -50,3 +50,29 @@ test("apiFetchJson throws timeout error when request hangs", async () => {
     global.fetch = originalFetch;
   }
 });
+
+test("apiFetchJson throws contextual error on invalid JSON payload", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON");
+    },
+    text: async () => "<html>not json</html>",
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        apiFetchJson({
+          apiBase: "https://unclick.world",
+          apiKey: "k",
+          action: "admin_channel_heartbeat",
+          timeoutMs: 50,
+        }),
+      /api admin_channel_heartbeat -> invalid json \(Unexpected token < in JSON\) body="<html>not json<\/html>"/
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- harden channel plugin HTTP helper to emit contextual errors when a 2xx response contains invalid JSON
- include parse reason and compact body snippet in the thrown error for faster reliability triage
- add focused regression test for invalid JSON payload handling

## Verification
- node --test packages/channel-plugin/*.test.js

## Autopilot Tier
- Ship without ask (small, reversible reliability hardening)