### PR TITLE
docs(ops): clarify proof workflow credential precedence

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -7,7 +7,12 @@ What's automated, what secrets are required, and what to do when something goes 
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `ci.yml` | PRs + push to main | Lint + build the website, typecheck + build the MCP server |
-| `publish-mcp-server.yml` | Push to main touching `packages/mcp-server/**` | Bumps patch version, publishes `@unclick/mcp-server` to npm, tags the commit |
+| `testpass-pr-check.yml` | PRs | Runs the shared TestPass action against the MCP endpoint under test and posts a receipt summary |
+| `testpass-scheduled-smoke.yml` | Every 5 minutes + manual dispatch | Runs scheduled TestPass smoke with explicit token precedence and fail-closed infra reporting |
+| `dogfood-report.yml` | Nightly schedule + manual dispatch | Rebuilds `public/dogfood/latest.json` with honest passing / blocked / pending proof status |
+| `event-wake-router.yml` | `issue_comment` + workflow fan-in | Routes ready-work wake events without waking healthy quiet cycles |
+| `auto-close-fishbowl-todo.yml` | PR merge hooks | Closes linked Fishbowl todos when a merged PR satisfies them |
+| `publish-mcp-package.yml` | Push to main touching `packages/mcp-server/**` | Bumps patch version, publishes `@unclick/mcp-server` to npm, tags the commit |
 | `apply-migrations.yml` | Push to main touching `supabase/migrations/**` | Runs `supabase db push` against production |
 | `dependabot.yml` | Weekly schedule | Opens PRs for npm + GH Actions updates, grouped sensibly |
 
@@ -19,12 +24,48 @@ Set these at **Settings → Secrets and variables → Actions → Repository sec
 
 | Secret | Used by | Where to get it |
 |---|---|---|
-| `NPM_TOKEN` | `publish-mcp-server.yml` | npm → Account → Access Tokens → Create Automation token (Bypass 2FA) |
+| `TESTPASS_TOKEN` | `testpass-pr-check.yml`, `dogfood-report.yml` TestPass proof | Active TestPass bearer for `/api/testpass-run` |
+| `TESTPASS_CRON_SECRET` | `testpass-scheduled-smoke.yml` first-choice token | Optional dedicated scheduled-smoke bearer for `/api/testpass-run` |
+| `UXPASS_TOKEN` | `dogfood-report.yml` UXPass proof | Active UXPass bearer for `/api/uxpass-run` |
+| `CRON_SECRET` | `testpass-scheduled-smoke.yml` fallback, `dogfood-report.yml` UXPass fallback | Shared cron bearer when a dedicated pass token is not set |
+| `NPM_TOKEN` | `publish-mcp-package.yml` | npm → Account → Access Tokens → Create Automation token (Bypass 2FA) |
 | `SUPABASE_ACCESS_TOKEN` | `apply-migrations.yml` | https://supabase.com/dashboard/account/tokens |
 | `SUPABASE_PROJECT_REF` | `apply-migrations.yml` | The subdomain from `xxxxx.supabase.co` |
 | `SUPABASE_DB_PASSWORD` | `apply-migrations.yml` | Supabase dashboard → Settings → Database |
 
 `GITHUB_TOKEN` is provided automatically; no setup needed.
+
+## Pass-family credential precedence
+
+These proof workflows are intentionally explicit about which token they use.
+If a receipt says `blocked`, prefer fixing the missing secret path instead of
+papering over the status.
+
+### `testpass-scheduled-smoke.yml`
+
+Scheduled TestPass smoke uses this precedence:
+
+1. `TESTPASS_CRON_SECRET`
+2. `CRON_SECRET`
+3. `TESTPASS_TOKEN`
+
+This keeps the scheduled lane fail-closed while still allowing a shared cron
+bearer or the normal TestPass bearer as a fallback.
+
+### `dogfood-report.yml`
+
+Nightly dogfood splits the proof lanes on purpose:
+
+| Proof lane | Secret precedence | Notes |
+|---|---|---|
+| TestPass | `TESTPASS_TOKEN` | Exported into the script as `DOGFOOD_TESTPASS_TOKEN`; no cron fallback in the current workflow |
+| UXPass | `UXPASS_TOKEN`, then `CRON_SECRET` | Exported into the script as `DOGFOOD_UXPASS_TOKEN`; a blocked receipt is expected if neither secret exists |
+
+The public receipt at `public/dogfood/latest.json` should stay honest:
+
+- `passing` only when the live scheduled check actually completed.
+- `blocked` when the workflow cannot run because a secret path is missing.
+- `pending` for proof families that are intentionally scaffolded but not live yet.
 
 ## Runtime env vars
 
@@ -78,15 +119,21 @@ including `[skip ci]` in your message and running `npm publish` locally).
    - If the error is `npm ci` lockfile mismatch on a Dependabot PR (often `Missing: esbuild@... from lock file`), treat it as lockfile drift.
    - Resolve by rebasing the Dependabot branch onto latest `main` first. If still failing, run `npm install --no-audit --no-fund`, commit the lockfile refresh to the Dependabot branch, then rerun checks.
    - Do not patch around this by loosening CI from `npm ci` to `npm install`.
-2. **`publish-mcp-server.yml` 401/403** - `NPM_TOKEN` expired or wrong type.
+2. **`testpass-pr-check.yml` or `testpass-scheduled-smoke.yml` 401/403** - token precedence resolved to an expired or wrong bearer.
+   - Scheduled smoke checks `TESTPASS_CRON_SECRET`, then `CRON_SECRET`, then `TESTPASS_TOKEN`.
+   - Dogfood TestPass uses `TESTPASS_TOKEN`.
+   - Dogfood UXPass uses `UXPASS_TOKEN` first, then `CRON_SECRET`.
+   - If `public/dogfood/latest.json` flips to `blocked`, treat that as honest evidence and refresh the missing secret instead of forcing a green status.
+3. **`publish-mcp-package.yml` 401/403** - `NPM_TOKEN` expired or wrong type.
    Generate a new **Automation** token (not Classic) and update the secret.
-3. **`apply-migrations.yml` link failure** - the access token may have been
+4. **`apply-migrations.yml` link failure** - the access token may have been
    rotated. Regenerate at https://supabase.com/dashboard/account/tokens.
-4. **`apply-migrations.yml` migration error** - open the run logs. If it's a
+5. **`apply-migrations.yml` migration error** - open the run logs. If it's a
    destructive change we don't want automated, revert the migration commit
    and apply it manually via the SQL editor instead.
 
 ## Manual escape hatches
 
-All workflows (publish + migrations) accept `workflow_dispatch`, so you can
-re-run them from the Actions tab without needing a new commit.
+Most live workflows here, including publish, migrations, scheduled TestPass,
+and dogfood report, accept `workflow_dispatch`, so you can re-run them from
+the Actions tab without needing a new commit.


### PR DESCRIPTION
## Summary
- refresh .github/OPERATIONS.md against the live workflow set on main
- document TestPass scheduled-smoke token precedence and nightly dogfood proof token precedence
- make the public dogfood receipt status contract explicit so locked stays an honest state, not a fake green

## Safety
- docs only
- no runtime, auth, secrets, billing, DNS/domains, migrations, or dependency changes

## Why now
- live GitHub state has multiple proof workflows (	estpass-scheduled-smoke.yml, dogfood-report.yml, vent-wake-router.yml) that were not reflected in the ops guide
- workers are already hitting repeated confusion around which secret powers scheduled TestPass vs nightly UXPass dogfood

## Verification
- read live workflow files on origin/main and matched the documented precedence to workflow env wiring
- no code paths changed
