### PR TITLE
fix(wakepass): sync wake handoff message ids

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -382,6 +382,25 @@ export function buildReliabilityDispatchRequest({
   };
 }
 
+export function buildReliabilityDispatchHandoffSyncRequest({
+  eventId,
+  decision,
+  triage,
+  result,
+  event,
+  ackSeconds = 600,
+}) {
+  if (!result?.message_id) return null;
+  return buildReliabilityDispatchRequest({
+    eventId,
+    decision,
+    triage,
+    result,
+    event,
+    ackSeconds,
+  });
+}
+
 async function registerWakeDispatch({ eventId, decision, triage, result, event }) {
   const dispatchRequest = buildReliabilityDispatchRequest({
     eventId,
@@ -466,6 +485,58 @@ async function registerWakeDispatch({ eventId, decision, triage, result, event }
     status: claimResponse.status,
     dispatch_id: dispatchRequest.dispatch_id,
     error: claimResponse.ok ? null : compactText(claimBody, 500),
+  };
+}
+
+async function syncWakeDispatchHandoffMessage({ eventId, decision, triage, result, event }) {
+  const upsert = buildReliabilityDispatchHandoffSyncRequest({
+    eventId,
+    decision,
+    triage,
+    result,
+    event,
+    ackSeconds: ackFailSeconds,
+  });
+
+  if (!upsert) {
+    return { attempted: false, synced: false, skipped: true, reason: "missing_message_id" };
+  }
+
+  if (dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          reliability_dispatch_handoff_sync_dry_run: true,
+          missing_key: !unclickApiKey,
+          upsert,
+        },
+        null,
+        2,
+      ),
+    );
+    return { attempted: true, synced: true, dry_run: true };
+  }
+
+  if (!unclickApiKey) {
+    return { attempted: true, synced: false, error: "missing_wake_token" };
+  }
+
+  const response = await fetch(`${apiUrl}?action=reliability_dispatches&method=upsert`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${unclickApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(upsert),
+  });
+  const body = await response.text();
+  console.log(`Reliability dispatch handoff sync HTTP ${response.status}`);
+  console.log(body);
+  return {
+    attempted: true,
+    synced: response.ok,
+    status: response.status,
+    error: response.ok ? null : compactText(body, 500),
   };
 }
 
@@ -584,11 +655,19 @@ async function main() {
     return;
   }
   const result = await postWake(finalDecision, triage, eventId, event);
+  const handoffSync = await syncWakeDispatchHandoffMessage({
+    eventId,
+    decision: finalDecision,
+    triage,
+    result,
+    event,
+  });
   const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
   writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, status });
   if (
     (!result.posted && !result.dry_run) ||
-    (!reliability?.registered && !reliability?.dry_run)
+    (!reliability?.registered && !reliability?.dry_run) ||
+    (handoffSync.attempted && !handoffSync.synced)
   ) {
     process.exitCode = 1;
   }

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  buildReliabilityDispatchHandoffSyncRequest,
   buildReliabilityDispatchRequest,
   deriveAckThresholds,
   normalizeDispatchOwner,
@@ -113,6 +114,26 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(request.payload.ack_required, true);
     assert.equal(request.payload.route_attempted, "fishbowl");
     assert.equal(request.payload.handoff_message_id, null);
+  });
+
+  it("builds a dispatch upsert sync when Fishbowl returns a message id", () => {
+    const upsert = buildReliabilityDispatchHandoffSyncRequest({
+      eventId: "wake-workflow_run-workflow-run-321-jkl",
+      decision: {
+        owner: "🤖",
+        reason: "Scheduled TestPass smoke failure",
+        urgency: "urgent",
+      },
+      triage: { used: false },
+      result: { message_id: "msg-321" },
+      event: { workflow_run: { id: 321 } },
+      ackSeconds: 120,
+    });
+
+    assert.ok(upsert);
+    assert.equal(upsert.dispatch_id, wakeDispatchId("wake-workflow_run-workflow-run-321-jkl"));
+    assert.equal(upsert.payload.handoff_message_id, "msg-321");
+    assert.equal(upsert.payload.ack_fail_after_seconds, 120);
   });
 
   it("normalizes fanout owner to a concrete ACK owner for reliability dispatch", () => {


### PR DESCRIPTION
## Summary
- rebuild the useful #425 handoff sync on current main
- after Fishbowl wake post returns a message id, sync that id back into the WakePass reliability dispatch
- fail the router if the post succeeds but the dispatch handoff-message sync fails

## Scope
- Event Wake Router reliability hardening only
- replaces stale conflicted draft #425

## Verification
- node --test scripts/event-wake-router.test.mjs
- npm run build
- git diff --check