### PR TITLE
fix(fishbowl): label duplicate profiles in settings

### DIFF
--- a/src/pages/admin/fishbowl/Settings.tsx
+++ b/src/pages/admin/fishbowl/Settings.tsx
@@ -10,6 +10,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Settings as SettingsIcon } from "lucide-react";
+import { findDuplicateProfileAgentIds } from "./clusterProfiles";
 
 /* -- types -- */
 interface FishbowlProfile {
@@ -111,6 +112,10 @@ export default function FishbowlSettings({
   const agentProfiles = useMemo(
     () => profiles.filter((p) => !p.agent_id.startsWith("human-")),
     [profiles],
+  );
+  const duplicateAgentIds = useMemo(
+    () => findDuplicateProfileAgentIds(agentProfiles),
+    [agentProfiles],
   );
 
   return (
@@ -254,6 +259,7 @@ export default function FishbowlSettings({
               <div className="flex flex-wrap gap-2">
                 {agentProfiles.map((p) => {
                   const muted = prefs.mutedAgentIds.includes(p.agent_id);
+                  const duplicate = duplicateAgentIds.has(p.agent_id);
                   return (
                     <button
                       key={p.agent_id}
@@ -269,6 +275,14 @@ export default function FishbowlSettings({
                       <span className="max-w-[100px] truncate">
                         {p.display_name ?? p.agent_id}
                       </span>
+                      {duplicate && (
+                        <span
+                          className="rounded bg-white/[0.05] px-1 py-0.5 font-mono text-[9px] text-[#888]"
+                          title={p.agent_id}
+                        >
+                          {p.agent_id.slice(0, 6)}
+                        </span>
+                      )}
                     </button>
                   );
                 })}

--- a/src/pages/admin/fishbowl/clusterProfiles.test.ts
+++ b/src/pages/admin/fishbowl/clusterProfiles.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   clusterProfiles,
   clusterKey,
+  findDuplicateProfileAgentIds,
   CLUSTER_FRESH_THRESHOLD_MS,
   type FishbowlProfileForCluster,
 } from "./clusterProfiles";
@@ -99,5 +100,26 @@ describe("clusterProfiles", () => {
     expect(clusters[0].primaries).toHaveLength(1);
     expect(clusters[0].primaries[0].agent_id).toBe("fresh-1");
     expect(clusters[0].staleAliasCount).toBe(1);
+  });
+
+  it("finds duplicate profile ids by emoji and display name", () => {
+    const duplicates = findDuplicateProfileAgentIds([
+      profile("fresh-1", "🐠", "Fishy", 60_000),
+      profile("old-1", "🐠", "Fishy", CLUSTER_FRESH_THRESHOLD_MS + 60_000),
+      profile("different-emoji", "🦊", "Fishy", 60_000),
+      profile("different-name", "🐠", "Other", 60_000),
+    ]);
+
+    expect([...duplicates].sort()).toEqual(["fresh-1", "old-1"]);
+  });
+
+  it("treats null display names as their own duplicate group", () => {
+    const duplicates = findDuplicateProfileAgentIds([
+      { agent_id: "null-name-1", emoji: "🐠", display_name: null, last_seen_at: null },
+      { agent_id: "null-name-2", emoji: "🐠", display_name: null, last_seen_at: null },
+      { agent_id: "named", emoji: "🐠", display_name: "Fishy", last_seen_at: null },
+    ]);
+
+    expect([...duplicates].sort()).toEqual(["null-name-1", "null-name-2"]);
   });
 });

--- a/src/pages/admin/fishbowl/clusterProfiles.ts
+++ b/src/pages/admin/fishbowl/clusterProfiles.ts
@@ -63,3 +63,27 @@ export function clusterProfiles<P extends FishbowlProfileForCluster>(
   }
   return result;
 }
+
+export function findDuplicateProfileAgentIds<P extends FishbowlProfileForCluster>(
+  profiles: P[],
+): Set<string> {
+  const buckets = new Map<string, P[]>();
+  for (const profile of profiles) {
+    const key = clusterKey(profile.emoji, profile.display_name);
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.push(profile);
+    } else {
+      buckets.set(key, [profile]);
+    }
+  }
+
+  const duplicateAgentIds = new Set<string>();
+  for (const bucket of buckets.values()) {
+    if (bucket.length <= 1) continue;
+    for (const profile of bucket) {
+      duplicateAgentIds.add(profile.agent_id);
+    }
+  }
+  return duplicateAgentIds;
+}


### PR DESCRIPTION
Summary:
- Adds visible stable-id chips to Fishbowl Settings mute controls when multiple profiles share the same emoji and display name.
- Reuses the existing Fishbowl profile collision grouping contract with a small tested helper for duplicate agent ids.

Scope:
- Fishbowl admin UI only.
- Owned files: src/pages/admin/fishbowl/Settings.tsx, src/pages/admin/fishbowl/clusterProfiles.ts, src/pages/admin/fishbowl/clusterProfiles.test.ts.
- Linked Fishbowl todo: b828c26e-2fdb-4157-a658-0103df84869d.

Non-overlap:
- Does not touch Fishbowl APIs, MCP server code, signals, WakePass, RotatePass, credentials, auth, billing, DNS, migrations, dependencies, or provider calls.
- Does not change roster/Now Playing behavior already landed in #188.

Verification:
- npx vitest run src/pages/admin/fishbowl/clusterProfiles.test.ts
- npx eslint src/pages/admin/fishbowl/Settings.tsx src/pages/admin/fishbowl/clusterProfiles.ts src/pages/admin/fishbowl/clusterProfiles.test.ts
- npm run build
- git diff --check HEAD~1..HEAD

Risk:
- Low UI-only render change. No secret, auth, migration, cron, API, or data-write risk.

Follow-up:
- If this lands cleanly, the remaining duplicate-profile todo can be reviewed for close after visual QC.