### PR TITLE
feat(pinballwake): add build executor

### DIFF
--- a/scripts/pinballwake-build-executor.mjs
+++ b/scripts/pinballwake-build-executor.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+import {
+  createCodingRoomJobLedger,
+  readCodingRoomJobLedger,
+  submitCodingRoomBuildResult,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+
+const DEFAULT_PATCH_MAX_BYTES = 120000;
+
+function parseBoolean(value) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function compactOutput(value, max = 2000) {
+  const text = String(value ?? "").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function normalizePath(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .trim();
+}
+
+function isUnsafePath(value) {
+  const normalized = normalizePath(value);
+  if (!normalized || normalized === "/dev/null") {
+    return true;
+  }
+
+  if (normalized.startsWith("../") || normalized.includes("/../") || normalized.endsWith("/..")) {
+    return true;
+  }
+
+  if (normalized.startsWith(".git/") || /^[a-zA-Z]:/.test(normalized)) {
+    return true;
+  }
+
+  return false;
+}
+
+function parseDiffPath(value) {
+  const raw = String(value ?? "").trim();
+  if (raw === "/dev/null") return raw;
+  return normalizePath(raw.replace(/^[ab]\//, "").split(/\s+/)[0]);
+}
+
+export function validateCodingRoomBuildPatch({ patch, ownedFiles = [], maxBytes = DEFAULT_PATCH_MAX_BYTES } = {}) {
+  const text = String(patch ?? "");
+  if (!text.trim()) {
+    return { ok: false, reason: "missing_patch" };
+  }
+
+  if (Buffer.byteLength(text, "utf8") > maxBytes) {
+    return { ok: false, reason: "patch_too_large" };
+  }
+
+  if (/^GIT binary patch$/m.test(text) || /^Binary files /m.test(text)) {
+    return { ok: false, reason: "binary_patch_not_allowed" };
+  }
+
+  const owned = new Set((ownedFiles || []).map(normalizePath));
+  if (owned.size === 0) {
+    return { ok: false, reason: "missing_owned_files" };
+  }
+
+  const changedFiles = new Set();
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      const match = /^diff --git\s+a\/(.+?)\s+b\/(.+)$/.exec(line);
+      if (!match) {
+        return { ok: false, reason: "malformed_diff_header" };
+      }
+
+      const left = parseDiffPath(match[1]);
+      const right = parseDiffPath(match[2]);
+      for (const file of [left, right]) {
+        if (isUnsafePath(file)) {
+          return { ok: false, reason: "unsafe_patch_path", file };
+        }
+      }
+
+      if (left !== right) {
+        return { ok: false, reason: "rename_or_move_not_allowed", file: right };
+      }
+
+      changedFiles.add(right);
+      continue;
+    }
+
+    if (line.startsWith("--- ") || line.startsWith("+++ ")) {
+      const file = parseDiffPath(line.slice(4));
+      if (file === "/dev/null") {
+        return { ok: false, reason: "create_or_delete_not_allowed" };
+      }
+
+      if (isUnsafePath(file)) {
+        return { ok: false, reason: "unsafe_patch_path", file };
+      }
+
+      changedFiles.add(file);
+    }
+  }
+
+  if (changedFiles.size === 0) {
+    return { ok: false, reason: "patch_has_no_files" };
+  }
+
+  const outside = [...changedFiles].find((file) => !owned.has(file));
+  if (outside) {
+    return { ok: false, reason: "patch_file_outside_ownership", file: outside };
+  }
+
+  return { ok: true, changed_files: [...changedFiles] };
+}
+
+export async function runGitApplyPatch(patch, { cwd = process.cwd(), check = false } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn("git", check ? ["apply", "--check", "--whitespace=error"] : ["apply", "--whitespace=nowarn"], {
+      cwd,
+      shell: false,
+      windowsHide: true,
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({
+        ok: false,
+        exit_code: null,
+        output: compactOutput(error.message),
+      });
+    });
+    child.on("close", (code) => {
+      resolve({
+        ok: code === 0,
+        exit_code: code,
+        output: compactOutput(`${stdout}\n${stderr}`),
+      });
+    });
+    child.stdin.end(patch);
+  });
+}
+
+function buildBlocker({ job, blocker, now }) {
+  return {
+    ok: true,
+    job: submitCodingRoomBuildResult({
+      job,
+      buildResult: {
+        result: "blocker",
+        blocker,
+      },
+      now,
+    }).job,
+    result: "blocker",
+    reason: "build_blocker",
+    blocker,
+  };
+}
+
+export async function executeCodingRoomBuildJob({
+  job,
+  cwd = process.cwd(),
+  applyPatch = runGitApplyPatch,
+  now = new Date().toISOString(),
+  dryRun = false,
+} = {}) {
+  if (!job) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  if (job.status !== "claimed" && job.status !== "building") {
+    return { ok: false, reason: "job_not_claimed" };
+  }
+
+  const patch = job.build?.patch || "";
+  const validation = validateCodingRoomBuildPatch({
+    patch,
+    ownedFiles: job.owned_files || [],
+  });
+  if (!validation.ok) {
+    return buildBlocker({
+      job,
+      blocker: `Build patch rejected: ${validation.reason}${validation.file ? ` (${validation.file})` : ""}`,
+      now,
+    });
+  }
+
+  const checked = await applyPatch(patch, { cwd, check: true });
+  if (!checked.ok) {
+    return buildBlocker({
+      job,
+      blocker: `Build patch check failed: ${checked.output || `exit ${checked.exit_code}`}`,
+      now,
+    });
+  }
+
+  if (dryRun) {
+    return {
+      ok: true,
+      job,
+      result: "dry_run",
+      changed_files: validation.changed_files,
+    };
+  }
+
+  const applied = await applyPatch(patch, { cwd, check: false });
+  if (!applied.ok) {
+    return buildBlocker({
+      job,
+      blocker: `Build patch apply failed: ${applied.output || `exit ${applied.exit_code}`}`,
+      now,
+    });
+  }
+
+  const result = submitCodingRoomBuildResult({
+    job,
+    buildResult: {
+      result: "done",
+      changedFiles: validation.changed_files,
+      summary: "Applied owned-file build patch; ready for proof executor.",
+    },
+    now,
+  });
+
+  return {
+    ok: result.ok,
+    reason: result.reason,
+    job: result.job,
+    result: result.ok ? "done" : "blocker",
+    changed_files: validation.changed_files,
+  };
+}
+
+export async function executeCodingRoomBuildLedgerJob({
+  ledger,
+  jobId,
+  cwd = process.cwd(),
+  applyPatch = runGitApplyPatch,
+  now = new Date().toISOString(),
+  dryRun = false,
+} = {}) {
+  const next = createCodingRoomJobLedger({
+    jobs: ledger?.jobs || [],
+    updatedAt: now,
+  });
+  const index = next.jobs.findIndex((job) => job.job_id === jobId);
+  if (index === -1) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  const result = await executeCodingRoomBuildJob({
+    job: next.jobs[index],
+    cwd,
+    applyPatch,
+    now,
+    dryRun,
+  });
+
+  if (result.job) {
+    next.jobs[index] = result.job;
+  }
+
+  return {
+    ...result,
+    ledger: next,
+  };
+}
+
+export async function executeCodingRoomBuildLedgerFile({
+  ledgerPath,
+  jobId,
+  cwd = process.cwd(),
+  dryRun = false,
+} = {}) {
+  if (!ledgerPath) {
+    return { ok: false, reason: "missing_ledger_path" };
+  }
+
+  if (!jobId) {
+    return { ok: false, reason: "missing_job_id" };
+  }
+
+  const ledger = await readCodingRoomJobLedger(ledgerPath);
+  const result = await executeCodingRoomBuildLedgerJob({
+    ledger,
+    jobId,
+    cwd,
+    dryRun,
+  });
+
+  if (result.ok && !dryRun) {
+    await writeCodingRoomJobLedger(ledgerPath, result.ledger);
+  }
+
+  return {
+    ...result,
+    dry_run: dryRun,
+    ledger_path: ledgerPath,
+  };
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  executeCodingRoomBuildLedgerFile({
+    ledgerPath: getArg("ledger", process.env.CODING_ROOM_LEDGER_PATH || ""),
+    jobId: getArg("job-id", process.env.CODING_ROOM_JOB_ID || ""),
+    dryRun: process.argv.includes("--dry-run") || parseBoolean(process.env.CODING_ROOM_BUILD_DRY_RUN),
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-build-executor.mjs
+++ b/scripts/pinballwake-build-executor.mjs
@@ -78,6 +78,17 @@ export function validateCodingRoomBuildPatch({ patch, ownedFiles = [], maxBytes 
 
   const changedFiles = new Set();
   const lines = text.split(/\r?\n/);
+  const unsafeMetadata = lines.find((line) =>
+    /^(rename|copy) (from|to) /.test(line) ||
+    /^(new|deleted) file mode /.test(line) ||
+    /^(old|new) mode /.test(line) ||
+    /^similarity index /.test(line) ||
+    /^dissimilarity index /.test(line)
+  );
+  if (unsafeMetadata) {
+    return { ok: false, reason: "unsafe_patch_metadata" };
+  }
+
   for (const line of lines) {
     if (line.startsWith("diff --git ")) {
       const match = /^diff --git\s+a\/(.+?)\s+b\/(.+)$/.exec(line);

--- a/scripts/pinballwake-build-executor.test.mjs
+++ b/scripts/pinballwake-build-executor.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  claimCodingRoomJob,
+  createCodingRoomJob,
+  createCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+import {
+  executeCodingRoomBuildJob,
+  executeCodingRoomBuildLedgerJob,
+  runGitApplyPatch,
+  validateCodingRoomBuildPatch,
+} from "./pinballwake-build-executor.mjs";
+
+const runner = {
+  id: "pinballwake-job-runner",
+  readiness: "builder_ready",
+  capabilities: ["implementation"],
+};
+
+function patchFor(file = "scripts/example.mjs") {
+  return `diff --git a/${file} b/${file}
+--- a/${file}
++++ b/${file}
+@@ -1 +1 @@
+-old
++new
+`;
+}
+
+function buildJob(input = {}) {
+  return claimCodingRoomJob({
+    runner,
+    job: createCodingRoomJob({
+      jobId: input.jobId || "coding-room:build:test",
+      worker: "pinballwake-job-runner",
+      chip: "apply tiny patch",
+      files: input.files || ["scripts/example.mjs"],
+      build: {
+        patch: input.patch || patchFor(),
+      },
+      expectedProof: {
+        requiresPr: false,
+        requiresChangedFiles: true,
+        requiresNonOverlap: true,
+        requiresTests: true,
+        tests: ["node --test scripts/example.test.mjs"],
+      },
+    }),
+    now: "2026-05-04T00:00:00.000Z",
+  }).job;
+}
+
+describe("PinballWake build executor", () => {
+  it("accepts small unified diffs that only touch owned files", () => {
+    const result = validateCodingRoomBuildPatch({
+      patch: patchFor("scripts/example.mjs"),
+      ownedFiles: ["scripts/example.mjs"],
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.changed_files, ["scripts/example.mjs"]);
+  });
+
+  it("rejects unsafe paths, unowned files, binary patches, and create/delete patches", () => {
+    assert.equal(
+      validateCodingRoomBuildPatch({
+        patch: patchFor("scripts/../evil.mjs"),
+        ownedFiles: ["scripts/../evil.mjs"],
+      }).reason,
+      "unsafe_patch_path",
+    );
+
+    assert.equal(
+      validateCodingRoomBuildPatch({
+        patch: patchFor("api/unowned.ts"),
+        ownedFiles: ["scripts/example.mjs"],
+      }).reason,
+      "patch_file_outside_ownership",
+    );
+
+    assert.equal(
+      validateCodingRoomBuildPatch({
+        patch: "GIT binary patch\nliteral 0\n",
+        ownedFiles: ["scripts/example.mjs"],
+      }).reason,
+      "binary_patch_not_allowed",
+    );
+
+    assert.equal(
+      validateCodingRoomBuildPatch({
+        patch: "diff --git a/scripts/new.mjs b/scripts/new.mjs\n--- /dev/null\n+++ b/scripts/new.mjs\n@@ -0,0 +1 @@\n+new\n",
+        ownedFiles: ["scripts/new.mjs"],
+      }).reason,
+      "create_or_delete_not_allowed",
+    );
+  });
+
+  it("applies a checked owned-file patch and moves the job to testing", async () => {
+    const calls = [];
+    const result = await executeCodingRoomBuildJob({
+      job: buildJob(),
+      now: "2026-05-04T00:01:00.000Z",
+      applyPatch: async (_patch, options) => {
+        calls.push(options.check ? "check" : "apply");
+        return { ok: true, exit_code: 0, output: "" };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "done");
+    assert.deepEqual(calls, ["check", "apply"]);
+    assert.equal(result.job.status, "testing");
+    assert.deepEqual(result.job.build_result.changed_files, ["scripts/example.mjs"]);
+    assert.equal(result.job.proof, null);
+  });
+
+  it("checks and applies a real patch without shell expansion", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "build-executor-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+      await mkdir(join(dir, "scripts"), { recursive: true });
+      await writeFile(join(dir, "scripts", "example.mjs"), "old\n", "utf8");
+
+      const patch = patchFor("scripts/example.mjs");
+      assert.equal((await runGitApplyPatch(patch, { cwd: dir, check: true })).ok, true);
+      assert.equal((await runGitApplyPatch(patch, { cwd: dir, check: false })).ok, true);
+      assert.equal((await readFile(join(dir, "scripts", "example.mjs"), "utf8")).replace(/\r\n/g, "\n"), "new\n");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-runs after patch check without applying or mutating the job", async () => {
+    const calls = [];
+    const job = buildJob();
+    const result = await executeCodingRoomBuildJob({
+      job,
+      dryRun: true,
+      applyPatch: async (_patch, options) => {
+        calls.push(options.check ? "check" : "apply");
+        return { ok: true, exit_code: 0, output: "" };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "dry_run");
+    assert.deepEqual(calls, ["check"]);
+    assert.equal(result.job.status, "claimed");
+  });
+
+  it("records blocker build result when validation or git apply check fails", async () => {
+    const invalid = await executeCodingRoomBuildJob({
+      job: buildJob({
+        patch: patchFor("api/unowned.ts"),
+      }),
+    });
+
+    assert.equal(invalid.ok, true);
+    assert.equal(invalid.result, "blocker");
+    assert.equal(invalid.job.status, "blocked");
+    assert.match(invalid.job.build_result.blocker, /outside_ownership/);
+
+    const failedCheck = await executeCodingRoomBuildJob({
+      job: buildJob(),
+      applyPatch: async () => ({ ok: false, exit_code: 1, output: "patch does not apply" }),
+    });
+
+    assert.equal(failedCheck.ok, true);
+    assert.equal(failedCheck.result, "blocker");
+    assert.equal(failedCheck.job.status, "blocked");
+    assert.match(failedCheck.job.build_result.blocker, /patch does not apply/);
+  });
+
+  it("refuses unclaimed jobs and updates build results inside a ledger", async () => {
+    const unclaimed = createCodingRoomJob({
+      worker: "pinballwake-job-runner",
+      chip: "not claimed",
+      files: ["scripts/example.mjs"],
+      build: { patch: patchFor() },
+    });
+    assert.equal((await executeCodingRoomBuildJob({ job: unclaimed })).reason, "job_not_claimed");
+
+    const job = buildJob({ jobId: "coding-room:build:ledger" });
+    const result = await executeCodingRoomBuildLedgerJob({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      jobId: job.job_id,
+      now: "2026-05-04T00:01:00.000Z",
+      applyPatch: async () => ({ ok: true, exit_code: 0, output: "" }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ledger.jobs[0].status, "testing");
+  });
+});

--- a/scripts/pinballwake-build-executor.test.mjs
+++ b/scripts/pinballwake-build-executor.test.mjs
@@ -101,6 +101,65 @@ describe("PinballWake build executor", () => {
     );
   });
 
+  it("rejects rename, copy, mode, and symlink metadata before git apply", () => {
+    const metadataCases = [
+      {
+        patch: `diff --git a/scripts/example.mjs b/scripts/renamed.mjs
+similarity index 100%
+rename from scripts/example.mjs
+rename to scripts/renamed.mjs
+`,
+        label: "rename",
+      },
+      {
+        patch: `diff --git a/scripts/example.mjs b/scripts/copied.mjs
+similarity index 100%
+copy from scripts/example.mjs
+copy to scripts/copied.mjs
+`,
+        label: "copy",
+      },
+      {
+        patch: `diff --git a/scripts/example.mjs b/scripts/example.mjs
+old mode 100644
+new mode 100755
+`,
+        label: "mode",
+      },
+      {
+        patch: `diff --git a/scripts/link.mjs b/scripts/link.mjs
+new file mode 120000
+--- /dev/null
++++ b/scripts/link.mjs
+@@ -0,0 +1 @@
++../outside
+`,
+        label: "symlink/new mode",
+      },
+      {
+        patch: `diff --git a/scripts/example.mjs b/scripts/example.mjs
+deleted file mode 100644
+--- a/scripts/example.mjs
++++ /dev/null
+@@ -1 +0,0 @@
+-old
+`,
+        label: "deleted mode",
+      },
+    ];
+
+    for (const item of metadataCases) {
+      assert.equal(
+        validateCodingRoomBuildPatch({
+          patch: item.patch,
+          ownedFiles: ["scripts/example.mjs", "scripts/renamed.mjs", "scripts/copied.mjs", "scripts/link.mjs"],
+        }).reason,
+        "unsafe_patch_metadata",
+        item.label,
+      );
+    }
+  });
+
   it("applies a checked owned-file patch and moves the job to testing", async () => {
     const calls = [];
     const result = await executeCodingRoomBuildJob({

--- a/scripts/pinballwake-coding-room.mjs
+++ b/scripts/pinballwake-coding-room.mjs
@@ -30,6 +30,11 @@ function compactText(value, max = 240) {
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
 }
 
+function compactMultiline(value, max = 12000) {
+  const text = String(value ?? "").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
 function normalizePath(value) {
   return String(value ?? "")
     .replace(/\\/g, "/")
@@ -82,6 +87,7 @@ export function codingRoomClaimId({ jobId = "", runnerId = "", now = new Date().
 export function createCodingRoomJob(input = {}) {
   const ownedFiles = uniq((input.ownedFiles || input.files || []).map(normalizePath));
   const expectedProof = input.expectedProof || {};
+  const build = input.build || {};
   const status = input.status || "queued";
 
   if (!CODING_ROOM_STATUSES.has(status)) {
@@ -114,6 +120,10 @@ export function createCodingRoomJob(input = {}) {
       requires_non_overlap: expectedProof.requiresNonOverlap !== false,
       requires_tests: expectedProof.requiresTests !== false,
     },
+    build: {
+      patch: compactMultiline(build.patch || input.patch || ""),
+      patch_format: compactText(build.patchFormat || build.patch_format || "unified_diff", 80),
+    },
     safety: {
       no_secrets: true,
       draft_pr_only: true,
@@ -126,6 +136,63 @@ export function createCodingRoomJob(input = {}) {
     lease_expires_at: input.leaseExpiresAt || null,
     claimed_by: input.claimedBy || null,
     proof: input.proof || null,
+    build_result: input.buildResult || input.build_result || null,
+  };
+}
+
+export function submitCodingRoomBuildResult({ job, buildResult = {}, now = new Date().toISOString() }) {
+  if (!job) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  const result = String(buildResult.result || "").trim().toLowerCase();
+  if (!["done", "blocker"].includes(result)) {
+    return { ok: false, reason: "build_result_required" };
+  }
+
+  if (result === "blocker") {
+    const blocker = compactText(buildResult.blocker || "", 500);
+    if (!blocker) {
+      return { ok: false, reason: "blocker_text_required" };
+    }
+
+    return {
+      ok: true,
+      job: {
+        ...job,
+        status: "blocked",
+        build_result: {
+          result: "blocker",
+          blocker,
+          submitted_at: now,
+        },
+      },
+    };
+  }
+
+  const changedFiles = uniq((buildResult.changedFiles || []).map(normalizePath));
+  if (changedFiles.length === 0) {
+    return { ok: false, reason: "changed_files_required" };
+  }
+
+  const owned = new Set(job.owned_files || []);
+  const outside = changedFiles.find((file) => !owned.has(file));
+  if (outside) {
+    return { ok: false, reason: "changed_file_outside_ownership", file: outside };
+  }
+
+  return {
+    ok: true,
+    job: {
+      ...job,
+      status: "testing",
+      build_result: {
+        result: "done",
+        changed_files: changedFiles,
+        summary: compactText(buildResult.summary || "", 500),
+        submitted_at: now,
+      },
+    },
   };
 }
 

--- a/scripts/pinballwake-coding-room.test.mjs
+++ b/scripts/pinballwake-coding-room.test.mjs
@@ -22,6 +22,7 @@ import {
   runnerCanClaimCodingRoomJob,
   serializeCodingRoomJobLedger,
   submitCodingRoomLedgerReviewAck,
+  submitCodingRoomBuildResult,
   submitCodingRoomProof,
   submitCodingRoomReviewAck,
   upsertCodingRoomJob,
@@ -383,6 +384,59 @@ describe("PinballWake Coding Room skeleton", () => {
     assert.equal(result.ok, true);
     assert.equal(result.job.status, "proof_submitted");
     assert.equal(result.job.proof.pr_url, "https://github.com/example/repo/pull/1");
+  });
+
+  it("records build results as testing without pretending proof is done", () => {
+    const job = createCodingRoomJob({
+      worker: "forge",
+      chip: "scoped build",
+      files: ["scripts/pinballwake-build-executor.mjs"],
+    });
+
+    const result = submitCodingRoomBuildResult({
+      job,
+      buildResult: {
+        result: "done",
+        changedFiles: ["scripts/pinballwake-build-executor.mjs"],
+        summary: "Patch applied.",
+      },
+      now: "2026-05-04T00:03:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.job.status, "testing");
+    assert.deepEqual(result.job.build_result.changed_files, ["scripts/pinballwake-build-executor.mjs"]);
+    assert.equal(result.job.proof, null);
+  });
+
+  it("records build blockers and rejects changed files outside ownership", () => {
+    const job = createCodingRoomJob({
+      worker: "forge",
+      chip: "scoped build",
+      files: ["scripts/pinballwake-build-executor.mjs"],
+    });
+
+    assert.equal(
+      submitCodingRoomBuildResult({
+        job,
+        buildResult: {
+          result: "done",
+          changedFiles: ["api/unowned.ts"],
+        },
+      }).reason,
+      "changed_file_outside_ownership",
+    );
+
+    const blocker = submitCodingRoomBuildResult({
+      job,
+      buildResult: {
+        result: "blocker",
+        blocker: "Patch check failed.",
+      },
+    });
+    assert.equal(blocker.ok, true);
+    assert.equal(blocker.job.status, "blocked");
+    assert.equal(blocker.job.build_result.result, "blocker");
   });
 
   it("creates timed review jobs that do not need owned files", () => {


### PR DESCRIPTION
## Summary
- add `scripts/pinballwake-build-executor.mjs`, a conservative Build Executor v1 for claimed Coding Room jobs
- accepts only a pre-supplied unified diff patch stored on the job
- validates patch paths are safe, non-binary, not create/delete, no rename/copy/mode metadata, and fully inside `owned_files`
- checks the patch with `git apply --check` using `spawn(..., shell:false)` before applying
- records BLOCKER build results instead of guessing when validation/check/apply fails
- moves successful build jobs to `testing` with changed files, leaving proof to the Proof Executor

## Scope / Ownership
owner: 🧠 master
owned files:
- scripts/pinballwake-build-executor.mjs
- scripts/pinballwake-build-executor.test.mjs
- scripts/pinballwake-coding-room.mjs
- scripts/pinballwake-coding-room.test.mjs
non-overlap: Build Executor v1 + Coding Room build-result ledger support only; no auth/secrets/billing/DNS/migrations/raw keys; no desktop wake changes; no broad repo rewrite; no PR/merge automation.
status: draft / ready for re-review after GitHub checks complete

## Proof
- node --test scripts/pinballwake-build-executor.test.mjs passed 8/8
- node --test scripts/pinballwake-coding-room.test.mjs passed 29/29
- node --test scripts/pinballwake-proof-executor.test.mjs passed 10/10
- node --test scripts/pinballwake-coding-room-runner.test.mjs passed 9/9
- node --test scripts/fleet-throughput-watch.test.mjs passed 23/23
- git diff --check passed

## Safety
Build Executor v1 is patch-only and job-scoped. It does not invent code, create branches, open PRs, merge, force-push, or run arbitrary shell. It rejects unsafe patch metadata before `git apply`, only checks/applies a supplied patch after owned-file validation, then records build done/blocker state for the Proof Executor/review path.