### PR TITLE
test(fishbowl): normalize direct handoff recipient matching

### DIFF
--- a/api/fishbowl-message-handoff.test.ts
+++ b/api/fishbowl-message-handoff.test.ts
@@ -136,6 +136,22 @@ describe("planFishbowlMessageHandoffs", () => {
     ).toEqual([]);
   });
 
+  it("matches recipient by normalized agent id and emoji", () => {
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        recipients: [" AGENT_BUILDER "],
+      }),
+    ).toHaveLength(1);
+
+    expect(
+      planFishbowlMessageHandoffs({
+        ...baseInput,
+        recipients: [" b "],
+      }),
+    ).toHaveLength(1);
+  });
+
   it("normalizes author id when suppressing self-handoffs", () => {
     expect(
       planFishbowlMessageHandoffs({

--- a/api/lib/fishbowl-message-handoff.ts
+++ b/api/lib/fishbowl-message-handoff.ts
@@ -88,19 +88,22 @@ export function planFishbowlMessageHandoffs(
   const plannedTargets = new Set<string>();
 
   for (const recipient of recipients) {
+    const normalizedRecipient = normalizeToken(recipient);
     const matches = input.recipientProfiles.filter(
       (profile) =>
         !isHumanProfile(profile) &&
-        (profile.agentId === recipient || profile.emoji === recipient),
+        (normalizeToken(profile.agentId) === normalizedRecipient ||
+          normalizeToken(profile.emoji ?? "") === normalizedRecipient),
     );
     if (matches.length !== 1) continue;
 
     const targetAgentId = matches[0].agentId;
+    const normalizedTargetAgentId = normalizeToken(targetAgentId);
     if (
-      normalizeToken(targetAgentId) === normalizedAuthorAgentId ||
-      plannedTargets.has(targetAgentId)
+      normalizedTargetAgentId === normalizedAuthorAgentId ||
+      plannedTargets.has(normalizedTargetAgentId)
     ) continue;
-    plannedTargets.add(targetAgentId);
+    plannedTargets.add(normalizedTargetAgentId);
 
     plans.push({
       source: "fishbowl",


### PR DESCRIPTION
## Summary
- normalize Fishbowl direct-message handoff recipient matching so agent IDs and emoji are matched case-insensitively with whitespace trimming
- preserve existing 600-second ACK lease behavior and no-broadcast/no-human/no-self handoff guardrails
- add focused regression tests for normalized recipient routing

## Scope
- `api/lib/fishbowl-message-handoff.ts`
- `api/fishbowl-message-handoff.test.ts`

## Non-overlap
- tiny reliability guard only, no schema/auth/secrets/billing/migrations/provider writes
- no changes to wake lease values, dispatch shape, or watcher policy

## Verification
- attempted: `npx vitest run api/fishbowl-message-handoff.test.ts`
- result: blocked in this worktree (`vitest` package not installed, `ERR_MODULE_NOT_FOUND`)

## Risk
- low: matching logic now normalizes comparison tokens; behavior remains unchanged for already-normalized recipients
- targeted tests cover both normalized agent-id and emoji recipient forms

## Follow-up
- run the same test command in a provisioned environment with dev dependencies installed
- if green, lift from draft and merge as a standalone hygiene slice