### PR TITLE
feat(autopilot): route pipeline through merge room

### DIFF
--- a/scripts/pinballwake-pipeline-dry-run.mjs
+++ b/scripts/pinballwake-pipeline-dry-run.mjs
@@ -17,7 +17,7 @@ import {
   getProofCommandsForJob,
   isProofCommandAllowed,
 } from "./pinballwake-proof-executor.mjs";
-import { evaluateMergeReadiness } from "./pinballwake-merge-controller.mjs";
+import { evaluateMergeRoom } from "./pinballwake-merge-room.mjs";
 
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -78,19 +78,20 @@ function buildBlocker(stage, reason, extra = {}) {
   };
 }
 
-function mergeResultStep(readiness) {
-  if (readiness.ok) {
-    return step("merge", "merge_ready", {
-      reason: readiness.reason,
-      pr_number: readiness.pr_number,
+function mergeResultStep(decision) {
+  if (decision.ok) {
+    return step("merge", decision.result, {
+      reason: decision.reason,
+      pr_number: decision.pr_number,
+      draft_lift_required: decision.draft_lift_required || false,
       execute: false,
     });
   }
 
   return step("merge", "merge_blocked", {
-    reason: readiness.reason,
-    missing_reviewers: readiness.missing_reviewers || [],
-    failed_checks: readiness.failed_checks || [],
+    reason: decision.reason,
+    missing_reviewers: decision.missing_reviewers || [],
+    failed_checks: decision.failed_checks || [],
   });
 }
 
@@ -103,6 +104,8 @@ export function planCodingRoomPipelineDryRun({
   proofJob,
   reviews,
   requiredReviewers,
+  fallbackEvidence,
+  allowDraftLift = false,
 } = {}) {
   const safeLedger = createCodingRoomJobLedger({
     jobs: cloneJson(ledger?.jobs || []),
@@ -269,19 +272,21 @@ export function planCodingRoomPipelineDryRun({
     };
   }
 
-  const readiness = evaluateMergeReadiness({
+  const readiness = evaluateMergeRoom({
     pr,
     ledger: safeLedger,
     proofJob,
     reviews,
     requiredReviewers,
+    fallbackEvidence,
+    allowDraftLift,
   });
   steps.push(mergeResultStep(readiness));
 
   return {
     ok: true,
     action: "dry_run",
-    result: readiness.ok ? "merge_ready" : "blocker",
+    result: readiness.ok ? readiness.result : "blocker",
     stage: "merge",
     reason: readiness.reason,
     job_id: job.job_id,

--- a/scripts/pinballwake-pipeline-dry-run.test.mjs
+++ b/scripts/pinballwake-pipeline-dry-run.test.mjs
@@ -144,8 +144,8 @@ describe("PinballWake pipeline dry-run planner", () => {
     });
 
     assert.equal(result.ok, true);
-    assert.equal(result.result, "merge_ready");
-    assert.equal(result.summary, "would_claim -> build_would_validate_patch -> proof_would_run -> merge_ready");
+    assert.equal(result.result, "ready_to_merge");
+    assert.equal(result.summary, "would_claim -> build_would_validate_patch -> proof_would_run -> ready_to_merge");
     assert.deepEqual(result.steps.map((item) => item.stage), ["claim", "build", "proof", "merge"]);
     assert.equal(JSON.stringify(ledger), before);
     assert.equal(job.status, "queued");
@@ -209,8 +209,43 @@ describe("PinballWake pipeline dry-run planner", () => {
       pr: readyPr(),
     });
 
-    assert.equal(result.result, "merge_ready");
+    assert.equal(result.result, "ready_to_merge");
     assert.equal(result.merge.reason, "merge_ready");
+    assert.equal(result.merge.action, "merge_room");
+    assert.deepEqual(result.merge.execute_plan, ["merge", "watch_post_merge"]);
+  });
+
+  it("routes full-PASS draft PRs through Merge Room lift authorization", () => {
+    const job = codeJob();
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job, proofJob(), ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr({ isDraft: true }),
+    });
+
+    assert.equal(result.result, "blocker");
+    assert.equal(result.stage, "merge");
+    assert.equal(result.reason, "draft_lift_not_authorized");
+    assert.equal(result.merge.result, "needs_lift");
+    assert.deepEqual(result.merge.missing, ["master_lift_authorization"]);
+    assert.equal(result.steps.at(-1).result, "merge_blocked");
+  });
+
+  it("uses explicit fallback evidence to plan lift and merge without executing", () => {
+    const job = codeJob();
+    const result = planCodingRoomPipelineDryRun({
+      ledger: createCodingRoomJobLedger({ jobs: [job, proofJob(), ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr({ isDraft: true }),
+      fallbackEvidence: { full_ack_set: true },
+    });
+
+    assert.equal(result.result, "ready_to_lift_and_merge");
+    assert.equal(result.merge.draft_lift_required, true);
+    assert.deepEqual(result.merge.execute_plan, ["lift_draft", "merge", "watch_post_merge"]);
+    assert.equal(result.steps.at(-1).result, "ready_to_lift_and_merge");
   });
 
   it("reports idle when no queued job can be claimed", () => {
@@ -299,7 +334,7 @@ describe("PinballWake pipeline dry-run planner", () => {
       pr: readyPr(),
     });
 
-    assert.equal(result.result, "merge_ready");
+    assert.equal(result.result, "ready_to_merge");
     assert.equal(result.steps[0].result, "already_in_progress");
   });
 });

--- a/scripts/pinballwake-pipeline-executor.mjs
+++ b/scripts/pinballwake-pipeline-executor.mjs
@@ -20,7 +20,7 @@ import {
   executeCodingRoomProofJob,
   runProofCommand,
 } from "./pinballwake-proof-executor.mjs";
-import { evaluateMergeReadiness } from "./pinballwake-merge-controller.mjs";
+import { evaluateMergeRoom } from "./pinballwake-merge-room.mjs";
 
 function parseBoolean(value) {
   const raw = String(value ?? "").trim().toLowerCase();
@@ -107,6 +107,8 @@ export async function executeCodingRoomPipeline({
   pr,
   reviews,
   requiredReviewers,
+  fallbackEvidence,
+  allowDraftLift = false,
   allowlist = DEFAULT_PROOF_COMMAND_ALLOWLIST,
   cwd = process.cwd(),
   applyPatch = runGitApplyPatch,
@@ -351,17 +353,20 @@ export async function executeCodingRoomPipeline({
     };
   }
 
-  const merge = evaluateMergeReadiness({
+  const merge = evaluateMergeRoom({
     pr,
     ledger: working,
     reviews,
     requiredReviewers,
+    fallbackEvidence,
+    allowDraftLift,
   });
   steps.push(
-    step("merge", merge.ok ? "merge_ready" : "merge_blocked", {
+    step("merge", merge.ok ? merge.result : "merge_blocked", {
       reason: merge.reason,
       missing_reviewers: merge.missing_reviewers || [],
       failed_checks: merge.failed_checks || [],
+      draft_lift_required: merge.draft_lift_required || false,
       execute: false,
     }),
   );
@@ -369,7 +374,7 @@ export async function executeCodingRoomPipeline({
   return {
     ok: true,
     action: "pipeline",
-    result: merge.ok ? "merge_ready" : "blocker",
+    result: merge.ok ? merge.result : "blocker",
     stage: "merge",
     reason: merge.reason,
     job_id: job.job_id,

--- a/scripts/pinballwake-pipeline-executor.test.mjs
+++ b/scripts/pinballwake-pipeline-executor.test.mjs
@@ -120,7 +120,7 @@ function passingProofRunner(calls = []) {
 }
 
 describe("PinballWake pipeline executor", () => {
-  it("claims, builds, proves, and reports merge ready without executing merge", async () => {
+  it("claims, builds, proves, and reports Merge Room ready without executing merge", async () => {
     const buildCalls = [];
     const proofCalls = [];
     const job = codeJob();
@@ -135,13 +135,55 @@ describe("PinballWake pipeline executor", () => {
     });
 
     assert.equal(result.ok, true);
-    assert.equal(result.result, "merge_ready");
-    assert.equal(result.summary, "claimed -> built -> proved -> merge_ready");
+    assert.equal(result.result, "ready_to_merge");
+    assert.equal(result.summary, "claimed -> built -> proved -> ready_to_merge");
     assert.deepEqual(buildCalls, ["check", "apply"]);
     assert.deepEqual(proofCalls, ["node --test scripts/pinballwake-pipeline-executor.test.mjs"]);
     assert.equal(result.job.status, "proof_submitted");
     assert.deepEqual(result.job.proof.changed_files, ["scripts/pipeline-executor-example.mjs"]);
     assert.equal(result.merge.reason, "merge_ready");
+    assert.equal(result.merge.action, "merge_room");
+    assert.deepEqual(result.merge.execute_plan, ["merge", "watch_post_merge"]);
+  });
+
+  it("routes full-PASS draft PRs to Merge Room lift decision instead of vague merge blocker", async () => {
+    const job = codeJob();
+    const result = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [job, ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr({ isDraft: true }),
+      applyPatch: passingPatchRunner(),
+      runCommand: passingProofRunner(),
+      now: "2026-05-04T00:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "blocker");
+    assert.equal(result.reason, "draft_lift_not_authorized");
+    assert.equal(result.merge.result, "needs_lift");
+    assert.deepEqual(result.merge.missing, ["master_lift_authorization"]);
+    assert.equal(result.steps.at(-1).result, "merge_blocked");
+  });
+
+  it("allows explicit fallback evidence to produce a lift-and-merge room plan", async () => {
+    const job = codeJob();
+    const result = await executeCodingRoomPipeline({
+      ledger: createCodingRoomJobLedger({ jobs: [job, ...reviewJobs()] }),
+      runner,
+      jobId: job.job_id,
+      pr: readyPr({ isDraft: true }),
+      fallbackEvidence: { full_ack_set: true },
+      applyPatch: passingPatchRunner(),
+      runCommand: passingProofRunner(),
+      now: "2026-05-04T00:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "ready_to_lift_and_merge");
+    assert.equal(result.merge.draft_lift_required, true);
+    assert.deepEqual(result.merge.execute_plan, ["lift_draft", "merge", "watch_post_merge"]);
+    assert.equal(result.steps.at(-1).result, "ready_to_lift_and_merge");
   });
 
   it("stops after proof when no PR state is supplied", async () => {


### PR DESCRIPTION
## Summary
- routes pipeline executor merge decisions through Merge Room instead of the raw merge controller
- routes pipeline dry-run merge planning through Merge Room as well
- turns full-PASS draft PRs into explicit `needs_lift` / `ready_to_lift_and_merge` outcomes instead of vague draft blockers

## Safety
- advisory by default; no auto-merge or auto-lift added
- explicit fallback evidence is required before a draft PR can plan lift + merge
- existing proof, review, terminal-status, ownership, and patch gates still run first

## Proof
- `node --test scripts/pinballwake-pipeline-executor.test.mjs scripts/pinballwake-pipeline-dry-run.test.mjs scripts/pinballwake-merge-room.test.mjs` passed 27/27
- `node --test scripts/pinballwake-*-room.test.mjs scripts/pinballwake-*executor.test.mjs scripts/pinballwake-pipeline-*.test.mjs scripts/pinballwake-autopilot-triage.test.mjs scripts/pinballwake-coding-room*.test.mjs` passed 151/151
- `git diff --check` passed
