### PR TITLE
test: expand RotatePass doc redaction for JSON token fields

### DIFF
--- a/src/__tests__/rotatepass-doc-redaction.test.ts
+++ b/src/__tests__/rotatepass-doc-redaction.test.ts
@@ -19,6 +19,11 @@ const SECRET_PATTERNS = [
   { name: "Cookie header", pattern: /\bCookie:\s*[^\r\n;]{8,}/gi },
   { name: "Set-Cookie header", pattern: /\bSet-Cookie:\s*[^\r\n;]{8,}/gi },
   { name: "Provider response body wording", pattern: /\b(?:provider|api)\s+response\s+body\b/gi },
+  {
+    name: "JSON secret-like field value",
+    pattern:
+      /"(?:access_token|refresh_token|api_key|token|secret|password)"\s*:\s*"(?!<redacted>|REDACTED|\*{3,})[A-Za-z0-9._~+/=-]{10,}"/gi,
+  },
 ];
 
 function withoutAllowedPrefixReferenceLines(content: string): string {
@@ -27,6 +32,8 @@ function withoutAllowedPrefixReferenceLines(content: string): string {
     .filter((line) => !line.includes("common secret prefixes"))
     .filter((line) => !line.includes("approved redacted example"))
     .filter((line) => !line.includes("such as `sk-`"))
+    .filter((line) => !line.includes('"<redacted>"'))
+    .filter((line) => !line.includes('"REDACTED"'))
     .join("\n");
 }
 


### PR DESCRIPTION
## Summary
- extend RotatePass doc redaction guard with a JSON secret-like field detector
- allow explicit redacted placeholders only (<redacted>, REDACTED, or asterisks)
- keep scope to one non-overlapping test-only slice in the Connectors/RotatePass lane

## Non-overlap
- open PR #481 is wake-router flag parsing; this PR touches only RotatePass redaction tests

## Testing
- npx vitest run src/__tests__/rotatepass-doc-redaction.test.ts *(fails in this worktree: vitest dependencies missing)*