### PR TITLE
Harden wake router ACK threshold ordering

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -27,9 +27,11 @@ function parseBoundedSeconds(value, fallback, min, max) {
 }
 
 export function deriveAckThresholds(failAfterSeconds) {
-  const fail = Number.isFinite(failAfterSeconds) ? Math.max(1, Math.floor(failAfterSeconds)) : 600;
-  const expected = Math.min(120, Math.max(15, Math.floor(fail * 0.2)));
-  const warning = Math.min(300, Math.max(expected + 1, Math.floor(fail * 0.5)));
+  const fail = Number.isFinite(failAfterSeconds) ? Math.max(3, Math.floor(failAfterSeconds)) : 600;
+  const expectedBase = fail >= 60 ? Math.max(15, Math.floor(fail * 0.2)) : Math.max(1, Math.floor(fail * 0.2));
+  const expected = Math.min(120, Math.min(fail - 2, expectedBase));
+  const warningBase = fail >= 60 ? Math.floor(fail * 0.5) : Math.max(expected + 1, Math.floor(fail * 0.5));
+  const warning = Math.min(300, Math.max(expected + 1, Math.min(fail - 1, warningBase)));
   return {
     expected_within_seconds: expected,
     warning_after_seconds: warning,

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -590,4 +590,13 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(thresholds.warning_after_seconds, 300);
     assert.equal(thresholds.fail_after_seconds, 600);
   });
+
+  it("keeps ACK telemetry thresholds ordered for tiny direct inputs", () => {
+    const thresholds = deriveAckThresholds(1);
+    assert.equal(thresholds.fail_after_seconds, 3);
+    assert.equal(thresholds.expected_within_seconds, 1);
+    assert.equal(thresholds.warning_after_seconds, 2);
+    assert.ok(thresholds.expected_within_seconds < thresholds.warning_after_seconds);
+    assert.ok(thresholds.warning_after_seconds < thresholds.fail_after_seconds);
+  });
 });


### PR DESCRIPTION
## Summary
- harden deriveAckThresholds() to keep xpected < warning < fail even for tiny direct inputs
- preserve existing 60s/600s behavior used by WakePass telemetry
- add regression coverage for tiny direct inputs

## Scope
- scripts/event-wake-router.mjs
- scripts/event-wake-router.test.mjs

## Verification
- 
ode --test scripts/event-wake-router.test.mjs

## Non-overlap
- no changes to Connections UI, Fishbowl UI, deps, migrations, auth, secrets, or payments