### PR TITLE
fix(channel): package http helper

### DIFF
--- a/packages/channel-plugin/http.js
+++ b/packages/channel-plugin/http.js
@@ -24,10 +24,10 @@ export async function apiFetchJson({
       const text = await res.text().catch(() => "");
       throw new Error(`api ${action} -> ${res.status} ${text.slice(0, 200)}`);
     }
+    const text = await res.text();
     try {
-      return await res.json();
+      return JSON.parse(text);
     } catch (err) {
-      const text = await res.text().catch(() => "");
       const reason = err instanceof Error ? err.message : String(err);
       throw new Error(
         `api ${action} invalid json response: ${reason}${text ? ` body=${text.slice(0, 200)}` : ""}`

--- a/packages/channel-plugin/http.test.js
+++ b/packages/channel-plugin/http.test.js
@@ -6,7 +6,7 @@ test("apiFetchJson returns parsed JSON on success", async () => {
   const originalFetch = global.fetch;
   global.fetch = async () => ({
     ok: true,
-    json: async () => ({ ok: true }),
+    text: async () => JSON.stringify({ ok: true }),
   });
 
   try {
@@ -55,9 +55,6 @@ test("apiFetchJson throws useful error when JSON decoding fails", async () => {
   const originalFetch = global.fetch;
   global.fetch = async () => ({
     ok: true,
-    json: async () => {
-      throw new SyntaxError("Unexpected token < in JSON");
-    },
     text: async () => "<html>upstream proxy error</html>",
   });
 

--- a/packages/channel-plugin/package.json
+++ b/packages/channel-plugin/package.json
@@ -9,6 +9,7 @@
     "unclick-channel": "./index.js"
   },
   "files": [
+    "http.js",
     "index.js",
     "README.md"
   ],


### PR DESCRIPTION
Summary:
- Includes the channel plugin HTTP helper in the published package allow-list.
- Parses successful API responses from response text once so invalid JSON diagnostics can include the body reliably.
- Updates focused channel HTTP tests.

Scope:
- packages/channel-plugin/http.js
- packages/channel-plugin/http.test.js
- packages/channel-plugin/package.json

Non-overlap:
- No Fishbowl API, wake router, Connectors, TestPass, secrets, auth, migrations, billing, DNS, or UI changes.

Verification:
- node --test packages/channel-plugin/http.test.js
- npm pack --dry-run --workspace @unclick/channel
- npm run build
- git diff --check

Risk:
- Low. Package/helper-only hardening after #413.

Status:
- Draft for fleet review.