### PR TITLE
feat(pinballwake): add admin clock routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ import CrewsSettings from "./pages/admin/crews/CrewsSettings.tsx";
 import CrewRun from "./pages/admin/crews/CrewRun.tsx";
 import AdminUsers from "./pages/admin/AdminUsers.tsx";
 import AdminSystemHealth from "./pages/admin/AdminSystemHealth.tsx";
+import AdminPinballWake from "./pages/admin/AdminPinballWake.tsx";
 import AdminModeration from "./pages/admin/AdminModeration.tsx";
 import AdminAuditLog from "./pages/admin/AdminAuditLog.tsx";
 import SignalsCatalog from "./pages/admin/signals/SignalsCatalog.tsx";
@@ -167,6 +168,7 @@ const App = () => (
             <Route path="orchestrator"   element={<RequireAdmin><AdminOrchestratorPage /></RequireAdmin>} />
             <Route path="users"          element={<RequireAdmin><AdminUsers /></RequireAdmin>} />
             <Route path="system-health"  element={<RequireAdmin><AdminSystemHealth /></RequireAdmin>} />
+            <Route path="pinballwake"    element={<RequireAdmin><AdminPinballWake /></RequireAdmin>} />
             <Route path="moderation"     element={<RequireAdmin><AdminModeration /></RequireAdmin>} />
             <Route path="audit-log"      element={<RequireAdmin><AdminAuditLog /></RequireAdmin>} />
             <Route path="signals"          element={<SignalsCatalog />} />

--- a/src/pages/admin/AdminPinballWake.tsx
+++ b/src/pages/admin/AdminPinballWake.tsx
@@ -1,0 +1,177 @@
+import {
+  BellRing,
+  CheckCircle2,
+  Clock3,
+  ExternalLink,
+  Gauge,
+  RadioTower,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import {
+  PINBALLWAKE_CLOCK_ROUTES,
+  summarizePinballWakeClockRoutes,
+  type PinballWakeClockRoute,
+  type PinballWakeClockStatus,
+} from "./pinballwakeClockRoutes";
+
+const STATUS_STYLES: Record<PinballWakeClockStatus, string> = {
+  live: "border-[#61C1C4]/40 bg-[#61C1C4]/10 text-[#61C1C4]",
+  watching: "border-[#E2B93B]/40 bg-[#E2B93B]/10 text-[#E2B93B]",
+  ready: "border-emerald-400/35 bg-emerald-400/10 text-emerald-300",
+  candidate: "border-white/15 bg-white/[0.04] text-white/65",
+  later: "border-white/10 bg-white/[0.02] text-white/40",
+};
+
+function StatusBadge({ status }: { status: PinballWakeClockStatus }) {
+  return (
+    <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase ${STATUS_STYLES[status]}`}>
+      {status.replace("-", " ")}
+    </span>
+  );
+}
+
+function MetricCard({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof BellRing;
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <section className="rounded-lg border border-white/[0.06] bg-[#111111] p-4">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase text-white/40">
+        <Icon className="h-4 w-4 text-[#E2B93B]" />
+        {label}
+      </div>
+      <p className="mt-3 text-2xl font-semibold text-white">{value}</p>
+    </section>
+  );
+}
+
+function RouteRow({ route }: { route: PinballWakeClockRoute }) {
+  return (
+    <article className="rounded-lg border border-white/[0.06] bg-[#111111] p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold text-white">{route.name}</h2>
+            <StatusBadge status={route.status} />
+          </div>
+          <p className="mt-1 text-sm text-white/55">{route.role}</p>
+        </div>
+        <div className="shrink-0 rounded-md border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-xs text-white/55">
+          {route.owner} · {route.automationLevel}
+        </div>
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+        <div>
+          <dt className="text-xs font-medium uppercase text-white/35">Technique</dt>
+          <dd className="mt-1 text-white/70">{route.technique}</dd>
+        </div>
+        <div>
+          <dt className="text-xs font-medium uppercase text-white/35">User Required</dt>
+          <dd className="mt-1 text-white/70">{route.userRequired}</dd>
+        </div>
+        <div>
+          <dt className="text-xs font-medium uppercase text-white/35">Safety</dt>
+          <dd className="mt-1 text-white/70">{route.safety}</dd>
+        </div>
+        <div>
+          <dt className="text-xs font-medium uppercase text-white/35">Next Step</dt>
+          <dd className="mt-1 text-white/70">{route.nextStep}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+export default function AdminPinballWake() {
+  const summary = summarizePinballWakeClockRoutes();
+
+  const primaryRoutes = PINBALLWAKE_CLOCK_ROUTES.filter((route) =>
+    ["live", "watching", "ready"].includes(route.status),
+  );
+  const futureRoutes = PINBALLWAKE_CLOCK_ROUTES.filter((route) =>
+    ["candidate", "later"].includes(route.status),
+  );
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#61C1C4]/10 text-[#61C1C4]">
+            <BellRing className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-white">PinballWake</h1>
+            <p className="mt-1 max-w-2xl text-sm text-white/50">
+              Wake routes, clocks, ACK proof, and safe fallback paths for the worker fleet.
+            </p>
+          </div>
+        </div>
+        <a
+          href="/admin/fishbowl"
+          className="inline-flex items-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-sm font-medium text-white/65 transition-colors hover:bg-white/[0.06] hover:text-white"
+        >
+          Fishbowl
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+
+      <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <MetricCard icon={RadioTower} label="Clock Routes" value={summary.total} />
+        <MetricCard icon={CheckCircle2} label="Live" value={summary.byStatus.live ?? 0} />
+        <MetricCard icon={Gauge} label="Automated" value={summary.automated} />
+        <MetricCard icon={ShieldCheck} label="No New Setup" value={summary.noNewUserSetup} />
+      </div>
+
+      <section className="mb-6 rounded-lg border border-[#E2B93B]/25 bg-[#E2B93B]/[0.06] p-4">
+        <div className="flex items-start gap-3">
+          <Clock3 className="mt-0.5 h-4 w-4 shrink-0 text-[#E2B93B]" />
+          <div>
+            <h2 className="text-sm font-semibold text-[#E2B93B]">Operating Rule</h2>
+            <p className="mt-1 text-sm leading-relaxed text-white/65">
+              QueuePush should stay one safe button. PinballWake manages the clocks that press it,
+              WakePass proves ACK or reclaim, and every late duplicate must re-read current state
+              before doing anything.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div className="space-y-6">
+        <section>
+          <div className="mb-3 flex items-center gap-2">
+            <RadioTower className="h-4 w-4 text-[#61C1C4]" />
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+              Active And Ready Routes
+            </h2>
+          </div>
+          <div className="space-y-3">
+            {primaryRoutes.map((route) => (
+              <RouteRow key={route.id} route={route} />
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-3 flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-[#E2B93B]" />
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+              Candidate Routes
+            </h2>
+          </div>
+          <div className="space-y-3">
+            {futureRoutes.map((route) => (
+              <RouteRow key={route.id} route={route} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -45,6 +45,7 @@ import {
   ShieldCheck,
   ScrollText,
   Fish,
+  BellRing,
 } from "lucide-react";
 
 function SurfaceLink({ path, label, icon: Icon, onClick, badge }: {
@@ -83,6 +84,7 @@ const ADMIN_SUBMENU = [
   { path: "/admin/orchestrator",  label: "Orchestrator",          icon: Terminal    },
   { path: "/admin/users",         label: "User Management",       icon: UsersIcon   },
   { path: "/admin/system-health", label: "System Health",         icon: HeartPulse  },
+  { path: "/admin/pinballwake",   label: "PinballWake",           icon: BellRing    },
   { path: "/admin/moderation",    label: "Marketplace Moderation", icon: ShieldCheck },
   { path: "/admin/audit-log",     label: "Audit Log",             icon: ScrollText  },
 ] as const;

--- a/src/pages/admin/pinballwakeClockRoutes.test.ts
+++ b/src/pages/admin/pinballwakeClockRoutes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  PINBALLWAKE_CLOCK_ROUTES,
+  summarizePinballWakeClockRoutes,
+} from "./pinballwakeClockRoutes";
+
+describe("PinballWake clock routes", () => {
+  it("keeps QueuePush and WakePass as live non-destructive routes", () => {
+    const queuepush = PINBALLWAKE_CLOCK_ROUTES.find((route) => route.id === "queuepush-pr-scanner");
+    const wakepass = PINBALLWAKE_CLOCK_ROUTES.find((route) => route.id === "wakepass-ack-reclaim");
+
+    expect(queuepush?.status).toBe("live");
+    expect(queuepush?.safety).toMatch(/duplicate/i);
+    expect(wakepass?.status).toBe("live");
+    expect(wakepass?.safety).toMatch(/not destructive/i);
+  });
+
+  it("does not mark provider-key routes as live requirements", () => {
+    const paidOrKeyedRoutes = PINBALLWAKE_CLOCK_ROUTES.filter((route) =>
+      /OpenRouter|Groq|QStash|Cloudflare|Vercel/.test(`${route.name} ${route.technique}`),
+    );
+
+    expect(paidOrKeyedRoutes.length).toBeGreaterThan(0);
+    expect(paidOrKeyedRoutes.every((route) => route.userRequired !== "None after setup.")).toBe(true);
+  });
+
+  it("summarizes the current clock ladder for the admin page", () => {
+    const summary = summarizePinballWakeClockRoutes();
+
+    expect(summary.total).toBe(PINBALLWAKE_CLOCK_ROUTES.length);
+    expect(summary.automated).toBeGreaterThanOrEqual(4);
+    expect(summary.byStatus.live).toBeGreaterThanOrEqual(3);
+    expect(summary.byStatus.ready).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/pages/admin/pinballwakeClockRoutes.ts
+++ b/src/pages/admin/pinballwakeClockRoutes.ts
@@ -1,0 +1,195 @@
+export type PinballWakeClockStatus =
+  | "live"
+  | "watching"
+  | "ready"
+  | "candidate"
+  | "later";
+
+export type PinballWakeClockOwner =
+  | "PinballWake"
+  | "QueuePush"
+  | "WakePass"
+  | "Master"
+  | "Operator";
+
+export interface PinballWakeClockRoute {
+  id: string;
+  name: string;
+  owner: PinballWakeClockOwner;
+  status: PinballWakeClockStatus;
+  automationLevel: "automatic" | "watchdog" | "one-time setup" | "manual fallback" | "future";
+  technique: string;
+  role: string;
+  userRequired: string;
+  safety: string;
+  nextStep: string;
+}
+
+export const PINBALLWAKE_CLOCK_ROUTES: PinballWakeClockRoute[] = [
+  {
+    id: "queuepush-pr-scanner",
+    name: "QueuePush PR scanner",
+    owner: "QueuePush",
+    status: "live",
+    automationLevel: "automatic",
+    technique: "GitHub workflow plus Fishbowl packet",
+    role: "Scans stuck pull requests and creates one-worker packets.",
+    userRequired: "None after setup.",
+    safety: "Stable packet IDs stop duplicate late runs from spamming workers.",
+    nextStep: "Keep as the first PinballWake queue route.",
+  },
+  {
+    id: "master-watchdog",
+    name: "Master watchdog",
+    owner: "Master",
+    status: "watching",
+    automationLevel: "watchdog",
+    technique: "Codex heartbeat",
+    role: "Checks whether QueuePush moved work; bridges missed GitHub cron runs.",
+    userRequired: "Keep this thread heartbeat active.",
+    safety: "Triggers QueuePush only as a bridge and never edits branches.",
+    nextStep: "Use as the current reliability backstop.",
+  },
+  {
+    id: "github-actions-schedule",
+    name: "GitHub Actions schedule",
+    owner: "PinballWake",
+    status: "live",
+    automationLevel: "automatic",
+    technique: "Scheduled workflow",
+    role: "Runs QueuePush on a staggered schedule from GitHub.",
+    userRequired: "None, but GitHub may delay or drop schedule runs.",
+    safety: "QueuePush re-reads current PR state every run.",
+    nextStep: "Keep, but do not trust as the only clock.",
+  },
+  {
+    id: "wakepass-ack-reclaim",
+    name: "WakePass ACK reclaim",
+    owner: "WakePass",
+    status: "live",
+    automationLevel: "automatic",
+    technique: "Fishbowl handoff and stale ACK watcher",
+    role: "Turns missed worker ACKs into visible reclaim work.",
+    userRequired: "None once workers reply with ACK or blocker.",
+    safety: "Reclaim is based on stale leases, not destructive branch action.",
+    nextStep: "Use as the proof layer behind every route.",
+  },
+  {
+    id: "vercel-cron",
+    name: "Vercel Cron",
+    owner: "PinballWake",
+    status: "ready",
+    automationLevel: "one-time setup",
+    technique: "Secure API endpoint",
+    role: "External product clock that can call QueuePush outside GitHub.",
+    userRequired: "One-time endpoint and secret setup.",
+    safety: "Endpoint should accept only signed requests and run advisory QueuePush.",
+    nextStep: "Best next production fallback.",
+  },
+  {
+    id: "cloudflare-cron",
+    name: "Cloudflare Workers Cron",
+    owner: "PinballWake",
+    status: "candidate",
+    automationLevel: "one-time setup",
+    technique: "Worker scheduled trigger",
+    role: "Independent outside clock if Vercel or GitHub are quiet.",
+    userRequired: "One-time Worker and secret setup.",
+    safety: "Calls the same idempotent QueuePush button.",
+    nextStep: "Add only if Vercel Cron is not enough.",
+  },
+  {
+    id: "supabase-pg-cron",
+    name: "Supabase pg_cron",
+    owner: "PinballWake",
+    status: "candidate",
+    automationLevel: "one-time setup",
+    technique: "Database schedule plus HTTP call",
+    role: "Database-owned clock that can also store last-run receipts.",
+    userRequired: "Migration approval before use.",
+    safety: "Hold until migrations are approved.",
+    nextStep: "Good later fit for receipt storage, not today's fastest move.",
+  },
+  {
+    id: "qstash",
+    name: "Upstash QStash",
+    owner: "PinballWake",
+    status: "candidate",
+    automationLevel: "one-time setup",
+    technique: "HTTP schedule with retries",
+    role: "Retries webhook delivery when a route misses.",
+    userRequired: "Provider account and token setup.",
+    safety: "Use idempotency keys so retries are harmless.",
+    nextStep: "Consider when QueuePush needs delivery retries, not just schedule retries.",
+  },
+  {
+    id: "external-healthcheck",
+    name: "External healthcheck",
+    owner: "Operator",
+    status: "ready",
+    automationLevel: "one-time setup",
+    technique: "Cronitor, Healthchecks, Better Stack, or UptimeRobot",
+    role: "Alerts when no QueuePush healthy receipt appears in the expected window.",
+    userRequired: "One-time monitor setup.",
+    safety: "Monitor only; does not touch branches or secrets.",
+    nextStep: "Pair with a last-run receipt before enabling alerts.",
+  },
+  {
+    id: "plex-task-scheduler",
+    name: "Plex PC task",
+    owner: "Operator",
+    status: "candidate",
+    automationLevel: "manual fallback",
+    technique: "Windows Task Scheduler",
+    role: "Local backup clock for Chris's own machines.",
+    userRequired: "Machine must be awake, synced, and configured.",
+    safety: "Useful fallback, but not a public-product foundation.",
+    nextStep: "Keep as emergency redundancy only.",
+  },
+  {
+    id: "doorbell-classifier",
+    name: "Cheap doorbell classifier",
+    owner: "PinballWake",
+    status: "candidate",
+    automationLevel: "one-time setup",
+    technique: "OpenRouter or Groq",
+    role: "Decides wake or no-wake when deterministic routing is unsure.",
+    userRequired: "Optional model key and budget cap.",
+    safety: "Classifier only; cannot code, review, merge, or change product state.",
+    nextStep: "Keep optional until routing ambiguity becomes expensive.",
+  },
+  {
+    id: "local-browser-extension",
+    name: "Local browser extension",
+    owner: "PinballWake",
+    status: "later",
+    automationLevel: "future",
+    technique: "User-owned browser wake route",
+    role: "Wakes browser-resident agents while cookies and MFA stay local.",
+    userRequired: "Future extension install and one-button revoke.",
+    safety: "Do not store raw keys; user keeps browser session locally.",
+    nextStep: "Phase 0 only until core clocks are stable.",
+  },
+];
+
+export function summarizePinballWakeClockRoutes(routes = PINBALLWAKE_CLOCK_ROUTES) {
+  return routes.reduce(
+    (summary, route) => {
+      summary.total += 1;
+      summary.byStatus[route.status] = (summary.byStatus[route.status] ?? 0) + 1;
+      if (route.automationLevel === "automatic" || route.automationLevel === "watchdog") {
+        summary.automated += 1;
+      }
+      if (route.userRequired === "None after setup." || route.userRequired === "None once workers reply with ACK or blocker.") {
+        summary.noNewUserSetup += 1;
+      }
+      return summary;
+    },
+    {
+      total: 0,
+      automated: 0,
+      noNewUserSetup: 0,
+      byStatus: {} as Record<PinballWakeClockStatus, number>,
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- add an admin-only PinballWake page for clock route management
- inventory QueuePush, WakePass, GitHub cron, Master watchdog, Vercel/Cloudflare/Supabase/QStash/external/local fallback routes
- add focused tests so live/keyed/future routes stay separated

## Owner / non-overlap
- owner: 🧠 Master / safe proof lane
- non-overlap: UI + typed inventory only; no secrets, auth, billing, DNS/domains, migrations, workflow edits, queue execution, or live scheduler mutation

## Tests
- PASS: npx vitest run src/pages/admin/pinballwakeClockRoutes.test.ts
- PASS: npm run build
- PASS: git diff --check

## Notes
- npm install produced an unstaged line-ending metadata change in packages/channel-plugin/index.js; it was not staged or included.