### PR TITLE
test(connectors): reject secret-like credential names

### DIFF
--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -83,6 +83,10 @@ describe("system credential inventory", () => {
     expect(shouldTrackCredentialName("GITHUB_TOKEN")).toBe(false);
     expect(shouldTrackCredentialName("VERCEL_URL")).toBe(false);
     expect(shouldTrackCredentialName("lowercase-token")).toBe(false);
+    expect(shouldTrackCredentialName("AKIAIOSFODNN7EXAMPLE")).toBe(false);
+    expect(shouldTrackCredentialName("ghp_12345678abcdefgh")).toBe(false);
+    expect(shouldTrackCredentialName("sk-test_12345678")).toBe(false);
+    expect(shouldTrackCredentialName("xoxb-12345678-abcdef12")).toBe(false);
   });
 
   it("rejects records that include value-shaped fields", () => {
@@ -96,6 +100,20 @@ describe("system credential inventory", () => {
       source: "vercel_env",
       name: "TESTPASS_TOKEN",
       value: "never-print-me",
+    })).toBeNull();
+  });
+
+  it("rejects records whose names look like pasted secret literals", () => {
+    expect(sanitizeInventoryRecord({
+      provider: "github",
+      source: "github_actions_secret",
+      name: "AKIAIOSFODNN7EXAMPLE",
+    })).toBeNull();
+
+    expect(sanitizeInventoryRecord({
+      provider: "vercel",
+      source: "vercel_env",
+      name: "sk-test_12345678",
     })).toBeNull();
   });
 

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -31,6 +31,12 @@ const EXCLUDED_NAMES = new Set([
 ]);
 
 const NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const SECRET_LITERAL_NAME_PATTERNS: readonly RegExp[] = [
+  /^AKIA[0-9A-Z]{8,}$/,
+  /^gh[pousr]_[a-z0-9]{8,}$/i,
+  /^sk-[a-z0-9_-]{8,}$/i,
+  /^xox[baprs]-[a-z0-9-]{8,}$/i,
+];
 const UNSAFE_METADATA_COPY_PATTERN =
   /(authorization:|bearer\s+[a-z0-9._-]{8,}|x-api-key|apikey|api[_ -]?key|refresh[_ -]?token|set-cookie:|cookie:|sk-[a-z0-9_-]{8,}|ghp_[a-z0-9]{8,}|xox[baprs]-[a-z0-9-]{8,})/i;
 const UNSAFE_ROTATION_GUIDANCE_PATTERN =
@@ -350,8 +356,11 @@ export const SYSTEM_CREDENTIAL_INVENTORY: readonly SystemCredentialInventoryEntr
 ]);
 
 export function shouldTrackCredentialName(name: string): boolean {
-  const normalized = name.trim().toUpperCase();
-  return NAME_PATTERN.test(normalized) && !EXCLUDED_NAMES.has(normalized);
+  const trimmed = name.trim();
+  const normalized = trimmed.toUpperCase();
+  if (!NAME_PATTERN.test(normalized)) return false;
+  if (EXCLUDED_NAMES.has(normalized)) return false;
+  return !SECRET_LITERAL_NAME_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
 
 export function hasSecretValueField(record: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Summary
- rebuild the useful #418 guard on current main
- reject pasted secret-looking literals when sanitizing System Credentials inventory names
- add regression tests for AWS, GitHub, OpenAI, and Slack token-shaped names

## Safety
- metadata-only Connectors/RotatePass guard
- no raw secret values displayed or stored
- no auth, billing, DNS, migrations, provider writes, or rotation behavior

## Verification
- npm run test -- src/pages/admin/systemCredentialInventory.test.ts
- npx eslint src/pages/admin/systemCredentialInventory.ts src/pages/admin/systemCredentialInventory.test.ts
- npm run build
- git diff --check

Replaces stale conflicted draft #418.