### PR TITLE
fix(autopilot): require scopepack before runner claim

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7984,6 +7984,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             completed_at: t.completed_at,
             comment_count: countMap[t.id as string] ?? 0,
             actionable_rank: index + 1,
+            scope_pack:
+              t.scope_pack ??
+              t.scopePack ??
+              t.runner_scope ??
+              t.runnerScope ??
+              t.autonomous_scope ??
+              t.autonomousScope ??
+              t.coding_room_scope ??
+              t.codingRoomScope ??
+              null,
           }));
           return res.status(200).json({
             todos: decorated,

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -100,6 +100,11 @@ function compact(value, max = 240) {
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
 }
 
+function compactMultiline(value, max = 12000) {
+  const text = String(value ?? "").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
 function stableTodoJobId(todo = {}) {
   return `boardroom-todo:${String(todo.id || todo.todo_id || "unknown").trim()}`;
 }
@@ -125,6 +130,91 @@ function extractMcpTextJson(payload) {
   }
 
   return payload;
+}
+
+function parseJsonObject(value) {
+  if (!value) return null;
+  if (typeof value === "object" && !Array.isArray(value)) return value;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function firstPresentObject(...values) {
+  for (const value of values) {
+    const parsed = parseJsonObject(value);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+function listFromUnknown(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizePath(item)).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n|,/)
+      .map((item) => normalizePath(item))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function extractBoardroomTodoScopePack(todo = {}) {
+  const scope = firstPresentObject(
+    todo.scope_pack,
+    todo.scopePack,
+    todo.runner_scope,
+    todo.runnerScope,
+    todo.autonomous_scope,
+    todo.autonomousScope,
+    todo.coding_room_scope,
+    todo.codingRoomScope,
+  );
+
+  if (!scope) {
+    return {
+      hasScopePack: false,
+      files: [],
+      patch: "",
+      tests: [],
+      jobType: "code",
+    };
+  }
+
+  const build = parseJsonObject(scope.build) || {};
+  const expectedProof = parseJsonObject(scope.expected_proof) || parseJsonObject(scope.expectedProof) || {};
+  const files = listFromUnknown(
+    scope.owned_files ??
+      scope.ownedFiles ??
+      scope.files ??
+      scope.paths,
+  );
+  const patch = compactMultiline(
+    scope.patch ??
+      scope.diff ??
+      build.patch ??
+      "",
+  );
+  const tests = listFromUnknown(
+    scope.tests ??
+      expectedProof.tests,
+  );
+
+  return {
+    hasScopePack: true,
+    files,
+    patch,
+    tests,
+    jobType: String(scope.job_type || scope.jobType || "code").trim() || "code",
+  };
 }
 
 export function parseMcpEventStreamPayload(text = "") {
@@ -359,11 +449,13 @@ export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date
   const title = compact(todo.title || "Untitled Boardroom todo", 180);
   const priority = String(todo.priority || "normal").trim().toLowerCase();
   const assignee = String(todo.assigned_to_agent_id || "").trim();
+  const scopePack = extractBoardroomTodoScopePack(todo);
   const contextParts = [
     id ? `Boardroom todo ${id}` : "Boardroom todo",
     priority ? `priority=${priority}` : "",
     assignee ? `assigned=${assignee}` : "unassigned",
     todo.status ? `status=${todo.status}` : "",
+    scopePack.hasScopePack ? "scopepack=present" : "scopepack=missing",
   ].filter(Boolean);
 
   return createCodingRoomJob({
@@ -371,14 +463,18 @@ export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date
     source: "unclick-boardroom-actionable-todo",
     worker: assignee || "builder",
     chip: title,
-    context: `${contextParts.join("; ")}. Imported for autonomous claim/routing; do not build unless a ScopePack names owned files.`,
-    files: [`boardroom-todos/${id || "unknown"}.md`],
+    context: `${contextParts.join("; ")}. Imported for autonomous claim/routing; claim only when a ScopePack names owned files and an executable patch.`,
+    jobType: scopePack.jobType,
+    files: scopePack.files,
     expectedProof: {
       requiresPr: false,
-      requiresChangedFiles: false,
+      requiresChangedFiles: scopePack.hasScopePack,
       requiresNonOverlap: true,
-      requiresTests: false,
-      tests: [],
+      requiresTests: scopePack.tests.length > 0,
+      tests: scopePack.tests,
+    },
+    build: {
+      patch: scopePack.patch,
     },
     createdAt: todo.created_at || now,
   });

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -143,12 +143,15 @@ describe("PinballWake autonomous Runner seat", () => {
       });
 
       assert.equal(result.ok, true);
-      assert.equal(result.action, "claimed");
+      assert.equal(result.action, "idle");
       assert.equal(result.persisted, false);
       assert.equal(result.queue_source.source, "unclick");
       assert.equal(result.queue_source.seen, 1);
       assert.equal(result.queue_source.imported, 1);
-      assert.equal(result.job.job_id, "boardroom-todo:b744462e-8e50-4cad-babb-5468adc2a3d9");
+      assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:b744462e-8e50-4cad-babb-5468adc2a3d9");
+      assert.deepEqual(result.ledger.jobs[0].owned_files, []);
+      assert.equal(result.ledger.jobs[0].build.patch, "");
+      assert.equal(result.skipped[0].reason, "boardroom_todo_missing_scopepack");
       assert.equal(calls.length, 1);
       assert.equal(calls[0].url, "https://unclick.test/api/mcp");
       assert.equal(calls[0].init.headers.authorization, "Bearer uc_test");
@@ -287,6 +290,11 @@ describe("PinballWake autonomous Runner seat", () => {
                             priority: "high",
                             assigned_to_agent_id: null,
                             created_at: "2026-05-08T05:00:00.000Z",
+                            scope_pack: {
+                              owned_files: ["docs/runner-scope.md"],
+                              patch: "diff --git a/docs/runner-scope.md b/docs/runner-scope.md\n--- a/docs/runner-scope.md\n+++ b/docs/runner-scope.md\n@@ -1 +1 @@\n-old\n+new\n",
+                              tests: [],
+                            },
                           },
                         ],
                       }),
@@ -406,6 +414,10 @@ describe("PinballWake autonomous Runner seat", () => {
                             status: "open",
                             priority: "high",
                             assigned_to_agent_id: null,
+                            scope_pack: {
+                              owned_files: ["docs/safe-chip.md"],
+                              patch: "diff --git a/docs/safe-chip.md b/docs/safe-chip.md\n--- a/docs/safe-chip.md\n+++ b/docs/safe-chip.md\n@@ -1 +1 @@\n-old\n+new\n",
+                            },
                           },
                         ],
                       }),

--- a/scripts/pinballwake-coding-room.mjs
+++ b/scripts/pinballwake-coding-room.mjs
@@ -72,6 +72,18 @@ function normalizeWorkerToken(value) {
   return String(value ?? "").trim().toLowerCase();
 }
 
+function hasExecutableBuildPatch(job = {}) {
+  return String(job?.build?.patch ?? "").trim().length > 0;
+}
+
+function isUnscopedBoardroomTodoJob(job = {}) {
+  return (
+    String(job?.source || "").trim() === "unclick-boardroom-actionable-todo" &&
+    job?.job_type !== "review" &&
+    ((job?.owned_files || []).length === 0 || !hasExecutableBuildPatch(job))
+  );
+}
+
 export function codingRoomJobId({ source = "manual", prNumber = "none", chip = "", worker = "" }) {
   const digest = createHash("sha256")
     .update([source, prNumber, chip, worker].map((part) => String(part ?? "").trim()).join("|"))
@@ -324,6 +336,10 @@ export function runnerCanClaimCodingRoomJob({ runner = {}, job, activeJobs = [] 
     }
 
     return { ok: true, reason: "claimable_review" };
+  }
+
+  if (isUnscopedBoardroomTodoJob(job)) {
+    return { ok: false, reason: "boardroom_todo_missing_scopepack" };
   }
 
   const readiness = String(runner.readiness || "").trim();


### PR DESCRIPTION
## Summary
- stop imported Boardroom todos from becoming claimable code jobs unless they include a ScopePack with owned files and an executable patch
- pass optional scope_pack fields through list_actionable_todos for future structured runner work
- keep unscoped specs visible instead of flipping them into fake in-progress Builder work

## Proof
- node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-pipeline-executor.test.mjs
- npm run build
- npx tsc --noEmit
- npx eslint scripts/pinballwake-autonomous-runner.mjs scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-coding-room.mjs api/memory-admin.ts --max-warnings=0