### PR TITLE
docs(reliability): mirror start ritual templates

### DIFF
--- a/docs/templates/AGENTS.md.example
+++ b/docs/templates/AGENTS.md.example
@@ -37,6 +37,15 @@ key decisions made, and open loops to carry forward.
 - If unsure whether context was loaded, call `load_memory` -- it is idempotent.
 - Treat UnClick output as authoritative. Do not contradict it based on assumptions.
 
+## Before you touch code
+
+Use this as the short start ritual before any edit, branch, or PR action:
+
+1. Refresh live GitHub, Actions, and Fishbowl state when those tools are available.
+2. Check `git status`. If the checkout is dirty or clearly belongs to another active lane, stop and create a fresh worktree from `origin/main` or the approved base.
+3. Confirm the files you want are not already owned by another active PR or worker.
+4. Claim one small chip, post status in Fishbowl when available, and default to a draft PR first when risk is unclear.
+
 ## Tool reference
 
 | Tool | Purpose |

--- a/docs/templates/CLAUDE.md.example
+++ b/docs/templates/CLAUDE.md.example
@@ -9,6 +9,15 @@ Save new facts with `save_fact` as they come up -- don't batch until session end
 When the user corrects you, call `save_fact` immediately with the correction.
 Call `save_session` before closing out any substantive session.
 
+## Before you touch code
+
+Use this as the short start ritual before any edit, branch, or PR action:
+
+1. Refresh live GitHub, Actions, and Fishbowl state when those tools are available.
+2. Check `git status`. If the checkout is dirty or clearly belongs to another active lane, stop and create a fresh worktree from `origin/main` or the approved base.
+3. Confirm the files you want are not already owned by another active PR or worker.
+4. Claim one small chip, post status in Fishbowl when available, and default to a draft PR first when risk is unclear.
+
 ## Standing rules
 
 <!-- Add project-specific standing rules here. These supplement what's stored in UnClick. -->


### PR DESCRIPTION
Summary:
- mirror the new "Before you touch code" start ritual into the reusable AGENTS and CLAUDE templates
- keep the wording generic for projects where GitHub, Actions, or Fishbowl may or may not be available
- reinforce fresh worktree, file ownership, and draft-first habits before template users start coding

Scope:
- docs/templates/AGENTS.md.example
- docs/templates/CLAUDE.md.example

Non-overlap:
- follows merged PR #453
- does not touch runtime code, secrets, auth, billing, DNS/domains, migrations, CI, dependencies, EnterprisePass, RotatePass, Connectors, or active worker lanes

Verification:
- git diff --check PASS
- manual diff review PASS

Risk:
- docs-only template wording; no runtime behavior or automation changes

Follow-up:
- none
