### PR TITLE
feat(autopilot): add personality room

### DIFF
--- a/scripts/pinballwake-personality-room.mjs
+++ b/scripts/pinballwake-personality-room.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function safeList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalize(value) {
+  return String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function compactText(value, max = 1000) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function uniq(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export const RESPONSE_LENGTHS = {
+  short: {
+    label: "Short",
+    instruction: "Keep most answers to one or two short paragraphs unless the user asks for detail.",
+  },
+  medium: {
+    label: "Medium",
+    instruction: "Use a concise explanation with enough detail to avoid follow-up confusion.",
+  },
+  long: {
+    label: "Long",
+    instruction: "Give a fuller answer with structure, examples, and tradeoffs when useful.",
+  },
+};
+
+export const COMPLEXITY_LEVELS = {
+  very_simple_with_analogies: {
+    label: "Very simple with analogies",
+    instruction: "Explain in plain language first, then use a concrete analogy for hard ideas.",
+  },
+  simple: {
+    label: "Simple",
+    instruction: "Use simple words, short sentences, and avoid unnecessary technical terms.",
+  },
+  normal: {
+    label: "Normal",
+    instruction: "Use everyday professional language and define uncommon terms briefly.",
+  },
+  advanced: {
+    label: "Advanced",
+    instruction: "Assume a capable operator; include technical detail when it helps decisions.",
+  },
+  expert: {
+    label: "Expert",
+    instruction: "Use precise technical language, edge cases, and implementation tradeoffs.",
+  },
+};
+
+export const EMOJI_LEVELS = {
+  none: {
+    label: "None",
+    instruction: "Do not use emojis.",
+    palette: {},
+  },
+  light: {
+    label: "Light",
+    instruction: "Use emojis only when they improve scanning, such as status or urgency markers.",
+    palette: { pass: "green", watch: "yellow", blocker: "red", working: "blue" },
+  },
+  medium: {
+    label: "Medium",
+    instruction: "Use smart status emojis and occasional section markers, but keep business text clean.",
+    palette: { pass: "green", watch: "yellow", blocker: "red", working: "blue", proof: "check", build: "tool" },
+  },
+  heavy: {
+    label: "Heavy",
+    instruction: "Use expressive emojis for personality and status, while keeping safety/proof text readable.",
+    palette: { pass: "green", watch: "yellow", blocker: "red", working: "blue", proof: "check", build: "tool", launch: "rocket" },
+  },
+};
+
+export const WRITING_STYLE_PRESETS = {
+  plain_english_operator: {
+    label: "Plain English Operator",
+    tone: "calm, direct, practical",
+    best_for: "daily operations, status updates, non-technical users",
+    instruction: "Lead with the simple answer, then give the next action. Avoid jargon unless it saves time.",
+  },
+  professional_founder: {
+    label: "Professional Founder",
+    tone: "clear, ambitious, credible",
+    best_for: "LinkedIn, investors, product narrative, team direction",
+    instruction: "Sound sharp and commercially grounded without hype. Tie details back to the bigger product direction.",
+  },
+  friendly_builder: {
+    label: "Friendly Builder",
+    tone: "warm, capable, collaborative",
+    best_for: "product building, troubleshooting, creative iteration",
+    instruction: "Be upbeat and useful. Explain what is happening, what changed, and the safest next step.",
+  },
+  concise_executive: {
+    label: "Concise Executive",
+    tone: "brief, decisive, outcome-focused",
+    best_for: "high-level decisions, priority calls, handoffs",
+    instruction: "Summarize the decision, risk, and next move. Keep supporting detail short.",
+  },
+  technical_expert: {
+    label: "Technical Expert",
+    tone: "precise, evidence-led, implementation-aware",
+    best_for: "engineering, architecture, code review, proofs",
+    instruction: "Name assumptions, edge cases, files, tests, and failure modes. Do not hide uncertainty.",
+  },
+  creative_strategist: {
+    label: "Creative Strategist",
+    tone: "imaginative, memorable, still practical",
+    best_for: "naming, branding, analogies, product positioning",
+    instruction: "Offer vivid options that flow naturally. Keep the ideas usable, not theatrical.",
+  },
+};
+
+export const STATUS_SYMBOL_SETS = {
+  plain: {
+    pass: "PASS",
+    watch: "WATCH",
+    blocker: "BLOCKER",
+    working: "WORKING",
+    idle: "IDLE",
+    progress: "[####------] 40%",
+  },
+  traffic_light: {
+    pass: "green light",
+    watch: "yellow light",
+    blocker: "red light",
+    working: "blue dot",
+    idle: "grey dot",
+    progress: "40%",
+  },
+  expressive: {
+    pass: "green light",
+    watch: "yellow light",
+    blocker: "red alert",
+    working: "blue work marker",
+    idle: "quiet marker",
+    progress: "four-bar progress",
+  },
+};
+
+function normalizeEnum(value, allowed, fallback) {
+  const key = normalize(value);
+  return allowed[key] ? key : fallback;
+}
+
+function buildStylePrompt({
+  identity,
+  audience,
+  memoryNotes,
+  preset,
+  responseLength,
+  complexity,
+  emojiLevel,
+  customInstructions,
+}) {
+  const style = WRITING_STYLE_PRESETS[preset];
+  const length = RESPONSE_LENGTHS[responseLength];
+  const complexityConfig = COMPLEXITY_LEVELS[complexity];
+  const emoji = EMOJI_LEVELS[emojiLevel];
+
+  return [
+    `Identity: ${identity}`,
+    audience ? `Audience: ${audience}` : "",
+    memoryNotes.length ? `Useful context: ${memoryNotes.join("; ")}` : "",
+    `Writing style: ${style.label} (${style.tone}). ${style.instruction}`,
+    `Response length: ${length.label}. ${length.instruction}`,
+    `Complexity: ${complexityConfig.label}. ${complexityConfig.instruction}`,
+    `Emoji level: ${emoji.label}. ${emoji.instruction}`,
+    customInstructions ? `Custom instructions: ${customInstructions}` : "",
+  ].filter(Boolean).join("\n");
+}
+
+export function evaluatePersonalityRoom({
+  identity = "",
+  audience = "",
+  memoryNotes = [],
+  writingStyle = "plain_english_operator",
+  responseLength = "medium",
+  complexity = "simple",
+  emojiLevel = "light",
+  statusSymbols = "traffic_light",
+  customInstructions = "",
+} = {}) {
+  const normalizedIdentity = compactText(identity, 500);
+  const normalizedAudience = compactText(audience, 260);
+  const normalizedMemory = uniq(safeList(memoryNotes).map((note) => compactText(note, 220)));
+  const preset = normalizeEnum(writingStyle, WRITING_STYLE_PRESETS, "plain_english_operator");
+  const length = normalizeEnum(responseLength, RESPONSE_LENGTHS, "medium");
+  const complexityKey = normalizeEnum(complexity, COMPLEXITY_LEVELS, "simple");
+  const emoji = normalizeEnum(emojiLevel, EMOJI_LEVELS, "light");
+  const symbols = normalizeEnum(statusSymbols, STATUS_SYMBOL_SETS, emoji === "none" ? "plain" : "traffic_light");
+  const custom = compactText(customInstructions, 500);
+  const setup = [];
+
+  if (!normalizedIdentity) {
+    setup.push({ kind: "add_identity", detail: "Add the assistant/company identity before using Launchpad broadly.", priority: 100 });
+  }
+
+  if (normalizedMemory.length === 0) {
+    setup.push({ kind: "add_memory_context", detail: "Add durable memory notes: who the user is, what UnClick is, and what matters.", priority: 70 });
+  }
+
+  if (emoji === "heavy" && length === "short") {
+    setup.push({ kind: "watch_style_conflict", detail: "Heavy emoji with short replies can crowd the answer; keep status markers purposeful.", priority: 35 });
+  }
+
+  return {
+    ok: true,
+    action: "personality_room",
+    result: setup.some((step) => step.priority >= 75) ? "setup_needed" : "ready",
+    identity: normalizedIdentity,
+    audience: normalizedAudience,
+    memory_notes: normalizedMemory,
+    writing_style: { key: preset, ...WRITING_STYLE_PRESETS[preset] },
+    controls: {
+      response_length: length,
+      complexity: complexityKey,
+      emoji_level: emoji,
+      status_symbols: symbols,
+    },
+    emoji_palette: EMOJI_LEVELS[emoji].palette,
+    status_symbols: STATUS_SYMBOL_SETS[symbols],
+    style_prompt: buildStylePrompt({
+      identity: normalizedIdentity || "UnClick assistant identity not set",
+      audience: normalizedAudience,
+      memoryNotes: normalizedMemory,
+      preset,
+      responseLength: length,
+      complexity: complexityKey,
+      emojiLevel: emoji,
+      customInstructions: custom,
+    }),
+    setup_steps: setup.sort((a, b) => b.priority - a.priority || a.kind.localeCompare(b.kind)),
+    admin_fields: [
+      "identity",
+      "audience",
+      "memoryNotes",
+      "writingStyle",
+      "responseLength",
+      "complexity",
+      "emojiLevel",
+      "statusSymbols",
+      "customInstructions",
+    ],
+    safety: {
+      advisory_only: true,
+      no_execution: true,
+      no_repo_changes: true,
+      no_secret_storage: true,
+    },
+  };
+}
+
+export async function readPersonalityRoomInput(filePath) {
+  if (!filePath) return { ok: false, reason: "missing_input_path" };
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  readPersonalityRoomInput(getArg("input", process.env.PINBALLWAKE_PERSONALITY_ROOM_INPUT || ""))
+    .then((input) => evaluatePersonalityRoom(input))
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-personality-room.test.mjs
+++ b/scripts/pinballwake-personality-room.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  COMPLEXITY_LEVELS,
+  EMOJI_LEVELS,
+  evaluatePersonalityRoom,
+  RESPONSE_LENGTHS,
+  STATUS_SYMBOL_SETS,
+  WRITING_STYLE_PRESETS,
+} from "./pinballwake-personality-room.mjs";
+
+describe("PinballWake Personality Room", () => {
+  it("creates a ready style prompt from identity, memory, and controls", () => {
+    const result = evaluatePersonalityRoom({
+      identity: "UnClick is an AI-native infrastructure ecosystem.",
+      audience: "Founder/operator using AI agents and automation.",
+      memoryNotes: ["Chris prefers simple English.", "Use analogies when the system gets complex."],
+      writingStyle: "friendly_builder",
+      responseLength: "short",
+      complexity: "very_simple_with_analogies",
+      emojiLevel: "light",
+    });
+
+    assert.equal(result.result, "ready");
+    assert.equal(result.writing_style.key, "friendly_builder");
+    assert.equal(result.controls.response_length, "short");
+    assert.equal(result.controls.complexity, "very_simple_with_analogies");
+    assert.match(result.style_prompt, /UnClick is an AI-native infrastructure ecosystem/);
+    assert.match(result.style_prompt, /Very simple with analogies/);
+  });
+
+  it("falls back to safe defaults for unknown preset values", () => {
+    const result = evaluatePersonalityRoom({
+      identity: "UnClick assistant",
+      memoryNotes: ["Keep the user moving."],
+      writingStyle: "chaos_mode",
+      responseLength: "tiny",
+      complexity: "wizard",
+      emojiLevel: "extreme",
+      statusSymbols: "laser_show",
+    });
+
+    assert.equal(result.writing_style.key, "plain_english_operator");
+    assert.equal(result.controls.response_length, "medium");
+    assert.equal(result.controls.complexity, "simple");
+    assert.equal(result.controls.emoji_level, "light");
+    assert.equal(result.controls.status_symbols, "traffic_light");
+  });
+
+  it("flags missing identity as setup-needed", () => {
+    const result = evaluatePersonalityRoom({
+      memoryNotes: ["User likes direct practical answers."],
+    });
+
+    assert.equal(result.result, "setup_needed");
+    assert.equal(result.setup_steps[0].kind, "add_identity");
+    assert.match(result.style_prompt, /identity not set/);
+  });
+
+  it("keeps emoji-free profiles plain when no status set is provided", () => {
+    const result = evaluatePersonalityRoom({
+      identity: "Professional assistant",
+      memoryNotes: ["No emoji for formal work."],
+      emojiLevel: "none",
+      statusSymbols: "unknown",
+    });
+
+    assert.equal(result.controls.emoji_level, "none");
+    assert.equal(result.controls.status_symbols, "plain");
+    assert.equal(Object.keys(result.emoji_palette).length, 0);
+    assert.match(result.style_prompt, /Do not use emojis/);
+  });
+
+  it("warns when short replies are paired with heavy emoji", () => {
+    const result = evaluatePersonalityRoom({
+      identity: "UnClick assistant",
+      memoryNotes: ["Use status markers."],
+      responseLength: "short",
+      emojiLevel: "heavy",
+    });
+
+    assert.equal(result.result, "ready");
+    assert.ok(result.setup_steps.some((step) => step.kind === "watch_style_conflict"));
+  });
+
+  it("exports the expected preset surfaces", () => {
+    assert.deepEqual(Object.keys(RESPONSE_LENGTHS), ["short", "medium", "long"]);
+    assert.ok(Object.keys(COMPLEXITY_LEVELS).includes("very_simple_with_analogies"));
+    assert.ok(Object.keys(EMOJI_LEVELS).includes("heavy"));
+    assert.ok(Object.keys(WRITING_STYLE_PRESETS).includes("professional_founder"));
+    assert.ok(Object.keys(STATUS_SYMBOL_SETS).includes("traffic_light"));
+  });
+});

--- a/src/pages/admin/AdminPinballWake.tsx
+++ b/src/pages/admin/AdminPinballWake.tsx
@@ -24,6 +24,16 @@ import {
   type PinballWakeRunnerReadiness,
 } from "./pinballwakeJobRunners";
 import {
+  COMPLEXITY_LABELS,
+  DEFAULT_PERSONALITY_PROFILE,
+  EMOJI_LEVEL_LABELS,
+  PERSONALITY_STYLE_PRESETS,
+  RESPONSE_LENGTH_LABELS,
+  selectedPersonalityPreset,
+  summarizePersonalityProfile,
+  type PersonalityStylePreset,
+} from "./pinballwakePersonality";
+import {
   activeOrchestrator,
   LAUNCHPAD_ORCHESTRATORS,
   LAUNCHPAD_ROOM_COVERAGE,
@@ -264,11 +274,44 @@ function SetupStepRow({ step }: { step: LaunchpadSetupStep }) {
   );
 }
 
+function PersonalityPresetCard({ preset, selected }: { preset: PersonalityStylePreset; selected: boolean }) {
+  return (
+    <article
+      className={`rounded-lg border p-3 ${
+        selected
+          ? "border-[#61C1C4]/35 bg-[#61C1C4]/10"
+          : "border-white/[0.06] bg-white/[0.025]"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-white">{preset.label}</h3>
+          <p className="mt-1 text-xs text-white/45">{preset.tone}</p>
+        </div>
+        {selected ? <SmallBadge className="border-[#61C1C4]/40 bg-[#61C1C4]/10 text-[#61C1C4]">active</SmallBadge> : null}
+      </div>
+      <p className="mt-3 text-xs leading-relaxed text-white/60">{preset.description}</p>
+      <p className="mt-2 text-xs text-white/35">{preset.bestFor}</p>
+    </article>
+  );
+}
+
+function PersonalityControlRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-white/[0.06] bg-white/[0.025] px-3 py-2">
+      <p className="text-xs font-medium uppercase text-white/35">{label}</p>
+      <p className="mt-1 text-sm font-semibold text-white">{value}</p>
+    </div>
+  );
+}
+
 export default function AdminPinballWake() {
   const summary = summarizePinballWakeClockRoutes();
   const runnerSummary = summarizePinballWakeJobRunners();
   const launchpadSummary = summarizeLaunchpadSeats();
   const orchestrator = activeOrchestrator();
+  const personalitySummary = summarizePersonalityProfile();
+  const activePersonalityPreset = selectedPersonalityPreset();
 
   const primaryRoutes = PINBALLWAKE_CLOCK_ROUTES.filter((route) =>
     ["live", "watching", "ready"].includes(route.status),
@@ -306,6 +349,68 @@ export default function AdminPinballWake() {
         <MetricCard icon={Cpu} label="Code Hands" value={runnerSummary.codeHands} />
         <MetricCard icon={Gauge} label="Need Probe" value={runnerSummary.needsProbe} />
       </div>
+
+      <section className="mb-6 border-y border-white/[0.08] bg-[#101213] py-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-[#E2B93B]" />
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                Personality Room
+              </h2>
+            </div>
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-white/60">
+              Admin-editable identity, memory notes, writing style, complexity, response length,
+              and emoji/status preferences that can be applied before Launchpad routes work.
+            </p>
+          </div>
+          <div className="rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-sm">
+            <p className="text-xs font-medium uppercase text-white/35">Current Style</p>
+            <p className="mt-1 font-semibold text-white">{personalitySummary.preset}</p>
+            <p className="mt-0.5 text-xs text-white/45">{personalitySummary.memoryNotes} memory notes</p>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <PersonalityControlRow label="Length" value={RESPONSE_LENGTH_LABELS[DEFAULT_PERSONALITY_PROFILE.responseLength]} />
+          <PersonalityControlRow label="Complexity" value={COMPLEXITY_LABELS[DEFAULT_PERSONALITY_PROFILE.complexity]} />
+          <PersonalityControlRow label="Emoji Level" value={EMOJI_LEVEL_LABELS[DEFAULT_PERSONALITY_PROFILE.emojiLevel]} />
+          <PersonalityControlRow label="Audience" value="Founder/operator" />
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
+          <div className="rounded-lg border border-white/[0.06] bg-[#111111] p-4">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-white/45">
+              Identity
+            </h3>
+            <p className="mt-2 text-sm leading-relaxed text-white/70">{DEFAULT_PERSONALITY_PROFILE.identity}</p>
+            <h3 className="mt-4 text-xs font-semibold uppercase tracking-wide text-white/45">
+              Memory Notes
+            </h3>
+            <div className="mt-2 space-y-2">
+              {DEFAULT_PERSONALITY_PROFILE.memoryNotes.map((note) => (
+                <div key={note} className="rounded-md border border-white/[0.06] bg-white/[0.025] px-3 py-2 text-xs text-white/60">
+                  {note}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-white/45">
+              Writing Style Presets
+            </h3>
+            <div className="grid gap-3 md:grid-cols-2">
+              {PERSONALITY_STYLE_PRESETS.map((preset) => (
+                <PersonalityPresetCard
+                  key={preset.id}
+                  preset={preset}
+                  selected={preset.id === activePersonalityPreset.id}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
 
       <section className="mb-6 border-y border-[#61C1C4]/20 bg-[#061314] py-4">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">

--- a/src/pages/admin/pinballwakePersonality.test.ts
+++ b/src/pages/admin/pinballwakePersonality.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PERSONALITY_PROFILE,
+  PERSONALITY_STYLE_PRESETS,
+  selectedPersonalityPreset,
+  summarizePersonalityProfile,
+} from "./pinballwakePersonality";
+
+describe("PinballWake Personality admin model", () => {
+  it("ships with practical editable defaults", () => {
+    const summary = summarizePersonalityProfile();
+
+    expect(summary.preset).toBe("Plain English Operator");
+    expect(summary.memoryNotes).toBeGreaterThanOrEqual(3);
+    expect(summary.complexity).toContain("analogies");
+    expect(DEFAULT_PERSONALITY_PROFILE.identity).toContain("UnClick");
+  });
+
+  it("offers a useful spread of writing style presets", () => {
+    expect(PERSONALITY_STYLE_PRESETS.map((preset) => preset.id)).toEqual([
+      "plain-english-operator",
+      "professional-founder",
+      "friendly-builder",
+      "concise-executive",
+      "technical-expert",
+      "creative-strategist",
+    ]);
+  });
+
+  it("falls back to the first preset when profile selection is stale", () => {
+    expect(selectedPersonalityPreset({ ...DEFAULT_PERSONALITY_PROFILE, writingStyle: "missing" }).id).toBe(
+      "plain-english-operator",
+    );
+  });
+});

--- a/src/pages/admin/pinballwakePersonality.ts
+++ b/src/pages/admin/pinballwakePersonality.ts
@@ -1,0 +1,120 @@
+export type PersonalityResponseLength = "short" | "medium" | "long";
+export type PersonalityComplexity = "very_simple_with_analogies" | "simple" | "normal" | "advanced" | "expert";
+export type PersonalityEmojiLevel = "none" | "light" | "medium" | "heavy";
+
+export interface PersonalityStylePreset {
+  id: string;
+  label: string;
+  tone: string;
+  bestFor: string;
+  description: string;
+}
+
+export interface PersonalityProfile {
+  identity: string;
+  audience: string;
+  responseLength: PersonalityResponseLength;
+  complexity: PersonalityComplexity;
+  emojiLevel: PersonalityEmojiLevel;
+  writingStyle: string;
+  memoryNotes: string[];
+  customInstructions: string;
+}
+
+export const PERSONALITY_STYLE_PRESETS: PersonalityStylePreset[] = [
+  {
+    id: "plain-english-operator",
+    label: "Plain English Operator",
+    tone: "Calm, direct, practical",
+    bestFor: "Operations, status, non-technical control",
+    description: "Leads with the simple answer, then the next action.",
+  },
+  {
+    id: "professional-founder",
+    label: "Professional Founder",
+    tone: "Clear, ambitious, credible",
+    bestFor: "LinkedIn, investors, product direction",
+    description: "Connects product detail to a larger commercial story without hype.",
+  },
+  {
+    id: "friendly-builder",
+    label: "Friendly Builder",
+    tone: "Warm, capable, collaborative",
+    bestFor: "Build sessions, troubleshooting, creative iteration",
+    description: "Explains what changed, why it matters, and what happens next.",
+  },
+  {
+    id: "concise-executive",
+    label: "Concise Executive",
+    tone: "Brief, decisive, outcome-focused",
+    bestFor: "Decisions, handoffs, priority calls",
+    description: "Summarizes the decision, risk, and next move.",
+  },
+  {
+    id: "technical-expert",
+    label: "Technical Expert",
+    tone: "Precise, evidence-led, implementation-aware",
+    bestFor: "Engineering, architecture, code review",
+    description: "Names assumptions, edge cases, files, tests, and failure modes.",
+  },
+  {
+    id: "creative-strategist",
+    label: "Creative Strategist",
+    tone: "Imaginative, memorable, practical",
+    bestFor: "Naming, branding, analogies, positioning",
+    description: "Creates options that flow naturally without losing usefulness.",
+  },
+];
+
+export const DEFAULT_PERSONALITY_PROFILE: PersonalityProfile = {
+  identity: "UnClick is an AI-native infrastructure ecosystem building the connective layer between agents, tools, memory, integrations, and workflow automation.",
+  audience: "Founder/operator who wants simple English, fast leverage, and safety-grounded automation.",
+  responseLength: "medium",
+  complexity: "very_simple_with_analogies",
+  emojiLevel: "light",
+  writingStyle: "plain-english-operator",
+  memoryNotes: [
+    "Prefer simple English first, then deeper detail only when useful.",
+    "Use analogies for complex automation and infrastructure ideas.",
+    "Keep automation safety, proof, and next action visible.",
+  ],
+  customInstructions: "Be warm, practical, and decisive. Avoid hype; make the user feel more capable.",
+};
+
+export const RESPONSE_LENGTH_LABELS: Record<PersonalityResponseLength, string> = {
+  short: "Short",
+  medium: "Medium",
+  long: "Long",
+};
+
+export const COMPLEXITY_LABELS: Record<PersonalityComplexity, string> = {
+  very_simple_with_analogies: "Very simple + analogies",
+  simple: "Simple",
+  normal: "Normal",
+  advanced: "Advanced",
+  expert: "Expert",
+};
+
+export const EMOJI_LEVEL_LABELS: Record<PersonalityEmojiLevel, string> = {
+  none: "None",
+  light: "Light",
+  medium: "Medium",
+  heavy: "Heavy",
+};
+
+export function selectedPersonalityPreset(
+  profile = DEFAULT_PERSONALITY_PROFILE,
+  presets = PERSONALITY_STYLE_PRESETS,
+) {
+  return presets.find((preset) => preset.id === profile.writingStyle) ?? presets[0];
+}
+
+export function summarizePersonalityProfile(profile = DEFAULT_PERSONALITY_PROFILE) {
+  return {
+    memoryNotes: profile.memoryNotes.length,
+    responseLength: RESPONSE_LENGTH_LABELS[profile.responseLength],
+    complexity: COMPLEXITY_LABELS[profile.complexity],
+    emojiLevel: EMOJI_LEVEL_LABELS[profile.emojiLevel],
+    preset: selectedPersonalityPreset(profile).label,
+  };
+}


### PR DESCRIPTION
## Summary
Adds Personality Room v1 for UnClick Autopilot.

What it does:
- Models assistant/company identity, audience, durable memory notes, writing style presets, response length, complexity, emoji level, status symbol sets, and custom style instructions.
- Adds safe defaults for UnClick: simple English, analogies for complex systems, light status emojis, and proof/next-action visibility.
- Adds PinballWake admin visibility so Personality Room appears before Launchpad as an editable foundation layer.

Why it matters:
Personality becomes a first-class room instead of a loose prompt blob. Launchpad can later apply this before routing work to worker seats.

Safety:
- advisory/config only
- no model calls
- no worker execution
- no repo writes from room decisions
- no PR state changes
- no secrets/auth/billing/DNS/migrations/raw keys

Proof:
- node --test scripts/pinballwake-personality-room.test.mjs passed 6/6
- npx vitest run src/pages/admin/pinballwakePersonality.test.ts src/pages/admin/pinballwakeLaunchpad.test.ts passed 7/7
- node --test scripts/pinballwake-personality-room.test.mjs scripts/pinballwake-launchpad-room.test.mjs scripts/pinballwake-jobs-room.test.mjs scripts/pinballwake-merge-room.test.mjs scripts/pinballwake-pipeline-dry-run.test.mjs passed 41/41
- npm run build passed
- git diff --check passed