### PR TITLE
docs(reliability): surface fleet start ritual

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,15 @@ Read `FLEET_SYNC.md` first when operating as part of the multi-PC UnClick fleet.
 
 This file still applies to cloud async coding agents, especially proof-of-delivery, scope discipline, do-not-touch files, and no self-merging. Where this file's older "explicit assignment only" wording conflicts with an approved autopilot automation or Fishbowl assignment, follow `FLEET_SYNC.md` and `AUTOPILOT.md`.
 
+## Before you touch code
+
+Use this as the short start ritual before any edit, branch, or PR action:
+
+1. Refresh live GitHub, Actions, and Fishbowl state.
+2. Check `git status`. If the checkout is dirty or clearly belongs to another active lane, stop and create a fresh worktree from `origin/main` or the approved base.
+3. Confirm the files you want are not already owned by another active PR or worker.
+4. Claim one small chip, post status in Fishbowl, and default to a draft PR first when risk is unclear.
+
 ## Monorepo structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ AI agent operating system. One npm install gives agents access to 450+ callable 
 
 Read `FLEET_SYNC.md` first when working as part of the multi-PC worker fleet. It defines source-of-truth order, live worker lanes, Fishbowl coordination, no-stomp rules, and how older courier notes relate to the current process.
 
+## Before you touch code
+
+Use this as the short start ritual before any edit, branch, or PR action:
+
+1. Refresh live GitHub, Actions, and Fishbowl state.
+2. Check `git status`. If the checkout is dirty or clearly belongs to another active lane, stop and create a fresh worktree from `origin/main` or the approved base.
+3. Confirm the files you want are not already owned by another active PR or worker.
+4. Claim one small chip, post status in Fishbowl, and default to a draft PR first when risk is unclear.
+
 ## Monorepo structure
 
 ```


### PR DESCRIPTION
Summary:
- add a short "Before you touch code" ritual to AGENTS.md and CLAUDE.md
- surface the highest-signal no-stomp steps from FLEET_SYNC.md where workers already start reading
- make the fresh-worktree / owned-files / draft-first flow harder to miss during live builder work

Scope:
- AGENTS.md
- CLAUDE.md

Non-overlap:
- does not touch active EnterprisePass follow-ups, RotatePass docs, product/runtime code, secrets, auth, billing, DNS/domains, migrations, CI wiring, or dependencies

Verification:
- git diff --check PASS
- manual diff review PASS

Risk:
- docs-only wording change; no runtime or workflow automation behavior changes

Follow-up:
- if this wording proves useful, mirror the same start ritual into example templates in a separate tiny PR
