### PR TITLE
Harden channel plugin env-int parsing

### DIFF
--- a/packages/channel-plugin/config.js
+++ b/packages/channel-plugin/config.js
@@ -1,0 +1,9 @@
+export function parseEnvInt(value, fallback, { min = Number.NEGATIVE_INFINITY, max = Number.POSITIVE_INFINITY } = {}) {
+  const raw = String(value ?? "").trim();
+  if (!/^\d+$/.test(raw)) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < min) return fallback;
+  if (parsed > max) return max;
+  return parsed;
+}

--- a/packages/channel-plugin/config.test.js
+++ b/packages/channel-plugin/config.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseEnvInt } from "./config.js";
+
+test("parseEnvInt returns fallback for malformed values", () => {
+  assert.equal(parseEnvInt("10s", 5000), 5000);
+  assert.equal(parseEnvInt("", 5000), 5000);
+  assert.equal(parseEnvInt(undefined, 5000), 5000);
+});
+
+test("parseEnvInt enforces minimum", () => {
+  assert.equal(parseEnvInt("0", 10000, { min: 1 }), 10000);
+  assert.equal(parseEnvInt("1", 10000, { min: 1 }), 1);
+});
+
+test("parseEnvInt caps maximum", () => {
+  assert.equal(parseEnvInt("99999", 5000, { max: 30000 }), 30000);
+});

--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -34,14 +34,15 @@ import process from "node:process";
 import readline from "node:readline";
 import { apiFetchJson } from "./http.js";
 import { createHeartbeatGate } from "./heartbeat-gate.js";
+import { parseEnvInt } from "./config.js";
 
 const API_BASE       = process.env.UNCLICK_API_BASE     || "https://unclick.world";
 const API_KEY        = process.env.UNCLICK_API_KEY      || "";
 const SUPABASE_URL   = process.env.UNCLICK_SUPABASE_URL || "";
 const SUPABASE_ANON  = process.env.UNCLICK_SUPABASE_ANON || "";
-const POLL_INTERVAL  = parseInt(process.env.UNCLICK_CHANNEL_POLL || "5000", 10);
+const POLL_INTERVAL  = parseEnvInt(process.env.UNCLICK_CHANNEL_POLL, 5000, { min: 250, max: 60_000 });
 const HEARTBEAT_MS   = 30_000;
-const API_TIMEOUT_MS = parseInt(process.env.UNCLICK_API_TIMEOUT_MS || "10000", 10);
+const API_TIMEOUT_MS = parseEnvInt(process.env.UNCLICK_API_TIMEOUT_MS, 10_000, { min: 1000, max: 120_000 });
 const RESPONSE_TIMEOUT_MS = 5 * 60_000;
 const heartbeatGate = createHeartbeatGate();
 


### PR DESCRIPTION
## Summary
- add a shared parseEnvInt helper for channel-plugin env numeric settings
- harden UNCLICK_CHANNEL_POLL and UNCLICK_API_TIMEOUT_MS parsing with safe bounds
- add focused unit tests for malformed, minimum, and capped values

## Verification
- node --test packages/channel-plugin/*.test.js