### PR TITLE
docs(fishbowl): clarify parked todo hygiene

### DIFF
--- a/docs/fishbowl-board-priority-system.md
+++ b/docs/fishbowl-board-priority-system.md
@@ -94,6 +94,15 @@ Examples:
 
 PARKED items should not wake workers. They are memory anchors, not active work.
 
+If the current board view has no lane filter, do not rely on a `PARKED:` or `FUTURE:` title prefix alone. An open card can still appear in actionable queues.
+
+Use this rule:
+
+- Keep a PARKED item open only when it has a real next action and should remain visible to workers soon.
+- If the next action is intentionally "not now", leave an evidence comment and move the todo to `dropped`.
+- Treat `dropped` as "parked for history", not "deleted".
+- Create a fresh open todo when the parked lane becomes active again.
+
 ### BLOCKED
 
 Use BLOCKED when work cannot move without a specific external input.
@@ -119,7 +128,7 @@ When a worker handles a stale todo:
 2. Decide lane: NOW, NEXT, LATER, PARKED, or BLOCKED.
 3. Add a short evidence comment.
 4. Close only if done.
-5. Drop only if obsolete or superseded.
+5. Drop if obsolete, superseded, or intentionally parked with no current next action.
 6. Do not bulk delete.
 
 Good comment format:


### PR DESCRIPTION
## Summary
- Clarifies Fishbowl PARKED/FUTURE todo hygiene in the board priority guide.
- Documents that title prefixes alone do not keep open cards out of actionable queues.
- Defines when to keep a parked item open versus move it to `dropped` with evidence.

## Scope
- `docs/fishbowl-board-priority-system.md`
- Lane: Fishbowl status discipline / backlog noise reduction

## Non-overlap
- Does not mutate any Fishbowl todos.
- Does not touch runtime code, tests, secrets, auth, billing, DNS/domains, migrations, CI, dependencies, Connectors, RotatePass, EnterprisePass, or browser-extension work.
- Does not overlap #460 (`AGENTS.md`, `CLAUDE.md`) or #461 (`.github/OPERATIONS.md`).

## Verification
- `git diff --check HEAD~1 HEAD` PASS.
- Manual diff review PASS.
- No em dash/en dash added in the edited file.

## Risk
- Low. Docs-only process clarification.

## Follow-up
- A worker may later add evidence comments and drop individual PARKED/FUTURE open todos one at a time. This PR intentionally does not change board state.

Owned files: `docs/fishbowl-board-priority-system.md`.
Status: draft PR, not merge-ready until CI/checks finish.