### PR TITLE
RotatePass docs redaction guard for cookie/provider wording

### DIFF
--- a/src/__tests__/rotatepass-doc-redaction.test.ts
+++ b/src/__tests__/rotatepass-doc-redaction.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 const SCANNED_FILES = [
   "docs/rotatepass-connector-metadata.md",
   "docs/connectors/system-credentials-health-panel.md",
+  "docs/connectors/credential-action-routing.md",
+  "docs/connectors/setup-metadata-vocabulary.md",
   "docs/rotatepass-local-phase0.md",
 ] as const;
 
@@ -14,6 +16,9 @@ const SECRET_PATTERNS = [
   { name: "GitHub token", pattern: /\b(?:gh[pous]|ghs|pat)_[A-Za-z0-9_]{16,}\b/g },
   { name: "Stripe webhook secret", pattern: /\bwhsec_[A-Za-z0-9_]{16,}\b/g },
   { name: "Authorization bearer example", pattern: /\bAuthorization:\s*Bearer\s+[A-Za-z0-9._~+/=-]{16,}\b/g },
+  { name: "Cookie header", pattern: /\bCookie:\s*[^\r\n;]{8,}/gi },
+  { name: "Set-Cookie header", pattern: /\bSet-Cookie:\s*[^\r\n;]{8,}/gi },
+  { name: "Provider response body wording", pattern: /\b(?:provider|api)\s+response\s+body\b/gi },
 ];
 
 function withoutAllowedPrefixReferenceLines(content: string): string {


### PR DESCRIPTION
## Summary\n- extend RotatePass public-doc redaction scan to include connector routing/setup docs\n- block cookie/set-cookie header examples in scanned docs\n- block provider response-body wording in scanned docs\n\n## Scope\nTiny guardrail-only test update for Connectors/RotatePass lane.\n\n## Verification\n- npx vitest run src/__tests__/rotatepass-doc-redaction.test.ts *(fails in this worktree: vitest package missing)*\n- npx vitest run src/__tests__/rotatepass-metadata-fixture-redaction.test.ts *(fails in this worktree: vitest package missing)*