### PR TITLE
Wake router ledger: include handoff sync telemetry

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -546,7 +546,7 @@ async function syncWakeDispatchHandoffMessage({ eventId, decision, triage, resul
   };
 }
 
-function writeLedger({ eventId, event, decision, triage, result, reliability, status }) {
+function writeLedger({ eventId, event, decision, triage, result, reliability, handoffSync, status }) {
   const eventSeconds = secondsSince(decision.eventCreatedAt);
   const ackThresholds = deriveAckThresholds(ackFailSeconds);
   const ledger = {
@@ -582,6 +582,15 @@ function writeLedger({ eventId, event, decision, triage, result, reliability, st
       status: reliability?.status || null,
       dispatch_id: reliability?.dispatch_id || null,
       error: reliability?.error || null,
+      handoff_sync: {
+        attempted: Boolean(handoffSync?.attempted),
+        synced: Boolean(handoffSync?.synced),
+        dry_run: Boolean(handoffSync?.dry_run),
+        skipped: Boolean(handoffSync?.skipped),
+        status: handoffSync?.status || null,
+        reason: handoffSync?.reason || null,
+        error: handoffSync?.error || null,
+      },
     },
     ack: {
       requested: status === "wake_posted" || status === "wake_dry_run",
@@ -635,6 +644,7 @@ async function main() {
       triage: { used: false, error: fallbackDecision.reason, decision: fallbackDecision },
       result: null,
       reliability: null,
+      handoffSync: null,
       status: "wake_failed",
     });
     process.exitCode = 1;
@@ -657,6 +667,7 @@ async function main() {
       triage,
       result: null,
       reliability: null,
+      handoffSync: null,
       status: "no_wake",
     });
     return;
@@ -678,6 +689,7 @@ async function main() {
       triage,
       result: null,
       reliability,
+      handoffSync: null,
       status: "wake_failed",
     });
     process.exitCode = 1;
@@ -697,6 +709,7 @@ async function main() {
       triage,
       result,
       reliability: reliabilityWithError,
+      handoffSync: null,
       status: "wake_failed",
     });
     process.exitCode = 1;
@@ -710,7 +723,7 @@ async function main() {
     event,
   });
   const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
-  writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, status });
+  writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, handoffSync, status });
   if (
     (!result.posted && !result.dry_run) ||
     (!reliability?.registered && !reliability?.dry_run) ||

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
@@ -40,6 +40,35 @@ describe("event wake router reliability dispatch", () => {
 
     rmSync(tempDir, { recursive: true, force: true });
     return result;
+  }
+
+  function runDryWakeWithLedger(eventName, event) {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(eventPath, JSON.stringify(event));
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_EVENT_NAME: eventName,
+        GITHUB_EVENT_PATH: eventPath,
+        WAKE_LEDGER_DIR: ledgerDir,
+        WAKE_ROUTER_DRY_RUN: "true",
+      },
+      encoding: "utf8",
+    });
+
+    const eventIdMatch = result.stdout.match(/"eventId":\s*"([^"]+)"/);
+    const eventId = eventIdMatch?.[1] || null;
+    const ledger =
+      eventId && result.status === 0
+        ? JSON.parse(readFileSync(join(ledgerDir, `${eventId}.json`), "utf8"))
+        : null;
+
+    rmSync(tempDir, { recursive: true, force: true });
+    return { result, ledger };
   }
 
   it("creates stable dispatch IDs from wake event IDs", () => {
@@ -222,6 +251,30 @@ describe("event wake router reliability dispatch", () => {
     assert.match(result.stdout, /"wake_urgency": "urgent"/);
     assert.match(result.stdout, /reliability_dispatch_dry_run/);
     assert.match(result.stdout, /"ack_required": true/);
+  });
+
+  it("records handoff sync skip telemetry in dry-run wake ledger", () => {
+    const { result, ledger } = runDryWakeWithLedger("workflow_run", {
+      action: "completed",
+      workflow_run: {
+        id: 4561,
+        name: "TestPass Scheduled Smoke",
+        status: "completed",
+        conclusion: "failure",
+        html_url: "https://github.com/acme/repo/actions/runs/4561",
+        created_at: "2026-04-30T15:00:00Z",
+        updated_at: "2026-04-30T15:04:00Z",
+        pull_requests: [],
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(ledger);
+    assert.equal(ledger.reliability_dispatch.handoff_sync.attempted, false);
+    assert.equal(ledger.reliability_dispatch.handoff_sync.synced, false);
+    assert.equal(ledger.reliability_dispatch.handoff_sync.dry_run, false);
+    assert.equal(ledger.reliability_dispatch.handoff_sync.skipped, true);
+    assert.equal(ledger.reliability_dispatch.handoff_sync.reason, "missing_message_id");
   });
 
   it("keeps successful scheduled TestPass smoke runs silent", () => {


### PR DESCRIPTION
## Summary\n- add eliability_dispatch.handoff_sync telemetry to wake ledger output\n- persist attempted/synced/dry_run/skipped/status/reason/error for ACK handoff sync visibility\n- add regression test that validates dry-run ledger records missing_message_id handoff-sync skip\n\n## Verification\n- node --test scripts/event-wake-router.test.mjs