### PR TITLE
chore(connectors): reject secret-like literals in inventory names

### DIFF
--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -83,6 +83,10 @@ describe("system credential inventory", () => {
     expect(shouldTrackCredentialName("GITHUB_TOKEN")).toBe(false);
     expect(shouldTrackCredentialName("VERCEL_URL")).toBe(false);
     expect(shouldTrackCredentialName("lowercase-token")).toBe(false);
+    expect(shouldTrackCredentialName("AKIAIOSFODNN7EXAMPLE")).toBe(false);
+    expect(shouldTrackCredentialName("ghp_12345678abcdefgh")).toBe(false);
+    expect(shouldTrackCredentialName("sk-test_12345678")).toBe(false);
+    expect(shouldTrackCredentialName("xoxb-12345678-abcdef12")).toBe(false);
   });
 
   it("rejects records that include value-shaped fields", () => {
@@ -96,6 +100,20 @@ describe("system credential inventory", () => {
       source: "vercel_env",
       name: "TESTPASS_TOKEN",
       value: "never-print-me",
+    })).toBeNull();
+  });
+
+  it("rejects records whose names look like pasted secret literals", () => {
+    expect(sanitizeInventoryRecord({
+      provider: "github",
+      source: "github_actions_secret",
+      name: "AKIAIOSFODNN7EXAMPLE",
+    })).toBeNull();
+
+    expect(sanitizeInventoryRecord({
+      provider: "vercel",
+      source: "vercel_env",
+      name: "sk-test_12345678",
     })).toBeNull();
   });
 

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -31,6 +31,12 @@ const EXCLUDED_NAMES = new Set([
 ]);
 
 const NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const SECRET_LITERAL_PATTERNS: readonly RegExp[] = [
+  /^AKIA[0-9A-Z]{8,}$/,
+  /^gh[pousr]_[a-z0-9]{8,}$/i,
+  /^sk-[a-z0-9_-]{8,}$/i,
+  /^xox[baprs]-[a-z0-9-]{8,}$/i,
+];
 
 export const SYSTEM_CREDENTIAL_INVENTORY: readonly SystemCredentialInventoryEntry[] = Object.freeze([
   {
@@ -346,8 +352,11 @@ export const SYSTEM_CREDENTIAL_INVENTORY: readonly SystemCredentialInventoryEntr
 ]);
 
 export function shouldTrackCredentialName(name: string): boolean {
-  const normalized = name.trim().toUpperCase();
-  return NAME_PATTERN.test(normalized) && !EXCLUDED_NAMES.has(normalized);
+  const trimmed = name.trim();
+  const normalized = trimmed.toUpperCase();
+  if (!NAME_PATTERN.test(normalized)) return false;
+  if (EXCLUDED_NAMES.has(normalized)) return false;
+  return !SECRET_LITERAL_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
 
 export function hasSecretValueField(record: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Summary
- add parser-level guard to reject secret-like literal strings in system credential inventory names
- keep inventory metadata-only by blocking AWS/GitHub/OpenAI/Slack token-shaped names
- add unit tests for name filtering and sanitize path rejection

## Why this lane slice
- non-overlapping with current RotatePass PRs focused on provider response redaction and status copy
- reduces credential confusion when someone pastes a key into a name field

## Testing
- npm run test -- src/pages/admin/systemCredentialInventory.test.ts *(fails locally: vitest not installed in workspace)*
- npm exec vitest run src/pages/admin/systemCredentialInventory.test.ts *(fails locally: ERR_MODULE_NOT_FOUND for vitest)*