### PR TITLE
docs(fleet): require proof command results

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -144,7 +144,9 @@ Proof and reliability PRs should not merge on green CI alone. Before marking
 one ready, make the missing proof explicit:
 
 1. Confirm the diff only touches the expected files.
-2. Run the narrow local test command for the package or script under review.
+2. Run the narrow local test command for the package or script under review,
+   then record the exact command and PASS/FAIL result in the PR body before
+   lifting it from draft.
 3. If the local command cannot run, explain why and point to the equivalent CI
    job that covered the same code path.
 4. Check that public receipts stay honest: `passing` means a live check ran,

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,10 @@ None
 N/A - not a restore/reorg PR
 
 ## Testing
-<!-- How was this verified? Include commands run, screenshots, or links to CI. -->
+<!-- Required before marking ready: include exact command(s) run and PASS/FAIL result.
+     If relying on CI instead of local or equivalent verification, name the exact
+     job and why it covers the changed path.
+     If verification is incomplete, keep the PR draft/HOLD and list the missing proof. -->
 -
 
 ## UnClick Memory linkage


### PR DESCRIPTION
## Summary
- Tightens the PR template Testing guidance so ready PRs include exact command(s) plus PASS/FAIL result.
- Updates the proof PR review checklist to record the narrow local command and result before lifting a draft.

## Scope
- Fleet/process docs only: .github/PULL_REQUEST_TEMPLATE.md and .github/OPERATIONS.md.
- Owned by Gatekeeper as a release-safety/proof hygiene chip.

## Non-overlap
- Does not touch runtime code, tests, secrets, env vars, auth, billing, DNS/domains, migrations, RLS, CSP, analytics implementation, RotatePass behavior, or provider writes.
- No overlap with #469/#470 active docs files.

## Verification
- git diff --check PASS.
- node scripts/no-emdash-docs.test.mjs PASS (1/1).

## Risk
- Low. Docs/process wording only; draft until the active PR queue is safe.

## Follow-up
- Owners should keep explicit command + result in PR bodies before draft lift.