### PR TITLE
fix(rotatepass): mark system credential inventory as untested by default

### DIFF
--- a/src/__tests__/system-credential-inventory-status.test.ts
+++ b/src/__tests__/system-credential-inventory-status.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveSystemCredentialHealthRow,
+  listSystemCredentialInventory,
+} from "@/pages/admin/systemCredentialInventory";
+
+describe("System credential inventory status defaults", () => {
+  it("marks inventory rows as untested when no safe probe evidence exists", () => {
+    const row = deriveSystemCredentialHealthRow(listSystemCredentialInventory()[0]);
+    expect(row.displayStatus).toBe("untested");
+    expect(row.lastCheckedAt).toBeNull();
+  });
+});
+

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -271,8 +271,8 @@ const INVENTORY_STATUS_BADGES: Record<SystemCredentialDisplayStatus, {
   label: string;
   className: string;
 }> = {
-  metadata_only: {
-    label: "Metadata only",
+  untested: {
+    label: "Untested",
     className: "border-sky-500/20 bg-sky-500/10 text-sky-300",
   },
   manual_check_required: {

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -2,7 +2,7 @@ export type SystemCredentialProvider = "github" | "vercel";
 export type SystemCredentialSource = "github_actions_secret" | "vercel_env";
 export type SystemCredentialRisk = "critical" | "high" | "normal";
 export type SystemCredentialOwnerConfidence = "known" | "inferred" | "unknown";
-export type SystemCredentialDisplayStatus = "metadata_only" | "manual_check_required";
+export type SystemCredentialDisplayStatus = "untested" | "manual_check_required";
 
 export interface SystemCredentialInventoryEntry {
   provider: SystemCredentialProvider;
@@ -416,7 +416,7 @@ export function deriveSystemCredentialHealthRow(entry: SystemCredentialInventory
     sourceLabel: sourceLabelFor(entry),
     ownerLabel: ownerLabelFor(entry),
     ownerConfidence: "inferred",
-    displayStatus: "metadata_only",
+    displayStatus: "untested",
     healthEvidenceLabel: healthEvidenceLabelFor(entry),
     lastCheckedAt: null,
     rotationImpactSummary: rotationImpactSummaryFor(entry),


### PR DESCRIPTION
Status copy only: defaults system credential inventory rows to untested and adds a guard test. Presence alone no longer reads as health.