### PR TITLE
Harden wake router all-owner normalization

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -108,7 +108,10 @@ export function wakeDispatchId(eventId) {
 }
 
 export function normalizeDispatchOwner(owner) {
-  return owner === "all" ? "🤖" : owner;
+  const normalized = String(owner ?? "")
+    .trim()
+    .toLowerCase();
+  return normalized === "all" ? "🤖" : owner;
 }
 
 function baseDecision(event) {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -184,6 +184,10 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(request.payload.wake_owner, "all");
   });
 
+  it("normalizes trimmed case-variant all owner to concrete ACK owner", () => {
+    assert.equal(normalizeDispatchOwner(" ALL "), "🤖");
+  });
+
   it("keeps successful PR workflow green echoes silent", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- harden wake dispatch owner normalization to treat trimmed, case-variant ll as fanout
- preserve existing behavior for concrete emoji owners
- add focused regression coverage in wake-router tests

## Verification
- node --test scripts/event-wake-router.test.mjs

## Lane
- UnClick reliability hardening automation slice (Event Wake Router, no-ACK handoff robustness)