### PR TITLE
fix(reliability): recognize UnClick todo refs

### DIFF
--- a/.github/workflows/auto-close-fishbowl-todo.yml
+++ b/.github/workflows/auto-close-fishbowl-todo.yml
@@ -1,10 +1,11 @@
 name: Auto-close Fishbowl todo on PR merge
 
-# When a PR merges, scan its body for "Closes Fishbowl todo: <uuid>" markers
-# and POST to the existing memory-admin fishbowl_complete_todo action for
-# each match. Manual dispatch accepts explicit merged PR numbers for bounded
-# reconciliation. A Fishbowl outage must NOT block merge cleanup, so the job
-# always exits 0 even if the API call fails.
+# When a PR merges, scan its body and commit messages for
+# "Closes UnClick todo: <uuid>" markers, with the older "Closes Fishbowl todo"
+# marker still accepted for compatibility. POST each match to the existing
+# memory-admin fishbowl_complete_todo action. Manual dispatch accepts explicit
+# merged PR numbers for bounded reconciliation. A Fishbowl outage must NOT
+# block merge cleanup, so the job always exits 0 even if the API call fails.
 
 on:
   pull_request:
@@ -26,6 +27,9 @@ jobs:
     name: Close linked Fishbowl todos
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Extract todo ids and call memory-admin
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
@@ -67,37 +71,48 @@ jobs:
             exit 0
           fi
 
-          # Match "Closes Fishbowl todo: <uuid>" or "closes-fishbowl-todo: <uuid>",
-          # case-insensitive, allowing - or space between the words.
+          # Match the canonical "Closes UnClick todo: <uuid>" marker and the
+          # older "Closes Fishbowl todo: <uuid>" marker, case-insensitive,
+          # allowing - or space between the words.
           UUID_RE='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
           fail_count=0
           close_count=0
 
           for pr_number in "${PR_NUMBERS[@]}"; do
-            pr_body="${PR_BODY:-}"
+            pr_text="${PR_BODY:-}"
             if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-              pr_body=$(gh pr view "${pr_number}" \
+              pr_text=$(gh pr view "${pr_number}" \
                 --repo "${GITHUB_REPOSITORY}" \
-                --json body,mergedAt \
-                --jq 'if .mergedAt == null then "" else (.body // "") end' 2>/tmp/gh-pr-view.err) || {
+                --json body,commits,mergedAt \
+                --jq 'if .mergedAt == null then "" else [(.body // ""), (.commits[]?.messageHeadline // ""), (.commits[]?.messageBody // "")] | join("\n") end' 2>/tmp/gh-pr-view.err) || {
                   echo "::warning::Could not read PR #${pr_number}: $(cat /tmp/gh-pr-view.err)"
                   fail_count=$((fail_count + 1))
                   continue
                 }
+            else
+              pr_commits=$(gh pr view "${pr_number}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json commits \
+                --jq '[.commits[]?.messageHeadline // "", .commits[]?.messageBody // ""] | join("\n")' 2>/tmp/gh-pr-view.err) || {
+                  echo "::warning::Could not read commit messages for PR #${pr_number}: $(cat /tmp/gh-pr-view.err)"
+                  pr_commits=""
+                }
+              pr_text="${pr_text}
+${pr_commits}"
             fi
 
-            if [ -z "${pr_body:-}" ]; then
-              echo "PR #${pr_number} body empty or PR is not merged - nothing to close."
+            if [ -z "${pr_text:-}" ]; then
+              echo "PR #${pr_number} body/commit text empty or PR is not merged - nothing to close."
               continue
             fi
 
-            mapfile -t IDS < <(printf '%s\n' "$pr_body" \
-              | grep -Eio "closes[- ]fishbowl[- ]todo[: ][[:space:]]*${UUID_RE}" \
+            mapfile -t IDS < <(printf '%s\n' "$pr_text" \
+              | grep -Eio "closes[ -]+(unclick|fishbowl)[ -]+todo[[:space:]]*:[[:space:]]*${UUID_RE}" \
               | grep -Eio "${UUID_RE}" \
               | sort -u)
 
             if [ "${#IDS[@]}" -eq 0 ]; then
-              echo "No Fishbowl todo ids found in PR #${pr_number} body."
+              echo "No UnClick/Fishbowl todo ids found in PR #${pr_number} body or commits."
               continue
             fi
 

--- a/scripts/fishbowl-todo-reconciliation.mjs
+++ b/scripts/fishbowl-todo-reconciliation.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const UUID_RE_SOURCE =
+  "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+
+const TODO_REFERENCE_RE = new RegExp(
+  `\\bCloses[ -]+(?:UnClick|Fishbowl)[ -]+todo\\s*:\\s*(${UUID_RE_SOURCE})\\b`,
+  "gi",
+);
+
+const NO_TODO_RE = /^no-todo:\s*(\S.*)$/gim;
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function textParts(...parts) {
+  return parts.flatMap((part) => {
+    if (Array.isArray(part)) return textParts(...part);
+    if (part == null) return [];
+    return [String(part)];
+  });
+}
+
+function parseTime(value) {
+  const parsed = Date.parse(String(value ?? ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function daysBetween(nowMs, thenMs) {
+  return (nowMs - thenMs) / 86_400_000;
+}
+
+function prText(pr = {}) {
+  return textParts(
+    pr.body,
+    pr.title,
+    pr.commit_messages,
+    pr.commitMessages,
+    pr.commits?.map((commit) => [
+      commit.message,
+      commit.messageHeadline,
+      commit.messageBody,
+      commit.commit?.message,
+    ]),
+  ).join("\n");
+}
+
+export function extractTodoReferenceIds(...parts) {
+  const text = textParts(...parts).join("\n");
+  const ids = new Set();
+  for (const match of text.matchAll(TODO_REFERENCE_RE)) {
+    ids.add(match[1].toLowerCase());
+  }
+  return [...ids];
+}
+
+export function findNoTodoReason(...parts) {
+  const text = textParts(...parts).join("\n");
+  for (const match of text.matchAll(NO_TODO_RE)) {
+    const reason = String(match[1] ?? "").trim();
+    if (reason.length > 0) return reason;
+  }
+  return null;
+}
+
+export function evaluatePrTodoReference({ body = "", commitMessages = [] } = {}) {
+  const todoIds = extractTodoReferenceIds(body, commitMessages);
+  if (todoIds.length > 0) {
+    return { ok: true, reason: "todo_reference_found", todo_ids: todoIds };
+  }
+
+  const noTodoReason = findNoTodoReason(body, commitMessages);
+  if (noTodoReason) {
+    return { ok: true, reason: "explicit_no_todo", no_todo_reason: noTodoReason };
+  }
+
+  return {
+    ok: false,
+    reason: "missing_todo_reference",
+    accepted_formats: [
+      "Closes UnClick todo: <uuid>",
+      "no-todo: <reason>",
+    ],
+  };
+}
+
+export function buildInProgressReconciliationPlan({
+  todos = [],
+  pullRequests = [],
+  now = new Date().toISOString(),
+  mergedWindowDays = 30,
+  staleAfterDays = 7,
+} = {}) {
+  const nowMs = parseTime(now);
+  if (nowMs === null) {
+    return { ok: false, reason: "invalid_now", auto_close: [], stale: [], unchanged: [] };
+  }
+
+  const mergedRefs = new Map();
+  for (const pr of Array.isArray(pullRequests) ? pullRequests : []) {
+    const mergedAt = pr.merged_at ?? pr.mergedAt;
+    const mergedMs = parseTime(mergedAt);
+    if (mergedMs === null) continue;
+    if (daysBetween(nowMs, mergedMs) > mergedWindowDays) continue;
+
+    for (const todoId of extractTodoReferenceIds(prText(pr))) {
+      const list = mergedRefs.get(todoId) ?? [];
+      list.push({
+        number: pr.number ?? pr.pr_number ?? null,
+        url: pr.url ?? pr.html_url ?? null,
+        merged_at: new Date(mergedMs).toISOString(),
+      });
+      mergedRefs.set(todoId, list);
+    }
+  }
+
+  const autoClose = [];
+  const stale = [];
+  const unchanged = [];
+
+  for (const todo of Array.isArray(todos) ? todos : []) {
+    if (todo?.status !== "in_progress" || todo.completed_at != null || todo.completedAt != null) {
+      continue;
+    }
+
+    const todoId = String(todo.id ?? "").toLowerCase();
+    const matchingPrs = mergedRefs.get(todoId) ?? [];
+    if (matchingPrs.length > 0) {
+      autoClose.push({
+        todo_id: todo.id,
+        title: todo.title ?? "",
+        pr: matchingPrs[0],
+      });
+      continue;
+    }
+
+    const updatedMs = parseTime(todo.updated_at ?? todo.updatedAt ?? todo.created_at ?? todo.createdAt);
+    const ageDays = updatedMs === null ? null : daysBetween(nowMs, updatedMs);
+    if (ageDays !== null && ageDays >= staleAfterDays) {
+      stale.push({
+        todo_id: todo.id,
+        title: todo.title ?? "",
+        assigned_to_agent_id: todo.assigned_to_agent_id ?? null,
+        age_days: Number(ageDays.toFixed(2)),
+      });
+    } else {
+      unchanged.push({ todo_id: todo.id, title: todo.title ?? "" });
+    }
+  }
+
+  return {
+    ok: true,
+    reason: "reconciliation_plan",
+    auto_close: autoClose,
+    stale,
+    unchanged,
+  };
+}
+
+export async function readReconciliationInput(filePath) {
+  if (!filePath) return { ok: false, reason: "missing_input_path" };
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  readReconciliationInput(getArg("input", process.env.FISHBOWL_RECONCILIATION_INPUT || ""))
+    .then((input) => {
+      if (Array.isArray(input.todos) || Array.isArray(input.pullRequests) || Array.isArray(input.pull_requests)) {
+        return buildInProgressReconciliationPlan({
+          todos: input.todos,
+          pullRequests: input.pullRequests ?? input.pull_requests,
+          now: input.now,
+          mergedWindowDays: input.mergedWindowDays ?? input.merged_window_days,
+          staleAfterDays: input.staleAfterDays ?? input.stale_after_days,
+        });
+      }
+      return evaluatePrTodoReference({
+        body: input.body,
+        commitMessages: input.commitMessages ?? input.commit_messages,
+      });
+    })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/fishbowl-todo-reconciliation.test.mjs
+++ b/scripts/fishbowl-todo-reconciliation.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildInProgressReconciliationPlan,
+  evaluatePrTodoReference,
+  extractTodoReferenceIds,
+  findNoTodoReason,
+} from "./fishbowl-todo-reconciliation.mjs";
+
+const TODO_A = "1100f5ec-5b94-4a7e-89ef-0da47d6a3017";
+const TODO_B = "b744462e-8e50-4cad-babb-5468adc2a3d9";
+
+describe("fishbowl todo reconciliation helpers", () => {
+  it("extracts canonical UnClick todo references from body and commits", () => {
+    const ids = extractTodoReferenceIds(
+      "Small fix\n\nCloses UnClick todo: 1100f5ec-5b94-4a7e-89ef-0da47d6a3017",
+      ["follow-up\n\nCloses Fishbowl todo: b744462e-8e50-4cad-babb-5468adc2a3d9"],
+    );
+
+    assert.deepEqual(ids, [TODO_A, TODO_B]);
+  });
+
+  it("requires a non-empty no-todo reason", () => {
+    assert.equal(findNoTodoReason("no-todo: docs-only correction"), "docs-only correction");
+    assert.equal(findNoTodoReason("no-todo:   "), null);
+  });
+
+  it("passes PR reference checks only for todo refs or explicit no-todo reasons", () => {
+    assert.equal(evaluatePrTodoReference({ body: `Closes UnClick todo: ${TODO_A}` }).ok, true);
+    assert.equal(evaluatePrTodoReference({ body: "no-todo: release note typo" }).ok, true);
+
+    const missing = evaluatePrTodoReference({ body: "No linked work item here" });
+    assert.equal(missing.ok, false);
+    assert.equal(missing.reason, "missing_todo_reference");
+  });
+
+  it("plans auto-close only when an in-progress todo has a merged PR reference", () => {
+    const plan = buildInProgressReconciliationPlan({
+      now: "2026-05-08T12:00:00.000Z",
+      todos: [
+        {
+          id: TODO_A,
+          title: "linked shipped work",
+          status: "in_progress",
+          completed_at: null,
+          updated_at: "2026-05-08T08:00:00.000Z",
+        },
+        {
+          id: TODO_B,
+          title: "closed but not merged work",
+          status: "in_progress",
+          completed_at: null,
+          updated_at: "2026-05-08T08:00:00.000Z",
+        },
+      ],
+      pullRequests: [
+        {
+          number: 600,
+          merged_at: "2026-05-08T10:00:00.000Z",
+          body: `Closes UnClick todo: ${TODO_A}`,
+        },
+        {
+          number: 601,
+          merged_at: null,
+          body: `Closes UnClick todo: ${TODO_B}`,
+        },
+      ],
+    });
+
+    assert.equal(plan.ok, true);
+    assert.deepEqual(plan.auto_close.map((item) => item.todo_id), [TODO_A]);
+    assert.deepEqual(plan.unchanged.map((item) => item.todo_id), [TODO_B]);
+  });
+
+  it("surfaces old in-progress todos without marking them done", () => {
+    const plan = buildInProgressReconciliationPlan({
+      now: "2026-05-08T12:00:00.000Z",
+      staleAfterDays: 7,
+      todos: [
+        {
+          id: TODO_A,
+          title: "old active card",
+          status: "in_progress",
+          assigned_to_agent_id: "builder-seat",
+          completed_at: null,
+          updated_at: "2026-04-30T12:00:00.000Z",
+        },
+      ],
+      pullRequests: [],
+    });
+
+    assert.equal(plan.auto_close.length, 0);
+    assert.equal(plan.stale.length, 1);
+    assert.equal(plan.stale[0].todo_id, TODO_A);
+    assert.equal(plan.stale[0].assigned_to_agent_id, "builder-seat");
+  });
+});


### PR DESCRIPTION
Summary:
- Adds tested reconciliation helpers for canonical `Closes UnClick todo: <uuid>` references, `no-todo: <reason>` checks, and conservative in-progress reconciliation planning.
- Keeps legacy `Closes Fishbowl todo: <uuid>` references working for compatibility.
- Updates the existing auto-close workflow to scan merged PR body plus branch commit messages, so shipped work linked in commits can close the matching todo instead of leaving a stale `in_progress` card.

Scope:
- Owned files: `.github/workflows/auto-close-fishbowl-todo.yml`, `scripts/fishbowl-todo-reconciliation.mjs`, `scripts/fishbowl-todo-reconciliation.test.mjs`.
- Linked UnClick todo: `1100f5ec-5b94-4a7e-89ef-0da47d6a3017`.
- Lane: autopilot efficiency, stale `in_progress` reconciliation.

Non-overlap:
- Does not add a scheduled sweep yet.
- Does not enforce PR references in TestPass yet.
- Does not mark any todo done unless the existing merge auto-close workflow finds a merged PR reference.
- Does not touch Jobs page work, WakePass, CAS/lease schema, auth, secrets, billing, DNS, or migrations.

Verification:
- `node --test scripts/fishbowl-todo-reconciliation.test.mjs`
- `git diff --check`
- `git diff --cached --check`

Risk:
- Low. The workflow still exits 0 on UnClick transport/API failure, preserving the existing non-blocking merge-cleanup behavior.
- Auto-close remains guarded by merged PR events/manual merged-PR dispatch and an explicit todo UUID marker.

Follow-up:
- Wire the helper into a scheduled 6h reconciliation sweep.
- Add Builder-bot PR reference enforcement to TestPass once bot-author matching is agreed.
- Emit typed ledger events when the control ledger exists.
