### PR TITLE
feat(rotatepass): clarify credential health summary

### DIFF
--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -751,6 +751,7 @@ export default function AdminKeychain() {
                           <p>Owner: {entry.ownerLabel} ({entry.ownerConfidence})</p>
                           <p>Last checked: {entry.lastCheckedAt ? timeAgo(entry.lastCheckedAt) : "manual check required"}</p>
                         </div>
+                        <p className="mt-1 text-[#777]">Health: {entry.healthSummary}</p>
                         <p className="mt-1 text-[#666]">{entry.docsHint}</p>
                         <div className="mt-1 space-y-0.5 text-[#888]">
                           {entry.safeRotationNotes.map((note) => (

--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -100,6 +100,7 @@ describe("system credential inventory", () => {
       ownerLabel: "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints",
       ownerConfidence: "inferred",
       displayStatus: "metadata_only",
+      healthSummary: "Expected credential. Metadata-only inventory, no live provider check has run.",
       lastCheckedAt: null,
     });
     expect(testpass?.safeRotationNotes).toEqual(expect.arrayContaining([
@@ -111,11 +112,17 @@ describe("system credential inventory", () => {
     for (const entry of listSystemCredentialHealthRows()) {
       expect(entry.displayStatus).toBe("metadata_only");
       expect(entry.lastCheckedAt).toBeNull();
+      expect(entry.healthSummary).toContain("Metadata-only inventory");
+      expect(entry.healthSummary).toContain("no live provider check has run");
       expect(entry.safeRotationNotes.length).toBeGreaterThan(0);
-      expect(entry.safeRotationNotes.join("\n").toLowerCase()).not.toContain("secret value");
+      const displayCopy = [
+        entry.healthSummary,
+        ...entry.safeRotationNotes,
+      ].join("\n");
+      expect(displayCopy.toLowerCase()).not.toContain("secret value");
 
       for (const pattern of FORBIDDEN_SECRET_LIKE_PATTERNS) {
-        expect(entry.safeRotationNotes.join("\n")).not.toMatch(pattern);
+        expect(displayCopy).not.toMatch(pattern);
       }
     }
   });

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -20,6 +20,7 @@ export interface SystemCredentialHealthRow extends SystemCredentialInventoryEntr
   ownerLabel: string;
   ownerConfidence: SystemCredentialOwnerConfidence;
   displayStatus: SystemCredentialDisplayStatus;
+  healthSummary: string;
   lastCheckedAt: string | null;
   safeRotationNotes: readonly string[];
 }
@@ -413,6 +414,7 @@ export function deriveSystemCredentialHealthRow(entry: SystemCredentialInventory
     ownerLabel: ownerLabelFor(entry),
     ownerConfidence: "inferred",
     displayStatus: "metadata_only",
+    healthSummary: healthSummaryFor(entry),
     lastCheckedAt: null,
     safeRotationNotes: rotationNotesFor(entry),
   };
@@ -451,6 +453,14 @@ function rotationNotesFor(entry: SystemCredentialInventoryEntry): readonly strin
   }
 
   return notes;
+}
+
+function healthSummaryFor(entry: SystemCredentialInventoryEntry): string {
+  if (entry.expected) {
+    return "Expected credential. Metadata-only inventory, no live provider check has run.";
+  }
+
+  return "Optional credential. Metadata-only inventory, no live provider check has run.";
 }
 
 function verificationNoteFor(entry: SystemCredentialInventoryEntry): string {


### PR DESCRIPTION
## Summary
- add a metadata-only health summary to System Credential inventory rows
- show the health summary in Connections so each row plainly says whether it is expected or optional
- extend inventory tests to keep the health copy secret-free and clear that no live provider check has run

## Safety
- no raw secrets
- no token prefixes
- no provider-side reads, writes, rotation, or mutation
- no auth, billing, DNS, migrations, or dependency changes

## Verification
- npx vitest run src/pages/admin/systemCredentialInventory.test.ts
- npm run build