### PR TITLE
feat(autopilot): add jobs room

### DIFF
--- a/scripts/pinballwake-jobs-room.mjs
+++ b/scripts/pinballwake-jobs-room.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+import {
+  createCodingRoomJobLedger,
+  runnerCanClaimCodingRoomJob,
+} from "./pinballwake-coding-room.mjs";
+import { DEFAULT_CODING_ROOM_RUNNER, createCodingRoomRunner } from "./pinballwake-coding-room-runner.mjs";
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function safeList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalize(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function compactText(value, max = 600) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function parseMs(value) {
+  const ms = Date.parse(String(value ?? ""));
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function isExpired(job = {}, now = new Date().toISOString()) {
+  const expires = parseMs(job.lease_expires_at || job.ack_deadline_at);
+  const current = parseMs(now);
+  return expires !== null && current !== null && expires <= current;
+}
+
+function jobLabel(job = {}) {
+  return compactText(job.chip || job.job_id || "unknown job", 140);
+}
+
+function requestedWorker(job = {}) {
+  if (job.job_type === "review") {
+    const requested = safeList(job.requested_reviewers)[0];
+    if (requested) return requested;
+    if (job.review_kind === "release_safety") return "gatekeeper";
+    if (job.review_kind === "qc_review") return "popcorn";
+  }
+
+  return compactText(job.worker || "forge", 80);
+}
+
+function packetFor(job, nextAction, context, expectedProof, deadline = "next heartbeat") {
+  return {
+    worker: requestedWorker(job),
+    chip: jobLabel(job),
+    context: compactText(context || job.context || job.job_id),
+    expected_proof: expectedProof,
+    deadline,
+    ack: "done/blocker",
+  };
+}
+
+function classifyJob({ job, ledger, runner, now }) {
+  const status = normalize(job.status);
+  const type = normalize(job.job_type || "code");
+
+  if (status === "queued") {
+    const claim = runnerCanClaimCodingRoomJob({
+      runner,
+      job,
+      activeJobs: ledger.jobs || [],
+    });
+
+    if (claim.ok) {
+      const action = type === "review" ? "claim_review" : "claim_build";
+      return {
+        job_id: job.job_id,
+        status: job.status,
+        job_type: type,
+        next_action: action,
+        priority: type === "review" ? 70 : 80,
+        reason: claim.reason,
+        packet: packetFor(
+          job,
+          action,
+          type === "review"
+            ? "Review packet is queued and claimable."
+            : "Build packet is queued and claimable.",
+          type === "review"
+            ? "Reply PASS/BLOCKER with latest-head proof."
+            : "Claim the job, build only owned files, run listed proof, and report done/blocker.",
+        ),
+      };
+    }
+
+    return {
+      job_id: job.job_id,
+      status: job.status,
+      job_type: type,
+      next_action: "blocked_before_claim",
+      priority: 60,
+      reason: claim.reason,
+      file: claim.file || null,
+      packet: packetFor(
+        job,
+        "blocked_before_claim",
+        `Queued job is not claimable: ${claim.reason}${claim.file ? ` (${claim.file})` : ""}.`,
+        "Fix the blocker or reroute the job, then report done/blocker.",
+      ),
+    };
+  }
+
+  if (["claimed", "building", "testing"].includes(status)) {
+    if (isExpired(job, now)) {
+      return {
+        job_id: job.job_id,
+        status: job.status,
+        job_type: type,
+        next_action: "reclaim_or_refresh",
+        priority: 90,
+        reason: "lease_or_deadline_expired",
+        packet: packetFor(
+          job,
+          "reclaim_or_refresh",
+          "Active job lease/deadline expired; refresh status or allow reclaim.",
+          "Reply current status, blocker, or next safe action.",
+          "immediate",
+        ),
+      };
+    }
+
+    return {
+      job_id: job.job_id,
+      status: job.status,
+      job_type: type,
+      next_action: type === "review" ? "await_review_ack" : "await_build_or_proof",
+      priority: 40,
+      reason: "active_not_expired",
+    };
+  }
+
+  if (status === "proof_submitted") {
+    return {
+      job_id: job.job_id,
+      status: job.status,
+      job_type: type,
+      next_action: "review_or_merge_room",
+      priority: 75,
+      reason: "proof_submitted_needs_decision",
+      packet: packetFor(
+        job,
+        "review_or_merge_room",
+        "Proof is submitted; route review jobs or run Merge Room when PASS gates are complete.",
+        "Post required review packets or run Merge Room decision.",
+      ),
+    };
+  }
+
+  if (status === "fallback_ready") {
+    return {
+      job_id: job.job_id,
+      status: job.status,
+      job_type: type,
+      next_action: "master_fallback_decision",
+      priority: 85,
+      reason: "review_timeout_fallback_ready",
+      packet: packetFor(
+        job,
+        "master_fallback_decision",
+        "Review timed out and is fallback-ready.",
+        "Master decides fallback, re-nudge reviewer, or blocker.",
+        "immediate",
+      ),
+    };
+  }
+
+  if (status === "blocked") {
+    return {
+      job_id: job.job_id,
+      status: job.status,
+      job_type: type,
+      next_action: "repair_room",
+      priority: 95,
+      reason: compactText(job.build_result?.blocker || job.proof?.blocker || "job_blocked", 180),
+      packet: packetFor(
+        job,
+        "repair_room",
+        compactText(job.build_result?.blocker || job.proof?.blocker || job.context || "Blocked job needs repair."),
+        "Route a focused repair packet or close/supersede if obsolete.",
+        "next builder pulse",
+      ),
+    };
+  }
+
+  if (["done", "expired"].includes(status)) {
+    return {
+      job_id: job.job_id,
+      status: job.status,
+      job_type: type,
+      next_action: status === "expired" ? "requeue_or_close" : "none",
+      priority: status === "expired" ? 55 : 0,
+      reason: status === "expired" ? "job_expired" : "job_done",
+    };
+  }
+
+  return {
+    job_id: job.job_id,
+    status: job.status,
+    job_type: type,
+    next_action: "inspect",
+    priority: 50,
+    reason: "unknown_status",
+  };
+}
+
+function countsBy(items, key) {
+  return items.reduce((counts, item) => {
+    const value = item[key] || "unknown";
+    counts[value] = (counts[value] || 0) + 1;
+    return counts;
+  }, {});
+}
+
+export function evaluateJobsRoom({
+  ledger,
+  jobs,
+  runner = DEFAULT_CODING_ROOM_RUNNER,
+  now = new Date().toISOString(),
+  limit = 5,
+} = {}) {
+  const safeLedger = createCodingRoomJobLedger({
+    jobs: jobs || ledger?.jobs || [],
+    updatedAt: ledger?.updated_at || now,
+  });
+  const safeRunner = createCodingRoomRunner(runner);
+  const decisions = safeLedger.jobs
+    .map((job) => classifyJob({ job, ledger: safeLedger, runner: safeRunner, now }))
+    .sort((a, b) => b.priority - a.priority || String(a.job_id).localeCompare(String(b.job_id)));
+
+  const actionable = decisions.filter((decision) => decision.priority > 0 && decision.next_action !== "none");
+  const top = actionable.slice(0, limit);
+
+  return {
+    ok: true,
+    action: "jobs_room",
+    result: actionable.length ? "todos" : "idle",
+    reason: actionable.length ? "job_todos_found" : "no_actionable_jobs",
+    counts_by_status: countsBy(decisions, "status"),
+    counts_by_next_action: countsBy(decisions, "next_action"),
+    next: top[0] || null,
+    todos: top,
+    packets: top.map((decision) => decision.packet).filter(Boolean),
+  };
+}
+
+export async function readJobsRoomInput(filePath) {
+  if (!filePath) return { ok: false, reason: "missing_input_path" };
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  readJobsRoomInput(getArg("input", process.env.PINBALLWAKE_JOBS_ROOM_INPUT || ""))
+    .then((input) => evaluateJobsRoom(input))
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-jobs-room.test.mjs
+++ b/scripts/pinballwake-jobs-room.test.mjs
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  claimCodingRoomJob,
+  createCodingRoomJob,
+  createCodingRoomJobLedger,
+  createCodingRoomQcJob,
+  createCodingRoomSafetyJob,
+  submitCodingRoomBuildResult,
+  submitCodingRoomProof,
+} from "./pinballwake-coding-room.mjs";
+import { evaluateJobsRoom } from "./pinballwake-jobs-room.mjs";
+
+const builder = {
+  id: "forge",
+  name: "forge",
+  readiness: "builder_ready",
+  capabilities: ["implementation"],
+};
+
+const qcRunner = {
+  id: "popcorn",
+  name: "popcorn",
+  readiness: "review_only",
+  capabilities: ["qc_review"],
+};
+
+function codeJob(input = {}) {
+  return createCodingRoomJob({
+    jobId: input.jobId || "jobs-room:code",
+    prNumber: 528,
+    worker: input.worker || "forge",
+    chip: input.chip || "Jobs Room code chip",
+    context: input.context || "Build a small job room chip.",
+    files: input.files || ["scripts/pinballwake-jobs-room.mjs"],
+    expectedProof: {
+      requiresPr: false,
+      requiresChangedFiles: true,
+      requiresNonOverlap: true,
+      requiresTests: true,
+      tests: ["node --test scripts/pinballwake-jobs-room.test.mjs"],
+    },
+    status: input.status || "queued",
+    claimedBy: input.claimedBy,
+    leaseExpiresAt: input.leaseExpiresAt,
+    buildResult: input.buildResult,
+    proof: input.proof,
+  });
+}
+
+function proofSubmittedJob() {
+  const job = submitCodingRoomBuildResult({
+    job: codeJob({ status: "claimed", claimedBy: "forge" }),
+    buildResult: {
+      result: "done",
+      changedFiles: ["scripts/pinballwake-jobs-room.mjs"],
+    },
+    now: "2026-05-04T00:01:00.000Z",
+  }).job;
+
+  return submitCodingRoomProof({
+    job,
+    proof: {
+      result: "done",
+      changedFiles: ["scripts/pinballwake-jobs-room.mjs"],
+      tests: [{ command: "node --test scripts/pinballwake-jobs-room.test.mjs", status: "passed" }],
+      prUrl: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/528",
+      submittedAt: "2026-05-04T00:02:00.000Z",
+    },
+  }).job;
+}
+
+describe("PinballWake Jobs Room", () => {
+  it("turns queued code jobs into claim/build todos", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [codeJob()] }),
+      runner: builder,
+    });
+
+    assert.equal(result.result, "todos");
+    assert.equal(result.next.next_action, "claim_build");
+    assert.equal(result.next.priority, 80);
+    assert.equal(result.packets[0].worker, "forge");
+    assert.match(result.packets[0].expected_proof, /Claim the job/);
+  });
+
+  it("turns queued review jobs into reviewer todos only for matching reviewer", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [createCodingRoomQcJob({ prNumber: 528 })] }),
+      runner: qcRunner,
+    });
+
+    assert.equal(result.next.next_action, "claim_review");
+    assert.equal(result.packets[0].worker, "popcorn");
+
+    const blocked = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [createCodingRoomSafetyJob({ prNumber: 528 })] }),
+      runner: qcRunner,
+    });
+    assert.equal(blocked.next.next_action, "blocked_before_claim");
+    assert.equal(blocked.next.reason, "runner_lacks_review_kind_capability");
+  });
+
+  it("prioritizes expired active work as reclaim or refresh", () => {
+    const active = claimCodingRoomJob({
+      runner: builder,
+      job: codeJob(),
+      now: "2026-05-04T00:00:00.000Z",
+      leaseSeconds: 60,
+    }).job;
+
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [active, codeJob({ jobId: "jobs-room:queued-2" })] }),
+      runner: builder,
+      now: "2026-05-04T00:02:00.000Z",
+    });
+
+    assert.equal(result.next.next_action, "reclaim_or_refresh");
+    assert.equal(result.next.priority, 90);
+    assert.equal(result.packets[0].deadline, "immediate");
+  });
+
+  it("routes blocked jobs to Repair Room", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({
+        jobs: [
+          codeJob({
+            status: "blocked",
+            buildResult: { result: "blocker", blocker: "patch_file_outside_ownership" },
+          }),
+        ],
+      }),
+      runner: builder,
+    });
+
+    assert.equal(result.next.next_action, "repair_room");
+    assert.equal(result.next.priority, 95);
+    assert.match(result.packets[0].context, /patch_file_outside_ownership/);
+  });
+
+  it("routes submitted proof to review or Merge Room", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [proofSubmittedJob()] }),
+      runner: builder,
+    });
+
+    assert.equal(result.next.next_action, "review_or_merge_room");
+    assert.equal(result.counts_by_status.proof_submitted, 1);
+  });
+
+  it("reports idle when the todo list is complete", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [codeJob({ status: "done" })] }),
+      runner: builder,
+    });
+
+    assert.equal(result.result, "idle");
+    assert.equal(result.reason, "no_actionable_jobs");
+    assert.equal(result.packets.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- adds Jobs Room as the todo-board brain for Coding Room ledger jobs
- classifies queued, active, expired, blocked, fallback-ready, and proof-submitted jobs into next actions
- emits compact worker packets for build, review, reclaim/refresh, repair, and review/Merge Room handoff

## Safety
- advisory only; no code execution, no repo edits, no PR changes, no merges
- uses existing Coding Room claim rules to avoid unsafe claims or wrong reviewer claims
- blocked/expired work becomes packets rather than silent action

## Proof
- `node --test scripts/pinballwake-jobs-room.test.mjs` passed 6/6
- `node --test scripts/pinballwake-*-room.test.mjs scripts/pinballwake-*executor.test.mjs scripts/pinballwake-pipeline-*.test.mjs scripts/pinballwake-autopilot-triage.test.mjs scripts/pinballwake-coding-room*.test.mjs` passed 153/153
- `git diff --check` passed
