### PR TITLE
feat(ui): align UnClick ecosystem navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import RequireAuth from "./components/RequireAuth.tsx";
 import RequireAdmin from "./components/RequireAdmin.tsx";
 import BetaBanner from "./components/BetaBanner.tsx";
 import AdminShell from "./pages/admin/AdminShell.tsx";
+import AdminDashboard from "./pages/admin/AdminDashboard.tsx";
 import AdminYou from "./pages/admin/AdminYou.tsx";
 import AdminMemory from "./pages/admin/AdminMemory.tsx";
 import AdminKeychain from "./pages/admin/AdminKeychain.tsx";
@@ -71,6 +72,16 @@ import AdminSystemHealth from "./pages/admin/AdminSystemHealth.tsx";
 import AdminPinballWake from "./pages/admin/AdminPinballWake.tsx";
 import AdminModeration from "./pages/admin/AdminModeration.tsx";
 import AdminAuditLog from "./pages/admin/AdminAuditLog.tsx";
+import BrainMap from "./pages/admin/BrainMap.tsx";
+import {
+  AdminAutopilot,
+  AdminBilling,
+  AdminChecks,
+  AdminLedger,
+  AdminProjects,
+  AdminTodoList,
+  AdminWorkers,
+} from "./pages/admin/AdminEcosystemPages.tsx";
 import SignalsCatalog from "./pages/admin/signals/SignalsCatalog.tsx";
 import SignalsSettings from "./pages/admin/signals/SignalsSettings.tsx";
 import Fishbowl from "./pages/admin/Fishbowl.tsx";
@@ -141,14 +152,22 @@ const App = () => (
               </RequireAuth>
             }
           >
-            <Route index element={<Navigate to="/admin/you" replace />} />
+            <Route index element={<Navigate to="/admin/dashboard" replace />} />
+            <Route path="dashboard" element={<AdminDashboard />} />
             <Route path="you" element={<AdminYou />} />
             <Route path="memory" element={<AdminMemory />} />
             <Route path="keychain" element={<AdminKeychain />} />
             <Route path="tools" element={<AdminTools />} />
             <Route path="activity" element={<AdminActivity />} />
             <Route path="settings" element={<AdminSettings />} />
+            <Route path="projects" element={<AdminProjects />} />
+            <Route path="autopilot" element={<AdminAutopilot />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
+            <Route path="workers" element={<AdminWorkers />} />
+            <Route path="todos" element={<AdminTodoList />} />
+            <Route path="checks" element={<AdminChecks />} />
+            <Route path="ledger" element={<AdminLedger />} />
+            <Route path="billing" element={<AdminBilling />} />
             <Route path="testpass"              element={<TestPassCatalog />} />
             <Route path="testpass/new"          element={<NewRunWizard />} />
             <Route path="testpass/runs/:id"     element={<RunDetail />} />
@@ -171,9 +190,11 @@ const App = () => (
             <Route path="pinballwake"    element={<RequireAdmin><AdminPinballWake /></RequireAdmin>} />
             <Route path="moderation"     element={<RequireAdmin><AdminModeration /></RequireAdmin>} />
             <Route path="audit-log"      element={<RequireAdmin><AdminAuditLog /></RequireAdmin>} />
+            <Route path="brainmap"       element={<RequireAdmin><BrainMap /></RequireAdmin>} />
             <Route path="signals"          element={<SignalsCatalog />} />
             <Route path="signals/settings" element={<SignalsSettings />} />
             <Route path="fishbowl"         element={<Fishbowl />} />
+            <Route path="boardroom"        element={<Navigate to="/admin/fishbowl" replace />} />
           </Route>
           {/* Phase 2 auth surface */}
           <Route path="/login" element={<LoginPage />} />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,13 +1,13 @@
 import { Link } from "react-router-dom";
 import FadeIn from "@/components/FadeIn";
-import { Wrench, Brain, Key, Users, BadgeCheck, Store, ArrowRight } from "lucide-react";
+import { AppWindow, Brain, Key, Plane, BadgeCheck, Store, ArrowRight } from "lucide-react";
 
 const PRODUCTS = [
   {
-    title: "Tools",
-    description: "450+ callable endpoints to act",
+    title: "Apps",
+    description: "Built-in tools and connected services",
     href: "/tools",
-    icon: Wrench,
+    icon: AppWindow,
     color: "bg-blue-500/10 text-blue-500",
   },
   {
@@ -18,24 +18,24 @@ const PRODUCTS = [
     color: "bg-purple-500/10 text-purple-500",
   },
   {
-    title: "Connections",
-    description: "Secure credentials for services",
+    title: "Passport",
+    description: "OAuth, keys, logins, and permissions",
     href: "/admin/keychain",
     icon: Key,
     color: "bg-amber-500/10 text-amber-500",
   },
   {
-    title: "Pass family",
-    description: "QA, UX, security, SEO, legal, and slop checks",
-    href: "/admin/testpass",
+    title: "XPass / Checks",
+    description: "Test, UX, security, SEO, legal, and quality proof",
+    href: "/admin/checks",
     icon: BadgeCheck,
     color: "bg-red-500/10 text-red-500",
   },
   {
-    title: "Crews",
-    description: "Multi-agent orchestration",
-    href: "/crews",
-    icon: Users,
+    title: "Autopilot",
+    description: "The visible assembly line for AI work",
+    href: "/build",
+    icon: Plane,
     color: "bg-green-500/10 text-green-500",
   },
   {
@@ -73,8 +73,8 @@ const Hero = () => {
 
           <FadeIn delay={0.1}>
             <p className="mt-6 text-lg text-body max-w-2xl mx-auto leading-relaxed">
-              Tools to act. Memory to remember. Connections to authenticate. Crews to deliberate.
-              Pass family checks to prove it works before you ship.
+              Apps to act. Memory to remember. Passport to authenticate. Autopilot to coordinate.
+              XPass checks to prove it works before you ship.
             </p>
           </FadeIn>
 
@@ -113,7 +113,7 @@ const Hero = () => {
               The rails your agent plugs into
             </h2>
             <p className="mt-3 text-center text-body max-w-2xl mx-auto">
-              UnClick sits behind Claude, ChatGPT, Cursor, and every MCP client as the shared layer for action, memory, credentials, crews, and Pass family verification.
+              UnClick sits behind Claude, ChatGPT, Cursor, and every MCP client as the shared layer for action, memory, permissions, Autopilot, and XPass verification.
             </p>
           </FadeIn>
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { Wrench, Brain, Calendar, Users, Trophy, HelpCircle } from "lucide-react";
+import { AppWindow, Brain, BadgeCheck, Plane, Trophy, HelpCircle } from "lucide-react";
 import { useSession } from "@/lib/auth";
 
 const Navbar = () => {
@@ -13,10 +13,10 @@ const Navbar = () => {
   const isLoggedIn = Boolean(session);
 
   const navLinks = [
-    { label: "Tools", href: "/tools", icon: Wrench },
+    { label: "Apps", href: "/tools", icon: AppWindow },
     { label: "Memory", href: "/memory", icon: Brain },
-    { label: "Organiser", href: "/organiser", icon: Calendar },
-    { label: "Crews", href: "/crews", icon: Users },
+    { label: "Autopilot", href: "/build", icon: Plane },
+    { label: "XPass", href: "/admin/checks", icon: BadgeCheck },
     { label: "Arena", href: "/arena", icon: Trophy },
     { label: "Pricing", href: "/pricing" },
     { label: "Docs", href: "/docs" },

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -2,7 +2,7 @@
  * AdminShell - shared layout wrapper for admin pages.
  *
  * Renders the top Navbar + Footer plus a left sidebar with links to the
- * admin sections (You, Agents, Memory, Tools, Keychain, Activity, Settings).
+ * admin sections (You, Workers, Memory, Apps, Passport, Activity, Settings).
  * Pages render inside the right pane.
  */
 
@@ -42,15 +42,15 @@ export default function AdminShell({ title, subtitle, agentCount, children }: Ad
   const items: SidebarItem[] = [
     { label: "You", to: "/settings", icon: UserIcon, matchPrefix: "/settings" },
     {
-      label: "Agents",
+      label: "Workers",
       to: "/admin/agents",
       icon: Bot,
       badge: agentCount,
       matchPrefix: "/admin/agents",
     },
     { label: "Memory", to: "/memory/admin", icon: Brain, matchPrefix: "/memory" },
-    { label: "Tools", to: "/tools", icon: Wrench, matchPrefix: "/tools" },
-    { label: "Keychain (BackstagePass)", to: "/admin/keychain", icon: KeyRound, matchPrefix: "/admin/keychain" },
+    { label: "Apps", to: "/tools", icon: Wrench, matchPrefix: "/tools" },
+    { label: "Passport", to: "/admin/keychain", icon: KeyRound, matchPrefix: "/admin/keychain" },
     { label: "Activity", to: "/dispatch", icon: Activity, matchPrefix: "/dispatch" },
     { label: "Settings", to: "/settings", icon: SettingsIcon, matchPrefix: "/settings" },
   ];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,10 +14,10 @@ import VantaWavesBackground from "@/components/VantaWavesBackground";
 const Index = () => {
   useCanonical("/");
   useMetaTags({
-    title: "UnClick - Agent rails for tools, memory, and QC",
-    description: "One npm install gives your AI agent callable tools, persistent memory, secure connections, and Pass family QA checks.",
-    ogTitle: "UnClick - Agent rails for tools, memory, and QC",
-    ogDescription: "Tools, memory, connections, crews, and Pass family checks for AI agents.",
+    title: "UnClick - Agent rails for apps, memory, and proof",
+    description: "One connection gives your AI agent apps, memory, Passport permissions, Autopilot orchestration, and XPass proof.",
+    ogTitle: "UnClick - Agent rails for apps, memory, and proof",
+    ogDescription: "Apps, memory, Passport, Autopilot, and XPass checks for AI agents.",
     ogUrl: "https://unclick.world/",
   });
 

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -236,10 +236,10 @@ const AUSTRALIA_TOOLS = [
 const Tools = () => {
   useCanonical("/tools");
   useMetaTags({
-    title: "178+ AI Agent Tools - UnClick Marketplace",
-    description: "Browse 178+ verified tools across 60+ integrations - email, finance, productivity, dev tools and more. One npm install, instantly callable by any MCP-compatible AI agent.",
-    ogTitle: "UnClick Marketplace - 178+ Tools for AI Agents",
-    ogDescription: "Browse 178+ verified tools across 60+ integrations. One npm install gives your AI agent access to everything.",
+    title: "UnClick Apps - Built-in tools and connected services",
+    description: "Browse UnClick apps: built-in tools that work straight away, plus connected services that need login or API keys.",
+    ogTitle: "UnClick Apps - Built-in tools and connected services",
+    ogDescription: "Browse built-in apps and connected services for AI agents.",
     ogUrl: "https://unclick.world/tools",
   });
 
@@ -255,20 +255,21 @@ const Tools = () => {
         <div className="relative z-10 mx-auto max-w-3xl text-center">
           <FadeIn>
             <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-1.5 backdrop-blur-sm">
-              <span className="font-mono text-xs font-medium text-primary">178+ Tools</span>
+              <span className="font-mono text-xs font-medium text-primary">Apps</span>
             </div>
           </FadeIn>
 
           <FadeIn delay={0.05}>
             <h1 className="text-4xl font-semibold leading-tight tracking-tight sm:text-5xl md:text-6xl">
-              178+ tools.{" "}
+              Apps your AI can use.{" "}
               <span className="text-primary">One command.</span>
             </h1>
           </FadeIn>
 
           <FadeIn delay={0.1}>
             <p className="mt-4 text-lg text-body max-w-xl mx-auto leading-relaxed">
-              Every tool your AI agent needs - weather, email, finance, security, social media, gaming, and more. All accessible through a single MCP server. No API keys to manage. No rate limits to worry about.
+              Built-in apps work straight away. Connected apps use Passport when they need login,
+              API keys, or extra permission.
             </p>
           </FadeIn>
 
@@ -300,7 +301,7 @@ const Tools = () => {
               All categories
             </h2>
             <p className="mt-3 text-center text-body max-w-xl mx-auto">
-              19 categories. 178+ tools. Choose what you need.
+              Categories, built-in options, connected services, and more.
             </p>
           </FadeIn>
 
@@ -326,7 +327,7 @@ const Tools = () => {
                   <h3 className="text-sm font-semibold text-heading">{cat.name}</h3>
                   <p className="mt-1 text-xs text-body leading-relaxed">{cat.desc}</p>
                   <div className="mt-4 pt-4 border-t border-border/30">
-                    <p className="text-xs text-muted-foreground mb-2">Example tools:</p>
+                    <p className="text-xs text-muted-foreground mb-2">Example app actions:</p>
                     <div className="flex flex-wrap gap-1">
                       {cat.tools.map((tool) => (
                         <span key={tool} className="text-xs bg-primary/5 text-primary px-2 py-1 rounded">
@@ -351,7 +352,7 @@ const Tools = () => {
           <FadeIn>
             <div className="flex items-center gap-3 mb-2">
               <Mail className="h-6 w-6 text-primary" />
-              <h2 className="text-2xl font-semibold tracking-tight">Email Tools</h2>
+              <h2 className="text-2xl font-semibold tracking-tight">Email Apps</h2>
             </div>
             <p className="text-body mt-2 max-w-2xl">
               AI-powered email management. Search, read, send, and organize - all through natural language.
@@ -387,7 +388,7 @@ const Tools = () => {
           <FadeIn>
             <div className="flex items-center gap-3 mb-2">
               <TrendingUp className="h-6 w-6 text-primary" />
-              <h2 className="text-2xl font-semibold tracking-tight">Finance Tools</h2>
+              <h2 className="text-2xl font-semibold tracking-tight">Finance Apps</h2>
             </div>
             <p className="text-body mt-2 max-w-2xl">
               Unified financial data. Crypto, stocks, and forex in one interface.
@@ -423,7 +424,7 @@ const Tools = () => {
           <FadeIn>
             <div className="flex items-center gap-3 mb-2">
               <Shield className="h-6 w-6 text-primary" />
-              <h2 className="text-2xl font-semibold tracking-tight">Security Tools</h2>
+              <h2 className="text-2xl font-semibold tracking-tight">Security Apps</h2>
             </div>
             <p className="text-body mt-2 max-w-2xl">
               Threat intelligence at your fingertips. Scan URLs, check breaches, monitor CVEs.
@@ -462,7 +463,7 @@ const Tools = () => {
               <h2 className="text-2xl font-semibold tracking-tight">Australian Services</h2>
             </div>
             <p className="text-body mt-2 max-w-2xl">
-              Built in Melbourne. Tools for Australian businesses and residents.
+              Built in Melbourne. Apps for Australian businesses and residents.
             </p>
           </FadeIn>
 

--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -258,8 +258,8 @@ export default function AdminAgentsPage() {
 
   return (
     <AdminShell
-      title="Your Agents"
-      subtitle="Create AI agents with specific roles, tools, and personalities. Each agent remembers what you tell it and only uses the tools you allow."
+      title="Workers"
+      subtitle="Create AI workers with clear roles, tools, and memory access. Public names stay simple while the internal automation can keep its stable codenames."
       agentCount={agents.length}
     >
       {!hasApiKey && (
@@ -282,8 +282,8 @@ export default function AdminAgentsPage() {
         <div className="mb-6 rounded-xl border border-primary/30 bg-primary/5 p-5 text-sm text-body">
           <p className="font-medium text-heading">You haven't created any agents yet.</p>
           <p className="mt-1 text-xs">
-            UnClick is using default settings. All tools and all memory are available to every AI
-            session. Create an agent to customise what your AI can do.
+            UnClick is using default settings. All apps and all memory are available to every AI
+            session. Create a worker to customise what your AI can do.
           </p>
         </div>
       )}
@@ -300,7 +300,7 @@ export default function AdminAgentsPage() {
 
       <div className="mb-6 flex items-center justify-between">
         <p className="text-xs text-muted-foreground">
-          {agents.length} {agents.length === 1 ? "agent" : "agents"}
+          {agents.length} {agents.length === 1 ? "worker" : "workers"}
         </p>
         <button
           type="button"
@@ -308,12 +308,12 @@ export default function AdminAgentsPage() {
           className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-black transition-opacity hover:opacity-90"
         >
           <Plus className="h-4 w-4" />
-          New Agent
+          New Worker
         </button>
       </div>
 
       {loading && hasApiKey ? (
-        <p className="text-xs text-muted-foreground">Loading agents...</p>
+        <p className="text-xs text-muted-foreground">Loading workers...</p>
       ) : (
         <ul className="space-y-3">
           {agents.map((agent) => {

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -1,0 +1,143 @@
+import { Link } from "react-router-dom";
+import {
+  AppWindow,
+  Brain,
+  ClipboardCheck,
+  KeyRound,
+  LayoutDashboard,
+  Plane,
+  ReceiptText,
+  ShieldCheck,
+  Users,
+} from "lucide-react";
+
+const overview = [
+  {
+    title: "Autopilot",
+    body: "The assembly line for research, planning, building, testing, review, merge, publish, repair, and improvement.",
+    href: "/admin/autopilot",
+    icon: Plane,
+  },
+  {
+    title: "Apps",
+    body: "Built-in tools, connected apps, disabled apps, and services waiting for login or API keys.",
+    href: "/admin/tools",
+    icon: AppWindow,
+  },
+  {
+    title: "Memory",
+    body: "Saved facts, library items, chats, files, project briefs, preferences, and recall checks.",
+    href: "/admin/memory",
+    icon: Brain,
+  },
+  {
+    title: "Passport",
+    body: "The permission layer: OAuth, API keys, browser extension, password bridge, permissions, and login issues.",
+    href: "/admin/keychain",
+    icon: KeyRound,
+  },
+];
+
+const needsYou = [
+  "Review apps that need login or an API key",
+  "Check Autopilot blockers before merge or publish",
+  "Run Recall Check when an AI forgets important context",
+];
+
+export default function AdminDashboard() {
+  return (
+    <div>
+      <div className="mb-8">
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-1 text-xs font-medium text-[#61C1C4]">
+          <LayoutDashboard className="h-3.5 w-3.5" />
+          UnClick overview
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight text-white">Dashboard</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
+          A simple control panel for what UnClick knows, what it can use, what is running,
+          and what needs your attention.
+        </p>
+      </div>
+
+      <div className="mb-6 grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+        <section className="rounded-2xl border border-[#61C1C4]/25 bg-[#61C1C4]/[0.06] p-6">
+          <div className="flex items-start gap-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-[#61C1C4]/15 text-[#61C1C4]">
+              <ShieldCheck className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-white">Command and control first</h2>
+              <p className="mt-2 text-sm leading-6 text-white/60">
+                UnClick Autopilot is designed around visible approvals, proof, receipts, and a clear
+                stop path before agents can do real work.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Link to="/admin/ledger" className="rounded-md bg-[#61C1C4] px-3 py-1.5 text-xs font-semibold text-black">
+                  View Ledger
+                </Link>
+                <Link to="/admin/autopilot" className="rounded-md border border-white/10 px-3 py-1.5 text-xs font-semibold text-white/75 hover:bg-white/[0.04]">
+                  Open Autopilot
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-white/[0.06] bg-[#111] p-6">
+          <h2 className="text-sm font-semibold text-white">What needs you</h2>
+          <ul className="mt-4 space-y-3">
+            {needsYou.map((item) => (
+              <li key={item} className="flex gap-2 text-sm text-white/60">
+                <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-[#E2B93B]" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {overview.map((item) => {
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.title}
+              to={item.href}
+              className="rounded-2xl border border-white/[0.06] bg-[#111] p-5 transition-colors hover:border-[#61C1C4]/30 hover:bg-white/[0.04]"
+            >
+              <div className="mb-3 flex items-center gap-2">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#61C1C4]/10 text-[#61C1C4]">
+                  <Icon className="h-4 w-4" />
+                </div>
+                <h2 className="text-sm font-semibold text-white">{item.title}</h2>
+              </div>
+              <p className="text-sm leading-6 text-white/55">{item.body}</p>
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-3">
+        <MiniStat icon={Users} label="Workers" value="Role based" />
+        <MiniStat icon={ClipboardCheck} label="Checks" value="XPass proof" />
+        <MiniStat icon={ReceiptText} label="Ledger" value="Receipts kept" />
+      </div>
+    </div>
+  );
+}
+
+function MiniStat({ icon: Icon, label, value }: {
+  icon: typeof Users;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-4">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-white/35">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <p className="mt-2 text-sm font-semibold text-white">{value}</p>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -1,0 +1,288 @@
+import { Link } from "react-router-dom";
+import {
+  AppWindow,
+  Archive,
+  BadgeCheck,
+  BellRing,
+  Brain,
+  CheckCircle2,
+  ClipboardCheck,
+  Code2,
+  CreditCard,
+  Eye,
+  FileText,
+  FolderKanban,
+  Hammer,
+  KeyRound,
+  ListTodo,
+  MessagesSquare,
+  Microscope,
+  Plane,
+  ReceiptText,
+  RefreshCw,
+  Rocket,
+  SearchCheck,
+  ShieldCheck,
+  Tags,
+  UserCheck,
+  Users,
+  Wrench,
+} from "lucide-react";
+
+type Item = {
+  title: string;
+  body: string;
+  icon?: typeof Brain;
+  href?: string;
+  mote?: string;
+};
+
+function PageShell({
+  kicker,
+  title,
+  subtitle,
+  children,
+}: {
+  kicker?: string;
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      {kicker && (
+        <div className="mb-3 inline-flex items-center rounded-full border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-1 text-xs font-medium text-[#61C1C4]">
+          {kicker}
+        </div>
+      )}
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight text-white">{title}</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">{subtitle}</p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function TileGrid({ items }: { items: Item[] }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((item) => {
+        const Icon = item.icon ?? CheckCircle2;
+        const content = (
+          <>
+            <div className="mb-3 flex items-center gap-2">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#61C1C4]/10 text-[#61C1C4]">
+                <Icon className="h-4 w-4" />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-white">{item.title}</h2>
+                {item.mote && <p className="mt-0.5 text-[11px] text-[#E2B93B]">{item.mote}</p>}
+              </div>
+            </div>
+            <p className="text-sm leading-6 text-white/55">{item.body}</p>
+          </>
+        );
+
+        const className = "block rounded-2xl border border-white/[0.06] bg-[#111] p-5 transition-colors hover:border-[#61C1C4]/30 hover:bg-white/[0.04]";
+        return item.href ? (
+          <Link key={item.title} to={item.href} className={className}>{content}</Link>
+        ) : (
+          <div key={item.title} className={className}>{content}</div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function AdminProjects() {
+  return (
+    <PageShell
+      kicker="Work areas"
+      title="Projects"
+      subtitle="Projects are lightweight containers. They keep work together without forcing every user into a developer workflow."
+    >
+      <TileGrid
+        items={[
+          { title: "Active", body: "Current work areas UnClick can remember, organise, and run Autopilot against.", icon: FolderKanban },
+          { title: "Archived", body: "Finished or paused work areas kept for history and recall.", icon: Archive },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function AdminAutopilot() {
+  return (
+    <PageShell
+      kicker="Development and work assembly line"
+      title="Autopilot"
+      subtitle="Autopilot turns a request into a controlled path: research, plan, build, test, review, safety, merge, publish, repair, and improvement."
+    >
+      <TileGrid
+        items={[
+          { title: "Research Room", body: "Explores the idea, market, risks, options, and low-hanging fruit before work begins.", icon: Microscope },
+          { title: "Plan Room", body: "Turns research into an exact ScopePack: owned files, proof, risk, and handoff.", icon: FileText },
+          { title: "Build Room", body: "Applies tightly scoped code or content changes with ownership declared first.", icon: Hammer },
+          { title: "Test Room", body: "Runs the proof commands and records whether they passed.", icon: ClipboardCheck },
+          { title: "Review Room", body: "Checks shape, quality, clarity, and whether the change matches the request.", icon: SearchCheck },
+          { title: "Safety Room", body: "Looks for protected surfaces, stomp risk, unsafe merge state, and release blockers.", icon: ShieldCheck },
+          { title: "Merge Room", body: "Decides whether a clean, approved change can leave draft and merge.", icon: BadgeCheck },
+          { title: "Publish Room", body: "Watches deployment and publish proof after merge.", icon: Rocket },
+          { title: "Repair Room", body: "Routes failures into small repair chips instead of broad panic fixes.", icon: Wrench },
+          { title: "Improve Room", body: "Turns repeated resistance into a front-of-line improvement job.", icon: RefreshCw },
+          { title: "Wake & Retry", body: "Keeps stale jobs moving with retries, nudges, and fallback rules.", icon: BellRing, mote: "PinballWake plumbing stays internal" },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function AdminWorkers() {
+  return (
+    <PageShell
+      kicker="Worker setup and capacity"
+      title="Workers"
+      subtitle="Simple public worker names sit over the older internal fleet names. Users should see the job, not the codename."
+    >
+      <TileGrid
+        items={[
+          { title: "🧭 Coordinator", body: "Routes work, makes final safe decisions, and keeps the assembly line moving.", icon: Users },
+          { title: "🛠️ Builder", body: "Makes focused implementation changes.", icon: Hammer },
+          { title: "🧪 Tester", body: "Runs proof, checks, and repeatable test commands.", icon: ClipboardCheck },
+          { title: "🔍 Reviewer", body: "Reviews quality, clarity, and implementation shape.", icon: SearchCheck },
+          { title: "🛡️ Safety Checker", body: "Protects releases from overlap, secrets, unsafe paths, and stale proof.", icon: ShieldCheck },
+          { title: "🔬 Researcher", body: "Explores unknowns before a plan is made.", icon: Microscope },
+          { title: "📋 Planner", body: "Creates the exact work packet and ownership boundaries.", icon: FileText },
+          { title: "📣 Messenger", body: "Sends worker packets and chases missing ACKs.", icon: MessagesSquare },
+          { title: "👁️ Watcher", body: "Tracks status, proof, stale jobs, and visible changes.", icon: Eye },
+          { title: "🚀 Publisher", body: "Confirms deployment and public release proof.", icon: Rocket },
+          { title: "🩹 Repairer", body: "Fixes exact failed proof or broken workflow steps.", icon: Wrench },
+          { title: "♻️ Improver", body: "Finds recurring friction and creates improvement jobs.", icon: RefreshCw },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function AdminTodoList() {
+  return (
+    <PageShell
+      kicker="Tasks, separated from chatter"
+      title="To-Do List"
+      subtitle="Dedicated tasks belong here so the Boardroom can stay readable. Boardroom is for discussion; this is for work items."
+    >
+      <TileGrid
+        items={[
+          { title: "Open tasks", body: "Jobs waiting for a worker, owner, proof, or decision.", icon: ListTodo },
+          { title: "Blocked tasks", body: "Items that need user input, missing credentials, or a safety decision.", icon: ShieldCheck },
+          { title: "Done", body: "Completed tasks with receipts linked in the Ledger.", icon: CheckCircle2 },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function AdminChecks() {
+  return (
+    <PageShell
+      kicker="Proof and quality checks"
+      title="XPass / Checks"
+      subtitle="XPass is the check family. It proves work with receipts instead of relying on a worker saying 'done'."
+    >
+      <TileGrid
+        items={[
+          { title: "TestPass", body: "Functional and regression proof.", icon: ClipboardCheck, href: "/admin/testpass" },
+          { title: "UXPass", body: "User experience and interface checks.", icon: UserCheck },
+          { title: "SecurityPass", body: "Security and protected-surface checks.", icon: ShieldCheck },
+          { title: "LegalPass", body: "Legal/compliance wording and risk checks.", icon: FileText },
+          { title: "CopyPass", body: "Writing, messaging, and copy quality checks.", icon: FileText, href: "/admin/copypass" },
+          { title: "SEOPass", body: "Search visibility and metadata checks.", icon: SearchCheck },
+          { title: "QualityPass", body: "Public name for SlopPass-style quality checking.", icon: BadgeCheck },
+          { title: "CompliancePass", body: "Public name for EnterprisePass.", icon: ShieldCheck },
+          { title: "RotatePass", body: "Credential rotation checks, likely folding into SecurityPass later.", icon: KeyRound },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function AdminLedger() {
+  return (
+    <PageShell
+      kicker="Receipts, approvals, audit trail"
+      title="Ledger"
+      subtitle="Ledger is the flight recorder for AI work: what happened, who approved it, what proof exists, and how to recover."
+    >
+      <TileGrid
+        items={[
+          { title: "Activity", body: "What happened and when.", icon: ReceiptText, href: "/admin/activity" },
+          { title: "Approvals", body: "Trusted PASS, BLOCKER, and HOLD decisions.", icon: BadgeCheck },
+          { title: "Receipts", body: "Proof checks and completion evidence.", icon: ClipboardCheck },
+          { title: "Workers", body: "Trusted worker identity registry.", icon: Users },
+          { title: "Rollback", body: "Undo and recovery record.", icon: RefreshCw },
+          { title: "Audit", body: "Full immutable history for trust and investigation.", icon: FileText, href: "/admin/audit-log" },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function AdminBilling() {
+  return (
+    <PageShell
+      kicker="Plan and usage"
+      title="Billing"
+      subtitle="A simple place for plan, usage, seats, and invoices. Deeper payment controls can stay in Settings until needed."
+    >
+      <TileGrid
+        items={[
+          { title: "Plan", body: "Your current UnClick plan and limits.", icon: CreditCard },
+          { title: "Usage", body: "Calls, workers, checks, and account usage.", icon: ReceiptText },
+          { title: "Invoices", body: "Billing history and receipts.", icon: FileText },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function AdminAppsIntro() {
+  return (
+    <div className="mb-6 rounded-2xl border border-[#61C1C4]/20 bg-[#61C1C4]/[0.05] p-4">
+      <div className="flex items-start gap-3">
+        <AppWindow className="mt-0.5 h-4 w-4 shrink-0 text-[#61C1C4]" />
+        <div>
+          <p className="text-sm font-semibold text-white">Apps are what UnClick can use.</p>
+          <p className="mt-1 text-sm leading-6 text-white/55">
+            Built-in apps work straight away. Connected apps are approved. Turned Off apps stay quiet.
+            Needs Login and Needs API Key tell the user exactly why an app is waiting.
+          </p>
+        </div>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2 text-[11px]">
+        {["Built-In", "Connected", "Turned Off", "Needs Login", "Needs API Key", "Private Tools", "Marketplace"].map((label) => (
+          <span key={label} className="rounded-full border border-white/10 bg-black/20 px-2.5 py-1 text-white/55">
+            {label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AdminPassportIntro() {
+  return (
+    <div className="mb-6 rounded-2xl border border-[#E2B93B]/20 bg-[#E2B93B]/[0.05] p-4">
+      <div className="flex items-start gap-3">
+        <KeyRound className="mt-0.5 h-4 w-4 shrink-0 text-[#E2B93B]" />
+        <div>
+          <p className="text-sm font-semibold text-white">Passport is how UnClick gets permission.</p>
+          <p className="mt-1 text-sm leading-6 text-white/55">
+            OAuth, API keys, browser extension access, password bridge fallback, permissions,
+            and connection issues all belong here.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -55,6 +55,7 @@ import {
   type SystemCredentialProvider,
   type SystemCredentialRisk,
 } from "./systemCredentialInventory";
+import { AdminPassportIntro } from "./AdminEcosystemPages";
 
 // ─── Platform catalog ─────────────────────────────────────────────
 
@@ -666,9 +667,9 @@ export default function AdminKeychain() {
     <div>
       <div className="mb-8 flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold text-white">Connections</h1>
+          <h1 className="text-2xl font-semibold text-white">Passport</h1>
           <p className="mt-1 text-sm text-[#888]">
-            Connect services your agents can use. {credentials.length} connection{credentials.length === 1 ? "" : "s"} stored.
+            Permissions, keys, logins, and connection health. {credentials.length} connection{credentials.length === 1 ? "" : "s"} stored.
           </p>
         </div>
         <div className="flex gap-2">
@@ -676,7 +677,7 @@ export default function AdminKeychain() {
             onClick={() => { setExportOpen(true); setExportPassword(""); setExportConfirm(""); setExportError(null); }}
             className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] transition-colors hover:border-[#E2B93B]/20 hover:text-[#E2B93B]"
           >
-            Export connections
+            Export Passport
           </button>
           <button
             onClick={openAudit}
@@ -694,6 +695,8 @@ export default function AdminKeychain() {
           </button>
         </div>
       </div>
+
+      <AdminPassportIntro />
 
       {/* Encryption notice */}
       <div className="mb-6 flex items-start gap-3 rounded-xl border border-[#E2B93B]/20 bg-[#E2B93B]/5 px-4 py-3">

--- a/src/pages/admin/AdminMemory.tsx
+++ b/src/pages/admin/AdminMemory.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import { Brain } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import StorageBar from "./memory/StorageBar";
-import BrainMap from "./BrainMap";
 import ContextTab from "./memory/ContextTab";
 import FactsTab from "./memory/FactsTab";
 import SessionsTab from "./memory/SessionsTab";
@@ -11,22 +10,26 @@ import LibraryTab from "./memory/LibraryTab";
 import MemoryActivityTab from "./memory/MemoryActivityTab";
 
 const TABS = [
-  { id: "brain-map", label: "Brain Map" },
-  { id: "facts",     label: "Facts"     },
-  { id: "sessions",  label: "Sessions"  },
-  { id: "library",   label: "Library"   },
-  { id: "activity",  label: "Activity"  },
-  { id: "identity",  label: "Identity"  },
+  { id: "saved-facts",    label: "Saved Facts"    },
+  { id: "library",        label: "Library"        },
+  { id: "chats",          label: "Chats"          },
+  { id: "files-notes",    label: "Files & Notes"  },
+  { id: "project-briefs", label: "Project Briefs" },
+  { id: "preferences",    label: "Preferences"    },
+  { id: "recall-check",   label: "Recall Check"   },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
 
 // Back-compat for existing deep links that used ?tab=context
 function resolveTab(param: string | null): TabId {
-  if (param === "context") return "identity";
-  const valid: TabId[] = ["brain-map", "facts", "sessions", "library", "activity", "identity"];
+  if (param === "context" || param === "identity") return "preferences";
+  if (param === "facts") return "saved-facts";
+  if (param === "sessions") return "chats";
+  if (param === "activity" || param === "brain-map") return "recall-check";
+  const valid: TabId[] = ["saved-facts", "library", "chats", "files-notes", "project-briefs", "preferences", "recall-check"];
   if (valid.includes(param as TabId)) return param as TabId;
-  return "brain-map";
+  return "saved-facts";
 }
 
 export default function AdminMemoryPage() {
@@ -160,7 +163,7 @@ export default function AdminMemoryPage() {
           </div>
           <div>
             <h1 className="text-2xl font-semibold tracking-tight text-white">Memory</h1>
-            <p className="text-sm text-white/50">Everything UnClick remembers about you</p>
+            <p className="text-sm text-white/50">What UnClick remembers</p>
           </div>
         </div>
 
@@ -188,21 +191,20 @@ export default function AdminMemoryPage() {
         </div>
 
         {/* Tab content */}
-        {activeTab === "brain-map" && <BrainMap />}
-        {activeTab === "facts" && (
+        {activeTab === "saved-facts" && (
           <div>
             <p className="mb-4 text-sm text-white/60">
-              What UnClick remembers about you. Preferences, decisions, contacts, technical details.
-              These appear here automatically as you use UnClick. You can also add them manually.
+              Quick remembered facts. These appear automatically as you use UnClick,
+              and can be promoted into the Library when they become long-term reference material.
             </p>
             <FactsTab apiKey={accessToken} />
           </div>
         )}
-        {activeTab === "sessions" && (
+        {activeTab === "chats" && (
           <div>
             <p className="mb-4 text-sm text-white/60">
-              What happened in past conversations. Summaries, decisions made, open loops.
-              New sessions read the most recent ones so your agent picks up where you left off.
+              Conversation history and useful chat context. New sessions can read the recent
+              summaries so your AI picks up where you left off.
             </p>
             <SessionsTab apiKey={accessToken} />
           </div>
@@ -210,30 +212,47 @@ export default function AdminMemoryPage() {
         {activeTab === "library" && (
           <div>
             <p className="mb-4 text-sm text-white/60">
-              Knowledge documents stored by your agent. Reference material, guides, and notes
-              that get loaded on demand via search.
+              Curated memories with categories and tags. One memory can have many tags,
+              so UnClick can find it without duplicating it.
             </p>
             <LibraryTab apiKey={accessToken} />
           </div>
         )}
-        {activeTab === "activity" && (
+        {activeTab === "files-notes" && (
           <div>
             <p className="mb-4 text-sm text-white/60">
-              Memory activity over time. Fact growth, storage breakdown, decay signals,
-              and most-accessed items.
+              Uploaded files, notes, docs, and references. This currently uses the Library
+              storage path until the dedicated files view is split out.
             </p>
-            <MemoryActivityTab apiKey={accessToken} />
+            <LibraryTab apiKey={accessToken} />
           </div>
         )}
-        {activeTab === "identity" && (
+        {activeTab === "project-briefs" && (
+          <div>
+            <p className="mb-4 text-sm text-white/60">
+              Project-specific summaries. These are memory items tagged to projects,
+              while Memory itself stays global across UnClick.
+            </p>
+            <ContextTab apiKey={accessToken} />
+          </div>
+        )}
+        {activeTab === "preferences" && (
           <div>
             <div className="mb-4 rounded-lg border border-[#61C1C4]/30 bg-[#61C1C4]/[0.06] p-4">
               <p className="text-sm text-[#61C1C4]/90">
-                Everything here loads at the start of every AI session.
-                Think of it as your AI's permanent instructions.
+                Preferences mirror the canonical controls in You / AI Style, with project overrides later.
               </p>
             </div>
             <ContextTab apiKey={accessToken} />
+          </div>
+        )}
+        {activeTab === "recall-check" && (
+          <div>
+            <p className="mb-4 text-sm text-white/60">
+              Recall Check is an action, not a memory category. It helps test whether UnClick
+              is loading and using the right memory at the right time.
+            </p>
+            <MemoryActivityTab apiKey={accessToken} />
           </div>
         )}
     </>

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -44,8 +44,20 @@ import {
   HeartPulse,
   ShieldCheck,
   ScrollText,
-  Fish,
+  MessagesSquare,
   BellRing,
+  LayoutDashboard,
+  AppWindow,
+  FolderKanban,
+  Plane,
+  ListTodo,
+  ClipboardCheck,
+  ReceiptText,
+  CreditCard,
+  LockKeyhole,
+  Tags,
+  FileStack,
+  SlidersHorizontal,
 } from "lucide-react";
 
 function SurfaceLink({ path, label, icon: Icon, onClick, badge }: {
@@ -87,6 +99,7 @@ const ADMIN_SUBMENU = [
   { path: "/admin/pinballwake",   label: "PinballWake",           icon: BellRing    },
   { path: "/admin/moderation",    label: "Marketplace Moderation", icon: ShieldCheck },
   { path: "/admin/audit-log",     label: "Audit Log",             icon: ScrollText  },
+  { path: "/admin/brainmap",      label: "Brainmap",              icon: Sparkles    },
 ] as const;
 
 function AdminSubmenu({ onLinkClick }: { onLinkClick?: () => void }) {
@@ -135,12 +148,13 @@ function AdminSubmenu({ onLinkClick }: { onLinkClick?: () => void }) {
 }
 
 const MEMORY_TABS = [
-  { id: "brain-map", label: "Brain Map", icon: Sparkles   },
-  { id: "facts",     label: "Facts",     icon: FileText   },
-  { id: "sessions",  label: "Sessions",  icon: Clock      },
-  { id: "library",   label: "Library",   icon: BookOpen   },
-  { id: "activity",  label: "Activity",  icon: Activity   },
-  { id: "identity",  label: "Identity",  icon: Fingerprint },
+  { id: "saved-facts",    label: "Saved Facts",    icon: FileText   },
+  { id: "library",        label: "Library",        icon: BookOpen   },
+  { id: "chats",          label: "Chats",          icon: MessagesSquare },
+  { id: "files-notes",    label: "Files & Notes",  icon: FileStack  },
+  { id: "project-briefs", label: "Project Briefs", icon: FolderKanban },
+  { id: "preferences",    label: "Preferences",    icon: SlidersHorizontal },
+  { id: "recall-check",   label: "Recall Check",   icon: Fingerprint },
 ] as const;
 
 function MemoryNavItem({ onClick }: { onClick?: () => void }) {
@@ -243,19 +257,22 @@ export default function AdminShell() {
   function SidebarNav({ onLinkClick }: { onLinkClick?: () => void }) {
     return (
       <>
+        <SurfaceLink path="/admin/dashboard" label="Dashboard"               icon={LayoutDashboard} onClick={onLinkClick} />
         <SurfaceLink path="/admin/you"      label="You"                      icon={User}    onClick={onLinkClick} />
         <MemoryNavItem onClick={onLinkClick} />
-        <SurfaceLink path="/admin/fishbowl" label="Fishbowl"                 icon={Fish}     onClick={onLinkClick} />
-        <SurfaceLink path="/admin/keychain" label="Connections" icon={KeyRound} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/tools"    label="Tools"                    icon={Wrench}   onClick={onLinkClick} />
-        <SurfaceLink path="/admin/activity" label="Activity"                 icon={Activity} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/agents"       label="Agents"        icon={Bot}          onClick={onLinkClick} />
-        <SurfaceLink path="/admin/crews"        label="Crews"         icon={UsersIcon}    onClick={onLinkClick} />
-        <SurfaceLink path="/admin/testpass"     label="TestPass"      icon={FlaskConical} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/copypass"     label="CopyPass"      icon={PenSquare}    onClick={onLinkClick} />
+        <SurfaceLink path="/admin/tools"    label="Apps"                     icon={AppWindow} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/keychain" label="Passport"                 icon={KeyRound} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/projects" label="Projects"                 icon={FolderKanban} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/autopilot" label="Autopilot"               icon={Plane} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/agents"    label="Workers"                 icon={Bot} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/fishbowl"  label="Boardroom"               icon={MessagesSquare} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/todos"     label="To-Do List"              icon={ListTodo} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/checks"    label="XPass / Checks"          icon={ClipboardCheck} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/ledger"    label="Ledger"                  icon={ReceiptText} onClick={onLinkClick} />
         <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />
         {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}
         <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />
+        <SurfaceLink path="/admin/billing"  label="Billing"                  icon={CreditCard} onClick={onLinkClick} />
         {isAdmin && <AdminSubmenu onLinkClick={onLinkClick} />}
       </>
     );

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -5,6 +5,7 @@ import { useSession } from "@/lib/auth";
 import { InfoCard } from "./memory/InfoCard";
 import UnClickTools from "./tools/UnClickTools";
 import ConnectedServices from "./tools/ConnectedServices";
+import { AdminAppsIntro } from "./AdminEcosystemPages";
 
 interface Connector {
   id: string;
@@ -62,31 +63,33 @@ export default function AdminToolsPage() {
             <Wrench className="h-5 w-5 text-[#61C1C4]" />
           </div>
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight text-white">Tools</h1>
-            <p className="text-sm text-white/50">Everything your agent can use through UnClick</p>
+            <h1 className="text-2xl font-semibold tracking-tight text-white">Apps</h1>
+            <p className="text-sm text-white/50">Everything UnClick can use</p>
           </div>
         </div>
 
+        <AdminAppsIntro />
+
         {/* Section 1 - Your UnClick Tools */}
         <section className="mb-12">
-          <h2 className="mb-4 text-lg font-semibold text-white">Your UnClick Tools</h2>
+          <h2 className="mb-4 text-lg font-semibold text-white">Built-In</h2>
           <InfoCard
             id="tools-how"
-            title="How do these tools work?"
-            description="When you connect UnClick to your AI agent, it gets all these tools automatically. Your agent chooses which ones to use based on what you ask."
-            learnMore="Memory tools handle persistent context. Utility tools handle everyday tasks like formatting JSON, generating QR codes, converting timestamps. Your agent discovers and calls them as needed - no configuration required."
+            title="Ready to use"
+            description="These apps are available naturally through UnClick. Your AI can use the recommended built-in option without asking you to connect anything."
+            learnMore="Memory tools handle persistent context. Utility tools handle everyday tasks like formatting JSON, generating QR codes, converting timestamps. Your AI discovers and calls them as needed."
           />
           <UnClickTools metering={metering} />
         </section>
 
         {/* Section 2 - Connections */}
         <section className="mb-12">
-          <h2 className="mb-4 text-lg font-semibold text-white">Connections</h2>
+          <h2 className="mb-4 text-lg font-semibold text-white">Connected</h2>
           <InfoCard
             id="tools-services"
-            title="What are Connections?"
+            title="Apps you approved"
             description="Third-party platforms you have linked for your agents, like GitHub, Stripe, or Cloudflare."
-            learnMore="Connections keeps setup state, health, and encrypted secrets in one place so your agents can use approved services without you pasting keys into every run."
+            learnMore="Connected apps keep setup state, health, and encrypted secrets in Passport so your agents can use approved services without you pasting keys into every run."
           />
           <ConnectedServices connectors={connectors} loading={loading} />
         </section>
@@ -103,11 +106,11 @@ export default function AdminToolsPage() {
                 <PenSquare className="h-4 w-4 text-fuchsia-300" />
                 <h3 className="text-sm font-semibold text-white">CopyPass</h3>
                 <span className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-fuchsia-500/10 text-fuchsia-300">
-                  Pass family
+                  XPass / Checks
                 </span>
               </div>
               <p className="mt-2 text-xs text-white/50">
-                Scaffold-only MCP and admin surface for AI-generated copy review. Deterministic checks land in a later chunk.
+                Writing, messaging, and copy review checks.
               </p>
               <p className="mt-3 text-[11px] font-medium text-fuchsia-300">
                 Open CopyPass →
@@ -117,7 +120,7 @@ export default function AdminToolsPage() {
             <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-8 text-center">
               <Rocket className="mx-auto h-8 w-8 text-white/20 mb-3" />
               <p className="text-sm text-white/50">
-                Community tools and custom integrations - coming soon.
+                More apps, workers, templates, XPass checks, and private tools - coming soon.
               </p>
               <p className="mt-1 text-xs text-white/30">
                 Build your own MCP tools or install from the UnClick marketplace.

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -15,7 +15,6 @@ import {
   Mail,
   Shield,
   KeyRound,
-  Monitor,
   LogOut,
   Loader2,
   Clock,
@@ -26,6 +25,8 @@ import {
   AlertTriangle,
   Brain,
   ArrowRight,
+  SlidersHorizontal,
+  ShieldCheck,
 } from "lucide-react";
 
 // Mask a saved connection secret: first 4 chars + 8 bullets + last 4.
@@ -356,7 +357,7 @@ export default function AdminYou() {
     <div>
       <div className="mb-8">
         <h1 className="text-2xl font-semibold text-white">You</h1>
-        <p className="mt-1 text-sm text-[#888]">Identity, accounts, and devices</p>
+        <p className="mt-1 text-sm text-[#888]">Profile, AI Style, and access</p>
       </div>
 
       <ClaimKeyBanner />
@@ -382,12 +383,12 @@ export default function AdminYou() {
           </Link>
         </div>
       ) : (
-        <div className="grid gap-6 lg:grid-cols-2">
-          {/* Identity card */}
+        <div className="grid gap-6 xl:grid-cols-3">
+          {/* Profile card */}
           <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
             <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
               <User className="h-4 w-4 text-[#E2B93B]" />
-              Identity
+              Profile
             </h2>
 
             <div className="mt-4 space-y-3">
@@ -431,11 +432,38 @@ export default function AdminYou() {
             </button>
           </div>
 
-          {/* API Key card */}
+          {/* AI Style card */}
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+            <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+              <SlidersHorizontal className="h-4 w-4 text-[#E2B93B]" />
+              AI Style
+            </h2>
+            <p className="mt-4 text-sm leading-6 text-[#888]">
+              How UnClick should talk to you. These defaults mirror into Memory Preferences
+              so connected agents can carry the same tone.
+            </p>
+            <div className="mt-4 space-y-2">
+              {[
+                ["Response length", "Medium"],
+                ["Complexity", "Simple with analogies"],
+                ["Emoji level", "Light"],
+              ].map(([label, value]) => (
+                <div key={label} className="flex items-center justify-between rounded-lg bg-white/[0.03] px-3 py-2 text-xs">
+                  <span className="text-[#888]">{label}</span>
+                  <span className="text-white">{value}</span>
+                </div>
+              ))}
+            </div>
+            <p className="mt-4 text-[11px] leading-5 text-[#666]">
+              Editing controls land here first; project-specific overrides can sit beside Project Briefs later.
+            </p>
+          </div>
+
+          {/* Access card */}
           <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
             <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
               <KeyRound className="h-4 w-4 text-[#E2B93B]" />
-              API Key
+              Access
             </h2>
 
             {generatedKey ? (
@@ -543,44 +571,22 @@ export default function AdminYou() {
             )}
           </div>
 
-          {/* Devices card (full width) */}
-          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6 lg:col-span-2">
+          {/* Security pointer */}
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6 xl:col-span-3">
             <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
-              <Monitor className="h-4 w-4 text-[#E2B93B]" />
-              Paired Devices
-              <span className="ml-auto font-mono text-[11px] text-[#666]">
-                {devices.length} device{devices.length !== 1 ? "s" : ""}
-              </span>
+              <ShieldCheck className="h-4 w-4 text-[#E2B93B]" />
+              Security lives in Settings
             </h2>
-
-            {devices.length === 0 ? (
-              <div className="mt-4 rounded-lg border border-dashed border-white/[0.08] p-6 text-center">
-                <p className="text-xs text-[#666]">
-                  No paired devices yet. Devices appear here when you sign in from another browser or machine.
-                </p>
-              </div>
-            ) : (
-              <ul className="mt-4 divide-y divide-white/[0.04]">
-                {devices.map((d) => (
-                  <li key={d.id} className="flex items-center justify-between py-3">
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium text-white">
-                        {d.device_name ?? d.device_id}
-                      </p>
-                      <p className="text-[11px] text-[#666]">
-                        Paired {timeAgo(d.paired_at)} - Last seen {timeAgo(d.last_seen_at)}
-                      </p>
-                    </div>
-                    <button
-                      onClick={() => revokeDevice(d.device_id)}
-                      className="ml-4 shrink-0 rounded-md border border-red-500/20 px-2.5 py-1 text-[11px] font-medium text-red-400 transition-colors hover:bg-red-500/10"
-                    >
-                      Revoke
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
+            <p className="mt-3 text-sm leading-6 text-[#888]">
+              Paired devices, sign-in history, revoke access, and advanced security controls are kept in
+              Settings so this page stays focused on the essentials.
+            </p>
+            <Link
+              to="/admin/settings"
+              className="mt-4 inline-flex rounded-md border border-white/[0.08] px-3 py-1.5 text-xs font-semibold text-white/70 hover:bg-white/[0.04]"
+            >
+              Open Settings
+            </Link>
           </div>
 
         </div>

--- a/src/pages/admin/BrainMap.tsx
+++ b/src/pages/admin/BrainMap.tsx
@@ -1,265 +1,286 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
-import { useSession } from "@/lib/auth";
 import {
-  Zap, Heart, Clock, CheckCircle2, Circle, Monitor, Plug, Bot,
-  Fingerprint, FolderKanban, Code, Lightbulb, Wrench, MessageSquare, Save,
+  AppWindow,
+  BadgeCheck,
+  Brain,
+  CreditCard,
+  FolderKanban,
+  KeyRound,
+  LayoutDashboard,
+  ListTodo,
+  MessagesSquare,
+  Plane,
+  ReceiptText,
+  Settings,
+  ShieldAlert,
+  Sparkles,
+  Users,
 } from "lucide-react";
 
-type BootSummary = {
-  last_boot_at: string | null;
-  facts_loaded: number;
-  context_items_loaded: number;
-  sessions_loaded: number;
-  project_items_loaded: number;
+type Node = {
+  label: string;
+  note: string;
+  children?: Node[];
 };
 
-type ContextRow = { category: string };
+const TREE: Node[] = [
+  {
+    label: "Dashboard",
+    note: "simple overview of what is happening across UnClick",
+  },
+  {
+    label: "You",
+    note: "account and personal preferences",
+    children: [
+      { label: "Profile", note: "email, name, basic identity" },
+      { label: "AI Style", note: "how UnClick should talk to you" },
+      { label: "Access", note: "API key, plan, tier, account status" },
+    ],
+  },
+  {
+    label: "Memory",
+    note: "what UnClick remembers",
+    children: [
+      { label: "Saved Facts", note: "quick remembered facts" },
+      { label: "Library", note: "curated memories with categories and tags" },
+      { label: "Chats", note: "conversation history and useful chat context" },
+      { label: "Files & Notes", note: "uploaded files, notes, docs, references" },
+      { label: "Project Briefs", note: "project-specific memory summaries" },
+      { label: "Preferences", note: "mirrored preferences from You / AI Style" },
+      { label: "Recall Check", note: "action button to test recall quality" },
+    ],
+  },
+  {
+    label: "Apps",
+    note: "what UnClick can use",
+    children: [
+      { label: "Built-In", note: "works straight away" },
+      { label: "Connected", note: "apps approved by the user" },
+      { label: "Turned Off", note: "apps available but disabled" },
+      { label: "Needs Login", note: "waiting for sign-in" },
+      { label: "Needs API Key", note: "waiting for a pasted key" },
+      { label: "Private Tools", note: "plumbing only, hidden/off at first" },
+      { label: "Marketplace", note: "plumbing only, hidden/off at first" },
+    ],
+  },
+  {
+    label: "Passport",
+    note: "how UnClick gets permission",
+    children: [
+      { label: "OAuth", note: "sign in with Google, GitHub, etc." },
+      { label: "API Keys", note: "developer and service keys" },
+      { label: "Browser Extension", note: "approved browser/session access" },
+      { label: "Password Bridge", note: "fallback for username/password-only services" },
+      { label: "Permissions", note: "what each app may read/write/change" },
+      { label: "Issues", note: "broken logins, expired access, missing keys" },
+    ],
+  },
+  {
+    label: "Projects",
+    note: "work areas and containers",
+    children: [
+      { label: "Active", note: "current work" },
+      { label: "Archived", note: "finished or paused work" },
+    ],
+  },
+  {
+    label: "Autopilot",
+    note: "development and work assembly line",
+    children: [
+      { label: "Research Room", note: "explore idea, risk, feasibility" },
+      { label: "Plan Room", note: "turn work into ScopePack" },
+      { label: "Build Room", note: "make focused changes" },
+      { label: "Test Room", note: "run proof" },
+      { label: "Review Room", note: "quality and implementation check" },
+      { label: "Safety Room", note: "release safety and anti-stomp" },
+      { label: "Merge Room", note: "safe lift/merge decision" },
+      { label: "Publish Room", note: "deployment and public proof" },
+      { label: "Repair Room", note: "exact failure fixes" },
+      { label: "Improve Room", note: "turn friction into improvements" },
+      { label: "Wake & Retry", note: "stale packet retry and fallback" },
+    ],
+  },
+  {
+    label: "Workers",
+    note: "AI worker setup and capacity",
+    children: [
+      { label: "🧭 Coordinator", note: "routes and decides" },
+      { label: "🛠️ Builder", note: "implements" },
+      { label: "🧪 Tester", note: "runs proof" },
+      { label: "🔍 Reviewer", note: "reviews quality" },
+      { label: "🛡️ Safety Checker", note: "release safety" },
+      { label: "🔬 Researcher", note: "researches" },
+      { label: "📋 Planner", note: "plans" },
+      { label: "📣 Messenger", note: "sends packets" },
+      { label: "👁️ Watcher", note: "tracks status" },
+      { label: "🚀 Publisher", note: "publishes" },
+      { label: "🩹 Repairer", note: "repairs" },
+      { label: "♻️ Improver", note: "improves" },
+    ],
+  },
+  { label: "Boardroom", note: "shared worker discussion, public name for Fishbowl" },
+  { label: "To-Do List", note: "dedicated tasks separated from Boardroom chatter" },
+  {
+    label: "XPass / Checks",
+    note: "proof and quality checks",
+    children: [
+      { label: "TestPass", note: "functional proof" },
+      { label: "UXPass", note: "experience proof" },
+      { label: "SecurityPass", note: "security proof" },
+      { label: "LegalPass", note: "legal proof" },
+      { label: "CopyPass", note: "writing proof" },
+      { label: "SEOPass", note: "search proof" },
+      { label: "QualityPass", note: "public name for SlopPass-style checks" },
+      { label: "CompliancePass", note: "public name for EnterprisePass" },
+      { label: "RotatePass", note: "likely folded into SecurityPass later" },
+    ],
+  },
+  {
+    label: "Ledger",
+    note: "proof, approvals, receipts, audit trail",
+    children: [
+      { label: "Activity", note: "what happened" },
+      { label: "Approvals", note: "PASS / BLOCKER / HOLD" },
+      { label: "Receipts", note: "proof evidence" },
+      { label: "Workers", note: "trusted worker registry" },
+      { label: "Rollback", note: "undo and recovery record" },
+      { label: "Audit", note: "full immutable history" },
+    ],
+  },
+  {
+    label: "Settings",
+    note: "deeper account and system settings",
+    children: [
+      { label: "Security", note: "devices, sign-in history, revoke access" },
+      { label: "Preferences", note: "deeper preferences" },
+      { label: "Notifications", note: "alerts and updates" },
+      { label: "Advanced", note: "power-user controls" },
+    ],
+  },
+  { label: "Billing", note: "plan, usage, invoices" },
+];
 
-function timeAgo(iso: string | null): string {
-  if (!iso) return "never";
-  const ms = Date.now() - new Date(iso).getTime();
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
-}
+const INTERNAL_ADMIN = [
+  "Analytics",
+  "Codebase",
+  "Orchestrator",
+  "User Management",
+  "System Health",
+  "PinballWake",
+  "Marketplace Moderation",
+  "Audit Log",
+  "Brainmap",
+];
 
-async function tryFetch(url: string, token: string) {
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!res.ok) throw new Error(`${res.status}`);
-  return res.json();
-}
+const PUBLIC_ALIASES = [
+  ["Fishbowl", "Boardroom"],
+  ["Master", "Coordinator"],
+  ["Forge", "Builder"],
+  ["Popcorn", "Reviewer / Tester"],
+  ["Gatekeeper", "Safety Checker"],
+  ["Courier", "Messenger"],
+  ["Relay", "Watcher"],
+  ["EnterprisePass", "CompliancePass"],
+  ["SlopPass", "QualityPass"],
+];
+
+const ICONS = [
+  LayoutDashboard,
+  Users,
+  Brain,
+  AppWindow,
+  KeyRound,
+  FolderKanban,
+  Plane,
+  Users,
+  MessagesSquare,
+  ListTodo,
+  BadgeCheck,
+  ReceiptText,
+  Settings,
+  CreditCard,
+];
 
 export default function BrainMap() {
-  const { session } = useSession();
-  const [bootSummary, setBootSummary] = useState<BootSummary | null>(null);
-  const [contextRows, setContextRows] = useState<ContextRow[]>([]);
-  const [factCount, setFactCount] = useState(0);
-  const [sessionCount, setSessionCount] = useState(0);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const jwt = session?.access_token ?? "";
-    const apiKey = localStorage.getItem("unclick_api_key") ?? "";
-    const token = jwt || apiKey;
-    if (!token) {
-      setLoading(false);
-      return;
-    }
-
-    (async () => {
-      // Use allSettled so a missing admin_boot_summary doesn't block the rest
-      const [bootRes, ctxRes, factsRes, sessRes] = await Promise.allSettled([
-        tryFetch("/api/memory-admin?action=admin_boot_summary", token),
-        tryFetch("/api/memory-admin?action=business_context", token),
-        tryFetch("/api/memory-admin?action=facts", token),
-        tryFetch("/api/memory-admin?action=sessions&limit=1", token),
-      ]);
-      if (bootRes.status === "fulfilled")
-        setBootSummary(bootRes.value.data ?? bootRes.value ?? null);
-      if (ctxRes.status === "fulfilled")
-        setContextRows(ctxRes.value.data ?? []);
-      if (factsRes.status === "fulfilled")
-        setFactCount((factsRes.value.data ?? []).length);
-      if (sessRes.status === "fulfilled")
-        setSessionCount((sessRes.value.data ?? []).length);
-      setLoading(false);
-    })();
-  }, [session]);
-
-  const identityCount = useMemo(
-    () =>
-      contextRows.filter(
-        (r) =>
-          r.category === "identity" ||
-          r.category === "preference" ||
-          r.category === "standing_rule"
-      ).length,
-    [contextRows]
-  );
-  const repoCount = useMemo(
-    () => contextRows.filter((r) => r.category === "repository").length,
-    [contextRows]
-  );
-  const hasIdentity     = contextRows.some((r) => r.category === "identity");
-  const hasPreference   = contextRows.some((r) => r.category === "preference");
-  const hasStandingRule = contextRows.some((r) => r.category === "standing_rule");
-  const hasRepo         = repoCount > 0;
-  const hasFiveFacts    = factCount >= 5;
-  const hasSession      = sessionCount >= 1;
-
-  const checklist = [
-    { ok: hasIdentity,     label: "Identity set",        link: "/admin/memory?tab=identity" },
-    { ok: hasPreference,   label: "Preferences set",     link: "/admin/memory?tab=identity" },
-    { ok: hasFiveFacts,    label: "At least 5 facts",    link: "/admin/memory?tab=facts"    },
-    { ok: hasSession,      label: "A saved session",     link: "/admin/memory?tab=sessions" },
-    { ok: hasStandingRule, label: "Standing rules",      link: "/admin/memory?tab=identity" },
-    { ok: hasRepo,         label: "Repository context",  link: undefined                    },
-  ];
-  const healthPct = Math.round(
-    (checklist.filter((c) => c.ok).length / checklist.length) * 100
-  );
-
-  const bootLine = bootSummary
-    ? `Last load: ${bootSummary.facts_loaded} facts, ${bootSummary.context_items_loaded} context, ${bootSummary.sessions_loaded} sessions`
-    : "No load recorded yet";
-
-  const stages = [
-    { num: "0",  title: "Agent's Local Context", sub: "Before UnClick",     desc: "Your AI reads CLAUDE.md, .cursor/rules, or other config files from your machine before connecting.", color: "#888",     icon: Monitor  },
-    { num: "1",  title: "MCP Connection",         sub: "Handshake",          desc: "Your AI connects to UnClick via MCP. API key authenticates and identifies your account.",              color: "#61C1C4", icon: Plug     },
-    { num: "2",  title: "Agent Profile",           sub: "Who am I?",          desc: "UnClick loads the agent's persona, system prompt, and which memory layers are enabled.",              color: "#a78bfa", icon: Bot      },
-    { num: "3",  title: "Identity",                sub: "Who are you?",       desc: `Your brand, preferences, and standing rules. ${identityCount} items stored.`,                         color: "#E2B93B", icon: Fingerprint, link: "/admin/memory?tab=identity" },
-    { num: "4",  title: "Project Scope",           sub: "What are we working on?", desc: "If a project is active, project-scoped memory loads alongside global. Project wins on conflicts.", color: "#61C1C4", icon: FolderKanban },
-    { num: "5",  title: "Codebase",               sub: "How is the code shaped?",  desc: `Tech stack, deploy process, constraints, gotchas. ${repoCount} items stored.`,                  color: "#4ade80", icon: Code     },
-    { num: "6",  title: "Knowledge",              sub: "What do I know?",     desc: `Facts extracted from conversations. ${factCount} items stored.`,                                      color: "#f472b6", icon: Lightbulb, link: "/admin/memory?tab=facts" },
-    { num: "7",  title: "Sessions",               sub: "What happened recently?", desc: "Summaries of past conversations. Last 5 load at startup.",                                       color: "#fb923c", icon: Clock,   link: "/admin/memory?tab=sessions" },
-    { num: "8",  title: "Tool Guidance",           sub: "What can I use?",    desc: "Connected tools are classified: compatible, conflicting, or replaceable.",                            color: "#61C1C4", icon: Wrench   },
-    { num: "9",  title: "Brain Loaded",            sub: "Ready",              desc: bootLine,                                                                                               color: "#E2B93B", icon: Zap      },
-    { num: "10", title: "Live Session",            sub: "Working together",   desc: "Your AI searches memory on demand and saves new knowledge as it learns -- not just at session end.", color: "#4ade80", icon: MessageSquare },
-    { num: "11", title: "Session End",             sub: "Learning saved",     desc: "Summary written, new facts persisted, old facts decayed. Next session starts smarter.",              color: "#a78bfa", icon: Save     },
-  ];
-
-  const phaseLabels: Record<string, { text: string; color: string }> = {
-    "0":  { text: "PRE-BOOT",      color: "text-[#888]"     },
-    "1":  { text: "BOOT SEQUENCE", color: "text-[#61C1C4]"  },
-    "9":  { text: "READY",         color: "text-[#E2B93B]"  },
-    "10": { text: "LIVE SESSION",  color: "text-[#4ade80]"  },
-    "11": { text: "POST-SESSION",  color: "text-[#a78bfa]"  },
-  };
-
   return (
     <div>
-      <div className="mb-6 grid gap-4 lg:grid-cols-2">
-        {/* What Loaded */}
-        <div className="rounded-xl border border-[#61C1C4]/40 bg-[#111] p-5">
-          <div className="mb-1 flex items-center gap-2">
-            <Zap className="h-4 w-4 text-[#61C1C4]" />
-            <h2 className="text-sm font-semibold text-white">What Loaded</h2>
-          </div>
-          <p className="mb-4 text-xs text-[#888]">
-            What your AI loaded at the most recent session start
-          </p>
-          <div className="mb-3 grid grid-cols-3 gap-3">
-            {(
-              [
-                ["Facts",   bootSummary?.facts_loaded],
-                ["Context", bootSummary?.context_items_loaded],
-                ["Sessions",bootSummary?.sessions_loaded],
-              ] as const
-            ).map(([label, val]) => (
-              <div key={label} className="rounded-lg bg-white/[0.03] p-3">
-                <div className="text-lg font-semibold text-white">{loading ? "--" : (val ?? 0)}</div>
-                <div className="text-[10px] uppercase tracking-wide text-[#888]">{label}</div>
-              </div>
-            ))}
-          </div>
-          {!loading && (bootSummary?.project_items_loaded ?? 0) > 0 && (
-            <p className="mb-2 text-xs text-[#888]">
-              Project items: {bootSummary?.project_items_loaded}
-            </p>
-          )}
-          <p className="text-xs text-[#666]">
-            Loaded {loading ? "--" : timeAgo(bootSummary?.last_boot_at ?? null)}
-          </p>
+      <div className="mb-8">
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-3 py-1 text-xs font-medium text-[#E2B93B]">
+          <Sparkles className="h-3.5 w-3.5" />
+          Internal admin only
         </div>
-
-        {/* Memory Health */}
-        <div className="rounded-xl border border-[#E2B93B]/40 bg-[#111] p-5">
-          <div className="mb-1 flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Heart className="h-4 w-4 text-[#E2B93B]" />
-              <h2 className="text-sm font-semibold text-white">Memory Health</h2>
-            </div>
-            <span className="text-sm font-semibold text-[#E2B93B]">
-              {loading ? "--" : `${healthPct}%`}
-            </span>
-          </div>
-          <div className="mb-4 h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
-            <div
-              className="h-full bg-[#E2B93B] transition-all"
-              style={{ width: `${loading ? 0 : healthPct}%` }}
-            />
-          </div>
-          <ul className="space-y-2">
-            {checklist.map((item) => (
-              <li key={item.label} className="flex items-center justify-between text-xs">
-                <span className="flex items-center gap-2">
-                  {item.ok ? (
-                    <CheckCircle2 className="h-3.5 w-3.5 text-[#4ade80]" />
-                  ) : (
-                    <Circle className="h-3.5 w-3.5 text-[#444]" />
-                  )}
-                  <span className={item.ok ? "text-[#ccc]" : "text-[#888]"}>{item.label}</span>
-                </span>
-                {!item.ok && item.link && (
-                  <Link to={item.link} className="text-[#61C1C4] hover:underline">
-                    add
-                  </Link>
-                )}
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
-
-      {/* Timeline */}
-      <div className="mb-4">
-        <h2 className="text-lg font-semibold text-white">Memory Flow</h2>
-        <p className="text-xs text-[#888]">
-          How your AI builds its understanding, step by step.
+        <h1 className="text-2xl font-semibold tracking-tight text-white">Brainmap</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
+          The full UnClick ecosystem map. This is hidden from normal users and kept here so the
+          product language stays consistent as the system changes.
         </p>
       </div>
 
-      <div className="relative">
-        {stages.map((stage, idx) => {
-          const phase = phaseLabels[stage.num];
-          const Icon  = stage.icon;
-          const isLast = idx === stages.length - 1;
-          return (
-            <div key={stage.num}>
-              {phase && (
-                <div className={`mb-2 ml-12 text-[10px] font-bold uppercase tracking-widest ${phase.color}`}>
-                  {phase.text}
+      <div className="mb-6 grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+        <section className="rounded-2xl border border-white/[0.06] bg-[#111] p-5">
+          <h2 className="mb-4 text-sm font-semibold text-white">Public tree</h2>
+          <div className="space-y-3">
+            {TREE.map((node, index) => {
+              const Icon = ICONS[index] ?? ShieldAlert;
+              return <TreeNode key={node.label} node={node} icon={Icon} />;
+            })}
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <section className="rounded-2xl border border-[#E2B93B]/25 bg-[#E2B93B]/[0.04] p-5">
+            <h2 className="text-sm font-semibold text-[#E2B93B]">Internal Admin</h2>
+            <ul className="mt-4 space-y-2">
+              {INTERNAL_ADMIN.map((item) => (
+                <li key={item} className="text-sm text-white/60">{item}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-2xl border border-white/[0.06] bg-[#111] p-5">
+            <h2 className="text-sm font-semibold text-white">Alias table</h2>
+            <p className="mt-1 text-xs leading-5 text-white/45">
+              Public names are labels over existing automation plumbing, not destructive renames.
+            </p>
+            <div className="mt-4 space-y-2">
+              {PUBLIC_ALIASES.map(([internal, publicName]) => (
+                <div key={internal} className="flex items-center justify-between gap-3 rounded-lg bg-white/[0.03] px-3 py-2 text-xs">
+                  <span className="font-mono text-white/35">{internal}</span>
+                  <span className="text-[#61C1C4]">{publicName}</span>
                 </div>
-              )}
-              <div className="relative flex gap-4">
-                <div className="flex flex-col items-center">
-                  <div
-                    className="flex h-8 w-8 items-center justify-center rounded-full border-2 text-xs font-semibold"
-                    style={{ borderColor: stage.color, color: stage.color }}
-                  >
-                    {stage.num}
-                  </div>
-                  {!isLast && (
-                    <div className="w-0.5 flex-1 bg-gradient-to-b from-white/20 to-white/[0.04]" />
-                  )}
-                </div>
-                <div className="mb-2 flex-1 rounded-xl border border-white/[0.06] bg-[#111] p-4">
-                  <div className="flex items-center">
-                    <Icon className="mr-2 h-4 w-4" style={{ color: stage.color }} />
-                    {"link" in stage && stage.link ? (
-                      <Link
-                        to={stage.link}
-                        className="text-sm font-semibold text-[#61C1C4] hover:underline"
-                      >
-                        {stage.title}
-                      </Link>
-                    ) : (
-                      <h3 className="text-sm font-semibold text-white">{stage.title}</h3>
-                    )}
-                    <span className="ml-2 text-xs text-[#888]">{stage.sub}</span>
-                  </div>
-                  <p className="mt-1 text-xs text-[#666]">{stage.desc}</p>
-                </div>
-              </div>
+              ))}
             </div>
-          );
-        })}
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function TreeNode({ node, icon: Icon }: { node: Node; icon?: typeof Brain }) {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-white/[0.025] p-4">
+      <div className="flex items-start gap-3">
+        {Icon && (
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#61C1C4]/10 text-[#61C1C4]">
+            <Icon className="h-4 w-4" />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <h3 className="text-sm font-semibold text-white">{node.label}</h3>
+            <p className="text-xs text-white/45">{node.note}</p>
+          </div>
+          {node.children && (
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              {node.children.map((child) => (
+                <div key={child.label} className="rounded-lg border border-white/[0.04] bg-black/20 px-3 py-2">
+                  <p className="text-xs font-semibold text-white/75">{child.label}</p>
+                  <p className="mt-0.5 text-[11px] leading-4 text-white/35">{child.note}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -123,7 +123,7 @@ function ExplainerPanel({
       >
         <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
           <span aria-hidden>💡</span>
-          <span>What is the Fishbowl?</span>
+          <span>What is the Boardroom?</span>
         </span>
         {collapsed ? (
           <ChevronRight className="h-4 w-4 text-[#888]" aria-hidden />
@@ -139,7 +139,7 @@ function ExplainerPanel({
               What is this?
             </h3>
             <p>
-              Fishbowl is the group chat your AI agents use to coordinate. When something
+              Boardroom is the group chat your AI agents use to coordinate. When something
               material happens (a PR opens, a job finishes, a blocker hits, a decision is
               made), the agent posts here so other agents catch up at session start
               without you having to relay messages.
@@ -413,7 +413,7 @@ function PostBox({ disabled, onPost }: PostBoxProps) {
   return (
     <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
       <label htmlFor="fishbowl-post" className="mb-2 block text-xs font-semibold uppercase tracking-wide text-[#888]">
-        Post to your Fishbowl
+        Post to your Boardroom
       </label>
       <textarea
         id="fishbowl-post"
@@ -456,7 +456,7 @@ function PostBox({ disabled, onPost }: PostBoxProps) {
         <p className="mt-2 text-xs text-red-300">{postError}</p>
       )}
       {disabled && !postError && (
-        <p className="mt-2 text-xs text-[#666]">Setting up your Fishbowl identity...</p>
+        <p className="mt-2 text-xs text-[#666]">Setting up your Boardroom identity...</p>
       )}
     </section>
   );
@@ -635,11 +635,11 @@ export default function Fishbowl() {
         body: JSON.stringify({ limit: 100 }),
       });
       const body = (await res.json().catch(() => ({}))) as Partial<FishbowlResponse> & { error?: string };
-      if (!res.ok) throw new Error(body.error ?? "Failed to load Fishbowl");
+      if (!res.ok) throw new Error(body.error ?? "Failed to load Boardroom");
       setMessages(body.messages ?? []);
       setProfiles(body.profiles ?? []);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load Fishbowl");
+      setError(e instanceof Error ? e.message : "Failed to load Boardroom");
     } finally {
       setLoading(false);
       setFirstLoadDone(true);
@@ -696,7 +696,7 @@ export default function Fishbowl() {
       <header>
         <h1 className="flex items-center gap-2 text-2xl font-semibold text-[#ccc]">
           <span aria-hidden>🐠</span>
-          <span>Fishbowl</span>
+        <span>Boardroom</span>
         </h1>
         <p className="mt-1 text-sm text-[#888]">
           Your AI agents talking to each other. You are welcome to listen in, and to chime in.
@@ -705,7 +705,7 @@ export default function Fishbowl() {
 
       {error && (
         <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
-          <p className="font-medium">Could not load Fishbowl.</p>
+          <p className="font-medium">Could not load Boardroom.</p>
           <p className="mt-1 text-xs text-red-300/80">{error}</p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- align public/admin naming around Dashboard, You, Memory, Apps, Passport, Projects, Autopilot, Workers, Boardroom, To-Do List, XPass / Checks, Ledger, Settings, and Billing
- add a simple admin Dashboard and ecosystem placeholder surfaces for Projects, Autopilot, To-Do List, XPass / Checks, Ledger, and Billing
- move Brainmap to the internal yellow Admin menu as the full UnClick ecosystem tree and alias table
- update public labels/copy: Tools -> Apps, Connections -> Passport, Pass family -> XPass / Checks, Fishbowl -> Boardroom, Agents -> Workers

## Owner / Scope
- Owner: creativelead / Master UI taxonomy pass
- Owned files: `src/App.tsx`, `src/components/Hero.tsx`, `src/components/Navbar.tsx`, `src/components/admin/AdminShell.tsx`, `src/pages/Index.tsx`, plus the new/updated admin placeholder page modules and tests for the UI tree
- Non-overlap: public/admin label and navigation pass only; no Autopilot room logic, worker ledger logic, XPass execution, billing execution, auth execution, credential storage, or API wiring

## Protected-surface safety proof
- Billing is static placeholder/navigation only: no payment execution, no Stripe or billing API calls, no invoice mutation, no checkout/session behavior, and no billing webhook behavior
- Passport/keychain/auth-adjacent copy is static label/navigation only: no OAuth flow change, no credential behavior change, no browser extension behavior change, no password bridge behavior change, no raw keys, and no secret storage change
- No secrets, auth, billing, DNS/domains, migrations, destructive cleanup, raw keys, force-push, merge/lift automation, or release automation were added
- Internal plumbing names remain stable where renaming would break automation: Fishbowl routes/tables stay internal, PinballWake stays internal/admin, and public worker names are aliases rather than structural rewrites

## Status
- HOLD/ready for reviewer recheck: Gatekeeper/Forge protected-surface HOLD has been answered by this PR body refresh
- Still draft until Safety/Builder/Reviewer PASS confirms the refreshed proof is enough to lift

## Proof
- `npm run build` passed
- UXPass against localhost attempted but cannot fetch local-only URL from the connector
- UXPass against Vercel preview completed, but the preview returned HTTP 401 to the UXPass runner, so that score measured the protected preview/auth response rather than the actual UI
- UXPass public baseline for https://unclick.world/ completed: score 89.19, 14/16 checks passing
- GitHub checks green: Website, MCP, TestPass, Vercel, Vercel Preview Comments

## Notes
- This is a public-label/navigation pass. Internal plumbing names such as fishbowl routes and PinballWake stay stable where renaming would break automation.
- Full repo lint/test still have pre-existing failures outside this UI pass: credential inventory expectations and broad legacy lint rules.