### PR TITLE
Harden channel timing env parsing

### DIFF
--- a/packages/channel-plugin/config.js
+++ b/packages/channel-plugin/config.js
@@ -1,0 +1,14 @@
+export function parseEnvInt(rawValue, { fallback, min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const raw = String(rawValue ?? "").trim();
+  if (!/^\d+$/.test(raw)) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(parsed, max));
+}
+
+export function readTimingConfig(env = process.env) {
+  return {
+    pollIntervalMs: parseEnvInt(env.UNCLICK_CHANNEL_POLL, { fallback: 5_000, min: 250, max: 60_000 }),
+    apiTimeoutMs: parseEnvInt(env.UNCLICK_API_TIMEOUT_MS, { fallback: 10_000, min: 1_000, max: 120_000 }),
+  };
+}

--- a/packages/channel-plugin/config.test.js
+++ b/packages/channel-plugin/config.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseEnvInt, readTimingConfig } from "./config.js";
+
+test("parseEnvInt falls back for malformed and bounded values", () => {
+  assert.equal(parseEnvInt("abc", { fallback: 42, min: 1, max: 100 }), 42);
+  assert.equal(parseEnvInt("0", { fallback: 42, min: 1, max: 100 }), 1);
+  assert.equal(parseEnvInt("999", { fallback: 42, min: 1, max: 100 }), 100);
+  assert.equal(parseEnvInt(" 25 ", { fallback: 42, min: 1, max: 100 }), 25);
+});
+
+test("readTimingConfig applies safe defaults and clamps", () => {
+  const fromMalformed = readTimingConfig({
+    UNCLICK_CHANNEL_POLL: "NaN",
+    UNCLICK_API_TIMEOUT_MS: "5s",
+  });
+  assert.equal(fromMalformed.pollIntervalMs, 5000);
+  assert.equal(fromMalformed.apiTimeoutMs, 10000);
+
+  const fromLowValues = readTimingConfig({
+    UNCLICK_CHANNEL_POLL: "1",
+    UNCLICK_API_TIMEOUT_MS: "10",
+  });
+  assert.equal(fromLowValues.pollIntervalMs, 250);
+  assert.equal(fromLowValues.apiTimeoutMs, 1000);
+
+  const fromHighValues = readTimingConfig({
+    UNCLICK_CHANNEL_POLL: "999999",
+    UNCLICK_API_TIMEOUT_MS: "999999",
+  });
+  assert.equal(fromHighValues.pollIntervalMs, 60000);
+  assert.equal(fromHighValues.apiTimeoutMs, 120000);
+});

--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -34,15 +34,17 @@ import process from "node:process";
 import readline from "node:readline";
 import { apiFetchJson } from "./http.js";
 import { createHeartbeatGate } from "./heartbeat-gate.js";
+import { readTimingConfig } from "./config.js";
 
 const API_BASE       = process.env.UNCLICK_API_BASE     || "https://unclick.world";
 const API_KEY        = process.env.UNCLICK_API_KEY      || "";
 const SUPABASE_URL   = process.env.UNCLICK_SUPABASE_URL || "";
 const SUPABASE_ANON  = process.env.UNCLICK_SUPABASE_ANON || "";
-const POLL_INTERVAL  = parseInt(process.env.UNCLICK_CHANNEL_POLL || "5000", 10);
 const HEARTBEAT_MS   = 30_000;
-const API_TIMEOUT_MS = parseInt(process.env.UNCLICK_API_TIMEOUT_MS || "10000", 10);
 const RESPONSE_TIMEOUT_MS = 5 * 60_000;
+const timingConfig = readTimingConfig();
+const POLL_INTERVAL = timingConfig.pollIntervalMs;
+const API_TIMEOUT_MS = timingConfig.apiTimeoutMs;
 const heartbeatGate = createHeartbeatGate();
 
 function log(...args) {


### PR DESCRIPTION
## Summary
- add bounded env-int parsing for channel poll interval and API timeout
- centralize timing config in a new config helper
- add regression tests for malformed, low, and high timing env values

## Verification
- node --test packages/channel-plugin/*.test.js