### PR TITLE
fix(reliability): guard runner lease refreshes

### DIFF
--- a/scripts/pinballwake-coding-room.mjs
+++ b/scripts/pinballwake-coding-room.mjs
@@ -60,6 +60,10 @@ function isActiveClaimStatus(status) {
   return ["claimed", "building", "testing"].includes(status);
 }
 
+function claimRunnerId(runner = {}) {
+  return String(runner.id || runner.emoji || "").trim();
+}
+
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -365,10 +369,10 @@ export function claimCodingRoomJob({ runner = {}, job, activeJobs = [], now = ne
     job: {
       ...job,
       status: "claimed",
-      claimed_by: String(runner.id || runner.emoji || "").trim(),
+      claimed_by: claimRunnerId(runner),
       claim_id: codingRoomClaimId({
         jobId: job.job_id,
-        runnerId: String(runner.id || runner.emoji || "").trim(),
+        runnerId: claimRunnerId(runner),
         now,
       }),
       claimed_at: now,
@@ -476,6 +480,113 @@ export function claimCodingRoomLedgerJob({
       owned_files: result.job.owned_files || [],
       status: result.job.status,
     },
+  };
+}
+
+export function refreshCodingRoomJobLease({
+  job,
+  runner = {},
+  claimId = "",
+  now = new Date().toISOString(),
+  leaseSeconds,
+} = {}) {
+  if (!job) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  if (!isActiveClaimStatus(job.status)) {
+    return { ok: false, reason: "job_not_active" };
+  }
+
+  const runnerId = claimRunnerId(runner);
+  if (!runnerId) {
+    return { ok: false, reason: "missing_runner_id" };
+  }
+
+  if (String(job.claimed_by || "").trim() !== runnerId) {
+    return { ok: false, reason: "claim_owner_mismatch" };
+  }
+
+  const expectedClaimId = String(claimId || "").trim();
+  if (!expectedClaimId) {
+    return { ok: false, reason: "missing_claim_id" };
+  }
+
+  if (String(job.claim_id || "").trim() !== expectedClaimId) {
+    return { ok: false, reason: "claim_token_mismatch" };
+  }
+
+  const current = parseIso(now);
+  if (current === null) {
+    return { ok: false, reason: "invalid_now" };
+  }
+
+  const leaseExpiresAt = parseIso(job.lease_expires_at);
+  if (leaseExpiresAt === null) {
+    return { ok: false, reason: "invalid_lease" };
+  }
+
+  if (current > leaseExpiresAt) {
+    return { ok: false, reason: "lease_expired" };
+  }
+
+  const refreshed = {
+    ...job,
+    lease_expires_at: addSeconds(now, Number.isFinite(leaseSeconds) ? leaseSeconds : DEFAULT_LEASE_SECONDS),
+    lease_refreshed_at: now,
+  };
+
+  return {
+    ok: true,
+    job: refreshed,
+    lease: {
+      claim_id: refreshed.claim_id,
+      job_id: refreshed.job_id,
+      runner_id: refreshed.claimed_by,
+      lease_expires_at: refreshed.lease_expires_at,
+      lease_refreshed_at: refreshed.lease_refreshed_at,
+      status: refreshed.status,
+    },
+  };
+}
+
+export function refreshCodingRoomLedgerJobLease({
+  ledger,
+  jobId,
+  runner = {},
+  claimId = "",
+  now = new Date().toISOString(),
+  leaseSeconds,
+} = {}) {
+  const next = createCodingRoomJobLedger({
+    jobs: ledger?.jobs || [],
+    updatedAt: ledger?.updated_at || now,
+  });
+  const index = next.jobs.findIndex((job) => job.job_id === jobId);
+
+  if (index === -1) {
+    return { ok: false, reason: "missing_job" };
+  }
+
+  const refreshed = refreshCodingRoomJobLease({
+    job: next.jobs[index],
+    runner,
+    claimId,
+    now,
+    leaseSeconds,
+  });
+
+  if (!refreshed.ok) {
+    return refreshed;
+  }
+
+  next.jobs[index] = refreshed.job;
+  next.updated_at = now;
+  return {
+    ok: true,
+    ledger: next,
+    job: refreshed.job,
+    lease: refreshed.lease,
   };
 }
 

--- a/scripts/pinballwake-coding-room.test.mjs
+++ b/scripts/pinballwake-coding-room.test.mjs
@@ -18,6 +18,8 @@ import {
   parseCodingRoomJobLedger,
   readCodingRoomJobLedger,
   reclaimExpiredCodingRoomJobs,
+  refreshCodingRoomJobLease,
+  refreshCodingRoomLedgerJobLease,
   reviewJobNeedsFallback,
   runnerCanClaimCodingRoomJob,
   serializeCodingRoomJobLedger,
@@ -186,6 +188,142 @@ describe("PinballWake Coding Room skeleton", () => {
       owned_files: ["scripts/pinballwake-coding-room.mjs"],
       status: "claimed",
     });
+  });
+
+  it("refreshes a claimed job lease only with the matching owner and claim token", () => {
+    const claimed = claimCodingRoomJob({
+      runner: forgeRunner,
+      job: createCodingRoomJob({
+        jobId: "coding-room:test:refresh-lease",
+        worker: "forge",
+        chip: "refresh lease",
+        files: ["scripts/pinballwake-coding-room.mjs"],
+      }),
+      now: "2026-05-04T00:00:00.000Z",
+      leaseSeconds: 120,
+    }).job;
+
+    const result = refreshCodingRoomJobLease({
+      job: claimed,
+      runner: forgeRunner,
+      claimId: claimed.claim_id,
+      now: "2026-05-04T00:01:00.000Z",
+      leaseSeconds: 300,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.job.lease_refreshed_at, "2026-05-04T00:01:00.000Z");
+    assert.equal(result.job.lease_expires_at, "2026-05-04T00:06:00.000Z");
+    assert.deepEqual(result.lease, {
+      claim_id: claimed.claim_id,
+      job_id: "coding-room:test:refresh-lease",
+      runner_id: "forge",
+      lease_expires_at: "2026-05-04T00:06:00.000Z",
+      lease_refreshed_at: "2026-05-04T00:01:00.000Z",
+      status: "claimed",
+    });
+
+    assert.equal(
+      refreshCodingRoomJobLease({
+        job: claimed,
+        runner: { ...forgeRunner, id: "plex-builder" },
+        claimId: claimed.claim_id,
+        now: "2026-05-04T00:01:00.000Z",
+      }).reason,
+      "claim_owner_mismatch",
+    );
+
+    assert.equal(
+      refreshCodingRoomJobLease({
+        job: claimed,
+        runner: forgeRunner,
+        claimId: "coding-room-claim:stale",
+        now: "2026-05-04T00:01:00.000Z",
+      }).reason,
+      "claim_token_mismatch",
+    );
+  });
+
+  it("does not refresh expired leases or let a stale token overwrite a new claim", () => {
+    const firstClaim = claimCodingRoomJob({
+      runner: forgeRunner,
+      job: createCodingRoomJob({
+        jobId: "coding-room:test:refresh-expired",
+        worker: "forge",
+        chip: "expire then reclaim",
+        files: ["scripts/pinballwake-coding-room.mjs"],
+      }),
+      now: "2026-05-04T00:00:00.000Z",
+      leaseSeconds: 60,
+    }).job;
+
+    const expired = refreshCodingRoomJobLease({
+      job: firstClaim,
+      runner: forgeRunner,
+      claimId: firstClaim.claim_id,
+      now: "2026-05-04T00:01:01.000Z",
+    });
+    assert.equal(expired.ok, false);
+    assert.equal(expired.reason, "lease_expired");
+
+    const reclaimed = reclaimExpiredCodingRoomJobs({
+      ledger: createCodingRoomJobLedger({ jobs: [firstClaim] }),
+      now: "2026-05-04T00:01:01.000Z",
+    });
+    const secondClaim = claimCodingRoomLedgerJob({
+      ledger: reclaimed.ledger,
+      jobId: firstClaim.job_id,
+      runner: { ...forgeRunner, id: "plex-builder" },
+      now: "2026-05-04T00:01:02.000Z",
+    });
+
+    const staleRefresh = refreshCodingRoomLedgerJobLease({
+      ledger: secondClaim.ledger,
+      jobId: firstClaim.job_id,
+      runner: forgeRunner,
+      claimId: firstClaim.claim_id,
+      now: "2026-05-04T00:01:03.000Z",
+    });
+
+    assert.equal(staleRefresh.ok, false);
+    assert.equal(staleRefresh.reason, "claim_owner_mismatch");
+    assert.equal(secondClaim.ledger.jobs[0].claimed_by, "plex-builder");
+    assert.notEqual(secondClaim.ledger.jobs[0].claim_id, firstClaim.claim_id);
+  });
+
+  it("refreshes ledger leases without changing unrelated jobs", () => {
+    const claimed = claimCodingRoomJob({
+      runner: forgeRunner,
+      job: createCodingRoomJob({
+        jobId: "coding-room:test:ledger-refresh",
+        worker: "forge",
+        chip: "refresh from ledger",
+        files: ["scripts/pinballwake-coding-room.mjs"],
+      }),
+      now: "2026-05-04T00:00:00.000Z",
+      leaseSeconds: 90,
+    }).job;
+    const other = createCodingRoomJob({
+      jobId: "coding-room:test:other",
+      worker: "forge",
+      chip: "leave me queued",
+      files: ["scripts/other.mjs"],
+    });
+
+    const result = refreshCodingRoomLedgerJobLease({
+      ledger: createCodingRoomJobLedger({ jobs: [claimed, other], updatedAt: "2026-05-04T00:00:00.000Z" }),
+      jobId: claimed.job_id,
+      runner: forgeRunner,
+      claimId: claimed.claim_id,
+      now: "2026-05-04T00:01:00.000Z",
+      leaseSeconds: 120,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ledger.updated_at, "2026-05-04T00:01:00.000Z");
+    assert.equal(result.ledger.jobs[0].lease_expires_at, "2026-05-04T00:03:00.000Z");
+    assert.equal(result.ledger.jobs[1].status, "queued");
+    assert.equal(result.ledger.jobs[1].claim_id, undefined);
   });
 
   it("does not let two runners claim the same queued job", () => {


### PR DESCRIPTION
Status:
- Ready for review / owner-lifted on 2026-05-08.
- Draft hold cleared because the branch is clean, mergeable, and all required checks are green.

Summary:
- Adds token-guarded Coding Room lease refresh helpers for already-claimed runner jobs.
- Refresh now requires active status, matching claimed_by owner, matching claim_id, valid now, and an unexpired lease.
- Adds ledger-level refresh support that updates only the claimed job and returns a durable lease contract.

Scope:
- Owned files: scripts/pinballwake-coding-room.mjs and scripts/pinballwake-coding-room.test.mjs.
- Linked todo: b744462e-8e50-4cad-babb-5468adc2a3d9.
- Lane: runner / claim / lock path.

Non-overlap:
- Did not touch WakePass, QueuePush, stale check-in logic, UnClick MCP schema, auth/secrets, billing/DNS, migrations, execute mode, merge automation, or Jobs page UI.
- Did not change the autonomous runner queue-source sync from PR #564.

Verification:
- node --test scripts/pinballwake-coding-room.test.mjs scripts/pinballwake-coding-room-runner.test.mjs
- git diff --check
- GitHub checks green: Website (root package), MCP server package, TestPass smoke run, Vercel, Vercel Preview Comments.
- npm build not run locally in this clean worktree because node_modules is not installed; GitHub Website CI passed.

Risk:
- Low runtime risk: additive helpers plus tests; existing claim and reclaim behavior is preserved.
- This is not the full DB-level CAS implementation; it is the safe lease/heartbeat primitive needed before live lock wiring.

Follow-up:
- Wire the token-guarded refresh into the live runner heartbeat path.
- Add DB-backed CAS/lease columns only through the proper migration gate.