### PR TITLE
fix(autopilot): route missing final QC ACK

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -59,6 +59,7 @@ const queuepushRunnerRoster = resolveQueuePushRunnerRoster(process.env.QUEUEPUSH
 
 const STATES = new Set([
   "draft_green_needs_owner_lift",
+  "missing_final_qc_ack",
   "hold_overlap",
   "dirty_branch",
   "failed_targeted_proof",
@@ -180,14 +181,25 @@ export function latestCommentSignals(comments = []) {
   let lastOverlap = -1;
   let lastFailedProof = -1;
   let lastDirtyBranch = -1;
+  let lastGatekeeperPass = -1;
+  let lastForgePass = -1;
+  let lastPopcornPass = -1;
+  let lastMissingFinalQcAck = -1;
   let hasChrisOnly = false;
   let hasProof = false;
 
   sorted.forEach((comment, index) => {
     const text = normalizeText(comment.body);
     const authorLogin = normalizeText(comment.user?.login || comment.author?.login);
-    const clearPass =
+    const requestForPass = /\b(need|needs|needed|waiting|awaiting|missing|no final|no .*visible|please)\b.{0,80}\bpass\b/.test(
+      text,
+    );
+    const lanePass =
       !["github-actions", "vercel"].includes(authorLogin) &&
+      /\b(pass|merge-ok|qc pass)\b/.test(text) &&
+      !requestForPass &&
+      !/\b(please keep draft|stay draft|do not merge|do not lift)\b/.test(text);
+    const clearPass =
       (/^(?:\W+\s*)?(pass|merge-ok|qc pass)\b/.test(text) ||
         /\b(safe next action|safe to merge)\b/.test(text)) &&
       !/\b(please keep draft|stay draft|do not merge|do not lift)\b/.test(text);
@@ -195,8 +207,23 @@ export function latestCommentSignals(comments = []) {
       lastPass = index;
       hasProof = true;
     }
+    if (lanePass && /\b(gatekeeper|release safety|safety checker)\b|🛡️/.test(text)) {
+      lastGatekeeperPass = index;
+    }
+    if (lanePass && /\b(forge|builder|implementation-shape)\b|🛠️/.test(text)) {
+      lastForgePass = index;
+    }
+    if (lanePass && /\b(popcorn|qc|reviewer)\b|🍿/.test(text)) {
+      lastPopcornPass = index;
+    }
     if (/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text)) {
       lastHold = index;
+    }
+    if (
+      /\b(final qc|qc ack|qc pass|popcorn|reviewer)\b|🍿/.test(text) &&
+      /\b(missing|needed|needs|waiting|awaiting|only missing|no final|no .*visible)\b/.test(text)
+    ) {
+      lastMissingFinalQcAck = index;
     }
     if (/\b(overlap|anti-stomp|supersede|supersedes|rebase\/close|close one lane|same files)\b/.test(text)) {
       lastOverlap = index;
@@ -221,6 +248,10 @@ export function latestCommentSignals(comments = []) {
     hasOverlap: lastOverlap > lastPass,
     hasFailedProof: lastFailedProof > lastPass,
     hasDirtyBranch: lastDirtyBranch > lastPass,
+    hasGatekeeperPass: lastGatekeeperPass >= 0 && lastGatekeeperPass > lastHold,
+    hasForgePass: lastForgePass >= 0 && lastForgePass > lastHold,
+    hasPopcornPass: lastPopcornPass >= 0 && lastPopcornPass > lastHold,
+    hasMissingFinalQcAck: lastMissingFinalQcAck > lastPopcornPass,
     hasChrisOnly,
     hasProof,
   };
@@ -249,6 +280,7 @@ export function jobKindForState(state) {
     case "dirty_branch":
     case "failed_targeted_proof":
       return "implementation";
+    case "missing_final_qc_ack":
     case "ready_for_qc":
       return "qc_review";
     case "blocked_chris_only":
@@ -329,6 +361,17 @@ export function classifyPullRequest(input) {
   if (dirty || signals.hasDirtyBranch) return { state: "dirty_branch", reason: "Branch is not clean against main." };
   if (signals.hasFailedProof) return { state: "failed_targeted_proof", reason: "Targeted proof was reported as failing." };
   if (signals.hasOverlap) return { state: "hold_overlap", reason: "Overlap or anti-stomp blocker is present." };
+  if (
+    pr.draft &&
+    green &&
+    clean &&
+    ((signals.hasGatekeeperPass && signals.hasForgePass && !signals.hasPopcornPass) || signals.hasMissingFinalQcAck)
+  ) {
+    return {
+      state: "missing_final_qc_ack",
+      reason: "Safety and builder PASS are visible; final QC ACK is missing.",
+    };
+  }
   if (pr.draft && green && clean) {
     return {
       state: "draft_green_needs_owner_lift",
@@ -346,6 +389,8 @@ export function expectedProofForState(state, pr) {
   switch (state) {
     case "draft_green_needs_owner_lift":
       return "Update PR body with owner/non-overlap/status/tests, then lift draft or state exact HOLD.";
+    case "missing_final_qc_ack":
+      return "QC latest head only; reply PASS/BLOCKER, then hand back to Master for lift/merge.";
     case "hold_overlap":
       return "Decide supersede/rebase/close one overlapping lane; post exact non-overlap proof.";
     case "dirty_branch":
@@ -365,6 +410,8 @@ export function directActionForState(state) {
   switch (state) {
     case "draft_green_needs_owner_lift":
       return "Claim it, refresh proof, then lift draft or reply with the exact HOLD.";
+    case "missing_final_qc_ack":
+      return "Claim final QC, second-read latest head, then PASS/BLOCKER with exact evidence.";
     case "hold_overlap":
       return "Claim it, decide which lane survives, then rebase/supersede/close one lane.";
     case "dirty_branch":

--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -361,11 +361,14 @@ export function classifyPullRequest(input) {
   if (dirty || signals.hasDirtyBranch) return { state: "dirty_branch", reason: "Branch is not clean against main." };
   if (signals.hasFailedProof) return { state: "failed_targeted_proof", reason: "Targeted proof was reported as failing." };
   if (signals.hasOverlap) return { state: "hold_overlap", reason: "Overlap or anti-stomp blocker is present." };
+  if (signals.hasActiveHold) return { state: "blocked_chris_only", reason: "Active HOLD/blocker comment remains." };
   if (
     pr.draft &&
     green &&
     clean &&
-    ((signals.hasGatekeeperPass && signals.hasForgePass && !signals.hasPopcornPass) || signals.hasMissingFinalQcAck)
+    signals.hasGatekeeperPass &&
+    signals.hasForgePass &&
+    !signals.hasPopcornPass
   ) {
     return {
       state: "missing_final_qc_ack",
@@ -381,7 +384,6 @@ export function classifyPullRequest(input) {
   if (!pr.draft && green && clean && signals.hasProof && !signals.hasActiveHold) {
     return { state: "ready_for_qc", reason: "Non-draft PR is green, clean, and has proof." };
   }
-  if (signals.hasActiveHold) return { state: "blocked_chris_only", reason: "Active HOLD/blocker comment remains." };
   return { state: null, reason: "No QueuePush action needed." };
 }
 

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -48,6 +48,55 @@ describe("QueuePush PR classifier", () => {
     assert.equal(result.state, "draft_green_needs_owner_lift");
   });
 
+  it("routes draft PRs with Safety and Builder PASS but missing QC to final QC", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 535, draft: true, title: "feat(autopilot): add Event Ledger Room" }),
+      files: [{ filename: "scripts/pinballwake-event-ledger-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        { body: "Status refreshed. No final review yet.", created_at: "2026-05-03T01:20:00Z" },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "missing_final_qc_ack");
+  });
+
+  it("keeps overlap blockers ahead of missing final QC routing", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 537, draft: true, title: "docs(autopilot): add context boot packet" }),
+      files: [{ filename: "AUTOPILOT.md" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        { body: "Final QC ACK needed from Popcorn only.", created_at: "2026-05-03T01:20:00Z" },
+        { body: "HOLD: overlap with #535 on AUTOPILOT.md.", created_at: "2026-05-03T01:30:00Z" },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "hold_overlap");
+  });
+
+  it("returns draft owner lift after the final QC PASS is visible", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),
+      files: [{ filename: "scripts/pinballwake-worker-registry-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        { body: "PASS\n🍿", created_at: "2026-05-03T01:20:00Z" },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "draft_green_needs_owner_lift");
+  });
+
   it("routes overlap and anti-stomp blockers before generic draft lift", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 508, draft: true }),
@@ -174,6 +223,10 @@ describe("QueuePush routing and packets", () => {
     assert.equal(routeWorkerForPr(pr({ draft: false }), [], "ready_for_qc"), "🍿");
   });
 
+  it("routes missing final QC ACKs to Popcorn", () => {
+    assert.equal(routeWorkerForPr(pr({ draft: true }), [], "missing_final_qc_ack"), "🍿");
+  });
+
   it("does not treat probe-only runners as unattended code hands", () => {
     const runner = {
       emoji: "🦾",
@@ -242,10 +295,29 @@ describe("QueuePush routing and packets", () => {
 
   it("maps process states to job kinds and code requirements", () => {
     assert.equal(jobKindForState("draft_green_needs_owner_lift"), "owner_decision");
+    assert.equal(jobKindForState("missing_final_qc_ack"), "qc_review");
     assert.equal(jobKindForState("ready_for_qc"), "qc_review");
     assert.equal(jobKindForState("failed_targeted_proof"), "implementation");
     assert.equal(stateRequiresCode("failed_targeted_proof"), true);
+    assert.equal(stateRequiresCode("missing_final_qc_ack"), false);
     assert.equal(stateRequiresCode("draft_green_needs_owner_lift"), false);
+  });
+
+  it("builds compact final QC packets with deterministic id", () => {
+    const packet = buildQueuePacket({
+      pr: pr({ number: 535, title: "feat(autopilot): add Event Ledger Room" }),
+      state: "missing_final_qc_ack",
+      reason: "Safety and builder PASS are visible; final QC ACK is missing.",
+      files: [{ filename: "scripts/pinballwake-event-ledger-room.mjs" }],
+    });
+
+    assert.equal(packet.worker, "🍿");
+    assert.equal(packet.jobKind, "qc_review");
+    assert.equal(packet.requiresCode, false);
+    assert.match(packet.packetId, /^queuepush:v3:pr-535:missing_final_qc_ack:abcdef1:[a-f0-9]{10}$/);
+    assert.match(packet.text, /DIRECT QC PACKET/);
+    assert.match(packet.text, /worker: 🍿/);
+    assert.match(packet.text, /QC latest head only/);
   });
 
   it("builds compact decision packet text with deterministic id", () => {

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -64,6 +64,35 @@ describe("QueuePush PR classifier", () => {
     assert.equal(result.state, "missing_final_qc_ack");
   });
 
+  it("does not route to final QC from request text alone", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 535, draft: true, title: "feat(autopilot): add Event Ledger Room" }),
+      files: [{ filename: "scripts/pinballwake-event-ledger-room.mjs" }],
+      comments: [{ body: "Final QC ACK needed from Popcorn only.", created_at: "2026-05-03T01:20:00Z" }],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "draft_green_needs_owner_lift");
+  });
+
+  it("keeps later generic HOLDs ahead of missing final QC routing", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 535, draft: true, title: "feat(autopilot): add Event Ledger Room" }),
+      files: [{ filename: "scripts/pinballwake-event-ledger-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        { body: "Final QC ACK needed from Popcorn only.", created_at: "2026-05-03T01:20:00Z" },
+        { body: "HOLD: proof mismatch remains.", created_at: "2026-05-03T01:30:00Z" },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "blocked_chris_only");
+  });
+
   it("keeps overlap blockers ahead of missing final QC routing", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 537, draft: true, title: "docs(autopilot): add context boot packet" }),


### PR DESCRIPTION
## Summary
- add a QueuePush state for draft PRs where Safety + Builder PASS are visible but final QC is missing
- route that state directly to the QC lane instead of generic owner-decision routing
- add focused regression coverage for missing-QC, overlap precedence, generic HOLD precedence, and final QC packet text

## Status
- draft, CLEAN, latest head `d8ddb4e`
- classifier blocker fixed on latest head and Forge PASS posted
- waiting on final safety/QC/lift path; no lift/merge by Forge

## Proof
- `node --test scripts/fleet-throughput-watch.test.mjs` passed 30/30
- `git diff --check origin/main...HEAD` passed
- GitHub CI green
- TestPass green
- Vercel ready

## Safety
- routing-only change
- no repo-file execution, merge, release, auth, billing, DNS, migrations, raw keys, or destructive behavior
