### PR TITLE
feat(fishbowl): show handoff receipt badge

### DIFF
--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -5,7 +5,7 @@ import FishbowlTodos from "./fishbowl/Todos";
 import FishbowlIdeas from "./fishbowl/Ideas";
 import FishbowlSettings from "./fishbowl/Settings";
 import { clusterProfiles, type ProfileCluster } from "./fishbowl/clusterProfiles";
-import { getLaneMessages, getMainFeedMessages } from "./fishbowl/messageLanes";
+import { getLaneMessages, getMainFeedMessages, isHandoffMessage } from "./fishbowl/messageLanes";
 
 interface FishbowlMessage {
   id: string;
@@ -484,6 +484,12 @@ function MessageBody({ m }: { m: FishbowlMessage }) {
               {t}
             </span>
           ))}
+        </div>
+      )}
+      {isHandoffMessage(m) && (
+        <div className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/20 bg-[#E2B93B]/10 px-2 py-1 text-[11px] font-medium text-[#E2B93B]">
+          <span aria-hidden>🧾</span>
+          <span>handoff pending</span>
         </div>
       )}
     </>

--- a/src/pages/admin/fishbowl/messageLanes.test.ts
+++ b/src/pages/admin/fishbowl/messageLanes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getLaneMessages,
   getMainFeedMessages,
+  isHandoffMessage,
   isRoutineLaneOnlyMessage,
 } from "./messageLanes";
 
@@ -40,5 +41,12 @@ describe("Fishbowl message lanes", () => {
       "heartbeat-action",
     ]);
     expect(getLaneMessages(messages, "event").map((m) => m.id)).toEqual(["event"]);
+  });
+
+  it("detects handoff messages without treating them as routine lane chatter", () => {
+    const handoff = message("handoff", ["handoff", "needs-doing"]);
+
+    expect(isHandoffMessage(handoff)).toBe(true);
+    expect(getMainFeedMessages([handoff]).map((m) => m.id)).toEqual(["handoff"]);
   });
 });

--- a/src/pages/admin/fishbowl/messageLanes.ts
+++ b/src/pages/admin/fishbowl/messageLanes.ts
@@ -13,7 +13,18 @@ export function hasMessageLaneTag(
   message: FishbowlLaneMessage,
   tag: FishbowlMessageLaneTag,
 ): boolean {
+  return hasMessageTag(message, tag);
+}
+
+export function hasMessageTag(
+  message: FishbowlLaneMessage,
+  tag: string,
+): boolean {
   return message.tags?.includes(tag) ?? false;
+}
+
+export function isHandoffMessage(message: FishbowlLaneMessage): boolean {
+  return hasMessageTag(message, "handoff");
 }
 
 export function isRoutineLaneOnlyMessage(message: FishbowlLaneMessage): boolean {


### PR DESCRIPTION
## Summary

Adds a tiny UI-only handoff receipt badge for Fishbowl messages tagged handoff.

This rescues the remaining safe visual piece from old PR #164 without rebasing the stale broad branch.

## Scope

- Detects handoff-tagged messages with the existing message helper
- Keeps handoff messages in the main feed
- Renders a small handoff pending badge under those messages
- Adds focused regression coverage

## Non-overlap

No backend, auth, secrets, migrations, wake routing, reliability dispatches, analytics, DNS, or old branch conflict resolution.

## Verification

- npm run test -- src/pages/admin/fishbowl/messageLanes.test.ts
- npm run build
- git diff --check

## Risk

Low. UI-only display of already-present tags; no behavior changes to posting, ACK, or dispatch state.