### PR TITLE
RotatePass: keep metadata activity separate from health claims

### DIFF
--- a/docs/connectors/system-credentials-health-panel.md
+++ b/docs/connectors/system-credentials-health-panel.md
@@ -158,6 +158,7 @@ System Credentials uses a status model that can be shared with RotatePass.
 | `unknown` | Metadata is incomplete and the panel cannot make a useful claim | Gray |
 
 Do not show `healthy` from presence alone. `Untested` is a deliberate safety label, not a warning by itself.
+Treat metadata activity timestamps as inventory evidence only. Metadata activity alone must not upgrade a credential to `healthy`.
 
 `healthy` requires one of:
 

--- a/src/__tests__/rotatepass-system-credentials-panel-copy.test.ts
+++ b/src/__tests__/rotatepass-system-credentials-panel-copy.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const PANEL_DOC_PATH = "docs/connectors/system-credentials-health-panel.md";
+
+describe("RotatePass system credentials panel copy", () => {
+  it("keeps metadata activity separate from health claims", () => {
+    const content = readFileSync(PANEL_DOC_PATH, "utf8");
+
+    expect(content).toContain("Treat metadata activity timestamps as inventory evidence only.");
+    expect(content).toContain("must not upgrade a credential to `healthy`.");
+    expect(content.toLowerCase()).not.toContain("metadata activity alone means healthy");
+    expect(content.toLowerCase()).not.toContain("mark healthy from presence alone");
+  });
+});


### PR DESCRIPTION
Archived PR notes. Public planning details have been removed.