### PR TITLE
feat(pinballwake): add pipeline dry-run planner

### DIFF
--- a/scripts/pinballwake-pipeline-dry-run.mjs
+++ b/scripts/pinballwake-pipeline-dry-run.mjs
@@ -53,6 +53,19 @@ function isCodeJob(job = {}) {
   return !job.job_type || job.job_type === "code";
 }
 
+const ACTIVE_RUNNABLE_STATUSES = new Set(["claimed", "building", "testing"]);
+
+function runnerTokens(runner = {}) {
+  return [runner.id, runner.emoji, runner.agent_id, runner.name]
+    .map((token) => String(token || "").trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function activeJobOwnerMatchesRunner({ job, runner }) {
+  const claimedBy = String(job?.claimed_by || "").trim().toLowerCase();
+  return Boolean(claimedBy) && runnerTokens(runner).includes(claimedBy);
+}
+
 function buildBlocker(stage, reason, extra = {}) {
   return {
     ok: true,
@@ -147,8 +160,37 @@ export function planCodingRoomPipelineDryRun({
     }
 
     steps.push(step("claim", "would_claim", { reason: claim.reason, job_id: job.job_id }));
-  } else {
+  } else if (ACTIVE_RUNNABLE_STATUSES.has(job.status)) {
+    if (!activeJobOwnerMatchesRunner({ job, runner: safeRunner })) {
+      steps.push(step("claim", "claim_blocked", { reason: "active_job_not_owned_by_runner", status: job.status }));
+      return {
+        ok: true,
+        action: "dry_run",
+        result: "blocker",
+        stage: "claim",
+        reason: "active_job_not_owned_by_runner",
+        job_id: job.job_id,
+        steps,
+        summary: summarizeSteps(steps),
+        ledger: safeLedger,
+      };
+    }
+
     steps.push(step("claim", "already_in_progress", { status: job.status, job_id: job.job_id }));
+  } else {
+    steps.push(step("claim", "claim_blocked", { reason: "non_runnable_job_status", status: job.status }));
+    return {
+      ok: true,
+      action: "dry_run",
+      result: "blocker",
+      stage: "claim",
+      reason: "non_runnable_job_status",
+      status: job.status,
+      job_id: job.job_id,
+      steps,
+      summary: summarizeSteps(steps),
+      ledger: safeLedger,
+    };
   }
 
   if (!isCodeJob(job)) {

--- a/scripts/pinballwake-pipeline-dry-run.mjs
+++ b/scripts/pinballwake-pipeline-dry-run.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+import {
+  createCodingRoomJobLedger,
+  runnerCanClaimCodingRoomJob,
+} from "./pinballwake-coding-room.mjs";
+import {
+  DEFAULT_CODING_ROOM_RUNNER,
+  chooseClaimableCodingRoomJob,
+  createCodingRoomRunner,
+} from "./pinballwake-coding-room-runner.mjs";
+import { validateCodingRoomBuildPatch } from "./pinballwake-build-executor.mjs";
+import {
+  DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  getProofCommandsForJob,
+  isProofCommandAllowed,
+} from "./pinballwake-proof-executor.mjs";
+import { evaluateMergeReadiness } from "./pinballwake-merge-controller.mjs";
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function compactReason(value) {
+  return String(value || "").trim() || "unknown";
+}
+
+function step(stage, result, extra = {}) {
+  return {
+    stage,
+    result,
+    ...extra,
+  };
+}
+
+function summarizeSteps(steps) {
+  return steps.map((item) => item.result).join(" -> ");
+}
+
+function jobById(ledger, jobId) {
+  return (ledger?.jobs || []).find((job) => job.job_id === jobId);
+}
+
+function isCodeJob(job = {}) {
+  return !job.job_type || job.job_type === "code";
+}
+
+function buildBlocker(stage, reason, extra = {}) {
+  return {
+    ok: true,
+    action: "dry_run",
+    result: "blocker",
+    stage,
+    reason: compactReason(reason),
+    steps: [step(stage, "blocker", { reason: compactReason(reason), ...extra })],
+    summary: "blocker",
+  };
+}
+
+function mergeResultStep(readiness) {
+  if (readiness.ok) {
+    return step("merge", "merge_ready", {
+      reason: readiness.reason,
+      pr_number: readiness.pr_number,
+      execute: false,
+    });
+  }
+
+  return step("merge", "merge_blocked", {
+    reason: readiness.reason,
+    missing_reviewers: readiness.missing_reviewers || [],
+    failed_checks: readiness.failed_checks || [],
+  });
+}
+
+export function planCodingRoomPipelineDryRun({
+  ledger,
+  jobId,
+  runner = DEFAULT_CODING_ROOM_RUNNER,
+  allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  pr,
+  proofJob,
+  reviews,
+  requiredReviewers,
+} = {}) {
+  const safeLedger = createCodingRoomJobLedger({
+    jobs: cloneJson(ledger?.jobs || []),
+    updatedAt: ledger?.updated_at,
+  });
+  const safeRunner = createCodingRoomRunner(runner);
+  const steps = [];
+
+  let job = jobId ? jobById(safeLedger, jobId) : null;
+  let skipped = [];
+
+  if (jobId && !job) {
+    return buildBlocker("claim", "missing_job", { job_id: jobId });
+  }
+
+  if (!job) {
+    const choice = chooseClaimableCodingRoomJob({ ledger: safeLedger, runner: safeRunner });
+    skipped = choice.skipped || [];
+    if (!choice.ok) {
+      steps.push(step("claim", "idle", { reason: choice.reason, skipped }));
+      return {
+        ok: true,
+        action: "dry_run",
+        result: "idle",
+        reason: choice.reason,
+        skipped,
+        steps,
+        summary: summarizeSteps(steps),
+        ledger: safeLedger,
+      };
+    }
+
+    job = choice.job;
+  }
+
+  if (job.status === "queued") {
+    const claim = runnerCanClaimCodingRoomJob({
+      runner: safeRunner,
+      job,
+      activeJobs: safeLedger.jobs || [],
+    });
+    if (!claim.ok) {
+      steps.push(step("claim", "claim_blocked", { reason: claim.reason, file: claim.file || null }));
+      return {
+        ok: true,
+        action: "dry_run",
+        result: "blocker",
+        stage: "claim",
+        reason: claim.reason,
+        job_id: job.job_id,
+        steps,
+        summary: summarizeSteps(steps),
+        ledger: safeLedger,
+      };
+    }
+
+    steps.push(step("claim", "would_claim", { reason: claim.reason, job_id: job.job_id }));
+  } else {
+    steps.push(step("claim", "already_in_progress", { status: job.status, job_id: job.job_id }));
+  }
+
+  if (!isCodeJob(job)) {
+    steps.push(step("build", "build_skipped", { reason: "not_code_job", job_type: job.job_type }));
+  } else {
+    const patch = job.build?.patch || "";
+    const build = validateCodingRoomBuildPatch({
+      patch,
+      ownedFiles: job.owned_files || [],
+    });
+    if (!build.ok) {
+      steps.push(step("build", "build_blocked", { reason: build.reason, file: build.file || null }));
+      return {
+        ok: true,
+        action: "dry_run",
+        result: "blocker",
+        stage: "build",
+        reason: build.reason,
+        job_id: job.job_id,
+        steps,
+        summary: summarizeSteps(steps),
+        ledger: safeLedger,
+      };
+    }
+
+    steps.push(step("build", "build_would_validate_patch", { changed_files: build.changed_files }));
+  }
+
+  const proofCommands = getProofCommandsForJob(job);
+  if (proofCommands.length === 0) {
+    steps.push(step("proof", "proof_blocked", { reason: "missing_proof_commands" }));
+    return {
+      ok: true,
+      action: "dry_run",
+      result: "blocker",
+      stage: "proof",
+      reason: "missing_proof_commands",
+      job_id: job.job_id,
+      steps,
+      summary: summarizeSteps(steps),
+      ledger: safeLedger,
+    };
+  }
+
+  const disallowed = proofCommands.find((command) => !isProofCommandAllowed(command, allowlist));
+  if (disallowed) {
+    steps.push(step("proof", "proof_blocked", { reason: "proof_command_not_allowlisted", command: disallowed }));
+    return {
+      ok: true,
+      action: "dry_run",
+      result: "blocker",
+      stage: "proof",
+      reason: "proof_command_not_allowlisted",
+      command: disallowed,
+      job_id: job.job_id,
+      steps,
+      summary: summarizeSteps(steps),
+      ledger: safeLedger,
+    };
+  }
+
+  steps.push(step("proof", "proof_would_run", { commands: proofCommands }));
+
+  if (!pr) {
+    steps.push(step("merge", "merge_not_checked", { reason: "missing_pr" }));
+    return {
+      ok: true,
+      action: "dry_run",
+      result: "planned",
+      stage: "proof",
+      reason: "missing_pr",
+      job_id: job.job_id,
+      steps,
+      summary: summarizeSteps(steps),
+      ledger: safeLedger,
+    };
+  }
+
+  const readiness = evaluateMergeReadiness({
+    pr,
+    ledger: safeLedger,
+    proofJob,
+    reviews,
+    requiredReviewers,
+  });
+  steps.push(mergeResultStep(readiness));
+
+  return {
+    ok: true,
+    action: "dry_run",
+    result: readiness.ok ? "merge_ready" : "blocker",
+    stage: "merge",
+    reason: readiness.reason,
+    job_id: job.job_id,
+    steps,
+    summary: summarizeSteps(steps),
+    merge: readiness,
+    ledger: safeLedger,
+  };
+}
+
+export async function readPipelineDryRunInput(filePath) {
+  if (!filePath) {
+    return { ok: false, reason: "missing_input_path" };
+  }
+
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  readPipelineDryRunInput(getArg("input", process.env.PINBALLWAKE_PIPELINE_INPUT || ""))
+    .then((input) => planCodingRoomPipelineDryRun(input))
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-pipeline-dry-run.test.mjs
+++ b/scripts/pinballwake-pipeline-dry-run.test.mjs
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  claimCodingRoomJob,
+  createCodingRoomJob,
+  createCodingRoomJobLedger,
+  createCodingRoomQcJob,
+  createCodingRoomReviewJob,
+  createCodingRoomSafetyJob,
+  submitCodingRoomProof,
+  submitCodingRoomReviewAck,
+} from "./pinballwake-coding-room.mjs";
+import { planCodingRoomPipelineDryRun } from "./pinballwake-pipeline-dry-run.mjs";
+
+const runner = {
+  id: "pinballwake-job-runner",
+  readiness: "builder_ready",
+  capabilities: ["implementation"],
+};
+
+function patchFor(file = "scripts/pipeline-example.mjs") {
+  return `diff --git a/${file} b/${file}
+--- a/${file}
++++ b/${file}
+@@ -1 +1 @@
+-old
++new
+`;
+}
+
+function greenCheck(name = "CI") {
+  return {
+    name,
+    status: "COMPLETED",
+    conclusion: "SUCCESS",
+  };
+}
+
+function readyPr(input = {}) {
+  return {
+    number: 522,
+    title: "feat(pinballwake): add pipeline dry-run planner",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    statusCheckRollup: [greenCheck("Website"), greenCheck("TestPass"), greenCheck("Vercel")],
+    ...input,
+  };
+}
+
+function codeJob(input = {}) {
+  return createCodingRoomJob({
+    jobId: input.jobId || "coding-room:pipeline:job",
+    prNumber: 522,
+    worker: "pinballwake-job-runner",
+    chip: "pipeline dry-run",
+    files: input.files || ["scripts/pipeline-example.mjs"],
+    build: {
+      patch: input.patch || patchFor(),
+    },
+    expectedProof: {
+      requiresPr: false,
+      requiresChangedFiles: true,
+      requiresNonOverlap: true,
+      requiresTests: true,
+      tests: input.tests || ["node --test scripts/pinballwake-pipeline-dry-run.test.mjs"],
+    },
+    status: input.status || "queued",
+    ...input.extra,
+  });
+}
+
+function proofJob() {
+  const job = createCodingRoomJob({
+    jobId: "coding-room:pipeline:proof",
+    prNumber: 522,
+    worker: "pinballwake-job-runner",
+    chip: "pipeline proof",
+    files: ["scripts/pinballwake-pipeline-dry-run.mjs"],
+    status: "testing",
+    expectedProof: {
+      requiresPr: false,
+      requiresChangedFiles: false,
+      requiresNonOverlap: true,
+      requiresTests: true,
+      tests: ["node --test scripts/pinballwake-pipeline-dry-run.test.mjs"],
+    },
+  });
+
+  return submitCodingRoomProof({
+    job,
+    proof: {
+      result: "done",
+      changedFiles: [],
+      tests: [{ command: "node --test scripts/pinballwake-pipeline-dry-run.test.mjs", status: "passed" }],
+      prUrl: "",
+      submittedAt: "2026-05-04T00:02:00.000Z",
+    },
+  }).job;
+}
+
+function passReview(job, reviewer, summary = "PASS") {
+  return submitCodingRoomReviewAck({
+    job,
+    ack: {
+      result: "PASS",
+      reviewer,
+      summary,
+    },
+    now: "2026-05-04T00:03:00.000Z",
+  }).job;
+}
+
+function reviewJobs() {
+  return [
+    passReview(createCodingRoomSafetyJob({ prNumber: 522 }), "gatekeeper", "Safety passed."),
+    passReview(createCodingRoomQcJob({ prNumber: 522 }), "popcorn", "QC passed."),
+    passReview(
+      createCodingRoomReviewJob({
+        prNumber: 522,
+        worker: "forge",
+        reviewKind: "merge_proof",
+        requestedReviewers: ["forge"],
+      }),
+      "forge",
+      "Implementation shape passed.",
+    ),
+  ];
+}
+
+describe("PinballWake pipeline dry-run planner", () => {
+  it("plans claim, build validation, proof commands, and merge readiness without mutating the ledger", () => {
+    const job = codeJob();
+    const ledger = createCodingRoomJobLedger({
+      jobs: [job, proofJob(), ...reviewJobs()],
+    });
+    const before = JSON.stringify(ledger);
+
+    const result = planCodingRoomPipelineDryRun({
+      ledger,
+      runner,
+      jobId: job.job_id,
+      pr: readyPr(),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "merge_ready");
+    assert.equal(result.summary, "would_claim -> build_would_validate_patch -> proof_would_run -> merge_ready");
+    assert.deepEqual(result.steps.map((item) => item.stage), ["claim", "build", "proof", "merge"]);
+    assert.equal(JSON.stringify(ledger), before);
+    assert.equal(job.status, "queued");
+  });
+
+  it("blocks unsafe build patches before any live apply step exists", () => {
+    const job = codeJob({
+      patch: patchFor("api/outside.ts"),
+    });
+
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner,
+      jobId: job.job_id,
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "build");
+    assert.equal(result.reason, "patch_file_outside_ownership");
+    assert.equal(result.summary, "would_claim -> build_blocked");
+  });
+
+  it("blocks proof commands that are not allowlisted", () => {
+    const job = codeJob({
+      tests: ["node --eval console.log(1)"],
+    });
+
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner,
+      jobId: job.job_id,
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "proof");
+    assert.equal(result.reason, "proof_command_not_allowlisted");
+    assert.equal(result.command, "node --eval console.log(1)");
+  });
+
+  it("uses merge controller gates and blocks missing proof or reviews", () => {
+    const job = codeJob();
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr(),
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "merge");
+    assert.equal(result.reason, "missing_submitted_proof");
+    assert.equal(result.steps.at(-1).result, "merge_blocked");
+  });
+
+  it("returns merge-ready only when PR-scoped proof and review PASS gates exist", () => {
+    const job = codeJob();
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job, proofJob(), ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr(),
+    });
+
+    assert.equal(result.result, "merge_ready");
+    assert.equal(result.merge.reason, "merge_ready");
+  });
+
+  it("reports idle when no queued job can be claimed", () => {
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [] }),
+      runner,
+    });
+
+    assert.equal(result.result, "idle");
+    assert.equal(result.reason, "no_claimable_jobs");
+    assert.equal(result.summary, "idle");
+  });
+
+  it("blocks a queued job when owned files overlap with active work", () => {
+    const active = claimCodingRoomJob({
+      runner,
+      job: codeJob({ jobId: "coding-room:pipeline:active", status: "queued" }),
+      now: "2026-05-04T00:00:00.000Z",
+    }).job;
+    const queued = codeJob({ jobId: "coding-room:pipeline:queued" });
+
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [active, queued] }),
+      runner,
+      jobId: queued.job_id,
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "claim");
+    assert.equal(result.reason, "owned_file_overlap");
+  });
+});

--- a/scripts/pinballwake-pipeline-dry-run.test.mjs
+++ b/scripts/pinballwake-pipeline-dry-run.test.mjs
@@ -242,4 +242,64 @@ describe("PinballWake pipeline dry-run planner", () => {
     assert.equal(result.stage, "claim");
     assert.equal(result.reason, "owned_file_overlap");
   });
+
+  it("refuses terminal and fallback statuses even when merge gates are ready", () => {
+    for (const status of ["blocked", "done", "expired", "fallback_ready", "proof_submitted"]) {
+      const job = codeJob({
+        jobId: `coding-room:pipeline:${status}`,
+        status,
+      });
+
+      const result = planCodingRoomPipelineDryRun({
+        ledger: createCodingRoomJobLedger({ jobs: [job, proofJob(), ...reviewJobs()] }),
+        runner,
+        jobId: job.job_id,
+        pr: readyPr(),
+      });
+
+      assert.equal(result.result, "blocker", status);
+      assert.equal(result.stage, "claim", status);
+      assert.equal(result.reason, "non_runnable_job_status", status);
+      assert.equal(result.steps.at(-1).result, "claim_blocked", status);
+    }
+  });
+
+  it("refuses active jobs that are not owned by the planning runner", () => {
+    const job = codeJob({
+      status: "claimed",
+      extra: {
+        claimedBy: "another-runner",
+      },
+    });
+
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job, proofJob(), ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr(),
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "claim");
+    assert.equal(result.reason, "active_job_not_owned_by_runner");
+  });
+
+  it("lets active jobs owned by the planning runner continue through dry-run planning", () => {
+    const job = codeJob({
+      status: "claimed",
+      extra: {
+        claimedBy: "pinballwake-job-runner",
+      },
+    });
+
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job, proofJob(), ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr(),
+    });
+
+    assert.equal(result.result, "merge_ready");
+    assert.equal(result.steps[0].result, "already_in_progress");
+  });
 });


### PR DESCRIPTION
## Summary
- adds PinballWake Pipeline Dry-Run Planner
- connects claim planning, build patch validation, proof command planning, and merge readiness into one advisory view
- returns a simple step summary such as `would_claim -> build_would_validate_patch -> proof_would_run -> merge_blocked`

## Blocker fix on latest head
- refuses terminal/non-runnable job statuses before build/proof/merge planning
- queued jobs are still claim-checked
- active jobs only continue when they are claimed/building/testing and owned by the planning runner
- adds focused coverage for blocked, done, expired, fallback_ready, proof_submitted, non-owned active jobs, and owned active jobs

## Safety
- dry-run only
- does not apply patches
- does not run proof commands
- does not edit repo files
- does not merge PRs
- keeps Merge Controller PR-scoped proof/review gates

## Owned files
- `scripts/pinballwake-pipeline-dry-run.mjs`
- `scripts/pinballwake-pipeline-dry-run.test.mjs`

## Non-overlap
Pipeline Dry-Run Planner files only. No edits to existing executor/controller behavior.

## Proof
- `node --test scripts/pinballwake-pipeline-dry-run.test.mjs` passed 10/10
- `node --test scripts/pinballwake-merge-controller.test.mjs` passed 10/10
- `node --test scripts/pinballwake-build-executor.test.mjs` passed 8/8
- `node --test scripts/pinballwake-proof-executor.test.mjs` passed 10/10
- `node --test scripts/pinballwake-coding-room-runner.test.mjs` passed 9/9
- `node --test scripts/pinballwake-coding-room.test.mjs` passed 29/29
- `node --test scripts/fleet-throughput-watch.test.mjs` passed 23/23
- `git diff --check` passed

## Status
Draft. Latest head is green and ready for Gatekeeper, Popcorn, and Forge recheck.