### PR TITLE
Wake router fail-closed for non-object event payloads

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -49,7 +49,11 @@ export function deriveAckThresholds(failAfterSeconds) {
 function readEvent() {
   if (!eventPath) return {};
   try {
-    return JSON.parse(readFileSync(eventPath, "utf8"));
+    const parsed = JSON.parse(readFileSync(eventPath, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { read_error: "GitHub event payload must be a JSON object." };
+    }
+    return parsed;
   } catch (err) {
     return { read_error: err instanceof Error ? err.message : String(err) };
   }

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -561,6 +561,32 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("fails closed when the GitHub event payload is non-object JSON", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const eventPath = join(tempDir, "event.json");
+    const ledgerDir = join(tempDir, "ledger");
+    writeFileSync(eventPath, "null");
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: eventPath,
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /Failed to read GitHub event payload: GitHub event payload must be a JSON object/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to default ACK fail seconds when env value is malformed", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- fail closed when GITHUB_EVENT_PATH JSON is valid but not an object (
ull, array, scalar)
- return a ead_error so the router writes wake_failed ledger and exits non-zero instead of crashing
- add regression test for non-object payload path

## Scope
- scripts/event-wake-router.mjs
- scripts/event-wake-router.test.mjs

## Verification
- 
ode --test scripts/event-wake-router.test.mjs

## Non-overlap
- focused Event Wake Router reliability hardening only; no UI, deps, auth, migrations, or secrets changes