### PR TITLE
docs(fleet): link worker role map from boot docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ AI agent operating system. One npm install gives agents access to 450+ callable 
 
 Read `FLEET_SYNC.md` first when operating as part of the multi-PC UnClick fleet. It defines source-of-truth order, live worker lanes, Fishbowl coordination, and no-stomp rules.
 
+If you are unsure which worker should own a handoff, review `docs/fleet-worker-roles.md` for the current emoji role map and routing guide.
+
 This file still applies to cloud async coding agents, especially proof-of-delivery, scope discipline, do-not-touch files, and no self-merging. Where this file's older "explicit assignment only" wording conflicts with an approved autopilot automation or Fishbowl assignment, follow `FLEET_SYNC.md` and `AUTOPILOT.md`.
 
 ## Before you touch code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ AI agent operating system. One npm install gives agents access to 450+ callable 
 
 Read `FLEET_SYNC.md` first when working as part of the multi-PC worker fleet. It defines source-of-truth order, live worker lanes, Fishbowl coordination, no-stomp rules, and how older courier notes relate to the current process.
 
+If you are unsure which worker should own a handoff, review `docs/fleet-worker-roles.md` for the current emoji role map and routing guide.
+
 ## Before you touch code
 
 Use this as the short start ritual before any edit, branch, or PR action:


### PR DESCRIPTION
## Summary
- Adds a pointer from AGENTS.md and CLAUDE.md to docs/fleet-worker-roles.md.
- Makes the current emoji worker role map easier for new worker chats to find before routing handoffs.

## Scope
- AGENTS.md
- CLAUDE.md

## Non-overlap
- Docs-only.
- No runtime behavior, secrets, auth, billing, DNS/domains, migrations, workflows, Fishbowl code, or automation changes.

## Verification
- git diff --check

## Risk
Low. Boot-doc discoverability only.