### PR TITLE
chore(connectors): mark stale connection checks

### DIFF
--- a/src/pages/admin/tools/ConnectedServices.test.ts
+++ b/src/pages/admin/tools/ConnectedServices.test.ts
@@ -6,6 +6,8 @@ function fakeFormatLastTested(value: string | null): string {
 }
 
 describe("deriveConnectorStatus", () => {
+  const now = Date.parse("2026-05-02T00:00:00.000Z");
+
   it("uses metadata-only wording when a connector has no server test support", () => {
     const status = deriveConnectorStatus({
       test_endpoint: null,
@@ -13,7 +15,7 @@ describe("deriveConnectorStatus", () => {
         is_valid: true,
         last_tested_at: "2026-05-01T00:00:00.000Z",
       },
-    }, fakeFormatLastTested);
+    }, fakeFormatLastTested, now);
 
     expect(status.pill).toBe("Metadata only");
     expect(status.note.toLowerCase()).toContain("metadata");
@@ -27,9 +29,35 @@ describe("deriveConnectorStatus", () => {
         is_valid: true,
         last_tested_at: null,
       },
-    }, fakeFormatLastTested);
+    }, fakeFormatLastTested, now);
 
     expect(status.pill).toBe("Setup incomplete");
     expect(status.note).toContain("not validated");
+  });
+
+  it("marks old test evidence as stale", () => {
+    const status = deriveConnectorStatus({
+      test_endpoint: "/api/probe",
+      credential: {
+        is_valid: true,
+        last_tested_at: "2026-03-01T00:00:00.000Z",
+      },
+    }, fakeFormatLastTested, now);
+
+    expect(status.pill).toBe("Check stale");
+    expect(status.note.toLowerCase()).toContain("stale");
+  });
+
+  it("uses cautious wording for recent test evidence", () => {
+    const status = deriveConnectorStatus({
+      test_endpoint: "/api/probe",
+      credential: {
+        is_valid: true,
+        last_tested_at: "2026-05-01T00:00:00.000Z",
+      },
+    }, fakeFormatLastTested, now);
+
+    expect(status.pill).toBe("Check recent");
+    expect(status.note.toLowerCase()).toContain("not a live secret check");
   });
 });

--- a/src/pages/admin/tools/ConnectedServices.tsx
+++ b/src/pages/admin/tools/ConnectedServices.tsx
@@ -25,9 +25,12 @@ interface ConnectorStatus {
   note: string;
 }
 
+const STALE_TEST_EVIDENCE_MS = 1000 * 60 * 60 * 24 * 30;
+
 export function deriveConnectorStatus(
   connector: Pick<Connector, "credential" | "test_endpoint">,
   formatLastTested: (value: string | null) => string,
+  now = Date.now(),
 ): ConnectorStatus {
   const credential = connector.credential;
   const hasTest = Boolean(connector.test_endpoint);
@@ -69,11 +72,30 @@ export function deriveConnectorStatus(
     };
   }
 
+  const testedAt = new Date(credential.last_tested_at);
+  if (Number.isNaN(testedAt.getTime())) {
+    return {
+      dot: "bg-sky-400",
+      pillClass: "bg-sky-400/10 text-sky-200",
+      pill: "Check unknown",
+      note: `Credential metadata is present, but test time is unknown. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+    };
+  }
+
+  if (now - testedAt.getTime() > STALE_TEST_EVIDENCE_MS) {
+    return {
+      dot: "bg-yellow-400",
+      pillClass: "bg-yellow-400/10 text-yellow-200",
+      pill: "Check stale",
+      note: `Credential exists, but test evidence is stale. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+    };
+  }
+
   return {
     dot: "bg-green-500",
     pillClass: "bg-green-500/10 text-green-200",
-    pill: "Connected",
-    note: `Ready for approved agent workflows. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+    pill: "Check recent",
+    note: `Recent test evidence exists, but this is not a live secret check. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
   };
 }
 


### PR DESCRIPTION
## Summary
- rebuild the useful #406 status wording slice on current main
- mark old connector test evidence as Check stale
- use cautious Check recent wording instead of implying a live secret check

## Safety
- metadata/status wording only
- no secret values, provider writes, auth, billing, DNS, migrations, or rotation behavior

## Verification
- npm run test -- src/pages/admin/tools/ConnectedServices.test.ts
- npx eslint src/pages/admin/tools/ConnectedServices.tsx src/pages/admin/tools/ConnectedServices.test.ts (existing fast-refresh warning only)
- npm run build
- git diff --check

Replaces stale conflicted draft #406.