### PR TITLE
fix(reliability): suppress stale checkin noise

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { createHeartbeat, createReclaimSignal } from "../packages/mcp-server/src/reliability.js";
 import {
   CHECKIN_ACK_LEASE_SECONDS,
+  CHECKIN_ACTIVE_GRACE_MS,
+  CHECKIN_DORMANT_SUPPRESS_MS,
   WAKEPASS_REROUTE_LEASE_SECONDS,
   buildDispatchReclaimSignal,
   buildMissedCheckinDispatch,
@@ -20,9 +22,9 @@ const baseProfile: ProfileRow = {
   agent_id: "worker-1",
   emoji: "🦾",
   display_name: "Worker One",
-  last_seen_at: "2026-05-01T01:00:00.000Z",
+  last_seen_at: "2026-05-01T00:30:00.000Z",
   current_status: "working",
-  current_status_updated_at: "2026-05-01T01:00:00.000Z",
+  current_status_updated_at: "2026-05-01T00:30:00.000Z",
   next_checkin_at: "2026-05-01T01:10:00.000Z",
 };
 
@@ -93,6 +95,36 @@ describe("fishbowl watcher PinballWake ACK coverage", () => {
           next_checkin_at: null,
         },
         Date.parse("2026-05-01T01:22:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+
+  it("suppresses missed check-ins for agents seen within the active grace window", () => {
+    const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
+
+    expect(
+      isMissedCheckinCandidate(
+        {
+          ...baseProfile,
+          last_seen_at: new Date(nowMs - CHECKIN_ACTIVE_GRACE_MS + 1_000).toISOString(),
+          next_checkin_at: "2026-05-01T01:21:00.000Z",
+        },
+        nowMs,
+      ),
+    ).toBe(false);
+  });
+
+  it("suppresses missed check-ins for long-dormant agents", () => {
+    const nowMs = Date.parse("2026-05-08T01:22:00.000Z");
+
+    expect(
+      isMissedCheckinCandidate(
+        {
+          ...baseProfile,
+          last_seen_at: new Date(nowMs - CHECKIN_DORMANT_SUPPRESS_MS - 1_000).toISOString(),
+          next_checkin_at: "2026-05-08T01:10:00.000Z",
+        },
+        nowMs,
       ),
     ).toBe(false);
   });

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -65,6 +65,8 @@ const CHECKIN_DEDUP_WINDOW_MS = 30 * 60 * 1000;
 const MENTION_DIGEST_DEDUP_WINDOW_MS = 60 * 60 * 1000;
 const MENTION_AGE_THRESHOLD_MS = 10 * 60 * 1000;
 const STATUS_STALE_WINDOW_MS = 30 * 60 * 1000;
+export const CHECKIN_ACTIVE_GRACE_MS = 30 * 60 * 1000;
+export const CHECKIN_DORMANT_SUPPRESS_MS = 7 * 24 * 60 * 60 * 1000;
 export const CHECKIN_ACK_LEASE_SECONDS = 600;
 const STALE_DISPATCH_RECLAIM_LIMIT = 50;
 export const WAKEPASS_REROUTE_LEASE_SECONDS = 600;
@@ -94,6 +96,9 @@ export function isMissedCheckinCandidate(profile: ProfileRow, nowMs: number): bo
   if (Number.isNaN(dueMs)) return false;
   if (dueMs >= nowMs) return false;
   const seenMs = profile.last_seen_at ? new Date(profile.last_seen_at).getTime() : 0;
+  if (Number.isNaN(seenMs)) return false;
+  if (seenMs > 0 && nowMs - seenMs <= CHECKIN_ACTIVE_GRACE_MS) return false;
+  if (seenMs > 0 && nowMs - seenMs >= CHECKIN_DORMANT_SUPPRESS_MS) return false;
   return seenMs < dueMs;
 }
 


### PR DESCRIPTION
Summary:
- Adds missed-checkin candidate guards for recently active seats and long-dormant seats.
- Keeps the existing missed-checkin dispatch flow unchanged for genuinely overdue active workers.
- Extends the existing watcher tests with active-grace and dormant-suppression cases.

Scope:
- Owned files: api/fishbowl-watcher.ts, api/fishbowl-watcher.test.ts
- Lane/todo: reliability, UnClick todo 357f7138

Non-overlap:
- Does not touch WakePass ACK matcher, QueuePush dispatching, runner auto-claim, product routing, migrations, or merge gates.
- Does not change Signal delivery or Boardroom UI copy beyond the existing watcher candidate filter.

Verification:
- npx vitest run api/fishbowl-watcher.test.ts
- npm run build

Risk:
- Low. This only narrows checkin_missed emissions before dispatch/signal creation.
- Agents with last_seen_at within 30 minutes are treated as active and suppressed.
- Agents with last_seen_at older than 7 days are treated as dormant and suppressed from repeated user-facing check-in wakes.

Follow-up:
- Separate WakePass ACK matcher work remains for threaded ACK/wake_event_id handling.