### PR TITLE
docs(fleet): clarify Vercel proof hold

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -156,3 +156,6 @@ one ready, make the missing proof explicit:
    secrets, token prefixes, auth headers, cookies, or provider response bodies.
 6. Leave the PR draft or HOLD if any proof is incomplete, even when the visible
    checks are green.
+7. Treat a pending Vercel context as incomplete proof. Wait for `Vercel` to
+   report `success`, or comment the exact Vercel blocker before any lift or
+   merge recommendation.


### PR DESCRIPTION
## Summary
- Clarifies that a pending `Vercel` context is incomplete proof, even when GitHub checks are green.
- Tells reviewers to wait for `Vercel` success or comment the exact blocker before lift or merge recommendations.

## Scope
- Owned files: `.github/OPERATIONS.md`
- Lane: fleet proof / release-safety process docs
- Linked work: no Fishbowl todo claimed; follows repeated Vercel-pending hold friction seen around #471-#476.

## Non-overlap
- Docs-only.
- No runtime behavior, tests, workflows, secrets, env values, auth, billing, DNS/domains, migrations, RLS, CSP, provider settings, or analytics rebuild.
- Avoids the analytics checklist lane currently claimed by 🦾.

## Verification
- `git diff --check` PASS.
- `node scripts/no-emdash-docs.test.mjs` PASS (1/1).

## Risk
- Low. Process wording only.

## Follow-up
- None unless reviewers want this wording mirrored somewhere besides operations docs.