### PR TITLE
docs(autopilot): add UnClick context boot packet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ AI agent operating system. One npm install gives agents access to 450+ callable 
 
 ## Fleet alignment
 
+Read `docs/unclick-context-boot-packet.md` before making product-map claims about UnClick, Autopilot, Launchpad, Rooms, XPass, or old Pass wording. It is the canonical context boot packet for worker chats that start with partial memory or connector-only context.
+
 Read `FLEET_SYNC.md` first when operating as part of the multi-PC UnClick fleet. It defines source-of-truth order, live worker lanes, Fishbowl coordination, and no-stomp rules.
 
 If you are unsure which worker should own a handoff, review `docs/fleet-worker-roles.md` for the current emoji role map and routing guide.

--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -4,6 +4,8 @@ This file defines what workers may do without waiting for Chris, what needs one 
 
 Read `FLEET_SYNC.md` first. It is the current cross-PC fleet alignment layer and defines source-of-truth order, worker lanes, no-stomp rules, and continuity expectations. This file only defines autonomy tiers.
 
+Read `docs/unclick-context-boot-packet.md` before routing or summarizing product context. It defines the current hierarchy: UnClick is the platform, UnClick Autopilot is the top-level development assembly line, Launchpad is the control hub, Rooms are the stages, and XPass is the product line beneath or alongside the broader platform.
+
 The goal is simple: keep the fleet moving while protecting secrets, security, billing, migrations, and public claims.
 
 ## Operating Principles
@@ -51,7 +53,7 @@ Workers should ask once before turning these into standing behavior:
 - Dependency auto-merge policy for patch and minor updates.
 - Public dogfood reports and public status pages.
 - New recurring scheduled jobs.
-- Pass-family documentation generation.
+- XPass documentation generation.
 - Memory public-release checklist changes.
 - Any rule that changes who owns a class of work.
 
@@ -186,6 +188,6 @@ Before merging:
 
 ## Current Priority Rule
 
-Autopilot foundation work comes before new Pass-family expansion. Pass dogfood work may continue when it supports autopilot, but new Pass product lanes should wait until the autopilot rails are landed.
+Autopilot foundation work comes before new XPass expansion. XPass dogfood work may continue when it supports Autopilot, but new XPass product lanes should wait until the Autopilot rails are landed.
 
 <!-- build-d probe 4920fa -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ AI agent operating system. One npm install gives agents access to 450+ callable 
 
 ## Fleet alignment
 
+Read `docs/unclick-context-boot-packet.md` before making product-map claims about UnClick, Autopilot, Launchpad, Rooms, XPass, or old Pass wording. If you only have connector-level context, say so and load the context packet before answering confidently.
+
 Read `FLEET_SYNC.md` first when working as part of the multi-PC worker fleet. It defines source-of-truth order, live worker lanes, Fishbowl coordination, no-stomp rules, and how older courier notes relate to the current process.
 
 If you are unsure which worker should own a handoff, review `docs/fleet-worker-roles.md` for the current emoji role map and routing guide.

--- a/FLEET_SYNC.md
+++ b/FLEET_SYNC.md
@@ -4,6 +4,8 @@ This is the current operating agreement for UnClick workers across Lenovo, Plex,
 
 Read this first when a worker starts, resumes, or is spawned into an existing lane. Older courier notes are historical references. This file is the live alignment layer.
 
+Read `docs/unclick-context-boot-packet.md` before making product-map claims. It defines the current wording: UnClick is the platform, UnClick Autopilot is the development assembly line, Launchpad is the control hub, Rooms are the stages, and XPass is the product line.
+
 ## Source Of Truth Order
 
 When instructions conflict, use this order:
@@ -132,7 +134,7 @@ Current common worker lanes:
 | Navigator | Navigator | Scout, review, and next-chip recommendation |
 | Relay | Relay | Simple status, cross-worker summaries, handoff clarity |
 | Forge | Forge | Focused implementation lane |
-| XPass Assistant | XPass assistant | Pass-family proof, TestPass, UXPass, SecurityPass, and dogfood lanes |
+| XPass Assistant | XPass assistant | XPass proof, TestPass, UXPass, SecurityPass, and dogfood lanes |
 | Scheduled automations | Cron workers | Repeated health checks, triage, safe build lanes, and continuity audits |
 
 Names may vary between chats. The lane and live Fishbowl status matter more than the display name.
@@ -149,7 +151,7 @@ Every worker should do this before acting:
 
 1. Pull or inspect latest `main`.
 2. Read this file, then `AUTOPILOT.md`.
-3. Read `docs/unclick-deep-context.md` when making product, strategy, summary, or roadmap judgments.
+3. Read `docs/unclick-context-boot-packet.md` before product taxonomy claims, then `docs/unclick-deep-context.md` when making broader product, strategy, summary, or roadmap judgments.
 4. Check open PRs and recent merged PRs.
 5. Check Fishbowl direct mentions, assigned todos, and current worker statuses.
 6. Check whether the intended files are already owned by another active worker.
@@ -177,7 +179,7 @@ Autopilot workers may:
 - Review clean green PRs.
 - Ship tiny docs alignment PRs.
 - Ship tiny reliability, wake, or board-hygiene chips.
-- Continue approved Connectors, RotatePass, Pass proof, and PinballWake lanes within stated safety limits.
+- Continue approved Connectors, RotatePass, XPass proof, and PinballWake lanes within stated safety limits.
 - Post clear handoffs when blocked.
 
 Autopilot workers must not:
@@ -280,9 +282,9 @@ Do not build:
 
 Browser or local extension ideas remain Phase 0 until explicitly promoted.
 
-## Pass And Dogfood Lanes
+## XPass And Dogfood Lanes
 
-Pass work should prove UnClick is using itself.
+XPass work should prove UnClick is using itself.
 
 Priority order:
 
@@ -290,7 +292,7 @@ Priority order:
 2. UXPass stuck or failed run clarity.
 3. SecurityPass dogfood receipt clarity.
 4. Public dogfood report accuracy.
-5. New Pass product expansion only after foundation lanes are stable.
+5. New XPass product expansion only after foundation lanes are stable.
 
 Do not weaken fail-closed checks to make CI green. Fix the blocker or report it.
 

--- a/docs/unclick-context-boot-packet.md
+++ b/docs/unclick-context-boot-packet.md
@@ -20,6 +20,19 @@ Read this before summarizing UnClick, routing UnClick work, or correcting anothe
 - **Worker Registry** is verified worker identity and signed ACK authority.
 - **ACK Ledger** is trusted PASS, BLOCKER, and HOLD evidence.
 
+## Visibility Warning
+
+UnClick Autopilot may not appear in public search, the public website, or the current tool catalog yet.
+
+Do not conclude "UnClick Autopilot does not exist" just because:
+
+- public web search returns no result
+- `unclick.world` does not mention it yet
+- the MCP tool catalog has no tool named `autopilot`
+- older memory only mentions Crews, Build, or Pass-era names
+
+Autopilot is current internal product and operating-system context for the development assembly line. Public naming, tool exposure, and website copy may lag behind internal work.
+
 ## Current Hierarchy
 
 ```text
@@ -80,6 +93,12 @@ I have connector-level context only. I need to load UnClick memory, the context 
 ```
 
 Do not infer the product map from public search results, one failed run, or old memory names.
+
+If public sources do not mention Autopilot, say:
+
+```text
+I do not see public Autopilot docs yet, but the canonical UnClick context says Autopilot is the current internal development assembly line above XPass.
+```
 
 ## Startup Ritual For Workers
 

--- a/docs/unclick-context-boot-packet.md
+++ b/docs/unclick-context-boot-packet.md
@@ -1,0 +1,106 @@
+# UnClick Context Boot Packet
+
+**Status:** canonical worker startup context
+**Owner:** UnClick fleet
+**Purpose:** prevent new chats, connectors, and worker seats from guessing the UnClick product map from stale memory.
+
+Read this before summarizing UnClick, routing UnClick work, or correcting another worker's terminology.
+
+## Canonical Product Map
+
+- **UnClick** is the whole platform.
+- **UnClick Autopilot** is the top-level development assembly line for agent-powered work.
+- **Launchpad** is the control hub for Autopilot.
+- **Rooms** are the specialized stages inside Autopilot.
+- **XPass** is the product line beneath or alongside the broader platform, not the top-level automation system.
+- **PinballWake** is internal wake, queue, ACK, lease, reclaim, and routing heritage. It is not the public top-level name.
+- **Fishbowl** is coordination and work visibility.
+- **Memory** is persistent context, identity, active facts, and recall.
+- **Event Ledger** is the audit trail for actions and state.
+- **Worker Registry** is verified worker identity and signed ACK authority.
+- **ACK Ledger** is trusted PASS, BLOCKER, and HOLD evidence.
+
+## Current Hierarchy
+
+```text
+UnClick
+  UnClick Autopilot
+    Launchpad
+    Rooms
+      Research Room
+      Planning Room
+      Jobs Room
+      Coding Room
+      Proof Room
+      QC Room
+      Safety Room
+      Event Ledger
+      Worker Registry
+      ACK Ledger
+      Merge Room
+      Publish Room
+      Rollback Room
+      Repair Room
+      Continuous Improvement Room
+      Personality Room
+  XPass products
+    TestPass
+    UXPass
+    SecurityPass
+    LegalPass
+    SEOPass
+    GEOPass
+    other XPass variants when active
+  Core platform
+    MCP tools
+    Memory
+    Fishbowl
+    Keychain
+    Connectors
+    Admin
+```
+
+## Terms To Use
+
+- Say **XPass products**, not "Pass family", unless quoting old docs.
+- Say **UnClick Autopilot**, not PinballWake, when describing the whole automation factory.
+- Say **Launchpad**, not "master chat", when describing the user-facing control hub.
+- Say **worker seats** or **lanes** for ChatGPT, Claude, Codex, and other capacity accounts.
+- Say **trusted ACK** only when it is lane-authored or signed/verified by the current trust spine.
+- Say **observer chatter** for mirrored status text, summaries, or broadcasts that are not lane-authoritative.
+
+## Connector-Level Context Warning
+
+If a worker only sees tool results, run history, public GitHub search, or a partial memory snippet, it must not claim deep UnClick context.
+
+Use this wording:
+
+```text
+I have connector-level context only. I need to load UnClick memory, the context boot packet, and live GitHub/Fishbowl state before making product or engineering claims.
+```
+
+Do not infer the product map from public search results, one failed run, or old memory names.
+
+## Startup Ritual For Workers
+
+Before product claims or routing:
+
+1. Load memory if the tool exists.
+2. Read this file.
+3. Refresh live GitHub and Fishbowl state.
+4. Read `AUTOPILOT.md` for autonomy rules.
+5. Read `FLEET_SYNC.md` for live fleet coordination.
+6. If the requested lane is XPass-specific, read `docs/prd/xpass.md`.
+7. If summarizing older strategy, read `docs/unclick-deep-context.md`.
+
+## Drift Rules
+
+- If old docs say "Pass family", treat it as historical wording unless Chris says otherwise.
+- If old docs list Pass products beside Autopilot, prefer the current hierarchy: Autopilot sits higher as the development assembly line.
+- If a parked product name appears in old notes, label it parked unless a live PR, Fishbowl item, or Chris reactivates it.
+- If memory conflicts with live GitHub/Fishbowl state, live state wins for current work.
+- If connector output conflicts with this packet, this packet wins for product taxonomy.
+
+## One-Sentence Summary
+
+UnClick is the platform, Autopilot is the governed development assembly line, Launchpad is the control hub, Rooms are the stages, and XPass is the product line that can run through or benefit from that assembly line.

--- a/docs/unclick-deep-context.md
+++ b/docs/unclick-deep-context.md
@@ -2,6 +2,8 @@
 
 This note is for workers who need the older UnClick story, not just the current GitHub queue.
 
+For current product taxonomy, read `docs/unclick-context-boot-packet.md` first. If this older context says "Pass products" or lists Pass-era names beside Autopilot, treat that as historical wording. Current wording is XPass products, and UnClick Autopilot sits higher as the development assembly line.
+
 Recent Fishbowl and PR state explains what is moving now. This file explains why the work is shaped this way.
 
 This is not a roadmap promise. Some items are locked decisions, some are shipped foundations, and some are parked strategic options.


### PR DESCRIPTION
## Summary
- Adds `docs/unclick-context-boot-packet.md` as the canonical startup context for UnClick product taxonomy.
- Links the packet from AGENTS, CLAUDE, FLEET_SYNC, AUTOPILOT, and deep context docs.
- Clarifies that UnClick Autopilot sits above XPass as the development assembly line, with Launchpad as the control hub and Rooms as stages.
- Adds a connector-level context warning so new chats do not make confident product claims from partial tool output.

## Why
A worker chat recently started with connector-level context and guessed stale terms like Pass family. This PR gives every worker a short, canonical boot packet before product claims or routing.

## Verification
- `git diff --check` passed
- Docs-only change, no runtime tests needed

## Safety
- Docs only
- No secrets, auth, billing, DNS, migrations, raw keys, repo execution, merge, publish, or rollback behavior

## Owned files / Non-overlap
Owned files: `AGENTS.md`, `AUTOPILOT.md`, `CLAUDE.md`, `FLEET_SYNC.md`, `docs/unclick-context-boot-packet.md`, `docs/unclick-deep-context.md`.

Non-overlap proof: the prior HOLD referenced overlap with PR #535 on `AUTOPILOT.md`. PR #535 is now merged as `1036a8a436b3fd75f94a2575d5110f6ad1e79f56`, and PR #537 is currently CLEAN/MERGEABLE against `main`. This PR remains docs-only and does not touch runtime code, credentials, auth, billing, DNS, migrations, publishing, rollback, or production data.
