### PR TITLE
Wake router fail-closed on missing non-manual event path

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -47,7 +47,14 @@ export function deriveAckThresholds(failAfterSeconds) {
 }
 
 function readEvent() {
-  if (!eventPath) return {};
+  if (!eventPath) {
+    if (eventName !== "manual") {
+      return {
+        read_error: "GITHUB_EVENT_PATH is required for non-manual wake router events.",
+      };
+    }
+    return {};
+  }
   try {
     return JSON.parse(readFileSync(eventPath, "utf8"));
   } catch (err) {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -561,6 +561,21 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("fails closed when a non-manual event is missing GITHUB_EVENT_PATH", () => {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_EVENT_NAME: "workflow_run",
+        WAKE_ROUTER_DRY_RUN: "true",
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /GITHUB_EVENT_PATH is required for non-manual wake router events/);
+  });
+
   it("falls back to default ACK fail seconds when env value is malformed", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary\n- fail closed in event wake router when non-manual events are missing GITHUB_EVENT_PATH\n- keep manual mode behavior unchanged\n- add regression coverage for missing event path in non-manual runs\n\n## Verification\n- node --test scripts/event-wake-router.test.mjs