### PR TITLE
Fail closed when wake dispatch registration fails

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -553,6 +553,20 @@ async function main() {
     result: null,
     event,
   });
+  if (!reliability?.registered && !reliability?.dry_run) {
+    console.error("Reliability dispatch registration failed, skipping Fishbowl wake post.");
+    writeLedger({
+      eventId,
+      event,
+      decision: finalDecision,
+      triage,
+      result: null,
+      reliability,
+      status: "wake_failed",
+    });
+    process.exitCode = 1;
+    return;
+  }
   const result = await postWake(finalDecision, triage, eventId, event);
   const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
   writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, status });

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -400,7 +400,9 @@ describe("event wake router reliability dispatch", () => {
       });
 
       assert.equal(result.status, 1, result.stderr || result.stdout);
-      assert.match(result.stderr, /required for reliability dispatch|required for wake posting/);
+      assert.match(result.stderr, /required for reliability dispatch/);
+      assert.match(result.stderr, /Reliability dispatch registration failed, skipping Fishbowl wake post/);
+      assert.doesNotMatch(result.stderr, /required for wake posting/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fail closed in Event Wake Router: if reliability dispatch upsert/claim does not register, skip Fishbowl wake post, write wake_failed ledger, and exit non-zero. Adds regression assertion in wake-router tests.