### PR TITLE
feat(autopilot): add Event Ledger Room

### DIFF
--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -15,6 +15,28 @@ The goal is simple: keep the fleet moving while protecting secrets, security, bi
 - Run `/review` before opening PRs that change code, config, docs policy, or user-facing behavior.
 - Do not start new product lanes while an urgent foundation chip is blocked.
 
+## Command And Control Doctrine
+
+Autopilot can delegate work, but it cannot delegate responsibility to a black box. Any room or worker that can trigger workflows, call tools, change data, modify code, publish, merge, or roll back must leave a control trail clear enough for a human or safety room to answer five questions:
+
+- Who requested the action?
+- Which room or worker approved it?
+- What exact scope was approved?
+- What proof or review allowed it to continue?
+- How can it be stopped if the agent drifts?
+
+Core rules:
+
+- Autonomy without observability is a blocker, not a feature.
+- Status chatter is not authority. A PASS, approval, proof, or blocker must come from a trusted lane, room, master, or system event.
+- High-impact actions need explicit command authority before execution. Examples: merge, publish, rollback, destructive cleanup, secrets, auth, billing, DNS, migrations, or production data changes.
+- Every action that crosses a safety boundary must be reconstructable from an event ledger or audit trail, including actor, authority, scope, timestamp, source, and result.
+- Kill switches must be checked before high-impact execution. If the kill switch state is unclear, choose the safest interpretation and stop.
+- Human-readable prompts are allowed, but the system must convert them into structured scope, ownership, authority, and proof before acting.
+- Continuous Improvement owns repeated resistance. If the same manual nudge, missing ACK, stale proof, or routing confusion recurs, create a front-of-line improvement job instead of normalizing the friction.
+
+In short: agents may move the work, but UnClick must keep the chain of command visible.
+
 ## Autonomy Tiers
 
 | Tier | Meaning | Worker action |

--- a/scripts/pinballwake-event-ledger-room.mjs
+++ b/scripts/pinballwake-event-ledger-room.mjs
@@ -25,6 +25,7 @@ const AUTHORITY_RANK = {
 };
 
 const TRUSTED_REVIEW_AUTHORITIES = new Set(["lane", "room", "master", "system"]);
+const COMMAND_AUTHORITIES = new Set(["master", "system"]);
 
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -96,6 +97,8 @@ function normalizeAuthority(value = "observer") {
 function normalizePayload(payload = {}) {
   return {
     ...payload,
+    action: payload.action ? normalize(payload.action) : undefined,
+    enabled: typeof payload.enabled === "boolean" ? payload.enabled : undefined,
     verdict: payload.verdict ? normalize(payload.verdict).toUpperCase() : undefined,
     reviewer: payload.reviewer ? normalize(payload.reviewer) : undefined,
     summary: payload.summary ? compactText(payload.summary, 900) : undefined,
@@ -140,6 +143,27 @@ function eventTrust(event = {}) {
     }
     if (authority === "lane" && actor.role && actor.role !== reviewer) {
       return { trusted: false, reason: "lane_actor_reviewer_mismatch", authority };
+    }
+  }
+
+  if (event.kind === "approval") {
+    if (!payload.action) {
+      return { trusted: false, reason: "missing_action", authority };
+    }
+    if (!["APPROVED", "DENIED"].includes(payload.verdict)) {
+      return { trusted: false, reason: "invalid_approval_verdict", authority };
+    }
+    if (!COMMAND_AUTHORITIES.has(authority)) {
+      return { trusted: false, reason: "untrusted_command_authority", authority };
+    }
+  }
+
+  if (event.kind === "kill_switch") {
+    if (typeof payload.enabled !== "boolean") {
+      return { trusted: false, reason: "missing_kill_switch_state", authority };
+    }
+    if (!COMMAND_AUTHORITIES.has(authority)) {
+      return { trusted: false, reason: "untrusted_kill_switch_authority", authority };
     }
   }
 
@@ -278,6 +302,79 @@ export function summarizeEventLedgerScope({
   };
 }
 
+function latestTrustedEvent(events = [], predicate = () => true) {
+  return safeList(events)
+    .filter((event) => event.trust?.trusted)
+    .filter(predicate)
+    .reduce((latest, event) => (latest ? latestEvent(latest, event) : event), null);
+}
+
+export function summarizeCommandControlScope({
+  ledger,
+  scope,
+  action = "execute",
+  requireApproval = true,
+} = {}) {
+  const wanted = scopeKey(normalizeScope(scope || {}));
+  const normalizedAction = normalize(action || "execute");
+  const events = safeList(ledger?.events).filter((event) => scopeKey(event.scope) === wanted);
+  const latestKillSwitch = latestTrustedEvent(events, (event) => event.kind === "kill_switch");
+  const latestApproval = latestTrustedEvent(
+    events,
+    (event) => event.kind === "approval" && event.payload?.action === normalizedAction,
+  );
+
+  if (latestKillSwitch?.payload?.enabled === true) {
+    return {
+      ok: false,
+      action: "event_ledger_room",
+      result: "blocked",
+      reason: "kill_switch_enabled",
+      scope: normalizeScope(scope || {}),
+      requested_action: normalizedAction,
+      latest_kill_switch: latestKillSwitch,
+      latest_approval: latestApproval,
+    };
+  }
+
+  if (latestApproval?.payload?.verdict === "DENIED") {
+    return {
+      ok: false,
+      action: "event_ledger_room",
+      result: "blocked",
+      reason: "approval_denied",
+      scope: normalizeScope(scope || {}),
+      requested_action: normalizedAction,
+      latest_kill_switch: latestKillSwitch,
+      latest_approval: latestApproval,
+    };
+  }
+
+  if (requireApproval && latestApproval?.payload?.verdict !== "APPROVED") {
+    return {
+      ok: false,
+      action: "event_ledger_room",
+      result: "blocked",
+      reason: "missing_command_approval",
+      scope: normalizeScope(scope || {}),
+      requested_action: normalizedAction,
+      latest_kill_switch: latestKillSwitch,
+      latest_approval: latestApproval,
+    };
+  }
+
+  return {
+    ok: true,
+    action: "event_ledger_room",
+    result: "ready",
+    reason: "command_control_clear",
+    scope: normalizeScope(scope || {}),
+    requested_action: normalizedAction,
+    latest_kill_switch: latestKillSwitch,
+    latest_approval: latestApproval,
+  };
+}
+
 export function createTrustedReviewAckEvent({
   prNumber,
   reviewer,
@@ -346,7 +443,15 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
           requiredReviewers: input.requiredReviewers,
         })
         : null;
-      return { ok: validation.ok, action: "event_ledger_room", result: validation.result, ledger: withEvents, validation, summary };
+      const command_control = input.commandControl
+        ? summarizeCommandControlScope({
+          ledger: withEvents,
+          scope: input.commandControl.scope || input.scope,
+          action: input.commandControl.action,
+          requireApproval: input.commandControl.requireApproval,
+        })
+        : null;
+      return { ok: validation.ok, action: "event_ledger_room", result: validation.result, ledger: withEvents, validation, summary, command_control };
     })
     .then((result) => {
       console.log(JSON.stringify(result, null, 2));

--- a/scripts/pinballwake-event-ledger-room.mjs
+++ b/scripts/pinballwake-event-ledger-room.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const LEDGER_VERSION = 1;
+
+export const EVENT_LEDGER_AUTHORITIES = new Set([
+  "observer",
+  "reporter",
+  "lane",
+  "room",
+  "master",
+  "system",
+]);
+
+const AUTHORITY_RANK = {
+  observer: 0,
+  reporter: 10,
+  lane: 40,
+  room: 50,
+  master: 80,
+  system: 100,
+};
+
+const TRUSTED_REVIEW_AUTHORITIES = new Set(["lane", "room", "master", "system"]);
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function safeList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalize(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function compactText(value, max = 900) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function hashValue(value) {
+  return createHash("sha256").update(stableJson(value)).digest("hex");
+}
+
+function parseMs(value) {
+  const ms = Date.parse(String(value ?? ""));
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function scopeKey(scope = {}) {
+  const type = compactText(scope.type || scope.scope_type || "", 60);
+  const id = compactText(scope.id || scope.scope_id || "", 120);
+  return type && id ? `${type}:${id}` : "";
+}
+
+function normalizeScope(scope = {}) {
+  return {
+    type: compactText(scope.type || scope.scope_type || "", 60),
+    id: compactText(scope.id || scope.scope_id || "", 120),
+  };
+}
+
+function normalizeActor(actor = {}) {
+  return {
+    id: compactText(actor.id || actor.agent_id || actor.agentId || actor.worker || actor.name || "", 120),
+    role: normalize(actor.role || actor.lane || actor.worker || ""),
+    seat_id: compactText(actor.seat_id || actor.seatId || "", 120),
+  };
+}
+
+function normalizeAuthority(value = "observer") {
+  const authority = normalize(value || "observer");
+  return EVENT_LEDGER_AUTHORITIES.has(authority) ? authority : "observer";
+}
+
+function normalizePayload(payload = {}) {
+  return {
+    ...payload,
+    verdict: payload.verdict ? normalize(payload.verdict).toUpperCase() : undefined,
+    reviewer: payload.reviewer ? normalize(payload.reviewer) : undefined,
+    summary: payload.summary ? compactText(payload.summary, 900) : undefined,
+    blocker: payload.blocker ? compactText(payload.blocker, 900) : undefined,
+  };
+}
+
+function latestEvent(a, b) {
+  const aMs = parseMs(a?.occurred_at) ?? 0;
+  const bMs = parseMs(b?.occurred_at) ?? 0;
+  if (aMs !== bMs) return aMs > bMs ? a : b;
+  return String(a?.event_id || "").localeCompare(String(b?.event_id || "")) >= 0 ? a : b;
+}
+
+function eventTrust(event = {}) {
+  const authority = normalizeAuthority(event.authority);
+  const actor = event.actor || {};
+  const payload = event.payload || {};
+  const scope = event.scope || {};
+  const key = scopeKey(scope);
+
+  if (!key) {
+    return { trusted: false, reason: "missing_scope", authority };
+  }
+  if (!actor.id && !actor.role) {
+    return { trusted: false, reason: "missing_actor", authority };
+  }
+  if (authority === "observer" || authority === "reporter") {
+    return { trusted: false, reason: "observer_or_reporter_only", authority };
+  }
+
+  if (event.kind === "review_ack") {
+    const reviewer = normalize(payload.reviewer);
+    if (!reviewer) {
+      return { trusted: false, reason: "missing_reviewer", authority };
+    }
+    if (!["PASS", "BLOCKER"].includes(payload.verdict)) {
+      return { trusted: false, reason: "invalid_review_verdict", authority };
+    }
+    if (!TRUSTED_REVIEW_AUTHORITIES.has(authority)) {
+      return { trusted: false, reason: "untrusted_review_authority", authority };
+    }
+    if (authority === "lane" && actor.role && actor.role !== reviewer) {
+      return { trusted: false, reason: "lane_actor_reviewer_mismatch", authority };
+    }
+  }
+
+  return { trusted: true, reason: "trusted", authority };
+}
+
+export function createEventLedger(input = {}) {
+  return {
+    version: LEDGER_VERSION,
+    created_at: input.createdAt || input.created_at || new Date().toISOString(),
+    updated_at: input.updatedAt || input.updated_at || new Date().toISOString(),
+    events: safeList(input.events).map((event, index) => createLedgerEvent(event, {
+      previousHash: safeList(input.events)[index - 1]?.hash || null,
+      sequence: index + 1,
+    })),
+  };
+}
+
+export function createLedgerEvent(input = {}, { previousHash = null, sequence = 1 } = {}) {
+  const occurredAt = input.occurred_at || input.occurredAt || new Date().toISOString();
+  const event = {
+    version: LEDGER_VERSION,
+    sequence,
+    kind: normalize(input.kind || "status"),
+    scope: normalizeScope(input.scope || {}),
+    actor: normalizeActor(input.actor || {}),
+    authority: normalizeAuthority(input.authority),
+    occurred_at: occurredAt,
+    source: compactText(input.source || "", 160),
+    source_url: compactText(input.source_url || input.sourceUrl || "", 500),
+    payload: normalizePayload(input.payload || {}),
+    previous_hash: previousHash || null,
+  };
+  const trust = eventTrust(event);
+  const hash = hashValue({ ...event, trust });
+  return {
+    ...event,
+    event_id: input.event_id || `event:${hash.slice(0, 20)}`,
+    hash,
+    trust,
+  };
+}
+
+export function appendEventLedgerEvent({ ledger, event, now = new Date().toISOString() } = {}) {
+  const safeLedger = ledger?.version ? ledger : createEventLedger({ events: safeList(ledger?.events) });
+  const previous = safeList(safeLedger.events).at(-1);
+  const next = createLedgerEvent(event, {
+    previousHash: previous?.hash || null,
+    sequence: safeList(safeLedger.events).length + 1,
+  });
+
+  return {
+    ...safeLedger,
+    updated_at: now,
+    events: [...safeList(safeLedger.events), next],
+  };
+}
+
+export function validateEventLedger(ledger = {}) {
+  const events = safeList(ledger.events);
+  const broken = [];
+  for (const [index, event] of events.entries()) {
+    const expectedPrevious = index === 0 ? null : events[index - 1].hash;
+    if ((event.previous_hash || null) !== expectedPrevious) {
+      broken.push({ event_id: event.event_id, reason: "previous_hash_mismatch" });
+    }
+    const rebuilt = createLedgerEvent(event, {
+      previousHash: event.previous_hash || null,
+      sequence: event.sequence,
+    });
+    if (rebuilt.hash !== event.hash) {
+      broken.push({ event_id: event.event_id, reason: "event_hash_mismatch" });
+    }
+  }
+
+  return {
+    ok: broken.length === 0,
+    action: "event_ledger_room",
+    result: broken.length === 0 ? "valid" : "invalid",
+    broken,
+    event_count: events.length,
+  };
+}
+
+function reviewKey(event = {}) {
+  return `${scopeKey(event.scope)}:review:${normalize(event.payload?.reviewer)}`;
+}
+
+function latestTrustedReviewAcks(events = []) {
+  const latest = {};
+  for (const event of safeList(events)) {
+    if (event.kind !== "review_ack") continue;
+    if (!event.trust?.trusted) continue;
+    const key = reviewKey(event);
+    latest[key] = latest[key] ? latestEvent(latest[key], event) : event;
+  }
+  return latest;
+}
+
+export function summarizeEventLedgerScope({
+  ledger,
+  scope,
+  requiredReviewers = ["gatekeeper", "popcorn", "forge"],
+} = {}) {
+  const wanted = scopeKey(normalizeScope(scope || {}));
+  const events = safeList(ledger?.events).filter((event) => scopeKey(event.scope) === wanted);
+  const reviewAcks = latestTrustedReviewAcks(events);
+  const latest_by_reviewer = {};
+
+  for (const event of Object.values(reviewAcks)) {
+    latest_by_reviewer[event.payload.reviewer] = event;
+  }
+
+  const blockers = Object.values(latest_by_reviewer).filter((event) => event.payload.verdict === "BLOCKER");
+  const missing_reviewers = safeList(requiredReviewers)
+    .map(normalize)
+    .filter((reviewer) => latest_by_reviewer[reviewer]?.payload?.verdict !== "PASS");
+  const observer_events = events.filter((event) => !event.trust?.trusted);
+
+  return {
+    ok: blockers.length === 0,
+    action: "event_ledger_room",
+    result: blockers.length
+      ? "blocked"
+      : missing_reviewers.length
+        ? "missing_ack"
+        : "full_pass",
+    scope: normalizeScope(scope || {}),
+    event_count: events.length,
+    trusted_event_count: events.filter((event) => event.trust?.trusted).length,
+    observer_event_count: observer_events.length,
+    latest_by_reviewer,
+    blockers,
+    missing_reviewers,
+    full_ack_set: blockers.length === 0 && missing_reviewers.length === 0,
+  };
+}
+
+export function createTrustedReviewAckEvent({
+  prNumber,
+  reviewer,
+  actorId,
+  verdict,
+  summary = "",
+  blocker = "",
+  occurredAt,
+  source = "lane_ack",
+  sourceUrl = "",
+} = {}) {
+  return createLedgerEvent({
+    kind: "review_ack",
+    scope: { type: "pr", id: prNumber },
+    actor: { id: actorId || reviewer, role: reviewer },
+    authority: "lane",
+    occurred_at: occurredAt || new Date().toISOString(),
+    source,
+    source_url: sourceUrl,
+    payload: {
+      reviewer,
+      verdict,
+      summary,
+      blocker,
+    },
+  });
+}
+
+export async function readEventLedger(filePath) {
+  if (!filePath) return createEventLedger();
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return createEventLedger();
+    throw error;
+  }
+}
+
+export async function writeEventLedger(filePath, ledger) {
+  if (!filePath) return { ok: false, reason: "missing_ledger_path" };
+  await mkdir(dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(ledger, null, 2)}\n`, "utf8");
+  await rename(tempPath, filePath);
+  return { ok: true, path: filePath };
+}
+
+export async function readEventLedgerRoomInput(filePath) {
+  if (!filePath) return { ok: false, reason: "missing_input_path" };
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  readEventLedgerRoomInput(getArg("input", process.env.PINBALLWAKE_EVENT_LEDGER_INPUT || ""))
+    .then((input) => {
+      const ledger = createEventLedger(input.ledger || {});
+      const withEvents = safeList(input.append).reduce(
+        (current, event) => appendEventLedgerEvent({ ledger: current, event, now: input.now }),
+        ledger,
+      );
+      const validation = validateEventLedger(withEvents);
+      const summary = input.scope
+        ? summarizeEventLedgerScope({
+          ledger: withEvents,
+          scope: input.scope,
+          requiredReviewers: input.requiredReviewers,
+        })
+        : null;
+      return { ok: validation.ok, action: "event_ledger_room", result: validation.result, ledger: withEvents, validation, summary };
+    })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-event-ledger-room.mjs
+++ b/scripts/pinballwake-event-ledger-room.mjs
@@ -250,6 +250,9 @@ export function validateEventLedger(ledger = {}) {
     if (rebuilt.hash !== event.hash) {
       broken.push({ event_id: event.event_id, reason: "event_hash_mismatch" });
     }
+    if (stableJson(rebuilt.trust) !== stableJson(event.trust || null)) {
+      broken.push({ event_id: event.event_id, reason: "event_trust_mismatch" });
+    }
   }
 
   return {
@@ -265,11 +268,26 @@ function reviewKey(event = {}) {
   return `${scopeKey(event.scope)}:review:${normalize(event.payload?.reviewer)}`;
 }
 
+function verifiedTrust(event = {}) {
+  const rebuilt = createLedgerEvent(event, {
+    previousHash: event.previous_hash || null,
+    sequence: event.sequence,
+  });
+  const hashMatches = rebuilt.hash === event.hash;
+  const trustMatches = stableJson(rebuilt.trust) === stableJson(event.trust || null);
+  return {
+    ...rebuilt.trust,
+    trusted: hashMatches && trustMatches && rebuilt.trust.trusted,
+    hash_matches: hashMatches,
+    trust_matches: trustMatches,
+  };
+}
+
 function latestTrustedReviewAcks(events = []) {
   const latest = {};
   for (const event of safeList(events)) {
     if (event.kind !== "review_ack") continue;
-    if (!event.trust?.trusted) continue;
+    if (!verifiedTrust(event).trusted) continue;
     const key = reviewKey(event);
     latest[key] = latest[key] ? latestEvent(latest[key], event) : event;
   }
@@ -294,7 +312,8 @@ export function summarizeEventLedgerScope({
   const missing_reviewers = safeList(requiredReviewers)
     .map(normalize)
     .filter((reviewer) => latest_by_reviewer[reviewer]?.payload?.verdict !== "PASS");
-  const observer_events = events.filter((event) => !event.trust?.trusted);
+  const trustedEvents = events.filter((event) => verifiedTrust(event).trusted);
+  const observer_events = events.filter((event) => !verifiedTrust(event).trusted);
 
   return {
     ok: blockers.length === 0,
@@ -306,7 +325,7 @@ export function summarizeEventLedgerScope({
         : "full_pass",
     scope: normalizeScope(scope || {}),
     event_count: events.length,
-    trusted_event_count: events.filter((event) => event.trust?.trusted).length,
+    trusted_event_count: trustedEvents.length,
     observer_event_count: observer_events.length,
     latest_by_reviewer,
     blockers,
@@ -317,7 +336,7 @@ export function summarizeEventLedgerScope({
 
 function latestTrustedEvent(events = [], predicate = () => true) {
   return safeList(events)
-    .filter((event) => event.trust?.trusted)
+    .filter((event) => verifiedTrust(event).trusted)
     .filter(predicate)
     .reduce((latest, event) => (latest ? latestEvent(latest, event) : event), null);
 }

--- a/scripts/pinballwake-event-ledger-room.mjs
+++ b/scripts/pinballwake-event-ledger-room.mjs
@@ -24,7 +24,7 @@ const AUTHORITY_RANK = {
   system: 100,
 };
 
-const TRUSTED_REVIEW_AUTHORITIES = new Set(["lane", "room", "master", "system"]);
+const TRUSTED_REVIEW_AUTHORITIES = new Set(["lane"]);
 const COMMAND_AUTHORITIES = new Set(["master", "system"]);
 
 function getArg(name, fallback = "") {
@@ -141,7 +141,10 @@ function eventTrust(event = {}) {
     if (!TRUSTED_REVIEW_AUTHORITIES.has(authority)) {
       return { trusted: false, reason: "untrusted_review_authority", authority };
     }
-    if (authority === "lane" && actor.role && actor.role !== reviewer) {
+    if (!actor.role) {
+      return { trusted: false, reason: "missing_lane_actor_role", authority };
+    }
+    if (actor.role !== reviewer) {
       return { trusted: false, reason: "lane_actor_reviewer_mismatch", authority };
     }
   }
@@ -179,6 +182,16 @@ export function createEventLedger(input = {}) {
       previousHash: safeList(input.events)[index - 1]?.hash || null,
       sequence: index + 1,
     })),
+  };
+}
+
+export function loadEventLedger(input = {}) {
+  if (!input || typeof input !== "object") return createEventLedger();
+  return {
+    version: input.version || LEDGER_VERSION,
+    created_at: input.createdAt || input.created_at || new Date().toISOString(),
+    updated_at: input.updatedAt || input.updated_at || input.createdAt || input.created_at || new Date().toISOString(),
+    events: safeList(input.events),
   };
 }
 
@@ -406,7 +419,7 @@ export function createTrustedReviewAckEvent({
 export async function readEventLedger(filePath) {
   if (!filePath) return createEventLedger();
   try {
-    return JSON.parse(await readFile(filePath, "utf8"));
+    return loadEventLedger(JSON.parse(await readFile(filePath, "utf8")));
   } catch (error) {
     if (error?.code === "ENOENT") return createEventLedger();
     throw error;
@@ -430,7 +443,7 @@ export async function readEventLedgerRoomInput(filePath) {
 if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
   readEventLedgerRoomInput(getArg("input", process.env.PINBALLWAKE_EVENT_LEDGER_INPUT || ""))
     .then((input) => {
-      const ledger = createEventLedger(input.ledger || {});
+      const ledger = input.ledger ? loadEventLedger(input.ledger) : createEventLedger();
       const withEvents = safeList(input.append).reduce(
         (current, event) => appendEventLedgerEvent({ ledger: current, event, now: input.now }),
         ledger,

--- a/scripts/pinballwake-event-ledger-room.test.mjs
+++ b/scripts/pinballwake-event-ledger-room.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  appendEventLedgerEvent,
+  createEventLedger,
+  createTrustedReviewAckEvent,
+  readEventLedger,
+  summarizeEventLedgerScope,
+  validateEventLedger,
+  writeEventLedger,
+} from "./pinballwake-event-ledger-room.mjs";
+
+function append(ledger, event) {
+  return appendEventLedgerEvent({
+    ledger,
+    event,
+    now: "2026-05-05T01:00:00.000Z",
+  });
+}
+
+function reviewAck({ reviewer, verdict = "PASS", at = "2026-05-05T01:00:00.000Z", actorId, actorRole, authority = "lane" }) {
+  return {
+    kind: "review_ack",
+    scope: { type: "pr", id: 532 },
+    actor: { id: actorId || reviewer, role: actorRole || reviewer },
+    authority,
+    occurred_at: at,
+    source: "fishbowl",
+    payload: {
+      reviewer,
+      verdict,
+      summary: `${reviewer} ${verdict}`,
+    },
+  };
+}
+
+describe("PinballWake Event Ledger Room", () => {
+  it("creates an append-only hash chain and validates it", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({ reviewer: "gatekeeper" }));
+    ledger = append(ledger, reviewAck({ reviewer: "popcorn" }));
+
+    assert.equal(ledger.events.length, 2);
+    assert.equal(ledger.events[1].previous_hash, ledger.events[0].hash);
+    assert.deepEqual(validateEventLedger(ledger), {
+      ok: true,
+      action: "event_ledger_room",
+      result: "valid",
+      broken: [],
+      event_count: 2,
+    });
+  });
+
+  it("summarizes direct lane-authored review ACKs into full pass", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({ reviewer: "gatekeeper" }));
+    ledger = append(ledger, reviewAck({ reviewer: "popcorn" }));
+    ledger = append(ledger, reviewAck({ reviewer: "forge" }));
+
+    const summary = summarizeEventLedgerScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+    });
+
+    assert.equal(summary.result, "full_pass");
+    assert.equal(summary.full_ack_set, true);
+    assert.equal(summary.latest_by_reviewer.forge.payload.verdict, "PASS");
+  });
+
+  it("does not let observer/status events become trusted ACKs", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, {
+      kind: "review_ack",
+      scope: { type: "pr", id: 532 },
+      actor: { id: "courier", role: "courier" },
+      authority: "observer",
+      occurred_at: "2026-05-05T01:10:00.000Z",
+      source: "status_mirror",
+      payload: {
+        reviewer: "forge",
+        verdict: "PASS",
+        summary: "Status mirror says Forge PASS is visible.",
+      },
+    });
+
+    const summary = summarizeEventLedgerScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+    });
+
+    assert.equal(summary.result, "missing_ack");
+    assert.deepEqual(summary.missing_reviewers, ["gatekeeper", "popcorn", "forge"]);
+    assert.equal(summary.observer_event_count, 1);
+  });
+
+  it("does not let a newer observer mirror clear an older lane blocker", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({
+      reviewer: "gatekeeper",
+      verdict: "PASS",
+      at: "2026-05-05T01:00:00.000Z",
+    }));
+    ledger = append(ledger, reviewAck({
+      reviewer: "popcorn",
+      verdict: "PASS",
+      at: "2026-05-05T01:00:00.000Z",
+    }));
+    ledger = append(ledger, reviewAck({
+      reviewer: "forge",
+      verdict: "BLOCKER",
+      at: "2026-05-05T01:01:00.000Z",
+    }));
+    ledger = append(ledger, {
+      kind: "review_ack",
+      scope: { type: "pr", id: 532 },
+      actor: { id: "courier", role: "courier" },
+      authority: "observer",
+      occurred_at: "2026-05-05T01:10:00.000Z",
+      source: "status_mirror",
+      payload: {
+        reviewer: "forge",
+        verdict: "PASS",
+        summary: "Mirror summary says #532 Forge PASS.",
+      },
+    });
+
+    const summary = summarizeEventLedgerScope({ ledger, scope: { type: "pr", id: 532 } });
+
+    assert.equal(summary.result, "blocked");
+    assert.equal(summary.blockers[0].payload.reviewer, "forge");
+  });
+
+  it("does not trust lane ACK when actor role mismatches reviewer", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({
+      reviewer: "popcorn",
+      actorId: "forge",
+      actorRole: "forge",
+      authority: "lane",
+    }));
+
+    const event = ledger.events[0];
+    const summary = summarizeEventLedgerScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+      requiredReviewers: ["popcorn"],
+    });
+
+    assert.equal(event.trust.trusted, false);
+    assert.equal(event.trust.reason, "lane_actor_reviewer_mismatch");
+    assert.equal(summary.result, "missing_ack");
+  });
+
+  it("lets a newer lane PASS clear an older lane blocker for the same reviewer", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({
+      reviewer: "forge",
+      verdict: "BLOCKER",
+      at: "2026-05-05T01:00:00.000Z",
+    }));
+    ledger = append(ledger, reviewAck({
+      reviewer: "forge",
+      verdict: "PASS",
+      at: "2026-05-05T01:15:00.000Z",
+    }));
+
+    const summary = summarizeEventLedgerScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+      requiredReviewers: ["forge"],
+    });
+
+    assert.equal(summary.result, "full_pass");
+    assert.equal(summary.latest_by_reviewer.forge.payload.verdict, "PASS");
+  });
+
+  it("creates helper trusted review ACK events", () => {
+    const event = createTrustedReviewAckEvent({
+      prNumber: 532,
+      reviewer: "gatekeeper",
+      verdict: "PASS",
+      occurredAt: "2026-05-05T01:00:00.000Z",
+    });
+
+    assert.equal(event.trust.trusted, true);
+    assert.equal(event.scope.type, "pr");
+    assert.equal(event.payload.reviewer, "gatekeeper");
+  });
+
+  it("detects tampered event ledger entries", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({ reviewer: "gatekeeper" }));
+    ledger.events[0].payload.verdict = "BLOCKER";
+
+    const validation = validateEventLedger(ledger);
+
+    assert.equal(validation.ok, false);
+    assert.equal(validation.broken[0].reason, "event_hash_mismatch");
+  });
+
+  it("round-trips ledger files atomically", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pinballwake-event-ledger-"));
+    const filePath = join(dir, "ledger.json");
+    try {
+      let ledger = createEventLedger();
+      ledger = append(ledger, reviewAck({ reviewer: "gatekeeper" }));
+      const written = await writeEventLedger(filePath, ledger);
+      const read = await readEventLedger(filePath);
+
+      assert.equal(written.ok, true);
+      assert.equal(read.events.length, 1);
+      assert.equal(read.events[0].event_id, ledger.events[0].event_id);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/pinballwake-event-ledger-room.test.mjs
+++ b/scripts/pinballwake-event-ledger-room.test.mjs
@@ -9,6 +9,7 @@ import {
   createEventLedger,
   createTrustedReviewAckEvent,
   readEventLedger,
+  summarizeCommandControlScope,
   summarizeEventLedgerScope,
   validateEventLedger,
   writeEventLedger,
@@ -34,6 +35,43 @@ function reviewAck({ reviewer, verdict = "PASS", at = "2026-05-05T01:00:00.000Z"
       reviewer,
       verdict,
       summary: `${reviewer} ${verdict}`,
+    },
+  };
+}
+
+function commandApproval({
+  action = "merge",
+  verdict = "APPROVED",
+  authority = "master",
+  actorRole = "master",
+  at = "2026-05-05T01:00:00.000Z",
+} = {}) {
+  return {
+    kind: "approval",
+    scope: { type: "pr", id: 532 },
+    actor: { id: actorRole, role: actorRole },
+    authority,
+    occurred_at: at,
+    source: "master_decision",
+    payload: {
+      action,
+      verdict,
+      summary: `${action} ${verdict}`,
+    },
+  };
+}
+
+function killSwitch({ enabled = true, authority = "master", at = "2026-05-05T01:00:00.000Z" } = {}) {
+  return {
+    kind: "kill_switch",
+    scope: { type: "pr", id: 532 },
+    actor: { id: "master", role: "master" },
+    authority,
+    occurred_at: at,
+    source: "master_control",
+    payload: {
+      enabled,
+      summary: enabled ? "Stop this PR." : "Resume this PR.",
     },
   };
 }
@@ -217,5 +255,64 @@ describe("PinballWake Event Ledger Room", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("blocks command-control actions without master approval", () => {
+    const ledger = createEventLedger();
+
+    const summary = summarizeCommandControlScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+      action: "merge",
+    });
+
+    assert.equal(summary.ok, false);
+    assert.equal(summary.reason, "missing_command_approval");
+  });
+
+  it("allows command-control actions with trusted master approval", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, commandApproval({ action: "merge" }));
+
+    const summary = summarizeCommandControlScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+      action: "merge",
+    });
+
+    assert.equal(summary.ok, true);
+    assert.equal(summary.result, "ready");
+    assert.equal(summary.latest_approval.payload.verdict, "APPROVED");
+  });
+
+  it("does not trust lane approval for command-control actions", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, commandApproval({ action: "merge", authority: "lane", actorRole: "forge" }));
+
+    const event = ledger.events[0];
+    const summary = summarizeCommandControlScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+      action: "merge",
+    });
+
+    assert.equal(event.trust.trusted, false);
+    assert.equal(event.trust.reason, "untrusted_command_authority");
+    assert.equal(summary.reason, "missing_command_approval");
+  });
+
+  it("blocks command-control actions when trusted kill switch is enabled", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, commandApproval({ action: "merge" }));
+    ledger = append(ledger, killSwitch({ enabled: true, at: "2026-05-05T01:05:00.000Z" }));
+
+    const summary = summarizeCommandControlScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+      action: "merge",
+    });
+
+    assert.equal(summary.ok, false);
+    assert.equal(summary.reason, "kill_switch_enabled");
   });
 });

--- a/scripts/pinballwake-event-ledger-room.test.mjs
+++ b/scripts/pinballwake-event-ledger-room.test.mjs
@@ -275,6 +275,36 @@ describe("PinballWake Event Ledger Room", () => {
     assert.equal(validation.broken[0].reason, "event_hash_mismatch");
   });
 
+  it("detects stored trust tamper and keeps review summaries untrusted", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({
+      reviewer: "forge",
+      authority: "observer",
+      actorId: "courier",
+      actorRole: "courier",
+    }));
+
+    const tampered = JSON.parse(JSON.stringify(ledger));
+    tampered.events[0].trust = {
+      trusted: true,
+      authority: "lane",
+      reason: "trusted",
+    };
+
+    const validation = validateEventLedger(tampered);
+    const summary = summarizeEventLedgerScope({
+      ledger: tampered,
+      scope: { type: "pr", id: 532 },
+      requiredReviewers: ["forge"],
+    });
+
+    assert.equal(validation.ok, false);
+    assert.equal(validation.broken[0].reason, "event_trust_mismatch");
+    assert.equal(summary.result, "missing_ack");
+    assert.equal(summary.trusted_event_count, 0);
+    assert.equal(summary.latest_by_reviewer.forge, undefined);
+  });
+
   it("round-trips ledger files atomically", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pinballwake-event-ledger-"));
     const filePath = join(dir, "ledger.json");
@@ -333,6 +363,29 @@ describe("PinballWake Event Ledger Room", () => {
 
     assert.equal(event.trust.trusted, false);
     assert.equal(event.trust.reason, "untrusted_command_authority");
+    assert.equal(summary.reason, "missing_command_approval");
+  });
+
+  it("does not let stored trust tamper authorize command control", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, commandApproval({ action: "merge", authority: "lane", actorRole: "forge" }));
+
+    const tampered = JSON.parse(JSON.stringify(ledger));
+    tampered.events[0].trust = {
+      trusted: true,
+      authority: "master",
+      reason: "trusted",
+    };
+
+    const validation = validateEventLedger(tampered);
+    const summary = summarizeCommandControlScope({
+      ledger: tampered,
+      scope: { type: "pr", id: 532 },
+      action: "merge",
+    });
+
+    assert.equal(validation.ok, false);
+    assert.equal(validation.broken[0].reason, "event_trust_mismatch");
     assert.equal(summary.reason, "missing_command_approval");
   });
 

--- a/scripts/pinballwake-event-ledger-room.test.mjs
+++ b/scripts/pinballwake-event-ledger-room.test.mjs
@@ -8,6 +8,7 @@ import {
   appendEventLedgerEvent,
   createEventLedger,
   createTrustedReviewAckEvent,
+  loadEventLedger,
   readEventLedger,
   summarizeCommandControlScope,
   summarizeEventLedgerScope,
@@ -191,6 +192,40 @@ describe("PinballWake Event Ledger Room", () => {
     assert.equal(event.trust.trusted, false);
     assert.equal(event.trust.reason, "lane_actor_reviewer_mismatch");
     assert.equal(summary.result, "missing_ack");
+  });
+
+  it("does not trust non-lane authority as direct reviewer ACK evidence", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({
+      reviewer: "gatekeeper",
+      actorId: "master",
+      actorRole: "master",
+      authority: "master",
+    }));
+
+    const event = ledger.events[0];
+    const summary = summarizeEventLedgerScope({
+      ledger,
+      scope: { type: "pr", id: 532 },
+      requiredReviewers: ["gatekeeper"],
+    });
+
+    assert.equal(event.trust.trusted, false);
+    assert.equal(event.trust.reason, "untrusted_review_authority");
+    assert.equal(summary.result, "missing_ack");
+  });
+
+  it("does not re-sign tampered history when loading an existing ledger", () => {
+    let ledger = createEventLedger();
+    ledger = append(ledger, reviewAck({ reviewer: "gatekeeper" }));
+    const tampered = JSON.parse(JSON.stringify(ledger));
+    tampered.events[0].payload.verdict = "BLOCKER";
+
+    const loaded = loadEventLedger(tampered);
+    const validation = validateEventLedger(loaded);
+
+    assert.equal(validation.ok, false);
+    assert.equal(validation.broken[0].reason, "event_hash_mismatch");
   });
 
   it("lets a newer lane PASS clear an older lane blocker for the same reviewer", () => {


### PR DESCRIPTION
## Summary- Add Event Ledger Room for UnClick Autopilot provenance and command-and-control state.- Records append-only, hash-chained events with scope, actor, authority, timestamp, source, and payload.- Summarizes PR-scoped review ACK state without trusting observer/mirror/status chatter as authoritative review evidence.- Adds command-control checks so high-impact actions can require trusted master/system approval and stop when a trusted kill switch is enabled.## WhyAutomation has been weak where ACKs, proof, status, and handoffs are scattered across chat/Fishbowl/comments. This gives the automation ring one structured event trail so rooms can reason from provenance instead of summaries.## Command and control principleAutopilot can delegate work, but it cannot delegate responsibility to a black box. Agents may move the work, but UnClick must keep the chain of command visible: who requested it, who approved it, what scope was approved, what proof allowed it to continue, and how it stops if drift appears.## Safety- Advisory/persistence only.- No GitHub mutation, no repo edits, no merge/lift/publish/rollback behavior.- Observer/reporter events are stored but not trusted as reviewer ACKs.- Reviewer ACK gates require direct lane authority; `master` / `room` / `system` cannot synthesize Gatekeeper/Popcorn/Forge PASS for `full_ack_set`.- Existing ledger events load without re-signing stored hashes, so tampered history remains invalid.- A newer observer/status/mirror event cannot clear an older lane BLOCKER.- Lane ACK actor role must match the reviewer lane.- Trusted kill switch blocks command-control execution.- Ledger validation detects hash-chain tampering and stored trust tampering.## Owned files- `AUTOPILOT.md`- `scripts/pinballwake-event-ledger-room.mjs`- `scripts/pinballwake-event-ledger-room.test.mjs`## Non-overlapStandalone new room plus Autopilot doctrine. Does not modify ACK Ledger, Master Loop, Launchpad, Jobs, Merge, Build, Proof, or existing runner scripts.## Proof- `node --test scripts\pinballwake-event-ledger-room.test.mjs` passed 17/17- `node --test scripts\pinballwake-event-ledger-room.test.mjs scripts\pinballwake-launchpad-room.test.mjs scripts\pinballwake-jobs-room.test.mjs scripts\pinballwake-merge-room.test.mjs scripts\pinballwake-coding-room.test.mjs` passed 69/69- `node --test scripts\pinballwake-*room.test.mjs scripts\pinballwake-pipeline-dry-run.test.mjs scripts\pinballwake-pipeline-executor.test.mjs scripts\pinballwake-merge-controller.test.mjs scripts\pinballwake-build-executor.test.mjs scripts\pinballwake-proof-executor.test.mjs scripts\pinballwake-coding-room-runner.test.mjs scripts\fleet-throughput-watch.test.mjs` passed 202/202- `git diff --check` passed## Requested review- 🛡️ Gatekeeper: safety/provenance review, PASS/BLOCKER- 🍿 Popcorn: QC proof/scope clarity, PASS/BLOCKER- 🛠️ Forge: implementation-shape review, PASS/BLOCKER