### PR TITLE
Harden wake-router handoff message-id normalization

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -114,6 +114,11 @@ export function normalizeDispatchOwner(owner) {
   return normalized === "all" ? "🤖" : owner;
 }
 
+export function normalizeHandoffMessageId(messageId) {
+  const normalized = String(messageId ?? "").trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 function baseDecision(event) {
   const action = String(event.action || "");
 
@@ -370,6 +375,7 @@ export function buildReliabilityDispatchRequest({
   event,
   ackSeconds = 600,
 }) {
+  const handoffMessageId = normalizeHandoffMessageId(result?.message_id);
   return {
     dispatch_id: wakeDispatchId(eventId),
     source: "wakepass",
@@ -378,7 +384,7 @@ export function buildReliabilityDispatchRequest({
     time_bucket_seconds: ackSeconds,
     payload: {
       ack_required: true,
-      handoff_message_id: result?.message_id ?? null,
+      handoff_message_id: handoffMessageId,
       route_attempted: "fishbowl",
       wake_event_id: eventId,
       wake_reason: decision.reason,
@@ -402,7 +408,7 @@ export function buildReliabilityDispatchHandoffSyncRequest({
   event,
   ackSeconds = 600,
 }) {
-  if (!result?.message_id) return null;
+  if (!normalizeHandoffMessageId(result?.message_id)) return null;
   return buildReliabilityDispatchRequest({
     eventId,
     decision,
@@ -414,7 +420,7 @@ export function buildReliabilityDispatchHandoffSyncRequest({
 }
 
 export function shouldFailMissingHandoffMessageId(result) {
-  return Boolean(result?.posted) && !result?.message_id && !result?.dry_run;
+  return Boolean(result?.posted) && !normalizeHandoffMessageId(result?.message_id) && !result?.dry_run;
 }
 
 async function registerWakeDispatch({ eventId, decision, triage, result, event }) {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -10,6 +10,7 @@ import {
   buildReliabilityDispatchHandoffSyncRequest,
   buildReliabilityDispatchRequest,
   deriveAckThresholds,
+  normalizeHandoffMessageId,
   normalizeDispatchOwner,
   shouldFailMissingHandoffMessageId,
   wakeDispatchId,
@@ -164,6 +165,24 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(upsert.dispatch_id, wakeDispatchId("wake-workflow_run-workflow-run-321-jkl"));
     assert.equal(upsert.payload.handoff_message_id, "msg-321");
     assert.equal(upsert.payload.ack_fail_after_seconds, 120);
+  });
+
+  it("skips dispatch handoff sync when message id is whitespace only", () => {
+    const upsert = buildReliabilityDispatchHandoffSyncRequest({
+      eventId: "wake-workflow_run-workflow-run-321-jkl",
+      decision: {
+        owner: "🤖",
+        reason: "Scheduled TestPass smoke failure",
+        urgency: "urgent",
+      },
+      triage: { used: false },
+      result: { message_id: "   " },
+      event: { workflow_run: { id: 321 } },
+      ackSeconds: 120,
+    });
+
+    assert.equal(upsert, null);
+    assert.equal(normalizeHandoffMessageId("   "), null);
   });
 
   it("normalizes fanout owner to a concrete ACK owner for reliability dispatch", () => {
@@ -509,6 +528,7 @@ describe("event wake router reliability dispatch", () => {
 
   it("fails closed when Fishbowl post succeeds without a message id", () => {
     assert.equal(shouldFailMissingHandoffMessageId({ posted: true, message_id: null, dry_run: false }), true);
+    assert.equal(shouldFailMissingHandoffMessageId({ posted: true, message_id: "   ", dry_run: false }), true);
     assert.equal(shouldFailMissingHandoffMessageId({ posted: true, message_id: "msg-1", dry_run: false }), false);
     assert.equal(shouldFailMissingHandoffMessageId({ posted: true, message_id: null, dry_run: true }), false);
     assert.equal(shouldFailMissingHandoffMessageId({ posted: false, message_id: null, dry_run: false }), false);


### PR DESCRIPTION
## Summary
- normalize Fishbowl handoff message IDs using trim+empty-to-null before reliability dispatch payload generation
- treat whitespace-only message_id as missing in fail-closed no-ACK guard
- skip handoff sync upsert when the post response carries only whitespace message_id

## Testing
- node --test scripts/event-wake-router.test.mjs