### PR TITLE
feat(pinballwake): add proof executor

### DIFF
--- a/scripts/pinballwake-coding-room.mjs
+++ b/scripts/pinballwake-coding-room.mjs
@@ -106,7 +106,9 @@ export function createCodingRoomJob(input = {}) {
     status,
     owned_files: ownedFiles,
     expected_proof: {
-      tests: Array.isArray(expectedProof.tests) ? expectedProof.tests.map(compactText).filter(Boolean) : [],
+      tests: Array.isArray(expectedProof.tests)
+        ? expectedProof.tests.map((test) => compactText(test)).filter(Boolean)
+        : [],
       requires_pr: expectedProof.requiresPr !== false,
       requires_changed_files: expectedProof.requiresChangedFiles !== false,
       requires_non_overlap: expectedProof.requiresNonOverlap !== false,

--- a/scripts/pinballwake-proof-executor.mjs
+++ b/scripts/pinballwake-proof-executor.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+import {
+  createCodingRoomJobLedger,
+  readCodingRoomJobLedger,
+  submitCodingRoomProof,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+
+export const DEFAULT_PROOF_COMMAND_ALLOWLIST = [
+  "node --test scripts/",
+  "npm run test:",
+  "npm test --",
+];
+
+function parseBoolean(value) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function parseIntOption(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function compactOutput(value, max = 2000) {
+  const text = String(value ?? "").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function parseList(value, fallback = []) {
+  const text = String(value ?? "").trim();
+  if (!text) return fallback;
+  return text
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function commandToArgv(command) {
+  const parts = [];
+  let current = "";
+  let quote = "";
+
+  for (const char of String(command ?? "").trim()) {
+    if (quote) {
+      if (char === quote) {
+        quote = "";
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (quote) {
+    throw new Error("Unclosed quote in command");
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+export function isProofCommandAllowed(command, allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST) {
+  const normalized = String(command ?? "").replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return false;
+  }
+
+  if (/[;&|`$<>]/.test(normalized)) {
+    return false;
+  }
+
+  return allowlist.some((allowed) => normalized === allowed || normalized.startsWith(allowed));
+}
+
+export function getProofCommandsForJob(job) {
+  return Array.isArray(job?.expected_proof?.tests)
+    ? job.expected_proof.tests.map((command) => String(command).trim()).filter(Boolean)
+    : [];
+}
+
+export async function runProofCommand(command, { cwd = process.cwd(), timeoutMs = 120000 } = {}) {
+  const [bin, ...args] = commandToArgv(command);
+  if (!bin) {
+    return { command, status: "failed", exit_code: null, output: "Empty command" };
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, {
+      cwd,
+      shell: false,
+      windowsHide: true,
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      resolve({
+        command,
+        status: "failed",
+        exit_code: null,
+        output: compactOutput(`${stdout}\n${stderr}\nTimed out after ${timeoutMs}ms`),
+      });
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        command,
+        status: "failed",
+        exit_code: null,
+        output: compactOutput(error.message),
+      });
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        command,
+        status: code === 0 ? "passed" : "failed",
+        exit_code: code,
+        output: compactOutput(`${stdout}\n${stderr}`),
+      });
+    });
+  });
+}
+
+export async function executeCodingRoomProofJob({
+  job,
+  allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  cwd = process.cwd(),
+  timeoutMs = 120000,
+  runCommand = runProofCommand,
+  now = new Date().toISOString(),
+} = {}) {
+  if (!job) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  if (job.status !== "claimed" && job.status !== "testing") {
+    return { ok: false, reason: "job_not_claimed" };
+  }
+
+  const commands = getProofCommandsForJob(job);
+  if (commands.length === 0) {
+    return { ok: false, reason: "missing_proof_commands" };
+  }
+
+  const disallowed = commands.find((command) => !isProofCommandAllowed(command, allowlist));
+  if (disallowed) {
+    return {
+      ok: true,
+      job: submitCodingRoomProof({
+        job,
+        proof: {
+          result: "blocker",
+          blocker: `Proof command is not allowlisted: ${disallowed}`,
+          submittedAt: now,
+        },
+      }).job,
+      result: "blocker",
+      reason: "proof_command_not_allowlisted",
+      command: disallowed,
+    };
+  }
+
+  const tests = [];
+  for (const command of commands) {
+    const result = await runCommand(command, { cwd, timeoutMs });
+    tests.push(result);
+    if (result.status !== "passed") {
+      return {
+        ok: true,
+        job: submitCodingRoomProof({
+          job,
+          proof: {
+            result: "blocker",
+            blocker: `Proof command failed: ${command}`,
+            submittedAt: now,
+          },
+        }).job,
+        result: "blocker",
+        tests,
+      };
+    }
+  }
+
+  const proof = submitCodingRoomProof({
+    job,
+    proof: {
+      result: "done",
+      changedFiles: [],
+      tests,
+      prUrl: "",
+      submittedAt: now,
+    },
+  });
+
+  return {
+    ok: proof.ok,
+    reason: proof.reason,
+    job: proof.job,
+    result: proof.ok ? "done" : "blocker",
+    tests,
+  };
+}
+
+export async function executeCodingRoomProofLedgerJob({
+  ledger,
+  jobId,
+  allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  cwd = process.cwd(),
+  timeoutMs = 120000,
+  runCommand = runProofCommand,
+  now = new Date().toISOString(),
+} = {}) {
+  const next = createCodingRoomJobLedger({
+    jobs: ledger?.jobs || [],
+    updatedAt: now,
+  });
+  const index = next.jobs.findIndex((job) => job.job_id === jobId);
+  if (index === -1) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  const result = await executeCodingRoomProofJob({
+    job: next.jobs[index],
+    allowlist,
+    cwd,
+    timeoutMs,
+    runCommand,
+    now,
+  });
+
+  if (result.job) {
+    next.jobs[index] = result.job;
+  }
+
+  return {
+    ...result,
+    ledger: next,
+  };
+}
+
+export async function executeCodingRoomProofLedgerFile({
+  ledgerPath,
+  jobId,
+  allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  cwd = process.cwd(),
+  timeoutMs = 120000,
+  dryRun = false,
+} = {}) {
+  if (!ledgerPath) {
+    return { ok: false, reason: "missing_ledger_path" };
+  }
+
+  if (!jobId) {
+    return { ok: false, reason: "missing_job_id" };
+  }
+
+  const ledger = await readCodingRoomJobLedger(ledgerPath);
+  const result = await executeCodingRoomProofLedgerJob({
+    ledger,
+    jobId,
+    allowlist,
+    cwd,
+    timeoutMs,
+  });
+
+  if (result.ok && !dryRun) {
+    await writeCodingRoomJobLedger(ledgerPath, result.ledger);
+  }
+
+  return {
+    ...result,
+    dry_run: dryRun,
+    ledger_path: ledgerPath,
+  };
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  executeCodingRoomProofLedgerFile({
+    ledgerPath: getArg("ledger", process.env.CODING_ROOM_LEDGER_PATH || ""),
+    jobId: getArg("job-id", process.env.CODING_ROOM_JOB_ID || ""),
+    allowlist: parseList(process.env.CODING_ROOM_PROOF_ALLOWLIST, DEFAULT_PROOF_COMMAND_ALLOWLIST),
+    timeoutMs: parseIntOption(getArg("timeout-ms", process.env.CODING_ROOM_PROOF_TIMEOUT_MS), 120000),
+    dryRun: process.argv.includes("--dry-run") || parseBoolean(process.env.CODING_ROOM_PROOF_DRY_RUN),
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-proof-executor.mjs
+++ b/scripts/pinballwake-proof-executor.mjs
@@ -87,6 +87,13 @@ export function commandToArgv(command) {
   return parts;
 }
 
+function hasUnsafePathTraversal(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .some((part) => part === "..");
+}
+
 export function isProofCommandAllowed(command, allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST) {
   const normalized = String(command ?? "").replace(/\s+/g, " ").trim();
   if (!normalized) {
@@ -94,6 +101,17 @@ export function isProofCommandAllowed(command, allowlist = DEFAULT_PROOF_COMMAND
   }
 
   if (/[;&|`$<>]/.test(normalized)) {
+    return false;
+  }
+
+  let argv;
+  try {
+    argv = commandToArgv(normalized);
+  } catch {
+    return false;
+  }
+
+  if (argv.some(hasUnsafePathTraversal)) {
     return false;
   }
 
@@ -107,7 +125,13 @@ export function getProofCommandsForJob(job) {
 }
 
 export async function runProofCommand(command, { cwd = process.cwd(), timeoutMs = 120000 } = {}) {
-  const [bin, ...args] = commandToArgv(command);
+  let bin;
+  let args;
+  try {
+    [bin, ...args] = commandToArgv(command);
+  } catch (error) {
+    return { command, status: "failed", exit_code: null, output: compactOutput(error.message) };
+  }
   if (!bin) {
     return { command, status: "failed", exit_code: null, output: "Empty command" };
   }

--- a/scripts/pinballwake-proof-executor.test.mjs
+++ b/scripts/pinballwake-proof-executor.test.mjs
@@ -60,6 +60,8 @@ describe("PinballWake proof executor", () => {
     assert.equal(isProofCommandAllowed("npm run test:api"), true);
     assert.equal(isProofCommandAllowed("node scripts/delete-everything.mjs"), false);
     assert.equal(isProofCommandAllowed("node --test scripts/a.mjs && echo unsafe"), false);
+    assert.equal(isProofCommandAllowed("node --test scripts/../evil.test.mjs"), false);
+    assert.equal(isProofCommandAllowed("node --test \"scripts/broken.test.mjs"), false);
     assert.equal(isProofCommandAllowed("npm run build"), false);
   });
 
@@ -102,6 +104,23 @@ describe("PinballWake proof executor", () => {
       runCommand: async () => {
         throw new Error("should not run");
       },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "blocker");
+    assert.equal(result.reason, "proof_command_not_allowlisted");
+    assert.equal(result.job.status, "blocked");
+    assert.match(result.job.proof.blocker, /not allowlisted/);
+  });
+
+  it("records blocker proof for malformed proof commands instead of throwing", async () => {
+    const job = proofJob({
+      tests: ["node --test \"scripts/broken.test.mjs"],
+    });
+
+    const result = await executeCodingRoomProofJob({
+      job,
+      now: "2026-05-04T00:01:00.000Z",
     });
 
     assert.equal(result.ok, true);

--- a/scripts/pinballwake-proof-executor.test.mjs
+++ b/scripts/pinballwake-proof-executor.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  claimCodingRoomJob,
+  createCodingRoomJob,
+  createCodingRoomJobLedger,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+import {
+  commandToArgv,
+  executeCodingRoomProofJob,
+  executeCodingRoomProofLedgerFile,
+  executeCodingRoomProofLedgerJob,
+  getProofCommandsForJob,
+  isProofCommandAllowed,
+} from "./pinballwake-proof-executor.mjs";
+
+const runner = {
+  id: "pinballwake-job-runner",
+  readiness: "builder_ready",
+  capabilities: ["implementation", "test_fix"],
+};
+
+function proofJob(input = {}) {
+  return claimCodingRoomJob({
+    runner,
+    job: createCodingRoomJob({
+      jobId: input.jobId || "coding-room:proof:test",
+      worker: "pinballwake-job-runner",
+      chip: "proof only",
+      files: ["scripts/pinballwake-proof-executor.mjs"],
+      expectedProof: {
+        requiresPr: false,
+        requiresChangedFiles: false,
+        requiresNonOverlap: false,
+        requiresTests: true,
+        tests: input.tests || ["node --test scripts/pinballwake-proof-executor.test.mjs"],
+      },
+    }),
+    now: "2026-05-04T00:00:00.000Z",
+  }).job;
+}
+
+describe("PinballWake proof executor", () => {
+  it("parses simple quoted commands without shell expansion", () => {
+    assert.deepEqual(commandToArgv("node --test \"scripts/example test.mjs\""), [
+      "node",
+      "--test",
+      "scripts/example test.mjs",
+    ]);
+    assert.throws(() => commandToArgv("node --test 'scripts/example.mjs"), /Unclosed quote/);
+  });
+
+  it("allows only explicit proof command prefixes and blocks shell metacharacters", () => {
+    assert.equal(isProofCommandAllowed("node --test scripts/pinballwake-proof-executor.test.mjs"), true);
+    assert.equal(isProofCommandAllowed("npm run test:api"), true);
+    assert.equal(isProofCommandAllowed("node scripts/delete-everything.mjs"), false);
+    assert.equal(isProofCommandAllowed("node --test scripts/a.mjs && echo unsafe"), false);
+    assert.equal(isProofCommandAllowed("npm run build"), false);
+  });
+
+  it("reads expected proof commands from a coding room job", () => {
+    assert.deepEqual(getProofCommandsForJob(proofJob({ tests: ["node --test scripts/a.mjs"] })), [
+      "node --test scripts/a.mjs",
+    ]);
+  });
+
+  it("runs allowlisted proof commands and records done proof", async () => {
+    const job = proofJob({
+      tests: ["node --test scripts/pinballwake-proof-executor.test.mjs"],
+    });
+
+    const result = await executeCodingRoomProofJob({
+      job,
+      now: "2026-05-04T00:01:00.000Z",
+      runCommand: async (command) => ({
+        command,
+        status: "passed",
+        exit_code: 0,
+        output: "ok",
+      }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "done");
+    assert.equal(result.job.status, "proof_submitted");
+    assert.equal(result.job.proof.tests[0].status, "passed");
+  });
+
+  it("records blocker proof when a command is not allowlisted", async () => {
+    const job = proofJob({
+      tests: ["node scripts/danger.mjs"],
+    });
+
+    const result = await executeCodingRoomProofJob({
+      job,
+      now: "2026-05-04T00:01:00.000Z",
+      runCommand: async () => {
+        throw new Error("should not run");
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "blocker");
+    assert.equal(result.reason, "proof_command_not_allowlisted");
+    assert.equal(result.job.status, "blocked");
+    assert.match(result.job.proof.blocker, /not allowlisted/);
+  });
+
+  it("records blocker proof when an allowlisted command fails", async () => {
+    const job = proofJob({
+      tests: ["node --test scripts/pinballwake-proof-executor.test.mjs"],
+    });
+
+    const result = await executeCodingRoomProofJob({
+      job,
+      now: "2026-05-04T00:01:00.000Z",
+      runCommand: async (command) => ({
+        command,
+        status: "failed",
+        exit_code: 1,
+        output: "boom",
+      }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "blocker");
+    assert.equal(result.job.status, "blocked");
+    assert.match(result.job.proof.blocker, /failed/);
+  });
+
+  it("refuses to execute unclaimed jobs or jobs with no proof commands", async () => {
+    const unclaimed = createCodingRoomJob({
+      worker: "pinballwake-job-runner",
+      chip: "not claimed",
+      files: ["scripts/pinballwake-proof-executor.mjs"],
+      expectedProof: {
+        requiresPr: false,
+        requiresChangedFiles: false,
+        tests: ["node --test scripts/pinballwake-proof-executor.test.mjs"],
+      },
+    });
+    assert.equal((await executeCodingRoomProofJob({ job: unclaimed })).reason, "job_not_claimed");
+    assert.equal((await executeCodingRoomProofJob({ job: proofJob({ tests: [] }) })).reason, "missing_proof_commands");
+  });
+
+  it("updates proof results inside a ledger", async () => {
+    const job = proofJob({
+      jobId: "coding-room:proof:ledger",
+      tests: ["node --test scripts/pinballwake-proof-executor.test.mjs"],
+    });
+    const result = await executeCodingRoomProofLedgerJob({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      jobId: job.job_id,
+      now: "2026-05-04T00:01:00.000Z",
+      runCommand: async (command) => ({
+        command,
+        status: "passed",
+        exit_code: 0,
+        output: "ok",
+      }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ledger.jobs[0].status, "proof_submitted");
+  });
+
+  it("persists proof results to a ledger file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "proof-executor-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      const job = proofJob({
+        jobId: "coding-room:proof:file",
+        tests: ["node --test scripts/pinballwake-coding-room-runner.test.mjs"],
+      });
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger({ jobs: [job] }));
+
+      const result = await executeCodingRoomProofLedgerFile({
+        ledgerPath,
+        jobId: job.job_id,
+        now: "2026-05-04T00:01:00.000Z",
+        dryRun: true,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.dry_run, true);
+      assert.equal(result.ledger.jobs[0].status, "proof_submitted");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `scripts/pinballwake-proof-executor.mjs`, a proof-only executor for claimed Coding Room jobs
- allow only explicit proof command prefixes, block shell metacharacters/chaining, and reject `..` path traversal such as `scripts/../...`
- reject malformed proof commands before execution and write BLOCKER proof instead of crashing before ledger writeback
- run proof commands without shell expansion and write PASS/BLOCKER-style proof back into the Coding Room ledger
- record blockers for disallowed commands, failed proof commands, unclaimed jobs, or missing proof commands
- fix Coding Room proof command storage so test commands keep their full text instead of being truncated by `Array.map`

## Scope / Ownership
owner: 🧠 master
owned files:
- scripts/pinballwake-proof-executor.mjs
- scripts/pinballwake-proof-executor.test.mjs
- scripts/pinballwake-coding-room.mjs
non-overlap: proof executor + tiny command-storage fix only; no auth/secrets/billing/DNS/migrations/raw keys; no desktop wake changes; no branch/PR/merge automation.
status: draft / ready for re-review after GitHub checks complete

## Proof
- node --test scripts/pinballwake-proof-executor.test.mjs passed 10/10
- node --test scripts/pinballwake-coding-room-runner.test.mjs passed 9/9
- node --test scripts/pinballwake-coding-room.test.mjs passed 27/27
- node --test scripts/fleet-throughput-watch.test.mjs passed 23/23
- git diff --check passed

## Safety
Proof executor v1 is verification-only. It does not edit repo files, create branches, open PRs, merge, or run arbitrary shell. It only runs allowlisted proof commands without shell expansion and writes the resulting proof/blocker state into a configured Coding Room ledger.