### PR TITLE
Harden stale lease evaluation for invalid now

### DIFF
--- a/packages/mcp-server/src/__tests__/reliability.test.ts
+++ b/packages/mcp-server/src/__tests__/reliability.test.ts
@@ -149,6 +149,18 @@ describe("reliability helpers", () => {
     ).toEqual({ isStale: false, reason: "missing_lease_expiry", staleSeconds: 0 });
   });
 
+  it("fails closed when stale lease check receives an invalid current time", () => {
+    expect(
+      decideStaleLease(
+        {
+          status: "leased",
+          leaseExpiresAt: "2026-04-30T11:00:00.000Z",
+        },
+        new Date("invalid"),
+      ),
+    ).toEqual({ isStale: false, reason: "lease_active", staleSeconds: 0 });
+  });
+
   it("creates compact heartbeat metadata", () => {
     const heartbeat = createHeartbeat({
       apiKeyHash: "hash_123",

--- a/packages/mcp-server/src/reliability.ts
+++ b/packages/mcp-server/src/reliability.ts
@@ -189,6 +189,9 @@ export function decideStaleLease(
   }
 
   const staleMs = now.getTime() - leaseExpiresAtMs;
+  if (!Number.isFinite(staleMs)) {
+    return { isStale: false, reason: "lease_active", staleSeconds: 0 };
+  }
   if (staleMs <= 0) {
     return { isStale: false, reason: "lease_active", staleSeconds: 0 };
   }


### PR DESCRIPTION
## Summary
- fail closed in decideStaleLease when 
ow.getTime() is non-finite
- prevent staleSeconds: NaN from entering reliability telemetry and reclaim payloads
- add regression test for invalid current-time inputs

## Verification
- 
px vitest run packages/mcp-server/src/__tests__/reliability.test.ts *(fails in this worktree: missing vitest/vite deps)*