### PR TITLE
Harden wake router ACK dispatch owner for all-routes

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -87,6 +87,10 @@ export function wakeDispatchId(eventId) {
   return `dispatch_${digest}`;
 }
 
+export function normalizeDispatchOwner(owner) {
+  return owner === "all" ? "🤖" : owner;
+}
+
 function baseDecision(event) {
   const action = String(event.action || "");
 
@@ -346,7 +350,7 @@ export function buildReliabilityDispatchRequest({
   return {
     dispatch_id: wakeDispatchId(eventId),
     source: "wakepass",
-    target_agent_id: decision.owner,
+    target_agent_id: normalizeDispatchOwner(decision.owner),
     task_ref: eventId,
     time_bucket_seconds: ackSeconds,
     payload: {
@@ -379,7 +383,7 @@ async function registerWakeDispatch({ eventId, decision, triage, result, event }
 
   const claimRequest = {
     dispatch_id: dispatchRequest.dispatch_id,
-    agent_id: decision.owner,
+    agent_id: normalizeDispatchOwner(decision.owner),
     lease_seconds: ackFailSeconds,
   };
 

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   buildReliabilityDispatchRequest,
+  normalizeDispatchOwner,
   wakeDispatchId,
 } from "./event-wake-router.mjs";
 
@@ -111,6 +112,24 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(request.payload.ack_required, true);
     assert.equal(request.payload.route_attempted, "fishbowl");
     assert.equal(request.payload.handoff_message_id, null);
+  });
+
+  it("normalizes fanout owner to a concrete ACK owner for reliability dispatch", () => {
+    const request = buildReliabilityDispatchRequest({
+      eventId: "wake-issue_comment-comment-123-xyz",
+      decision: {
+        owner: "all",
+        reason: "Escalate broadly",
+        urgency: "urgent",
+      },
+      triage: { used: true },
+      result: { message_id: "msg-all-1" },
+      event: { comment: { id: 123 }, issue: { number: 99 } },
+    });
+
+    assert.equal(normalizeDispatchOwner("all"), "🤖");
+    assert.equal(request.target_agent_id, "🤖");
+    assert.equal(request.payload.wake_owner, "all");
   });
 
   it("keeps successful PR workflow green echoes silent", () => {


### PR DESCRIPTION
## Summary
- normalize WakePass reliability dispatch ownership when triage returns `owner: "all"`
- keep Fishbowl fanout owner unchanged (`wake_owner: all`) while routing ACK claim tracking to a concrete worker id
- add regression coverage for `owner: all` dispatch behavior

## Testing
- node --test scripts/event-wake-router.test.mjs

## Scope
- Event Wake Router reliability dispatch ownership only