### PR TITLE
RotatePass: clarify metadata activity vs probe health in AdminKeychain

### DIFF
--- a/src/__tests__/admin-keychain-last-check-display.test.ts
+++ b/src/__tests__/admin-keychain-last-check-display.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { credentialLastCheckDisplay } from "@/pages/admin/AdminKeychain";
+
+describe("credentialLastCheckDisplay", () => {
+  it("uses metadata wording and untested suffix when no probe is supported", () => {
+    const display = credentialLastCheckDisplay({
+      last_checked_at: "2026-05-01T00:00:00.000Z",
+      last_tested_at: null,
+      supports_connection_test: false,
+    });
+
+    expect(display.label).toBe("Last metadata activity");
+    expect(display.value.toLowerCase()).toContain("untested");
+  });
+
+  it("uses last checked wording when probe support exists", () => {
+    const display = credentialLastCheckDisplay({
+      last_checked_at: null,
+      last_tested_at: null,
+      supports_connection_test: true,
+    });
+
+    expect(display.label).toBe("Last checked");
+    expect(display.value).toBe("never");
+  });
+});

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -217,6 +217,23 @@ function credentialHealth(cred: Credential): CredentialHealthStatus {
   return "healthy";
 }
 
+export function credentialLastCheckDisplay(cred: Pick<Credential, "last_checked_at" | "last_tested_at" | "supports_connection_test">): {
+  label: string;
+  value: string;
+} {
+  const lastChecked = cred.last_checked_at ?? cred.last_tested_at;
+  if (cred.supports_connection_test === false) {
+    return {
+      label: "Last metadata activity",
+      value: `${lastChecked ? timeAgo(lastChecked) : "never"} - untested`,
+    };
+  }
+  return {
+    label: "Last checked",
+    value: lastChecked ? timeAgo(lastChecked) : "never",
+  };
+}
+
 const HEALTH_BADGES: Record<CredentialHealthStatus, {
   label: string;
   className: string;
@@ -863,7 +880,7 @@ export default function AdminKeychain() {
                   const HealthIcon = badge.icon;
                   const usedBy    = cred.used_by?.filter(Boolean) ?? ["manual connection"];
                   const fields    = cred.expected_fields?.filter((f) => f.name || f.label) ?? [];
-                  const lastChecked = cred.last_checked_at ?? cred.last_tested_at;
+                  const lastCheckDisplay = credentialLastCheckDisplay(cred);
 
                   return (
                     <div
@@ -960,11 +977,8 @@ export default function AdminKeychain() {
                           <p className="mt-0.5 truncate text-[#ccc]">{cred.owner_email ?? "This UnClick account"}</p>
                         </div>
                         <div>
-                          <p className="text-[#555]">Last checked</p>
-                          <p className="mt-0.5 text-[#ccc]">
-                            {lastChecked ? timeAgo(lastChecked) : "never"}
-                            {cred.supports_connection_test === false ? " · manual" : ""}
-                          </p>
+                          <p className="text-[#555]">{lastCheckDisplay.label}</p>
+                          <p className="mt-0.5 text-[#ccc]">{lastCheckDisplay.value}</p>
                         </div>
                         <div className="sm:col-span-2">
                           <p className="text-[#555]">Used by</p>


### PR DESCRIPTION
## Summary
- prevent over-claiming health for credentials without server probe support
- show \Last metadata activity\ and explicit \- untested\ suffix instead of \Last checked\
- add focused test coverage for label/value behavior in AdminKeychain

## Scope
- tiny RotatePass wording/status slice in AdminKeychain only
- no provider writes, no secret handling changes, no migrations/auth/env changes

## Testing
- npx vitest run src/__tests__/admin-keychain-last-check-display.test.ts *(fails in this workspace: vitest/vite deps missing)*
