### PR TITLE
fix(channel): include runtime helpers in package

### DIFF
--- a/packages/channel-plugin/package.json
+++ b/packages/channel-plugin/package.json
@@ -9,6 +9,8 @@
     "unclick-channel": "./index.js"
   },
   "files": [
+    "config.js",
+    "heartbeat-gate.js",
     "http.js",
     "index.js",
     "README.md"


### PR DESCRIPTION
## Summary
- Adds the channel plugin runtime helper files to the package files whitelist.
- Fixes the post-merge #485 pack risk where `index.js` imports helpers that `npm pack` excluded.

## Scope
- Owned files: `packages/channel-plugin/package.json` only.
- Release-safety follow-up for `@unclick/channel` packaging.

## Non-overlap
- Does not touch #486 RotatePass metadata redaction files, #490 TestPass/WakePass pack files, #491 Wake Router files, or #492 Dogfood files.
- No runtime logic changes, secrets, env values, auth, billing, DNS/domains, migrations, provider settings, or analytics rebuild.

## Verification
- `npm pack --dry-run --json` in `packages/channel-plugin` PASS; package now includes `config.js` and `heartbeat-gate.js`.
- `node --test packages/channel-plugin/*.test.js` PASS 6/6.
- `git diff --check` PASS.

## Risk
- Low. Package metadata whitelist only; fixes missing files for installed/published channel plugin consumers.

## Follow-up
- Keep draft until CI/TestPass/Vercel finish and queue review confirms no newer overlap.