### PR TITLE
Wake router: fail closed on missing event path

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -47,7 +47,10 @@ export function deriveAckThresholds(failAfterSeconds) {
 }
 
 function readEvent() {
-  if (!eventPath) return {};
+  if (!eventPath) {
+    if (eventName === "manual") return {};
+    return { read_error: "GITHUB_EVENT_PATH is empty for a non-manual event." };
+  }
   try {
     return JSON.parse(readFileSync(eventPath, "utf8"));
   } catch (err) {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -540,6 +540,29 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("fails closed when GITHUB_EVENT_PATH is missing for non-manual events", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const ledgerDir = join(tempDir, "ledger");
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /GITHUB_EVENT_PATH is empty for a non-manual event/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to default ACK fail seconds when env value is malformed", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- fail closed when GITHUB_EVENT_PATH is missing for non-manual events
- keep manual mode behavior unchanged
- add regression test to prevent silent no-wake on misconfigured workflow events

## Verification
- node --test scripts/event-wake-router.test.mjs