### PR TITLE
fix(admin): refine jobs board controls

### DIFF
--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -6,9 +6,11 @@ import {
   ChevronDown,
   ChevronRight,
   FileText,
+  GripVertical,
   Loader2,
+  MessageCircle,
   MessageSquare,
-  UserRound,
+  Send,
 } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import Comments from "./fishbowl/Comments";
@@ -46,7 +48,29 @@ const SECTION_LABELS: Record<JobSectionKey, string> = {
   active: "Actioning now",
   next: "Next up",
   inline: "In line",
-  done: "Done recently",
+  done: "Completed",
+};
+
+type ManualOrder = Record<JobSectionKey, string[]>;
+type CollapsibleSectionKey = Exclude<JobSectionKey, "active">;
+type SectionPreferences = {
+  expanded: Record<CollapsibleSectionKey, boolean>;
+  visible: Record<CollapsibleSectionKey, number>;
+};
+
+const ORDER_STORAGE_KEY = "unclick_jobs_manual_order_v1";
+const SECTION_PREF_STORAGE_KEY = "unclick_jobs_section_preferences_v1";
+const SECTION_PAGE_SIZE = 10;
+const COMPLETED_MAX_VISIBLE = 50;
+const EMPTY_MANUAL_ORDER: ManualOrder = {
+  active: [],
+  next: [],
+  inline: [],
+  done: [],
+};
+const DEFAULT_SECTION_PREFS: SectionPreferences = {
+  expanded: { next: true, inline: true, done: true },
+  visible: { next: SECTION_PAGE_SIZE, inline: SECTION_PAGE_SIZE, done: SECTION_PAGE_SIZE },
 };
 
 const PRIORITY_RANK: Record<JobTodo["priority"], number> = {
@@ -57,18 +81,23 @@ const PRIORITY_RANK: Record<JobTodo["priority"], number> = {
 };
 
 const PRIORITY_STYLE: Record<JobTodo["priority"], string> = {
-  urgent: "border-red-400/30 bg-red-500/10 text-red-200",
-  high: "border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#E2B93B]",
-  normal: "border-white/10 bg-white/[0.04] text-white/60",
+  urgent: "border-red-400/35 bg-red-500/10 text-red-200",
+  high: "border-[#E2B93B]/35 bg-[#E2B93B]/10 text-[#E2B93B]",
+  normal: "border-white/10 bg-white/[0.035] text-white/60",
   low: "border-white/[0.06] bg-white/[0.02] text-white/40",
 };
 
 const STATUS_STYLE: Record<JobTodo["status"], string> = {
-  open: "border-white/10 bg-white/[0.03] text-white/60",
+  open: "border-white/10 bg-white/[0.035] text-white/60",
   in_progress: "border-[#E2B93B]/35 bg-[#E2B93B]/10 text-[#E2B93B]",
   done: "border-green-400/25 bg-green-400/10 text-green-300",
   dropped: "border-white/[0.06] bg-white/[0.02] text-white/35",
 };
+
+const ACTION_BUTTONS = {
+  stale: ["Push workers", "Talk to AI agent", "Escalate"],
+  unowned: ["Claim / assign", "Push workers", "Drop priority"],
+} as const;
 
 const STAGES = ["Brief", "Build", "Proof", "Review", "Ship"] as const;
 
@@ -133,12 +162,12 @@ function StageStrip({ todo }: { todo: JobTodo }) {
   const active = activeStageCount(todo);
   return (
     <div className="space-y-1">
-      <div className="grid grid-cols-5 gap-0.5" aria-label="Assembly line progress">
+      <div className="grid grid-cols-5 gap-px" aria-label="Assembly line progress">
         {STAGES.map((stage, index) => (
           <span
             key={stage}
             title={stage}
-            className={`h-1.5 rounded-full ${
+            className={`h-1.5 rounded-[2px] ${
               index < active
                 ? todo.status === "done"
                   ? "bg-green-400"
@@ -148,13 +177,36 @@ function StageStrip({ todo }: { todo: JobTodo }) {
           />
         ))}
       </div>
-      <div className="hidden grid-cols-5 gap-0.5 text-[9px] uppercase tracking-wide text-white/30 lg:grid">
+      <div className="grid grid-cols-5 gap-px text-[9px] uppercase tracking-wide text-white/30">
         {STAGES.map((stage) => (
-          <span key={stage} className="truncate">{stage}</span>
+          <span key={stage}>{stage}</span>
         ))}
       </div>
     </div>
   );
+}
+
+function ownerEmoji(todo: JobTodo): string | null {
+  const raw = todo.assigned_to_agent_id?.trim();
+  if (!raw) return null;
+  const known: Record<string, string> = {
+    master: "🧭",
+    "chatgpt-codex-worker2": "🛠️",
+    "chatgpt-codex-runner-fix": "♻️",
+    "codex-tether-seat": "🛰️",
+    "claude-cowork-pc": "🧭",
+    tester: "🧪",
+    watcher: "👁️",
+  };
+  if (known[raw]) return known[raw];
+  if (/review|gatekeeper|safety/i.test(raw)) return "🛡️";
+  if (/test|qa|proof/i.test(raw)) return "🧪";
+  if (/builder|forge|build/i.test(raw)) return "🛠️";
+  if (/watch|heartbeat|qc/i.test(raw)) return "👁️";
+  if (/courier|messenger|relay|push/i.test(raw)) return "📣";
+  if (/research/i.test(raw)) return "🔬";
+  if (/plan/i.test(raw)) return "📋";
+  return null;
 }
 
 function sourceLabel(todo: JobTodo): string {
@@ -174,6 +226,19 @@ function needsAttention(todo: JobTodo): boolean {
   return todo.priority === "urgent" && !todo.assigned_to_agent_id;
 }
 
+function attentionCopy(todo: JobTodo): { message: string; actions: readonly string[] } {
+  if (isStaleActive(todo)) {
+    return {
+      message: "Active job has not moved recently.",
+      actions: ACTION_BUTTONS.stale,
+    };
+  }
+  return {
+    message: "Urgent job has no owner.",
+    actions: ACTION_BUTTONS.unowned,
+  };
+}
+
 function sortJobs(a: JobTodo, b: JobTodo): number {
   const priorityDiff = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority];
   if (priorityDiff !== 0) return priorityDiff;
@@ -191,6 +256,52 @@ function groupJobs(todos: JobTodo[]): Record<JobSectionKey, JobTodo[]> {
   return { active, next, inline, done };
 }
 
+function loadManualOrder(): ManualOrder {
+  if (typeof window === "undefined") return EMPTY_MANUAL_ORDER;
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(ORDER_STORAGE_KEY) ?? "{}") as Partial<ManualOrder>;
+    return {
+      active: Array.isArray(parsed.active) ? parsed.active : [],
+      next: Array.isArray(parsed.next) ? parsed.next : [],
+      inline: Array.isArray(parsed.inline) ? parsed.inline : [],
+      done: Array.isArray(parsed.done) ? parsed.done : [],
+    };
+  } catch {
+    return EMPTY_MANUAL_ORDER;
+  }
+}
+
+function loadSectionPreferences(): SectionPreferences {
+  if (typeof window === "undefined") return DEFAULT_SECTION_PREFS;
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(SECTION_PREF_STORAGE_KEY) ?? "{}") as Partial<SectionPreferences>;
+    return {
+      expanded: {
+        next: typeof parsed.expanded?.next === "boolean" ? parsed.expanded.next : true,
+        inline: typeof parsed.expanded?.inline === "boolean" ? parsed.expanded.inline : true,
+        done: typeof parsed.expanded?.done === "boolean" ? parsed.expanded.done : true,
+      },
+      visible: {
+        next: Number.isFinite(parsed.visible?.next) ? Number(parsed.visible?.next) : SECTION_PAGE_SIZE,
+        inline: Number.isFinite(parsed.visible?.inline) ? Number(parsed.visible?.inline) : SECTION_PAGE_SIZE,
+        done: Number.isFinite(parsed.visible?.done) ? Math.min(Number(parsed.visible?.done), COMPLETED_MAX_VISIBLE) : SECTION_PAGE_SIZE,
+      },
+    };
+  } catch {
+    return DEFAULT_SECTION_PREFS;
+  }
+}
+
+function applyManualOrder(jobs: JobTodo[], order: string[]): JobTodo[] {
+  if (order.length === 0) return jobs;
+  const byId = new Map(jobs.map((job) => [job.id, job]));
+  const ordered = order
+    .map((id) => byId.get(id))
+    .filter((job): job is JobTodo => Boolean(job));
+  const orderedIds = new Set(ordered.map((job) => job.id));
+  return [...ordered, ...jobs.filter((job) => !orderedIds.has(job.id))];
+}
+
 function JobRow({
   todo,
   expanded,
@@ -198,6 +309,9 @@ function JobRow({
   authHeader,
   humanAgentId,
   pollSeq,
+  onDragStart,
+  onDragEnd,
+  onDrop,
 }: {
   todo: JobTodo;
   expanded: boolean;
@@ -205,6 +319,9 @@ function JobRow({
   authHeader: Record<string, string>;
   humanAgentId: string | null;
   pollSeq: number;
+  onDragStart: (id: string) => void;
+  onDragEnd: () => void;
+  onDrop: (id: string) => void;
 }) {
   const attention = needsAttention(todo);
   const progress = progressFor(todo);
@@ -212,16 +329,38 @@ function JobRow({
   const [showDetails, setShowDetails] = useState(false);
   const [showComments, setShowComments] = useState(false);
   const rawOwner = todo.assigned_to_agent_id?.trim() || "unassigned";
+  const alert = attention ? attentionCopy(todo) : null;
+  const emoji = ownerEmoji(todo);
 
   return (
-    <li className="border-b border-white/[0.05] last:border-b-0">
+    <li
+      className="border-b border-white/[0.05] last:border-b-0"
+      draggable
+      onDragStart={(event) => {
+        event.dataTransfer.effectAllowed = "move";
+        onDragStart(todo.id);
+      }}
+      onDragEnd={onDragEnd}
+      onDragOver={(event) => {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        onDrop(todo.id);
+      }}
+    >
       <button
         type="button"
         onClick={onToggle}
-        className="grid w-full gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-white/[0.03] md:grid-cols-[minmax(280px,2fr)_76px_76px_minmax(120px,0.8fr)_86px_132px_44px]"
+        className="w-full space-y-2 px-3 py-2.5 text-left text-xs transition-colors hover:bg-white/[0.03]"
         aria-expanded={expanded}
       >
         <div className="flex min-w-0 items-start gap-2">
+          <GripVertical
+            className="mt-1 h-3.5 w-3.5 shrink-0 cursor-grab text-white/25 hover:text-white/45"
+            aria-hidden="true"
+          />
           {expanded ? (
             <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-white/40" />
           ) : (
@@ -234,48 +373,61 @@ function JobRow({
             >
               {todo.title}
             </p>
-            <p className="mt-0.5 text-[11px] text-white/35">
-              Updated {relativeTime(todo.updated_at)}
-            </p>
           </div>
         </div>
 
-        <span
-          className={`w-fit rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${STATUS_STYLE[todo.status]}`}
-        >
-          {statusLabel(todo.status)}
-        </span>
-        <span
-          className={`w-fit rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${PRIORITY_STYLE[todo.priority]}`}
-        >
-          {todo.priority}
-        </span>
-        <span className="flex min-w-0 items-center gap-1.5 text-[11px] text-white/45">
-          <UserRound className="h-3 w-3 shrink-0" />
-          <span className="truncate" title={ownerLabel(todo)}>
-            {ownerLabel(todo)}
-          </span>
-        </span>
-        <span className="flex items-center gap-1.5 text-[11px] text-white/45">
+        <div className="ml-9 flex flex-wrap items-center gap-x-4 gap-y-2">
           <span
-            className={`h-1.5 w-1.5 rounded-full ${isStaleActive(todo) ? "bg-red-300" : todo.status === "done" ? "bg-green-300" : "bg-green-400"}`}
-          />
-          {todo.status === "done" ? "shipped" : isStaleActive(todo) ? "stale" : "live"}
-        </span>
-        <span className="space-y-1 text-[11px] font-medium text-white/55">
-          <span>{progress}%</span>
-          <StageStrip todo={todo} />
-        </span>
-        <span className="flex items-center justify-end gap-1 text-[11px] text-white/45">
-          <MessageSquare className="h-3 w-3" />
-          {todo.comment_count ?? 0}
-        </span>
+            className={`inline-flex items-center rounded-[6px] border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${STATUS_STYLE[todo.status]}`}
+          >
+            {statusLabel(todo.status)}
+          </span>
+          <span
+            className={`inline-flex items-center rounded-[6px] border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${PRIORITY_STYLE[todo.priority]}`}
+          >
+            {todo.priority}
+          </span>
+          <span className="flex min-w-0 items-center gap-1.5 text-[11px] text-white/45">
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] bg-white/[0.04] text-[11px]">
+              {emoji ?? "AI"}
+            </span>
+            <span className="max-w-[180px] truncate" title={ownerLabel(todo)}>
+              {ownerLabel(todo)}
+            </span>
+          </span>
+          <span className="flex items-center gap-1.5 text-[11px] text-white/45">
+            <span
+              className={`h-1.5 w-1.5 rounded-full ${isStaleActive(todo) ? "bg-red-300" : todo.status === "done" ? "bg-green-300" : "bg-green-400"}`}
+            />
+            {todo.status === "done" ? "shipped" : isStaleActive(todo) ? "stale" : "live"}
+          </span>
+          <span className="min-w-[190px] space-y-1 text-[11px] font-medium text-white/55">
+            <span>{progress}%</span>
+            <StageStrip todo={todo} />
+          </span>
+          <span className="flex items-center gap-1 text-[11px] text-white/45">
+            <MessageSquare className="h-3 w-3" />
+            {todo.comment_count ?? 0}
+          </span>
+          <span className="text-[11px] text-white/35">Updated {relativeTime(todo.updated_at)}</span>
+        </div>
       </button>
 
-      {attention && (
-        <div className="mx-3 mb-3 flex items-center gap-2 rounded-md border border-red-400/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+      {alert && (
+        <div className="mx-3 mb-3 flex flex-wrap items-center gap-2 rounded-md border border-red-400/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span>{isStaleActive(todo) ? "Active job has not moved recently." : "Urgent job has no owner."}</span>
+          <span className="mr-2">{alert.message}</span>
+          {alert.actions.map((action) => (
+            <button
+              key={action}
+              type="button"
+              className="inline-flex items-center gap-1 rounded-[5px] border border-red-300/20 bg-black/20 px-2 py-1 text-[11px] text-red-100 transition-colors hover:bg-red-400/10"
+              title="Fallback action placeholder. Autopilot should normally resolve this without a manual click."
+            >
+              {action === "Talk to AI agent" ? <MessageCircle className="h-3 w-3" /> : <Send className="h-3 w-3" />}
+              {action}
+            </button>
+          ))}
         </div>
       )}
 
@@ -311,9 +463,9 @@ function JobRow({
               <button
                 type="button"
                 onClick={() => setShowDetails((value) => !value)}
-                className="rounded-md border border-white/[0.08] px-2 py-1 text-[11px] text-white/55 hover:bg-white/[0.05]"
+                className="text-[11px] text-[#61C1C4]/80 hover:text-[#61C1C4]"
               >
-                {showDetails ? "Hide full brief" : "Read full brief"}
+                {showDetails ? "See less" : "... See more"}
               </button>
             </div>
             {description ? (
@@ -322,9 +474,6 @@ function JobRow({
               </p>
             ) : (
               <p className="mt-2 text-xs italic text-white/35">No description yet.</p>
-            )}
-            {!showDetails && description && description.length > 260 && (
-              <div className="mt-1 text-[11px] text-white/30">Brief clipped for scanning. Open it when you need the heavy detail.</div>
             )}
           </div>
 
@@ -372,6 +521,11 @@ function JobSection({
   authHeader,
   humanAgentId,
   pollSeq,
+  onMoveJob,
+  sectionExpanded,
+  visibleCount,
+  onToggleSection,
+  onShowMore,
 }: {
   sectionKey: JobSectionKey;
   jobs: JobTodo[];
@@ -380,29 +534,52 @@ function JobSection({
   authHeader: Record<string, string>;
   humanAgentId: string | null;
   pollSeq: number;
+  onMoveJob: (sectionKey: JobSectionKey, sourceId: string, targetId: string) => void;
+  sectionExpanded?: boolean;
+  visibleCount?: number;
+  onToggleSection?: () => void;
+  onShowMore?: () => void;
 }) {
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const isCollapsible = sectionKey !== "active";
+  const open = !isCollapsible || sectionExpanded !== false;
+  const maxVisible = sectionKey === "done" ? COMPLETED_MAX_VISIBLE : jobs.length;
+  const cappedJobs = sectionKey === "done" ? jobs.slice(0, COMPLETED_MAX_VISIBLE) : jobs;
+  const displayCount = isCollapsible ? Math.min(visibleCount ?? SECTION_PAGE_SIZE, cappedJobs.length) : cappedJobs.length;
+  const visibleJobs = cappedJobs.slice(0, displayCount);
+  const canShowMore = isCollapsible && displayCount < cappedJobs.length;
+
   return (
     <section className="overflow-hidden rounded-lg border border-white/[0.06] bg-[#111]">
       <div className="flex items-center justify-between border-b border-white/[0.06] px-3 py-2">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-white/45">
-          {SECTION_LABELS[sectionKey]}
-        </h2>
-        <span className="text-xs text-white/35">{jobs.length}</span>
+        {isCollapsible ? (
+          <button
+            type="button"
+            onClick={onToggleSection}
+            className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-white/45 hover:text-white/70"
+            aria-expanded={open}
+          >
+            {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+            {SECTION_LABELS[sectionKey]}
+          </button>
+        ) : (
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-white/45">
+            {SECTION_LABELS[sectionKey]}
+          </h2>
+        )}
+        <span className="text-xs text-white/35">
+          {isCollapsible && open ? `${visibleJobs.length}/${sectionKey === "done" ? Math.min(jobs.length, COMPLETED_MAX_VISIBLE) : jobs.length}` : jobs.length}
+        </span>
       </div>
-      {jobs.length === 0 ? (
+      {!open ? null : jobs.length === 0 ? (
         <p className="px-3 py-4 text-sm italic text-white/30">Empty</p>
       ) : (
         <ul>
-          <li className="hidden border-b border-white/[0.05] bg-black/20 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-white/30 md:grid md:grid-cols-[minmax(280px,2fr)_76px_76px_minmax(120px,0.8fr)_86px_132px_44px]">
+          <li className="hidden border-b border-white/[0.05] bg-black/20 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-white/30 md:grid md:grid-cols-[minmax(280px,1fr)_minmax(520px,1.2fr)]">
             <span>Job</span>
-            <span>State</span>
-            <span>Priority</span>
-            <span>Worker</span>
-            <span>Live</span>
-            <span>Progress</span>
-            <span className="text-right">Notes</span>
+            <span>Markers, progress, notes</span>
           </li>
-          {jobs.map((todo) => (
+          {visibleJobs.map((todo) => (
             <JobRow
               key={todo.id}
               todo={todo}
@@ -411,8 +588,27 @@ function JobSection({
               authHeader={authHeader}
               humanAgentId={humanAgentId}
               pollSeq={pollSeq}
+              onDragStart={setDraggedId}
+              onDragEnd={() => setDraggedId(null)}
+              onDrop={(targetId) => {
+                if (draggedId && draggedId !== targetId) {
+                  onMoveJob(sectionKey, draggedId, targetId);
+                }
+                setDraggedId(null);
+              }}
             />
           ))}
+          {canShowMore && (
+            <li className="px-3 py-3">
+              <button
+                type="button"
+                onClick={onShowMore}
+                className="text-xs text-[#61C1C4]/80 hover:text-[#61C1C4]"
+              >
+                Show more
+              </button>
+            </li>
+          )}
         </ul>
       )}
     </section>
@@ -434,6 +630,8 @@ export default function AdminJobs() {
   const [firstLoadDone, setFirstLoadDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pollSeq, setPollSeq] = useState(0);
+  const [manualOrder, setManualOrder] = useState<ManualOrder>(() => loadManualOrder());
+  const [sectionPrefs, setSectionPrefs] = useState<SectionPreferences>(() => loadSectionPreferences());
 
   useEffect(() => {
     if (!token) return;
@@ -509,7 +707,26 @@ export default function AdminJobs() {
     };
   }, [authHeader, humanAgentId]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(ORDER_STORAGE_KEY, JSON.stringify(manualOrder));
+  }, [manualOrder]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(SECTION_PREF_STORAGE_KEY, JSON.stringify(sectionPrefs));
+  }, [sectionPrefs]);
+
   const grouped = useMemo(() => groupJobs(todos), [todos]);
+  const orderedGrouped = useMemo(
+    () => ({
+      active: applyManualOrder(grouped.active, manualOrder.active),
+      next: applyManualOrder(grouped.next, manualOrder.next),
+      inline: applyManualOrder(grouped.inline, manualOrder.inline),
+      done: applyManualOrder(grouped.done, manualOrder.done),
+    }),
+    [grouped, manualOrder],
+  );
   const activeCount = grouped.active.length;
   const queueCount = grouped.next.length + grouped.inline.length;
   const alertCount = todos.filter(needsAttention).length;
@@ -521,6 +738,46 @@ export default function AdminJobs() {
       else next.add(id);
       return next;
     });
+  };
+
+  const moveJob = (sectionKey: JobSectionKey, sourceId: string, targetId: string) => {
+    setManualOrder((prev) => {
+      const visibleIds = grouped[sectionKey].map((job) => job.id);
+      const visible = new Set(visibleIds);
+      const current = [
+        ...prev[sectionKey].filter((id) => visible.has(id)),
+        ...visibleIds.filter((id) => !prev[sectionKey].includes(id)),
+      ];
+      const withoutSource = current.filter((id) => id !== sourceId);
+      const targetIndex = Math.max(0, withoutSource.indexOf(targetId));
+      withoutSource.splice(targetIndex, 0, sourceId);
+      return {
+        ...prev,
+        [sectionKey]: withoutSource,
+      };
+    });
+  };
+
+  const toggleSection = (sectionKey: CollapsibleSectionKey) => {
+    setSectionPrefs((prev) => ({
+      ...prev,
+      expanded: {
+        ...prev.expanded,
+        [sectionKey]: !prev.expanded[sectionKey],
+      },
+    }));
+  };
+
+  const showMore = (sectionKey: CollapsibleSectionKey) => {
+    setSectionPrefs((prev) => ({
+      ...prev,
+      visible: {
+        ...prev.visible,
+        [sectionKey]: sectionKey === "done"
+          ? Math.min(prev.visible[sectionKey] + SECTION_PAGE_SIZE, COMPLETED_MAX_VISIBLE)
+          : prev.visible[sectionKey] + SECTION_PAGE_SIZE,
+      },
+    }));
   };
 
   return (
@@ -568,39 +825,55 @@ export default function AdminJobs() {
       <div className="space-y-4">
         <JobSection
           sectionKey="active"
-          jobs={grouped.active}
+          jobs={orderedGrouped.active}
           expanded={expanded}
           onToggle={toggleExpanded}
           authHeader={authHeader}
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
+          onMoveJob={moveJob}
         />
         <JobSection
           sectionKey="next"
-          jobs={grouped.next}
+          jobs={orderedGrouped.next}
           expanded={expanded}
           onToggle={toggleExpanded}
           authHeader={authHeader}
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
+          onMoveJob={moveJob}
+          sectionExpanded={sectionPrefs.expanded.next}
+          visibleCount={sectionPrefs.visible.next}
+          onToggleSection={() => toggleSection("next")}
+          onShowMore={() => showMore("next")}
         />
         <JobSection
           sectionKey="inline"
-          jobs={grouped.inline}
+          jobs={orderedGrouped.inline}
           expanded={expanded}
           onToggle={toggleExpanded}
           authHeader={authHeader}
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
+          onMoveJob={moveJob}
+          sectionExpanded={sectionPrefs.expanded.inline}
+          visibleCount={sectionPrefs.visible.inline}
+          onToggleSection={() => toggleSection("inline")}
+          onShowMore={() => showMore("inline")}
         />
         <JobSection
           sectionKey="done"
-          jobs={grouped.done}
+          jobs={orderedGrouped.done}
           expanded={expanded}
           onToggle={toggleExpanded}
           authHeader={authHeader}
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
+          onMoveJob={moveJob}
+          sectionExpanded={sectionPrefs.expanded.done}
+          visibleCount={sectionPrefs.visible.done}
+          onToggleSection={() => toggleSection("done")}
+          onShowMore={() => showMore("done")}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- make job markers smaller and less rounded
- move title to the full first row and markers/progress/status to the second row
- tighten pipeline segments with 1px divisions and sharper corners
- replace heavy full-brief buttons with subtle See more / See less text
- add discreet drag/reshuffle grip and local manual ordering persistence
- add fallback action buttons for stale or unowned jobs
- show worker emoji where the assigned worker can be inferred
- rename Done recently to Completed, keep recent first, cap at 50 visible
- make Next up, In line, and Completed collapsible with remembered preferences
- add Show more controls for long sections

## Visible job
UnClick todo: 6af146cf-d4e2-44b2-ada4-3a589c7b0c32

## Verification
- npm run build
- npx eslint src/pages/admin/AdminJobs.tsx
- git diff --check