### PR TITLE
feat(rotatepass): show credential health metadata

### DIFF
--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -48,8 +48,9 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import {
-  listSystemCredentialInventory,
-  type SystemCredentialInventoryEntry,
+  listSystemCredentialHealthRows,
+  type SystemCredentialDisplayStatus,
+  type SystemCredentialHealthRow,
   type SystemCredentialProvider,
   type SystemCredentialRisk,
 } from "./systemCredentialInventory";
@@ -262,6 +263,20 @@ const INVENTORY_RISK_BADGES: Record<SystemCredentialRisk, {
   normal: {
     label: "Normal",
     className: "border-white/[0.06] bg-white/[0.03] text-[#aaa]",
+  },
+};
+
+const INVENTORY_STATUS_BADGES: Record<SystemCredentialDisplayStatus, {
+  label: string;
+  className: string;
+}> = {
+  metadata_only: {
+    label: "Metadata only",
+    className: "border-sky-500/20 bg-sky-500/10 text-sky-300",
+  },
+  manual_check_required: {
+    label: "Manual check",
+    className: "border-amber-500/20 bg-amber-500/10 text-amber-300",
   },
 };
 
@@ -611,7 +626,7 @@ export default function AdminKeychain() {
     needs_rotation: 0,
   });
 
-  const systemCredentialInventory = useMemo(() => listSystemCredentialInventory(), []);
+  const systemCredentialInventory = useMemo(() => listSystemCredentialHealthRows(), []);
   const inventorySummary = useMemo(() => ({
     total:    systemCredentialInventory.length,
     critical: systemCredentialInventory.filter((entry) => entry.risk === "critical").length,
@@ -619,7 +634,7 @@ export default function AdminKeychain() {
     expected: systemCredentialInventory.filter((entry) => entry.expected).length,
   }), [systemCredentialInventory]);
   const inventoryByProvider = useMemo(() => (
-    systemCredentialInventory.reduce<Record<SystemCredentialProvider, SystemCredentialInventoryEntry[]>>((acc, entry) => {
+    systemCredentialInventory.reduce<Record<SystemCredentialProvider, SystemCredentialHealthRow[]>>((acc, entry) => {
       acc[entry.provider].push(entry);
       return acc;
     }, { github: [], vercel: [] })
@@ -675,7 +690,7 @@ export default function AdminKeychain() {
           <div>
             <p className="text-xs font-semibold uppercase tracking-wider text-[#666]">System credential inventory</p>
             <p className="mt-1 text-[11px] text-[#888]">
-              Name-only map of which GitHub and Vercel credentials power each workflow.
+              Name-only map of what powers each workflow, who owns it, and how to rotate safely.
             </p>
           </div>
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
@@ -703,22 +718,30 @@ export default function AdminKeychain() {
               <div className="divide-y divide-white/[0.04]">
                 {inventoryByProvider[provider].map((entry) => {
                   const risk = INVENTORY_RISK_BADGES[entry.risk];
+                  const status = INVENTORY_STATUS_BADGES[entry.displayStatus];
                   return (
-                    <div key={`${entry.provider}-${entry.name}-${entry.workload}`} className="grid gap-2 px-3 py-3 text-[11px] md:grid-cols-[minmax(12rem,0.9fr)_minmax(12rem,1fr)_auto]">
+                    <div key={`${entry.provider}-${entry.name}-${entry.workload}`} className="grid gap-2 px-3 py-3 text-[11px] md:grid-cols-[minmax(12rem,0.8fr)_minmax(16rem,1.2fr)_auto]">
                       <div className="min-w-0">
                         <p className="truncate font-mono text-[#ddd]">{entry.name}</p>
                         <p className="mt-0.5 text-[#555]">{entry.scope}</p>
                       </div>
                       <div className="min-w-0">
                         <p className="text-[#ccc]">{entry.workload}</p>
-                        <p className="mt-0.5 text-[#666]">{entry.docsHint}</p>
-                        {entry.rotationImpact && (
-                          <p className="mt-1 text-[#888]">
-                            If rotated: {entry.rotationImpact}
-                          </p>
-                        )}
+                        <div className="mt-1 grid gap-1 text-[#666] sm:grid-cols-2">
+                          <p>Owner: {entry.ownerLabel} ({entry.ownerConfidence})</p>
+                          <p>Last checked: {entry.lastCheckedAt ? timeAgo(entry.lastCheckedAt) : "manual check required"}</p>
+                        </div>
+                        <p className="mt-1 text-[#666]">{entry.docsHint}</p>
+                        <div className="mt-1 space-y-0.5 text-[#888]">
+                          {entry.safeRotationNotes.map((note) => (
+                            <p key={note}>Rotate: {note}</p>
+                          ))}
+                        </div>
                       </div>
                       <div className="flex flex-wrap items-start gap-1 md:justify-end">
+                        <span className={`rounded-full border px-2 py-0.5 text-[10px] font-medium ${status.className}`}>
+                          {status.label}
+                        </span>
                         <span className={`rounded-full border px-2 py-0.5 text-[10px] font-medium ${risk.className}`}>
                           {risk.label}
                         </span>

--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -1,5 +1,6 @@
 import {
   hasSecretValueField,
+  listSystemCredentialHealthRows,
   listSystemCredentialInventory,
   sanitizeInventoryRecord,
   shouldTrackCredentialName,
@@ -75,6 +76,42 @@ describe("system credential inventory", () => {
     for (const entry of criticalExpected) {
       expect(entry.rotationImpact?.length ?? 0).toBeGreaterThan(20);
       expect(entry.rotationImpact?.toLowerCase()).not.toContain("secret value");
+    }
+  });
+
+  it("derives metadata-only health rows with owner, status, and manual check state", () => {
+    const rows = listSystemCredentialHealthRows();
+    const testpass = rows.find((entry) => entry.name === "TESTPASS_TOKEN");
+
+    expect(testpass).toMatchObject({
+      ownerLabel: "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints",
+      ownerConfidence: "inferred",
+      displayStatus: "metadata_only",
+      lastCheckedAt: null,
+    });
+    expect(testpass?.safeRotationNotes).toEqual(expect.arrayContaining([
+      "After rotation, rerun the TestPass PR check.",
+    ]));
+  });
+
+  it("adds safe rotation notes without claiming live credential health", () => {
+    for (const entry of listSystemCredentialHealthRows()) {
+      expect(entry.displayStatus).toBe("metadata_only");
+      expect(entry.lastCheckedAt).toBeNull();
+      expect(entry.safeRotationNotes.length).toBeGreaterThan(0);
+      expect(entry.safeRotationNotes.join("\n").toLowerCase()).not.toContain("secret value");
+
+      for (const pattern of FORBIDDEN_SECRET_LIKE_PATTERNS) {
+        expect(entry.safeRotationNotes.join("\n")).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it("requires human review notes for critical system credentials", () => {
+    const criticalRows = listSystemCredentialHealthRows().filter((entry) => entry.risk === "critical");
+
+    for (const entry of criticalRows) {
+      expect(entry.safeRotationNotes.join("\n").toLowerCase()).toContain("human review");
     }
   });
 

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -1,6 +1,8 @@
 export type SystemCredentialProvider = "github" | "vercel";
 export type SystemCredentialSource = "github_actions_secret" | "vercel_env";
 export type SystemCredentialRisk = "critical" | "high" | "normal";
+export type SystemCredentialOwnerConfidence = "known" | "inferred" | "unknown";
+export type SystemCredentialDisplayStatus = "metadata_only" | "manual_check_required";
 
 export interface SystemCredentialInventoryEntry {
   provider: SystemCredentialProvider;
@@ -12,6 +14,14 @@ export interface SystemCredentialInventoryEntry {
   expected: boolean;
   docsHint: string;
   rotationImpact?: string;
+}
+
+export interface SystemCredentialHealthRow extends SystemCredentialInventoryEntry {
+  ownerLabel: string;
+  ownerConfidence: SystemCredentialOwnerConfidence;
+  displayStatus: SystemCredentialDisplayStatus;
+  lastCheckedAt: string | null;
+  safeRotationNotes: readonly string[];
 }
 
 const BLOCKED_VALUE_FIELDS = new Set([
@@ -393,6 +403,21 @@ export function listSystemCredentialInventory(): readonly SystemCredentialInvent
   return SYSTEM_CREDENTIAL_INVENTORY;
 }
 
+export function listSystemCredentialHealthRows(): readonly SystemCredentialHealthRow[] {
+  return SYSTEM_CREDENTIAL_INVENTORY.map((entry) => deriveSystemCredentialHealthRow(entry));
+}
+
+export function deriveSystemCredentialHealthRow(entry: SystemCredentialInventoryEntry): SystemCredentialHealthRow {
+  return {
+    ...entry,
+    ownerLabel: ownerLabelFor(entry),
+    ownerConfidence: "inferred",
+    displayStatus: "metadata_only",
+    lastCheckedAt: null,
+    safeRotationNotes: rotationNotesFor(entry),
+  };
+}
+
 function sanitizeMetadataCopy(
   value: unknown,
   fallback?: string,
@@ -404,4 +429,42 @@ function sanitizeMetadataCopy(
   if (UNSAFE_METADATA_COPY_PATTERN.test(trimmed)) return fallback;
   if (options?.forbidAutomationClaims && UNSAFE_ROTATION_GUIDANCE_PATTERN.test(trimmed)) return fallback;
   return trimmed;
+}
+
+function ownerLabelFor(entry: SystemCredentialInventoryEntry): string {
+  switch (entry.source) {
+    case "github_actions_secret":
+      return "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints";
+    case "vercel_env":
+      return "Vercel project environment";
+  }
+}
+
+function rotationNotesFor(entry: SystemCredentialInventoryEntry): readonly string[] {
+  const notes = [
+    entry.rotationImpact ?? "Confirm the owner and dependent workflow before changing this credential.",
+    verificationNoteFor(entry),
+  ];
+
+  if (entry.risk === "critical") {
+    notes.push("Use human review for rotation and keep dependent checks fail-closed.");
+  }
+
+  return notes;
+}
+
+function verificationNoteFor(entry: SystemCredentialInventoryEntry): string {
+  const workload = entry.workload.toLowerCase();
+  if (entry.name === "TESTPASS_TOKEN") return "After rotation, rerun the TestPass PR check.";
+  if (entry.name === "TESTPASS_CRON_SECRET") return "After rotation, trigger the scheduled TestPass smoke.";
+  if (entry.name === "UXPASS_TOKEN") return "After rotation, run the UXPass dogfood capture.";
+  if (entry.name === "FISHBOWL_WAKE_TOKEN") return "After rotation, run a dry WakePass route proof.";
+  if (entry.name === "FISHBOWL_AUTOCLOSE_TOKEN") return "After rotation, verify the Fishbowl todo auto-close workflow.";
+  if (entry.name === "OPENROUTER_API_KEY") return "After rotation, run a static wake classifier dry-run.";
+  if (entry.name === "SUPABASE_SERVICE_ROLE_KEY") return "After rotation, verify privileged admin/server health with human review.";
+  if (entry.name === "CRON_SECRET") return "After rotation, verify scheduled route gates and Pass receipts.";
+  if (workload.includes("analytics")) return "After rotation, confirm analytics receipt evidence.";
+  if (workload.includes("payment")) return "After rotation, verify payment webhook handling with explicit approval.";
+  if (workload.includes("email")) return "After rotation, verify delivery metadata only.";
+  return "After rotation, run the narrowest safe metadata or workflow receipt check.";
 }


### PR DESCRIPTION
## Summary
- derive metadata-only System Credential health rows from the existing name-only inventory
- show owner, last checked state, status, and safe rotation notes in Connections
- add tests that keep the panel metadata-only and avoid secret-shaped copy

## Safety
- no raw credential values
- no provider probes or spend-changing actions
- no auth, billing, DNS, migrations, or broad dependency changes

## Tests
- npx vitest run src/pages/admin/systemCredentialInventory.test.ts
- npm run test:rotatepass-redaction
- npm run build