### PR TITLE
fix(reliability): keep vercel env schema OpenAI-safe

### DIFF
--- a/packages/mcp-server/src/__tests__/openai-tool-schema.test.ts
+++ b/packages/mcp-server/src/__tests__/openai-tool-schema.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { ADDITIONAL_TOOLS } from "../tool-wiring.js";
+
+function toolSchema(name: string): Record<string, unknown> {
+  const tool = ADDITIONAL_TOOLS.find((candidate) => candidate.name === name);
+  expect(tool).toBeTruthy();
+  return tool?.inputSchema as Record<string, unknown>;
+}
+
+describe("OpenAI tool schema compatibility", () => {
+  it("keeps vercel_get_env as a plain top-level object schema", () => {
+    const schema = toolSchema("vercel_get_env");
+
+    expect(schema.type).toBe("object");
+    expect(schema.required).toEqual(["project_id"]);
+
+    for (const keyword of ["anyOf", "oneOf", "allOf", "enum", "not"]) {
+      expect(schema).not.toHaveProperty(keyword);
+    }
+
+    expect(schema.properties).toMatchObject({
+      project_id: { type: "string" },
+      projectId: { type: "string" },
+    });
+  });
+});

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -2270,7 +2270,7 @@ export const ADDITIONAL_TOOLS = [
         decrypt: { type: "boolean" },
         api_key: { type: "string" },
       },
-      anyOf: [{ required: ["project_id"] }, { required: ["projectId"] }],
+      required: ["project_id"],
     },
   },
   {


### PR DESCRIPTION
Summary:
- Removes the forbidden top-level anyOf from the vercel_get_env MCP input schema.
- Keeps project_id as the required canonical parameter while leaving projectId advertised as a legacy alias.
- Adds a regression test so OpenAI-incompatible top-level schema composition does not come back.

Scope:
- Owned files: packages/mcp-server/src/tool-wiring.ts, packages/mcp-server/src/__tests__/openai-tool-schema.test.ts
- Lane/todo: reliability, UnClick todo b2762345

Non-overlap:
- Does not touch local Codex cache patches, connector UI, auth, billing, migrations, or unrelated Vercel env handlers.
- Does not remove the projectId handler alias already present on main.

Verification:
- npx vitest run src/__tests__/openai-tool-schema.test.ts src/vercel-tool.test.ts (from packages/mcp-server)
- npm run test --workspace=@unclick/mcp-server
- npm run build --workspace=@unclick/mcp-server

Risk:
- Low API surface risk: schema now requires project_id for OpenAI compatibility while the handler still accepts projectId as a legacy alias.
- User-facing MCP availability risk is positive: this should stop OpenAI from rejecting the UnClick tool payload during tool-list load.

Follow-up:
- After merge/deploy, ChatGPT seats need tool-list refresh/restart before UnClick tools recover.