### PR TITLE
test(wake): guard trimmed digit-only ACK cap parsing

### DIFF
--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -559,6 +559,48 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("parses trimmed digit-only ACK fail seconds before applying the 10-minute cap", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        action: "completed",
+        workflow_run: {
+          id: 4621,
+          name: "TestPass Scheduled Smoke",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/acme/repo/actions/runs/4621",
+          created_at: "2026-04-30T17:20:00Z",
+          updated_at: "2026-04-30T17:25:00Z",
+          pull_requests: [],
+        },
+      }),
+    );
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+          WAKE_ACK_FAIL_SECONDS: " 601 ",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /"ack_fail_after_seconds": 600/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("floors ACK fail seconds to avoid immediate no-ACK false failures", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- add a narrow regression test for `WAKE_ACK_FAIL_SECONDS` parsing
- verify trimmed digit-only input (`" 601 "`) is treated as numeric and capped to 600 seconds

## Scope
- test-only change in wake router coverage
- no runtime logic changes

## Non-overlap
- isolated to `scripts/event-wake-router.test.mjs`
- does not touch secrets, auth, billing, migrations, or provider writes

## Verification
- `node --test scripts/event-wake-router.test.mjs`
- result: 26 passed, 0 failed

## Risk
- low, additive test only

## Follow-up
- if desired, mirror this contract check in any future parser extraction module