### PR TITLE
feat(uxpass): add site sweep dogfood receipt

### DIFF
--- a/.github/workflows/dogfood-report.yml
+++ b/.github/workflows/dogfood-report.yml
@@ -13,6 +13,10 @@ on:
         description: MCP endpoint URL for TestPass.
         required: false
         default: https://unclick.world/api/mcp
+      site_sweep_urls:
+        description: Comma-separated URLs for the UXPass site sweep.
+        required: false
+        default: https://unclick.world,https://unclick.world/dashboard,https://unclick.world/admin/you
 
 permissions:
   contents: write
@@ -39,11 +43,21 @@ jobs:
           DOGFOOD_UXPASS_TOKEN: ${{ secrets.UXPASS_TOKEN || secrets.CRON_SECRET }}
         run: node scripts/build-dogfood-report.mjs
 
+      - name: Build UXPass site sweep receipt
+        env:
+          DOGFOOD_API_BASE: https://unclick.world
+          DOGFOOD_PUBLIC_URL: ${{ inputs.public_url || 'https://unclick.world' }}
+          UXPASS_SITE_SWEEP_URLS: ${{ inputs.site_sweep_urls || 'https://unclick.world,https://unclick.world/dashboard,https://unclick.world/admin/you' }}
+          UXPASS_SITE_SWEEP_TOKEN: ${{ secrets.UXPASS_TOKEN || secrets.CRON_SECRET }}
+        run: node scripts/uxpass-site-sweep.mjs --output public/dogfood/uxpass-site-sweep.json --target-sha "$GITHUB_SHA" --allow-non-passing
+
       - name: Upload receipt artifact
         uses: actions/upload-artifact@v4
         with:
           name: dogfood-latest
-          path: public/dogfood/latest.json
+          path: |
+            public/dogfood/latest.json
+            public/dogfood/uxpass-site-sweep.json
 
       - name: Summarize receipt
         shell: bash
@@ -55,10 +69,13 @@ jobs:
             echo "- Status: \`$(jq -r '.status // \"unknown\"' public/dogfood/latest.json)\`"
             echo "- Source: \`$(jq -r '.source // \"unknown\"' public/dogfood/latest.json)\`"
             echo "- Output: \`public/dogfood/latest.json\`"
+            echo "- UXPass site sweep: \`$(jq -r '.status // \"unknown\"' public/dogfood/uxpass-site-sweep.json)\` across \`$(jq -r '.targets | length' public/dogfood/uxpass-site-sweep.json)\` URL(s)"
             echo "- Public URL: \`${{ inputs.public_url || 'https://unclick.world' }}\`"
             echo "- MCP URL: \`${{ inputs.mcp_url || 'https://unclick.world/api/mcp' }}\`"
             echo ""
             jq -r '.results[] | "- \(.name): \(.status) - \(.summary)\(if .blockedReason then " Blocked reason: \(.blockedReason)" else "" end)"' public/dogfood/latest.json
+            echo ""
+            jq -r '.targets[] | "- UXPass sweep \(.url): \(.status) - \(.summary)"' public/dogfood/uxpass-site-sweep.json
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit public receipt
@@ -66,7 +83,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add public/dogfood/latest.json
+          git add public/dogfood/latest.json public/dogfood/uxpass-site-sweep.json
           if git diff --cached --quiet; then
             echo "Dogfood receipt unchanged."
             exit 0

--- a/.github/workflows/dogfood-report.yml
+++ b/.github/workflows/dogfood-report.yml
@@ -48,6 +48,7 @@ jobs:
           DOGFOOD_API_BASE: https://unclick.world
           DOGFOOD_PUBLIC_URL: ${{ inputs.public_url || 'https://unclick.world' }}
           UXPASS_SITE_SWEEP_URLS: ${{ inputs.site_sweep_urls || 'https://unclick.world,https://unclick.world/dashboard,https://unclick.world/admin/you' }}
+          UXPASS_SITE_SWEEP_ALLOWED_ORIGINS: https://unclick.world,https://www.unclick.world
           UXPASS_SITE_SWEEP_TOKEN: ${{ secrets.UXPASS_TOKEN || secrets.CRON_SECRET }}
         run: node scripts/uxpass-site-sweep.mjs --output public/dogfood/uxpass-site-sweep.json --target-sha "$GITHUB_SHA" --allow-non-passing
 

--- a/scripts/uxpass-site-sweep.mjs
+++ b/scripts/uxpass-site-sweep.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_PATHS = ["/", "/dashboard", "/admin/you"];
+const DEFAULT_MIN_SCORE = 80;
+
+function argValue(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  if (found) return found.slice(prefix.length);
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] ?? fallback : fallback;
+}
+
+function argValues(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg.startsWith(prefix)) values.push(arg.slice(prefix.length));
+    if (arg === `--${name}` && process.argv[index + 1]) values.push(process.argv[index + 1]);
+  }
+  return values;
+}
+
+function trimTrailingSlash(value) {
+  return String(value ?? "").replace(/\/+$/, "");
+}
+
+function splitList(value) {
+  return String(value ?? "")
+    .split(/[\n,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function compactText(value, max = 500) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export function resolveSweepTargets({ publicUrl, urls = [] } = {}) {
+  const base = trimTrailingSlash(publicUrl || "https://unclick.world");
+  const requested = unique(urls.length > 0 ? urls : DEFAULT_PATHS);
+  return requested.map((url) => new URL(url, `${base}/`).toString());
+}
+
+async function postJson(fetchImpl, url, token, body) {
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  let json = {};
+  try {
+    json = await res.json();
+  } catch {
+    json = {};
+  }
+
+  return { ok: res.ok, status: res.status, json };
+}
+
+function statusFromTargets(targets) {
+  if (targets.some((target) => target.status === "failing")) return "failing";
+  if (targets.some((target) => target.status === "blocked")) return "blocked";
+  if (targets.some((target) => target.status === "pending")) return "pending";
+  return "passing";
+}
+
+function actionNeeded(targets) {
+  return targets
+    .filter((target) => target.status === "failing" || target.status === "blocked")
+    .map((target) => `${target.url}: ${target.summary}`);
+}
+
+function dryRunTarget(url, targetSha) {
+  const runId = `dry-uxpass-${Buffer.from(url).toString("hex").slice(0, 12)}`;
+  return {
+    url,
+    status: "passing",
+    run_id: runId,
+    ux_score: 100,
+    summary: "Dry-run site sweep validated the UXPass sweep receipt shape.",
+    proof: {
+      kind: "uxpass_run",
+      runId,
+      targetUrl: url,
+      target_sha: targetSha || null,
+    },
+  };
+}
+
+export async function runUxPassSiteSweep({
+  apiBase = "https://unclick.world",
+  publicUrl = "https://unclick.world",
+  urls = [],
+  token = "",
+  targetSha = "",
+  minScore = DEFAULT_MIN_SCORE,
+  dryRun = false,
+  now = new Date().toISOString(),
+  fetchImpl = fetch,
+} = {}) {
+  const targets = resolveSweepTargets({ publicUrl, urls });
+  const apiUrl = `${trimTrailingSlash(apiBase)}/api/uxpass-run`;
+
+  if (dryRun) {
+    const dryTargets = targets.map((url) => dryRunTarget(url, targetSha));
+    return {
+      kind: "uxpass_site_sweep_receipt",
+      generated_at: now,
+      status: "passing",
+      target_sha: targetSha || null,
+      min_score: minScore,
+      targets: dryTargets,
+      action_needed: [],
+      summary: `Dry-run UXPass site sweep covered ${dryTargets.length} URL(s).`,
+    };
+  }
+
+  if (!token) {
+    const blockedTargets = targets.map((url) => ({
+      url,
+      status: "blocked",
+      run_id: null,
+      ux_score: null,
+      summary: "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      proof: null,
+    }));
+    return {
+      kind: "uxpass_site_sweep_receipt",
+      generated_at: now,
+      status: "blocked",
+      target_sha: targetSha || null,
+      min_score: minScore,
+      targets: blockedTargets,
+      action_needed: actionNeeded(blockedTargets),
+      summary: "UXPass site sweep could not run because no token was available.",
+    };
+  }
+
+  const sweptTargets = [];
+  for (const url of targets) {
+    try {
+      const { ok, status, json } = await postJson(fetchImpl, apiUrl, token, {
+        url,
+        target_url: url,
+        source: "site_sweep",
+        target_sha: targetSha || undefined,
+      });
+
+      const runId = compactText(json.run_id || "", 160);
+      const uxScore = typeof json.ux_score === "number" ? json.ux_score : null;
+      const passed = ok && json.status === "complete" && (uxScore === null || uxScore >= minScore);
+      sweptTargets.push({
+        url,
+        status: passed ? "passing" : "failing",
+        run_id: runId || null,
+        ux_score: uxScore,
+        summary: passed
+          ? `UXPass completed${uxScore === null ? "" : ` with score ${uxScore}`}.`
+          : `UXPass returned HTTP ${status}, status ${json.status || "unknown"}${uxScore === null ? "" : `, score ${uxScore}`}.`,
+        proof: runId
+          ? {
+              kind: "uxpass_run",
+              runId,
+              targetUrl: url,
+              target_sha: targetSha || null,
+            }
+          : null,
+      });
+    } catch (error) {
+      sweptTargets.push({
+        url,
+        status: "failing",
+        run_id: null,
+        ux_score: null,
+        summary: `UXPass site sweep could not reach the API: ${error instanceof Error ? error.message : String(error)}`,
+        proof: null,
+      });
+    }
+  }
+
+  const status = statusFromTargets(sweptTargets);
+  return {
+    kind: "uxpass_site_sweep_receipt",
+    generated_at: now,
+    status,
+    target_sha: targetSha || null,
+    min_score: minScore,
+    targets: sweptTargets,
+    action_needed: actionNeeded(sweptTargets),
+    summary: `UXPass site sweep ${status} across ${sweptTargets.length} URL(s).`,
+  };
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  const dryRun = process.argv.includes("--dry-run") || process.env.UXPASS_SITE_SWEEP_DRY_RUN === "1";
+  const allowNonPassing = process.argv.includes("--allow-non-passing")
+    || process.env.UXPASS_SITE_SWEEP_ALLOW_NON_PASSING === "1";
+  const outputPath = argValue("output", "public/dogfood/uxpass-site-sweep.json");
+  const urls = [
+    ...splitList(process.env.UXPASS_SITE_SWEEP_URLS),
+    ...argValues("url"),
+  ];
+  const receipt = await runUxPassSiteSweep({
+    apiBase: argValue("api-base", process.env.DOGFOOD_API_BASE || "https://unclick.world"),
+    publicUrl: argValue("public-url", process.env.DOGFOOD_PUBLIC_URL || "https://unclick.world"),
+    urls,
+    token: process.env.UXPASS_SITE_SWEEP_TOKEN
+      || process.env.DOGFOOD_UXPASS_TOKEN
+      || process.env.UXPASS_TOKEN
+      || process.env.CRON_SECRET
+      || "",
+    targetSha: argValue("target-sha", process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || ""),
+    minScore: Number(argValue("min-score", process.env.UXPASS_SITE_SWEEP_MIN_SCORE || DEFAULT_MIN_SCORE)),
+    dryRun,
+  });
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log(JSON.stringify({
+    generated_at: receipt.generated_at,
+    status: receipt.status,
+    targets: receipt.targets.length,
+    action_needed: receipt.action_needed.length,
+    output: outputPath,
+  }, null, 2));
+  process.exitCode = receipt.status === "passing" || allowNonPassing ? 0 : 1;
+}

--- a/scripts/uxpass-site-sweep.mjs
+++ b/scripts/uxpass-site-sweep.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 
 const DEFAULT_PATHS = ["/", "/dashboard", "/admin/you"];
 const DEFAULT_MIN_SCORE = 80;
+const DEFAULT_ALLOWED_ORIGINS = ["https://unclick.world", "https://www.unclick.world"];
 
 function argValue(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -45,10 +46,47 @@ function unique(values) {
   return [...new Set(values.filter(Boolean))];
 }
 
+function normalizeOrigin(value) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
+  }
+}
+
+function resolveAllowedOrigins(values = []) {
+  return unique((values.length > 0 ? values : DEFAULT_ALLOWED_ORIGINS).map(normalizeOrigin));
+}
+
+function isAllowedOrigin(url, allowedOrigins) {
+  const origin = normalizeOrigin(url);
+  return Boolean(origin && allowedOrigins.includes(origin));
+}
+
 export function resolveSweepTargets({ publicUrl, urls = [] } = {}) {
   const base = trimTrailingSlash(publicUrl || "https://unclick.world");
   const requested = unique(urls.length > 0 ? urls : DEFAULT_PATHS);
   return requested.map((url) => new URL(url, `${base}/`).toString());
+}
+
+export function splitAllowedSweepTargets(targets, allowedOrigins) {
+  const allowed = [];
+  const blocked = [];
+  for (const target of targets) {
+    if (isAllowedOrigin(target, allowedOrigins)) {
+      allowed.push(target);
+    } else {
+      blocked.push({
+        url: target,
+        status: "blocked",
+        run_id: null,
+        ux_score: null,
+        summary: `Target origin is outside the owned-origin allowlist: ${allowedOrigins.join(", ")}.`,
+        proof: null,
+      });
+    }
+  }
+  return { allowed, blocked };
 }
 
 async function postJson(fetchImpl, url, token, body) {
@@ -109,10 +147,12 @@ export async function runUxPassSiteSweep({
   targetSha = "",
   minScore = DEFAULT_MIN_SCORE,
   dryRun = false,
+  allowedOrigins = DEFAULT_ALLOWED_ORIGINS,
   now = new Date().toISOString(),
   fetchImpl = fetch,
 } = {}) {
   const targets = resolveSweepTargets({ publicUrl, urls });
+  const ownedOrigins = resolveAllowedOrigins(allowedOrigins);
   const apiUrl = `${trimTrailingSlash(apiBase)}/api/uxpass-run`;
 
   if (dryRun) {
@@ -129,8 +169,45 @@ export async function runUxPassSiteSweep({
     };
   }
 
+  const { allowed: allowedTargets, blocked: blockedTargets } = splitAllowedSweepTargets(targets, ownedOrigins);
+  if (!isAllowedOrigin(apiUrl, ownedOrigins)) {
+    const apiBlockedTargets = targets.map((url) => ({
+      url,
+      status: "blocked",
+      run_id: null,
+      ux_score: null,
+      summary: `UXPass API origin is outside the owned-origin allowlist: ${ownedOrigins.join(", ")}.`,
+      proof: null,
+    }));
+    return {
+      kind: "uxpass_site_sweep_receipt",
+      generated_at: now,
+      status: "blocked",
+      target_sha: targetSha || null,
+      min_score: minScore,
+      allowed_origins: ownedOrigins,
+      targets: apiBlockedTargets,
+      action_needed: actionNeeded(apiBlockedTargets),
+      summary: "UXPass site sweep could not run because the API origin is not allowed.",
+    };
+  }
+
+  if (allowedTargets.length === 0) {
+    return {
+      kind: "uxpass_site_sweep_receipt",
+      generated_at: now,
+      status: "blocked",
+      target_sha: targetSha || null,
+      min_score: minScore,
+      allowed_origins: ownedOrigins,
+      targets: blockedTargets,
+      action_needed: actionNeeded(blockedTargets),
+      summary: "UXPass site sweep did not run because every target was outside the owned-origin allowlist.",
+    };
+  }
+
   if (!token) {
-    const blockedTargets = targets.map((url) => ({
+    const missingTokenTargets = allowedTargets.map((url) => ({
       url,
       status: "blocked",
       run_id: null,
@@ -144,14 +221,15 @@ export async function runUxPassSiteSweep({
       status: "blocked",
       target_sha: targetSha || null,
       min_score: minScore,
-      targets: blockedTargets,
-      action_needed: actionNeeded(blockedTargets),
+      allowed_origins: ownedOrigins,
+      targets: [...missingTokenTargets, ...blockedTargets],
+      action_needed: actionNeeded([...missingTokenTargets, ...blockedTargets]),
       summary: "UXPass site sweep could not run because no token was available.",
     };
   }
 
-  const sweptTargets = [];
-  for (const url of targets) {
+  const sweptTargets = [...blockedTargets];
+  for (const url of allowedTargets) {
     try {
       const { ok, status, json } = await postJson(fetchImpl, apiUrl, token, {
         url,
@@ -199,6 +277,7 @@ export async function runUxPassSiteSweep({
     status,
     target_sha: targetSha || null,
     min_score: minScore,
+    allowed_origins: ownedOrigins,
     targets: sweptTargets,
     action_needed: actionNeeded(sweptTargets),
     summary: `UXPass site sweep ${status} across ${sweptTargets.length} URL(s).`,
@@ -225,6 +304,7 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
       || "",
     targetSha: argValue("target-sha", process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || ""),
     minScore: Number(argValue("min-score", process.env.UXPASS_SITE_SWEEP_MIN_SCORE || DEFAULT_MIN_SCORE)),
+    allowedOrigins: splitList(process.env.UXPASS_SITE_SWEEP_ALLOWED_ORIGINS),
     dryRun,
   });
 

--- a/scripts/uxpass-site-sweep.test.mjs
+++ b/scripts/uxpass-site-sweep.test.mjs
@@ -10,6 +10,7 @@ import { test } from "node:test";
 import {
   resolveSweepTargets,
   runUxPassSiteSweep,
+  splitAllowedSweepTargets,
 } from "./uxpass-site-sweep.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -73,6 +74,7 @@ test("runs every target through the UXPass API and writes scoped proof", async (
       token: "ux-token",
       targetSha: "head-sha",
       now: "2026-05-05T00:00:00.000Z",
+      allowedOrigins: ["https://unclick.world", `http://127.0.0.1:${address.port}`],
     });
 
     assert.equal(receipt.status, "passing");
@@ -90,6 +92,93 @@ test("runs every target through the UXPass API and writes scoped proof", async (
   } finally {
     await close(server);
   }
+});
+
+test("splits owned URLs from off-origin site sweep targets", () => {
+  const targets = [
+    "https://unclick.world/",
+    "https://unclick.world/dashboard",
+    "https://example.com/steal-proof",
+  ];
+
+  const result = splitAllowedSweepTargets(targets, ["https://unclick.world"]);
+
+  assert.deepEqual(result.allowed, [
+    "https://unclick.world/",
+    "https://unclick.world/dashboard",
+  ]);
+  assert.equal(result.blocked.length, 1);
+  assert.equal(result.blocked[0].url, "https://example.com/steal-proof");
+  assert.equal(result.blocked[0].status, "blocked");
+  assert.match(result.blocked[0].summary, /owned-origin allowlist/i);
+});
+
+test("does not call the UXPass API for off-origin site sweep targets", async () => {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    requests.push({ url: req.url, body });
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({
+      run_id: `run-${requests.length}`,
+      status: "complete",
+      ux_score: 94,
+    }));
+  });
+
+  try {
+    await listen(server);
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    const receipt = await runUxPassSiteSweep({
+      apiBase: `http://127.0.0.1:${address.port}`,
+      publicUrl: "https://unclick.world",
+      urls: ["/", "https://example.com/off-origin"],
+      token: "ux-token",
+      allowedOrigins: ["https://unclick.world", `http://127.0.0.1:${address.port}`],
+    });
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].body.target_url, "https://unclick.world/");
+    assert.equal(receipt.status, "blocked");
+    assert.equal(receipt.targets.length, 2);
+    assert.equal(receipt.targets[0].url, "https://example.com/off-origin");
+    assert.equal(receipt.targets[0].status, "blocked");
+  } finally {
+    await close(server);
+  }
+});
+
+test("blocks live sweeps when the API origin is outside the allowlist", async () => {
+  const receipt = await runUxPassSiteSweep({
+    apiBase: "https://evil.example",
+    publicUrl: "https://unclick.world",
+    urls: ["/"],
+    token: "ux-token",
+    allowedOrigins: ["https://unclick.world"],
+  });
+
+  assert.equal(receipt.status, "blocked");
+  assert.match(receipt.summary, /API origin is not allowed/i);
+  assert.equal(receipt.targets[0].status, "blocked");
+});
+
+test("blocks without a token warning when every target is off-origin", async () => {
+  const receipt = await runUxPassSiteSweep({
+    apiBase: "https://unclick.world",
+    publicUrl: "https://unclick.world",
+    urls: ["https://example.com/off-origin"],
+    token: "",
+    allowedOrigins: ["https://unclick.world"],
+  });
+
+  assert.equal(receipt.status, "blocked");
+  assert.match(receipt.summary, /every target was outside/i);
+  assert.equal(receipt.targets[0].status, "blocked");
+  assert.match(receipt.action_needed[0], /owned-origin allowlist/i);
 });
 
 test("fails the sweep when a target is below the UX score floor", async () => {
@@ -113,6 +202,7 @@ test("fails the sweep when a target is below the UX score floor", async () => {
       urls: ["/"],
       token: "ux-token",
       minScore: 80,
+      allowedOrigins: ["https://unclick.world", `http://127.0.0.1:${address.port}`],
     });
 
     assert.equal(receipt.status, "failing");

--- a/scripts/uxpass-site-sweep.test.mjs
+++ b/scripts/uxpass-site-sweep.test.mjs
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { test } from "node:test";
+
+import {
+  resolveSweepTargets,
+  runUxPassSiteSweep,
+} from "./uxpass-site-sweep.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function listen(server) {
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+test("resolves default site sweep targets from the public URL", () => {
+  assert.deepEqual(resolveSweepTargets({ publicUrl: "https://unclick.world/" }), [
+    "https://unclick.world/",
+    "https://unclick.world/dashboard",
+    "https://unclick.world/admin/you",
+  ]);
+});
+
+test("returns a blocked receipt when no token is available", async () => {
+  const receipt = await runUxPassSiteSweep({
+    publicUrl: "https://unclick.world",
+    urls: ["/", "/dashboard"],
+    token: "",
+    targetSha: "abc123",
+    now: "2026-05-05T00:00:00.000Z",
+  });
+
+  assert.equal(receipt.status, "blocked");
+  assert.equal(receipt.target_sha, "abc123");
+  assert.equal(receipt.targets.length, 2);
+  assert.equal(receipt.action_needed.length, 2);
+  assert.match(receipt.summary, /no token/i);
+});
+
+test("runs every target through the UXPass API and writes scoped proof", async () => {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    requests.push({ url: req.url, body });
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({
+      run_id: `run-${requests.length}`,
+      status: "complete",
+      ux_score: requests.length === 1 ? 91 : 88,
+    }));
+  });
+
+  try {
+    await listen(server);
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    const receipt = await runUxPassSiteSweep({
+      apiBase: `http://127.0.0.1:${address.port}`,
+      publicUrl: "https://unclick.world",
+      urls: ["/", "/admin/you"],
+      token: "ux-token",
+      targetSha: "head-sha",
+      now: "2026-05-05T00:00:00.000Z",
+    });
+
+    assert.equal(receipt.status, "passing");
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].url, "/api/uxpass-run");
+    assert.equal(requests[0].body.source, "site_sweep");
+    assert.equal(requests[0].body.target_sha, "head-sha");
+    assert.equal(requests[1].body.target_url, "https://unclick.world/admin/you");
+    assert.deepEqual(receipt.targets[0].proof, {
+      kind: "uxpass_run",
+      runId: "run-1",
+      targetUrl: "https://unclick.world/",
+      target_sha: "head-sha",
+    });
+  } finally {
+    await close(server);
+  }
+});
+
+test("fails the sweep when a target is below the UX score floor", async () => {
+  const server = http.createServer((_req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({
+      run_id: "run-low",
+      status: "complete",
+      ux_score: 72,
+    }));
+  });
+
+  try {
+    await listen(server);
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    const receipt = await runUxPassSiteSweep({
+      apiBase: `http://127.0.0.1:${address.port}`,
+      publicUrl: "https://unclick.world",
+      urls: ["/"],
+      token: "ux-token",
+      minScore: 80,
+    });
+
+    assert.equal(receipt.status, "failing");
+    assert.equal(receipt.action_needed.length, 1);
+    assert.match(receipt.action_needed[0], /score 72/);
+  } finally {
+    await close(server);
+  }
+});
+
+test("CLI dry-run writes the sweep receipt to disk", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "uxpass-site-sweep-"));
+  const output = path.join(dir, "receipt.json");
+
+  try {
+    await execFileAsync(process.execPath, [
+      "scripts/uxpass-site-sweep.mjs",
+      "--dry-run",
+      "--output",
+      output,
+      "--target-sha",
+      "dry-sha",
+      "--url",
+      "/",
+    ]);
+
+    const receipt = JSON.parse(await fs.readFile(output, "utf8"));
+    assert.equal(receipt.status, "passing");
+    assert.equal(receipt.target_sha, "dry-sha");
+    assert.equal(receipt.targets.length, 1);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI can write a blocked receipt without failing the dogfood workflow", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "uxpass-site-sweep-"));
+  const output = path.join(dir, "blocked.json");
+
+  try {
+    await execFileAsync(process.execPath, [
+      "scripts/uxpass-site-sweep.mjs",
+      "--allow-non-passing",
+      "--output",
+      output,
+      "--url",
+      "/",
+    ], {
+      env: {
+        ...process.env,
+        UXPASS_SITE_SWEEP_TOKEN: "",
+        DOGFOOD_UXPASS_TOKEN: "",
+        UXPASS_TOKEN: "",
+        CRON_SECRET: "",
+      },
+    });
+
+    const receipt = JSON.parse(await fs.readFile(output, "utf8"));
+    assert.equal(receipt.status, "blocked");
+    assert.match(receipt.summary, /no token/i);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- adds a UXPass site sweep runner that turns multiple URL checks into a scoped receipt
- wires the sweep into the public Dogfood Report workflow as a separate uploaded/committed receipt
- constrains live secret-backed sweeps to owned UnClick origins so manual URL input cannot scan arbitrary/off-origin targets
- keeps blocked/non-passing sweep states honest without breaking the whole dogfood workflow when credentials are missing

## Scope
Owned files:
- .github/workflows/dogfood-report.yml
- scripts/uxpass-site-sweep.mjs
- scripts/uxpass-site-sweep.test.mjs

This is Build A for Continuous QC. It adds a secret-consuming dogfood workflow path for UXPass, but the live sweep is bounded to the owned-origin allowlist `https://unclick.world` and `https://www.unclick.world`. Off-origin targets are recorded as blocked receipt entries and are not sent to `/api/uxpass-run`.

It does not touch billing/DNS/migrations, does not run browser automation directly, and does not claim full UXPass visual critic completion. It gives Autopilot a stronger recurring site-sweep receipt for UI/admin changes.

## Proof
- node --test scripts\\uxpass-site-sweep.test.mjs: 10/10
- node --test scripts\\build-dogfood-report.test.mjs: 3/3
- node scripts\\uxpass-site-sweep.mjs --dry-run --output public\\dogfood\\uxpass-site-sweep.test-local.json --target-sha local-proof --url / --url /dashboard: passed, temp file removed
- UXPASS_SITE_SWEEP_TOKEN=fake-token node scripts\\uxpass-site-sweep.mjs --output public\\dogfood\\uxpass-site-sweep.off-origin-test.json --target-sha local-proof --url https://example.com/off-origin --allow-non-passing: blocked off-origin target without API sweep, temp file removed
- git diff --check: passed

## Notes
The sweep receipt includes `target_sha` where available so XPass Gate can reject stale or unscoped evidence later. The receipt also includes `allowed_origins` so Safety/Reviewer lanes can see the live boundary used for the run.