### PR TITLE
docs(reliability): document MCP package test commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,23 @@ api/                            # Vercel serverless functions (REST API endpoint
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
 | `src/pages/Tools.tsx` | Website tools grid, one tile per integration |
 
+## Local proof commands
+
+When a PR touches `packages/mcp-server/**`, run package-local tests from that workspace or use the workspace script. The root Vitest config only includes `src/**` and `api/**`, so a root command such as `npx vitest run packages/mcp-server/src/__tests__/reliability.test.ts` can report "No test files found" instead of proving the MCP package.
+
+Use this shape for one MCP package test file:
+
+```bash
+cd packages/mcp-server
+npx vitest run src/__tests__/reliability.test.ts
+```
+
+Use this for full MCP package coverage:
+
+```bash
+npm run test --workspace=@unclick/mcp-server
+```
+
 ## Architecture
 
 `CLAUDE.md` is the canonical source of truth for repo architecture and the MCP tool surface. Keep this section aligned with that file instead of expanding separate copies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,23 @@ api/                            # Vercel serverless functions (REST API endpoint
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
 | `src/pages/Tools.tsx` | Website tools grid, one tile per integration |
 
+## Local proof commands
+
+When a PR touches `packages/mcp-server/**`, run package-local tests from that workspace or use the workspace script. The root Vitest config only includes `src/**` and `api/**`, so a root command such as `npx vitest run packages/mcp-server/src/__tests__/reliability.test.ts` can report "No test files found" instead of proving the MCP package.
+
+Use this shape for one MCP package test file:
+
+```bash
+cd packages/mcp-server
+npx vitest run src/__tests__/reliability.test.ts
+```
+
+Use this for full MCP package coverage:
+
+```bash
+npm run test --workspace=@unclick/mcp-server
+```
+
 ## Architecture
 
 This is the canonical tool-surface summary for this repo.


### PR DESCRIPTION
## Summary
- Adds a short local proof command note to `AGENTS.md` and `CLAUDE.md`.
- Documents that root Vitest does not discover `packages/mcp-server/**` tests.
- Gives the package-local reliability test command and the full MCP package workspace test command.

## Scope
- `AGENTS.md`
- `CLAUDE.md`
- Lane: reliability proof hygiene / worker process docs

## Non-overlap
- Does not touch runtime code, tests, secrets, auth, billing, DNS/domains, migrations, CI, dependencies, Connectors, RotatePass, or EnterprisePass surfaces.
- Does not overlap draft #457, which owns `docs/fleet-worker-roles.md`.

## Verification
- `git diff --check HEAD~1 HEAD` PASS.
- Manual diff review PASS.
- Documented package-local command was verified in a detached review worktree: `cd packages/mcp-server && npx vitest run src/__tests__/reliability.test.ts` PASS 23/23.

## Risk
- Low. Docs-only process clarification.

## Follow-up
- None.

Owned files: `AGENTS.md`, `CLAUDE.md`.
Status: draft PR, not merge-ready until CI/checks finish.