### PR TITLE
RotatePass: mark no-probe connector status as untested

### DIFF
--- a/src/pages/admin/tools/ConnectedServices.test.ts
+++ b/src/pages/admin/tools/ConnectedServices.test.ts
@@ -8,7 +8,7 @@ function fakeFormatLastTested(value: string | null): string {
 describe("deriveConnectorStatus", () => {
   const now = Date.parse("2026-05-02T00:00:00.000Z");
 
-  it("uses metadata-only wording when a connector has no server test support", () => {
+  it("marks connectors without server test support as untested", () => {
     const status = deriveConnectorStatus({
       test_endpoint: null,
       credential: {
@@ -17,9 +17,23 @@ describe("deriveConnectorStatus", () => {
       },
     }, fakeFormatLastTested, now);
 
-    expect(status.pill).toBe("Metadata only");
-    expect(status.note.toLowerCase()).toContain("metadata");
+    expect(status.pill).toBe("Untested");
+    expect(status.note.toLowerCase()).toContain("untested");
+    expect(status.note.toLowerCase()).toContain("metadata activity");
     expect(status.note.toLowerCase()).toContain("no server-gated probe");
+  });
+
+  it("keeps untested wording when test support is missing and no test has run", () => {
+    const status = deriveConnectorStatus({
+      test_endpoint: null,
+      credential: {
+        is_valid: true,
+        last_tested_at: null,
+      },
+    }, fakeFormatLastTested, now);
+
+    expect(status.pill).toBe("Untested");
+    expect(status.note.toLowerCase()).toContain("remains untested");
   });
 
   it("keeps setup incomplete when test support exists but no test has run", () => {

--- a/src/pages/admin/tools/ConnectedServices.tsx
+++ b/src/pages/admin/tools/ConnectedServices.tsx
@@ -56,10 +56,10 @@ export function deriveConnectorStatus(
     return {
       dot: "bg-sky-400",
       pillClass: "bg-sky-400/10 text-sky-200",
-      pill: "Setup incomplete",
+      pill: hasTest ? "Setup incomplete" : "Untested",
       note: hasTest
         ? "Saved, but not validated with a connection test yet."
-        : "Saved. Probe support is not available for this connector, so status is metadata-only.",
+        : "Saved. No server-gated probe is available for this connector, so this remains untested.",
     };
   }
 
@@ -67,8 +67,8 @@ export function deriveConnectorStatus(
     return {
       dot: "bg-sky-400",
       pillClass: "bg-sky-400/10 text-sky-200",
-      pill: "Metadata only",
-      note: `Credential metadata is present. Last checked: ${formatLastTested(credential.last_tested_at)}. No server-gated probe is available for this connector.`,
+      pill: "Untested",
+      note: `No server-gated probe is available for this connector, so it remains untested. Last metadata activity: ${formatLastTested(credential.last_tested_at)}.`,
     };
   }
 


### PR DESCRIPTION
## Summary\n- mark connectors with no server-gated test endpoint as Untested instead of metadata-implied health states\n- clarify note copy that last checked is metadata activity only, not credential health proof\n- add focused tests for no-probe + no-test scenarios\n\n## Scope\n- Tiny RotatePass/connectors wording + tests only\n- No secret handling, no provider writes, no rotations\n\n## Verification\n- 
px vitest run src/pages/admin/tools/ConnectedServices.test.ts *(fails in this environment: vitest package unavailable / unresolved imports)*