### PR TITLE
feat(autopilot): add XPass gate room

### DIFF
--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -37,6 +37,43 @@ Core rules:
 
 In short: agents may move the work, but UnClick must keep the chain of command visible.
 
+## Worker Name Transition
+
+Use simple public worker names in UI, user-facing docs, and onboarding. Keep the existing internal lane names, emoji routing, and Fishbowl/Boardroom IDs as aliases until the automation substrate is explicitly migrated. Public names are labels; internal names are delivery addresses.
+
+| Public worker name | Emoji | Internal lane / alias | Plain role |
+| --- | --- | --- | --- |
+| Coordinator | 🧭 | Master / creativelead | Chooses priority, merge order, and owner decisions |
+| Builder | 🛠️ | Forge | Implements focused chips and opens PRs |
+| Tester | 🧪 | Proof Executor / TestPass lanes | Runs proof, tests, and test receipts |
+| Reviewer | 🔍 | Popcorn / QC | Checks user experience, scope, and final QC |
+| Safety Checker | 🛡️ | Gatekeeper | Blocks unsafe, dirty, overlapping, or risky releases |
+| Researcher | 🔬 | Research Room | Explores feasibility, options, risks, and outside ideas |
+| Planner | 📋 | Planning Room | Turns research or intent into buildable ScopePacks |
+| Messenger | 📣 | Courier | Delivers targeted handoffs without making product decisions |
+| Watcher | 👁️ | Relay / Navigator / watchers | Watches status, stale work, and proof drift |
+| Publisher | 🚀 | Publish Room | Handles publish readiness and post-publish proof |
+| Repairer | 🩹 | Repair Room | Routes failed checks or broken builds to a focused fix |
+| Improver | ♻️ | Continuous Improvement / Loop | Turns repeated friction into front-of-line improvements |
+
+Do not structurally rename database tables, MCP tools, GitHub labels, or worker agent IDs just to match public names. Rename the surface first, then migrate plumbing only with tests that prove old aliases still route correctly.
+
+## XPass Gate
+
+Autopilot should dogfood UnClick with UnClick. XPass is the conductor for that proof: it chooses the relevant Pass-family checks for a target and returns one combined receipt. It should not blindly run every Pass on every change.
+
+Selection defaults:
+
+- UI, dashboard, navigation, and admin changes select UXPass, plus visual evidence where available.
+- Tool, connector, MCP, and native endpoint changes select TestPass.
+- Auth, keys, tokens, redaction, and security-sensitive changes select SecurityPass.
+- Public wording, docs, and claims select CopyPass.
+- Public pages, metadata, sitemap, and discoverability changes select SEOPass.
+- Legal, pricing, billing copy, privacy, terms, and compliance-sensitive wording select LegalPass.
+- Code changes select QualityPass when a quality/smell receipt is useful.
+
+The gate may run in advisory mode while Pass-family coverage is still catching up. Enforcement should only turn on after the relevant Pass has a stable runner, clear receipt shape, and enough dogfood proof to avoid noisy false blockers.
+
 ## Autonomy Tiers
 
 | Tier | Meaning | Worker action |

--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -74,6 +74,34 @@ Selection defaults:
 
 The gate may run in advisory mode while Pass-family coverage is still catching up. Enforcement should only turn on after the relevant Pass has a stable runner, clear receipt shape, and enough dogfood proof to avoid noisy false blockers.
 
+## Continuous QC Project
+
+Continuous QC is now a standing Autopilot project, not a one-off cleanup. The goal is to keep running UnClick through its own proof system until the product feels coherent, visible, and trustworthy across public pages, admin pages, worker setup, Autopilot, XPass, Memory, Apps, Passport, Ledger, and Boardroom.
+
+Operating shape:
+
+- XPass Gate runs first in advisory mode and names the checks a change should receive.
+- Missing Passes are recorded as missing or skipped, never treated as PASS.
+- Continuous Improvement owns repeated QC friction and turns it into front-of-line build chips.
+- Dogfood Room owns realistic user journeys, not just isolated component checks.
+- Ledger should receive receipts for meaningful QC outcomes as the receipt surface matures.
+
+Priority order:
+
+1. Finish UXPass enough to support visual/site sweeps, screenshot evidence, console errors, obvious layout problems, navigation confusion, and mobile/desktop checks.
+2. Finish QualityPass enough to catch messy AI-build risks, weak abstractions, brittle tests, and obvious maintainability problems.
+3. Finish CopyPass enough to catch unclear product wording, old names, mixed metaphors, and overcomplicated user-facing copy.
+4. Harden SecurityPass for auth, keys, sessions, redaction, permissions, browser extension, OAuth, API keys, and Password Bridge surfaces.
+5. Add SEOPass and LegalPass when public, pricing, docs, legal, privacy, or compliance surfaces change.
+
+Enforcement path:
+
+- Phase 1: advisory only. XPass says what should run and what is missing.
+- Phase 2: enforce completed Passes only. A missing incomplete Pass is a recorded skip, not a blocker.
+- Phase 3: enforce all relevant completed Passes before merge for Autopilot, admin UI, public pages, tools/connectors, and security-sensitive surfaces.
+
+This project should bias toward fixing real user-visible confusion over inventing new dashboards. When in doubt, dogfood the current product, write down the friction, and ship the smallest improvement that removes it.
+
 ## Autonomy Tiers
 
 | Tier | Meaning | Worker action |

--- a/scripts/pinballwake-xpass-gate-room.mjs
+++ b/scripts/pinballwake-xpass-gate-room.mjs
@@ -1,0 +1,436 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const CHECK_ORDER = [
+  "testpass",
+  "uxpass",
+  "securitypass",
+  "copypass",
+  "seopass",
+  "legalpass",
+  "qualitypass",
+];
+
+const CHECK_LABELS = {
+  testpass: "TestPass",
+  uxpass: "UXPass",
+  securitypass: "SecurityPass",
+  copypass: "CopyPass",
+  seopass: "SEOPass",
+  legalpass: "LegalPass",
+  qualitypass: "QualityPass",
+};
+
+const PASS_STATUS = new Set(["pass", "passed", "success", "green", "ok"]);
+const BLOCKER_STATUS = new Set(["fail", "failed", "failure", "blocker", "blocked", "red"]);
+const SKIP_STATUS = new Set(["skip", "skipped", "not_applicable", "not-applicable"]);
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function safeList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalize(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function compactText(value, max = 500) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function normalizePath(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .trim()
+    .toLowerCase();
+}
+
+function uniq(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function hasAny(text, terms) {
+  return terms.some((term) => new RegExp(`\\b${term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i").test(text));
+}
+
+function codeFile(path) {
+  return /\.(mjs|js|cjs|ts|tsx|jsx|json|yaml|yml|css|scss|html)$/.test(path);
+}
+
+function testFile(path) {
+  return /(^|\/)(__tests__|tests?)\//.test(path) || /\.(test|spec)\.(mjs|js|ts|tsx|jsx)$/.test(path);
+}
+
+function targetText(input = {}) {
+  return [
+    input.title,
+    input.description,
+    input.context,
+    input.body,
+    input.summary,
+    input.target?.title,
+    input.target?.description,
+    ...safeList(input.tags),
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+function changedFiles(input = {}) {
+  return uniq([
+    ...safeList(input.changed_files),
+    ...safeList(input.changedFiles),
+    ...safeList(input.files),
+    ...safeList(input.owned_files),
+    ...safeList(input.ownedFiles),
+    ...safeList(input.target?.changed_files),
+    ...safeList(input.target?.files),
+  ].map(normalizePath));
+}
+
+function addReason(map, check, reason) {
+  if (!map.has(check)) map.set(check, new Set());
+  map.get(check).add(reason);
+}
+
+export function selectXPassChecks(input = {}) {
+  const files = changedFiles(input);
+  const text = targetText(input);
+  const reasons = new Map();
+  const allText = `${text} ${files.join(" ")}`;
+
+  for (const path of files) {
+    const pathWords = path.replace(/[\/_.-]+/g, " ");
+
+    if (
+      path.startsWith("packages/mcp-server/") ||
+      path.includes("/mcp") ||
+      path.endsWith("mcp.json") ||
+      path.includes("/tools/") ||
+      path.includes("connector") ||
+      path.includes("native-endpoints") ||
+      path.includes("testpass") ||
+      path.includes("uxpass")
+    ) {
+      addReason(reasons, "testpass", `tool or MCP surface: ${path}`);
+    }
+
+    if (
+      path.startsWith("src/pages/") ||
+      path.startsWith("src/components/") ||
+      path.startsWith("src/layout") ||
+      path.startsWith("src/App".toLowerCase()) ||
+      /\.(tsx|jsx|css|scss|html)$/.test(path) ||
+      path === "index.html"
+    ) {
+      addReason(reasons, "uxpass", `user interface surface: ${path}`);
+    }
+
+    if (
+      path.startsWith("public/") ||
+      path === "index.html" ||
+      path.includes("landing") ||
+      path.includes("homepage") ||
+      hasAny(pathWords, ["seo", "meta", "sitemap", "robots"])
+    ) {
+      addReason(reasons, "seopass", `public/SEO surface: ${path}`);
+    }
+
+    if (
+      /\.(md|mdx|txt)$/.test(path) ||
+      path.includes("copy") ||
+      path.includes("homepage") ||
+      path.includes("landing") ||
+      path.includes("pricing") ||
+      path.includes("docs/")
+    ) {
+      addReason(reasons, "copypass", `copy or docs surface: ${path}`);
+    }
+
+    if (
+      path.includes("legal") ||
+      path.includes("terms") ||
+      path.includes("privacy") ||
+      path.includes("license") ||
+      path.includes("billing") ||
+      path.includes("pricing") ||
+      path.includes("subprocessor") ||
+      path.includes("dpa")
+    ) {
+      addReason(reasons, "legalpass", `legal or commercial surface: ${path}`);
+    }
+
+    if (
+      path.includes("auth") ||
+      path.includes("oauth") ||
+      path.includes("session") ||
+      path.includes("password") ||
+      path.includes("passkey") ||
+      path.includes("keychain") ||
+      path.includes("credential") ||
+      path.includes("token") ||
+      path.includes("secret") ||
+      path.includes("security") ||
+      path.includes("redaction") ||
+      path.includes("sanitize") ||
+      path.includes("csrf") ||
+      path.includes("csp") ||
+      path.includes("rls") ||
+      path.includes("supabase/migrations")
+    ) {
+      addReason(reasons, "securitypass", `security-sensitive surface: ${path}`);
+    }
+
+    if (codeFile(path) && !testFile(path)) {
+      addReason(reasons, "qualitypass", `code quality surface: ${path}`);
+    }
+  }
+
+  if (hasAny(allText, ["mcp", "tool", "tools", "connector", "connectors", "api endpoint", "native endpoint"])) {
+    addReason(reasons, "testpass", "target text mentions tools/connectors/MCP");
+  }
+  if (hasAny(allText, ["ui", "ux", "visual", "screen", "screenshots", "navigation", "dashboard", "admin"])) {
+    addReason(reasons, "uxpass", "target text mentions UI/UX/visual changes");
+  }
+  if (hasAny(allText, ["security", "auth", "oauth", "credential", "credentials", "token", "tokens", "secret", "secrets", "key", "keys", "password", "redaction"])) {
+    addReason(reasons, "securitypass", "target text mentions security/auth/keys");
+  }
+  if (hasAny(allText, ["copy", "wording", "homepage", "landing", "docs", "faq", "marketing", "public claim", "public claims"])) {
+    addReason(reasons, "copypass", "target text mentions copy/docs/claims");
+  }
+  if (hasAny(allText, ["seo", "search", "meta", "sitemap", "robots"])) {
+    addReason(reasons, "seopass", "target text mentions SEO");
+  }
+  if (hasAny(allText, ["legal", "privacy", "terms", "license", "pricing", "billing", "invoice", "subprocessor", "compliance"])) {
+    addReason(reasons, "legalpass", "target text mentions legal/commercial risk");
+  }
+  if (hasAny(allText, ["quality", "slop", "refactor", "code smell", "bug", "bugfix"])) {
+    addReason(reasons, "qualitypass", "target text mentions quality or code risk");
+  }
+
+  return CHECK_ORDER
+    .filter((check) => reasons.has(check))
+    .map((check) => ({
+      check,
+      name: CHECK_LABELS[check],
+      reasons: [...reasons.get(check)],
+    }));
+}
+
+function normalizeCheckName(value) {
+  const key = normalize(value).replace(/[\s_-]+/g, "");
+  if (key === "sloppass") return "qualitypass";
+  if (key === "quality") return "qualitypass";
+  return CHECK_ORDER.find((check) => check === key || CHECK_LABELS[check].toLowerCase() === key) || key;
+}
+
+function normalizePassResult(result = {}) {
+  const check = normalizeCheckName(result.check || result.name || result.id || result.pass);
+  const status = normalize(result.status || result.result || result.verdict || "");
+  let normalized = "missing";
+  if (PASS_STATUS.has(status)) normalized = "passed";
+  if (BLOCKER_STATUS.has(status)) normalized = "blocker";
+  if (SKIP_STATUS.has(status)) normalized = "skipped";
+
+  return {
+    check,
+    name: CHECK_LABELS[check] || compactText(result.name || check, 80),
+    status: normalized,
+    raw_status: status || null,
+    run_id: compactText(result.run_id || result.runId || result.receipt_id || result.receiptId || "", 160),
+    url: compactText(result.url || result.target_url || result.targetUrl || result.details_url || result.detailsUrl || "", 500),
+    summary: compactText(result.summary || result.message || "", 500),
+    generated_at: result.generated_at || result.generatedAt || null,
+    target_sha: compactText(result.target_sha || result.targetSha || result.head_sha || result.headSha || "", 80),
+  };
+}
+
+function resultMap(passResults = []) {
+  if (Array.isArray(passResults)) {
+    return new Map(passResults.map((result) => {
+      const normalized = normalizePassResult(result);
+      return [normalized.check, normalized];
+    }));
+  }
+  if (passResults && typeof passResults === "object") {
+    return new Map(Object.entries(passResults).map(([check, result]) => {
+      const normalized = normalizePassResult({ check, ...(result || {}) });
+      return [normalized.check, normalized];
+    }));
+  }
+  return new Map();
+}
+
+function target(input = {}) {
+  const value = input.target || {};
+  return {
+    type: compactText(value.type || input.target_type || input.targetType || "change", 80),
+    id: compactText(value.id || value.pr_number || value.prNumber || input.pr_number || input.prNumber || input.id || "", 160),
+    sha: compactText(value.sha || value.head_sha || value.headSha || input.sha || input.head_sha || input.headSha || "", 80),
+    url: compactText(value.url || input.url || "", 500),
+  };
+}
+
+function isStaleForTarget(result, inspectedTarget) {
+  return Boolean(result?.target_sha && inspectedTarget?.sha && result.target_sha !== inspectedTarget.sha);
+}
+
+function makeReceipt({
+  inspectedTarget,
+  selected,
+  provided,
+  missing,
+  blockers,
+  stale,
+  skipped,
+  now,
+}) {
+  return {
+    kind: "xpass_receipt",
+    generated_at: now,
+    target: inspectedTarget,
+    checks_selected: selected.map((check) => ({
+      check: check.check,
+      name: check.name,
+      reasons: check.reasons,
+    })),
+    checks_skipped: skipped,
+    evidence: provided.map((result) => ({
+      check: result.check,
+      name: result.name,
+      status: result.status,
+      run_id: result.run_id || null,
+      url: result.url || null,
+      summary: result.summary || null,
+      target_sha: result.target_sha || null,
+    })),
+    action_needed: [
+      ...missing.map((check) => `Run ${CHECK_LABELS[check] || check}.`),
+      ...blockers.map((result) => `${result.name} returned ${result.status}.`),
+      ...stale.map((result) => `${result.name} receipt is stale for this target.`),
+    ],
+    staleness: {
+      stale_checks: stale.map((result) => result.check),
+      target_sha: inspectedTarget.sha || null,
+    },
+  };
+}
+
+export function evaluateXPassGate(input = {}) {
+  const mode = normalize(input.mode || "advisory");
+  const enforce = mode === "enforce" || input.enforce === true;
+  const now = input.now || new Date().toISOString();
+  const inspectedTarget = target(input);
+  const selected = selectXPassChecks(input);
+  const selectedChecks = selected.map((check) => check.check);
+  const available = new Set(safeList(input.available_checks || input.availableChecks).map(normalizeCheckName));
+  const hasAvailability = available.size > 0;
+  const results = resultMap(input.pass_results || input.passResults || input.results);
+
+  const skipped = [];
+  const missing = [];
+  const provided = [];
+  const blockers = [];
+  const stale = [];
+
+  for (const selectedCheck of selectedChecks) {
+    if (hasAvailability && !available.has(selectedCheck)) {
+      skipped.push({
+        check: selectedCheck,
+        name: CHECK_LABELS[selectedCheck],
+        reason: "pass_not_available",
+      });
+      continue;
+    }
+
+    const result = results.get(selectedCheck);
+    if (!result) {
+      missing.push(selectedCheck);
+      continue;
+    }
+
+    provided.push(result);
+    if (result.status === "blocker") blockers.push(result);
+    if (result.status === "missing") missing.push(selectedCheck);
+    if (isStaleForTarget(result, inspectedTarget)) stale.push(result);
+    if (result.status === "skipped") {
+      skipped.push({
+        check: selectedCheck,
+        name: CHECK_LABELS[selectedCheck],
+        reason: result.summary || "pass_result_skipped",
+      });
+    }
+  }
+
+  const receipt = makeReceipt({
+    inspectedTarget,
+    selected,
+    provided,
+    missing: uniq(missing),
+    blockers,
+    stale,
+    skipped,
+    now,
+  });
+
+  const hardIssues = blockers.length + stale.length;
+  const missingCount = uniq(missing).length;
+  const issueCount = hardIssues + missingCount;
+  const ok = enforce ? issueCount === 0 : hardIssues === 0;
+  const result = selected.length === 0
+    ? "no_relevant_checks"
+    : issueCount === 0
+      ? "passed"
+      : hardIssues > 0
+        ? "blocker"
+        : "xpass_needed";
+
+  return {
+    ok,
+    action: "xpass_gate_room",
+    mode: enforce ? "enforce" : "advisory",
+    result,
+    reason: selected.length === 0
+      ? "no_relevant_pass_family_checks"
+      : result === "passed"
+        ? "xpass_receipt_green"
+        : result === "xpass_needed"
+          ? "missing_relevant_pass_results"
+          : blockers.length
+            ? "pass_result_blocker"
+            : "stale_pass_result",
+    target: inspectedTarget,
+    selected_checks: selected,
+    missing_checks: uniq(missing),
+    blocked_checks: blockers.map((result) => result.check),
+    stale_checks: stale.map((result) => result.check),
+    skipped_checks: skipped,
+    receipt,
+  };
+}
+
+export async function readXPassGateInput(filePath) {
+  if (!filePath) return { ok: false, reason: "missing_input_path" };
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  readXPassGateInput(getArg("input", process.env.PINBALLWAKE_XPASS_GATE_INPUT || ""))
+    .then((input) => evaluateXPassGate(input))
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-xpass-gate-room.mjs
+++ b/scripts/pinballwake-xpass-gate-room.mjs
@@ -283,6 +283,10 @@ function isStaleForTarget(result, inspectedTarget) {
   return Boolean(result?.target_sha && inspectedTarget?.sha && result.target_sha !== inspectedTarget.sha);
 }
 
+function isUnscopedForTarget(result, inspectedTarget) {
+  return Boolean(result && inspectedTarget?.sha && !result.target_sha);
+}
+
 function makeReceipt({
   inspectedTarget,
   selected,
@@ -290,6 +294,7 @@ function makeReceipt({
   missing,
   blockers,
   stale,
+  unscoped,
   skipped,
   now,
 }) {
@@ -316,9 +321,11 @@ function makeReceipt({
       ...missing.map((check) => `Run ${CHECK_LABELS[check] || check}.`),
       ...blockers.map((result) => `${result.name} returned ${result.status}.`),
       ...stale.map((result) => `${result.name} receipt is stale for this target.`),
+      ...unscoped.map((result) => `${result.name} receipt is missing target scope for this target.`),
     ],
     staleness: {
       stale_checks: stale.map((result) => result.check),
+      unscoped_checks: unscoped.map((result) => result.check),
       target_sha: inspectedTarget.sha || null,
     },
   };
@@ -340,6 +347,7 @@ export function evaluateXPassGate(input = {}) {
   const provided = [];
   const blockers = [];
   const stale = [];
+  const unscoped = [];
 
   for (const selectedCheck of selectedChecks) {
     if (hasAvailability && !available.has(selectedCheck)) {
@@ -361,6 +369,7 @@ export function evaluateXPassGate(input = {}) {
     if (result.status === "blocker") blockers.push(result);
     if (result.status === "missing") missing.push(selectedCheck);
     if (isStaleForTarget(result, inspectedTarget)) stale.push(result);
+    if (isUnscopedForTarget(result, inspectedTarget)) unscoped.push(result);
     if (result.status === "skipped") {
       skipped.push({
         check: selectedCheck,
@@ -377,11 +386,12 @@ export function evaluateXPassGate(input = {}) {
     missing: uniq(missing),
     blockers,
     stale,
+    unscoped,
     skipped,
     now,
   });
 
-  const hardIssues = blockers.length + stale.length;
+  const hardIssues = blockers.length + stale.length + unscoped.length;
   const missingCount = uniq(missing).length;
   const issueCount = hardIssues + missingCount;
   const ok = enforce ? issueCount === 0 : hardIssues === 0;
@@ -406,12 +416,15 @@ export function evaluateXPassGate(input = {}) {
           ? "missing_relevant_pass_results"
           : blockers.length
             ? "pass_result_blocker"
-            : "stale_pass_result",
+            : stale.length
+              ? "stale_pass_result"
+              : "unscoped_pass_result",
     target: inspectedTarget,
     selected_checks: selected,
     missing_checks: uniq(missing),
     blocked_checks: blockers.map((result) => result.check),
     stale_checks: stale.map((result) => result.check),
+    unscoped_checks: unscoped.map((result) => result.check),
     skipped_checks: skipped,
     receipt,
   };

--- a/scripts/pinballwake-xpass-gate-room.test.mjs
+++ b/scripts/pinballwake-xpass-gate-room.test.mjs
@@ -100,6 +100,25 @@ describe("PinballWake XPass Gate Room", () => {
     assert.deepEqual(result.receipt.action_needed, []);
   });
 
+  it("blocks unscoped receipts that do not name the target head", () => {
+    const result = evaluateXPassGate({
+      mode: "enforce",
+      target: { type: "pr", id: 547, sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "UXPass", status: "passed", run_id: "ux-1" },
+        { check: "QualityPass", status: "passed", run_id: "quality-1", target_sha: "abc123" },
+      ],
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.result, "blocker");
+    assert.equal(result.reason, "unscoped_pass_result");
+    assert.deepEqual(result.unscoped_checks, ["uxpass"]);
+    assert.deepEqual(result.receipt.staleness.unscoped_checks, ["uxpass"]);
+    assert.match(result.receipt.action_needed.join("\n"), /UXPass receipt is missing target scope/);
+  });
+
   it("blocks stale receipts that were generated for another head", () => {
     const result = evaluateXPassGate({
       mode: "advisory",

--- a/scripts/pinballwake-xpass-gate-room.test.mjs
+++ b/scripts/pinballwake-xpass-gate-room.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  evaluateXPassGate,
+  selectXPassChecks,
+} from "./pinballwake-xpass-gate-room.mjs";
+
+function checks(input) {
+  return selectXPassChecks(input).map((check) => check.check);
+}
+
+describe("PinballWake XPass Gate Room", () => {
+  it("routes UI/admin/navigation changes to UXPass and QualityPass", () => {
+    const selected = checks({
+      title: "UI navigation polish",
+      changed_files: ["src/pages/admin/AdminShell.tsx", "src/components/Nav.tsx"],
+    });
+
+    assert.deepEqual(selected, ["uxpass", "qualitypass"]);
+  });
+
+  it("routes MCP/tool changes to TestPass and QualityPass", () => {
+    const selected = checks({
+      title: "Add connector tool",
+      changed_files: ["packages/mcp-server/src/weather-tool.ts"],
+    });
+
+    assert.deepEqual(selected, ["testpass", "qualitypass"]);
+  });
+
+  it("routes auth, key, and redaction changes to SecurityPass", () => {
+    const selected = checks({
+      title: "Harden keychain token redaction",
+      changed_files: ["src/lib/keychain/token-redaction.ts"],
+    });
+
+    assert.ok(selected.includes("securitypass"));
+    assert.ok(selected.includes("qualitypass"));
+  });
+
+  it("routes legal, pricing, and public claim copy to LegalPass and CopyPass", () => {
+    const selected = checks({
+      title: "Pricing page public claims",
+      changed_files: ["docs/pricing.md", "docs/legal/terms.md"],
+    });
+
+    assert.ok(selected.includes("copypass"));
+    assert.ok(selected.includes("legalpass"));
+  });
+
+  it("does not select every pass for a tiny docs-only wording change", () => {
+    const selected = checks({
+      title: "FAQ wording cleanup",
+      changed_files: ["docs/faq.md"],
+    });
+
+    assert.deepEqual(selected, ["copypass"]);
+  });
+
+  it("returns advisory xpass_needed when selected checks have no receipts yet", () => {
+    const result = evaluateXPassGate({
+      mode: "advisory",
+      target: { type: "pr", id: 547, sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "xpass_needed");
+    assert.deepEqual(result.missing_checks, ["uxpass", "qualitypass"]);
+    assert.equal(result.receipt.action_needed.length, 2);
+  });
+
+  it("blocks missing receipts in enforce mode", () => {
+    const result = evaluateXPassGate({
+      mode: "enforce",
+      target: { type: "pr", id: 547, sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.result, "xpass_needed");
+    assert.deepEqual(result.missing_checks, ["uxpass", "qualitypass"]);
+  });
+
+  it("passes when all selected receipts are current and green", () => {
+    const result = evaluateXPassGate({
+      mode: "enforce",
+      target: { type: "pr", id: 547, sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "UXPass", status: "passed", run_id: "ux-1", target_sha: "abc123", url: "https://example.test/ux" },
+        { check: "QualityPass", status: "green", run_id: "quality-1", target_sha: "abc123" },
+      ],
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "passed");
+    assert.equal(result.receipt.evidence.length, 2);
+    assert.deepEqual(result.receipt.action_needed, []);
+  });
+
+  it("blocks stale receipts that were generated for another head", () => {
+    const result = evaluateXPassGate({
+      mode: "advisory",
+      target: { type: "pr", id: 547, sha: "new-head" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "UXPass", status: "passed", run_id: "ux-1", target_sha: "old-head" },
+        { check: "QualityPass", status: "passed", run_id: "quality-1", target_sha: "new-head" },
+      ],
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.result, "blocker");
+    assert.deepEqual(result.stale_checks, ["uxpass"]);
+  });
+
+  it("blocks failed pass results", () => {
+    const result = evaluateXPassGate({
+      target: { type: "pr", id: 547, sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "uxpass", status: "failed", run_id: "ux-1", target_sha: "abc123" },
+        { check: "qualitypass", status: "passed", run_id: "quality-1", target_sha: "abc123" },
+      ],
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.result, "blocker");
+    assert.deepEqual(result.blocked_checks, ["uxpass"]);
+  });
+
+  it("records unavailable pass-family checks as explicit skips", () => {
+    const result = evaluateXPassGate({
+      mode: "enforce",
+      target: { type: "pr", id: 547, sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      available_checks: ["uxpass"],
+      pass_results: [
+        { check: "uxpass", status: "passed", run_id: "ux-1", target_sha: "abc123" },
+      ],
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "passed");
+    assert.deepEqual(result.skipped_checks, [
+      { check: "qualitypass", name: "QualityPass", reason: "pass_not_available" },
+    ]);
+  });
+
+  it("normalizes SlopPass receipts into public QualityPass", () => {
+    const result = evaluateXPassGate({
+      mode: "enforce",
+      target: { type: "pr", id: 547, sha: "abc123" },
+      changed_files: ["scripts/pinballwake-xpass-gate-room.mjs"],
+      pass_results: [
+        { check: "SlopPass", status: "passed", run_id: "slop-1", target_sha: "abc123" },
+      ],
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.receipt.evidence[0].check, "qualitypass");
+    assert.equal(result.receipt.evidence[0].name, "QualityPass");
+  });
+});


### PR DESCRIPTION
## Summary
- adds a new PinballWake XPass Gate Room that selects relevant Pass-family checks for a change instead of running every pass blindly
- emits a combined XPass receipt with selected checks, missing checks, skipped checks, stale receipts, unscoped receipts, blockers, and evidence
- documents the public worker-name transition while preserving internal aliases like Master/Forge/Popcorn/Gatekeeper
- fixes the latest-head blocker by rejecting receipts that do not name the target head when the target has a SHA

## Scope
Owned files:
- AUTOPILOT.md
- scripts/pinballwake-xpass-gate-room.mjs
- scripts/pinballwake-xpass-gate-room.test.mjs

This is advisory/control-plane only. It does not execute pass runners, mutate GitHub, merge, publish, touch secrets/auth/billing/DNS/migrations, or rename internal worker IDs.

## Proof
- node --test scripts\\pinballwake-xpass-gate-room.test.mjs: 13/13
- node --test scripts\\pinballwake-*room.test.mjs: 133/133
- git diff --check: passed

## Notes
The gate supports advisory mode now and enforce mode later. Enforcement should wait until each selected Pass has a stable runner and receipt shape.