### PR TITLE
RotatePass: mark Vercel env owner confidence as unknown

### DIFF
--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -60,7 +60,7 @@ describe("system credential inventory", () => {
     });
     expect(byName.get("SUPABASE_SERVICE_ROLE_KEY")).toMatchObject({
       ownerLabel: "Vercel project environment",
-      ownerConfidence: "inferred",
+      ownerConfidence: "unknown",
     });
   });
 

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -415,7 +415,7 @@ export function deriveSystemCredentialHealthRow(entry: SystemCredentialInventory
     ...entry,
     sourceLabel: sourceLabelFor(entry),
     ownerLabel: ownerLabelFor(entry),
-    ownerConfidence: "inferred",
+    ownerConfidence: ownerConfidenceFor(entry),
     displayStatus: "untested",
     healthEvidenceLabel: healthEvidenceLabelFor(entry),
     lastCheckedAt: null,
@@ -443,6 +443,15 @@ function ownerLabelFor(entry: SystemCredentialInventoryEntry): string {
       return "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints";
     case "vercel_env":
       return "Vercel project environment";
+  }
+}
+
+function ownerConfidenceFor(entry: SystemCredentialInventoryEntry): SystemCredentialOwnerConfidence {
+  switch (entry.source) {
+    case "github_actions_secret":
+      return "inferred";
+    case "vercel_env":
+      return "unknown";
   }
 }
 


### PR DESCRIPTION
## Summary
- derive system credential owner confidence by source instead of hardcoding inferred
- keep GitHub Actions rows as inferred metadata ownership
- mark Vercel env rows as unknown owner confidence when only env-name metadata is present
- update inventory tests to enforce this safety wording

## Scope
- tiny RotatePass Connections admin status wording chip
- no secret handling changes, no provider writes, no rotation behavior changes

## Verification
- 
px vitest run src/pages/admin/systemCredentialInventory.test.ts src/__tests__/system-credential-inventory-status.test.ts *(fails locally: missing vitest dependencies in this worktree)*

## Autonomy tier
- ship without ask (docs/safety wording alignment, low-risk and reversible)
