### PR TITLE
docs(fleet): add AFK autopilot queue guardrails

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -159,3 +159,23 @@ one ready, make the missing proof explicit:
 7. Treat a pending Vercel context as incomplete proof. Wait for `Vercel` to
    report `success`, or comment the exact Vercel blocker before any lift or
    merge recommendation.
+
+## AFK autopilot queue rules
+
+The overnight heartbeat may keep throughput moving while Chris is away, but it
+should stay conservative. Use this queue policy before taking action:
+
+1. Refresh GitHub, Actions, and Fishbowl before acting. Do not rely on stale
+   queue memory or an older Fishbowl summary.
+2. Leave draft PRs untouched unless the owner explicitly asks for review or
+   lift. Green draft checks are not merge permission.
+3. Merge only small, clean, non-draft PRs after verifying the touched files,
+   visible checks, and the narrow local test or equivalent CI proof.
+4. Hold anything involving secrets, auth, billing, DNS, migrations, raw key
+   display, destructive cleanup, or broad analytics rewrites for Chris.
+5. If no PR is safely mergeable, prefer one tiny docs, test, proof, or wording
+   chip with a non-overlapping file set.
+6. Post a Fishbowl update for material actions only: merged PR, opened PR,
+   exact blocker, stale active owner handoff, or verified cleanup.
+7. Keep quiet on healthy no-op cycles. Repeated "nothing changed" posts are
+   noise, not automation.


### PR DESCRIPTION
## Summary
- add AFK autopilot queue rules to the operations runbook
- clarify that green draft PRs are not merge permission
- document quiet healthy cycles, safe merge checks, and Chris-only hold categories

## Scope
- .github/OPERATIONS.md only
- docs-only fleet/process guardrail

## Non-overlap
- no #485/#486/#488 files touched
- no RotatePass implementation, channel plugin code, secrets, auth, billing, DNS, migrations, analytics rebuild, or runtime behavior

## Verification
- git diff --check
- node scripts/no-emdash-docs.test.mjs

## Risk
- low: docs-only

## Status
- draft until GitHub checks are green