### PR TITLE
Wake router: fail ledger status on handoff sync failure

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -423,6 +423,14 @@ export function shouldFailMissingHandoffMessageId(result) {
   return Boolean(result?.posted) && !normalizeHandoffMessageId(result?.message_id) && !result?.dry_run;
 }
 
+export function deriveWakeStatus(result, handoffSync) {
+  const baseStatus = result?.posted ? "wake_posted" : result?.dry_run ? "wake_dry_run" : "wake_failed";
+  if (handoffSync?.attempted && !handoffSync?.synced) {
+    return "wake_failed";
+  }
+  return baseStatus;
+}
+
 async function registerWakeDispatch({ eventId, decision, triage, result, event }) {
   const dispatchRequest = buildReliabilityDispatchRequest({
     eventId,
@@ -738,7 +746,7 @@ async function main() {
     result,
     event,
   });
-  const status = result.posted ? "wake_posted" : result.dry_run ? "wake_dry_run" : "wake_failed";
+  const status = deriveWakeStatus(result, handoffSync);
   writeLedger({ eventId, event, decision: finalDecision, triage, result, reliability, handoffSync, status });
   if (
     (!result.posted && !result.dry_run) ||

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -10,6 +10,7 @@ import {
   buildReliabilityDispatchHandoffSyncRequest,
   buildReliabilityDispatchRequest,
   deriveAckThresholds,
+  deriveWakeStatus,
   normalizeHandoffMessageId,
   normalizeDispatchOwner,
   shouldFailMissingHandoffMessageId,
@@ -797,5 +798,13 @@ describe("event wake router reliability dispatch", () => {
     assert.equal(thresholds.warning_after_seconds, 2);
     assert.ok(thresholds.expected_within_seconds < thresholds.warning_after_seconds);
     assert.ok(thresholds.warning_after_seconds < thresholds.fail_after_seconds);
+  });
+
+  it("marks ledger status failed when handoff sync attempt is unsynced", () => {
+    assert.equal(deriveWakeStatus({ posted: true, dry_run: false }, { attempted: true, synced: false }), "wake_failed");
+  });
+
+  it("keeps ledger status posted when handoff sync succeeds", () => {
+    assert.equal(deriveWakeStatus({ posted: true, dry_run: false }, { attempted: true, synced: true }), "wake_posted");
   });
 });


### PR DESCRIPTION
## Summary
- add deriveWakeStatus(result, handoffSync) helper to centralize wake ledger status derivation
- mark wake status as wake_failed when handoff sync was attempted but not synced
- add focused tests for failed and successful handoff sync status outcomes

## Scope
- Event Wake Router reliability telemetry for no-ACK handoff sync outcomes

## Non-overlap
- No changes to Connections UI, Fishbowl UI, dependencies, migrations, auth, secrets, or payments

## Verification
- 
ode --test scripts/event-wake-router.test.mjs (pass: 33/33)

## Risk
- Low. Status derivation logic only; no new endpoints or schema changes.

## Follow-up
- Optional: add an integration-level test path for real HTTP handoff sync failures once fetch stubbing is introduced for the script process path.
