### PR TITLE
Hardening: fail closed when wake handoff message id is missing

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -403,6 +403,10 @@ export function buildReliabilityDispatchHandoffSyncRequest({
   });
 }
 
+export function shouldFailMissingHandoffMessageId(result) {
+  return Boolean(result?.posted) && !result?.message_id && !result?.dry_run;
+}
+
 async function registerWakeDispatch({ eventId, decision, triage, result, event }) {
   const dispatchRequest = buildReliabilityDispatchRequest({
     eventId,
@@ -680,6 +684,24 @@ async function main() {
     return;
   }
   const result = await postWake(finalDecision, triage, eventId, event);
+  if (shouldFailMissingHandoffMessageId(result)) {
+    const reliabilityWithError = {
+      ...(reliability || {}),
+      error: compactText("Fishbowl wake post succeeded but returned no message_id for ACK handoff sync.", 500),
+    };
+    console.error("Fishbowl wake post succeeded but returned no message_id. Failing closed.");
+    writeLedger({
+      eventId,
+      event,
+      decision: finalDecision,
+      triage,
+      result,
+      reliability: reliabilityWithError,
+      status: "wake_failed",
+    });
+    process.exitCode = 1;
+    return;
+  }
   const handoffSync = await syncWakeDispatchHandoffMessage({
     eventId,
     decision: finalDecision,

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -11,6 +11,7 @@ import {
   buildReliabilityDispatchRequest,
   deriveAckThresholds,
   normalizeDispatchOwner,
+  shouldFailMissingHandoffMessageId,
   wakeDispatchId,
 } from "./event-wake-router.mjs";
 
@@ -447,6 +448,13 @@ describe("event wake router reliability dispatch", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("fails closed when Fishbowl post succeeds without a message id", () => {
+    assert.equal(shouldFailMissingHandoffMessageId({ posted: true, message_id: null, dry_run: false }), true);
+    assert.equal(shouldFailMissingHandoffMessageId({ posted: true, message_id: "msg-1", dry_run: false }), false);
+    assert.equal(shouldFailMissingHandoffMessageId({ posted: true, message_id: null, dry_run: true }), false);
+    assert.equal(shouldFailMissingHandoffMessageId({ posted: false, message_id: null, dry_run: false }), false);
   });
 
   it("fails closed when the GitHub event payload is invalid JSON", () => {


### PR DESCRIPTION
## Summary
- fail closed when Fishbowl wake post succeeds without returning `message.id`
- add explicit helper `shouldFailMissingHandoffMessageId` used by main wake flow
- add focused regression tests for missing message id behavior

## Verification
- node --test scripts/event-wake-router.test.mjs