### PR TITLE
feat(fishbowl): add action queue lane

### DIFF
--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -5,7 +5,12 @@ import FishbowlTodos from "./fishbowl/Todos";
 import FishbowlIdeas from "./fishbowl/Ideas";
 import FishbowlSettings from "./fishbowl/Settings";
 import { clusterProfiles, type ProfileCluster } from "./fishbowl/clusterProfiles";
-import { getLaneMessages, getMainFeedMessages, isHandoffMessage } from "./fishbowl/messageLanes";
+import {
+  getActionQueueMessages,
+  getLaneMessages,
+  getMainFeedMessages,
+  isHandoffMessage,
+} from "./fishbowl/messageLanes";
 
 interface FishbowlMessage {
   id: string;
@@ -594,6 +599,7 @@ export default function Fishbowl() {
     () => getLaneMessages(messages, "event"),
     [messages],
   );
+  const actionQueueMessages = useMemo(() => getActionQueueMessages(messages), [messages]);
   const mainFeedMessages = useMemo(() => getMainFeedMessages(messages), [messages]);
   const groupedMessages = useMemo(
     () => groupMessagesByThread(mainFeedMessages),
@@ -715,6 +721,8 @@ export default function Fishbowl() {
       <FishbowlIdeas authHeader={authHeader} humanAgentId={humanAgentId} />
 
       <PostBox disabled={!humanAgentId} onPost={postMessage} />
+
+      <MessageLane title="Action queue" icon="🟡" messages={actionQueueMessages} />
 
       <div className="grid gap-3 md:grid-cols-2">
         <MessageLane title="Heartbeats" icon="💓" messages={heartbeatMessages} />

--- a/src/pages/admin/fishbowl/messageLanes.test.ts
+++ b/src/pages/admin/fishbowl/messageLanes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getActionQueueMessages,
   getLaneMessages,
   getMainFeedMessages,
   isHandoffMessage,
@@ -48,5 +49,25 @@ describe("Fishbowl message lanes", () => {
 
     expect(isHandoffMessage(handoff)).toBe(true);
     expect(getMainFeedMessages([handoff]).map((m) => m.id)).toEqual(["handoff"]);
+  });
+
+  it("collects action-needed tags into the action queue", () => {
+    const messages = [
+      message("blocker", ["blocker"]),
+      message("handoff", ["handoff"]),
+      message("needs-doing", ["needs-doing"]),
+      message("tripwire", ["tripwire"]),
+      message("heartbeat-action", ["heartbeat", "needs-doing"]),
+      message("routine", ["heartbeat"]),
+      message("normal", ["note"]),
+    ];
+
+    expect(getActionQueueMessages(messages).map((m) => m.id)).toEqual([
+      "blocker",
+      "handoff",
+      "needs-doing",
+      "tripwire",
+      "heartbeat-action",
+    ]);
   });
 });

--- a/src/pages/admin/fishbowl/messageLanes.ts
+++ b/src/pages/admin/fishbowl/messageLanes.ts
@@ -4,6 +4,13 @@ export interface FishbowlLaneMessage {
   tags: string[] | null;
 }
 
+const ACTION_QUEUE_TAGS = new Set([
+  "blocker",
+  "handoff",
+  "needs-doing",
+  "tripwire",
+]);
+
 const ROUTINE_LANE_TAGS = new Set<FishbowlMessageLaneTag>([
   "heartbeat",
   "event",
@@ -27,6 +34,10 @@ export function isHandoffMessage(message: FishbowlLaneMessage): boolean {
   return hasMessageTag(message, "handoff");
 }
 
+export function isActionQueueMessage(message: FishbowlLaneMessage): boolean {
+  return message.tags?.some((tag) => ACTION_QUEUE_TAGS.has(tag)) ?? false;
+}
+
 export function isRoutineLaneOnlyMessage(message: FishbowlLaneMessage): boolean {
   const tags = message.tags ?? [];
   return tags.length > 0 && tags.every((tag) => ROUTINE_LANE_TAGS.has(tag as FishbowlMessageLaneTag));
@@ -41,4 +52,8 @@ export function getLaneMessages<T extends FishbowlLaneMessage>(
 
 export function getMainFeedMessages<T extends FishbowlLaneMessage>(messages: T[]): T[] {
   return messages.filter((message) => !isRoutineLaneOnlyMessage(message));
+}
+
+export function getActionQueueMessages<T extends FishbowlLaneMessage>(messages: T[]): T[] {
+  return messages.filter(isActionQueueMessage);
 }


### PR DESCRIPTION
## Summary

Adds a current-data Action Queue lane to /admin/fishbowl.

Messages tagged locker, handoff, 
eeds-doing, or 	ripwire are grouped into a collapsed Action Queue so active work is easier to scan without reviving the stale Drafts backend from old PR #171.

## Scope

- Adds action-tag detection to the existing Fishbowl message lane helper
- Adds focused tests for action queue inclusion
- Renders an Action Queue lane using already-loaded Fishbowl messages

## Non-overlap

No backend, auth, secrets, migrations, draft inbox endpoints, wake routing, reliability dispatches, analytics, DNS, or old branch conflict resolution.

## Verification

- npm run test -- src/pages/admin/fishbowl/messageLanes.test.ts
- npm run build
- git diff --check

## Risk

Low. UI-only grouping of existing message tags. Action messages still remain in the main feed; this only adds a scannable lane.