### PR TITLE
feat(autopilot): add autonomous runner seat

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1,0 +1,365 @@
+#!/usr/bin/env node
+
+import {
+  createCodingRoomJobLedger,
+  readCodingRoomJobLedger,
+  submitCodingRoomProof,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+import {
+  DEFAULT_CODING_ROOM_RUNNER,
+  createCodingRoomRunner,
+  createCodingRoomRunnerFromEnv,
+  runCodingRoomRunnerCycle,
+} from "./pinballwake-coding-room-runner.mjs";
+
+export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
+
+export const DEFAULT_AUTONOMOUS_RUNNER = {
+  id: "pinballwake-autonomous-runner",
+  readiness: "builder_ready",
+  capabilities: ["implementation", "test_fix", "docs_update"],
+};
+
+export const DEFAULT_AUTONOMOUS_RUNNER_POLICY = {
+  disabled: false,
+  allowProtectedSurfaces: false,
+  allowExecute: false,
+  maxCycles: 1,
+};
+
+const PROTECTED_SURFACE_PATTERNS = [
+  {
+    reason: "protected_surface_secret",
+    pattern: /\b(secret|secrets|credential|credentials|token|tokens|api key|apikey|raw key|private key|env var|env)\b/i,
+  },
+  {
+    reason: "protected_surface_auth",
+    pattern: /\b(auth|oauth|login|session|jwt|rls|tenant|permission|permissions)\b/i,
+  },
+  {
+    reason: "protected_surface_billing",
+    pattern: /\b(billing|stripe|payment|payments|invoice|subscription)\b/i,
+  },
+  {
+    reason: "protected_surface_dns",
+    pattern: /\b(dns|domain|domains|vercel domain|apex|www redirect)\b/i,
+  },
+  {
+    reason: "protected_surface_migration",
+    pattern: /\b(migration|migrations|schema|supabase sql|alter table|drop table)\b/i,
+  },
+  {
+    reason: "protected_surface_destructive",
+    pattern: /\b(force[- ]?push|delete|remove|destructive cleanup|rm -rf|reset --hard)\b/i,
+  },
+];
+
+const PROTECTED_PATH_PATTERNS = [
+  /\.env/i,
+  /(^|\/)supabase\/migrations\//i,
+  /(^|\/)(auth|billing|payments?|secrets?|credentials?|keychain)(\/|\.|$)/i,
+  /stripe/i,
+];
+
+function parseBoolean(value) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function parseIntOption(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseList(value, fallback = []) {
+  const text = String(value ?? "").trim();
+  if (!text) return fallback;
+  return text
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function normalizePath(value) {
+  return String(value ?? "").replace(/\\/g, "/").trim();
+}
+
+function compact(value, max = 240) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+export function createAutonomousRunner(input = {}) {
+  return createCodingRoomRunner({
+    ...DEFAULT_AUTONOMOUS_RUNNER,
+    ...input,
+    id: input.id || input.runnerId || DEFAULT_AUTONOMOUS_RUNNER.id,
+    agentId: input.agentId || input.agent_id || "",
+    capabilities: Array.isArray(input.capabilities)
+      ? input.capabilities
+      : DEFAULT_AUTONOMOUS_RUNNER.capabilities,
+  });
+}
+
+export function createAutonomousRunnerFromEnv(env = process.env) {
+  const base = createCodingRoomRunnerFromEnv(env);
+  return createAutonomousRunner({
+    ...base,
+    id: env.AUTONOMOUS_RUNNER_ID || base.id || DEFAULT_AUTONOMOUS_RUNNER.id,
+    readiness: env.AUTONOMOUS_RUNNER_READINESS || base.readiness || DEFAULT_AUTONOMOUS_RUNNER.readiness,
+    capabilities: parseList(
+      env.AUTONOMOUS_RUNNER_CAPABILITIES,
+      base.capabilities?.length ? base.capabilities : DEFAULT_AUTONOMOUS_RUNNER.capabilities,
+    ),
+  });
+}
+
+export function createAutonomousRunnerPolicy(input = {}) {
+  return {
+    ...DEFAULT_AUTONOMOUS_RUNNER_POLICY,
+    ...input,
+    disabled: Boolean(input.disabled),
+    allowProtectedSurfaces: Boolean(input.allowProtectedSurfaces),
+    allowExecute: Boolean(input.allowExecute),
+    maxCycles: Math.max(1, Number.isFinite(input.maxCycles) ? input.maxCycles : DEFAULT_AUTONOMOUS_RUNNER_POLICY.maxCycles),
+  };
+}
+
+export function normalizeAutonomousRunnerMode(value) {
+  const mode = String(value || "dry-run").trim().toLowerCase();
+  return AUTONOMOUS_RUNNER_MODES.has(mode) ? mode : "dry-run";
+}
+
+export function inspectAutonomousRunnerJobSafety(job) {
+  if (!job) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  const searchable = [
+    job.worker,
+    job.chip,
+    job.context,
+    job.source,
+    ...(job.expected_proof?.tests || []),
+  ].join(" ");
+
+  for (const { reason, pattern } of PROTECTED_SURFACE_PATTERNS) {
+    if (pattern.test(searchable)) {
+      return { ok: false, reason, surface: compact(searchable) };
+    }
+  }
+
+  const protectedPath = (job.owned_files || []).map(normalizePath).find((file) =>
+    PROTECTED_PATH_PATTERNS.some((pattern) => pattern.test(file)),
+  );
+  if (protectedPath) {
+    return { ok: false, reason: "protected_surface_path", file: protectedPath };
+  }
+
+  return { ok: true, reason: "safe_for_autonomous_runner" };
+}
+
+export function markUnsafeJobsBlockedForAutonomousRunner({
+  ledger,
+  allowProtectedSurfaces = false,
+  now = new Date().toISOString(),
+} = {}) {
+  const next = createCodingRoomJobLedger({
+    jobs: ledger?.jobs || [],
+    updatedAt: now,
+  });
+
+  if (allowProtectedSurfaces) {
+    return { ok: true, ledger: next, blocked: [] };
+  }
+
+  const blocked = [];
+  next.jobs = next.jobs.map((job) => {
+    if (job.status !== "queued") {
+      return job;
+    }
+
+    const safety = inspectAutonomousRunnerJobSafety(job);
+    if (safety.ok) {
+      return job;
+    }
+
+    const proof = submitCodingRoomProof({
+      job,
+      proof: {
+        result: "blocker",
+        blocker: `Autonomous Runner blocked protected work: ${safety.reason}`,
+        submittedAt: now,
+      },
+    });
+
+    if (!proof.ok) {
+      return {
+        ...job,
+        status: "blocked",
+        proof: {
+          result: "blocker",
+          blocker: `Autonomous Runner blocked protected work: ${safety.reason}`,
+          submitted_at: now,
+        },
+      };
+    }
+
+    blocked.push({
+      job_id: job.job_id,
+      reason: safety.reason,
+      file: safety.file || null,
+    });
+    return proof.job;
+  });
+
+  return { ok: true, ledger: next, blocked };
+}
+
+export function runAutonomousRunnerCycle({
+  ledger,
+  runner = DEFAULT_AUTONOMOUS_RUNNER,
+  mode = "dry-run",
+  policy = DEFAULT_AUTONOMOUS_RUNNER_POLICY,
+  now = new Date().toISOString(),
+  leaseSeconds,
+} = {}) {
+  const safePolicy = createAutonomousRunnerPolicy(policy);
+  const safeMode = normalizeAutonomousRunnerMode(mode);
+  const safeRunner = createAutonomousRunner(runner);
+
+  if (safePolicy.disabled) {
+    return {
+      ok: true,
+      action: "disabled",
+      mode: safeMode,
+      reason: "kill_switch_enabled",
+      runner: safeRunner.id,
+      ledger: createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now }),
+    };
+  }
+
+  const hardened = markUnsafeJobsBlockedForAutonomousRunner({
+    ledger,
+    allowProtectedSurfaces: safePolicy.allowProtectedSurfaces,
+    now,
+  });
+
+  if (!hardened.ok) {
+    return hardened;
+  }
+
+  if (safeMode === "execute" && !safePolicy.allowExecute) {
+    return {
+      ok: true,
+      action: "blocked",
+      mode: safeMode,
+      reason: "execute_mode_disabled",
+      runner: safeRunner.id,
+      ledger: hardened.ledger,
+      safety_blocked: hardened.blocked,
+    };
+  }
+
+  const claim = runCodingRoomRunnerCycle({
+    ledger: hardened.ledger,
+    runner: safeRunner,
+    now,
+    leaseSeconds,
+  });
+
+  return {
+    ...claim,
+    mode: safeMode,
+    runner: safeRunner.id,
+    dry_run: safeMode === "dry-run",
+    safety_blocked: hardened.blocked,
+  };
+}
+
+export async function runAutonomousRunnerFile({
+  ledgerPath,
+  runner = createAutonomousRunnerFromEnv(),
+  mode = "dry-run",
+  policy = createAutonomousRunnerPolicy(),
+  now = new Date().toISOString(),
+  leaseSeconds,
+} = {}) {
+  if (!ledgerPath) {
+    return { ok: false, reason: "missing_ledger_path" };
+  }
+
+  const safePolicy = createAutonomousRunnerPolicy(policy);
+  const safeMode = normalizeAutonomousRunnerMode(mode);
+  let ledger = await readCodingRoomJobLedger(ledgerPath);
+  const results = [];
+
+  for (let index = 0; index < safePolicy.maxCycles; index += 1) {
+    const result = runAutonomousRunnerCycle({
+      ledger,
+      runner,
+      mode: safeMode,
+      policy: safePolicy,
+      now,
+      leaseSeconds,
+    });
+    results.push(result);
+    ledger = result.ledger || ledger;
+
+    if (!result.ok || ["idle", "disabled", "blocked"].includes(result.action)) {
+      break;
+    }
+  }
+
+  const shouldPersist = safeMode !== "dry-run" && !safePolicy.disabled;
+  if (shouldPersist) {
+    await writeCodingRoomJobLedger(ledgerPath, ledger);
+  }
+
+  const last = results[results.length - 1] || { ok: true, action: "idle", reason: "no_cycle_run", ledger };
+  return {
+    ...last,
+    ok: results.every((result) => result.ok),
+    action: last.action,
+    mode: safeMode,
+    dry_run: safeMode === "dry-run",
+    persisted: shouldPersist,
+    cycles: results,
+    ledger,
+    ledger_path: ledgerPath,
+  };
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  const explicitMode = getArg("mode", process.env.AUTONOMOUS_RUNNER_MODE || "");
+  const dryRun = process.argv.includes("--dry-run") || parseBoolean(process.env.AUTONOMOUS_RUNNER_DRY_RUN);
+  const mode = dryRun ? "dry-run" : normalizeAutonomousRunnerMode(explicitMode || "dry-run");
+
+  runAutonomousRunnerFile({
+    ledgerPath: getArg("ledger", process.env.CODING_ROOM_LEDGER_PATH || ""),
+    mode,
+    runner: createAutonomousRunnerFromEnv(),
+    leaseSeconds: parseIntOption(getArg("lease-seconds", process.env.CODING_ROOM_LEASE_SECONDS), undefined),
+    policy: createAutonomousRunnerPolicy({
+      disabled: parseBoolean(process.env.AUTONOMOUS_RUNNER_DISABLED),
+      allowProtectedSurfaces: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES),
+      allowExecute: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_EXECUTE),
+      maxCycles: parseIntOption(getArg("max-cycles", process.env.AUTONOMOUS_RUNNER_MAX_CYCLES), 1),
+    }),
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  createCodingRoomJob,
+  createCodingRoomJobLedger,
+  writeCodingRoomJobLedger,
+} from "./pinballwake-coding-room.mjs";
+import {
+  createAutonomousRunner,
+  inspectAutonomousRunnerJobSafety,
+  markUnsafeJobsBlockedForAutonomousRunner,
+  normalizeAutonomousRunnerMode,
+  runAutonomousRunnerCycle,
+  runAutonomousRunnerFile,
+} from "./pinballwake-autonomous-runner.mjs";
+
+const runner = createAutonomousRunner({
+  id: "runner-plex-1",
+  readiness: "builder_ready",
+  capabilities: ["implementation", "test_fix", "docs_update"],
+});
+
+function safeJob(input = {}) {
+  return createCodingRoomJob({
+    jobId: input.jobId || "coding-room:autonomous-runner:safe",
+    worker: "builder",
+    chip: "safe scoped docs chip",
+    files: ["docs/runner.md"],
+    expectedProof: {
+      requiresPr: false,
+      requiresChangedFiles: false,
+      requiresNonOverlap: true,
+      requiresTests: false,
+      tests: [],
+    },
+    ...input,
+  });
+}
+
+describe("PinballWake autonomous Runner seat", () => {
+  it("defaults unknown modes back to dry-run", () => {
+    assert.equal(normalizeAutonomousRunnerMode("claim"), "claim");
+    assert.equal(normalizeAutonomousRunnerMode("ship-it"), "dry-run");
+  });
+
+  it("claims safe scoped work through the existing Coding Room runner", () => {
+    const result = runAutonomousRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [safeJob()] }),
+      runner,
+      mode: "claim",
+      now: "2026-05-06T03:00:00.000Z",
+      leaseSeconds: 60,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "claimed");
+    assert.equal(result.runner, "runner-plex-1");
+    assert.equal(result.ledger.jobs[0].claimed_by, "runner-plex-1");
+    assert.equal(result.ledger.jobs[0].lease_expires_at, "2026-05-06T03:01:00.000Z");
+  });
+
+  it("does not persist dry-run claims to disk", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger({ jobs: [safeJob()] }));
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        now: "2026-05-06T03:00:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.persisted, false);
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs[0].status, "queued");
+      assert.equal(persisted.jobs[0].claimed_by, null);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists claim mode to disk", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger({ jobs: [safeJob()] }));
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        now: "2026-05-06T03:00:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.persisted, true);
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs[0].status, "claimed");
+      assert.equal(persisted.jobs[0].claimed_by, "runner-plex-1");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks protected surfaces before claim", () => {
+    const unsafe = safeJob({
+      jobId: "coding-room:autonomous-runner:unsafe",
+      chip: "rotate billing secret",
+      files: ["api/billing/stripe.ts"],
+    });
+
+    assert.equal(inspectAutonomousRunnerJobSafety(unsafe).ok, false);
+
+    const result = runAutonomousRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [unsafe] }),
+      runner,
+      mode: "claim",
+      now: "2026-05-06T03:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "idle");
+    assert.equal(result.safety_blocked.length, 1);
+    assert.equal(result.ledger.jobs[0].status, "blocked");
+    assert.match(result.ledger.jobs[0].proof.blocker, /protected work/);
+  });
+
+  it("supports a hard kill switch", () => {
+    const result = runAutonomousRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [safeJob()] }),
+      runner,
+      mode: "claim",
+      policy: { disabled: true },
+      now: "2026-05-06T03:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "disabled");
+    assert.equal(result.reason, "kill_switch_enabled");
+    assert.equal(result.ledger.jobs[0].status, "queued");
+  });
+
+  it("does not enter execute mode unless explicitly enabled", () => {
+    const result = runAutonomousRunnerCycle({
+      ledger: createCodingRoomJobLedger({ jobs: [safeJob()] }),
+      runner,
+      mode: "execute",
+      now: "2026-05-06T03:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "blocked");
+    assert.equal(result.reason, "execute_mode_disabled");
+    assert.equal(result.ledger.jobs[0].status, "queued");
+  });
+
+  it("can block unsafe queued jobs without protected-surface exemptions", () => {
+    const result = markUnsafeJobsBlockedForAutonomousRunner({
+      ledger: createCodingRoomJobLedger({
+        jobs: [
+          safeJob({
+            jobId: "coding-room:autonomous-runner:migration",
+            chip: "alter table for auth sessions",
+            files: ["supabase/migrations/001.sql"],
+          }),
+        ],
+      }),
+      now: "2026-05-06T03:00:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.ledger.jobs[0].status, "blocked");
+  });
+});


### PR DESCRIPTION
Summary:
Adds a PinballWake autonomous Runner seat script and focused tests for the first PR-gated bootstrap step. The Runner defaults to dry-run, supports claim-only mode, includes a hard kill switch, blocks protected surfaces before claim, and refuses execute mode unless explicitly enabled.

Scope:
- Owned todo: 2cf28a34
- Files touched: scripts/pinballwake-autonomous-runner.mjs, scripts/pinballwake-autonomous-runner.test.mjs
- Lane: autopilot Runner bootstrap

Non-overlap:
- Does not enable live execution.
- Does not add cron, deployment, secrets, auth, billing, DNS, migrations, raw keys, force-pushes, destructive cleanup, or merge automation.
- Does not edit another worker branch.
- Does not merge draft, HOLD, BLOCKER, or DIRTY PRs.

Verification:
- node --test scripts/pinballwake-autonomous-runner.test.mjs: 8/8 passing
- node --test scripts/pinballwake-coding-room-runner.test.mjs: 9/9 passing
- node --test scripts/pinballwake-proof-executor.test.mjs: 11/11 passing
- git diff --cached --check passed before commit

Risk:
- Draft PR only. Runner is not enabled.
- Default mode is dry-run. Claim mode only persists claim/ACK state.
- Execute mode is blocked unless explicitly enabled, and this PR does not wire any live scheduler or executor.
- Safety review should verify protected-surface blocking and env gates before any future enablement.

Follow-up:
- Tester gate: dry-run persistence, claim-only persistence, kill-switch, protected-surface blocking, and no execute side effects.
- Reviewer gate: no self-edit, self-merge, gate bypass, or outside-owned-file actions.
- Safety Checker gate: confirm code/config boundaries before live enablement.