### PR TITLE
feat(autopilot): add pipeline executor v1

### DIFF
--- a/scripts/pinballwake-pipeline-executor.mjs
+++ b/scripts/pinballwake-pipeline-executor.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+import {
+  claimCodingRoomLedgerJob,
+  createCodingRoomJobLedger,
+  readCodingRoomJobLedger,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+import {
+  DEFAULT_CODING_ROOM_RUNNER,
+  createCodingRoomRunner,
+  createCodingRoomRunnerFromEnv,
+  runCodingRoomRunnerCycle,
+} from "./pinballwake-coding-room-runner.mjs";
+import { executeCodingRoomBuildJob, runGitApplyPatch } from "./pinballwake-build-executor.mjs";
+import {
+  DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  executeCodingRoomProofJob,
+  runProofCommand,
+} from "./pinballwake-proof-executor.mjs";
+import { evaluateMergeReadiness } from "./pinballwake-merge-controller.mjs";
+
+function parseBoolean(value) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function parseIntOption(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseList(value, fallback = []) {
+  const text = String(value ?? "").trim();
+  if (!text) return fallback;
+  return text
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function replaceJob(ledger, job, now = new Date().toISOString()) {
+  const next = createCodingRoomJobLedger({
+    jobs: ledger?.jobs || [],
+    updatedAt: now,
+  });
+  const index = next.jobs.findIndex((item) => item.job_id === job?.job_id);
+  if (index === -1) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  next.jobs[index] = job;
+  return { ok: true, ledger: next, job };
+}
+
+function step(stage, result, extra = {}) {
+  return {
+    stage,
+    result,
+    ...extra,
+  };
+}
+
+function summarizeSteps(steps) {
+  return steps.map((item) => item.result).join(" -> ");
+}
+
+function jobById(ledger, jobId) {
+  return (ledger?.jobs || []).find((job) => job.job_id === jobId);
+}
+
+function activeOwnerMatches({ job, runner }) {
+  const claimedBy = String(job?.claimed_by || "").trim().toLowerCase();
+  const tokens = [runner.id, runner.emoji, runner.agent_id, runner.name]
+    .map((token) => String(token || "").trim().toLowerCase())
+    .filter(Boolean);
+  return Boolean(claimedBy) && tokens.includes(claimedBy);
+}
+
+function claimBlock({ ledger, job, reason, steps }) {
+  return {
+    ok: true,
+    action: "pipeline",
+    result: "blocker",
+    stage: "claim",
+    reason,
+    job_id: job?.job_id || null,
+    ledger,
+    job,
+    steps,
+    summary: summarizeSteps(steps),
+  };
+}
+
+export async function executeCodingRoomPipeline({
+  ledger,
+  jobId,
+  runner = DEFAULT_CODING_ROOM_RUNNER,
+  pr,
+  reviews,
+  requiredReviewers,
+  allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  cwd = process.cwd(),
+  applyPatch = runGitApplyPatch,
+  runCommand = runProofCommand,
+  now = new Date().toISOString(),
+  leaseSeconds,
+  proofTimeoutMs = 120000,
+  buildDryRun = false,
+} = {}) {
+  const safeRunner = createCodingRoomRunner(runner);
+  let working = createCodingRoomJobLedger({
+    jobs: ledger?.jobs || [],
+    updatedAt: ledger?.updated_at || now,
+  });
+  const steps = [];
+  let job;
+
+  if (jobId) {
+    job = jobById(working, jobId);
+    if (!job) {
+      steps.push(step("claim", "claim_blocked", { reason: "missing_job", job_id: jobId }));
+      return {
+        ok: false,
+        action: "pipeline",
+        result: "blocker",
+        stage: "claim",
+        reason: "missing_job",
+        job_id: jobId,
+        ledger: working,
+        steps,
+        summary: summarizeSteps(steps),
+      };
+    }
+
+    if (job.status === "queued") {
+      const claimed = claimCodingRoomLedgerJob({
+        ledger: working,
+        jobId,
+        runner: safeRunner,
+        now,
+        leaseSeconds,
+      });
+      if (!claimed.ok) {
+        steps.push(step("claim", "claim_blocked", { reason: claimed.reason, file: claimed.file || null }));
+        return claimBlock({
+          ledger: working,
+          job,
+          reason: claimed.reason,
+          steps,
+        });
+      }
+
+      working = claimed.ledger;
+      job = claimed.job;
+      steps.push(step("claim", "claimed", { job_id: job.job_id, claim_id: job.claim_id }));
+    } else if (["claimed", "building", "testing"].includes(job.status)) {
+      if (!activeOwnerMatches({ job, runner: safeRunner })) {
+        steps.push(step("claim", "claim_blocked", { reason: "active_job_not_owned_by_runner", status: job.status }));
+        return claimBlock({
+          ledger: working,
+          job,
+          reason: "active_job_not_owned_by_runner",
+          steps,
+        });
+      }
+
+      steps.push(step("claim", "already_claimed", { job_id: job.job_id, status: job.status }));
+    } else {
+      steps.push(step("claim", "claim_blocked", { reason: "non_runnable_job_status", status: job.status }));
+      return claimBlock({
+        ledger: working,
+        job,
+        reason: "non_runnable_job_status",
+        steps,
+      });
+    }
+  } else {
+    const claimed = runCodingRoomRunnerCycle({
+      ledger: working,
+      runner: safeRunner,
+      now,
+      leaseSeconds,
+    });
+    working = claimed.ledger || working;
+    if (!claimed.ok) {
+      steps.push(step("claim", "claim_blocked", { reason: claimed.reason }));
+      return {
+        ok: false,
+        action: "pipeline",
+        result: "blocker",
+        stage: "claim",
+        reason: claimed.reason,
+        ledger: working,
+        steps,
+        summary: summarizeSteps(steps),
+      };
+    }
+
+    if (claimed.action === "idle") {
+      steps.push(step("claim", "idle", { reason: claimed.reason, skipped: claimed.skipped || [] }));
+      return {
+        ok: true,
+        action: "pipeline",
+        result: "idle",
+        reason: claimed.reason,
+        ledger: working,
+        steps,
+        summary: summarizeSteps(steps),
+      };
+    }
+
+    job = claimed.job;
+    steps.push(step("claim", "claimed", { job_id: job.job_id, claim_id: job.claim_id }));
+  }
+
+  if (job.job_type && job.job_type !== "code") {
+    steps.push(step("build", "build_blocked", { reason: "not_code_job", job_type: job.job_type }));
+    return claimBlock({
+      ledger: working,
+      job,
+      reason: "not_code_job",
+      steps,
+    });
+  }
+
+  const build = await executeCodingRoomBuildJob({
+    job,
+    cwd,
+    applyPatch,
+    now,
+    dryRun: buildDryRun,
+  });
+  if (!build.ok || !build.job) {
+    steps.push(step("build", "build_blocked", { reason: build.reason || "build_failed" }));
+    return {
+      ok: false,
+      action: "pipeline",
+      result: "blocker",
+      stage: "build",
+      reason: build.reason || "build_failed",
+      job_id: job.job_id,
+      ledger: working,
+      steps,
+      summary: summarizeSteps(steps),
+    };
+  }
+
+  const built = replaceJob(working, build.job, now);
+  working = built.ok ? built.ledger : working;
+  job = build.job;
+  if (build.result === "blocker") {
+    steps.push(step("build", "build_blocked", { reason: build.blocker || build.reason }));
+    return {
+      ok: true,
+      action: "pipeline",
+      result: "blocker",
+      stage: "build",
+      reason: build.reason,
+      blocker: build.blocker,
+      job_id: job.job_id,
+      ledger: working,
+      job,
+      steps,
+      summary: summarizeSteps(steps),
+    };
+  }
+
+  steps.push(step("build", buildDryRun ? "build_dry_run" : "built", { changed_files: build.changed_files || [] }));
+
+  if (buildDryRun) {
+    return {
+      ok: true,
+      action: "pipeline",
+      result: "planned",
+      stage: "build",
+      reason: "build_dry_run",
+      job_id: job.job_id,
+      ledger: working,
+      job,
+      steps,
+      summary: summarizeSteps(steps),
+    };
+  }
+
+  const proof = await executeCodingRoomProofJob({
+    job,
+    allowlist,
+    cwd,
+    timeoutMs: proofTimeoutMs,
+    runCommand,
+    now,
+  });
+  if (!proof.ok || !proof.job) {
+    steps.push(step("proof", "proof_blocked", { reason: proof.reason || "proof_failed" }));
+    return {
+      ok: false,
+      action: "pipeline",
+      result: "blocker",
+      stage: "proof",
+      reason: proof.reason || "proof_failed",
+      job_id: job.job_id,
+      ledger: working,
+      steps,
+      summary: summarizeSteps(steps),
+    };
+  }
+
+  const proved = replaceJob(working, proof.job, now);
+  working = proved.ok ? proved.ledger : working;
+  job = proof.job;
+  if (proof.result === "blocker") {
+    steps.push(step("proof", "proof_blocked", { reason: proof.reason || "proof_blocker" }));
+    return {
+      ok: true,
+      action: "pipeline",
+      result: "blocker",
+      stage: "proof",
+      reason: proof.reason,
+      job_id: job.job_id,
+      ledger: working,
+      job,
+      steps,
+      summary: summarizeSteps(steps),
+    };
+  }
+
+  steps.push(step("proof", "proved", { tests: proof.tests || [] }));
+
+  if (!pr) {
+    steps.push(step("merge", "merge_not_checked", { reason: "missing_pr" }));
+    return {
+      ok: true,
+      action: "pipeline",
+      result: "proof_submitted",
+      stage: "proof",
+      reason: "missing_pr",
+      job_id: job.job_id,
+      ledger: working,
+      job,
+      steps,
+      summary: summarizeSteps(steps),
+    };
+  }
+
+  const merge = evaluateMergeReadiness({
+    pr,
+    ledger: working,
+    reviews,
+    requiredReviewers,
+  });
+  steps.push(
+    step("merge", merge.ok ? "merge_ready" : "merge_blocked", {
+      reason: merge.reason,
+      missing_reviewers: merge.missing_reviewers || [],
+      failed_checks: merge.failed_checks || [],
+      execute: false,
+    }),
+  );
+
+  return {
+    ok: true,
+    action: "pipeline",
+    result: merge.ok ? "merge_ready" : "blocker",
+    stage: "merge",
+    reason: merge.reason,
+    job_id: job.job_id,
+    ledger: working,
+    job,
+    merge,
+    steps,
+    summary: summarizeSteps(steps),
+  };
+}
+
+export async function readPipelineExecutorInput(filePath) {
+  if (!filePath) {
+    return { ok: false, reason: "missing_input_path" };
+  }
+
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+export async function executeCodingRoomPipelineFile({
+  ledgerPath,
+  inputPath,
+  jobId,
+  runner = createCodingRoomRunnerFromEnv(),
+  allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST,
+  cwd = process.cwd(),
+  applyPatch = runGitApplyPatch,
+  runCommand = runProofCommand,
+  now = new Date().toISOString(),
+  leaseSeconds,
+  proofTimeoutMs = 120000,
+  buildDryRun = false,
+  dryRun = false,
+} = {}) {
+  if (!ledgerPath) {
+    return { ok: false, reason: "missing_ledger_path" };
+  }
+
+  const ledger = await readCodingRoomJobLedger(ledgerPath);
+  const input = inputPath ? await readPipelineExecutorInput(inputPath) : {};
+  const result = await executeCodingRoomPipeline({
+    ...input,
+    ledger,
+    jobId: jobId || input.jobId,
+    runner: input.runner || runner,
+    allowlist: input.allowlist || allowlist,
+    cwd,
+    now,
+    leaseSeconds,
+    proofTimeoutMs,
+    buildDryRun: buildDryRun || dryRun,
+    applyPatch,
+    runCommand,
+  });
+
+  if (result.ok && !dryRun) {
+    await writeCodingRoomJobLedger(ledgerPath, result.ledger);
+  }
+
+  return {
+    ...result,
+    dry_run: dryRun,
+    ledger_path: ledgerPath,
+  };
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  executeCodingRoomPipelineFile({
+    ledgerPath: getArg("ledger", process.env.CODING_ROOM_LEDGER_PATH || ""),
+    inputPath: getArg("input", process.env.PINBALLWAKE_PIPELINE_INPUT || ""),
+    jobId: getArg("job-id", process.env.CODING_ROOM_JOB_ID || ""),
+    allowlist: parseList(process.env.CODING_ROOM_PROOF_ALLOWLIST, DEFAULT_PROOF_COMMAND_ALLOWLIST),
+    leaseSeconds: parseIntOption(getArg("lease-seconds", process.env.CODING_ROOM_LEASE_SECONDS), undefined),
+    proofTimeoutMs: parseIntOption(getArg("proof-timeout-ms", process.env.CODING_ROOM_PROOF_TIMEOUT_MS), 120000),
+    buildDryRun: process.argv.includes("--build-dry-run") || parseBoolean(process.env.CODING_ROOM_BUILD_DRY_RUN),
+    dryRun: process.argv.includes("--dry-run") || parseBoolean(process.env.PINBALLWAKE_PIPELINE_DRY_RUN),
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-pipeline-executor.test.mjs
+++ b/scripts/pinballwake-pipeline-executor.test.mjs
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  createCodingRoomJob,
+  createCodingRoomJobLedger,
+  createCodingRoomQcJob,
+  createCodingRoomReviewJob,
+  createCodingRoomSafetyJob,
+  serializeCodingRoomJobLedger,
+  submitCodingRoomReviewAck,
+} from "./pinballwake-coding-room.mjs";
+import {
+  executeCodingRoomPipeline,
+  executeCodingRoomPipelineFile,
+} from "./pinballwake-pipeline-executor.mjs";
+
+const runner = {
+  id: "pinballwake-job-runner",
+  readiness: "builder_ready",
+  capabilities: ["implementation"],
+};
+
+function patchFor(file = "scripts/pipeline-executor-example.mjs") {
+  return `diff --git a/${file} b/${file}
+--- a/${file}
++++ b/${file}
+@@ -1 +1 @@
+-old
++new
+`;
+}
+
+function greenCheck(name = "CI") {
+  return {
+    name,
+    status: "COMPLETED",
+    conclusion: "SUCCESS",
+  };
+}
+
+function readyPr(input = {}) {
+  return {
+    number: 523,
+    title: "feat(autopilot): add pipeline executor",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    statusCheckRollup: [greenCheck("Website"), greenCheck("TestPass"), greenCheck("Vercel")],
+    ...input,
+  };
+}
+
+function codeJob(input = {}) {
+  return createCodingRoomJob({
+    jobId: input.jobId || "coding-room:pipeline-executor:job",
+    prNumber: 523,
+    worker: "pinballwake-job-runner",
+    chip: "pipeline executor",
+    files: input.files || ["scripts/pipeline-executor-example.mjs"],
+    build: {
+      patch: input.patch || patchFor(),
+    },
+    expectedProof: {
+      requiresPr: false,
+      requiresChangedFiles: true,
+      requiresNonOverlap: true,
+      requiresTests: true,
+      tests: input.tests || ["node --test scripts/pinballwake-pipeline-executor.test.mjs"],
+    },
+    status: input.status || "queued",
+    claimedBy: input.claimedBy,
+    ...input.extra,
+  });
+}
+
+function passReview(job, reviewer, summary = "PASS") {
+  return submitCodingRoomReviewAck({
+    job,
+    ack: {
+      result: "PASS",
+      reviewer,
+      summary,
+    },
+    now: "2026-05-04T00:03:00.000Z",
+  }).job;
+}
+
+function reviewJobs() {
+  return [
+    passReview(createCodingRoomSafetyJob({ prNumber: 523 }), "gatekeeper", "Safety passed."),
+    passReview(createCodingRoomQcJob({ prNumber: 523 }), "popcorn", "QC passed."),
+    passReview(
+      createCodingRoomReviewJob({
+        prNumber: 523,
+        worker: "forge",
+        reviewKind: "merge_proof",
+        requestedReviewers: ["forge"],
+      }),
+      "forge",
+      "Implementation shape passed.",
+    ),
+  ];
+}
+
+function passingPatchRunner(calls = []) {
+  return async (_patch, options) => {
+    calls.push(options.check ? "check" : "apply");
+    return { ok: true, exit_code: 0, output: "" };
+  };
+}
+
+function passingProofRunner(calls = []) {
+  return async (command) => {
+    calls.push(command);
+    return { command, status: "passed", exit_code: 0, output: "" };
+  };
+}
+
+describe("PinballWake pipeline executor", () => {
+  it("claims, builds, proves, and reports merge ready without executing merge", async () => {
+    const buildCalls = [];
+    const proofCalls = [];
+    const job = codeJob();
+    const result = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [job, ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr(),
+      applyPatch: passingPatchRunner(buildCalls),
+      runCommand: passingProofRunner(proofCalls),
+      now: "2026-05-04T00:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "merge_ready");
+    assert.equal(result.summary, "claimed -> built -> proved -> merge_ready");
+    assert.deepEqual(buildCalls, ["check", "apply"]);
+    assert.deepEqual(proofCalls, ["node --test scripts/pinballwake-pipeline-executor.test.mjs"]);
+    assert.equal(result.job.status, "proof_submitted");
+    assert.deepEqual(result.job.proof.changed_files, ["scripts/pipeline-executor-example.mjs"]);
+    assert.equal(result.merge.reason, "merge_ready");
+  });
+
+  it("stops after proof when no PR state is supplied", async () => {
+    const job = codeJob();
+    const result = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner,
+      jobId: job.job_id,
+      applyPatch: passingPatchRunner(),
+      runCommand: passingProofRunner(),
+    });
+
+    assert.equal(result.result, "proof_submitted");
+    assert.equal(result.reason, "missing_pr");
+    assert.equal(result.summary, "claimed -> built -> proved -> merge_not_checked");
+  });
+
+  it("records a build blocker and does not run proof", async () => {
+    const proofCalls = [];
+    const job = codeJob({
+      patch: patchFor("api/outside.ts"),
+    });
+    const result = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner,
+      jobId: job.job_id,
+      applyPatch: passingPatchRunner(),
+      runCommand: passingProofRunner(proofCalls),
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "build");
+    assert.equal(result.job.status, "blocked");
+    assert.match(result.blocker, /outside_ownership/);
+    assert.deepEqual(proofCalls, []);
+  });
+
+  it("records a proof blocker after a successful build", async () => {
+    const job = codeJob({
+      tests: ["node --eval console.log(1)"],
+    });
+    const result = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [job] }),
+      runner,
+      jobId: job.job_id,
+      applyPatch: passingPatchRunner(),
+      runCommand: passingProofRunner(),
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "proof");
+    assert.equal(result.reason, "proof_command_not_allowlisted");
+    assert.equal(result.job.status, "blocked");
+  });
+
+  it("does not mutate terminal or non-owned active jobs", async () => {
+    for (const status of ["blocked", "done", "expired", "fallback_ready", "proof_submitted"]) {
+      const job = codeJob({ status });
+      const ledger = createCodingRoomJobLedger({ jobs: [job] });
+      const before = JSON.stringify(ledger);
+      const result = await executeCodingRoomPipeline({
+        ledger,
+        runner,
+        jobId: job.job_id,
+      });
+
+      assert.equal(result.result, "blocker", status);
+      assert.equal(result.reason, "non_runnable_job_status", status);
+      assert.equal(JSON.stringify(ledger), before, status);
+      assert.equal(result.ledger.jobs[0].status, status, status);
+    }
+
+    const active = codeJob({ status: "claimed", claimedBy: "other-runner" });
+    const activeResult = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [active] }),
+      runner,
+      jobId: active.job_id,
+    });
+    assert.equal(activeResult.reason, "active_job_not_owned_by_runner");
+    assert.equal(activeResult.ledger.jobs[0].status, "claimed");
+  });
+
+  it("can choose the first claimable job when no job id is supplied", async () => {
+    const blocked = codeJob({
+      jobId: "coding-room:pipeline-executor:blocked-choice",
+      files: ["scripts/pipeline-executor-example.mjs"],
+    });
+    const job = codeJob({
+      jobId: "coding-room:pipeline-executor:choice",
+      files: ["scripts/pipeline-executor-choice.mjs"],
+      patch: patchFor("scripts/pipeline-executor-choice.mjs"),
+    });
+    const active = {
+      ...blocked,
+      status: "claimed",
+      claimed_by: "other-runner",
+    };
+
+    const result = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [active, job] }),
+      runner,
+      applyPatch: passingPatchRunner(),
+      runCommand: passingProofRunner(),
+    });
+
+    assert.equal(result.result, "proof_submitted");
+    assert.equal(result.job_id, job.job_id);
+  });
+
+  it("persists ledger file updates only when not in dry-run mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pipeline-executor-"));
+    try {
+      const ledgerPath = join(dir, "ledger.json");
+      const job = codeJob();
+      await writeFile(ledgerPath, serializeCodingRoomJobLedger(createCodingRoomJobLedger({ jobs: [job] })), "utf8");
+
+      const dryBuildCalls = [];
+      const dry = await executeCodingRoomPipelineFile({
+        ledgerPath,
+        jobId: job.job_id,
+        runner,
+        dryRun: true,
+        applyPatch: passingPatchRunner(dryBuildCalls),
+      });
+      assert.equal(dry.result, "planned");
+      assert.deepEqual(dryBuildCalls, ["check"]);
+      assert.match(await readFile(ledgerPath, "utf8"), /"status": "queued"/);
+
+      const live = await executeCodingRoomPipelineFile({
+        ledgerPath,
+        jobId: job.job_id,
+        runner,
+        applyPatch: passingPatchRunner(),
+        runCommand: passingProofRunner(),
+      });
+      assert.equal(live.result, "proof_submitted");
+      assert.match(await readFile(ledgerPath, "utf8"), /"status": "proof_submitted"/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/pinballwake-proof-executor.mjs
+++ b/scripts/pinballwake-proof-executor.mjs
@@ -253,7 +253,7 @@ export async function executeCodingRoomProofJob({
     job,
     proof: {
       result: "done",
-      changedFiles: [],
+      changedFiles: job.build_result?.changed_files || [],
       tests,
       prUrl: "",
       submittedAt: now,

--- a/scripts/pinballwake-proof-executor.test.mjs
+++ b/scripts/pinballwake-proof-executor.test.mjs
@@ -93,6 +93,41 @@ describe("PinballWake proof executor", () => {
     assert.equal(result.job.proof.tests[0].status, "passed");
   });
 
+  it("carries build changed files into done proof when required", async () => {
+    const job = {
+      ...proofJob({
+        tests: ["node --test scripts/pinballwake-proof-executor.test.mjs"],
+      }),
+      build_result: {
+        result: "done",
+        changed_files: ["scripts/pinballwake-proof-executor.mjs"],
+        submitted_at: "2026-05-04T00:00:30.000Z",
+      },
+      expected_proof: {
+        tests: ["node --test scripts/pinballwake-proof-executor.test.mjs"],
+        requires_pr: false,
+        requires_changed_files: true,
+        requires_non_overlap: true,
+        requires_tests: true,
+      },
+    };
+
+    const result = await executeCodingRoomProofJob({
+      job,
+      now: "2026-05-04T00:01:00.000Z",
+      runCommand: async (command) => ({
+        command,
+        status: "passed",
+        exit_code: 0,
+        output: "ok",
+      }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "done");
+    assert.deepEqual(result.job.proof.changed_files, ["scripts/pinballwake-proof-executor.mjs"]);
+  });
+
   it("records blocker proof when a command is not allowlisted", async () => {
     const job = proofJob({
       tests: ["node scripts/danger.mjs"],


### PR DESCRIPTION
## Summary
- adds UnClick Autopilot Pipeline Executor v1
- drives one Coding Room code job through claim -> build apply -> proof execution -> merge-readiness check
- keeps merge advisory-only; it does not merge PRs
- carries build changed files into proof receipts so build and proof are connected

## Safety
- one job per run
- owned-file patch validation still comes from Build Executor
- proof commands stay allowlisted and run without shell expansion
- terminal/non-runnable jobs are not mutated or forced through the pipeline
- non-owned active jobs are refused
- CLI `--dry-run` does not apply patches and does not persist ledger changes
- no force-push, branch rewrite, destructive cleanup, secrets/auth/billing/DNS/migrations/raw keys

## Owned files
- `scripts/pinballwake-pipeline-executor.mjs`
- `scripts/pinballwake-pipeline-executor.test.mjs`
- `scripts/pinballwake-proof-executor.mjs`
- `scripts/pinballwake-proof-executor.test.mjs`

## Non-overlap
Autopilot executor/proof handoff only. No changes to QueuePush, Merge Controller merge execution, UI, secrets, auth, billing, DNS, or migrations.

## Proof
- `node --test scripts/pinballwake-pipeline-executor.test.mjs` passed 7/7
- `node --test scripts/pinballwake-proof-executor.test.mjs` passed 11/11
- `node --test scripts/pinballwake-build-executor.test.mjs` passed 8/8
- `node --test scripts/pinballwake-merge-controller.test.mjs` passed 10/10
- `node --test scripts/pinballwake-coding-room.test.mjs` passed 29/29
- `node --test scripts/pinballwake-coding-room-runner.test.mjs` passed 9/9
- `node --test scripts/pinballwake-pipeline-dry-run.test.mjs` passed 10/10
- `node --test scripts/fleet-throughput-watch.test.mjs` passed 23/23
- `git diff --check` passed

## Status
Draft. Ready for CI, Vercel, Gatekeeper, Popcorn, and Forge review.