### PR TITLE
Harden wake router handoff message sync

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -367,6 +367,25 @@ export function buildReliabilityDispatchRequest({
   };
 }
 
+export function buildReliabilityDispatchHandoffSyncRequest({
+  eventId,
+  decision,
+  triage,
+  result,
+  event,
+  ackSeconds = 600,
+}) {
+  if (!result?.message_id) return null;
+  return buildReliabilityDispatchRequest({
+    eventId,
+    decision,
+    triage,
+    result,
+    event,
+    ackSeconds,
+  });
+}
+
 async function registerWakeDispatch({ eventId, decision, triage, result, event }) {
   const dispatchRequest = buildReliabilityDispatchRequest({
     eventId,
@@ -451,6 +470,58 @@ async function registerWakeDispatch({ eventId, decision, triage, result, event }
     status: claimResponse.status,
     dispatch_id: dispatchRequest.dispatch_id,
     error: claimResponse.ok ? null : compactText(claimBody, 500),
+  };
+}
+
+async function syncWakeDispatchHandoffMessage({ eventId, decision, triage, result, event }) {
+  const upsert = buildReliabilityDispatchHandoffSyncRequest({
+    eventId,
+    decision,
+    triage,
+    result,
+    event,
+    ackSeconds: ackFailSeconds,
+  });
+
+  if (!upsert) {
+    return { attempted: false, synced: false, skipped: true, reason: "missing_message_id" };
+  }
+
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          reliability_dispatch_handoff_sync_dry_run: true,
+          missing_key: !unclickApiKey,
+          upsert,
+        },
+        null,
+        2,
+      ),
+    );
+    return { attempted: true, synced: true, dry_run: true };
+  }
+
+  if (!unclickApiKey) {
+    return { attempted: true, synced: false, error: "missing_wake_token" };
+  }
+
+  const response = await fetch(`${apiUrl}?action=reliability_dispatches&method=upsert`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${unclickApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(upsert),
+  });
+  const body = await response.text();
+  console.log(`Reliability dispatch handoff sync HTTP ${response.status}`);
+  console.log(body);
+  return {
+    attempted: true,
+    synced: response.ok,
+    status: response.status,
+    error: response.ok ? null : compactText(body, 500),
   };
 }
 
@@ -554,11 +625,19 @@ async function main() {
     event,
   });
   const result = await postWake(finalDecision, triage, eventId, event);
+  const handoffSync = await syncWakeDispatchHandoffMessage({
+    eventId,
+    decision: finalDecision,
+    triage,
+    result,
+    event,
+  });
   const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
   writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, status });
   if (
     (!result.posted && !result.dry_run) ||
-    (!reliability?.registered && !reliability?.dry_run)
+    (!reliability?.registered && !reliability?.dry_run) ||
+    (handoffSync.attempted && !handoffSync.synced)
   ) {
     process.exitCode = 1;
   }

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   buildReliabilityDispatchRequest,
+  buildReliabilityDispatchHandoffSyncRequest,
   wakeDispatchId,
 } from "./event-wake-router.mjs";
 
@@ -111,6 +112,26 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(request.payload.ack_required, true);
     assert.equal(request.payload.route_attempted, "fishbowl");
     assert.equal(request.payload.handoff_message_id, null);
+  });
+
+  it("builds a dispatch upsert sync when Fishbowl returns a message id", () => {
+    const upsert = buildReliabilityDispatchHandoffSyncRequest({
+      eventId: "wake-workflow_run-workflow-run-321-jkl",
+      decision: {
+        owner: "🤖",
+        reason: "Scheduled TestPass smoke failure",
+        urgency: "urgent",
+      },
+      triage: { used: false },
+      result: { message_id: "msg-321" },
+      event: { workflow_run: { id: 321 } },
+      ackSeconds: 120,
+    });
+
+    assert.ok(upsert);
+    assert.equal(upsert.dispatch_id, wakeDispatchId("wake-workflow_run-workflow-run-321-jkl"));
+    assert.equal(upsert.payload.handoff_message_id, "msg-321");
+    assert.equal(upsert.payload.ack_fail_after_seconds, 120);
   });
 
   it("keeps successful PR workflow green echoes silent", () => {


### PR DESCRIPTION
## Summary
- add a post-wake reliability dispatch sync step so handoff_message_id is persisted after Fishbowl post returns
- add buildReliabilityDispatchHandoffSyncRequest helper for explicit payload construction
- fail closed when handoff sync is attempted but dispatch upsert fails
- add unit coverage for the new sync request builder

## Testing
- node --test scripts/event-wake-router.test.mjs

## Scope
- Event Wake Router reliability hardening slice only
