### PR TITLE
feat(dogfood): add XPass family index

### DIFF
--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -26,6 +26,72 @@ const statusLegend = {
 const proofPolicy =
   "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.";
 
+const xpassIndex = [
+  {
+    id: "testpass",
+    name: "TestPass",
+    stage: "live_gate",
+    label: "Live trust gate",
+    automation: "PR check, scheduled smoke, dogfood receipt, wake-router watched",
+    mentionProfile: "High mention volume because it protects merges and cron trust.",
+    nextStep: "Keep it as the default proof gate while the rest of XPass catches up.",
+  },
+  {
+    id: "uxpass",
+    name: "UXPass",
+    stage: "live_dogfood",
+    label: "Live dogfood lane",
+    automation: "Dogfood receipt and run endpoint",
+    mentionProfile: "Medium mention volume when the dogfood receipt or runner needs attention.",
+    nextStep: "Promote to scheduled proof once the credential path is consistently healthy.",
+  },
+  {
+    id: "securitypass",
+    name: "SecurityPass",
+    stage: "scope_gated",
+    label: "Scope-gated",
+    automation: "Blocked public receipt until safe recurring proof exists",
+    mentionProfile: "Low mention volume by design because unsafe probes stay disabled.",
+    nextStep: "Add a deny-by-default recurring runner proof before live security checks.",
+  },
+  {
+    id: "seopass",
+    name: "SEOPass",
+    stage: "planned",
+    label: "Planned",
+    automation: "Scaffold-only public receipt",
+    mentionProfile: "Low mention volume until a recurring search and metadata runner lands.",
+    nextStep: "Define the smallest recurring metadata proof.",
+  },
+  {
+    id: "copypass",
+    name: "CopyPass",
+    stage: "planned",
+    label: "Planned",
+    automation: "Scaffold-only public receipt",
+    mentionProfile: "Low mention volume until copy checks become scheduled evidence.",
+    nextStep: "Define the copy quality receipt shape.",
+  },
+  {
+    id: "legalpass",
+    name: "LegalPass",
+    stage: "planned",
+    label: "Planned",
+    automation: "Scaffold-only public receipt",
+    mentionProfile: "Low mention volume until policy and claims checks become scheduled evidence.",
+    nextStep: "Keep guidance-only until legal review boundaries are explicit.",
+  },
+  {
+    id: "enterprisepass",
+    name: "EnterprisePass",
+    stage: "guidance",
+    label: "Guidance report",
+    automation: "Receipt guard and readiness report boundary",
+    mentionProfile: "Low mention volume while it remains a guidance layer, not certification.",
+    nextStep: "Add low-risk readiness checks without claiming compliance certification.",
+  },
+];
+
 function trimTrailingSlash(value) {
   return value.replace(/\/+$/, "");
 }
@@ -330,6 +396,7 @@ const report = {
   nextAutomation: "Nightly dogfood receipts refresh this board with live scheduled evidence.",
   statusLegend,
   proofPolicy,
+  xpassIndex,
   results,
   trend: buildTrend(results),
   lastActionableFailure: buildLastActionableFailure(results),

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -41,6 +41,12 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
     assert.match(report.statusLegend.pending, /live proof is not available yet/i);
     assert.match(report.proofPolicy, /passing only when a live check actually ran/i);
     assert.match(report.lastActionableFailure.detail, /Blocked reason:/);
+    assert.equal(report.xpassIndex.find((entry) => entry.id === "testpass")?.stage, "live_gate");
+    assert.match(
+      report.xpassIndex.find((entry) => entry.id === "testpass")?.mentionProfile ?? "",
+      /protects merges/i,
+    );
+    assert.equal(report.xpassIndex.find((entry) => entry.id === "enterprisepass")?.stage, "guidance");
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
@@ -108,6 +114,7 @@ test("dogfood receipt includes structured proof for live TestPass and UXPass run
 
     assert.match(report.statusLegend.passing, /live check ran/i);
     assert.match(report.proofPolicy, /Blocked and pending are honest product states/i);
+    assert.equal(report.xpassIndex.length, 7);
 
     assert.equal(testpassRequest.body.source, "scheduled");
     assert.equal(testpass.runId, "testpass-run-123");

--- a/src/__tests__/dogfood-report-proof-policy.test.ts
+++ b/src/__tests__/dogfood-report-proof-policy.test.ts
@@ -17,4 +17,14 @@ describe("Dogfood report proof policy", () => {
     expect(securitypass?.reasonCode).toBe("scope_gate");
     expect(securitypass?.nextProof).toMatch(/before marking this passing/i);
   });
+
+  it("keeps the XPass family maturity index visible", () => {
+    const testpass = dogfoodReport.xpassIndex.find((entry) => entry.id === "testpass");
+    const enterprisepass = dogfoodReport.xpassIndex.find((entry) => entry.id === "enterprisepass");
+
+    expect(testpass?.stage).toBe("live_gate");
+    expect(testpass?.mentionProfile).toMatch(/protects merges/i);
+    expect(enterprisepass?.stage).toBe("guidance");
+    expect(enterprisepass?.nextStep).toMatch(/without claiming compliance certification/i);
+  });
 });

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -29,6 +29,16 @@ export interface DogfoodTrendPoint {
 
 export type DogfoodStatusLegend = Record<DogfoodStatus, string>;
 
+export interface XPassIndexEntry {
+  id: string;
+  name: string;
+  stage: "live_gate" | "live_dogfood" | "scope_gated" | "planned" | "guidance";
+  label: string;
+  automation: string;
+  mentionProfile: string;
+  nextStep: string;
+}
+
 export const dogfoodReport = {
   generatedAt: "2026-05-01T17:16:13.158Z",
   lastRunAt: "2026-05-01T17:16:13.158Z",
@@ -44,6 +54,71 @@ export const dogfoodReport = {
     pending: "The check is planned or scaffolded, but live proof is not available yet.",
   } satisfies DogfoodStatusLegend,
   proofPolicy: "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.",
+  xpassIndex: [
+    {
+      id: "testpass",
+      name: "TestPass",
+      stage: "live_gate",
+      label: "Live trust gate",
+      automation: "PR check, scheduled smoke, dogfood receipt, wake-router watched",
+      mentionProfile: "High mention volume because it protects merges and cron trust.",
+      nextStep: "Keep it as the default proof gate while the rest of XPass catches up.",
+    },
+    {
+      id: "uxpass",
+      name: "UXPass",
+      stage: "live_dogfood",
+      label: "Live dogfood lane",
+      automation: "Dogfood receipt and run endpoint",
+      mentionProfile: "Medium mention volume when the dogfood receipt or runner needs attention.",
+      nextStep: "Promote to scheduled proof once the credential path is consistently healthy.",
+    },
+    {
+      id: "securitypass",
+      name: "SecurityPass",
+      stage: "scope_gated",
+      label: "Scope-gated",
+      automation: "Blocked public receipt until safe recurring proof exists",
+      mentionProfile: "Low mention volume by design because unsafe probes stay disabled.",
+      nextStep: "Add a deny-by-default recurring runner proof before live security checks.",
+    },
+    {
+      id: "seopass",
+      name: "SEOPass",
+      stage: "planned",
+      label: "Planned",
+      automation: "Scaffold-only public receipt",
+      mentionProfile: "Low mention volume until a recurring search and metadata runner lands.",
+      nextStep: "Define the smallest recurring metadata proof.",
+    },
+    {
+      id: "copypass",
+      name: "CopyPass",
+      stage: "planned",
+      label: "Planned",
+      automation: "Scaffold-only public receipt",
+      mentionProfile: "Low mention volume until copy checks become scheduled evidence.",
+      nextStep: "Define the copy quality receipt shape.",
+    },
+    {
+      id: "legalpass",
+      name: "LegalPass",
+      stage: "planned",
+      label: "Planned",
+      automation: "Scaffold-only public receipt",
+      mentionProfile: "Low mention volume until policy and claims checks become scheduled evidence.",
+      nextStep: "Keep guidance-only until legal review boundaries are explicit.",
+    },
+    {
+      id: "enterprisepass",
+      name: "EnterprisePass",
+      stage: "guidance",
+      label: "Guidance report",
+      automation: "Receipt guard and readiness report boundary",
+      mentionProfile: "Low mention volume while it remains a guidance layer, not certification.",
+      nextStep: "Add low-risk readiness checks without claiming compliance certification.",
+    },
+  ] satisfies XPassIndexEntry[],
   results: [
     {
       id: "testpass",

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -11,6 +11,7 @@ import {
   type DogfoodStatus,
   type DogfoodStatusLegend,
   type DogfoodTrendPoint,
+  type XPassIndexEntry,
 } from "@/data/dogfoodReport";
 
 type DogfoodReportData = Omit<typeof fallbackReport, "results" | "trend"> & {
@@ -18,6 +19,7 @@ type DogfoodReportData = Omit<typeof fallbackReport, "results" | "trend"> & {
   trend: DogfoodTrendPoint[];
   statusLegend: DogfoodStatusLegend;
   proofPolicy: string;
+  xpassIndex?: XPassIndexEntry[];
 };
 
 const STATUS_STYLES: Record<DogfoodStatus, { label: string; badge: string; icon: typeof CheckCircle2 }> = {
@@ -41,6 +43,14 @@ const STATUS_STYLES: Record<DogfoodStatus, { label: string; badge: string; icon:
     badge: "border-sky-400/25 bg-sky-400/10 text-sky-200",
     icon: AlertTriangle,
   },
+};
+
+const XPASS_STAGE_STYLES: Record<XPassIndexEntry["stage"], string> = {
+  live_gate: "border-emerald-400/20 bg-emerald-400/10 text-emerald-200",
+  live_dogfood: "border-cyan-400/20 bg-cyan-400/10 text-cyan-200",
+  scope_gated: "border-sky-400/25 bg-sky-400/10 text-sky-200",
+  planned: "border-amber-400/20 bg-amber-400/10 text-amber-200",
+  guidance: "border-violet-400/20 bg-violet-400/10 text-violet-200",
 };
 
 function countByStatus(results: DogfoodPassResult[], status: DogfoodStatus): number {
@@ -87,6 +97,7 @@ export default function DogfoodReportPage() {
   }), [report.results]);
   const receiptStatus = STATUS_STYLES[(report.status || "pending") as DogfoodStatus] || STATUS_STYLES.pending;
   const ReceiptIcon = receiptStatus.icon;
+  const xpassIndex = report.xpassIndex?.length ? report.xpassIndex : fallbackReport.xpassIndex;
 
   return (
     <div className="min-h-screen bg-background">
@@ -145,6 +156,53 @@ export default function DogfoodReportPage() {
               </div>
             </FadeIn>
           ))}
+        </section>
+
+        <section className="mx-auto mt-10 max-w-5xl">
+          <FadeIn delay={0.09}>
+            <div className="rounded-2xl border border-border/70 bg-card/40 p-5">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="font-mono text-[10px] uppercase tracking-widest text-muted-custom">
+                    XPass family index
+                  </p>
+                  <h2 className="mt-2 text-xl font-semibold text-heading">
+                    TestPass is loud because it is the live gate.
+                  </h2>
+                </div>
+                <p className="max-w-md text-xs leading-relaxed text-muted-custom">
+                  This index shows which Pass products are live gates, dogfood lanes, scope-gated,
+                  planned, or guidance-only so the whole family stays visible.
+                </p>
+              </div>
+              <div className="mt-5 grid gap-3 md:grid-cols-2">
+                {xpassIndex.map((entry) => (
+                  <div key={entry.id} className="rounded-xl border border-border/50 bg-background/40 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <h3 className="text-sm font-semibold text-heading">{entry.name}</h3>
+                      <span className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-medium ${XPASS_STAGE_STYLES[entry.stage]}`}>
+                        {entry.label}
+                      </span>
+                    </div>
+                    <dl className="mt-3 space-y-2 text-xs leading-relaxed">
+                      <div>
+                        <dt className="font-medium text-heading">Automation</dt>
+                        <dd className="text-muted-custom">{entry.automation}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-heading">Mention profile</dt>
+                        <dd className="text-muted-custom">{entry.mentionProfile}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-heading">Next step</dt>
+                        <dd className="text-muted-custom">{entry.nextStep}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </FadeIn>
         </section>
 
         <section className="mx-auto mt-10 max-w-5xl">


### PR DESCRIPTION
Owner: 🧠 ChatGPT Codex (creativelead)

Non-overlap: Dogfood/XPass reporting only. Touches scripts/build-dogfood-report.mjs, scripts/build-dogfood-report.test.mjs, src/data/dogfoodReport.ts, src/pages/DogfoodReport.tsx, and src/__tests__/dogfood-report-proof-policy.test.ts. Does not touch secrets, auth, billing, DNS/domains, migrations, raw key display/storage, event-wake-router, TestPass workflow gates, RotatePass branches, or Pass runner behavior.

Status: draft pending GitHub CI.

Summary:
- Adds an XPass family index to the public dogfood receipt model.
- Shows why TestPass gets high mention volume: it is the live PR/scheduled trust gate.
- Makes UXPass, SecurityPass, SEOPass, CopyPass, LegalPass, and EnterprisePass visible with honest maturity labels and next steps.
- Renders the index on /dogfood, with fallback support if the public JSON is one cycle behind.

Verification:
- node --test scripts/build-dogfood-report.test.mjs
- npx vitest run src/__tests__/dogfood-report-proof-policy.test.ts
- git diff --check HEAD~1 HEAD
- npm run build

Risk:
Low. Reporting/UI only. No secrets or runtime Pass behavior changed.