### PR TITLE
RotatePass: guard rotation-impact docs from secret-like leakage

### DIFF
--- a/docs/connectors/credential-action-routing.md
+++ b/docs/connectors/credential-action-routing.md
@@ -114,6 +114,12 @@ tag: act
 
 The handoff must not include secret values, token prefixes, auth headers, provider response bodies, or copied browser/session material.
 
+Rotation impact and follow-up guidance must stay metadata-only:
+
+- Name the affected workflow or product surface.
+- Name the next safe verification step after rotation.
+- Do not include key fragments, token prefixes, auth headers, cookies, passkeys, MFA material, or provider response snippets.
+
 ## ACK And Lease Rules
 
 Use ACK-required WakePass routing only for action-needed states.

--- a/src/__tests__/rotatepass-rotation-impact-redaction.test.ts
+++ b/src/__tests__/rotatepass-rotation-impact-redaction.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const ROTATION_DOCS = [
+  "docs/connectors/credential-action-routing.md",
+  "docs/connectors/system-credentials-health-panel.md",
+] as const;
+
+const FORBIDDEN_SECRET_PATTERNS: readonly RegExp[] = [
+  /\b(?:Authorization|Proxy-Authorization)\s*:/i,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/i,
+  /\b(?:Set-Cookie|Cookie)\s*:/i,
+  /\b(?:gh[pous]|ghs|pat)_[A-Za-z0-9_]{8,}\b/i,
+  /\bsk[-_][A-Za-z0-9_-]{8,}\b/i,
+  /\bxox[baprs]-[A-Za-z0-9-]{8,}\b/i,
+  /\bwhsec_[A-Za-z0-9_]{8,}\b/i,
+  /"(?:access_token|refresh_token|api_key|token|secret|password)"\s*:\s*"(?!<redacted>|REDACTED|\*{3,})[^"]{8,}"/i,
+];
+
+function rotationGuidanceLines(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => /rotat|rotation/i.test(line));
+}
+
+describe("RotatePass rotation guidance redaction", () => {
+  it("keeps rotation guidance metadata-only", () => {
+    const findings: string[] = [];
+
+    for (const file of ROTATION_DOCS) {
+      const lines = rotationGuidanceLines(readFileSync(file, "utf8"));
+      lines.forEach((line, index) => {
+        FORBIDDEN_SECRET_PATTERNS.forEach((pattern) => {
+          if (pattern.test(line)) {
+            findings.push(`${file}:${index + 1}: ${line}`);
+          }
+        });
+      });
+    }
+
+    expect(findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- tighten credential routing docs with explicit metadata-only requirements for rotation impact guidance
- add a focused redaction test that scans rotation guidance lines in RotatePass docs
- block secret-like snippets (headers, token prefixes, cookie headers, and unredacted secret fields) from rotation guidance text

## Scope
- tiny docs + test chip for Connectors/RotatePass build lane
- no provider writes, no env changes, no secrets handling, no migrations

## Verification
- 
px vitest run src/__tests__/rotatepass-rotation-impact-redaction.test.ts *(fails locally: missing vitest package/deps in this workspace; CI should validate in provisioned environment)*