### PR TITLE
RotatePass: clarify untested status timestamps

### DIFF
--- a/src/pages/admin/tools/ConnectedServices.test.ts
+++ b/src/pages/admin/tools/ConnectedServices.test.ts
@@ -19,7 +19,7 @@ describe("deriveConnectorStatus", () => {
 
     expect(status.pill).toBe("Untested");
     expect(status.note.toLowerCase()).toContain("untested");
-    expect(status.note.toLowerCase()).toContain("metadata activity");
+    expect(status.note.toLowerCase()).toContain("metadata timestamp");
     expect(status.note.toLowerCase()).toContain("no server-gated probe");
   });
 
@@ -60,6 +60,7 @@ describe("deriveConnectorStatus", () => {
 
     expect(status.pill).toBe("Check stale");
     expect(status.note.toLowerCase()).toContain("stale");
+    expect(status.note.toLowerCase()).toContain("test timestamp");
   });
 
   it("uses cautious wording for recent test evidence", () => {
@@ -73,5 +74,6 @@ describe("deriveConnectorStatus", () => {
 
     expect(status.pill).toBe("Check recent");
     expect(status.note.toLowerCase()).toContain("not a live secret check");
+    expect(status.note.toLowerCase()).toContain("test timestamp");
   });
 });

--- a/src/pages/admin/tools/ConnectedServices.tsx
+++ b/src/pages/admin/tools/ConnectedServices.tsx
@@ -48,7 +48,7 @@ export function deriveConnectorStatus(
       dot: "bg-amber-400",
       pillClass: "bg-amber-400/10 text-amber-200",
       pill: "Needs reconnection",
-      note: `Reconnect or retest this service in Connections. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+      note: `Reconnect or retest this service in Connections. Last test timestamp: ${formatLastTested(credential.last_tested_at)}.`,
     };
   }
 
@@ -68,7 +68,7 @@ export function deriveConnectorStatus(
       dot: "bg-sky-400",
       pillClass: "bg-sky-400/10 text-sky-200",
       pill: "Untested",
-      note: `No server-gated probe is available for this connector, so it remains untested. Last metadata activity: ${formatLastTested(credential.last_tested_at)}.`,
+      note: `No server-gated probe is available for this connector, so it remains untested. Last metadata timestamp: ${formatLastTested(credential.last_tested_at)}.`,
     };
   }
 
@@ -78,7 +78,7 @@ export function deriveConnectorStatus(
       dot: "bg-sky-400",
       pillClass: "bg-sky-400/10 text-sky-200",
       pill: "Check unknown",
-      note: `Credential metadata is present, but test time is unknown. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+      note: `Credential metadata is present, but test time is unknown. Last test timestamp: ${formatLastTested(credential.last_tested_at)}.`,
     };
   }
 
@@ -87,7 +87,7 @@ export function deriveConnectorStatus(
       dot: "bg-yellow-400",
       pillClass: "bg-yellow-400/10 text-yellow-200",
       pill: "Check stale",
-      note: `Credential exists, but test evidence is stale. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+      note: `Credential exists, but test evidence is stale. Last test timestamp: ${formatLastTested(credential.last_tested_at)}.`,
     };
   }
 
@@ -95,7 +95,7 @@ export function deriveConnectorStatus(
     dot: "bg-green-500",
     pillClass: "bg-green-500/10 text-green-200",
     pill: "Check recent",
-    note: `Recent test evidence exists, but this is not a live secret check. Last checked: ${formatLastTested(credential.last_tested_at)}.`,
+    note: `Recent test evidence exists, but this is not a live secret check. Last test timestamp: ${formatLastTested(credential.last_tested_at)}.`,
   };
 }
 


### PR DESCRIPTION
## Summary
- tighten Connected Services status copy so timestamps are explicitly metadata/test timestamps
- avoid implying live health from credential presence alone
- update ConnectedServices unit assertions to match the safer wording

## Verification
- 
px vitest run src/pages/admin/tools/ConnectedServices.test.ts *(fails in this worktree: missing local vitest/vite dependencies)*

## Lane fit
- tiny RotatePass-safe copy/test slice
- no provider writes, no secret exposure, no env/auth/migration changes