### PR TITLE
fix(heartbeat): stop saving healthy pulses as facts

### DIFF
--- a/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
@@ -52,9 +52,9 @@ describe("heartbeat_protocol payload", () => {
       procedure: [...protocol.procedure, "new instruction"],
     };
 
-    expect(formatHeartbeatProtocolVersion(2)).toBe("2026-05-07.v2");
-    expect(protocol.version).toBe("2026-05-07.v1");
-    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("2c8cce6cbde3c0f4");
+    expect(formatHeartbeatProtocolVersion(3)).toBe("2026-05-07.v3");
+    expect(protocol.version).toBe("2026-05-07.v2");
+    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("2004d11c449534bc");
     expect(heartbeatProtocolContentFingerprint(changed)).not.toBe(
       heartbeatProtocolContentFingerprint(protocol),
     );

--- a/packages/mcp-server/src/heartbeat-protocol.ts
+++ b/packages/mcp-server/src/heartbeat-protocol.ts
@@ -23,7 +23,7 @@ export type HeartbeatProtocol = {
 };
 
 export const HEARTBEAT_PROTOCOL_DATE = "2026-05-07";
-export const HEARTBEAT_PROTOCOL_REVISION = 1;
+export const HEARTBEAT_PROTOCOL_REVISION = 2;
 
 export function formatHeartbeatProtocolVersion(revision: number): string {
   return `${HEARTBEAT_PROTOCOL_DATE}.v${revision}`;
@@ -33,9 +33,9 @@ const HEARTBEAT_PROTOCOL: HeartbeatProtocol = {
   version: formatHeartbeatProtocolVersion(HEARTBEAT_PROTOCOL_REVISION),
   procedure: [
     "Call UnClick check_signals first. If unavailable, fall back to list_actionable_todos and read_messages. Cap to the most recent items UnClick returns.",
-    "Compare against prior tether state saved under heartbeat_last_state via search_memory. The diff is the only thing worth surfacing.",
+    "Compare against prior tether state from local automation state first, then heartbeat_last_state search_memory only if no transient state is available. The diff is the only thing worth surfacing.",
     'If no change, send nothing or exactly: "UnClick healthy." If UnClick surfaces action_needed, blocker, failed check, stale ACK, or approval-required items, send only the alert format.',
-    "Save the new tether state via save_fact with heartbeat_last_state, timestamp, and a small fingerprint under 2KB.",
+    "Keep healthy heartbeat state transient. Do not save recurring healthy or no-change heartbeats as Memory facts; use save_fact only for actionable diffs, tether errors, or explicit user-relevant state changes.",
     "Do not retry, escalate, route, build, merge, edit code, or perform actions outside this heartbeat procedure.",
   ],
   alert_format: {


### PR DESCRIPTION
## Summary
- bumps heartbeat_protocol to v2
- tells seats to prefer transient automation state for heartbeat fingerprints
- stops recurring healthy/no-change pulses from being saved as Memory facts
- keeps save_fact only for actionable diffs, tether errors, or explicit user-relevant state changes

## Proof
- `vitest run src/__tests__/heartbeat-protocol.test.ts` from `packages/mcp-server` PASS
- `npm run build` from `packages/mcp-server` PASS

## Safety
- no secrets, auth, billing, DNS, migrations, destructive cleanup, execute mode, or merge automation touched