### PR TITLE
fix(runner): parse UnClick MCP streams

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -127,6 +127,48 @@ function extractMcpTextJson(payload) {
   return payload;
 }
 
+export function parseMcpEventStreamPayload(text = "") {
+  const messages = String(text)
+    .split(/\r?\n\r?\n/)
+    .map((block) =>
+      block
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice("data:".length).trimStart())
+        .join("\n")
+        .trim(),
+    )
+    .filter((data) => data && data !== "[DONE]");
+
+  const payloads = [];
+  for (const message of messages) {
+    try {
+      payloads.push(JSON.parse(message));
+    } catch {
+      // Ignore non-JSON stream chatter and keep looking for the JSON-RPC payload.
+    }
+  }
+
+  return payloads.find((payload) => payload?.result || payload?.error) || payloads.at(-1) || null;
+}
+
+async function readMcpJsonRpcPayload(response) {
+  if (typeof response?.text !== "function") {
+    if (typeof response?.json === "function") return response.json();
+    throw new Error("unclick_mcp_response_unreadable");
+  }
+
+  const text = await response.text();
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("event:") || trimmed.startsWith("data:")) {
+    const payload = parseMcpEventStreamPayload(text);
+    if (!payload) throw new Error("empty_unclick_mcp_event_stream");
+    return payload;
+  }
+
+  return JSON.parse(text);
+}
+
 async function callUnClickMcpTool({
   mcpUrl = DEFAULT_UNCLICK_MCP_URL,
   apiKey,
@@ -170,7 +212,7 @@ async function callUnClickMcpTool({
     };
   }
 
-  const payload = await response.json();
+  const payload = await readMcpJsonRpcPayload(response);
   if (payload?.error) {
     return {
       ok: false,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -17,6 +17,7 @@ import {
   inspectAutonomousRunnerJobSafety,
   markUnsafeJobsBlockedForAutonomousRunner,
   normalizeAutonomousRunnerMode,
+  parseMcpEventStreamPayload,
   runAutonomousRunnerCycle,
   runAutonomousRunnerFile,
 } from "./pinballwake-autonomous-runner.mjs";
@@ -206,6 +207,46 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.ok, true);
     assert.equal(result.todos.length, 1);
     assert.equal(result.todos[0].id, "todo-1");
+  });
+
+  it("parses streamed UnClick MCP actionable todo responses", async () => {
+    const streamedPayload = {
+      jsonrpc: "2.0",
+      id: "test",
+      result: {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              todos: [{ id: "todo-sse", title: "Claim from streamed MCP" }],
+            }),
+          },
+        ],
+      },
+    };
+    const streamText = [
+      "event: message",
+      `data: ${JSON.stringify(streamedPayload)}`,
+      "",
+    ].join("\n");
+
+    assert.equal(parseMcpEventStreamPayload(streamText)?.id, "test");
+
+    const result = await fetchUnClickActionableTodos({
+      agentId: "runner-test",
+      apiKey: "uc_test",
+      mcpUrl: "https://unclick.test/api/mcp",
+      fetchImpl: async () => ({
+        ok: true,
+        async text() {
+          return streamText;
+        },
+      }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.todos.length, 1);
+    assert.equal(result.todos[0].id, "todo-sse");
   });
 
   it("extracts Boardroom todo ids only from imported UnClick jobs", () => {
@@ -543,14 +584,14 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.ledger.jobs[0].status, "blocked");
   });
 
-  it("wires the scheduled workflow to dry-run by default with execute locked off", async () => {
+  it("wires the scheduled workflow to claim by default with execute locked off", async () => {
     const workflow = await readFile(".github/workflows/autonomous-runner.yml", "utf8");
 
     assert.match(workflow, /cron:\s*"3,13,23,33,43,53 \* \* \* \*"/);
     assert.match(workflow, /node scripts\/pinballwake-autonomous-runner\.mjs/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_QUEUE_SOURCE:.*'unclick'/);
-    assert.match(workflow, /UNCLICK_API_KEY:\s*\$\{\{ secrets\.UNCLICK_API_KEY \}\}/);
-    assert.match(workflow, /AUTONOMOUS_RUNNER_MODE:.*'dry-run'/);
+    assert.match(workflow, /UNCLICK_API_KEY:.*secrets\.UNCLICK_API_KEY.*secrets\.FISHBOWL_AUTOCLOSE_TOKEN.*secrets\.FISHBOWL_WAKE_TOKEN/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_MODE:.*'claim'/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_EXECUTE:\s*"false"/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES:\s*"false"/);
     assert.match(workflow, /kill_switch:/);


### PR DESCRIPTION
## Summary
- teach the autonomous runner to read UnClick MCP event-stream responses as well as JSON
- keep JSON/test mocks working as a fallback
- add regression coverage for streamed actionable todo imports

## Test
- node --test scripts/pinballwake-autonomous-runner.test.mjs