### PR TITLE
Harden wake router dry-run flag parsing

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -12,7 +12,14 @@ const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
 const runId = process.env.GITHUB_RUN_ID || "";
 const apiUrl = process.env.UNCLICK_API_URL || "https://unclick.world/api/memory-admin";
 const unclickApiKey = process.env.FISHBOWL_WAKE_TOKEN || process.env.FISHBOWL_AUTOCLOSE_TOKEN || "";
-const dryRun = process.env.WAKE_ROUTER_DRY_RUN === "1" || process.env.WAKE_ROUTER_DRY_RUN === "true";
+function parseBooleanFlag(value) {
+  const raw = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+const dryRun = parseBooleanFlag(process.env.WAKE_ROUTER_DRY_RUN);
 const ackFailSeconds = parseBoundedSeconds(process.env.WAKE_ACK_FAIL_SECONDS, 600, 60, 600);
 const receivedAt = new Date().toISOString();
 const ledgerDir = process.env.WAKE_LEDGER_DIR || ".wake-ledger";

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -662,6 +662,52 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("treats case-insensitive trimmed dry-run flags as dry-run mode", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        action: "completed",
+        workflow_run: {
+          id: 4622,
+          name: "TestPass Scheduled Smoke",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://github.com/acme/repo/actions/runs/4622",
+          created_at: "2026-04-30T17:20:00Z",
+          updated_at: "2026-04-30T17:25:00Z",
+          pull_requests: [],
+        },
+      }),
+    );
+
+    try {
+      const env = { ...process.env };
+      delete env.FISHBOWL_WAKE_TOKEN;
+      delete env.FISHBOWL_AUTOCLOSE_TOKEN;
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: " TRUE ",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /reliability_dispatch_dry_run/);
+      assert.match(result.stdout, /"missing_key": true/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("floors ACK fail seconds to avoid immediate no-ACK false failures", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- normalize WAKE_ROUTER_DRY_RUN parsing to accept trimmed/case-insensitive true values
- prevent accidental live wake posting when CI/env uses values like TRUE
- add regression test covering missing-token dry-run behavior

## Scope
- files changed: scripts/event-wake-router.mjs, scripts/event-wake-router.test.mjs
- limited to dry-run flag parsing and test coverage for wake router behavior

## Non-overlap
- no changes to secrets, auth, billing, migrations, provider writes, or broad UI flows
- isolated to event wake router script logic and unit tests

## Verification
- node --test scripts/event-wake-router.test.mjs (pass)
- PR checks green: MCP server package, Website, TestPass smoke run, Vercel

## Risk
- low, because behavior only broadens accepted true-values for an existing env flag
- regression test added for missing-token dry-run path

## Follow-up
- ready for reviewer confirmation and merge if no policy concerns