### PR TITLE
fix(wakepass): fail closed without event payload

### DIFF
--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -47,7 +47,14 @@ export function deriveAckThresholds(failAfterSeconds) {
 }
 
 function readEvent() {
-  if (!eventPath) return {};
+  if (!eventPath) {
+    if (eventName !== "manual") {
+      return {
+        read_error: "GITHUB_EVENT_PATH is required for non-manual wake router events.",
+      };
+    }
+    return {};
+  }
   try {
     const parsed = JSON.parse(readFileSync(eventPath, "utf8"));
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -587,6 +587,30 @@ describe("event wake router reliability dispatch", () => {
     }
   });
 
+  it("fails closed when a non-manual event is missing GITHUB_EVENT_PATH", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
+    const ledgerDir = join(tempDir, "ledger");
+
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_EVENT_PATH: "",
+          WAKE_LEDGER_DIR: ledgerDir,
+          WAKE_ROUTER_DRY_RUN: "true",
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /GITHUB_EVENT_PATH is required for non-manual wake router events/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to default ACK fail seconds when env value is malformed", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "wake-router-"));
     const eventPath = join(tempDir, "event.json");


### PR DESCRIPTION
## Summary
- Rebuilds the safe part of #505 on fresh `origin/main` instead of force-pushing the dirty branch.
- Makes non-manual wake-router runs fail closed when `GITHUB_EVENT_PATH` is missing.
- Adds a regression test for the missing-event-path case.

## Scope
- Owned files: `scripts/event-wake-router.mjs`, `scripts/event-wake-router.test.mjs`
- Lane: WakePass / event wake router reliability
- QueuePush packet: `queuepush:pr-505:dirty_branch:7747ec9:bed34c6487`

## Non-overlap
- Does not touch #505's branch, does not force-push another worker branch, and does not merge/close #505.
- Does not touch Fishbowl watcher files, RotatePass/System Credentials files, workflows, secrets, auth, billing, DNS/domains, migrations, or raw keys.

## Verification
- `node --test scripts/event-wake-router.test.mjs` PASS, 35/35
- `git diff --check` PASS

## Risk
- Narrow behavior change: manual runs still allow missing `GITHUB_EVENT_PATH`; non-manual runs now fail closed with wake_failed ledger evidence.
- No secrets, env values, provider settings, workflows, or persistence changes.

## Follow-up
- If this replacement is accepted, #505 can be closed as superseded by this PR.

Status: draft; ready for QC once remote checks finish.