### PR TITLE
fix(admin): clarify AI seats and compact jobs rows

### DIFF
--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -19,7 +19,6 @@ import {
   X,
   Check,
   Cpu,
-  Gauge,
   AlertTriangle,
   Save,
 } from "lucide-react";
@@ -118,43 +117,35 @@ interface AISeat {
 const AI_SEAT_STORAGE_KEY = "unclick_ai_seat_manual_slots_v1";
 
 const AI_SEAT_EMOJI_OPTIONS = [
-  { emoji: "🤖", label: "Robot" },
-  { emoji: "🧠", label: "Brain" },
-  { emoji: "🛰️", label: "Relay" },
-  { emoji: "🧭", label: "Navigator" },
-  { emoji: "⚡", label: "Fast" },
-  { emoji: "💡", label: "Ideas" },
-  { emoji: "🔍", label: "Reviewer" },
-  { emoji: "🛠️", label: "Builder" },
-  { emoji: "🧪", label: "Tester" },
-  { emoji: "🛡️", label: "Safety" },
-  { emoji: "📣", label: "Courier" },
-  { emoji: "👁️", label: "Watcher" },
-  { emoji: "🚀", label: "Publisher" },
-  { emoji: "♻️", label: "Improver" },
-  { emoji: "🧰", label: "Toolkit" },
-  { emoji: "📡", label: "Signal" },
-  { emoji: "🧬", label: "System" },
-  { emoji: "🗂️", label: "Organizer" },
-  { emoji: "📋", label: "Planner" },
-  { emoji: "🔬", label: "Research" },
-  { emoji: "💻", label: "Desktop" },
+  { emoji: "💻", label: "Laptop / default" },
+  { emoji: "🖥️", label: "Desktop" },
+  { emoji: "📱", label: "Mobile" },
+  { emoji: "🔳", label: "Tablet" },
+  { emoji: "🔲", label: "Virtual slot" },
+  { emoji: "🖱️", label: "Mouse" },
   { emoji: "⌨️", label: "Keyboard" },
-  { emoji: "🧑‍💻", label: "Coder" },
-  { emoji: "🕹️", label: "Control" },
-  { emoji: "🎛️", label: "Console" },
-  { emoji: "🧱", label: "Stack" },
-  { emoji: "🔐", label: "Secure" },
-  { emoji: "✅", label: "Checker" },
-  { emoji: "🌐", label: "Web" },
-  { emoji: "✨", label: "Creative" },
+  { emoji: "🎛️", label: "Control panel" },
+  { emoji: "🕹️", label: "Controller" },
+  { emoji: "📺", label: "Display" },
+  { emoji: "🔌", label: "Plugged in" },
+  { emoji: "🔋", label: "Battery" },
+  { emoji: "🪫", label: "Low battery" },
+  { emoji: "📶", label: "Signal bars" },
+  { emoji: "🛜", label: "Wi-Fi" },
+  { emoji: "🌐", label: "Web seat" },
+  { emoji: "💾", label: "Local disk" },
+  { emoji: "💽", label: "Archive disk" },
+  { emoji: "🧮", label: "Compute" },
+  { emoji: "📟", label: "Terminal" },
+  { emoji: "🖨️", label: "Printer" },
+  { emoji: "📠", label: "Legacy line" },
 ] as const;
 
 const AI_SEATS: AISeat[] = [
   {
     id: "seat-1",
     name: "AI Seat 1",
-    emoji: "🤖",
+    emoji: "💻",
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
@@ -166,7 +157,7 @@ const AI_SEATS: AISeat[] = [
   {
     id: "seat-2",
     name: "AI Seat 2",
-    emoji: "🤖",
+    emoji: "💻",
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
@@ -178,7 +169,7 @@ const AI_SEATS: AISeat[] = [
   {
     id: "seat-3",
     name: "AI Seat 3",
-    emoji: "🤖",
+    emoji: "💻",
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
@@ -190,7 +181,7 @@ const AI_SEATS: AISeat[] = [
   {
     id: "seat-4",
     name: "AI Seat 4",
-    emoji: "🤖",
+    emoji: "💻",
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
@@ -202,7 +193,7 @@ const AI_SEATS: AISeat[] = [
   {
     id: "virtual-review",
     name: "Virtual review seat",
-    emoji: "🧪",
+    emoji: "🔲",
     provider: "Virtual support",
     device: "Spawned when physical capacity is unavailable",
     status: "Standby",
@@ -218,7 +209,11 @@ function loadSeatOverrides(): AISeat[] {
   if (typeof window === "undefined") return AI_SEATS;
   try {
     const overrides = JSON.parse(window.localStorage.getItem(AI_SEAT_STORAGE_KEY) ?? "{}") as Record<string, Partial<AISeat>>;
-    return AI_SEATS.map((seat) => ({ ...seat, ...(overrides[seat.id] ?? {}) }));
+    return AI_SEATS.map((seat) => {
+      const override = overrides[seat.id] ?? {};
+      const wasOldDefaultEmoji = (!seat.isVirtual && override.emoji === "🤖") || (seat.isVirtual && override.emoji === "🧪");
+      return { ...seat, ...override, emoji: wasOldDefaultEmoji ? seat.emoji : override.emoji ?? seat.emoji };
+    });
   } catch {
     return AI_SEATS;
   }
@@ -253,7 +248,6 @@ export default function AdminAgentsPage() {
   const [showTemplates, setShowTemplates] = useState(false);
   const [hasApiKey, setHasApiKey] = useState(true);
   const [activeView, setActiveView] = useState<"workers" | "seats">("workers");
-  const [autoBalance, setAutoBalance] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -453,9 +447,7 @@ export default function AdminAgentsPage() {
         </div>
       </div>
 
-      {activeView === "seats" && (
-        <AISeatsPanel autoBalance={autoBalance} setAutoBalance={setAutoBalance} />
-      )}
+      {activeView === "seats" && <AISeatsPanel />}
 
       {activeView === "workers" && (
         <>
@@ -670,13 +662,7 @@ function WorkerRolesPanel() {
   );
 }
 
-function AISeatsPanel({
-  autoBalance,
-  setAutoBalance,
-}: {
-  autoBalance: boolean;
-  setAutoBalance: (value: boolean) => void;
-}) {
+function AISeatsPanel() {
   const [seats, setSeats] = useState<AISeat[]>(() => loadSeatOverrides());
   const [editingSeatId, setEditingSeatId] = useState<string | null>(null);
   const issues = seats.filter((seat) => seat.issue);
@@ -719,59 +705,32 @@ function AISeatsPanel({
   };
 
   return (
-    <section className="space-y-5">
-      <div className="rounded-xl border border-border/40 bg-card/20 p-5">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <h2 className="text-sm font-semibold text-heading">Connected capacity</h2>
-            <p className="mt-1 max-w-2xl text-xs text-body">
-              AI Seats are capacity slots behind the workers. Live platform/device detection is not wired here yet, so unknown seats stay generic until UnClick has real metadata.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              onClick={spreadEvenly}
-              className="rounded-lg border border-border/40 bg-card/40 px-3 py-2 text-xs font-semibold text-heading transition-colors hover:border-primary/40"
-            >
-              Even split
-            </button>
-            <label className="flex items-center gap-3 rounded-lg border border-border/40 bg-card/40 px-3 py-2 text-xs text-heading">
-              <span className="font-semibold">Auto paused</span>
-              <button
-                type="button"
-                onClick={() => setAutoBalance(false)}
-                className={`relative h-5 w-9 rounded-full transition-colors ${
-                  autoBalance ? "bg-primary" : "bg-muted"
-                }`}
-                aria-pressed={autoBalance}
-                title="Auto-balance plumbing is kept, but manual distribution is active for now."
-              >
-                <span
-                  className={`absolute top-0.5 h-4 w-4 rounded-full bg-black transition-transform ${
-                    autoBalance ? "translate-x-4" : "translate-x-0.5"
-                  }`}
-                />
-              </button>
-            </label>
-          </div>
-        </div>
-
-        <div className="mt-4 rounded-lg border border-border/40 bg-card/30 p-4">
-          <div className="flex items-start gap-3">
-            <Gauge className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-            <p className="text-xs text-body">
-              Manual mode is the default. If only one physical seat is available, keep space for virtual review/fallback support. With multiple physical seats, start even and adjust by hand.
-            </p>
-          </div>
-        </div>
-      </div>
-
+    <section className="space-y-4">
       <div className="overflow-hidden rounded-xl border border-border/40 bg-card/20">
+        <div className="flex flex-col gap-2 border-b border-border/40 px-4 py-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-heading">AI Seats</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Manual capacity slots. Unknown platform/device details stay generic until UnClick has real metadata.
+            </p>
+          </div>
+          <span className="inline-flex w-fit items-center rounded-md border border-border/40 bg-card/40 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Manual mode
+          </span>
+        </div>
         <div className="grid grid-cols-[minmax(210px,1.4fr)_110px_130px_minmax(180px,1.2fr)_minmax(190px,1fr)] gap-3 border-b border-border/40 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
           <span>Seat</span>
           <span>Status</span>
-          <span>Manual load</span>
+          <span className="flex items-center justify-between gap-2">
+            <span>Manual load</span>
+            <button
+              type="button"
+              onClick={spreadEvenly}
+              className="rounded border border-border/40 bg-card/40 px-1.5 py-0.5 text-[10px] normal-case tracking-normal text-heading transition-colors hover:border-primary/40"
+            >
+              Even split
+            </button>
+          </span>
           <span>Assigned work</span>
           <span>Controls</span>
         </div>
@@ -885,10 +844,6 @@ function AISeatsPanel({
             );
           })}
         </div>
-      </div>
-
-      <div className="rounded-xl border border-[#61C1C4]/25 bg-[#61C1C4]/5 p-4 text-xs text-body">
-        This page is currently a manual capacity planner. When UnClick has trusted live seat metadata, provider/device names can be filled automatically. Until then, generic AI Seat labels avoid guessing.
       </div>
 
       {issues.length > 0 && (

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -46,17 +46,16 @@ type SortKey = "queue" | "title" | "status" | "priority" | "worker" | "live" | "
 type SortDirection = "asc" | "desc";
 
 const SECTION_LABELS: Record<JobSectionKey, string> = {
-  active: "Actioning now",
+  active: "Active",
   next: "Next up",
   inline: "In line",
   done: "Completed",
 };
 
 type ManualOrder = Record<JobSectionKey, string[]>;
-type CollapsibleSectionKey = Exclude<JobSectionKey, "active">;
 type SectionPreferences = {
-  expanded: Record<CollapsibleSectionKey, boolean>;
-  visible: Record<CollapsibleSectionKey, number>;
+  expanded: Record<JobSectionKey, boolean>;
+  visible: Record<JobSectionKey, number>;
 };
 
 const ORDER_STORAGE_KEY = "unclick_jobs_manual_order_v1";
@@ -70,8 +69,8 @@ const EMPTY_MANUAL_ORDER: ManualOrder = {
   done: [],
 };
 const DEFAULT_SECTION_PREFS: SectionPreferences = {
-  expanded: { next: true, inline: true, done: true },
-  visible: { next: SECTION_PAGE_SIZE, inline: SECTION_PAGE_SIZE, done: SECTION_PAGE_SIZE },
+  expanded: { active: true, next: true, inline: true, done: true },
+  visible: { active: SECTION_PAGE_SIZE, next: SECTION_PAGE_SIZE, inline: SECTION_PAGE_SIZE, done: SECTION_PAGE_SIZE },
 };
 
 const PRIORITY_RANK: Record<JobTodo["priority"], number> = {
@@ -103,7 +102,7 @@ const ACTION_BUTTONS = {
 const STAGES = ["Brief", "Build", "Proof", "Review", "Ship"] as const;
 
 const JOB_ROW_GRID =
-  "md:grid md:grid-cols-[56px_minmax(260px,1fr)_64px_70px_minmax(120px,0.6fr)_52px_250px_42px_78px_24px] md:items-center md:gap-2";
+  "md:grid md:grid-cols-[56px_minmax(440px,1.25fr)_58px_64px_minmax(112px,0.45fr)_48px_236px_34px_68px_20px] md:items-center md:gap-1.5";
 
 function relativeTime(iso: string | null | undefined): string {
   if (!iso) return "never";
@@ -166,8 +165,8 @@ function StageStrip({ todo }: { todo: JobTodo }) {
   const active = activeStageCount(todo);
   const progress = progressFor(todo);
   return (
-    <div className="flex min-w-[230px] items-center gap-2" aria-label="Assembly line progress">
-      <span className="w-8 shrink-0 text-right text-[10px] font-semibold text-white/55">
+    <div className="flex min-w-[220px] items-center gap-1.5" aria-label="Assembly line progress">
+      <span className="w-7 shrink-0 text-right text-[10px] font-semibold text-white/55">
         {progress}%
       </span>
       <div className="grid flex-1 grid-cols-5 gap-px overflow-hidden rounded-[3px]">
@@ -175,7 +174,7 @@ function StageStrip({ todo }: { todo: JobTodo }) {
           <span
             key={stage}
             title={stage}
-            className={`flex h-4 items-center justify-center text-[8px] font-semibold uppercase tracking-wide ${
+            className={`flex h-4 items-center justify-center text-[8px] font-semibold uppercase ${
               index < active
                 ? todo.status === "done"
                   ? "bg-green-400/85 text-black/70"
@@ -408,11 +407,13 @@ function loadSectionPreferences(): SectionPreferences {
     const parsed = JSON.parse(window.localStorage.getItem(SECTION_PREF_STORAGE_KEY) ?? "{}") as Partial<SectionPreferences>;
     return {
       expanded: {
+        active: typeof parsed.expanded?.active === "boolean" ? parsed.expanded.active : true,
         next: typeof parsed.expanded?.next === "boolean" ? parsed.expanded.next : true,
         inline: typeof parsed.expanded?.inline === "boolean" ? parsed.expanded.inline : true,
         done: typeof parsed.expanded?.done === "boolean" ? parsed.expanded.done : true,
       },
       visible: {
+        active: Number.isFinite(parsed.visible?.active) ? Number(parsed.visible?.active) : SECTION_PAGE_SIZE,
         next: Number.isFinite(parsed.visible?.next) ? Number(parsed.visible?.next) : SECTION_PAGE_SIZE,
         inline: Number.isFinite(parsed.visible?.inline) ? Number(parsed.visible?.inline) : SECTION_PAGE_SIZE,
         done: Number.isFinite(parsed.visible?.done) ? Math.min(Number(parsed.visible?.done), COMPLETED_MAX_VISIBLE) : SECTION_PAGE_SIZE,
@@ -512,7 +513,7 @@ function JobRow({
           </button>
         </div>
         <p
-          className={`min-w-0 select-text truncate text-sm font-medium leading-5 ${todo.status === "done" ? "text-white/35 line-through" : "text-white/85"}`}
+          className={`min-w-0 select-text truncate text-[13px] font-medium leading-5 ${todo.status === "done" ? "text-white/35 line-through" : "text-white/85"}`}
           title={todo.title}
         >
           {todo.title}
@@ -520,24 +521,24 @@ function JobRow({
 
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 md:contents">
           <span
-            className={`inline-flex items-center justify-center rounded-[4px] border px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide ${STATUS_STYLE[todo.status]}`}
+            className={`inline-flex items-center justify-center rounded-[4px] border px-1.5 py-px text-[9px] font-semibold uppercase ${STATUS_STYLE[todo.status]}`}
           >
             {statusLabel(todo.status)}
           </span>
           <span
-            className={`inline-flex items-center justify-center rounded-[4px] border px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide ${PRIORITY_STYLE[todo.priority]}`}
+            className={`inline-flex items-center justify-center rounded-[4px] border px-1.5 py-px text-[9px] font-semibold uppercase ${PRIORITY_STYLE[todo.priority]}`}
           >
             {todo.priority}
           </span>
-          <span className="flex min-w-0 items-center gap-1.5 text-[11px] text-white/45">
+          <span className="flex min-w-0 items-center gap-1 text-[11px] text-white/45">
             <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] bg-white/[0.04] text-[11px]">
               {emoji ?? "AI"}
             </span>
-            <span className="max-w-[180px] truncate" title={ownerLabel(todo)}>
+            <span className="max-w-[130px] truncate" title={ownerLabel(todo)}>
               {ownerLabel(todo)}
             </span>
           </span>
-          <span className="flex items-center gap-1.5 text-[11px] text-white/45">
+          <span className="flex items-center gap-1 text-[11px] text-white/45">
             <span
               className={`h-1.5 w-1.5 rounded-full ${isStaleActive(todo) ? "bg-red-300" : todo.status === "done" ? "bg-green-300" : "bg-green-400"}`}
             />
@@ -546,11 +547,11 @@ function JobRow({
           <span className="text-[11px] font-medium text-white/55">
             <StageStrip todo={todo} />
           </span>
-          <span className="flex items-center gap-1 text-[11px] text-white/45">
+          <span className="flex items-center gap-0.5 text-[11px] text-white/45">
             <MessageSquare className="h-3 w-3" />
             {todo.comment_count ?? 0}
           </span>
-          <span className="text-[11px] text-white/35">{relativeTime(todo.updated_at)}</span>
+          <span className="truncate text-[10px] text-white/35">{relativeTime(todo.updated_at)}</span>
           {alert ? (
             <span
               className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-red-300/20 bg-red-500/10 text-[11px] font-bold text-red-200"
@@ -683,8 +684,7 @@ function JobSection({
   const [draggedId, setDraggedId] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("queue");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
-  const isCollapsible = sectionKey !== "active";
-  const open = !isCollapsible || sectionExpanded !== false;
+  const open = sectionExpanded !== false;
   const maxVisible = sectionKey === "done" ? COMPLETED_MAX_VISIBLE : jobs.length;
   const cappedJobs = sectionKey === "done" ? jobs.slice(0, COMPLETED_MAX_VISIBLE) : jobs;
   const rankById = useMemo(
@@ -695,9 +695,9 @@ function JobSection({
     () => [...cappedJobs].sort((a, b) => compareSortedJobs(a, b, sortKey, sortDirection, rankById)),
     [cappedJobs, rankById, sortDirection, sortKey],
   );
-  const displayCount = isCollapsible ? Math.min(visibleCount ?? SECTION_PAGE_SIZE, cappedJobs.length) : cappedJobs.length;
+  const displayCount = Math.min(visibleCount ?? SECTION_PAGE_SIZE, cappedJobs.length);
   const visibleJobs = sortedJobs.slice(0, displayCount);
-  const canShowMore = isCollapsible && displayCount < cappedJobs.length;
+  const canShowMore = displayCount < cappedJobs.length;
   const sectionAccent: Record<JobSectionKey, string> = {
     active: "bg-[#E2B93B]",
     next: "bg-red-300",
@@ -716,23 +716,17 @@ function JobSection({
     <section className="overflow-hidden rounded-lg border border-white/[0.08] bg-[#101010]">
       <div className={`h-0.5 ${sectionAccent[sectionKey]}`} />
       <div className="flex items-center justify-between border-b border-white/[0.08] bg-white/[0.045] px-3 py-2">
-        {isCollapsible ? (
-          <button
-            type="button"
-            onClick={onToggleSection}
-            className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-white/70 hover:text-white/90"
-            aria-expanded={open}
-          >
-            {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-            {SECTION_LABELS[sectionKey]}
-          </button>
-        ) : (
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-white/70">
-            {SECTION_LABELS[sectionKey]}
-          </h2>
-        )}
+        <button
+          type="button"
+          onClick={onToggleSection}
+          className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-white/70 hover:text-white/90"
+          aria-expanded={open}
+        >
+          {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+          {SECTION_LABELS[sectionKey]}
+        </button>
         <span className="rounded-[4px] border border-white/[0.08] bg-black/20 px-2 py-0.5 text-[11px] font-semibold text-white/50">
-          {isCollapsible && open ? `${visibleJobs.length}/${sectionKey === "done" ? Math.min(jobs.length, COMPLETED_MAX_VISIBLE) : jobs.length}` : jobs.length}
+          {open ? `${visibleJobs.length}/${sectionKey === "done" ? Math.min(jobs.length, COMPLETED_MAX_VISIBLE) : jobs.length}` : jobs.length}
         </span>
       </div>
       {!open ? null : jobs.length === 0 ? (
@@ -936,7 +930,7 @@ export default function AdminJobs() {
     });
   };
 
-  const toggleSection = (sectionKey: CollapsibleSectionKey) => {
+  const toggleSection = (sectionKey: JobSectionKey) => {
     setSectionPrefs((prev) => ({
       ...prev,
       expanded: {
@@ -946,7 +940,7 @@ export default function AdminJobs() {
     }));
   };
 
-  const showMore = (sectionKey: CollapsibleSectionKey) => {
+  const showMore = (sectionKey: JobSectionKey) => {
     setSectionPrefs((prev) => ({
       ...prev,
       visible: {
@@ -1039,6 +1033,10 @@ export default function AdminJobs() {
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
           onMoveJob={moveJob}
+          sectionExpanded={sectionPrefs.expanded.active}
+          visibleCount={sectionPrefs.visible.active}
+          onToggleSection={() => toggleSection("active")}
+          onShowMore={() => showMore("active")}
         />
         <JobSection
           sectionKey="next"


### PR DESCRIPTION
## Summary
- switch AI Seat defaults to device/capacity emojis and remove worker-role emoji collisions from the picker
- migrate stale robot/tester defaults to laptop/virtual slot symbols while preserving custom seat edits
- remove the detached auto-balance explainer, move Even split beside Manual load, and keep manual mode visible
- rename Actioning now to Active, make it collapsible, widen job titles, and compact row markers/progress

## Checks
- npx eslint src/pages/admin/AdminAgents.tsx src/pages/admin/AdminJobs.tsx
- npm run build