### PR TITLE
fix(autopilot): route QC-wait holds to final QC

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -134,6 +134,35 @@ function normalizeText(value) {
     .toLowerCase();
 }
 
+function isMissingFinalQcText(text) {
+  return (
+    /\b(final qc|qc ack|qc pass|popcorn|reviewer)\b|🍿/.test(text) &&
+    /\b(missing|needed|needs|waiting|awaiting|only missing|no final|no .*visible)\b/.test(text)
+  );
+}
+
+function isQcWaitOnlyHold(text) {
+  if (!/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text)) return false;
+  if (!isMissingFinalQcText(text)) return false;
+  const exactHoldClause = text.match(/\bexact hold:\s*([^.!?]{0,180})/)?.[1] || "";
+  const exactHoldIsQcOnly =
+    Boolean(exactHoldClause) &&
+    /\b(?:missing|waiting|awaiting|needs?)\b.{0,80}\b(?:final qc|qc ack|qc pass|popcorn|reviewer)\b/.test(
+      exactHoldClause,
+    ) &&
+    !/\b(and|but|however|unresolved|remains|concern|issue|blocker|risk|schema|protected|mismatch|overlap|anti-stomp|dirty|failing|failed|red)\b/.test(
+      exactHoldClause,
+    );
+  const explicitQcOnlyWait =
+    /\b(?:final qc|qc ack|qc pass|popcorn|reviewer)\b.{0,80}\b(?:only|sole|solely|just)\b/.test(text) ||
+    /\b(?:only|sole|solely|just)\b.{0,80}\b(?:final qc|qc ack|qc pass|popcorn|reviewer)\b/.test(text) ||
+    exactHoldIsQcOnly;
+  if (!explicitQcOnlyWait) return false;
+  return !/\b(exact blocker|proof mismatch|body proof|stale proof|stale pr body|overlap|anti-stomp|dirty branch|not clean against main|targeted proof|focused proof|failing|failed|red|secrets|auth|billing|dns|migration|raw key|human decision|chris-only|needs chris)\b/.test(
+    text,
+  );
+}
+
 function sourceUrl(pr) {
   return pr.html_url || `${serverUrl}/${repository}/pull/${pr.number}`;
 }
@@ -216,13 +245,11 @@ export function latestCommentSignals(comments = []) {
     if (lanePass && /\b(popcorn|qc|reviewer)\b|🍿/.test(text)) {
       lastPopcornPass = index;
     }
-    if (/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text)) {
+    const qcWaitOnlyHold = isQcWaitOnlyHold(text);
+    if (/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text) && !qcWaitOnlyHold) {
       lastHold = index;
     }
-    if (
-      /\b(final qc|qc ack|qc pass|popcorn|reviewer)\b|🍿/.test(text) &&
-      /\b(missing|needed|needs|waiting|awaiting|only missing|no final|no .*visible)\b/.test(text)
-    ) {
+    if (isMissingFinalQcText(text)) {
       lastMissingFinalQcAck = index;
     }
     if (/\b(overlap|anti-stomp|supersede|supersedes|rebase\/close|close one lane|same files)\b/.test(text)) {

--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -134,6 +134,28 @@ function normalizeText(value) {
     .toLowerCase();
 }
 
+function isMissingFinalQcText(text) {
+  return (
+    /\b(final qc|qc ack|qc pass|popcorn|reviewer)\b|🍿/.test(text) &&
+    /\b(missing|needed|needs|waiting|awaiting|only missing|no final|no .*visible)\b/.test(text)
+  );
+}
+
+function isQcWaitOnlyHold(text) {
+  if (!/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text)) return false;
+  if (!isMissingFinalQcText(text)) return false;
+  const explicitQcOnlyWait =
+    /\b(?:final qc|qc ack|qc pass|popcorn|reviewer)\b.{0,80}\b(?:only|sole|solely|just)\b/.test(text) ||
+    /\b(?:only|sole|solely|just)\b.{0,80}\b(?:final qc|qc ack|qc pass|popcorn|reviewer)\b/.test(text) ||
+    /\bexact hold:\s*(?:missing|waiting|awaiting|needs?).{0,80}\b(?:final qc|qc ack|qc pass|popcorn|reviewer)\b/.test(
+      text,
+    );
+  if (!explicitQcOnlyWait) return false;
+  return !/\b(exact blocker|proof mismatch|body proof|stale proof|stale pr body|overlap|anti-stomp|dirty branch|not clean against main|targeted proof|focused proof|failing|failed|red|secrets|auth|billing|dns|migration|raw key|human decision|chris-only|needs chris)\b/.test(
+    text,
+  );
+}
+
 function sourceUrl(pr) {
   return pr.html_url || `${serverUrl}/${repository}/pull/${pr.number}`;
 }
@@ -216,13 +238,11 @@ export function latestCommentSignals(comments = []) {
     if (lanePass && /\b(popcorn|qc|reviewer)\b|🍿/.test(text)) {
       lastPopcornPass = index;
     }
-    if (/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text)) {
+    const qcWaitOnlyHold = isQcWaitOnlyHold(text);
+    if (/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text) && !qcWaitOnlyHold) {
       lastHold = index;
     }
-    if (
-      /\b(final qc|qc ack|qc pass|popcorn|reviewer)\b|🍿/.test(text) &&
-      /\b(missing|needed|needs|waiting|awaiting|only missing|no final|no .*visible)\b/.test(text)
-    ) {
+    if (isMissingFinalQcText(text)) {
       lastMissingFinalQcAck = index;
     }
     if (/\b(overlap|anti-stomp|supersede|supersedes|rebase\/close|close one lane|same files)\b/.test(text)) {

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -93,6 +93,45 @@ describe("QueuePush PR classifier", () => {
     assert.equal(result.state, "blocked_chris_only");
   });
 
+  it("treats HOLDs that only wait on Popcorn as missing final QC routing", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),
+      files: [{ filename: "scripts/pinballwake-worker-registry-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        {
+          body:
+            "Forge HOLD on QueuePush owner-decision packet. Exact HOLD: missing 🍿 Popcorn QC PASS on latest head. No code changes and no merge/lift by Forge.",
+          created_at: "2026-05-03T01:30:00Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "missing_final_qc_ack");
+  });
+
+  it("keeps missing Popcorn plus another unresolved concern as an active blocker", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),
+      files: [{ filename: "scripts/pinballwake-worker-registry-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        {
+          body: "HOLD: missing Popcorn QC PASS and unresolved schema concern remains.",
+          created_at: "2026-05-03T01:30:00Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "blocked_chris_only");
+  });
+
   it("keeps overlap blockers ahead of missing final QC routing", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 537, draft: true, title: "docs(autopilot): add context boot packet" }),

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -93,6 +93,64 @@ describe("QueuePush PR classifier", () => {
     assert.equal(result.state, "blocked_chris_only");
   });
 
+  it("treats HOLDs that only wait on Popcorn as missing final QC routing", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),
+      files: [{ filename: "scripts/pinballwake-worker-registry-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        {
+          body:
+            "Forge HOLD on QueuePush owner-decision packet. Exact HOLD: missing 🍿 Popcorn QC PASS on latest head. No code changes and no merge/lift by Forge.",
+          created_at: "2026-05-03T01:30:00Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "missing_final_qc_ack");
+  });
+
+  it("keeps missing Popcorn plus another unresolved concern as an active blocker", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),
+      files: [{ filename: "scripts/pinballwake-worker-registry-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        {
+          body: "HOLD: missing Popcorn QC PASS and unresolved schema concern remains.",
+          created_at: "2026-05-03T01:30:00Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "blocked_chris_only");
+  });
+
+  it("keeps exact HOLD missing Popcorn plus another unresolved concern as an active blocker", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),
+      files: [{ filename: "scripts/pinballwake-worker-registry-room.mjs" }],
+      comments: [
+        { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+        { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+        {
+          body: "Exact HOLD: missing Popcorn QC PASS and unresolved schema concern remains.",
+          created_at: "2026-05-03T01:30:00Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "blocked_chris_only");
+  });
+
   it("keeps overlap blockers ahead of missing final QC routing", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 537, draft: true, title: "docs(autopilot): add context boot packet" }),


### PR DESCRIPTION
## Summary
- treat HOLD/BLOCKER comments that only say Popcorn/final-QC is missing as `missing_final_qc_ack`, not as a Chris-only blocker
- keep real blockers ahead of QC routing, including mixed Exact HOLD text such as missing Popcorn plus unresolved schema concerns
- add regressions for the live stuck shape where Forge says HOLD only because Popcorn QC PASS is missing and for the stricter mixed Exact HOLD blocker

## Proof
- `node --test scripts/fleet-throughput-watch.test.mjs` passed 33/33
- `git diff --check` passed

## Safety
Routing-only change. No repo execution, merge/lift, publish/release, auth, billing, DNS, migrations, raw keys, destructive cleanup, or force-push behavior.
