### PR TITLE
feat(dogfood): link receipt proof targets

### DIFF
--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -53,6 +53,10 @@ function formatDate(value: string): string {
   }).format(date);
 }
 
+function proofTarget(result: DogfoodPassResult): string | null {
+  return result.targetUrl || result.proof?.targetUrl || null;
+}
+
 export default function DogfoodReportPage() {
   const [report, setReport] = useState<DogfoodReportData>(fallbackReport);
 
@@ -175,6 +179,15 @@ export default function DogfoodReportPage() {
                         {result.runId ? <p>Run: {result.runId}</p> : null}
                         {result.targetUrl ? <p className="break-all">Target: {result.targetUrl}</p> : null}
                       </div>
+                    ) : null}
+                    {proofTarget(result) ? (
+                      <a
+                        href={proofTarget(result) || undefined}
+                        className="mt-3 inline-flex items-center gap-1.5 break-all text-[11px] font-medium text-primary transition-opacity hover:opacity-80"
+                      >
+                        View proof target
+                        <ExternalLink className="h-3 w-3 shrink-0" />
+                      </a>
                     ) : null}
                   </article>
                 </FadeIn>


### PR DESCRIPTION
## Summary
- Adds a proof-target link to Dogfood result cards when receipt data includes a targetUrl or planned proof target.
- Makes planned receipts such as EnterprisePass /enterprise/latest.json easier to inspect from the public Dogfood page.

## Scope
- src/pages/DogfoodReport.tsx only

## Non-overlap
- No Dogfood runner behavior changes.
- No public JSON changes.
- No Connectors/RotatePass changes; avoids conflicted #442.
- No secrets, auth, workflows, migrations, WakePass, Fishbowl, DNS, or domain changes.

## Verification
- npm run build
- git diff --check

## Risk
Low. UI-only proof-link surfacing for existing receipt fields.