### PR TITLE
fix(reliability): sync runner todo claims

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -213,6 +213,105 @@ export async function fetchUnClickActionableTodos({
   };
 }
 
+export function extractBoardroomTodoIdFromCodingRoomJob(job = {}) {
+  const jobId = String(job?.job_id || "").trim();
+  const source = String(job?.source || "").trim();
+  if (source !== "unclick-boardroom-actionable-todo" && !jobId.startsWith("boardroom-todo:")) {
+    return "";
+  }
+
+  const todoId = jobId.startsWith("boardroom-todo:")
+    ? jobId.slice("boardroom-todo:".length).trim()
+    : "";
+  return todoId && todoId !== "unknown" ? todoId : "";
+}
+
+function boardroomClaimAgentId(runner = {}) {
+  const safeRunner = createAutonomousRunner(runner);
+  return safeRunner.agent_id || safeRunner.id || DEFAULT_AUTONOMOUS_RUNNER.id;
+}
+
+export async function syncClaimedBoardroomTodoToUnClick({
+  job,
+  runner = DEFAULT_AUTONOMOUS_RUNNER,
+  mcpUrl = DEFAULT_UNCLICK_MCP_URL,
+  apiKey = "",
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const todoId = extractBoardroomTodoIdFromCodingRoomJob(job);
+  if (!todoId) {
+    return { ok: true, skipped: true, reason: "not_boardroom_todo_claim" };
+  }
+
+  const agentId = boardroomClaimAgentId(runner);
+  const update = await callUnClickMcpTool({
+    mcpUrl,
+    apiKey,
+    fetchImpl,
+    toolName: "update_todo",
+    arguments: {
+      agent_id: agentId,
+      todo_id: todoId,
+      status: "in_progress",
+      assigned_to_agent_id: agentId,
+    },
+  });
+
+  if (!update.ok) {
+    return {
+      ok: false,
+      reason: "update_todo_failed",
+      todo_id: todoId,
+      detail: update.reason || update.error || null,
+      status: update.status ?? null,
+    };
+  }
+
+  const comment = await callUnClickMcpTool({
+    mcpUrl,
+    apiKey,
+    fetchImpl,
+    toolName: "comment_on",
+    arguments: {
+      agent_id: agentId,
+      target_kind: "todo",
+      target_id: todoId,
+      text: compact(
+        [
+          "Autonomous Runner claim synced: status open -> in_progress.",
+          `owner=${agentId}.`,
+          `dispatch=${job?.claim_id || "none"}.`,
+          `source=${job?.source || "unknown"}.`,
+          `job=${job?.job_id || "unknown"}.`,
+        ].join(" "),
+        600,
+      ),
+    },
+  });
+
+  if (!comment.ok) {
+    return {
+      ok: true,
+      reason: "claim_synced_comment_failed",
+      todo_id: todoId,
+      assigned_to_agent_id: agentId,
+      status: "in_progress",
+      comment_ok: false,
+      comment_detail: comment.reason || comment.error || null,
+      comment_status: comment.status ?? null,
+    };
+  }
+
+  return {
+    ok: true,
+    todo_id: todoId,
+    assigned_to_agent_id: agentId,
+    status: "in_progress",
+    comment_ok: true,
+    comment_id: comment.data?.comment?.id || null,
+  };
+}
+
 export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date().toISOString() } = {}) {
   const id = String(todo.id || todo.todo_id || "").trim();
   const title = compact(todo.title || "Untitled Boardroom todo", 180);
@@ -575,14 +674,48 @@ export async function runAutonomousRunnerFile({
 
   const executeBlocked = safeMode === "execute" && !safePolicy.allowExecute;
   const shouldPersist = safeMode !== "dry-run" && !safePolicy.disabled && !executeBlocked;
+  const last = results[results.length - 1] || { ok: true, action: "idle", reason: "no_cycle_run", ledger };
+  let todoClaimSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
+
+  if (
+    shouldPersist &&
+    queueSourceResult.source === "unclick" &&
+    last.action === "claimed" &&
+    last.job
+  ) {
+    todoClaimSync = await syncClaimedBoardroomTodoToUnClick({
+      job: last.job,
+      runner,
+      apiKey: unclickApiKey,
+      mcpUrl: unclickMcpUrl,
+      fetchImpl,
+    });
+
+    if (!todoClaimSync.ok) {
+      return {
+        ...last,
+        ok: false,
+        action: "blocked",
+        reason: "todo_claim_sync_failed",
+        mode: safeMode,
+        dry_run: safeMode === "dry-run",
+        persisted: false,
+        cycles: results,
+        ledger,
+        ledger_path: ledgerPath,
+        queue_source: queueSourceResult,
+        todo_claim_sync: todoClaimSync,
+      };
+    }
+  }
+
   if (shouldPersist) {
     await writeCodingRoomJobLedger(ledgerPath, ledger);
   }
 
-  const last = results[results.length - 1] || { ok: true, action: "idle", reason: "no_cycle_run", ledger };
   return {
     ...last,
-    ok: results.every((result) => result.ok),
+    ok: results.every((result) => result.ok) && todoClaimSync.ok,
     action: last.action,
     mode: safeMode,
     dry_run: safeMode === "dry-run",
@@ -591,6 +724,7 @@ export async function runAutonomousRunnerFile({
     ledger,
     ledger_path: ledgerPath,
     queue_source: queueSourceResult,
+    todo_claim_sync: todoClaimSync,
   };
 }
 

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
+  extractBoardroomTodoIdFromCodingRoomJob,
   fetchUnClickActionableTodos,
   inspectAutonomousRunnerJobSafety,
   markUnsafeJobsBlockedForAutonomousRunner,
@@ -205,6 +206,207 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.ok, true);
     assert.equal(result.todos.length, 1);
     assert.equal(result.todos[0].id, "todo-1");
+  });
+
+  it("extracts Boardroom todo ids only from imported UnClick jobs", () => {
+    const job = createCodingRoomJobFromBoardroomTodo({
+      id: "todo-claim-1",
+      title: "Auto-flip todo open to in_progress on start_code_task fire",
+    });
+
+    assert.equal(extractBoardroomTodoIdFromCodingRoomJob(job), "todo-claim-1");
+    assert.equal(extractBoardroomTodoIdFromCodingRoomJob(safeJob()), "");
+  });
+
+  it("syncs claimed UnClick todos back to in_progress in claim mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const calls = [];
+      const fetchImpl = async (url, init = {}) => {
+        calls.push({ url, init, body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-claim-1",
+                            title: "Auto-flip todo open to in_progress on start_code_task fire",
+                            status: "open",
+                            priority: "high",
+                            assigned_to_agent_id: null,
+                            created_at: "2026-05-08T05:00:00.000Z",
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "update_todo") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todo: {
+                          id: "todo-claim-1",
+                          status: "in_progress",
+                          assigned_to_agent_id: "runner-plex-1",
+                        },
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "comment_on") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({ comment: { id: "comment-1" } }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-08T05:30:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.persisted, true);
+      assert.deepEqual(calls.map((call) => call.body.params.name), [
+        "list_actionable_todos",
+        "update_todo",
+        "comment_on",
+      ]);
+      assert.deepEqual(calls[1].body.params.arguments, {
+        agent_id: "runner-plex-1",
+        todo_id: "todo-claim-1",
+        status: "in_progress",
+        assigned_to_agent_id: "runner-plex-1",
+      });
+      assert.equal(calls[2].body.params.arguments.target_id, "todo-claim-1");
+      assert.match(calls[2].body.params.arguments.text, /dispatch=coding-room-claim:/);
+      assert.equal(result.todo_claim_sync.ok, true);
+      assert.equal(result.todo_claim_sync.todo_id, "todo-claim-1");
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs[0].status, "claimed");
+      assert.equal(persisted.jobs[0].claimed_by, "runner-plex-1");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks and avoids persisting when UnClick todo claim sync fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const fetchImpl = async (_url, init = {}) => {
+        const body = JSON.parse(init.body);
+        if (body.params.name === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-claim-2",
+                            title: "Safe docs chip",
+                            status: "open",
+                            priority: "high",
+                            assigned_to_agent_id: null,
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        return {
+          ok: false,
+          status: 503,
+          async json() {
+            return {};
+          },
+        };
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-08T05:30:00.000Z",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "todo_claim_sync_failed");
+      assert.equal(result.persisted, false);
+      assert.equal(result.todo_claim_sync.reason, "update_todo_failed");
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs.length, 0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("marks sensitive Boardroom todos unsafe before autonomous claim", () => {


### PR DESCRIPTION
Summary:
- Syncs Runner todo claims back to UnClick todo status so claimed open todos move to in_progress with owner and dispatch proof.
- Keeps the change focused on claim visibility, not broader queue behavior.

Scope:
- Claim sync only.
- No merge behavior changes.
- No broad runner refactor.

Non-overlap:
- Separate from PR #563 stale check-in noise guard.
- Separate from PR #565 runner lease refresh.
- Separate from Vercel env schema PR #562.

Verification:
- GitHub checks are green as of 2026-05-08 06:38 UTC: Website, MCP server package, TestPass smoke, Vercel, and Vercel Preview Comments.
- Local build was not rerun here because this seat is doing a proof/lift pass, not a code-change pass.

Ready status:
- Owner: chatgpt-codex-worker2 acting on Chris tether push.
- Status: ready for review.
- Next action: review or merge through the normal UnClick gate.

Risk:
- Low runtime risk. The change narrows visibility drift by aligning claim state with todo state.

Follow-up:
- Continue toward auto-claim plus CAS/lock and typed ledger source-of-truth work.