### PR TITLE
feat(admin): add analytics health checklist

### DIFF
--- a/src/pages/admin/AdminAnalytics.tsx
+++ b/src/pages/admin/AdminAnalytics.tsx
@@ -62,6 +62,25 @@ const DASHBOARDS = [
 
 const POSTHOG_APP = "https://us.posthog.com/project/391352/dashboards";
 
+const HEALTH_CHECKS = [
+  {
+    label: "Key present",
+    detail: "Vercel build includes a PostHog key, but the value is never shown here.",
+  },
+  {
+    label: "Host expected",
+    detail: "Browser network traffic should target the configured PostHog ingest host.",
+  },
+  {
+    label: "Pageview receipt",
+    detail: "A recent public route visit should emit one $pageview event.",
+  },
+  {
+    label: "Dashboard filters",
+    detail: "PostHog date, path, and project filters should match the surface being tested.",
+  },
+] as const;
+
 // ── Component ─────────────────────────────────────────────────────
 
 export default function AdminAnalytics() {
@@ -150,6 +169,29 @@ export default function AdminAnalytics() {
           </p>
         </div>
       )}
+
+      <div className="mb-6 rounded-xl border border-[#61C1C4]/20 bg-[#61C1C4]/5 p-4">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm font-medium text-[#61C1C4]">Analytics health is untested by default</p>
+            <p className="mt-1 max-w-2xl text-xs text-[#888]">
+              Treat analytics as healthy only after a fresh browser or receipt check proves capture.
+              Key presence and dashboard embeds are setup hints, not proof.
+            </p>
+          </div>
+          <span className="mt-2 rounded-full border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-2.5 py-1 text-[11px] font-medium text-[#E2B93B] sm:mt-0">
+            Untested until receipt
+          </span>
+        </div>
+        <div className="mt-4 grid gap-2 sm:grid-cols-2">
+          {HEALTH_CHECKS.map((check) => (
+            <div key={check.label} className="rounded-lg border border-white/[0.06] bg-black/20 p-3">
+              <p className="text-xs font-medium text-[#ddd]">{check.label}</p>
+              <p className="mt-1 text-[11px] leading-5 text-[#777]">{check.detail}</p>
+            </div>
+          ))}
+        </div>
+      </div>
 
       {/* Dashboard tabs */}
       <div className="mb-4 flex gap-1 overflow-x-auto rounded-xl border border-white/[0.06] bg-[#111111] p-1">


### PR DESCRIPTION
## Summary
- adds a read-only analytics health checklist to `/admin/analytics`
- makes analytics status explicit: untested until a fresh browser or receipt check proves capture
- keeps dashboard embeds and key presence as setup hints, not proof of health

## Owned files
- src/pages/admin/AdminAnalytics.tsx

## Non-overlap
- Does not touch Dogfood, WakePass, RotatePass inventory, System Credentials, auth, billing, DNS, migrations, provider settings, or analytics runtime capture.
- No secret values, env values, token prefixes, provider calls, or storage changes.

## Verification
- `git diff --check` PASS
- Diff secret-pattern scan PASS for common token prefixes and Authorization literals
- `npm run build` BLOCKED locally because `vite` is not installed in this worktree (`'vite' is not recognized as an internal or external command`)
- Equivalent CI proof needed before lift: `Website (root package)`