### PR TITLE
RotatePass: widen redaction guards for secret-like headers

### DIFF
--- a/src/__tests__/rotatepass-doc-redaction.test.ts
+++ b/src/__tests__/rotatepass-doc-redaction.test.ts
@@ -12,10 +12,13 @@ const SCANNED_FILES = [
 const SECRET_PATTERNS = [
   { name: "UnClick API key", pattern: /\buc_[A-Za-z0-9]{16,}\b/g },
   { name: "OpenAI-style API key", pattern: /\bsk[-_][A-Za-z0-9_-]{16,}\b/g },
+  { name: "Anthropic-style API key", pattern: /\bsk-ant-[A-Za-z0-9_-]{16,}\b/g },
   { name: "Slack bot token", pattern: /\bxoxb-[A-Za-z0-9-]{16,}\b/g },
   { name: "GitHub token", pattern: /\b(?:gh[pous]|ghs|pat)_[A-Za-z0-9_]{16,}\b/g },
   { name: "Stripe webhook secret", pattern: /\bwhsec_[A-Za-z0-9_]{16,}\b/g },
   { name: "Authorization bearer example", pattern: /\bAuthorization:\s*Bearer\s+[A-Za-z0-9._~+/=-]{16,}\b/g },
+  { name: "X-API-Key header", pattern: /\bX-API-Key:\s*[A-Za-z0-9._~+/=-]{10,}\b/gi },
+  { name: "X-Auth-Token header", pattern: /\bX-Auth-Token:\s*[A-Za-z0-9._~+/=-]{10,}\b/gi },
   { name: "Cookie header", pattern: /\bCookie:\s*[^\r\n;]{8,}/gi },
   { name: "Set-Cookie header", pattern: /\bSet-Cookie:\s*[^\r\n;]{8,}/gi },
   { name: "Provider response body wording", pattern: /\b(?:provider|api)\s+response\s+body\b/gi },

--- a/src/__tests__/rotatepass-metadata-fixture-redaction.test.ts
+++ b/src/__tests__/rotatepass-metadata-fixture-redaction.test.ts
@@ -22,9 +22,12 @@ const FIXTURE_PATH = "tests/rotatepass/fixtures/system-credentials.metadata.json
 
 const BANNED_PATTERNS = [
   { name: "OpenAI secret literal", pattern: /\bsk[-_][A-Za-z0-9_-]{10,}\b/g },
+  { name: "Anthropic secret literal", pattern: /\bsk-ant-[A-Za-z0-9_-]{10,}\b/g },
   { name: "GitHub token literal", pattern: /\b(?:gh[pous]|ghs|pat)_[A-Za-z0-9_]{10,}\b/g },
   { name: "Slack token literal", pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g },
   { name: "Authorization bearer header", pattern: /\bAuthorization:\s*Bearer\s+\S+/gi },
+  { name: "X-API-Key header", pattern: /\bX-API-Key:\s*[A-Za-z0-9._~+/=-]{10,}\b/gi },
+  { name: "X-Auth-Token header", pattern: /\bX-Auth-Token:\s*[A-Za-z0-9._~+/=-]{10,}\b/gi },
   { name: "Cookie-like assignment", pattern: /\bset-cookie\s*:/gi },
   { name: "Provider response body wording", pattern: /\b(?:provider|api)\s+response\s+body\b/gi },
 ];


### PR DESCRIPTION
## Summary\n- expand RotatePass docs redaction test patterns to catch Anthropic-style tokens\n- add header-style guard patterns for X-API-Key and X-Auth-Token\n- mirror those patterns in metadata fixture redaction tests\n\n## Scope\n- tiny test-only chip for RotatePass safety lane\n- non-overlapping with open PRs #494, #491, #486\n\n## Verification\n- 
px vitest run src/__tests__/rotatepass-doc-redaction.test.ts src/__tests__/rotatepass-metadata-fixture-redaction.test.ts *(fails in this worktree because vitest/vite dependencies are missing)*\n