### PR TITLE
fix(memory): exempt owner account from memory caps

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -29,6 +29,10 @@ import { createClient } from "@supabase/supabase-js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "../packages/mcp-server/src/server.js";
 import { normalizeAcceptHeader } from "./lib/mcp-protocol.js";
+import {
+  effectiveMemoryTier,
+  isMemoryQuotaExemptEmail,
+} from "../packages/mcp-server/src/memory/quota-policy.js";
 
 function sha256hex(input: string): string {
   return crypto.createHash("sha256").update(input).digest("hex");
@@ -73,6 +77,8 @@ interface ApiKeyContext {
   api_key_hash: string;
   tier: string;
   user_id: string | null;
+  account_email: string | null;
+  memory_quota_exempt: boolean;
 }
 
 function getSupabaseEnv(): { url: string; key: string } | null {
@@ -106,6 +112,17 @@ async function validateApiKey(apiKey: string): Promise<ApiKeyContext | null> {
 
   if (error || !data || data.is_active === false) return null;
 
+  let accountEmail: string | null = null;
+  if (data.user_id) {
+    try {
+      const { data: userData } = await supabase.auth.admin.getUserById(data.user_id);
+      accountEmail = userData.user?.email ?? null;
+    } catch {
+      accountEmail = null;
+    }
+  }
+  const memoryQuotaExempt = isMemoryQuotaExemptEmail(accountEmail);
+
   // Fire-and-forget last_used_at + usage_count bump
   supabase
     .from("api_keys")
@@ -115,8 +132,10 @@ async function validateApiKey(apiKey: string): Promise<ApiKeyContext | null> {
 
   return {
     api_key_hash: apiKeyHash,
-    tier: data.tier ?? "free",
+    tier: effectiveMemoryTier(data.tier ?? "free", accountEmail),
     user_id: data.user_id ?? null,
+    account_email: accountEmail,
+    memory_quota_exempt: memoryQuotaExempt,
   };
 }
 
@@ -182,8 +201,10 @@ async function validateSessionCookie(
 
   return {
     api_key_hash: keyRow.key_hash,
-    tier: keyRow.tier ?? "free",
+    tier: effectiveMemoryTier(keyRow.tier ?? "free", userData.user.email ?? null),
     user_id: userId,
+    account_email: userData.user.email ?? null,
+    memory_quota_exempt: isMemoryQuotaExemptEmail(userData.user.email ?? null),
   };
 }
 
@@ -327,6 +348,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (ctx) {
     process.env.UNCLICK_API_KEY_HASH = ctx.api_key_hash;
     process.env.UNCLICK_TIER = ctx.tier;
+    if (ctx.account_email) {
+      process.env.UNCLICK_ACCOUNT_EMAIL = ctx.account_email;
+    } else {
+      delete process.env.UNCLICK_ACCOUNT_EMAIL;
+    }
+    process.env.UNCLICK_MEMORY_QUOTA_EXEMPT = ctx.memory_quota_exempt ? "true" : "false";
     if (ctx.user_id) {
       process.env.UNCLICK_USER_ID = ctx.user_id;
     } else {
@@ -336,6 +363,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     delete process.env.UNCLICK_API_KEY_HASH;
     delete process.env.UNCLICK_TIER;
     delete process.env.UNCLICK_USER_ID;
+    delete process.env.UNCLICK_ACCOUNT_EMAIL;
+    delete process.env.UNCLICK_MEMORY_QUOTA_EXEMPT;
   }
 
   // ── MCP over Streamable HTTP (stateless per-request) ───────────────────────

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -121,6 +121,10 @@ import {
   decideStaleLease,
 } from "../packages/mcp-server/src/reliability.js";
 import { emitSignal } from "../packages/mcp-server/src/signals/emit.js";
+import {
+  effectiveMemoryTier,
+  isMemoryQuotaExemptEmail,
+} from "../packages/mcp-server/src/memory/quota-policy.js";
 import { streamText, tool, stepCountIs, convertToModelMessages, type UIMessage, type ModelMessage } from "ai";
 import { google } from "@ai-sdk/google";
 import { z } from "zod";
@@ -529,7 +533,7 @@ async function resolveSessionTenant(
       userId: user.id,
       email: user.email,
       apiKeyHash: newRow.key_hash,
-      tier: newRow.tier ?? "free",
+      tier: effectiveMemoryTier(newRow.tier ?? "free", user.email),
     };
   }
 
@@ -548,7 +552,7 @@ async function resolveSessionTenant(
         userId: user.id,
         email: user.email,
         apiKeyHash: sha256hex(oldRow.api_key),
-        tier: "free",
+        tier: effectiveMemoryTier("free", user.email),
       };
     }
   } catch {
@@ -3587,6 +3591,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         // `generated_api_key`, so the frontend can surface it behind
         // the reveal UI. Subsequent calls only return the prefix.
         let generatedApiKey: string | null = null;
+        const provisionTier = effectiveMemoryTier("free", user.email);
         if (!keyRow) {
           const rawKey = `uc_${crypto.randomBytes(16).toString("hex")}`;
           const keyHash = sha256hex(rawKey);
@@ -3598,7 +3603,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               key_hash:  keyHash,
               key_prefix: keyPrefix,
               label:     "auto-provisioned",
-              tier:      "free",
+              tier:      provisionTier,
               is_active: true,
               usage_count: 0,
             })
@@ -3625,7 +3630,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               id: keyRow.id,
               prefix: keyRow.key_prefix ?? "",
               label:  keyRow.label ?? "",
-              tier:   keyRow.tier ?? "free",
+              tier:   effectiveMemoryTier(keyRow.tier ?? "free", user.email),
               is_active: Boolean(keyRow.is_active),
               usage_count: Number(keyRow.usage_count ?? 0),
               last_used_at: keyRow.last_used_at ?? null,
@@ -3649,11 +3654,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({
           user_id: user.id,
           email:   user.email,
-          tier:    apiKey ? apiKey.tier : "free",
+          tier:    apiKey ? apiKey.tier : effectiveMemoryTier("free", user.email),
           needs_key: !apiKey,
           api_key: apiKey,
           generated_api_key: generatedApiKey,
           is_admin: isAdmin,
+          memory_quota_exempt: isMemoryQuotaExemptEmail(user.email),
         });
       }
 
@@ -3676,7 +3682,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(200).json({
             api_key: null,
             prefix:  existing.key_prefix ?? "",
-            tier:    existing.tier ?? "free",
+            tier:    effectiveMemoryTier(existing.tier ?? "free", user.email),
             already_provisioned: true,
           });
         }
@@ -3687,7 +3693,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           key_hash:  sha256hex(rawKey),
           key_prefix: rawKey.slice(0, 8),
           label:     "default",
-          tier:      "free",
+          tier:      effectiveMemoryTier("free", user.email),
           is_active: true,
           usage_count: 0,
         });
@@ -3696,7 +3702,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({
           api_key: rawKey,
           prefix:  rawKey.slice(0, 8),
-          tier:    "free",
+          tier:    effectiveMemoryTier("free", user.email),
           already_provisioned: false,
         });
       }
@@ -3747,7 +3753,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({
           api_key: rawKey,
           prefix:  rawKey.slice(0, 8),
-          tier:    existing.tier ?? "free",
+          tier:    effectiveMemoryTier(existing.tier ?? "free", user.email),
         });
       }
 

--- a/api/memory-quota-policy.test.ts
+++ b/api/memory-quota-policy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  effectiveMemoryTier,
+  isMemoryQuotaExemptEmail,
+  shouldEnforceManagedMemoryCaps,
+} from "../packages/mcp-server/src/memory/quota-policy.js";
+
+describe("memory quota policy", () => {
+  it("exempts the owner account from memory quotas by default", () => {
+    expect(isMemoryQuotaExemptEmail("creativelead@malamutemayhem.com")).toBe(true);
+    expect(isMemoryQuotaExemptEmail(" CreativeLead@MalamuteMayhem.com ")).toBe(true);
+  });
+
+  it("does not exempt unrelated accounts unless explicitly allowlisted", () => {
+    expect(isMemoryQuotaExemptEmail("user@example.com")).toBe(false);
+    expect(isMemoryQuotaExemptEmail("user@example.com", "user@example.com")).toBe(true);
+  });
+
+  it("reports owner as the effective memory tier without changing other tiers", () => {
+    expect(effectiveMemoryTier("free", "creativelead@malamutemayhem.com")).toBe("owner");
+    expect(effectiveMemoryTier("pro", "user@example.com")).toBe("pro");
+    expect(effectiveMemoryTier(null, "user@example.com")).toBe("free");
+  });
+
+  it("only enforces managed-cloud caps for non-exempt free-tier users", () => {
+    expect(
+      shouldEnforceManagedMemoryCaps({
+        tenancyMode: "managed",
+        tier: "free",
+        accountEmail: "user@example.com",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldEnforceManagedMemoryCaps({
+        tenancyMode: "managed",
+        tier: "free",
+        accountEmail: "creativelead@malamutemayhem.com",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldEnforceManagedMemoryCaps({
+        tenancyMode: "managed",
+        tier: "free",
+        quotaExempt: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldEnforceManagedMemoryCaps({
+        tenancyMode: "byod",
+        tier: "free",
+        accountEmail: "user@example.com",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/memory/quota-policy.ts
+++ b/packages/mcp-server/src/memory/quota-policy.ts
@@ -1,0 +1,43 @@
+const DEFAULT_MEMORY_QUOTA_EXEMPT_EMAILS = ["creativelead@malamutemayhem.com"];
+
+function normalizeEmail(email: string | null | undefined): string | null {
+  const normalized = email?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function quotaExemptEmails(raw = process.env.UNCLICK_MEMORY_QUOTA_EXEMPT_EMAILS ?? ""): Set<string> {
+  const emails = new Set(DEFAULT_MEMORY_QUOTA_EXEMPT_EMAILS);
+  for (const item of raw.split(",")) {
+    const normalized = normalizeEmail(item);
+    if (normalized) emails.add(normalized);
+  }
+  return emails;
+}
+
+export function isMemoryQuotaExemptEmail(
+  email: string | null | undefined,
+  rawAllowlist = process.env.UNCLICK_MEMORY_QUOTA_EXEMPT_EMAILS ?? "",
+): boolean {
+  const normalized = normalizeEmail(email);
+  return normalized ? quotaExemptEmails(rawAllowlist).has(normalized) : false;
+}
+
+export function effectiveMemoryTier(
+  tier: string | null | undefined,
+  email: string | null | undefined,
+): string {
+  if (isMemoryQuotaExemptEmail(email)) return "owner";
+  return tier?.trim().toLowerCase() || "free";
+}
+
+export function shouldEnforceManagedMemoryCaps(input: {
+  tenancyMode: "byod" | "managed";
+  tier: string | null | undefined;
+  accountEmail?: string | null;
+  quotaExempt?: boolean;
+}): boolean {
+  if (input.tenancyMode !== "managed") return false;
+  if (input.quotaExempt === true) return false;
+  if (isMemoryQuotaExemptEmail(input.accountEmail)) return false;
+  return (input.tier?.trim().toLowerCase() || "free") === "free";
+}

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -27,6 +27,7 @@ import type {
   CodeInput,
   LibraryDocInput,
 } from "./types.js";
+import { shouldEnforceManagedMemoryCaps } from "./quota-policy.js";
 
 function pgError(context: string, err: unknown): Error {
   if (err instanceof Error) return err;
@@ -187,9 +188,13 @@ export class SupabaseBackend implements MemoryBackend {
    * extracted_facts has a separate row count limit.
    */
   private async enforceCaps(kind: "fact" | "general"): Promise<void> {
-    if (this.tenancy.mode !== "managed") return;
-    const tier = (process.env.UNCLICK_TIER || "free").toLowerCase();
-    if (tier !== "free") return;
+    const shouldEnforceCaps = shouldEnforceManagedMemoryCaps({
+      tenancyMode: this.tenancy.mode,
+      tier: process.env.UNCLICK_TIER,
+      accountEmail: process.env.UNCLICK_ACCOUNT_EMAIL,
+      quotaExempt: process.env.UNCLICK_MEMORY_QUOTA_EXEMPT === "true",
+    });
+    if (!shouldEnforceCaps) return;
 
     if (kind === "fact") {
       const { data, error } = await this.client.rpc("mc_get_fact_count", {

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -188,6 +188,8 @@ export class SupabaseBackend implements MemoryBackend {
    * extracted_facts has a separate row count limit.
    */
   private async enforceCaps(kind: "fact" | "general"): Promise<void> {
+    if (this.tenancy.mode !== "managed") return;
+
     const shouldEnforceCaps = shouldEnforceManagedMemoryCaps({
       tenancyMode: this.tenancy.mode,
       tier: process.env.UNCLICK_TIER,


### PR DESCRIPTION
## Summary
- Exempts `creativelead@malamutemayhem.com` from UnClick-managed memory quota caps by treating the account as an effective `owner` memory tier.
- Carries account email/quota-exempt context through MCP API-key and browser-session auth paths.
- Keeps normal free-tier managed-memory caps enforced for all non-exempt users.

## Proof
- `npm test -- api` -> 10/10 files, 48/48 tests passed
- `npm run build` -> passed
- `git diff --check` -> passed

## Notes
- This removes UnClick's managed memory cap for the owner account only.
- It does not bypass upstream provider limits such as OpenAI/Supabase billing, rate limits, missing keys, or service outages.