### PR TITLE
test: expand RotatePass redaction guard coverage

### DIFF
--- a/scripts/rotatepass-redaction-guard.test.mjs
+++ b/scripts/rotatepass-redaction-guard.test.mjs
@@ -13,6 +13,8 @@ const scanPaths = [
   "docs/rotatepass-connector-metadata.md",
   "docs/rotatepass-local-phase0.md",
   "docs/connectors/phase-1-plan.md",
+  "docs/connectors/credential-action-routing.md",
+  "docs/connectors/setup-metadata-vocabulary.md",
   "docs/connectors/spec.md",
   "docs/connectors/system-credentials-health-panel.md",
   "docs/prd/backstagepass.md",
@@ -48,6 +50,14 @@ const blockedPatterns = [
   {
     name: "authorization-header",
     pattern: /\bAuthorization:\s*(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/gi,
+  },
+  {
+    name: "cookie-header",
+    pattern: /\bCookie:\s*[A-Za-z0-9._~+/%=-]{8,}\s*=\s*[A-Za-z0-9._~+/%=-]{8,}/gi,
+  },
+  {
+    name: "set-cookie-header",
+    pattern: /\bSet-Cookie:\s*[A-Za-z0-9._~+/%=-]{8,}\s*=\s*[A-Za-z0-9._~+/%=-]{8,}/gi,
   },
   {
     name: "provider-response-access-token",


### PR DESCRIPTION
## Summary\n- extend RotatePass redaction guard scan coverage to connector routing/vocabulary docs\n- add blocked patterns for Cookie and Set-Cookie headers\n- keep scope test-only with no provider writes or secrets handling changes\n\n## Verification\n- node --test scripts/rotatepass-redaction-guard.test.mjs\n\n## Non-overlap\n- avoids open PR #455 (stale lease evaluation)\n