### PR TITLE
fix(autopilot): retry stale queue packets

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -171,7 +171,14 @@ function isAckRequestText(text) {
   );
 }
 
+function isExplicitActiveBlockerText(text) {
+  return /(?:^|\n)\s*(?:[-*]\s*)?(?:(?:gatekeeper|forge|popcorn|reviewer|safety checker|release safety|builder|qc)\s+|[🛡️🛠️🍿]\s*)?(?:blocker|hold)\s*:/.test(
+    text,
+  );
+}
+
 function isBlockerResolutionText(text) {
+  if (isExplicitActiveBlockerText(text)) return false;
   return (
     /\b(?:blocker|hold)\b.{0,80}\b(?:fix|fixed|resolved|cleared|closed)\b/.test(text) ||
     /\b(?:fix|fixed|resolved|cleared|closed)\b.{0,80}\b(?:blocker|hold)\b/.test(text)

--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -172,7 +172,7 @@ function isAckRequestText(text) {
 }
 
 function isExplicitActiveBlockerText(text) {
-  return /(?:^|\n)\s*(?:[-*]\s*)?(?:(?:gatekeeper|forge|popcorn|reviewer|safety checker|release safety|builder|qc)\s+|[🛡️🛠️🍿]\s*)?(?:blocker|hold)\s*:/.test(
+  return /(?:^|\n)\s*(?:[-*]\s*)?(?:[^\w\s]+\s*)?(?:(?:gatekeeper|forge|popcorn|reviewer|safety checker|release safety|builder|qc)\s+)?(?:blocker|hold)(?:\s*:|\s+on\b)/.test(
     text,
   );
 }

--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -11,6 +11,7 @@ const unclickApiKey = process.env.FISHBOWL_WAKE_TOKEN || process.env.FISHBOWL_AU
 const dryRun = parseBooleanFlag(process.env.QUEUEPUSH_DRY_RUN) || process.argv.includes("--dry-run");
 const maxPackets = parseBoundedInt(process.env.QUEUEPUSH_MAX_PACKETS, 10, 1, 12);
 const recentFishbowlLimit = parseBoundedInt(process.env.QUEUEPUSH_FISHBOWL_LIMIT, 100, 20, 100);
+const packetRetryMinutes = parseBoundedInt(process.env.QUEUEPUSH_PACKET_RETRY_MINUTES, 180, 15, 1440);
 const agentId = "github-action-queuepush";
 const agentEmoji = "📬";
 const agentDisplayName = "QueuePush";
@@ -163,6 +164,20 @@ function isQcWaitOnlyHold(text) {
   );
 }
 
+function isAckRequestText(text) {
+  return (
+    /\b(?:need|needs|needed|please|reply|ack)\b.{0,120}\bpass\s*(?:\/|or)\s*blocker\b/.test(text) ||
+    /\back:\s*pass\/blocker\b/.test(text)
+  );
+}
+
+function isBlockerResolutionText(text) {
+  return (
+    /\b(?:blocker|hold)\b.{0,80}\b(?:fix|fixed|resolved|cleared|closed)\b/.test(text) ||
+    /\b(?:fix|fixed|resolved|cleared|closed)\b.{0,80}\b(?:blocker|hold)\b/.test(text)
+  );
+}
+
 function sourceUrl(pr) {
   return pr.html_url || `${serverUrl}/${repository}/pull/${pr.number}`;
 }
@@ -246,7 +261,12 @@ export function latestCommentSignals(comments = []) {
       lastPopcornPass = index;
     }
     const qcWaitOnlyHold = isQcWaitOnlyHold(text);
-    if (/\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text) && !qcWaitOnlyHold) {
+    if (
+      /\b(hold|do not merge|do not lift|blocker|blocked)\b/.test(text) &&
+      !qcWaitOnlyHold &&
+      !isAckRequestText(text)
+      && !isBlockerResolutionText(text)
+    ) {
       lastHold = index;
     }
     if (isMissingFinalQcText(text)) {
@@ -514,9 +534,30 @@ export function buildQueuePacket(input) {
   };
 }
 
-export function filterDuplicatePackets(packets, fishbowlMessages = []) {
-  const recentText = fishbowlMessages.map((message) => String(message.text || "")).join("\n");
-  return packets.filter((packet) => !recentText.includes(packet.packetId));
+function messageCreatedAt(message) {
+  const value =
+    message?.created_at ||
+    message?.createdAt ||
+    message?.inserted_at ||
+    message?.timestamp ||
+    message?.created ||
+    "";
+  const time = Date.parse(String(value));
+  return Number.isFinite(time) ? time : null;
+}
+
+export function filterDuplicatePackets(
+  packets,
+  fishbowlMessages = [],
+  { now = Date.now(), retryAfterMinutes = packetRetryMinutes } = {},
+) {
+  const retryMs = retryAfterMinutes * 60 * 1000;
+  return packets.filter((packet) => {
+    const matches = fishbowlMessages.filter((message) => String(message.text || "").includes(packet.packetId));
+    if (matches.length === 0) return true;
+    const newest = Math.max(...matches.map((message) => messageCreatedAt(message) ?? now));
+    return now - newest >= retryMs;
+  });
 }
 
 async function githubJson(path) {
@@ -637,8 +678,9 @@ function prioritizePackets(packets) {
     hold_overlap: 1,
     failed_targeted_proof: 2,
     blocked_chris_only: 3,
-    ready_for_qc: 4,
-    draft_green_needs_owner_lift: 5,
+    missing_final_qc_ack: 4,
+    ready_for_qc: 5,
+    draft_green_needs_owner_lift: 6,
   };
   return [...packets].sort((a, b) => {
     const stateDiff = (priority[a.state] ?? 99) - (priority[b.state] ?? 99);

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -166,6 +166,27 @@ describe("QueuePush PR classifier", () => {
     assert.equal(result.state, "blocked_chris_only");
   });
 
+  for (const body of [
+    "BLOCKER: blocker fix did not work; unsafe global clear remains.",
+    "HOLD: blocker fix still clears unrelated Gatekeeper HOLD.",
+    "Gatekeeper BLOCKER: blocker-fix detector is still unsafe.",
+  ]) {
+    it(`keeps explicit active blocker text even when it mentions a fix: ${body}`, () => {
+      const result = classifyPullRequest({
+        pr: pr({ number: 546, draft: false, title: "fix(autopilot): retry stale queue packets" }),
+        files: [{ filename: "scripts/fleet-throughput-watch.mjs" }],
+        comments: [
+          { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-05T13:59:31Z" },
+          { body, created_at: "2026-05-05T14:21:04Z" },
+        ],
+        checkRuns: greenChecks,
+        statuses: greenStatus,
+      });
+
+      assert.equal(result.state, "blocked_chris_only");
+    });
+  }
+
   it("treats HOLDs that only wait on Popcorn as missing final QC routing", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -170,6 +170,10 @@ describe("QueuePush PR classifier", () => {
     "BLOCKER: blocker fix did not work; unsafe global clear remains.",
     "HOLD: blocker fix still clears unrelated Gatekeeper HOLD.",
     "Gatekeeper BLOCKER: blocker-fix detector is still unsafe.",
+    "🛠️ Forge BLOCKER on #546 latest head. Finding: blocker-fix detector is still unsafe and needs focused fix.",
+    "🛡️ Gatekeeper HOLD on #546 latest head. Explicit blocker fix wording can still hide active blockers.",
+    "🛠️ Forge BLOCKER: blocker-fix detector is still unsafe.",
+    "🛡️ Gatekeeper HOLD: blocker-fix detector is still unsafe.",
   ]) {
     it(`keeps explicit active blocker text even when it mentions a fix: ${body}`, () => {
       const result = classifyPullRequest({

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   buildQueuePacket,
+  buildPacketsFromInputs,
   checksAreGreen,
   chooseQueuePushRunner,
   classifyPullRequest,
@@ -76,6 +77,40 @@ describe("QueuePush PR classifier", () => {
     assert.equal(result.state, "draft_green_needs_owner_lift");
   });
 
+  it("does not treat PASS/BLOCKER review requests as active blockers", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 546, draft: true, title: "fix(autopilot): retry stale queue packets" }),
+      files: [{ filename: "scripts/fleet-throughput-watch.mjs" }],
+      comments: [
+        {
+          body: "Need:\n🛡️ Gatekeeper: reply PASS/BLOCKER.\n🛠️ Forge: reply PASS/BLOCKER.\n🍿 Popcorn: reply PASS/BLOCKER.\n\nack:\nPASS/BLOCKER",
+          created_at: "2026-05-05T13:26:48Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "draft_green_needs_owner_lift");
+  });
+
+  it("does not treat PASS or BLOCKER review requests as active blockers", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 546, draft: true, title: "fix(autopilot): retry stale queue packets" }),
+      files: [{ filename: "scripts/fleet-throughput-watch.mjs" }],
+      comments: [
+        {
+          body: "Need: Gatekeeper reply PASS or BLOCKER. Forge reply PASS or BLOCKER. Popcorn reply PASS or BLOCKER.",
+          created_at: "2026-05-05T13:35:00Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "draft_green_needs_owner_lift");
+  });
+
   it("keeps later generic HOLDs ahead of missing final QC routing", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 535, draft: true, title: "feat(autopilot): add Event Ledger Room" }),
@@ -85,6 +120,44 @@ describe("QueuePush PR classifier", () => {
         { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
         { body: "Final QC ACK needed from Popcorn only.", created_at: "2026-05-03T01:20:00Z" },
         { body: "HOLD: proof mismatch remains.", created_at: "2026-05-03T01:30:00Z" },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "blocked_chris_only");
+  });
+
+  it("does not treat blocker-fix updates as new active blockers", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 546, draft: true, title: "fix(autopilot): retry stale queue packets" }),
+      files: [{ filename: "scripts/fleet-throughput-watch.mjs" }],
+      comments: [
+        {
+          body: "Blocker fix pushed. Fixed Forge blocker: PASS or BLOCKER review request wording no longer becomes a fake active blocker.",
+          created_at: "2026-05-05T13:38:22Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "draft_green_needs_owner_lift");
+  });
+
+  it("does not let unrelated blocker-fix updates clear an earlier safety HOLD", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 546, draft: true, title: "fix(autopilot): retry stale queue packets" }),
+      files: [{ filename: "scripts/fleet-throughput-watch.mjs" }],
+      comments: [
+        {
+          body: "Gatekeeper HOLD: unsafe path / proof mismatch remains.",
+          created_at: "2026-05-05T13:35:00Z",
+        },
+        {
+          body: "Blocker fix pushed: fixed Forge PASS-or-BLOCKER classifier issue.",
+          created_at: "2026-05-05T13:38:00Z",
+        },
       ],
       checkRuns: greenChecks,
       statuses: greenStatus,
@@ -466,6 +539,73 @@ describe("QueuePush routing and packets", () => {
       remaining.map((packet) => packet.packetId),
       [second.packetId],
     );
+  });
+
+  it("retries stale QueuePush packets after the retry window", () => {
+    const packet = buildQueuePacket({
+      pr: pr({ number: 535, title: "feat(autopilot): add Event Ledger Room" }),
+      state: "missing_final_qc_ack",
+      reason: "Safety and builder PASS are visible; final QC ACK is missing.",
+      files: [{ filename: "scripts/pinballwake-event-ledger-room.mjs" }],
+    });
+    const now = Date.parse("2026-05-05T06:30:00Z");
+    const messages = [
+      {
+        text: `old post ${packet.packetId}`,
+        created_at: "2026-05-05T02:08:00Z",
+      },
+    ];
+
+    const remaining = filterDuplicatePackets([packet], messages, { now, retryAfterMinutes: 180 });
+    assert.deepEqual(
+      remaining.map((candidate) => candidate.packetId),
+      [packet.packetId],
+    );
+  });
+
+  it("keeps fresh QueuePush packets deduped before the retry window", () => {
+    const packet = buildQueuePacket({
+      pr: pr({ number: 535, title: "feat(autopilot): add Event Ledger Room" }),
+      state: "missing_final_qc_ack",
+      reason: "Safety and builder PASS are visible; final QC ACK is missing.",
+      files: [{ filename: "scripts/pinballwake-event-ledger-room.mjs" }],
+    });
+    const now = Date.parse("2026-05-05T06:30:00Z");
+    const messages = [
+      {
+        text: `fresh post ${packet.packetId}`,
+        created_at: "2026-05-05T06:00:00Z",
+      },
+    ];
+
+    const remaining = filterDuplicatePackets([packet], messages, { now, retryAfterMinutes: 180 });
+    assert.deepEqual(remaining, []);
+  });
+
+  it("prioritizes missing final QC before routine owner lift", async () => {
+    const packets = await buildPacketsFromInputs([
+      {
+        pr: pr({ number: 536, draft: true, title: "feat(autopilot): add Worker Registry Room" }),
+        files: [{ filename: "scripts/pinballwake-worker-registry-room.mjs" }],
+        comments: [
+          { body: "Gatekeeper PASS. CLEAN, safety PASS.", created_at: "2026-05-03T01:00:00Z" },
+          { body: "Forge PASS. Implementation-shape review is clean.", created_at: "2026-05-03T01:10:00Z" },
+          { body: "Status refreshed. No final review yet.", created_at: "2026-05-03T01:20:00Z" },
+        ],
+        checkRuns: greenChecks,
+        statuses: greenStatus,
+      },
+      {
+        pr: pr({ number: 531, draft: true, title: "feat(autopilot): add personality room" }),
+        files: [{ filename: "scripts/pinballwake-personality-room.mjs" }],
+        comments: [{ body: "Gatekeeper PASS. Scope looks low risk.", created_at: "2026-05-03T01:00:00Z" }],
+        checkRuns: greenChecks,
+        statuses: greenStatus,
+      },
+    ]);
+
+    assert.equal(packets[0]?.state, "missing_final_qc_ack");
+    assert.equal(packets[0]?.pr, 536);
   });
 });
 


### PR DESCRIPTION
## Summary
- retry stale QueuePush packets after `QUEUEPUSH_PACKET_RETRY_MINUTES` so unanswered ACK requests do not disappear forever
- keep fresh duplicate packets deduped so the bridge does not spam workers
- give `missing_final_qc_ack` an explicit priority ahead of routine owner-lift packets
- stop `PASS/BLOCKER` and `PASS or BLOCKER` review request text from being misread as real blockers
- avoid treating blocker-fix update text as a new active blocker, while preserving earlier HOLD/BLOCKER comments until a real lane PASS clears them
- keep explicit `BLOCKER:` / `HOLD:` lane statements active even when they mention fix/resolution wording
- keep real lane-review phrasing like `Forge BLOCKER on...`, `Gatekeeper HOLD on...`, and emoji + lane blocker forms active

## Proof
- `node --test scripts/fleet-throughput-watch.test.mjs` passed 47/47
- `git diff --check` passed

## Safety
Routing-only change. No repo execution, merge execution, lift execution, auth, billing, DNS/domains, migrations, raw keys, destructive cleanup, or force-push behavior.