### PR TITLE
Suppress stale missed-checkin noise

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -4,10 +4,12 @@ import {
   CHECKIN_ACK_LEASE_SECONDS,
   CHECKIN_ACTIVE_GRACE_MS,
   CHECKIN_DORMANT_SUPPRESS_MS,
+  CHECKIN_OVERDUE_SUPPRESS_MS,
   WAKEPASS_REROUTE_LEASE_SECONDS,
   buildDispatchReclaimSignal,
   buildMissedCheckinDispatch,
   buildWakepassAutoReroutePlan,
+  isMissedCheckinDispatch,
   isMissedCheckinCandidate,
   isReclaimableDispatchCandidate,
   isWakepassAutoRerouteEligible,
@@ -108,6 +110,21 @@ describe("fishbowl watcher PinballWake ACK coverage", () => {
           ...baseProfile,
           last_seen_at: new Date(nowMs - CHECKIN_ACTIVE_GRACE_MS + 1_000).toISOString(),
           next_checkin_at: "2026-05-01T01:21:00.000Z",
+        },
+        nowMs,
+      ),
+    ).toBe(false);
+  });
+
+  it("suppresses missed check-ins once the missed window is old noise", () => {
+    const nowMs = Date.parse("2026-05-01T14:00:00.000Z");
+
+    expect(
+      isMissedCheckinCandidate(
+        {
+          ...baseProfile,
+          last_seen_at: new Date(nowMs - CHECKIN_OVERDUE_SUPPRESS_MS - 60_000).toISOString(),
+          next_checkin_at: new Date(nowMs - CHECKIN_OVERDUE_SUPPRESS_MS - 1_000).toISOString(),
         },
         nowMs,
       ),
@@ -282,6 +299,14 @@ describe("fishbowl watcher PinballWake ACK coverage", () => {
     };
     const signal = buildDispatchReclaimSignal(staleCheckinDispatch, nowMs);
 
+    expect(isMissedCheckinDispatch(staleCheckinDispatch)).toBe(true);
+    expect(signal).toMatchObject({
+      action: "stale_dispatch_reclaimed",
+      summary: "Reclaimed stale missed check-in dispatch for worker-1",
+      payload: {
+        wake_reason: "missed_next_checkin",
+      },
+    });
     expect(isWakepassAutoRerouteEligible(staleCheckinDispatch)).toBe(false);
     expect(
       buildWakepassAutoReroutePlan({

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -66,6 +66,7 @@ const MENTION_DIGEST_DEDUP_WINDOW_MS = 60 * 60 * 1000;
 const MENTION_AGE_THRESHOLD_MS = 10 * 60 * 1000;
 const STATUS_STALE_WINDOW_MS = 30 * 60 * 1000;
 export const CHECKIN_ACTIVE_GRACE_MS = 30 * 60 * 1000;
+export const CHECKIN_OVERDUE_SUPPRESS_MS = 12 * 60 * 60 * 1000;
 export const CHECKIN_DORMANT_SUPPRESS_MS = 7 * 24 * 60 * 60 * 1000;
 export const CHECKIN_ACK_LEASE_SECONDS = 600;
 const STALE_DISPATCH_RECLAIM_LIMIT = 50;
@@ -95,6 +96,7 @@ export function isMissedCheckinCandidate(profile: ProfileRow, nowMs: number): bo
   const dueMs = new Date(profile.next_checkin_at).getTime();
   if (Number.isNaN(dueMs)) return false;
   if (dueMs >= nowMs) return false;
+  if (nowMs - dueMs >= CHECKIN_OVERDUE_SUPPRESS_MS) return false;
   const seenMs = profile.last_seen_at ? new Date(profile.last_seen_at).getTime() : 0;
   if (Number.isNaN(seenMs)) return false;
   if (seenMs > 0 && nowMs - seenMs <= CHECKIN_ACTIVE_GRACE_MS) return false;
@@ -341,6 +343,14 @@ export function isReclaimableDispatchCandidate(row: DispatchRow, nowMs: number):
   ).isStale;
 }
 
+export function isMissedCheckinDispatch(row: DispatchRow): boolean {
+  const payload = row.payload ?? {};
+  return (
+    normalizeToken(payload.wake_reason) === "missed_next_checkin" ||
+    normalizeToken(row.task_ref).startsWith("fishbowl-checkin:")
+  );
+}
+
 export function buildDispatchReclaimSignal(row: DispatchRow, nowMs: number) {
   const staleDecision = decideStaleLease(
     {
@@ -352,6 +362,21 @@ export function buildDispatchReclaimSignal(row: DispatchRow, nowMs: number) {
   );
 
   if (!staleDecision.isStale) return null;
+
+  if (isMissedCheckinDispatch(row)) {
+    return {
+      action: "stale_dispatch_reclaimed" as const,
+      summary: `Reclaimed stale missed check-in dispatch for ${row.target_agent_id}`,
+      payload: {
+        dispatch_id: row.dispatch_id,
+        source: row.source,
+        target_agent_id: row.target_agent_id,
+        task_ref: row.task_ref ?? null,
+        stale_seconds: staleDecision.staleSeconds,
+        ...(row.payload ?? {}),
+      },
+    };
+  }
 
   return createReclaimSignal(
     {
@@ -458,6 +483,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   let checkinSignalsEmitted = 0;
   let checkinDispatchesEmitted = 0;
+  let checkinTimersCleared = 0;
   let staleDispatchesReclaimed = 0;
   let staleDispatchesRerouted = 0;
   let staleDispatchRerouteFailures = 0;
@@ -537,6 +563,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       );
     } else {
       checkinSignalsEmitted++;
+      const { error: clearCheckinErr } = await supabase
+        .from("mc_fishbowl_profiles")
+        .update({ next_checkin_at: null })
+        .eq("api_key_hash", profile.api_key_hash)
+        .eq("agent_id", profile.agent_id)
+        .eq("next_checkin_at", profile.next_checkin_at);
+      if (clearCheckinErr) {
+        console.error(
+          "[fishbowl-watcher] missed checkin timer clear error:",
+          clearCheckinErr.message,
+        );
+      } else {
+        checkinTimersCleared++;
+      }
     }
   }
 
@@ -750,6 +790,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   return res.status(200).json({
     checkin_signals_emitted: checkinSignalsEmitted,
     checkin_dispatches_emitted: checkinDispatchesEmitted,
+    checkin_timers_cleared: checkinTimersCleared,
     stale_dispatches_reclaimed: staleDispatchesReclaimed,
     stale_dispatches_rerouted: staleDispatchesRerouted,
     stale_dispatch_reroute_failures: staleDispatchRerouteFailures,


### PR DESCRIPTION
## Summary
- suppress missed check-in nudges once the missed window is old noise
- reclaim expired missed-check-in dispatches as informational stale cleanup instead of urgent WakePass missing-ACK alerts
- clear spent next_checkin_at timers after the one-shot missed-check-in signal is emitted

## Proof
- npx vitest run api/fishbowl-watcher.test.ts
- npx eslint api/fishbowl-watcher.ts api/fishbowl-watcher.test.ts --max-warnings=0
- npx tsc --noEmit
- npm run build