### PR TITLE
fix(wake-router): fail closed when event path is missing

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -47,7 +47,10 @@ export function deriveAckThresholds(failAfterSeconds) {
 }
 
 function readEvent() {
-  if (!eventPath) return {};
+  if (!eventPath) {
+    if (eventName === "manual") return {};
+    return { read_error: "GITHUB_EVENT_PATH is required for non-manual events." };
+  }
   try {
     return JSON.parse(readFileSync(eventPath, "utf8"));
   } catch (err) {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -560,6 +560,22 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("fails closed when non-manual events are missing GITHUB_EVENT_PATH", () => {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_EVENT_NAME: "workflow_run",
+        GITHUB_EVENT_PATH: "",
+        WAKE_ROUTER_DRY_RUN: "true",
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /GITHUB_EVENT_PATH is required for non-manual events/);
+  });
+
   it("falls back to default ACK fail seconds when env value is malformed", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- fail closed when non-manual GitHub events do not provide GITHUB_EVENT_PATH
- keep manual mode behavior unchanged ({} fallback)
- add regression test to assert non-manual missing path exits non-zero

## Verification
- node --test scripts/event-wake-router.test.mjs