### PR TITLE
feat(autopilot): schedule autonomous runner

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -1,0 +1,69 @@
+name: PinballWake Autonomous Runner
+
+on:
+  schedule:
+    - cron: "3,13,23,33,43,53 * * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Runner mode. Execute is intentionally unavailable here.
+        required: false
+        default: "dry-run"
+        type: choice
+        options:
+          - dry-run
+          - claim
+      kill_switch:
+        description: Stop before any claim cycle, even if claim mode is selected.
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      max_cycles:
+        description: Maximum runner cycles for this invocation.
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+
+jobs:
+  runner:
+    name: Run autonomous queue cycle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare runner ledger
+        env:
+          CODING_ROOM_LEDGER_PATH: ${{ vars.CODING_ROOM_LEDGER_PATH || '.pinballwake/coding-room-ledger.json' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${CODING_ROOM_LEDGER_PATH}")"
+          if [ ! -f "${CODING_ROOM_LEDGER_PATH}" ]; then
+            printf '{"version":1,"updated_at":"%s","jobs":[]}\n' "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" > "${CODING_ROOM_LEDGER_PATH}"
+          fi
+
+      - name: Run autonomous Runner
+        env:
+          CODING_ROOM_LEDGER_PATH: ${{ vars.CODING_ROOM_LEDGER_PATH || '.pinballwake/coding-room-ledger.json' }}
+          CODING_ROOM_LEASE_SECONDS: ${{ vars.CODING_ROOM_LEASE_SECONDS || '1800' }}
+          AUTONOMOUS_RUNNER_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || vars.AUTONOMOUS_RUNNER_MODE || 'dry-run' }}
+          AUTONOMOUS_RUNNER_DISABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.kill_switch == 'true' && 'true' || vars.AUTONOMOUS_RUNNER_DISABLED || 'false' }}
+          AUTONOMOUS_RUNNER_ALLOW_EXECUTE: "false"
+          AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES: "false"
+          AUTONOMOUS_RUNNER_MAX_CYCLES: ${{ github.event_name == 'workflow_dispatch' && inputs.max_cycles || vars.AUTONOMOUS_RUNNER_MAX_CYCLES || '1' }}
+        run: node scripts/pinballwake-autonomous-runner.mjs
+
+      - name: Upload runner ledger
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: autonomous-runner-ledger-${{ github.run_id }}
+          path: ${{ vars.CODING_ROOM_LEDGER_PATH || '.pinballwake/coding-room-ledger.json' }}
+          if-no-files-found: ignore
+          retention-days: 14
+          include-hidden-files: true

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -246,6 +246,18 @@ export function runAutonomousRunnerCycle({
     };
   }
 
+  if (safeMode === "execute" && !safePolicy.allowExecute) {
+    return {
+      ok: true,
+      action: "blocked",
+      mode: safeMode,
+      reason: "execute_mode_disabled",
+      runner: safeRunner.id,
+      ledger: createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now }),
+      safety_blocked: [],
+    };
+  }
+
   const hardened = markUnsafeJobsBlockedForAutonomousRunner({
     ledger,
     allowProtectedSurfaces: safePolicy.allowProtectedSurfaces,
@@ -254,18 +266,6 @@ export function runAutonomousRunnerCycle({
 
   if (!hardened.ok) {
     return hardened;
-  }
-
-  if (safeMode === "execute" && !safePolicy.allowExecute) {
-    return {
-      ok: true,
-      action: "blocked",
-      mode: safeMode,
-      reason: "execute_mode_disabled",
-      runner: safeRunner.id,
-      ledger: hardened.ledger,
-      safety_blocked: hardened.blocked,
-    };
   }
 
   const claim = runCodingRoomRunnerCycle({
@@ -318,7 +318,8 @@ export async function runAutonomousRunnerFile({
     }
   }
 
-  const shouldPersist = safeMode !== "dry-run" && !safePolicy.disabled;
+  const executeBlocked = safeMode === "execute" && !safePolicy.allowExecute;
+  const shouldPersist = safeMode !== "dry-run" && !safePolicy.disabled && !executeBlocked;
   if (shouldPersist) {
     await writeCodingRoomJobLedger(ledgerPath, ledger);
   }

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -164,6 +164,32 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.ledger.jobs[0].status, "queued");
   });
 
+  it("does not persist blocked execute-mode invocations", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger({ jobs: [safeJob()] }));
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "execute",
+        now: "2026-05-06T03:00:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "execute_mode_disabled");
+      assert.equal(result.persisted, false);
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs[0].status, "queued");
+      assert.equal(persisted.jobs[0].claimed_by, null);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("can block unsafe queued jobs without protected-surface exemptions", () => {
     const result = markUnsafeJobsBlockedForAutonomousRunner({
       ledger: createCodingRoomJobLedger({
@@ -181,5 +207,17 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.ok, true);
     assert.equal(result.blocked.length, 1);
     assert.equal(result.ledger.jobs[0].status, "blocked");
+  });
+
+  it("wires the scheduled workflow to dry-run by default with execute locked off", async () => {
+    const workflow = await readFile(".github/workflows/autonomous-runner.yml", "utf8");
+
+    assert.match(workflow, /cron:\s*"3,13,23,33,43,53 \* \* \* \*"/);
+    assert.match(workflow, /node scripts\/pinballwake-autonomous-runner\.mjs/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_MODE:.*'dry-run'/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_EXECUTE:\s*"false"/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES:\s*"false"/);
+    assert.match(workflow, /kill_switch:/);
+    assert.doesNotMatch(workflow, /^\s+- execute$/m);
   });
 });


### PR DESCRIPTION
Summary:
- Adds a scheduled PinballWake Autonomous Runner workflow using the fleet-throughput-watch style GitHub Actions pattern.
- Defaults scheduled/manual runs to dry-run unless repo config or manual dispatch selects claim mode.
- Adds workflow kill-switch config and keeps execute mode unavailable in dispatch and locked off in env.
- Hardens the runner so blocked execute-mode invocations do not persist ledger changes when execute is not explicitly allowed.

Scope:
- Owned files: .github/workflows/autonomous-runner.yml, scripts/pinballwake-autonomous-runner.mjs, scripts/pinballwake-autonomous-runner.test.mjs.
- Linked todo: 6cbfa2fa.

Non-overlap:
- Does not enable execute mode.
- Does not merge, lift draft, touch secrets/auth/billing/DNS/migrations/raw keys, or edit another worker branch.
- Does not change queue routing, worker registry, or proof executor behavior beyond the runner safety guard.

Verification:
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- node --test scripts/pinballwake-coding-room-runner.test.mjs
- node --test scripts/pinballwake-proof-executor.test.mjs
- git diff --cached --check

Risk:
- Adds a scheduled GitHub Actions workflow; default behavior is dry-run.
- Claim mode can be selected by repo variable or manual dispatch, but execute is not exposed and AUTONOMOUS_RUNNER_ALLOW_EXECUTE is false.
- Kill switch is testable through workflow_dispatch input and repo variable AUTONOMOUS_RUNNER_DISABLED.

Follow-up:
- Keep draft until Tester, Reviewer, and Safety Checker all PASS; Coordinator can then lift/merge under the stated gates.