### PR TITLE
feat(admin): add single-column jobs page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,7 +164,8 @@ const App = () => (
             <Route path="autopilot" element={<AdminAutopilot />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
             <Route path="workers" element={<AdminWorkers />} />
-            <Route path="todos" element={<AdminTodoList />} />
+            <Route path="jobs" element={<AdminTodoList />} />
+            <Route path="todos" element={<Navigate to="/admin/jobs" replace />} />
             <Route path="checks" element={<AdminChecks />} />
             <Route path="ledger" element={<AdminLedger />} />
             <Route path="billing" element={<AdminBilling />} />

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -1,4 +1,7 @@
 import { Link } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSession } from "@/lib/auth";
+import FishbowlTodos from "./fishbowl/Todos";
 import {
   AppWindow,
   Archive,
@@ -14,7 +17,6 @@ import {
   FolderKanban,
   Hammer,
   KeyRound,
-  ListTodo,
   MessagesSquare,
   Microscope,
   Plane,
@@ -166,19 +168,44 @@ export function AdminWorkers() {
 }
 
 export function AdminTodoList() {
+  const { session } = useSession();
+  const token = session?.access_token;
+  const authHeader = useMemo(
+    () => (token ? { Authorization: `Bearer ${token}` } : {}),
+    [token],
+  );
+  const [humanAgentId, setHumanAgentId] = useState<string | null>(null);
+
+  const claimHumanProfile = useCallback(async () => {
+    if (!token) return;
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_admin_claim", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        profile?: { agent_id?: string };
+      };
+      if (res.ok && body.profile?.agent_id) {
+        setHumanAgentId(body.profile.agent_id);
+      }
+    } catch {
+      // Non-fatal: the Jobs page can still render, but add/edit controls stay disabled.
+    }
+  }, [authHeader, token]);
+
+  useEffect(() => {
+    void claimHumanProfile();
+  }, [claimHumanProfile]);
+
   return (
     <PageShell
       kicker="Tasks, separated from chatter"
-      title="To-Do List"
-      subtitle="Dedicated tasks belong here so the Boardroom can stay readable. Boardroom is for discussion; this is for work items."
+      title="Jobs"
+      subtitle="A single-column source of truth for active, next, in-line, and completed work. Boardroom stays for discussion; Jobs is the work list."
     >
-      <TileGrid
-        items={[
-          { title: "Open tasks", body: "Jobs waiting for a worker, owner, proof, or decision.", icon: ListTodo },
-          { title: "Blocked tasks", body: "Items that need user input, missing credentials, or a safety decision.", icon: ShieldCheck },
-          { title: "Done", body: "Completed tasks with receipts linked in the Ledger.", icon: CheckCircle2 },
-        ]}
-      />
+      <FishbowlTodos authHeader={authHeader} humanAgentId={humanAgentId} variant="page" />
     </PageShell>
   );
 }

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -266,7 +266,7 @@ export default function AdminShell() {
         <SurfaceLink path="/admin/autopilot" label="Autopilot"               icon={Plane} onClick={onLinkClick} />
         <SurfaceLink path="/admin/agents"    label="Workers"                 icon={Bot} onClick={onLinkClick} />
         <SurfaceLink path="/admin/boardroom" label="Boardroom"               icon={MessagesSquare} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/todos"     label="To-Do List"              icon={ListTodo} onClick={onLinkClick} />
+        <SurfaceLink path="/admin/jobs"      label="Jobs"                    icon={ListTodo} onClick={onLinkClick} />
         <SurfaceLink path="/admin/checks"    label="XPass / Checks"          icon={ClipboardCheck} onClick={onLinkClick} />
         <SurfaceLink path="/admin/ledger"    label="Ledger"                  icon={ReceiptText} onClick={onLinkClick} />
         <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />

--- a/src/pages/admin/BrainMap.tsx
+++ b/src/pages/admin/BrainMap.tsx
@@ -118,7 +118,7 @@ const TREE: Node[] = [
     ],
   },
   { label: "Boardroom", note: "build worker discussion" },
-  { label: "To-Do List", note: "dedicated tasks separated from Boardroom chatter" },
+  { label: "Jobs", note: "dedicated work list separated from Boardroom chatter" },
   {
     label: "XPass / Checks",
     note: "proof and quality checks",

--- a/src/pages/admin/fishbowl/Todos.tsx
+++ b/src/pages/admin/fishbowl/Todos.tsx
@@ -20,6 +20,7 @@ interface Todo {
 interface TodosProps {
   authHeader: Record<string, string>;
   humanAgentId: string | null;
+  variant?: "boardroom" | "page";
 }
 
 const STORAGE_KEY = "unclick.fishbowl.todos.collapsed";
@@ -45,6 +46,38 @@ function priorityPill(p: Todo["priority"]) {
       {p}
     </span>
   );
+}
+
+const STATUS_STYLE: Record<Todo["status"], string> = {
+  open: "bg-white/[0.05] text-[#aaa]",
+  in_progress: "bg-[#E2B93B]/15 text-[#E2B93B]",
+  done: "bg-green-500/15 text-green-300",
+  dropped: "bg-red-500/15 text-red-300",
+};
+
+function statusPill(status: Todo["status"]) {
+  const label = status === "in_progress" ? "active" : status;
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${STATUS_STYLE[status]}`}>
+      {label}
+    </span>
+  );
+}
+
+function progressFor(todo: Todo) {
+  if (todo.status === "done") return 100;
+  if (todo.status === "in_progress") return 45;
+  if (todo.priority === "urgent") return 15;
+  if (todo.priority === "high") return 10;
+  return 5;
+}
+
+function attentionText(todo: Todo) {
+  if (todo.status === "done") return "receipt";
+  if (todo.status === "in_progress") return todo.assigned_to_agent_id ? "moving" : "needs owner";
+  if (todo.priority === "urgent") return "next";
+  if (todo.priority === "high") return "in line";
+  return "waiting";
 }
 
 function AddTodoForm({
@@ -378,8 +411,10 @@ function TodoCard({
   );
 }
 
-export default function FishbowlTodos({ authHeader, humanAgentId }: TodosProps) {
+export default function FishbowlTodos({ authHeader, humanAgentId, variant = "boardroom" }: TodosProps) {
+  const pageMode = variant === "page";
   const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (pageMode) return false;
     if (typeof window === "undefined") return true;
     return window.localStorage.getItem(STORAGE_KEY) !== "0";
   });
@@ -450,6 +485,14 @@ export default function FishbowlTodos({ authHeader, humanAgentId }: TodosProps) 
     return map;
   }, [todos]);
 
+  const pageGroups = useMemo(() => {
+    const active = todos.filter((t) => t.status === "in_progress");
+    const next = todos.filter((t) => t.status === "open" && (t.priority === "urgent" || t.priority === "high"));
+    const inLine = todos.filter((t) => t.status === "open" && t.priority !== "urgent" && t.priority !== "high");
+    const done = todos.filter((t) => t.status === "done");
+    return { active, next, inLine, done };
+  }, [todos]);
+
   const toggleCard = (id: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -460,6 +503,124 @@ export default function FishbowlTodos({ authHeader, humanAgentId }: TodosProps) 
   };
 
   const totalActive = grouped.open.length + grouped.in_progress.length;
+
+  if (pageMode) {
+    const renderPageSection = (label: string, items: Todo[], helper: string) => (
+      <section className="rounded-lg border border-white/[0.06] bg-black/20">
+        <div className="flex items-center justify-between border-b border-white/[0.06] px-3 py-2">
+          <div>
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-[#888]">{label}</h2>
+            <p className="mt-0.5 text-[11px] text-[#555]">{helper}</p>
+          </div>
+          <span className="rounded-full bg-white/[0.05] px-2 py-0.5 text-[10px] text-[#888]">{items.length}</span>
+        </div>
+        {items.length === 0 ? (
+          <p className="px-3 py-3 text-xs italic text-[#555]">empty</p>
+        ) : (
+          <div className="divide-y divide-white/[0.06]">
+            {items.slice(0, 100).map((t) => {
+              const progress = progressFor(t);
+              const expandedRow = expanded.has(t.id);
+              return (
+                <div key={t.id} className={t.status === "done" ? "opacity-70" : ""}>
+                  <button
+                    type="button"
+                    onClick={() => toggleCard(t.id)}
+                    className="grid w-full grid-cols-[1fr_auto] items-center gap-3 px-3 py-2 text-left md:grid-cols-[minmax(0,1fr)_90px_110px_110px_80px_auto]"
+                    aria-expanded={expandedRow}
+                  >
+                    <div className="min-w-0">
+                      <p className={`truncate text-sm font-medium ${t.status === "done" ? "text-[#666] line-through" : "text-[#ddd]"}`}>
+                        {t.status === "done" && <span className="mr-1 text-green-400">✓</span>}
+                        {t.title}
+                      </p>
+                      <p className="mt-0.5 truncate text-[11px] text-[#666]">
+                        {t.assigned_to_agent_id ? `owner ${t.assigned_to_agent_id}` : "unassigned"}
+                        {(t.comment_count ?? 0) > 0 ? ` · ${t.comment_count} comments` : ""}
+                      </p>
+                    </div>
+                    <div className="hidden md:block">{statusPill(t.status)}</div>
+                    <div className="hidden md:block">{priorityPill(t.priority)}</div>
+                    <div className="hidden text-xs text-[#888] md:block">{attentionText(t)}</div>
+                    <div className="hidden md:block">
+                      <div className="h-1.5 rounded-full bg-white/[0.06]">
+                        <div className="h-1.5 rounded-full bg-[#61C1C4]" style={{ width: `${progress}%` }} />
+                      </div>
+                      <p className="mt-0.5 text-[10px] text-[#666]">{progress}%</p>
+                    </div>
+                    {expandedRow ? (
+                      <ChevronDown className="h-4 w-4 text-[#888]" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-[#888]" />
+                    )}
+                  </button>
+                  {expandedRow && (
+                    <div className="space-y-3 border-t border-white/[0.06] bg-black/20 px-3 py-3">
+                      {t.description && <p className="whitespace-pre-wrap text-xs leading-5 text-[#bbb]">{t.description}</p>}
+                      <div className="flex flex-wrap items-center gap-2">
+                        {t.status !== "done" && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              void fetch(`/api/memory-admin?action=fishbowl_complete_todo`, {
+                                method: "POST",
+                                headers: { ...authHeader, "Content-Type": "application/json" },
+                                body: JSON.stringify({ agent_id: humanAgentId, todo_id: t.id }),
+                              }).then(onMutated);
+                            }}
+                            disabled={!humanAgentId}
+                            className="rounded-md border border-green-400/40 bg-green-400/10 px-2 py-1 text-xs font-medium text-green-300 disabled:opacity-40"
+                          >
+                            Complete
+                          </button>
+                        )}
+                        <span className="text-xs text-[#666]">Created {new Date(t.created_at).toLocaleDateString()}</span>
+                      </div>
+                      <Comments
+                        authHeader={authHeader}
+                        humanAgentId={humanAgentId}
+                        targetKind="todo"
+                        targetId={t.id}
+                        pollSeq={pollSeq}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+            {items.length > 100 && (
+              <p className="px-3 py-2 text-xs text-[#666]">Showing first 100. Narrow the queue by completing or dropping older jobs.</p>
+            )}
+          </div>
+        )}
+      </section>
+    );
+
+    return (
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="text-xs text-[#666]">
+            Single source of truth from Boardroom todos. One job per line.
+          </div>
+          <div className="flex items-center gap-2">
+            {loading && <Loader2 className="h-3.5 w-3.5 animate-spin text-[#888]" />}
+            <AddTodoForm authHeader={authHeader} humanAgentId={humanAgentId} onCreated={onMutated} />
+          </div>
+        </div>
+
+        {error && (
+          <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+            {error}
+          </p>
+        )}
+
+        {renderPageSection("Active now", pageGroups.active, "Work already claimed or moving.")}
+        {renderPageSection("Next", pageGroups.next, "Urgent and high-priority jobs waiting for owner, proof, or decision.")}
+        {renderPageSection("In line", pageGroups.inLine, "Normal and low-priority jobs kept visible without drowning the page.")}
+        {renderPageSection("Done", pageGroups.done, "Completed jobs with receipts and comments kept expandable.")}
+      </div>
+    );
+  }
 
   return (
     <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">


### PR DESCRIPTION
Summary:
- Adds /admin/jobs as the visible Jobs surface and redirects /admin/todos there.
- Changes the sidebar label from To-Do List to Jobs.
- Reuses the live Boardroom todo source but renders it as a single-column page grouped by Active now, Next, In line, and Done.
- Keeps Boardroom as the discussion room and Jobs as the work list.

Scope:
- UI/presentation layer only.
- No database schema changes.
- No Boardroom data model changes.
- No merge/autopilot behavior changes.

Verification:
- npm run build passed.
- npm run lint still fails on existing repo-wide lint debt, mostly unrelated no-explicit-any and react-hooks/set-state-in-effect issues already present across old files.

UnClick todo:
- 0b869052-bdf8-431a-a3f3-af75f8e3e91b Jobs page v1.

Next:
- Review UI shape.
- Follow-up can add richer edit/drop/reorder controls, ETA fields, and true progress once the typed ledger exists.