### PR TITLE
fix(reliability): add build desk idempotency keys

### DIFF
--- a/api/build-desk-idempotency.test.ts
+++ b/api/build-desk-idempotency.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  attachBuildDeskIdempotencyKey,
+  findBuildDeskRowByIdempotencyKey,
+  getBuildDeskIdempotencyKey,
+  parseBuildDeskIdempotencyKey,
+} from "./lib/build-desk-idempotency";
+
+describe("Build Desk idempotency helpers", () => {
+  it("normalizes valid idempotency keys", () => {
+    expect(parseBuildDeskIdempotencyKey(" retry-123 ")).toEqual({ value: "retry-123" });
+    expect(parseBuildDeskIdempotencyKey(undefined)).toEqual({});
+    expect(parseBuildDeskIdempotencyKey(" ")).toEqual({});
+  });
+
+  it("rejects malformed idempotency keys", () => {
+    expect(parseBuildDeskIdempotencyKey(123).error).toBe("idempotency_key must be a string");
+    expect(parseBuildDeskIdempotencyKey("bad key").error).toBe(
+      "idempotency_key must not contain whitespace",
+    );
+    expect(parseBuildDeskIdempotencyKey("x".repeat(257)).error).toBe(
+      "idempotency_key must be at most 256 characters",
+    );
+    expect(parseBuildDeskIdempotencyKey(`a${"\u0001"}b`).error).toBe(
+      "idempotency_key contains invalid control characters",
+    );
+  });
+
+  it("attaches keys without dropping existing payload", () => {
+    expect(attachBuildDeskIdempotencyKey({ title: "ship" }, "retry-123")).toEqual({
+      title: "ship",
+      idempotency_key: "retry-123",
+    });
+    expect(attachBuildDeskIdempotencyKey("raw", "retry-123")).toEqual({
+      value: "raw",
+      idempotency_key: "retry-123",
+    });
+    expect(attachBuildDeskIdempotencyKey(undefined, undefined)).toBeNull();
+  });
+
+  it("finds existing rows by payload key", () => {
+    const rows = [
+      { id: "a", payload_json: { idempotency_key: "first" } },
+      { id: "b", payload_json: { idempotency_key: "second" } },
+    ];
+
+    expect(getBuildDeskIdempotencyKey(rows[0].payload_json)).toBe("first");
+    expect(findBuildDeskRowByIdempotencyKey(rows, "payload_json", "second")).toEqual(rows[1]);
+    expect(findBuildDeskRowByIdempotencyKey(rows, "payload_json", "missing")).toBeNull();
+  });
+});

--- a/api/lib/build-desk-idempotency.ts
+++ b/api/lib/build-desk-idempotency.ts
@@ -1,0 +1,47 @@
+export type IdempotencyKeyParseResult =
+  | { value: string; error?: never }
+  | { value?: never; error: string }
+  | { value?: undefined; error?: never };
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseBuildDeskIdempotencyKey(value: unknown): IdempotencyKeyParseResult {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== "string") return { error: "idempotency_key must be a string" };
+
+  const trimmed = value.trim();
+  if (!trimmed) return {};
+  if (trimmed.length > 256) return { error: "idempotency_key must be at most 256 characters" };
+  if (/\s/.test(trimmed)) return { error: "idempotency_key must not contain whitespace" };
+  if (/[\u0000-\u001f\u007f]/.test(trimmed)) {
+    return { error: "idempotency_key contains invalid control characters" };
+  }
+  return { value: trimmed };
+}
+
+export function getBuildDeskIdempotencyKey(payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
+  const parsed = parseBuildDeskIdempotencyKey(payload.idempotency_key);
+  return parsed.value ?? null;
+}
+
+export function attachBuildDeskIdempotencyKey(payload: unknown, key?: string): unknown {
+  if (!key) return payload ?? null;
+  if (isRecord(payload)) return { ...payload, idempotency_key: key };
+  return { value: payload ?? null, idempotency_key: key };
+}
+
+export function findBuildDeskRowByIdempotencyKey<T extends Record<string, unknown>>(
+  rows: T[] | null | undefined,
+  jsonField: keyof T,
+  key: string,
+): T | null {
+  for (const row of rows ?? []) {
+    if (getBuildDeskIdempotencyKey(row[jsonField]) === key) return row;
+  }
+  return null;
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -34,7 +34,7 @@
  * Build Desk admin actions (Bearer <api_key>, tenant-scoped by sha256hex):
  *   - admin_build_tasks: method=list|get|create|update_status|soft_delete
  *   - admin_build_workers: method=list|register|update|delete|health_check
- *   - admin_build_dispatch: POST with task_id + worker_id (same tenant)
+ *   - admin_build_dispatch: POST with task_id + worker_id (same tenant) and optional idempotency_key
  *   - reliability_dispatches: method=list|get|upsert|claim|release
  *   - reliability_heartbeats: method=list|publish
  *   - reliability_reclaim_stale: POST with optional { limit, dry_run }
@@ -97,6 +97,11 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
+import {
+  attachBuildDeskIdempotencyKey,
+  findBuildDeskRowByIdempotencyKey,
+  parseBuildDeskIdempotencyKey,
+} from "./lib/build-desk-idempotency.js";
 import {
   buildFishbowlMessageHandoffDispatchRow,
   planFishbowlMessageHandoffs,
@@ -1355,10 +1360,33 @@ function buildAdminChatTools(supabase: SupabaseClient, apiKeyHash: string | null
           .array(z.string())
           .optional()
           .describe("Concrete checklist items defining done"),
+        idempotency_key: z
+          .string()
+          .optional()
+          .describe("Optional retry key. Reusing it returns the existing build task instead of creating a duplicate."),
       }),
-      execute: async ({ title, description, acceptance_criteria }) => {
+      execute: async ({ title, description, acceptance_criteria, idempotency_key }) => {
         const missing = requireKey();
         if (missing) return missing;
+        const parsedIdempotencyKey = parseBuildDeskIdempotencyKey(idempotency_key);
+        if (parsedIdempotencyKey.error) return { success: false, error: parsedIdempotencyKey.error };
+
+        if (parsedIdempotencyKey.value) {
+          const { data: existingTasks, error: existingErr } = await supabase
+            .from("build_tasks")
+            .select("id, title, status, created_at, plan_json")
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(50);
+          if (existingErr) return { success: false, error: existingErr.message };
+          const existing = findBuildDeskRowByIdempotencyKey(
+            existingTasks ?? [],
+            "plan_json",
+            parsedIdempotencyKey.value,
+          );
+          if (existing) return { success: true, task: existing, was_duplicate: true };
+        }
+
         const { data, error } = await supabase
           .from("build_tasks")
           .insert({
@@ -1366,12 +1394,13 @@ function buildAdminChatTools(supabase: SupabaseClient, apiKeyHash: string | null
             title,
             description,
             acceptance_criteria_json: acceptance_criteria ?? [],
+            plan_json: attachBuildDeskIdempotencyKey(null, parsedIdempotencyKey.value),
             status: "draft",
           })
           .select("id, title, status, created_at")
           .single();
         if (error) return { success: false, error: error.message };
-        return { success: true, task: data };
+        return { success: true, task: data, was_duplicate: false };
       },
     }),
 
@@ -4529,8 +4558,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               acceptance_criteria_json,
               assigned_worker_id,
               parent_task_id,
+              idempotency_key,
             } = req.body ?? {};
             if (!title) return res.status(400).json({ error: "title required" });
+            const parsedIdempotencyKey = parseBuildDeskIdempotencyKey(
+              idempotency_key ?? (isRecord(plan_json) ? plan_json.idempotency_key : undefined),
+            );
+            if (parsedIdempotencyKey.error) {
+              return res.status(400).json({ error: parsedIdempotencyKey.error });
+            }
+
+            if (parsedIdempotencyKey.value) {
+              const { data: existingTasks, error: existingErr } = await supabase
+                .from("build_tasks")
+                .select("*")
+                .eq("api_key_hash", apiKeyHash)
+                .order("created_at", { ascending: false })
+                .limit(50);
+              if (existingErr) throw existingErr;
+              const existing = findBuildDeskRowByIdempotencyKey(
+                existingTasks ?? [],
+                "plan_json",
+                parsedIdempotencyKey.value,
+              );
+              if (existing) return res.status(200).json({ data: existing, was_duplicate: true });
+            }
 
             if (assigned_worker_id) {
               const { data: w, error: wErr } = await supabase
@@ -4560,7 +4612,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 title,
                 description: description ?? null,
                 status: status ?? "draft",
-                plan_json: plan_json ?? null,
+                plan_json: attachBuildDeskIdempotencyKey(plan_json, parsedIdempotencyKey.value),
                 acceptance_criteria_json: acceptance_criteria_json ?? null,
                 assigned_worker_id: assigned_worker_id ?? null,
                 parent_task_id: parent_task_id ?? null,
@@ -4568,7 +4620,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               .select()
               .single();
             if (error) throw error;
-            return res.status(200).json({ data });
+            return res.status(200).json({ data, was_duplicate: false });
           }
           case "update_status": {
             if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
@@ -4715,6 +4767,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (!task_id || !worker_id) {
           return res.status(400).json({ error: "task_id and worker_id required" });
         }
+        const parsedIdempotencyKey = parseBuildDeskIdempotencyKey(
+          req.body?.idempotency_key ?? (isRecord(payload_json) ? payload_json.idempotency_key : undefined),
+        );
+        if (parsedIdempotencyKey.error) {
+          return res.status(400).json({ error: parsedIdempotencyKey.error });
+        }
 
         const [taskRes, workerRes] = await Promise.all([
           supabase
@@ -4735,6 +4793,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (!taskRes.data) return res.status(404).json({ error: "task_id not found" });
         if (!workerRes.data) return res.status(404).json({ error: "worker_id not found" });
 
+        if (parsedIdempotencyKey.value) {
+          const { data: existingEvents, error: existingErr } = await supabase
+            .from("build_dispatch_events")
+            .select()
+            .eq("api_key_hash", apiKeyHash)
+            .eq("task_id", task_id)
+            .eq("worker_id", worker_id)
+            .eq("event_type", "dispatched")
+            .order("created_at", { ascending: false })
+            .limit(50);
+          if (existingErr) throw existingErr;
+          const existingEvent = findBuildDeskRowByIdempotencyKey(
+            existingEvents ?? [],
+            "payload_json",
+            parsedIdempotencyKey.value,
+          );
+          if (existingEvent) {
+            const { error: updErr } = await supabase
+              .from("build_tasks")
+              .update({
+                status: "dispatched",
+                assigned_worker_id: worker_id,
+                updated_at: new Date().toISOString(),
+              })
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", task_id);
+            if (updErr) throw updErr;
+            return res.status(200).json({ data: existingEvent, was_duplicate: true });
+          }
+        }
+
         const { data: eventData, error: eventErr } = await supabase
           .from("build_dispatch_events")
           .insert({
@@ -4742,7 +4831,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             task_id,
             worker_id,
             event_type: "dispatched",
-            payload_json: payload_json ?? null,
+            payload_json: attachBuildDeskIdempotencyKey(payload_json, parsedIdempotencyKey.value),
           })
           .select()
           .single();
@@ -4759,7 +4848,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("id", task_id);
         if (updErr) throw updErr;
 
-        return res.status(200).json({ data: eventData });
+        return res.status(200).json({ data: eventData, was_duplicate: false });
       }
 
       case "reliability_dispatches": {


### PR DESCRIPTION
Summary:
Adds optional idempotency_key support to Build Desk task creation and dispatch so timeout retries can return existing rows instead of creating duplicate work or dispatch events.

Scope:
Owned files are api/memory-admin.ts, api/lib/build-desk-idempotency.ts, and api/build-desk-idempotency.test.ts. Linked todo: 1bb1582d-471c-4b13-a09f-1598cb969ac5. PR is draft.

Non-overlap:
Does not add migrations, touch auth/secrets/billing/DNS, enable execute mode, or change worker execution semantics.

Verification:
- npm exec vitest run api/build-desk-idempotency.test.ts
- npm exec vitest run api/fishbowl-todo-handoff.test.ts api/fishbowl-message-handoff.test.ts api/fishbowl-watcher.test.ts api/build-desk-idempotency.test.ts
- npx tsc --noEmit --pretty false
- npm run build

Risk:
Low to medium. It changes Build Desk API response shape by adding was_duplicate and stores retry keys inside existing JSON fields, avoiding schema changes. Concurrent first writes are still best-effort without a DB unique constraint.

Follow-up:
A future migration can add a first-class unique idempotency column if hard concurrent de-dupe is needed.