### PR TITLE
Dogfood: show proof reason codes

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -36,7 +36,9 @@
       "summary": "Scheduled UXPass could not run because DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET is missing.",
       "evidence": "Set one workflow secret so the nightly dogfood workflow can create a fresh uxpass_runs row.",
       "checkedAt": "2026-05-01T17:16:13.158Z",
-      "blockedReason": "Missing DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET."
+      "blockedReason": "Missing DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      "reasonCode": "missing_credential",
+      "nextProof": "Set one UXPass workflow secret, then rerun the dogfood report workflow."
     },
     {
       "id": "securitypass",
@@ -45,7 +47,9 @@
       "summary": "SecurityPass is blocked until the recurring runner proof is ready.",
       "evidence": "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
       "checkedAt": "2026-05-01T17:16:13.158Z",
-      "blockedReason": "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands."
+      "blockedReason": "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
+      "reasonCode": "scope_gate",
+      "nextProof": "Land a safe recurring SecurityPass runner receipt before marking this passing."
     },
     {
       "id": "seopass",
@@ -53,7 +57,9 @@
       "status": "pending",
       "summary": "Queued for recurring search and metadata review.",
       "evidence": "SEOPass is still scaffold-only for public dogfood receipts.",
-      "checkedAt": "2026-05-01T17:16:13.158Z"
+      "checkedAt": "2026-05-01T17:16:13.158Z",
+      "reasonCode": "planned_runner",
+      "nextProof": "Add a recurring SEOPass receipt before moving this out of pending."
     },
     {
       "id": "copypass",
@@ -61,7 +67,9 @@
       "status": "pending",
       "summary": "Queued for recurring copy quality review.",
       "evidence": "CopyPass recurring public receipts will land after the runner surface is available.",
-      "checkedAt": "2026-05-01T17:16:13.158Z"
+      "checkedAt": "2026-05-01T17:16:13.158Z",
+      "reasonCode": "planned_runner",
+      "nextProof": "Add a recurring CopyPass receipt before moving this out of pending."
     },
     {
       "id": "legalpass",
@@ -69,7 +77,9 @@
       "status": "pending",
       "summary": "Queued for recurring policy and claims review.",
       "evidence": "LegalPass recurring public receipts will land after the runner surface is available.",
-      "checkedAt": "2026-05-01T17:16:13.158Z"
+      "checkedAt": "2026-05-01T17:16:13.158Z",
+      "reasonCode": "planned_runner",
+      "nextProof": "Add a recurring LegalPass receipt before moving this out of pending."
     },
     {
       "id": "enterprisepass",
@@ -81,7 +91,9 @@
       "proof": {
         "kind": "planned",
         "targetUrl": "/enterprise/latest.json"
-      }
+      },
+      "reasonCode": "planned_runner",
+      "nextProof": "Wire automated evidence checks before moving this beyond readiness guidance."
     }
   ],
   "trend": [

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -41,11 +41,14 @@ function result(id, name, status, summary, evidence, details = {}) {
 }
 
 function pendingResult(id, name, summary, evidence, details = {}) {
-  return result(id, name, "pending", summary, evidence, details);
+  return result(id, name, "pending", summary, evidence, {
+    reasonCode: "planned_runner",
+    ...details,
+  });
 }
 
-function blockedResult(id, name, summary, evidence, blockedReason) {
-  return result(id, name, "blocked", summary, evidence, { blockedReason });
+function blockedResult(id, name, summary, evidence, blockedReason, details = {}) {
+  return result(id, name, "blocked", summary, evidence, { blockedReason, ...details });
 }
 
 function failureResult(id, name, summary, evidence, details = {}) {
@@ -93,6 +96,10 @@ async function runTestPass() {
       "Scheduled TestPass could not run because DOGFOOD_TESTPASS_TOKEN or TESTPASS_TOKEN is missing.",
       "Set the GitHub secret so the nightly dogfood workflow can create a fresh testpass_runs row.",
       "Missing DOGFOOD_TESTPASS_TOKEN or TESTPASS_TOKEN.",
+      {
+        reasonCode: "missing_credential",
+        nextProof: "Set one TestPass workflow secret, then rerun the dogfood report workflow.",
+      },
     );
   }
 
@@ -171,6 +178,10 @@ async function runUXPass() {
       "Scheduled UXPass could not run because DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET is missing.",
       "Set one workflow secret so the nightly dogfood workflow can create a fresh uxpass_runs row.",
       "Missing DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      {
+        reasonCode: "missing_credential",
+        nextProof: "Set one UXPass workflow secret, then rerun the dogfood report workflow.",
+      },
     );
   }
 
@@ -271,31 +282,41 @@ const results = [
     "SecurityPass is blocked until the recurring runner proof is ready.",
     "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
     "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
+    {
+      reasonCode: "scope_gate",
+      nextProof: "Land a safe recurring SecurityPass runner receipt before marking this passing.",
+    },
   ),
   pendingResult(
     "seopass",
     "SEOPass",
     "Queued for recurring search and metadata review.",
     "SEOPass is still scaffold-only for public dogfood receipts.",
+    { nextProof: "Add a recurring SEOPass receipt before moving this out of pending." },
   ),
   pendingResult(
     "copypass",
     "CopyPass",
     "Queued for recurring copy quality review.",
     "CopyPass recurring public receipts will land after the runner surface is available.",
+    { nextProof: "Add a recurring CopyPass receipt before moving this out of pending." },
   ),
   pendingResult(
     "legalpass",
     "LegalPass",
     "Queued for recurring policy and claims review.",
     "LegalPass recurring public receipts will land after the runner surface is available.",
+    { nextProof: "Add a recurring LegalPass receipt before moving this out of pending." },
   ),
   pendingResult(
     "enterprisepass",
     "EnterprisePass",
     "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
     "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
-    { proof: { kind: "planned", targetUrl: "/enterprise/latest.json" } },
+    {
+      proof: { kind: "planned", targetUrl: "/enterprise/latest.json" },
+      nextProof: "Wire automated evidence checks before moving this beyond readiness guidance.",
+    },
   ),
 ];
 

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -27,7 +27,11 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
 
     assert.equal(securitypass?.status, "blocked");
     assert.match(securitypass?.blockedReason ?? "", /scope-gated/i);
+    assert.equal(securitypass?.reasonCode, "scope_gate");
+    assert.match(securitypass?.nextProof ?? "", /safe recurring SecurityPass runner receipt/i);
     assert.equal(enterprisepass?.status, "pending");
+    assert.equal(enterprisepass?.reasonCode, "planned_runner");
+    assert.match(enterprisepass?.nextProof ?? "", /automated evidence checks/i);
     assert.deepEqual(enterprisepass?.proof, {
       kind: "planned",
       targetUrl: "/enterprise/latest.json",
@@ -124,6 +128,37 @@ test("dogfood receipt includes structured proof for live TestPass and UXPass run
     });
   } finally {
     await new Promise((resolve) => server.close(resolve));
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("dogfood receipt uses structured missing-credential proof for blocked UXPass", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
+  const output = path.join(dir, "latest.json");
+
+  try {
+    await execFileAsync(process.execPath, [
+      "scripts/build-dogfood-report.mjs",
+      "--output",
+      output,
+    ], {
+      env: {
+        ...process.env,
+        TESTPASS_TOKEN: "",
+        DOGFOOD_TESTPASS_TOKEN: "",
+        UXPASS_TOKEN: "",
+        DOGFOOD_UXPASS_TOKEN: "",
+        CRON_SECRET: "",
+      },
+    });
+
+    const report = JSON.parse(await fs.readFile(output, "utf8"));
+    const uxpass = report.results.find((result) => result.id === "uxpass");
+
+    assert.equal(uxpass?.status, "blocked");
+    assert.equal(uxpass?.reasonCode, "missing_credential");
+    assert.match(uxpass?.nextProof ?? "", /rerun the dogfood report workflow/i);
+  } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
 });

--- a/src/__tests__/dogfood-report-proof-policy.test.ts
+++ b/src/__tests__/dogfood-report-proof-policy.test.ts
@@ -8,5 +8,13 @@ describe("Dogfood report proof policy", () => {
     expect(dogfoodReport.statusLegend.blocked).toMatch(/action is needed/i);
     expect(dogfoodReport.statusLegend.pending).toMatch(/live proof is not available yet/i);
     expect(dogfoodReport.proofPolicy).toMatch(/passing only when a live check actually ran/i);
+
+    const uxpass = dogfoodReport.results.find((result) => result.id === "uxpass");
+    const securitypass = dogfoodReport.results.find((result) => result.id === "securitypass");
+
+    expect(uxpass?.reasonCode).toBe("missing_credential");
+    expect(uxpass?.nextProof).toMatch(/rerun the dogfood report workflow/i);
+    expect(securitypass?.reasonCode).toBe("scope_gate");
+    expect(securitypass?.nextProof).toMatch(/before marking this passing/i);
   });
 });

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -8,6 +8,8 @@ export interface DogfoodPassResult {
   evidence: string;
   checkedAt?: string;
   blockedReason?: string;
+  reasonCode?: string;
+  nextProof?: string;
   runId?: string;
   targetUrl?: string;
   proof?: {
@@ -66,6 +68,8 @@ export const dogfoodReport = {
       evidence: "Set one workflow secret so the nightly dogfood workflow can create a fresh uxpass_runs row.",
       checkedAt: "2026-05-01T17:16:13.158Z",
       blockedReason: "Missing DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      reasonCode: "missing_credential",
+      nextProof: "Set one UXPass workflow secret, then rerun the dogfood report workflow.",
     },
     {
       id: "securitypass",
@@ -75,6 +79,8 @@ export const dogfoodReport = {
       evidence: "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
       checkedAt: "2026-05-01T17:16:13.158Z",
       blockedReason: "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
+      reasonCode: "scope_gate",
+      nextProof: "Land a safe recurring SecurityPass runner receipt before marking this passing.",
     },
     {
       id: "seopass",
@@ -83,6 +89,8 @@ export const dogfoodReport = {
       summary: "Queued for recurring search and metadata review.",
       evidence: "SEOPass is still scaffold-only for public dogfood receipts.",
       checkedAt: "2026-05-01T17:16:13.158Z",
+      reasonCode: "planned_runner",
+      nextProof: "Add a recurring SEOPass receipt before moving this out of pending.",
     },
     {
       id: "copypass",
@@ -91,6 +99,8 @@ export const dogfoodReport = {
       summary: "Queued for recurring copy quality review.",
       evidence: "CopyPass recurring public receipts will land after the runner surface is available.",
       checkedAt: "2026-05-01T17:16:13.158Z",
+      reasonCode: "planned_runner",
+      nextProof: "Add a recurring CopyPass receipt before moving this out of pending.",
     },
     {
       id: "legalpass",
@@ -99,6 +109,8 @@ export const dogfoodReport = {
       summary: "Queued for recurring policy and claims review.",
       evidence: "LegalPass recurring public receipts will land after the runner surface is available.",
       checkedAt: "2026-05-01T17:16:13.158Z",
+      reasonCode: "planned_runner",
+      nextProof: "Add a recurring LegalPass receipt before moving this out of pending.",
     },
     {
       id: "enterprisepass",
@@ -108,6 +120,8 @@ export const dogfoodReport = {
       evidence: "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
       checkedAt: "2026-05-02T02:30:00Z",
       proof: { kind: "planned", targetUrl: "/enterprise/latest.json" },
+      reasonCode: "planned_runner",
+      nextProof: "Wire automated evidence checks before moving this beyond readiness guidance.",
     },
   ] satisfies DogfoodPassResult[],
   trend: [

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -203,6 +203,20 @@ export default function DogfoodReportPage() {
                         Blocked reason: {result.blockedReason}
                       </p>
                     ) : null}
+                    {result.reasonCode || result.nextProof ? (
+                      <div className="mt-3 rounded-xl border border-border/50 bg-background/40 p-3 text-xs leading-relaxed text-muted-custom">
+                        {result.reasonCode ? (
+                          <p>
+                            Reason code: <span className="font-mono text-heading">{result.reasonCode}</span>
+                          </p>
+                        ) : null}
+                        {result.nextProof ? (
+                          <p className={result.reasonCode ? "mt-1" : undefined}>
+                            Next proof: {result.nextProof}
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : null}
                     {result.checkedAt ? (
                       <p className="mt-3 text-[11px] text-muted-custom">Checked: {formatDate(result.checkedAt)}</p>
                     ) : null}


### PR DESCRIPTION
## Summary
- add structured reasonCode and nextProof fields to Dogfood receipt results
- show reason/next-proof details on public Dogfood result cards
- keep generated public JSON, fallback data, and receipt tests aligned for UXPass/SecurityPass/pending Pass states

## Owner
- 🧪 XPass Assistant

## Non-overlap
- Owns only Dogfood/XPass proof receipt files:
  - `public/dogfood/latest.json`
  - `scripts/build-dogfood-report.mjs`
  - `scripts/build-dogfood-report.test.mjs`
  - `src/__tests__/dogfood-report-proof-policy.test.ts`
  - `src/data/dogfoodReport.ts`
  - `src/pages/DogfoodReport.tsx`
- Does not touch #486 RotatePass/systemCredentialInventory, #491 wake-router, or #494 Connected Services files.

## Scope
- XPass/Dogfood proof clarity only
- No runner behavior changes beyond receipt metadata
- No credential storage, raw secret display, provider writes, auth, billing, DNS, migrations, or analytics runtime changes

## Verification
- `node --test scripts/build-dogfood-report.test.mjs` PASS (3/3)
- `npx vitest run src/__tests__/dogfood-report-proof-policy.test.ts` PASS (1/1)
- `npx eslint src/pages/DogfoodReport.tsx src/data/dogfoodReport.ts src/__tests__/dogfood-report-proof-policy.test.ts` PASS
- `npm run build` PASS
- `git diff --check` PASS
- Secret-pattern sweep: only credential names already present in receipt copy/tests; no raw secret values
- GitHub CI: Website (root package) PASS, MCP server package PASS
- TestPass PR Check PASS
- Vercel PASS

## Status
ready
