### PR TITLE
feat(reliability): expose dispatch throughput metrics

### DIFF
--- a/api/lib/throughput-observability.ts
+++ b/api/lib/throughput-observability.ts
@@ -1,0 +1,150 @@
+type DispatchStatus = "queued" | "leased" | "completed" | "failed" | "stale" | "cancelled";
+
+export type ThroughputDispatchRow = {
+  dispatch_id: string;
+  source: string;
+  target_agent_id: string;
+  task_ref: string | null;
+  status: DispatchStatus;
+  lease_owner: string | null;
+  lease_expires_at: string | null;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DispatchThroughputMetrics = {
+  total_dispatches: number;
+  queued_dispatches: number;
+  leased_dispatches: number;
+  completed_dispatches: number;
+  failed_dispatches: number;
+  stale_dispatches: number;
+  cancelled_dispatches: number;
+  duplicate_dispatch_count: number;
+  collision_count: number;
+  wasted_work_dispatches: number;
+  oldest_queue_age_seconds: number;
+  average_queue_age_seconds: number;
+  max_claim_age_seconds: number;
+  lease_owner_counts: Record<string, number>;
+  blocker_reason_counts: Record<string, number>;
+};
+
+export type ThroughputDecoratedDispatch<T extends ThroughputDispatchRow> = T & {
+  queue_age_seconds: number | null;
+  claim_age_seconds: number | null;
+};
+
+function secondsSince(iso: string | null | undefined, now: Date): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, Math.floor((now.getTime() - ms) / 1000));
+}
+
+function increment(map: Record<string, number>, key: string): void {
+  map[key] = (map[key] ?? 0) + 1;
+}
+
+function activeCollisionKey(row: ThroughputDispatchRow): string | null {
+  if (row.status !== "queued" && row.status !== "leased") return null;
+  return [row.source, row.target_agent_id, row.task_ref ?? ""].join("|");
+}
+
+function blockerReason(row: ThroughputDispatchRow): string | null {
+  const payload = row.payload ?? {};
+  const raw = payload.blocker_reason ?? payload.blocker ?? payload.failure_reason;
+  return typeof raw === "string" && raw.trim() ? raw.trim().slice(0, 120) : null;
+}
+
+export function decorateThroughputDispatch<T extends ThroughputDispatchRow>(
+  row: T,
+  now = new Date(),
+): ThroughputDecoratedDispatch<T> {
+  return {
+    ...row,
+    queue_age_seconds: row.status === "queued" ? secondsSince(row.created_at, now) : null,
+    claim_age_seconds: row.status === "leased" ? secondsSince(row.updated_at, now) : null,
+  };
+}
+
+export function createDispatchThroughputMetrics(
+  rows: ThroughputDispatchRow[],
+  now = new Date(),
+): DispatchThroughputMetrics {
+  const metrics: DispatchThroughputMetrics = {
+    total_dispatches: rows.length,
+    queued_dispatches: 0,
+    leased_dispatches: 0,
+    completed_dispatches: 0,
+    failed_dispatches: 0,
+    stale_dispatches: 0,
+    cancelled_dispatches: 0,
+    duplicate_dispatch_count: 0,
+    collision_count: 0,
+    wasted_work_dispatches: 0,
+    oldest_queue_age_seconds: 0,
+    average_queue_age_seconds: 0,
+    max_claim_age_seconds: 0,
+    lease_owner_counts: {},
+    blocker_reason_counts: {},
+  };
+
+  const dispatchIds = new Map<string, number>();
+  const activeCollisions = new Map<string, number>();
+  let queueAgeTotal = 0;
+  let queueAgeCount = 0;
+
+  for (const row of rows) {
+    dispatchIds.set(row.dispatch_id, (dispatchIds.get(row.dispatch_id) ?? 0) + 1);
+    if (row.status === "queued") {
+      metrics.queued_dispatches++;
+      const age = secondsSince(row.created_at, now);
+      if (age !== null) {
+        queueAgeTotal += age;
+        queueAgeCount++;
+        metrics.oldest_queue_age_seconds = Math.max(metrics.oldest_queue_age_seconds, age);
+      }
+    }
+    if (row.status === "leased") {
+      metrics.leased_dispatches++;
+      const claimAge = secondsSince(row.updated_at, now);
+      if (claimAge !== null) {
+        metrics.max_claim_age_seconds = Math.max(metrics.max_claim_age_seconds, claimAge);
+      }
+      if (row.lease_owner) increment(metrics.lease_owner_counts, row.lease_owner);
+    }
+    if (row.status === "completed") metrics.completed_dispatches++;
+    if (row.status === "failed") metrics.failed_dispatches++;
+    if (row.status === "stale") metrics.stale_dispatches++;
+    if (row.status === "cancelled") metrics.cancelled_dispatches++;
+
+    const collisionKey = activeCollisionKey(row);
+    if (collisionKey) activeCollisions.set(collisionKey, (activeCollisions.get(collisionKey) ?? 0) + 1);
+
+    const reason = blockerReason(row);
+    if (reason) increment(metrics.blocker_reason_counts, reason);
+  }
+
+  for (const count of dispatchIds.values()) {
+    if (count > 1) metrics.duplicate_dispatch_count += count - 1;
+  }
+  for (const count of activeCollisions.values()) {
+    if (count > 1) metrics.collision_count += count - 1;
+  }
+
+  metrics.wasted_work_dispatches =
+    metrics.failed_dispatches + metrics.stale_dispatches + metrics.cancelled_dispatches;
+  metrics.average_queue_age_seconds =
+    queueAgeCount > 0 ? Math.round(queueAgeTotal / queueAgeCount) : 0;
+
+  return metrics;
+}
+
+export function shouldIncludeThroughputMetrics(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -98,6 +98,11 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import {
+  createDispatchThroughputMetrics,
+  decorateThroughputDispatch,
+  shouldIncludeThroughputMetrics,
+} from "./lib/throughput-observability.js";
+import {
   buildFishbowlMessageHandoffDispatchRow,
   planFishbowlMessageHandoffs,
 } from "./lib/fishbowl-message-handoff.js";
@@ -4772,6 +4777,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             const limit = getClampedLimit(req.query.limit ?? req.body?.limit, 50, 200);
             const status = String(req.query.status ?? req.body?.status ?? "").trim();
             const source = String(req.query.source ?? req.body?.source ?? "").trim();
+            const includeMetrics = shouldIncludeThroughputMetrics(
+              req.query.include_metrics ?? req.body?.include_metrics,
+            );
             const targetAgentIdFilter = parseOptionalFilterToken(
               req.query.target_agent_id ?? req.body?.target_agent_id,
               "target_agent_id",
@@ -4807,7 +4815,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
             const { data, error } = await query;
             if (error) throw error;
-            return res.status(200).json({ dispatches: data ?? [] });
+            const dispatchRows = (data ?? []) as ReliabilityDispatchRow[];
+            return res.status(200).json({
+              dispatches: includeMetrics
+                ? dispatchRows.map((row) => decorateThroughputDispatch(row))
+                : dispatchRows,
+              ...(includeMetrics
+                ? { throughput: createDispatchThroughputMetrics(dispatchRows) }
+                : {}),
+            });
           }
 
           case "get": {

--- a/api/throughput-observability.test.ts
+++ b/api/throughput-observability.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createDispatchThroughputMetrics,
+  decorateThroughputDispatch,
+  shouldIncludeThroughputMetrics,
+  type ThroughputDispatchRow,
+} from "./lib/throughput-observability";
+
+const baseRow: ThroughputDispatchRow = {
+  dispatch_id: "dispatch_a",
+  source: "wakepass",
+  target_agent_id: "reviewer",
+  task_ref: "pr-123",
+  status: "queued",
+  lease_owner: null,
+  lease_expires_at: null,
+  payload: null,
+  created_at: "2026-05-07T10:00:00.000Z",
+  updated_at: "2026-05-07T10:00:00.000Z",
+};
+
+describe("throughput observability helpers", () => {
+  it("decorates queued and leased dispatches with age fields", () => {
+    const now = new Date("2026-05-07T10:05:00.000Z");
+    const queued = decorateThroughputDispatch(baseRow, now);
+    const leased = decorateThroughputDispatch(
+      {
+        ...baseRow,
+        status: "leased",
+        lease_owner: "reviewer",
+        updated_at: "2026-05-07T10:03:00.000Z",
+      },
+      now,
+    );
+
+    expect(queued.queue_age_seconds).toBe(300);
+    expect(queued.claim_age_seconds).toBeNull();
+    expect(leased.queue_age_seconds).toBeNull();
+    expect(leased.claim_age_seconds).toBe(120);
+  });
+
+  it("summarizes queue age, collisions, duplicates, lease owners, and wasted work", () => {
+    const now = new Date("2026-05-07T10:10:00.000Z");
+    const rows: ThroughputDispatchRow[] = [
+      baseRow,
+      {
+        ...baseRow,
+        dispatch_id: "dispatch_b",
+        created_at: "2026-05-07T10:05:00.000Z",
+      },
+      {
+        ...baseRow,
+        dispatch_id: "dispatch_b",
+        status: "leased",
+        lease_owner: "reviewer",
+        updated_at: "2026-05-07T10:08:00.000Z",
+      },
+      {
+        ...baseRow,
+        dispatch_id: "dispatch_c",
+        status: "failed",
+        task_ref: "pr-456",
+        payload: { blocker_reason: "ci_failed" },
+      },
+      {
+        ...baseRow,
+        dispatch_id: "dispatch_d",
+        status: "stale",
+        task_ref: "pr-789",
+      },
+    ];
+
+    expect(createDispatchThroughputMetrics(rows, now)).toMatchObject({
+      total_dispatches: 5,
+      queued_dispatches: 2,
+      leased_dispatches: 1,
+      failed_dispatches: 1,
+      stale_dispatches: 1,
+      duplicate_dispatch_count: 1,
+      collision_count: 2,
+      wasted_work_dispatches: 2,
+      oldest_queue_age_seconds: 600,
+      average_queue_age_seconds: 450,
+      max_claim_age_seconds: 120,
+      lease_owner_counts: { reviewer: 1 },
+      blocker_reason_counts: { ci_failed: 1 },
+    });
+  });
+
+  it("parses the include metrics flag safely", () => {
+    expect(shouldIncludeThroughputMetrics(true)).toBe(true);
+    expect(shouldIncludeThroughputMetrics("true")).toBe(true);
+    expect(shouldIncludeThroughputMetrics("1")).toBe(true);
+    expect(shouldIncludeThroughputMetrics("yes")).toBe(true);
+    expect(shouldIncludeThroughputMetrics("no")).toBe(false);
+    expect(shouldIncludeThroughputMetrics(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary:
Adds opt-in dispatch throughput observability to the reliability_dispatches list endpoint. When include_metrics is true, dispatch rows include queue_age_seconds and claim_age_seconds, and the response includes aggregate duplicate, collision, lease owner, blocker reason, and wasted-work metrics.

Scope:
Owned files are api/memory-admin.ts, api/lib/throughput-observability.ts, and api/throughput-observability.test.ts. Linked todo: cb43dffb-9d4e-4e0a-ae0f-51069131ecb6. PR is draft.

Non-overlap:
Does not add migrations, change dispatch claiming, enable execute mode, touch secrets/auth/billing/DNS, or alter default reliability_dispatches list output unless include_metrics is requested.

Verification:
- npm exec vitest run api/throughput-observability.test.ts api/fishbowl-watcher.test.ts
- npx tsc --noEmit --pretty false
- npm run build

Risk:
Low. Read-only metrics are computed from rows already returned by the existing tenant-scoped endpoint. Default response remains unchanged unless include_metrics is explicitly truthy.

Follow-up:
Wire these metrics into the admin UI or Runner selection logic after review.