### PR TITLE
feat(dogfood): show proof policy legend

### DIFF
--- a/src/__tests__/dogfood-report-proof-policy.test.ts
+++ b/src/__tests__/dogfood-report-proof-policy.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { dogfoodReport } from "@/data/dogfoodReport";
+
+describe("Dogfood report proof policy", () => {
+  it("keeps public status wording honest in the fallback receipt", () => {
+    expect(dogfoodReport.statusLegend.passing).toMatch(/live check ran/i);
+    expect(dogfoodReport.statusLegend.blocked).toMatch(/action is needed/i);
+    expect(dogfoodReport.statusLegend.pending).toMatch(/live proof is not available yet/i);
+    expect(dogfoodReport.proofPolicy).toMatch(/passing only when a live check actually ran/i);
+  });
+});

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -25,6 +25,8 @@ export interface DogfoodTrendPoint {
   pending: number;
 }
 
+export type DogfoodStatusLegend = Record<DogfoodStatus, string>;
+
 export const dogfoodReport = {
   generatedAt: "2026-05-01T17:16:13.158Z",
   lastRunAt: "2026-05-01T17:16:13.158Z",
@@ -33,6 +35,13 @@ export const dogfoodReport = {
   headline: "We dogfood UnClick on UnClick.",
   target: "UnClick public and agent-facing product surfaces",
   nextAutomation: "Nightly dogfood receipts refresh this board with live scheduled evidence.",
+  statusLegend: {
+    passing: "A live check ran and returned a passing result.",
+    failing: "A live check ran and returned a failing result or could not reach its API.",
+    blocked: "The check could not run because an action is needed, such as a missing credential or scope gate.",
+    pending: "The check is planned or scaffolded, but live proof is not available yet.",
+  } satisfies DogfoodStatusLegend,
+  proofPolicy: "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.",
   results: [
     {
       id: "testpass",

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -9,12 +9,15 @@ import {
   dogfoodReport as fallbackReport,
   type DogfoodPassResult,
   type DogfoodStatus,
+  type DogfoodStatusLegend,
   type DogfoodTrendPoint,
 } from "@/data/dogfoodReport";
 
 type DogfoodReportData = Omit<typeof fallbackReport, "results" | "trend"> & {
   results: DogfoodPassResult[];
   trend: DogfoodTrendPoint[];
+  statusLegend: DogfoodStatusLegend;
+  proofPolicy: string;
 };
 
 const STATUS_STYLES: Record<DogfoodStatus, { label: string; badge: string; icon: typeof CheckCircle2 }> = {
@@ -142,6 +145,35 @@ export default function DogfoodReportPage() {
               </div>
             </FadeIn>
           ))}
+        </section>
+
+        <section className="mx-auto mt-10 max-w-5xl">
+          <FadeIn delay={0.1}>
+            <div className="rounded-2xl border border-border/70 bg-card/40 p-5">
+              <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">
+                Proof policy
+              </p>
+              <p className="mt-3 text-sm leading-relaxed text-body">{report.proofPolicy}</p>
+              <div className="mt-4 grid gap-3 md:grid-cols-2">
+                {(Object.keys(report.statusLegend) as DogfoodStatus[]).map((statusKey) => {
+                  const status = STATUS_STYLES[statusKey];
+                  const Icon = status.icon;
+
+                  return (
+                    <div key={statusKey} className="rounded-xl border border-border/50 bg-background/40 p-3">
+                      <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium ${status.badge}`}>
+                        <Icon className="h-3.5 w-3.5" />
+                        {status.label}
+                      </span>
+                      <p className="mt-2 text-xs leading-relaxed text-muted-custom">
+                        {report.statusLegend[statusKey]}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </FadeIn>
         </section>
 
         <section className="mx-auto mt-10 max-w-5xl">


### PR DESCRIPTION
## Summary
- Displays the public Dogfood proof policy and status legend on `/dogfood`.
- Adds the same proof-policy fields to the static fallback receipt so the page stays honest if `/dogfood/latest.json` cannot load.
- Adds a focused fallback receipt test for passing/blocked/pending wording.

## Scope
- `src/pages/DogfoodReport.tsx`
- `src/data/dogfoodReport.ts`
- `src/__tests__/dogfood-report-proof-policy.test.ts`

## Non-overlap
- Dogfood public proof UI/data only.
- No secrets, env values, auth, billing, DNS/domains, migrations, provider writes, analytics rebuild, raw credential handling, or compliance claims.

## Verification
- `npx vitest run src/__tests__/dogfood-report-proof-policy.test.ts` PASS.
- `npx eslint src/pages/DogfoodReport.tsx src/data/dogfoodReport.ts src/__tests__/dogfood-report-proof-policy.test.ts` PASS.
- `npm run build` PASS.
- `git diff --check` PASS.
- Secret-pattern sweep over the diff returned no matches.

## Risk
Low. Public Dogfood report copy/rendering only, with fallback data covered by a focused test.