### PR TITLE
RotatePass: tighten setup owner-confidence vocabulary

### DIFF
--- a/docs/connectors/setup-metadata-vocabulary.md
+++ b/docs/connectors/setup-metadata-vocabulary.md
@@ -58,6 +58,7 @@ interface ConnectorSetupMetadata {
   connectorId: string;
   displayName: string;
   setupFlow: SetupFlow;
+  ownerConfidence: OwnerConfidence;
   supportsConnectionTest: boolean;
   capabilitySummary: string;
   docsUrl: string | null;
@@ -75,6 +76,11 @@ type SetupFlow =
   | "local_only"
   | "hybrid"
   | "not_applicable";
+
+type OwnerConfidence =
+  | "owner_mapped"
+  | "owner_inferred"
+  | "owner_unknown";
 
 type SafeProbeKind =
   | "none"
@@ -139,6 +145,18 @@ How the operator should expect to connect or verify the connector.
 | `not_applicable` | Connector has no user setup step | Public docs link |
 
 Use `system_secret` for GitHub Actions or Vercel env names that appear in System Credentials. Do not imply UnClick can read the value.
+
+### `ownerConfidence`
+
+How certain the setup metadata is about owner mapping, based on metadata only.
+
+| Value | Meaning |
+| --- | --- |
+| `owner_mapped` | Owner mapping is explicitly documented in inventory metadata |
+| `owner_inferred` | Owner mapping is inferred from scope, source, or workflow context |
+| `owner_unknown` | No safe owner mapping is known yet |
+
+UI copy should not claim certainty from these values alone. Prefer labels like `Owner mapped`, `Owner inferred`, and `Owner unknown`. Avoid copy like `Owner verified` unless human review evidence exists.
 
 ### `supportsConnectionTest`
 

--- a/src/__tests__/rotatepass-setup-vocabulary-claims.test.ts
+++ b/src/__tests__/rotatepass-setup-vocabulary-claims.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const SETUP_VOCAB_DOC = "docs/connectors/setup-metadata-vocabulary.md";
+
+describe("RotatePass setup vocabulary safety claims", () => {
+  it("keeps anti-overclaim language for health and owner confidence", () => {
+    const content = readFileSync(SETUP_VOCAB_DOC, "utf8");
+
+    expect(content).toContain("Do not mark this `true` from presence alone.");
+    expect(content).toContain("UI copy should not claim certainty from these values alone.");
+    expect(content).toContain("Avoid copy like `Owner verified` unless human review evidence exists.");
+    expect(content).toContain("`false` means the connector can still exist, but the UI should not claim a live health result.");
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit ownerConfidence vocabulary for setup metadata
- document non-overclaim UI language for owner certainty
- add a focused RotatePass test guarding anti-overclaim language

## Safety
- metadata-only wording changes
- no secrets, provider writes, or rotation automation

## Testing
- 
px vitest run src/__tests__/rotatepass-setup-vocabulary-claims.test.ts *(fails in this environment because vitest dependencies are unavailable)*