### PR TITLE
test(connectors): block provider token payload leaks in RotatePass guard

### DIFF
--- a/scripts/rotatepass-redaction-guard.test.mjs
+++ b/scripts/rotatepass-redaction-guard.test.mjs
@@ -16,6 +16,7 @@ const scanPaths = [
   "docs/connectors/spec.md",
   "docs/connectors/system-credentials-health-panel.md",
   "docs/prd/backstagepass.md",
+  "api/credentials.ts",
   "tests/rotatepass/fixtures/system-credentials.metadata.json",
 ];
 
@@ -47,6 +48,18 @@ const blockedPatterns = [
   {
     name: "authorization-header",
     pattern: /\bAuthorization:\s*(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/gi,
+  },
+  {
+    name: "provider-response-access-token",
+    pattern: /["']access_token["']\s*:\s*["'][A-Za-z0-9._-]{12,}["']/gi,
+  },
+  {
+    name: "provider-response-refresh-token",
+    pattern: /["']refresh_token["']\s*:\s*["'][A-Za-z0-9._-]{12,}["']/gi,
+  },
+  {
+    name: "provider-response-id-token",
+    pattern: /["']id_token["']\s*:\s*["'][A-Za-z0-9._-]{12,}["']/gi,
   },
   {
     name: "private-key-block",


### PR DESCRIPTION
## Summary\n- extend RotatePass redaction guard scan coverage to include pi/credentials.ts\n- add token-payload patterns that fail if access/refresh/id tokens appear as literal response body values\n- keep scope test-only and non-overlapping with open PRs #406 and #415\n\n## Why\nThis narrows a common confusion/leak path by failing fast if metadata-safe surfaces accidentally include provider response bodies with token-like values.\n\n## Testing\n- node --test scripts/rotatepass-redaction-guard.test.mjs