### PR TITLE
feat(reliability): add heartbeat protocol tool

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -56,6 +56,10 @@ Memory works out of the box. No setup needed — data is stored as JSON files in
 
 Memory tools exposed at session level: `load_memory`, `save_session`, `save_fact`, `search_memory`, `save_identity`. Full 17 operations available via `unclick_call` with `endpoint_id: "memory.*"`. The prior names (`get_startup_context`, `write_session_summary`, `add_fact`, `set_business_context`) still work as backward-compatible aliases.
 
+## AI Seat Heartbeats
+
+Scheduled AI Seats can call `heartbeat_protocol` with no arguments to fetch the canonical UnClick heartbeat playbook. The response is versioned and includes the current procedure, alert format, throttle rules, and `watch_state_key`, so seat prompts can shrink to: "Call heartbeat_protocol on UnClick. Follow what it returns."
+
 ## Configuration
 
 | Environment Variable | Default | Description |

--- a/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatHeartbeatProtocolVersion,
+  getHeartbeatProtocol,
+  heartbeatProtocolContentFingerprint,
+  type HeartbeatProtocol,
+} from "../heartbeat-protocol.js";
+
+describe("heartbeat_protocol payload", () => {
+  it("returns the same read-only playbook across cycles", () => {
+    const first = getHeartbeatProtocol();
+    const second = getHeartbeatProtocol();
+
+    expect(first).toEqual(second);
+    first.procedure[0] = "mutated by caller";
+    expect(getHeartbeatProtocol().procedure[0]).toContain("check_signals");
+  });
+
+  it("keeps the public payload schema stable", () => {
+    const protocol = getHeartbeatProtocol();
+
+    expect(Object.keys(protocol)).toEqual([
+      "version",
+      "procedure",
+      "alert_format",
+      "throttle_rules",
+      "watch_state_key",
+    ]);
+    expect(protocol.version).toMatch(/^\d{4}-\d{2}-\d{2}\.v\d+$/);
+    expect(protocol.procedure).toHaveLength(5);
+    expect(protocol.alert_format).toEqual({
+      heading: "UnClick alert",
+      line_template: "owner -- target -- status -- next safe action",
+      max_items: 3,
+      max_line_chars: 140,
+      style: ["no prose", "no bullets", "no bold"],
+      content_source: "UnClick",
+    });
+    expect(protocol.throttle_rules).toMatchObject({
+      idle_after: "24h without signals",
+      idle_cadence: "daily 9am",
+      active_cadence: "10 minutes",
+    });
+    expect(protocol.watch_state_key).toBe("heartbeat_last_state");
+  });
+
+  it("guards the version when the playbook content changes", () => {
+    const protocol = getHeartbeatProtocol();
+    const changed: HeartbeatProtocol = {
+      ...protocol,
+      procedure: [...protocol.procedure, "new instruction"],
+    };
+
+    expect(formatHeartbeatProtocolVersion(2)).toBe("2026-05-07.v2");
+    expect(protocol.version).toBe("2026-05-07.v1");
+    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("2c8cce6cbde3c0f4");
+    expect(heartbeatProtocolContentFingerprint(changed)).not.toBe(
+      heartbeatProtocolContentFingerprint(protocol),
+    );
+  });
+
+  it("does not return secrets or execution permissions", () => {
+    const serialized = JSON.stringify(getHeartbeatProtocol()).toLowerCase();
+
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("api_key");
+    expect(serialized).not.toContain("execute mode enabled");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -7,6 +7,7 @@ describe("runtime tool schema validation", () => {
     { name: "load_memory", args: { num_sessions: 1, bogus_field: "should reject" } },
     { name: "search_memory", args: { query: "strict schema probe", bogus_field: "should reject" } },
     { name: "check_signals", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
+    { name: "heartbeat_protocol", args: { bogus_field: "should reject" } },
     {
       name: "ack_handoff",
       args: {
@@ -63,6 +64,7 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("check_signals", {
       agent_id: "strict-probe",
     })).toBeNull();
+    expect(validateToolArgumentsForRuntime("heartbeat_protocol", {})).toBeNull();
     expect(validateToolArgumentsForRuntime("ack_handoff", {
       agent_id: "strict-probe",
       thread_id: "11111111-1111-4111-8111-111111111111",

--- a/packages/mcp-server/src/heartbeat-protocol.ts
+++ b/packages/mcp-server/src/heartbeat-protocol.ts
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto";
+
+export type HeartbeatProtocol = {
+  version: string;
+  procedure: string[];
+  alert_format: {
+    heading: string;
+    line_template: string;
+    max_items: number;
+    max_line_chars: number;
+    style: string[];
+    content_source: string;
+  };
+  throttle_rules: {
+    idle_after: string;
+    idle_cadence: string;
+    active_cadence: string;
+    idle_message: string;
+    active_message: string;
+    tether_error: string;
+  };
+  watch_state_key: string;
+};
+
+export const HEARTBEAT_PROTOCOL_DATE = "2026-05-07";
+export const HEARTBEAT_PROTOCOL_REVISION = 1;
+
+export function formatHeartbeatProtocolVersion(revision: number): string {
+  return `${HEARTBEAT_PROTOCOL_DATE}.v${revision}`;
+}
+
+const HEARTBEAT_PROTOCOL: HeartbeatProtocol = {
+  version: formatHeartbeatProtocolVersion(HEARTBEAT_PROTOCOL_REVISION),
+  procedure: [
+    "Call UnClick check_signals first. If unavailable, fall back to list_actionable_todos and read_messages. Cap to the most recent items UnClick returns.",
+    "Compare against prior tether state saved under heartbeat_last_state via search_memory. The diff is the only thing worth surfacing.",
+    'If no change, send nothing or exactly: "UnClick healthy." If UnClick surfaces action_needed, blocker, failed check, stale ACK, or approval-required items, send only the alert format.',
+    "Save the new tether state via save_fact with heartbeat_last_state, timestamp, and a small fingerprint under 2KB.",
+    "Do not retry, escalate, route, build, merge, edit code, or perform actions outside this heartbeat procedure.",
+  ],
+  alert_format: {
+    heading: "UnClick alert",
+    line_template: "owner -- target -- status -- next safe action",
+    max_items: 3,
+    max_line_chars: 140,
+    style: ["no prose", "no bullets", "no bold"],
+    content_source: "UnClick",
+  },
+  throttle_rules: {
+    idle_after: "24h without signals",
+    idle_cadence: "daily 9am",
+    active_cadence: "10 minutes",
+    idle_message: "UnClick idle -- heartbeat throttled to daily digest.",
+    active_message: "UnClick active again -- heartbeat back to 10-minute cadence.",
+    tether_error: "fail quietly and save heartbeat_last_error with a short reason",
+  },
+  watch_state_key: "heartbeat_last_state",
+};
+
+export function heartbeatProtocolContentFingerprint(protocol = HEARTBEAT_PROTOCOL): string {
+  const { version: _version, ...content } = protocol;
+  return createHash("sha256").update(JSON.stringify(content)).digest("hex").slice(0, 16);
+}
+
+export function getHeartbeatProtocol(): HeartbeatProtocol {
+  return JSON.parse(JSON.stringify(HEARTBEAT_PROTOCOL)) as HeartbeatProtocol;
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -13,6 +13,7 @@ import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
 import { markContextLoaded, recordToolCall, sessionState } from "./memory/session-state.js";
 import { emitSignal } from "./signals/emit.js";
+import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
 import { createHash } from "node:crypto";
 
 // ─── Umami tool-usage tracking ──────────────────────────────────────────────
@@ -430,6 +431,18 @@ const VISIBLE_TOOLS = [
           description: "Stable Boardroom agent_id for read attribution, e.g. chatgpt-codex-worker2.",
         },
       },
+    },
+  },
+  {
+    name: "heartbeat_protocol",
+    title: "Heartbeat protocol",
+    description:
+      "Returns the canonical UnClick AI Seat heartbeat playbook. " +
+      "Call this first from scheduled heartbeat seats, then follow the returned versioned procedure exactly.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
     },
   },
   {
@@ -1482,6 +1495,13 @@ export function createServer(): Server {
     trackToolCall(name);
 
     try {
+      // ── Heartbeat protocol: static, read-only AI Seat tether contract ──
+      if (name === "heartbeat_protocol") {
+        return {
+          content: [{ type: "text", text: JSON.stringify(getHeartbeatProtocol(), null, 2) }],
+        };
+      }
+
       // ── Signals: catch up on unread signals at session start ─────
       if (name === "check_signals") {
         const apiKey = process.env.UNCLICK_API_KEY;


### PR DESCRIPTION
Summary:
Adds a read-only heartbeat_protocol MCP tool that returns the canonical UnClick AI Seat heartbeat playbook as a versioned payload.

Scope:
Owned files are packages/mcp-server/src/heartbeat-protocol.ts, packages/mcp-server/src/server.ts, package MCP tests, and the MCP README. Linked todo: 0a78d812. PR is draft.

Non-overlap:
Does not enable execute mode, change Runner execution, touch secrets/auth/billing/DNS/migrations, or collapse scheduled task prompts yet.

Verification:
- npm --workspace @unclick/mcp-server run build
- npm --workspace @unclick/mcp-server test

Risk:
Low. Tool is static, stateless, no-arg, read-only, and returns JSON from local constants. No remote fetch, API key, or protected surface involved.

Follow-up:
Collapse the four PC heartbeat task prompts to the one-liner once gates pass.