### PR TITLE
test(dogfood): clarify receipt status legend

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -6,6 +6,13 @@
   "headline": "We dogfood UnClick on UnClick.",
   "target": "UnClick public and agent-facing product surfaces",
   "nextAutomation": "Nightly dogfood receipts refresh this board with live scheduled evidence.",
+  "statusLegend": {
+    "passing": "A live check ran and returned a passing result.",
+    "failing": "A live check ran and returned a failing result or could not reach its API.",
+    "blocked": "The check could not run because an action is needed, such as a missing credential or scope gate.",
+    "pending": "The check is planned or scaffolded, but live proof is not available yet."
+  },
+  "proofPolicy": "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.",
   "results": [
     {
       "id": "testpass",

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -16,6 +16,16 @@ const publicUrl = process.env.DOGFOOD_PUBLIC_URL || "https://unclick.world";
 const mcpUrl = process.env.DOGFOOD_MCP_URL || "https://unclick.world/api/mcp";
 const generatedAt = new Date().toISOString();
 
+const statusLegend = {
+  passing: "A live check ran and returned a passing result.",
+  failing: "A live check ran and returned a failing result or could not reach its API.",
+  blocked: "The check could not run because an action is needed, such as a missing credential or scope gate.",
+  pending: "The check is planned or scaffolded, but live proof is not available yet.",
+};
+
+const proofPolicy =
+  "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.";
+
 function trimTrailingSlash(value) {
   return value.replace(/\/+$/, "");
 }
@@ -297,6 +307,8 @@ const report = {
   headline: "We dogfood UnClick on UnClick.",
   target: "UnClick public and agent-facing product surfaces",
   nextAutomation: "Nightly dogfood receipts refresh this board with live scheduled evidence.",
+  statusLegend,
+  proofPolicy,
   results,
   trend: buildTrend(results),
   lastActionableFailure: buildLastActionableFailure(results),

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -33,6 +33,9 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
       targetUrl: "/enterprise/latest.json",
     });
     assert.equal(report.status, "blocked");
+    assert.match(report.statusLegend.blocked, /action is needed/i);
+    assert.match(report.statusLegend.pending, /live proof is not available yet/i);
+    assert.match(report.proofPolicy, /passing only when a live check actually ran/i);
     assert.match(report.lastActionableFailure.detail, /Blocked reason:/);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
@@ -98,6 +101,9 @@ test("dogfood receipt includes structured proof for live TestPass and UXPass run
     const uxpass = report.results.find((result) => result.id === "uxpass");
     const testpassRequest = requests.find((request) => request.url === "/api/testpass-run");
     const uxpassRequest = requests.find((request) => request.url === "/api/uxpass-run");
+
+    assert.match(report.statusLegend.passing, /live check ran/i);
+    assert.match(report.proofPolicy, /Blocked and pending are honest product states/i);
 
     assert.equal(testpassRequest.body.source, "scheduled");
     assert.equal(testpass.runId, "testpass-run-123");


### PR DESCRIPTION
## Summary
- adds a public dogfood receipt status legend for passing/failing/blocked/pending
- adds a proof policy that says passing only means a live check actually ran
- updates the latest public receipt fixture and focused receipt-builder tests

## Owned files
- scripts/build-dogfood-report.mjs
- scripts/build-dogfood-report.test.mjs
- public/dogfood/latest.json

## Non-overlap
- Does not touch #469 RotatePass docs or recent Wake/RotatePass implementation files.
- No secrets, auth, billing, DNS, migrations, provider calls, or raw credential handling.

## Verification
- node --test scripts/build-dogfood-report.test.mjs
- git diff --check
- diff secret-pattern scan clean for common token prefixes