### PR TITLE
feat(enterprisepass): seed readiness report receipt

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -63,6 +63,18 @@
       "summary": "Queued for recurring policy and claims review.",
       "evidence": "LegalPass recurring public receipts will land after the runner surface is available.",
       "checkedAt": "2026-05-01T17:16:13.158Z"
+    },
+    {
+      "id": "enterprisepass",
+      "name": "EnterprisePass",
+      "status": "pending",
+      "summary": "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
+      "evidence": "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
+      "checkedAt": "2026-05-02T02:30:00Z",
+      "proof": {
+        "kind": "planned",
+        "targetUrl": "/enterprise/latest.json"
+      }
     }
   ],
   "trend": [
@@ -71,7 +83,7 @@
       "passing": 1,
       "failing": 0,
       "blocked": 2,
-      "pending": 3
+      "pending": 4
     }
   ],
   "lastActionableFailure": {

--- a/public/enterprise/latest.json
+++ b/public/enterprise/latest.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "0.1",
+  "generated_at": "2026-05-02T02:30:00Z",
+  "source": "public seed receipt",
+  "product": "EnterprisePass",
+  "headline": "Enterprise-readiness guidance, not compliance certification.",
+  "target": {
+    "name": "UnClick",
+    "surface": "repo, docs, workflow, and public proof surfaces"
+  },
+  "status": "pending",
+  "readiness_band": "seed",
+  "wording_notice": "This report describes readiness indicators and evidence alignment. It is not a compliance certification, SOC report, ISO audit, legal opinion, or security attestation.",
+  "summary": {
+    "score_overall": null,
+    "headline": "EnterprisePass has a product boundary and seed artifact. Automated evidence checks are not live yet.",
+    "checks_total": 0,
+    "checks_pass": 0,
+    "checks_partial": 0,
+    "checks_fail": 0,
+    "checks_unknown": 0,
+    "checks_pending": 7
+  },
+  "categories": [
+    {
+      "id": "code_maintainability",
+      "name": "Code maintainability",
+      "status": "pending",
+      "summary": "Will review tests, build, lint, type safety, structure, oversized files, and brittle code signals."
+    },
+    {
+      "id": "secure_development",
+      "name": "Secure development",
+      "status": "pending",
+      "summary": "Will review security policy, dependency checks, branch protection evidence, and secret-scanning signals."
+    },
+    {
+      "id": "evidence_over_claims",
+      "name": "Evidence over claims",
+      "status": "pending",
+      "summary": "Will flag bold claims that do not point to docs, tests, PRs, workflow runs, or public receipts."
+    },
+    {
+      "id": "documentation_quality",
+      "name": "Documentation quality",
+      "status": "pending",
+      "summary": "Will review README, ADRs, runbooks, architecture notes, onboarding, and operating docs."
+    },
+    {
+      "id": "credential_environment_hygiene",
+      "name": "Credential and environment hygiene",
+      "status": "pending",
+      "summary": "Will review ownership, used-by mapping, staleness, rotation notes, and safe evidence from RotatePass or Connections."
+    },
+    {
+      "id": "investor_readiness",
+      "name": "Investor readiness",
+      "status": "pending",
+      "summary": "Will review license, bus-factor signals, operational discipline, and audit trail evidence."
+    },
+    {
+      "id": "ai_governance_readiness",
+      "name": "AI governance readiness",
+      "status": "pending",
+      "summary": "Will review model/provider inventory, human oversight, data/source notes, and AI-system evidence where applicable."
+    }
+  ],
+  "next_actions": [
+    "Build the Phase 0 static repo/docs scanner.",
+    "Link findings to existing TestPass, SecurityPass, SlopPass, LegalPass, RotatePass, and XPass receipts.",
+    "Render this JSON as a simple EnterprisePass report page only after evidence checks are available.",
+    "Keep all public copy in readiness language and avoid compliance-certification claims."
+  ],
+  "evidence": [
+    {
+      "type": "doc",
+      "path": "docs/enterprisepass-product-brief.md",
+      "summary": "Product boundary: readiness report, not certification."
+    },
+    {
+      "type": "doc",
+      "path": "docs/prd/xpass.md",
+      "summary": "EnterprisePass is listed as a scoped Pass-family product under XPass."
+    }
+  ],
+  "exclusions": [
+    "No ISO/SOC compliance conclusion.",
+    "No legal opinion.",
+    "No network security probing.",
+    "No raw secret storage.",
+    "No customer-facing certification claim."
+  ]
+}

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -280,6 +280,13 @@ const results = [
     "Queued for recurring policy and claims review.",
     "LegalPass recurring public receipts will land after the runner surface is available.",
   ),
+  pendingResult(
+    "enterprisepass",
+    "EnterprisePass",
+    "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
+    "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
+    { proof: { kind: "planned", targetUrl: "/enterprise/latest.json" } },
+  ),
 ];
 
 const report = {

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -23,9 +23,15 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
 
     const report = JSON.parse(await fs.readFile(output, "utf8"));
     const securitypass = report.results.find((result) => result.id === "securitypass");
+    const enterprisepass = report.results.find((result) => result.id === "enterprisepass");
 
     assert.equal(securitypass?.status, "blocked");
     assert.match(securitypass?.blockedReason ?? "", /scope-gated/i);
+    assert.equal(enterprisepass?.status, "pending");
+    assert.deepEqual(enterprisepass?.proof, {
+      kind: "planned",
+      targetUrl: "/enterprise/latest.json",
+    });
     assert.equal(report.status, "blocked");
     assert.match(report.lastActionableFailure.detail, /Blocked reason:/);
   } finally {

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -83,11 +83,20 @@ export const dogfoodReport = {
       evidence: "Public legal-quality receipts will appear here once recurring checks begin.",
       checkedAt: "2026-05-01T00:50:00Z",
     },
+    {
+      id: "enterprisepass",
+      name: "EnterprisePass",
+      status: "pending",
+      summary: "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
+      evidence: "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
+      checkedAt: "2026-05-02T02:30:00Z",
+      proof: { kind: "planned", targetUrl: "/enterprise/latest.json" },
+    },
   ] satisfies DogfoodPassResult[],
   trend: [
     { date: "2026-04-29", passing: 0, failing: 0, pending: 6 },
     { date: "2026-04-30", passing: 1, failing: 0, pending: 5 },
-    { date: "2026-05-01", passing: 1, failing: 0, blocked: 1, pending: 4 },
+    { date: "2026-05-01", passing: 1, failing: 0, blocked: 1, pending: 5 },
   ] satisfies DogfoodTrendPoint[],
   lastActionableFailure: {
     title: "SecurityPass needs attention",


### PR DESCRIPTION
## Summary

Publishes the first EnterprisePass seed receipt at /enterprise/latest.json and lists EnterprisePass in the public dogfood receipt as pending evidence.

This creates the product proof surface without claiming the scanner is live or making compliance/certification claims.

## Scope

- Add public/enterprise/latest.json seed readiness report
- Add EnterprisePass pending row to public dogfood fallback data
- Add EnterprisePass pending row to the dogfood receipt builder
- Add regression coverage for the planned EnterprisePass dogfood proof row

## Non-overlap

No scanner implementation, no auth, no secrets, no migrations, no network probing, no formal compliance claims, no EnterprisePass UI page.

## Verification

- node --test scripts/build-dogfood-report.test.mjs
- JSON parse check for public/enterprise/latest.json and public/dogfood/latest.json
- npm run build
- git diff --check

## Risk

Low. Static/public receipt plus dogfood metadata only. The wording explicitly says readiness guidance, not certification.