### PR TITLE
Harden wake router ACK telemetry thresholds

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -26,6 +26,17 @@ function parseBoundedSeconds(value, fallback, min, max) {
   return Math.max(min, Math.min(parsed, max));
 }
 
+export function deriveAckThresholds(failAfterSeconds) {
+  const fail = Number.isFinite(failAfterSeconds) ? Math.max(1, Math.floor(failAfterSeconds)) : 600;
+  const expected = Math.min(120, Math.max(15, Math.floor(fail * 0.2)));
+  const warning = Math.min(300, Math.max(expected + 1, Math.floor(fail * 0.5)));
+  return {
+    expected_within_seconds: expected,
+    warning_after_seconds: warning,
+    fail_after_seconds: fail,
+  };
+}
+
 function readEvent() {
   if (!eventPath) return {};
   try {
@@ -460,6 +471,7 @@ async function registerWakeDispatch({ eventId, decision, triage, result, event }
 
 function writeLedger({ eventId, event, decision, triage, result, reliability, status }) {
   const eventSeconds = secondsSince(decision.eventCreatedAt);
+  const ackThresholds = deriveAckThresholds(ackFailSeconds);
   const ledger = {
     event_id: eventId,
     status,
@@ -496,9 +508,9 @@ function writeLedger({ eventId, event, decision, triage, result, reliability, st
     },
     ack: {
       requested: status === "wake_posted" || status === "wake_dry_run",
-      expected_within_seconds: Math.min(120, ackFailSeconds),
-      warning_after_seconds: Math.min(300, ackFailSeconds),
-      fail_after_seconds: ackFailSeconds,
+      expected_within_seconds: ackThresholds.expected_within_seconds,
+      warning_after_seconds: ackThresholds.warning_after_seconds,
+      fail_after_seconds: ackThresholds.fail_after_seconds,
       observed_at: null,
     },
   };

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   buildReliabilityDispatchRequest,
+  deriveAckThresholds,
   normalizeDispatchOwner,
   wakeDispatchId,
 } from "./event-wake-router.mjs";
@@ -551,5 +552,21 @@ describe("event wake router reliability dispatch", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("derives monotonic ACK telemetry thresholds for short leases", () => {
+    const thresholds = deriveAckThresholds(60);
+    assert.equal(thresholds.fail_after_seconds, 60);
+    assert.equal(thresholds.expected_within_seconds, 15);
+    assert.equal(thresholds.warning_after_seconds, 30);
+    assert.ok(thresholds.expected_within_seconds < thresholds.warning_after_seconds);
+    assert.ok(thresholds.warning_after_seconds < thresholds.fail_after_seconds);
+  });
+
+  it("preserves default ACK telemetry thresholds for ten-minute leases", () => {
+    const thresholds = deriveAckThresholds(600);
+    assert.equal(thresholds.expected_within_seconds, 120);
+    assert.equal(thresholds.warning_after_seconds, 300);
+    assert.equal(thresholds.fail_after_seconds, 600);
   });
 });


### PR DESCRIPTION
## Summary\n- add deriveAckThresholds() for wake-router ledger ACK telemetry\n- keep default 10 minute lease thresholds at 120s/300s/600s\n- ensure short ACK leases keep monotonic target/warn/fail ordering\n- add tests covering short-lease monotonic thresholds and default behavior\n\n## Verification\n- node --test scripts/event-wake-router.test.mjs\n\n## Autopilot tier\n- Ship without ask (small, reversible reliability telemetry hardening)