### PR TITLE
feat(pinballwake): add coding room runner loop

### DIFF
--- a/scripts/pinballwake-coding-room-runner.mjs
+++ b/scripts/pinballwake-coding-room-runner.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import {
+  claimCodingRoomLedgerJob,
+  createCodingRoomJobLedger,
+  listCodingRoomJobs,
+  markReviewFallbackReady,
+  readCodingRoomJobLedger,
+  reclaimExpiredCodingRoomJobs,
+  runnerCanClaimCodingRoomJob,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+
+export const DEFAULT_CODING_ROOM_RUNNER = {
+  id: "pinballwake-job-runner",
+  readiness: "builder_ready",
+  capabilities: ["implementation", "test_fix", "docs_update"],
+};
+
+function parseList(value, fallback = []) {
+  const text = String(value ?? "").trim();
+  if (!text) return fallback;
+  return text
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseBoolean(value) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function parseIntOption(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+export function createCodingRoomRunner(input = {}) {
+  return {
+    id: String(input.id || DEFAULT_CODING_ROOM_RUNNER.id).trim(),
+    emoji: String(input.emoji || "").trim(),
+    agent_id: String(input.agentId || input.agent_id || "").trim(),
+    name: String(input.name || "").trim(),
+    readiness: String(input.readiness || DEFAULT_CODING_ROOM_RUNNER.readiness).trim(),
+    capabilities: Array.isArray(input.capabilities)
+      ? input.capabilities.map((capability) => String(capability).trim()).filter(Boolean)
+      : [...DEFAULT_CODING_ROOM_RUNNER.capabilities],
+  };
+}
+
+export function createCodingRoomRunnerFromEnv(env = process.env) {
+  return createCodingRoomRunner({
+    id: env.CODING_ROOM_RUNNER_ID,
+    emoji: env.CODING_ROOM_RUNNER_EMOJI,
+    agentId: env.CODING_ROOM_RUNNER_AGENT_ID,
+    name: env.CODING_ROOM_RUNNER_NAME,
+    readiness: env.CODING_ROOM_RUNNER_READINESS,
+    capabilities: parseList(env.CODING_ROOM_RUNNER_CAPABILITIES, DEFAULT_CODING_ROOM_RUNNER.capabilities),
+  });
+}
+
+export function markTimedOutReviewJobs({ ledger, now = new Date().toISOString() } = {}) {
+  let fallbackReady = 0;
+  const next = createCodingRoomJobLedger({
+    jobs: (ledger?.jobs || []).map((job) => {
+      const marked = markReviewFallbackReady({ job, now });
+      if (!marked.ok) {
+        return job;
+      }
+
+      fallbackReady += 1;
+      return marked.job;
+    }),
+    updatedAt: now,
+  });
+
+  return { ok: true, fallbackReady, ledger: next };
+}
+
+export function chooseClaimableCodingRoomJob({ ledger, runner } = {}) {
+  const queuedJobs = listCodingRoomJobs({ ledger, statuses: "queued" });
+  const skipped = [];
+
+  for (const job of queuedJobs) {
+    const decision = runnerCanClaimCodingRoomJob({ runner, job, activeJobs: ledger?.jobs || [] });
+    if (decision.ok) {
+      return { ok: true, job, skipped };
+    }
+
+    skipped.push({
+      job_id: job.job_id,
+      worker: job.worker,
+      chip: job.chip,
+      reason: decision.reason,
+      file: decision.file || null,
+      review_kind: decision.review_kind || null,
+    });
+  }
+
+  return { ok: false, reason: "no_claimable_jobs", skipped };
+}
+
+export function runCodingRoomRunnerCycle({
+  ledger,
+  runner = DEFAULT_CODING_ROOM_RUNNER,
+  now = new Date().toISOString(),
+  leaseSeconds,
+} = {}) {
+  const reclaimed = reclaimExpiredCodingRoomJobs({ ledger, now });
+  if (!reclaimed.ok) {
+    return reclaimed;
+  }
+
+  const fallback = markTimedOutReviewJobs({ ledger: reclaimed.ledger, now });
+  const choice = chooseClaimableCodingRoomJob({ ledger: fallback.ledger, runner });
+  if (!choice.ok) {
+    return {
+      ok: true,
+      action: "idle",
+      reason: choice.reason,
+      ledger: fallback.ledger,
+      reclaimed: reclaimed.reclaimed,
+      fallback_ready: fallback.fallbackReady,
+      skipped: choice.skipped,
+    };
+  }
+
+  const claimed = claimCodingRoomLedgerJob({
+    ledger: fallback.ledger,
+    jobId: choice.job.job_id,
+    runner,
+    now,
+    leaseSeconds,
+  });
+  if (!claimed.ok) {
+    return claimed;
+  }
+
+  return {
+    ok: true,
+    action: "claimed",
+    ledger: claimed.ledger,
+    job: claimed.job,
+    claim: claimed.claim,
+    reclaimed: reclaimed.reclaimed,
+    fallback_ready: fallback.fallbackReady,
+    skipped: choice.skipped,
+  };
+}
+
+export async function runCodingRoomRunnerFile({
+  ledgerPath,
+  runner = DEFAULT_CODING_ROOM_RUNNER,
+  now = new Date().toISOString(),
+  leaseSeconds,
+  dryRun = false,
+} = {}) {
+  if (!ledgerPath) {
+    return { ok: false, reason: "missing_ledger_path" };
+  }
+
+  const ledger = await readCodingRoomJobLedger(ledgerPath);
+  const result = runCodingRoomRunnerCycle({
+    ledger,
+    runner,
+    now,
+    leaseSeconds,
+  });
+
+  if (result.ok && !dryRun) {
+    await writeCodingRoomJobLedger(ledgerPath, result.ledger);
+  }
+
+  return {
+    ...result,
+    dry_run: dryRun,
+    ledger_path: ledgerPath,
+  };
+}
+
+function cliRunner() {
+  const runner = createCodingRoomRunnerFromEnv();
+  return createCodingRoomRunner({
+    ...runner,
+    id: getArg("runner-id", runner.id),
+    readiness: getArg("readiness", runner.readiness),
+    capabilities: parseList(getArg("capabilities", runner.capabilities.join(",")), runner.capabilities),
+  });
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  const ledgerPath = getArg("ledger", process.env.CODING_ROOM_LEDGER_PATH || "");
+  const dryRun = process.argv.includes("--dry-run") || parseBoolean(process.env.CODING_ROOM_RUNNER_DRY_RUN);
+  const leaseSeconds = parseIntOption(getArg("lease-seconds", process.env.CODING_ROOM_LEASE_SECONDS), undefined);
+
+  runCodingRoomRunnerFile({
+    ledgerPath,
+    runner: cliRunner(),
+    leaseSeconds,
+    dryRun,
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-coding-room-runner.test.mjs
+++ b/scripts/pinballwake-coding-room-runner.test.mjs
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  claimCodingRoomJob,
+  createCodingRoomJob,
+  createCodingRoomJobLedger,
+  createCodingRoomQcJob,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+import {
+  chooseClaimableCodingRoomJob,
+  createCodingRoomRunner,
+  createCodingRoomRunnerFromEnv,
+  markTimedOutReviewJobs,
+  runCodingRoomRunnerCycle,
+  runCodingRoomRunnerFile,
+} from "./pinballwake-coding-room-runner.mjs";
+
+const forgeRunner = createCodingRoomRunner({
+  id: "forge",
+  readiness: "builder_ready",
+  capabilities: ["implementation", "test_fix"],
+});
+
+describe("PinballWake Coding Room runner loop", () => {
+  it("creates runners from explicit input and environment", () => {
+    assert.deepEqual(
+      createCodingRoomRunner({
+        id: "popcorn",
+        readiness: "review_only",
+        capabilities: ["qc_review"],
+      }),
+      {
+        id: "popcorn",
+        emoji: "",
+        agent_id: "",
+        name: "",
+        readiness: "review_only",
+        capabilities: ["qc_review"],
+      },
+    );
+
+    assert.deepEqual(
+      createCodingRoomRunnerFromEnv({
+        CODING_ROOM_RUNNER_ID: "gatekeeper",
+        CODING_ROOM_RUNNER_READINESS: "review_only",
+        CODING_ROOM_RUNNER_CAPABILITIES: "release_safety,merge_proof",
+      }).capabilities,
+      ["release_safety", "merge_proof"],
+    );
+  });
+
+  it("claims the first matching queued job and writes a lease", () => {
+    const job = createCodingRoomJob({
+      jobId: "coding-room:runner:claim",
+      worker: "forge",
+      chip: "claim by runner",
+      files: ["scripts/pinballwake-coding-room-runner.mjs"],
+    });
+
+    const result = runCodingRoomRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner: forgeRunner,
+      now: "2026-05-04T00:00:00.000Z",
+      leaseSeconds: 120,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "claimed");
+    assert.equal(result.job.status, "claimed");
+    assert.equal(result.claim.runner_id, "forge");
+    assert.equal(result.claim.lease_expires_at, "2026-05-04T00:02:00.000Z");
+  });
+
+  it("skips unclaimable jobs and claims the next safe job", () => {
+    const reviewJob = createCodingRoomQcJob({
+      jobId: "coding-room:runner:qc",
+      prNumber: 517,
+      requestedReviewers: ["popcorn"],
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+    const codeJob = createCodingRoomJob({
+      jobId: "coding-room:runner:code",
+      worker: "forge",
+      chip: "claim by runner",
+      files: ["scripts/pinballwake-coding-room-runner.mjs"],
+    });
+
+    const result = runCodingRoomRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [reviewJob, codeJob] }),
+      runner: forgeRunner,
+      now: "2026-05-04T00:00:00.000Z",
+    });
+
+    assert.equal(result.action, "claimed");
+    assert.equal(result.job.job_id, "coding-room:runner:code");
+    assert.equal(result.skipped[0].job_id, "coding-room:runner:qc");
+    assert.equal(result.skipped[0].reason, "runner_lacks_review_kind_capability");
+  });
+
+  it("returns idle with skip reasons when there is no claimable job", () => {
+    const job = createCodingRoomQcJob({
+      jobId: "coding-room:runner:only-qc",
+      prNumber: 517,
+      requestedReviewers: ["popcorn"],
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    const result = runCodingRoomRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner: forgeRunner,
+      now: "2026-05-04T00:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "idle");
+    assert.equal(result.reason, "no_claimable_jobs");
+    assert.equal(result.skipped[0].reason, "runner_lacks_review_kind_capability");
+  });
+
+  it("reclaims expired leases before choosing work", () => {
+    const expired = claimCodingRoomJob({
+      runner: forgeRunner,
+      job: createCodingRoomJob({
+        jobId: "coding-room:runner:expired",
+        worker: "forge",
+        chip: "expired lease",
+        files: ["scripts/pinballwake-coding-room-runner.mjs"],
+      }),
+      now: "2026-05-04T00:00:00.000Z",
+      leaseSeconds: 60,
+    }).job;
+
+    const result = runCodingRoomRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [expired] }),
+      runner: forgeRunner,
+      now: "2026-05-04T00:01:01.000Z",
+    });
+
+    assert.equal(result.action, "claimed");
+    assert.equal(result.reclaimed, 1);
+    assert.equal(result.job.job_id, "coding-room:runner:expired");
+    assert.equal(result.ledger.jobs[0].previous_claims[0].reason, "lease_expired");
+  });
+
+  it("marks timed out review jobs fallback-ready before claiming new work", () => {
+    const reviewJob = createCodingRoomQcJob({
+      jobId: "coding-room:runner:stale-review",
+      prNumber: 517,
+      requestedReviewers: ["popcorn"],
+      fallbackWorker: "master",
+      createdAt: "2026-05-04T00:00:00.000Z",
+      timeoutSeconds: 60,
+    });
+    const codeJob = createCodingRoomJob({
+      jobId: "coding-room:runner:after-review",
+      worker: "forge",
+      chip: "claim after review timeout",
+      files: ["scripts/pinballwake-coding-room-runner.mjs"],
+    });
+
+    const result = runCodingRoomRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [reviewJob, codeJob] }),
+      runner: forgeRunner,
+      now: "2026-05-04T00:01:01.000Z",
+    });
+
+    assert.equal(result.fallback_ready, 1);
+    assert.equal(result.ledger.jobs[0].status, "fallback_ready");
+    assert.equal(result.job.job_id, "coding-room:runner:after-review");
+  });
+
+  it("can mark review fallback without claiming anything", () => {
+    const reviewJob = createCodingRoomQcJob({
+      jobId: "coding-room:runner:mark-review",
+      prNumber: 517,
+      requestedReviewers: ["popcorn"],
+      createdAt: "2026-05-04T00:00:00.000Z",
+      timeoutSeconds: 60,
+    });
+
+    const result = markTimedOutReviewJobs({
+      ledger: createCodingRoomJobLedger({ jobs: [reviewJob] }),
+      now: "2026-05-04T00:01:01.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.fallbackReady, 1);
+    assert.equal(result.ledger.jobs[0].status, "fallback_ready");
+  });
+
+  it("persists runner cycle results to a ledger file unless dry-run is set", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "coding-room-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      const job = createCodingRoomJob({
+        jobId: "coding-room:runner:file",
+        worker: "forge",
+        chip: "persist claim",
+        files: ["scripts/pinballwake-coding-room-runner.mjs"],
+      });
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger({ jobs: [job] }));
+
+      const result = await runCodingRoomRunnerFile({
+        ledgerPath,
+        runner: forgeRunner,
+        now: "2026-05-04T00:00:00.000Z",
+        leaseSeconds: 60,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+
+      const dryRun = await runCodingRoomRunnerFile({
+        ledgerPath,
+        runner: forgeRunner,
+        now: "2026-05-04T00:00:10.000Z",
+        dryRun: true,
+      });
+
+      assert.equal(dryRun.ok, true);
+      assert.equal(dryRun.action, "idle");
+      assert.equal(dryRun.dry_run, true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("chooses no job from an empty ledger", () => {
+    const result = chooseClaimableCodingRoomJob({
+      ledger: createCodingRoomJobLedger(),
+      runner: forgeRunner,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "no_claimable_jobs");
+    assert.deepEqual(result.skipped, []);
+  });
+});


### PR DESCRIPTION
## Summary
- add `scripts/pinballwake-coding-room-runner.mjs`, a small runner loop for the Coding Room ledger
- runner cycle reclaims expired job leases, marks timed-out review jobs fallback-ready, chooses one claimable job, claims it, and persists the ledger
- add environment/CLI runner config for `runner-id`, readiness, capabilities, ledger path, dry-run, and lease seconds
- add focused tests covering claim, skip reasons, lease reclaim, review fallback, file persistence, and empty-ledger idle behavior

## Scope / Ownership
owner: 🧠 master
owned files:
- scripts/pinballwake-coding-room-runner.mjs
- scripts/pinballwake-coding-room-runner.test.mjs
non-overlap: new runner-loop files only; no auth/secrets/billing/DNS/migrations/raw keys; no desktop wake changes; no branch/merge automation.
status: draft / ready for automation QC after GitHub checks complete

## Proof
- node --test scripts/pinballwake-coding-room-runner.test.mjs passed 9/9
- node --test scripts/pinballwake-coding-room.test.mjs passed 27/27
- node --test scripts/fleet-throughput-watch.test.mjs passed 23/23
- git diff --check passed

## Safety
This is still claim/persist/fallback plumbing only. It does not edit repo files for a job, does not create branches/PRs from claimed jobs, does not merge, and does not bypass QC/Safety. It is the next foundation toward an actual always-on runner loop.