### PR TITLE
Harden Wake Router ACK timeout floor

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -13,17 +13,17 @@ const runId = process.env.GITHUB_RUN_ID || "";
 const apiUrl = process.env.UNCLICK_API_URL || "https://unclick.world/api/memory-admin";
 const unclickApiKey = process.env.FISHBOWL_WAKE_TOKEN || process.env.FISHBOWL_AUTOCLOSE_TOKEN || "";
 const dryRun = process.env.WAKE_ROUTER_DRY_RUN === "1" || process.env.WAKE_ROUTER_DRY_RUN === "true";
-const ackFailSeconds = parseBoundedSeconds(process.env.WAKE_ACK_FAIL_SECONDS, 600, 600);
+const ackFailSeconds = parseBoundedSeconds(process.env.WAKE_ACK_FAIL_SECONDS, 600, 60, 600);
 const receivedAt = new Date().toISOString();
 const ledgerDir = process.env.WAKE_LEDGER_DIR || ".wake-ledger";
 const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY || "";
 
-function parseBoundedSeconds(value, fallback, max) {
+function parseBoundedSeconds(value, fallback, min, max) {
   const raw = String(value ?? "").trim();
   if (!/^\d+$/.test(raw)) return fallback;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
-  return Math.min(parsed, max);
+  return Math.max(min, Math.min(parsed, max));
 }
 
 function readEvent() {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -489,4 +489,46 @@ describe("event wake router reliability dispatch", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("floors ACK fail seconds to avoid immediate no-ACK false failures", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        action: "completed",
+        workflow_run: {
+          id: 463,
+          name: "TestPass Scheduled Smoke",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/acme/repo/actions/runs/463",
+          created_at: "2026-04-30T17:30:00Z",
+          updated_at: "2026-04-30T17:35:00Z",
+          pull_requests: [],
+        },
+      }),
+    );
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+          WAKE_ACK_FAIL_SECONDS: "1",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /"ack_fail_after_seconds": 60/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- harden wake router ACK timeout parsing with a minimum floor to prevent immediate no-ACK false failures
- keep existing malformed and max-cap behavior intact
- add a regression test covering WAKE_ACK_FAIL_SECONDS=1

## Verification
- node --test scripts/event-wake-router.test.mjs