### PR TITLE
Wake router: fail closed on invalid event payload JSON

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -613,6 +613,29 @@ function writeLedger({ eventId, event, decision, triage, result, reliability, st
 
 async function main() {
   const event = readEvent();
+  if (event.read_error) {
+    const fallbackDecision = {
+      wake: false,
+      owner: "none",
+      urgency: "low",
+      reason: `Failed to read GitHub event payload: ${compactText(event.read_error, 200)}`,
+      eventCreatedAt: new Date().toISOString(),
+      needsTriage: false,
+    };
+    const eventId = wakeEventId(event, fallbackDecision);
+    console.error(fallbackDecision.reason);
+    writeLedger({
+      eventId,
+      event,
+      decision: fallbackDecision,
+      triage: { used: false, error: fallbackDecision.reason, decision: fallbackDecision },
+      result: null,
+      reliability: null,
+      status: "wake_failed",
+    });
+    process.exitCode = 1;
+    return;
+  }
   const initialDecision = baseDecision(event);
   const brief = eventBrief(event, initialDecision);
   const triage = await cheapTriage(brief, initialDecision);

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -449,6 +449,32 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("fails closed when the GitHub event payload is invalid JSON", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(eventPath, "{ not json");
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /Failed to read GitHub event payload:/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to default ACK fail seconds when env value is malformed", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- fail closed when the GitHub event payload cannot be parsed
- write a wake_failed ledger entry with the parse error context instead of silently no-oping
- add a regression test for invalid JSON in GITHUB_EVENT_PATH

## Verification
- node --test scripts/event-wake-router.test.mjs