### PR TITLE
test(wakepass): add Fishbowl action-needed pack guard

### DIFF
--- a/packages/testpass/packs/testpass-fishbowl-v0.yaml
+++ b/packages/testpass/packs/testpass-fishbowl-v0.yaml
@@ -215,3 +215,26 @@ items:
       NULL into mc_fishbowl_profiles.next_checkin_at, not skip the update.
     tags: [fishbowl, dead-mans-switch, regression-check]
     profiles: [standard, deep]
+
+  - id: FB-013
+    title: action-needed handoffs require direct owner ACK dispatch
+    category: fishbowl-wakepass
+    severity: high
+    check_type: agent
+    description: |
+      Fishbowl handoffs that are actually action-needed must dispatch WakePass
+      with proof, a direct worker owner, ACK required, and a 10 minute lease.
+      Quiet health checks, successful receipts, dashboard reads, no-op
+      heartbeats, broad all broadcasts, and normal chatter must stay silent.
+    expected:
+      action_tags: [needs-doing, blocker, tripwire]
+      recipient_scope: direct worker only
+      ack_required: true
+      lease_seconds: 600
+      quiet_paths: [health-check, success-receipt, dashboard-read, no-op-heartbeat, all-broadcast]
+    on_fail: |
+      Recheck the Fishbowl handoff and wake routing path. Action-needed
+      messages should be reclaimable when unacked, while quiet/no-op paths
+      should not create WakePass noise.
+    tags: [fishbowl, wakepass, pinballwake, action-needed, ack-required, regression-check]
+    profiles: [standard, deep]

--- a/packages/testpass/src/__tests__/pack-loader.test.ts
+++ b/packages/testpass/src/__tests__/pack-loader.test.ts
@@ -4,6 +4,7 @@ import { loadPackFromFile, loadPackFromYaml, packToJsonb, packFromJsonb, packToY
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CORE_PACK_PATH = path.resolve(__dirname, "../../packs/testpass-core.yaml");
+const FISHBOWL_PACK_PATH = path.resolve(__dirname, "../../packs/testpass-fishbowl-v0.yaml");
 
 describe("loadPackFromFile", () => {
   it("loads and validates testpass-core.yaml without errors", () => {
@@ -11,6 +12,21 @@ describe("loadPackFromFile", () => {
     expect(pack.id).toBe("testpass-core");
     expect(pack.version).toMatch(/^\d+\.\d+\.\d+$/);
     expect(pack.items.length).toBeGreaterThanOrEqual(26);
+  });
+
+  it("loads the Fishbowl WakePass action-needed guard", () => {
+    const pack = loadPackFromFile(FISHBOWL_PACK_PATH);
+    const guard = pack.items.find((item) => item.id === "FB-013");
+
+    expect(pack.id).toBe("testpass-fishbowl-v0");
+    expect(guard?.title).toBe("action-needed handoffs require direct owner ACK dispatch");
+    expect(guard?.expected).toMatchObject({
+      action_tags: ["needs-doing", "blocker", "tripwire"],
+      recipient_scope: "direct worker only",
+      ack_required: true,
+      lease_seconds: 600,
+    });
+    expect(guard?.tags).toEqual(expect.arrayContaining(["wakepass", "action-needed", "ack-required"]));
   });
 
   it("throws when file does not exist", () => {


### PR DESCRIPTION
## Summary
- add a Fishbowl TestPass pack guard for WakePass action-needed handoffs
- document the expected direct-owner ACK dispatch contract with a 10 minute lease
- add a pack-loader assertion so the guard stays present and schema-valid

## Scope
- Owned files: packages/testpass/packs/testpass-fishbowl-v0.yaml, packages/testpass/src/__tests__/pack-loader.test.ts
- Product lane: WakePass / PinballWake proof via TestPass pack metadata

## Non-overlap
- Does not touch wake-router runtime behavior, Fishbowl handlers, secrets, auth, billing, DNS, migrations, provider settings, or analytics.
- Does not overlap active draft PRs #485, #486, or #488.

## Verification
- git diff --check: PASS
- node -e YAML guard assertion for FB-013: PASS
- npm ci --no-audit --no-fund --workspace=packages/testpass --include-workspace-root=false: PASS in throwaway worktree only; no committed dependency changes
- npm run test --workspace=packages/testpass -- --runTestsByPath src/__tests__/pack-loader.test.ts: BLOCKED locally because the package script looks for packages/testpass/node_modules/.bin/jest
- node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --runTestsByPath src/__tests__/pack-loader.test.ts: BLOCKED by existing ts-jest/types config (missing node/jest globals), before tests execute

## Risk
- Low. Declarative TestPass pack/test-only guard; no runtime route, secret, credential, or provider behavior changes.

## Follow-up
- Keep draft until GitHub checks and Vercel are green. If package Jest proof is required, fix the existing TestPass package test configuration in a separate PR.