### PR TITLE
feat(connectors): clarify credential card answers

### DIFF
--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -743,15 +743,18 @@ export default function AdminKeychain() {
                     <div key={`${entry.provider}-${entry.name}-${entry.workload}`} className="grid gap-2 px-3 py-3 text-[11px] md:grid-cols-[minmax(12rem,0.8fr)_minmax(16rem,1.2fr)_auto]">
                       <div className="min-w-0">
                         <p className="truncate font-mono text-[#ddd]">{entry.name}</p>
-                        <p className="mt-0.5 text-[#555]">{entry.scope}</p>
+                        <p className="mt-0.5 text-[#555]">{entry.sourceLabel}</p>
+                        <p className="mt-0.5 text-[#666]">{entry.scope}</p>
                       </div>
                       <div className="min-w-0">
-                        <p className="text-[#ccc]">{entry.workload}</p>
+                        <p className="text-[#ccc]">Used by: {entry.workload}</p>
                         <div className="mt-1 grid gap-1 text-[#666] sm:grid-cols-2">
                           <p>Owner: {entry.ownerLabel} ({entry.ownerConfidence})</p>
                           <p>Last checked: {entry.lastCheckedAt ? timeAgo(entry.lastCheckedAt) : "manual check required"}</p>
                         </div>
+                        <p className="mt-1 text-[#666]">Health evidence: {entry.healthEvidenceLabel}</p>
                         <p className="mt-1 text-[#666]">{entry.docsHint}</p>
+                        <p className="mt-1 text-[#888]">Impact: {entry.rotationImpactSummary}</p>
                         <div className="mt-1 space-y-0.5 text-[#888]">
                           {entry.safeRotationNotes.map((note) => (
                             <p key={note}>Rotate: {note}</p>

--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -97,25 +97,37 @@ describe("system credential inventory", () => {
     const testpass = rows.find((entry) => entry.name === "TESTPASS_TOKEN");
 
     expect(testpass).toMatchObject({
+      sourceLabel: "GitHub Actions secret name",
       ownerLabel: "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints",
       ownerConfidence: "inferred",
       displayStatus: "metadata_only",
+      healthEvidenceLabel: "Use latest TestPass PR check receipt.",
       lastCheckedAt: null,
     });
+    expect(testpass?.rotationImpactSummary).toContain("TestPass checks");
     expect(testpass?.safeRotationNotes).toEqual(expect.arrayContaining([
       "After rotation, rerun the TestPass PR check.",
     ]));
   });
 
-  it("adds safe rotation notes without claiming live credential health", () => {
+  it("adds operator card answers without claiming live credential health", () => {
     for (const entry of listSystemCredentialHealthRows()) {
       expect(entry.displayStatus).toBe("metadata_only");
       expect(entry.lastCheckedAt).toBeNull();
+      expect(entry.sourceLabel.length).toBeGreaterThan(0);
+      expect(entry.healthEvidenceLabel.length).toBeGreaterThan(0);
+      expect(entry.rotationImpactSummary.length).toBeGreaterThan(0);
       expect(entry.safeRotationNotes.length).toBeGreaterThan(0);
-      expect(entry.safeRotationNotes.join("\n").toLowerCase()).not.toContain("secret value");
+      const combinedCopy = [
+        entry.sourceLabel,
+        entry.healthEvidenceLabel,
+        entry.rotationImpactSummary,
+        ...entry.safeRotationNotes,
+      ].join("\n");
+      expect(combinedCopy.toLowerCase()).not.toContain("secret value");
 
       for (const pattern of FORBIDDEN_SECRET_LIKE_PATTERNS) {
-        expect(entry.safeRotationNotes.join("\n")).not.toMatch(pattern);
+        expect(combinedCopy).not.toMatch(pattern);
       }
     }
   });

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -17,10 +17,13 @@ export interface SystemCredentialInventoryEntry {
 }
 
 export interface SystemCredentialHealthRow extends SystemCredentialInventoryEntry {
+  sourceLabel: string;
   ownerLabel: string;
   ownerConfidence: SystemCredentialOwnerConfidence;
   displayStatus: SystemCredentialDisplayStatus;
+  healthEvidenceLabel: string;
   lastCheckedAt: string | null;
+  rotationImpactSummary: string;
   safeRotationNotes: readonly string[];
 }
 
@@ -410,10 +413,13 @@ export function listSystemCredentialHealthRows(): readonly SystemCredentialHealt
 export function deriveSystemCredentialHealthRow(entry: SystemCredentialInventoryEntry): SystemCredentialHealthRow {
   return {
     ...entry,
+    sourceLabel: sourceLabelFor(entry),
     ownerLabel: ownerLabelFor(entry),
     ownerConfidence: "inferred",
     displayStatus: "metadata_only",
+    healthEvidenceLabel: healthEvidenceLabelFor(entry),
     lastCheckedAt: null,
+    rotationImpactSummary: rotationImpactSummaryFor(entry),
     safeRotationNotes: rotationNotesFor(entry),
   };
 }
@@ -440,9 +446,38 @@ function ownerLabelFor(entry: SystemCredentialInventoryEntry): string {
   }
 }
 
+function sourceLabelFor(entry: SystemCredentialInventoryEntry): string {
+  switch (entry.source) {
+    case "github_actions_secret":
+      return "GitHub Actions secret name";
+    case "vercel_env":
+      return "Vercel environment variable name";
+  }
+}
+
+function healthEvidenceLabelFor(entry: SystemCredentialInventoryEntry): string {
+  const workload = entry.workload.toLowerCase();
+  if (entry.name === "TESTPASS_TOKEN") return "Use latest TestPass PR check receipt.";
+  if (entry.name === "TESTPASS_CRON_SECRET") return "Use scheduled TestPass smoke receipt.";
+  if (entry.name === "UXPASS_TOKEN") return "Use UXPass dogfood capture receipt.";
+  if (entry.name === "FISHBOWL_WAKE_TOKEN") return "Use Wake Router dispatch proof.";
+  if (entry.name === "FISHBOWL_AUTOCLOSE_TOKEN") return "Use Fishbowl auto-close workflow result.";
+  if (entry.name === "OPENROUTER_API_KEY") return "Use static classifier dry-run proof.";
+  if (entry.name === "SUPABASE_SERVICE_ROLE_KEY") return "Use human-reviewed admin/server health proof.";
+  if (entry.name === "CRON_SECRET") return "Use scheduled route gate receipt.";
+  if (workload.includes("analytics")) return "Use analytics receipt evidence.";
+  if (workload.includes("payment")) return "Use approved payment webhook proof.";
+  if (workload.includes("email")) return "Use delivery metadata evidence.";
+  return "No live probe is claimed; use manual metadata review.";
+}
+
+function rotationImpactSummaryFor(entry: SystemCredentialInventoryEntry): string {
+  return entry.rotationImpact ?? `Changing this can affect ${entry.workload}.`;
+}
+
 function rotationNotesFor(entry: SystemCredentialInventoryEntry): readonly string[] {
   const notes = [
-    entry.rotationImpact ?? "Confirm the owner and dependent workflow before changing this credential.",
+    rotationImpactSummaryFor(entry),
     verificationNoteFor(entry),
   ];
 


### PR DESCRIPTION
## Summary
- adds explicit metadata-only answers for System Credential cards: source type, health evidence, and rotation impact
- updates Connections UI copy so each row clearly shows what it is, what uses it, who owns it, last checked state, health evidence, and rotation impact
- extends inventory tests to keep those card answers secret-free and honest

## Safety
- no raw credential values
- no token prefixes
- no provider calls or probes
- no auth, billing, DNS/domains, migrations, destructive cleanup, or dependency changes

## Tests
- npx vitest run src/pages/admin/systemCredentialInventory.test.ts
- npm run test:rotatepass-redaction
- npm run build