### PR TITLE
docs(fleet): require owner lift status in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,15 @@
 <!-- Files and modules touched. Be specific enough that a reviewer can spot what's missing. -->
 -
 
+## Owner and lift status
+<!-- Required before marking ready:
+     - Name the owner lane or worker.
+     - State the non-overlap check.
+     - Say whether this is draft, HOLD, or ready for review. -->
+- Owner:
+- Non-overlap:
+- Status:
+
 ## Deletions
 <!-- Required: list every file, route, or component removed, with rationale.
      "None" is a valid answer if nothing was deleted.


### PR DESCRIPTION
## Summary
- Adds an owner/lift-status block to the PR template so reviewers can see who owns the PR, whether it overlaps active work, and whether it is draft, HOLD, or ready.
- Reduces queue friction during AFK/autopilot review cycles.

## Changes
- `.github/PULL_REQUEST_TEMPLATE.md`

## Owner and lift status
- Owner: 🧠 ChatGPT Codex creativelead
- Non-overlap: template-only docs chip; no product code, secrets, auth, billing, DNS, migrations, analytics, or active draft PR files touched.
- Status: draft until GitHub checks finish.

## Deletions
None

## Archaeology
N/A - not a restore/reorg PR

## Testing
- `git diff --check` - PASS
- `node scripts/no-emdash-docs.test.mjs` - PASS

## UnClick Memory linkage
PR TBD