### PR TITLE
feat(autopilot): add typed control ledger

### DIFF
--- a/api/autopilot-control-ledger.test.ts
+++ b/api/autopilot-control-ledger.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAutopilotEventRow,
+  planFishbowlPostLedgerEvent,
+  planTodoLedgerEvents,
+} from "./lib/autopilot-control-ledger";
+
+const now = new Date("2026-05-09T00:00:00.000Z");
+
+describe("autopilot control ledger helpers", () => {
+  it("builds idempotent typed event rows", () => {
+    const row = buildAutopilotEventRow({
+      apiKeyHash: "hash_123",
+      eventType: "claim",
+      actorAgentId: "runner",
+      refKind: "todo",
+      refId: "todo-123",
+      now,
+      payload: { to: "runner", status: "in_progress" },
+    });
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash_123",
+      event_type: "claim",
+      actor_agent_id: "runner",
+      ref_kind: "todo",
+      ref_id: "todo-123",
+      created_at: "2026-05-09T00:00:00.000Z",
+    });
+    expect(row.idempotency_key).toContain("claim:todo:todo-123:runner:");
+  });
+
+  it("plans todo state and claim events from before/after rows", () => {
+    const events = planTodoLedgerEvents({
+      todoId: "todo-123",
+      actorAgentId: "runner",
+      now,
+      before: { status: "open", assigned_to_agent_id: null, title: "Build ledger" },
+      after: { status: "in_progress", assigned_to_agent_id: "runner", title: "Build ledger" },
+    });
+
+    expect(events.map((event) => event.eventType)).toEqual(["todo_state_change", "claim"]);
+    expect(events[0]).toMatchObject({
+      actorAgentId: "runner",
+      refKind: "todo",
+      refId: "todo-123",
+      payload: { from: "open", to: "in_progress", title: "Build ledger" },
+    });
+    expect(events[1]).toMatchObject({
+      payload: { from: null, to: "runner", status: "in_progress" },
+    });
+  });
+
+  it("plans release events when a todo is unassigned", () => {
+    const events = planTodoLedgerEvents({
+      todoId: "todo-123",
+      actorAgentId: "runner",
+      now,
+      before: { status: "in_progress", assigned_to_agent_id: "runner" },
+      after: { status: "open", assigned_to_agent_id: null },
+    });
+
+    expect(events.map((event) => event.eventType)).toEqual(["todo_state_change", "release"]);
+  });
+
+  it("turns structured ACK posts into ack events without storing full chat text", () => {
+    const event = planFishbowlPostLedgerEvent({
+      actorAgentId: "reviewer",
+      messageId: "message-2",
+      threadId: "message-1",
+      now,
+      tags: ["answer", "handoff"],
+      recipients: ["all"],
+      text: [
+        "ACK",
+        "Current chip: PR #600 review",
+        "Next action: run focused proof",
+        "ETA: 15m",
+        "Blocker: none",
+      ].join("\n"),
+    });
+
+    expect(event).toMatchObject({
+      eventType: "ack",
+      actorAgentId: "reviewer",
+      refKind: "dispatch",
+      refId: "message-1",
+      payload: {
+        current_chip: "PR #600 review",
+        next_action: "run focused proof",
+        eta: "15m",
+        blocker: "none",
+        message_id: "message-2",
+        thread_id: "message-1",
+      },
+    });
+    expect(JSON.stringify(event?.payload)).not.toContain("ACK\\n");
+  });
+
+  it("rejects payloads that look like secrets", () => {
+    expect(() =>
+      buildAutopilotEventRow({
+        apiKeyHash: "hash_123",
+        eventType: "proof_result",
+        actorAgentId: "runner",
+        refKind: "todo",
+        refId: "todo-123",
+        now,
+        payload: { api_key: "uc_abc1234567890def" },
+      }),
+    ).toThrow(/sensitive key/);
+  });
+});

--- a/api/lib/autopilot-control-ledger.ts
+++ b/api/lib/autopilot-control-ledger.ts
@@ -1,0 +1,333 @@
+import { createHash } from "crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const AUTOPILOT_EVENT_TYPES = [
+  "claim",
+  "lease_refresh",
+  "lease_expired",
+  "release",
+  "build_start",
+  "build_end",
+  "proof_request",
+  "proof_result",
+  "ack",
+  "blocker",
+  "merge_decision",
+  "watch_start",
+  "watch_end",
+  "dispatch",
+  "pick",
+  "todo_state_change",
+] as const;
+
+export type AutopilotEventType = (typeof AUTOPILOT_EVENT_TYPES)[number];
+
+export const AUTOPILOT_REF_KINDS = ["todo", "pr", "dispatch", "agent", "run"] as const;
+export type AutopilotRefKind = (typeof AUTOPILOT_REF_KINDS)[number];
+
+export interface AutopilotEventInput {
+  apiKeyHash: string;
+  eventType: AutopilotEventType | string;
+  actorAgentId: string;
+  refKind: AutopilotRefKind | string;
+  refId: string;
+  payload?: Record<string, unknown>;
+  now?: Date;
+}
+
+export interface AutopilotEventRow {
+  api_key_hash: string;
+  event_type: AutopilotEventType;
+  actor_agent_id: string;
+  ref_kind: AutopilotRefKind;
+  ref_id: string;
+  payload: Record<string, unknown>;
+  idempotency_key: string;
+  created_at: string;
+}
+
+export interface TodoLedgerPlanInput {
+  todoId: string;
+  actorAgentId: string;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  now?: Date;
+}
+
+export interface FishbowlPostLedgerInput {
+  actorAgentId: string;
+  messageId: string;
+  threadId?: string | null;
+  text: string;
+  tags?: string[] | null;
+  recipients?: string[] | null;
+  now?: Date;
+}
+
+const EVENT_TYPE_SET = new Set<string>(AUTOPILOT_EVENT_TYPES);
+const REF_KIND_SET = new Set<string>(AUTOPILOT_REF_KINDS);
+const SENSITIVE_KEY_RE = /(api[_-]?key|secret|token|password|credential|authorization|cookie)/i;
+const SENSITIVE_TEXT_RE =
+  /(authorization:\s*bearer\s+\S+|uc_[a-f0-9]{16,}|sk-[a-z0-9_-]{12,}|gh[pousr]_[a-z0-9_]{20,})/i;
+
+function compact(value: unknown, max = 500): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fiveSecondBucket(date: Date): string {
+  return String(Math.floor(date.getTime() / 5000));
+}
+
+function normalizeEventType(value: string): AutopilotEventType {
+  if (!EVENT_TYPE_SET.has(value)) throw new Error(`Unsupported autopilot event_type: ${value}`);
+  return value as AutopilotEventType;
+}
+
+function normalizeRefKind(value: string): AutopilotRefKind {
+  if (!REF_KIND_SET.has(value)) throw new Error(`Unsupported autopilot ref_kind: ${value}`);
+  return value as AutopilotRefKind;
+}
+
+function sanitizeUnknown(key: string, value: unknown): unknown {
+  if (SENSITIVE_KEY_RE.test(key)) {
+    throw new Error(`Autopilot event payload contains sensitive key: ${key}`);
+  }
+  if (typeof value === "string") {
+    const text = compact(value);
+    if (SENSITIVE_TEXT_RE.test(text)) {
+      throw new Error(`Autopilot event payload contains sensitive text in: ${key}`);
+    }
+    return text;
+  }
+  if (value == null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeUnknown(key, item));
+  }
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
+        childKey,
+        sanitizeUnknown(childKey, childValue),
+      ]),
+    );
+  }
+  return undefined;
+}
+
+function sanitizePayload(payload: Record<string, unknown> = {}): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (SENSITIVE_KEY_RE.test(key)) {
+      throw new Error(`Autopilot event payload contains sensitive key: ${key}`);
+    }
+    const safeValue = sanitizeUnknown(key, value);
+    if (safeValue !== undefined) {
+      sanitized[key] = safeValue;
+    }
+  }
+  return sanitized;
+}
+
+export function buildAutopilotEventRow(input: AutopilotEventInput): AutopilotEventRow {
+  const now = input.now ?? new Date();
+  const eventType = normalizeEventType(input.eventType);
+  const refKind = normalizeRefKind(input.refKind);
+  if (!input.apiKeyHash) throw new Error("api_key_hash required");
+  const actorAgentId = compact(input.actorAgentId, 128);
+  const refId = compact(input.refId, 160);
+  if (!actorAgentId) throw new Error("actor_agent_id required");
+  if (!refId) throw new Error("ref_id required");
+
+  const payload = sanitizePayload(input.payload ?? {});
+  const payloadHash = sha256(stableJson(payload));
+  const idempotencyKey = [
+    eventType,
+    refKind,
+    refId,
+    actorAgentId,
+    payloadHash,
+    fiveSecondBucket(now),
+  ].join(":");
+
+  return {
+    api_key_hash: input.apiKeyHash,
+    event_type: eventType,
+    actor_agent_id: actorAgentId,
+    ref_kind: refKind,
+    ref_id: refId,
+    payload,
+    idempotency_key: idempotencyKey,
+    created_at: now.toISOString(),
+  };
+}
+
+export function planTodoLedgerEvents(input: TodoLedgerPlanInput): AutopilotEventInput[] {
+  const before = input.before ?? {};
+  const after = input.after ?? {};
+  const events: AutopilotEventInput[] = [];
+  const beforeStatus = typeof before.status === "string" ? before.status : null;
+  const afterStatus = typeof after.status === "string" ? after.status : null;
+  const beforeAssignee =
+    typeof before.assigned_to_agent_id === "string" && before.assigned_to_agent_id.trim()
+      ? before.assigned_to_agent_id.trim()
+      : null;
+  const afterAssignee =
+    typeof after.assigned_to_agent_id === "string" && after.assigned_to_agent_id.trim()
+      ? after.assigned_to_agent_id.trim()
+      : null;
+
+  if (beforeStatus !== afterStatus && afterStatus) {
+    events.push({
+      apiKeyHash: "",
+      eventType: "todo_state_change",
+      actorAgentId: input.actorAgentId,
+      refKind: "todo",
+      refId: input.todoId,
+      now: input.now,
+      payload: {
+        from: beforeStatus,
+        to: afterStatus,
+        title: after.title ?? before.title ?? "",
+      },
+    });
+  }
+
+  if (beforeAssignee !== afterAssignee) {
+    events.push({
+      apiKeyHash: "",
+      eventType: afterAssignee ? "claim" : "release",
+      actorAgentId: input.actorAgentId,
+      refKind: "todo",
+      refId: input.todoId,
+      now: input.now,
+      payload: {
+        from: beforeAssignee,
+        to: afterAssignee,
+        status: afterStatus ?? beforeStatus,
+      },
+    });
+  }
+
+  return events;
+}
+
+function extractAckFields(text: string): Record<string, string> | null {
+  if (!/^ACK\b/i.test(text.trim())) return null;
+  const fields: Record<string, string> = {};
+  const labels: Record<string, string> = {
+    "current chip": "current_chip",
+    "next action": "next_action",
+    eta: "eta",
+    blocker: "blocker",
+  };
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^([^:]{2,40}):\s*(.+)$/);
+    if (!match) continue;
+    const key = labels[match[1].trim().toLowerCase()];
+    if (key) fields[key] = compact(match[2], 300);
+  }
+  return Object.keys(fields).length > 0 ? fields : null;
+}
+
+export function planFishbowlPostLedgerEvent(input: FishbowlPostLedgerInput): AutopilotEventInput | null {
+  const tagSet = new Set((input.tags ?? []).map((tag) => tag.toLowerCase()));
+  const ackFields = extractAckFields(input.text);
+  const now = input.now;
+
+  if (ackFields) {
+    return {
+      apiKeyHash: "",
+      eventType: "ack",
+      actorAgentId: input.actorAgentId,
+      refKind: "dispatch",
+      refId: input.threadId || input.messageId,
+      now,
+      payload: {
+        ...ackFields,
+        message_id: input.messageId,
+        thread_id: input.threadId ?? null,
+      },
+    };
+  }
+
+  if (tagSet.has("blocker") || /\bBLOCKER\b/i.test(input.text)) {
+    return {
+      apiKeyHash: "",
+      eventType: "blocker",
+      actorAgentId: input.actorAgentId,
+      refKind: "run",
+      refId: input.threadId || input.messageId,
+      now,
+      payload: {
+        message_id: input.messageId,
+        thread_id: input.threadId ?? null,
+        reason: compact(input.text, 500),
+      },
+    };
+  }
+
+  if (tagSet.has("needs-doing") || tagSet.has("queuepush") || tagSet.has("wake")) {
+    return {
+      apiKeyHash: "",
+      eventType: "dispatch",
+      actorAgentId: input.actorAgentId,
+      refKind: "dispatch",
+      refId: input.messageId,
+      now,
+      payload: {
+        thread_id: input.threadId ?? null,
+        recipients: input.recipients ?? [],
+        tags: input.tags ?? [],
+      },
+    };
+  }
+
+  return null;
+}
+
+export async function recordAutopilotEvent(
+  supabase: SupabaseClient,
+  input: AutopilotEventInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const row = buildAutopilotEventRow(input);
+    const { error } = await supabase
+      .from("mc_autopilot_events")
+      .upsert(row, { onConflict: "api_key_hash,idempotency_key", ignoreDuplicates: true });
+    if (error) throw error;
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+export async function recordAutopilotEvents(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+  inputs: AutopilotEventInput[],
+): Promise<void> {
+  for (const input of inputs) {
+    const result = await recordAutopilotEvent(supabase, { ...input, apiKeyHash });
+    if (!result.ok) {
+      console.warn("[autopilot_events] write skipped:", result.error);
+    }
+  }
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -119,6 +119,12 @@ import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
+import {
+  planFishbowlPostLedgerEvent,
+  planTodoLedgerEvents,
+  recordAutopilotEvent,
+  recordAutopilotEvents,
+} from "./lib/autopilot-control-ledger.js";
 import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
 import {
   createDispatchId,
@@ -7103,6 +7109,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({ profile: data });
       }
 
+      case "autopilot_record_event": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'.",
+          });
+        }
+        const body = (req.body ?? {}) as {
+          event_type?: string | null;
+          actor_agent_id?: string | null;
+          ref_kind?: string | null;
+          ref_id?: string | null;
+          payload?: Record<string, unknown> | null;
+        };
+        const actorAgentId = String(body.actor_agent_id ?? "").trim();
+        const refId = String(body.ref_id ?? "").trim();
+        if (!actorAgentId) return res.status(400).json({ error: "actor_agent_id required" });
+        if (!refId) return res.status(400).json({ error: "ref_id required" });
+        if (actorAgentId.length > 128) return res.status(400).json({ error: "actor_agent_id must be at most 128 characters" });
+        if (refId.length > 160) return res.status(400).json({ error: "ref_id must be at most 160 characters" });
+        if (body.payload != null && !isRecord(body.payload)) {
+          return res.status(400).json({ error: "payload must be an object" });
+        }
+
+        const result = await recordAutopilotEvent(supabase, {
+          apiKeyHash,
+          eventType: String(body.event_type ?? ""),
+          actorAgentId,
+          refKind: String(body.ref_kind ?? ""),
+          refId,
+          payload: body.payload ?? {},
+        });
+        if (!result.ok) return res.status(400).json({ error: result.error });
+        return res.status(200).json({ ok: true });
+      }
+
       case "fishbowl_post": {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
@@ -7245,6 +7289,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .select("id, author_emoji, author_name, author_agent_id, recipients, text, tags, thread_id, created_at")
           .single();
         if (insertErr) throw insertErr;
+
+        const ledgerEvent = planFishbowlPostLedgerEvent({
+          actorAgentId: agentId,
+          messageId: inserted.id,
+          threadId,
+          text,
+          tags,
+          recipients,
+        });
+        if (ledgerEvent) {
+          const ledgerResult = await recordAutopilotEvent(supabase, {
+            ...ledgerEvent,
+            apiKeyHash,
+          });
+          if (!ledgerResult.ok) {
+            console.warn("[fishbowl_post] autopilot ledger write skipped:", ledgerResult.error);
+          }
+        }
 
         // Bump post-side presence so active authors do not look stale on Now Playing.
         // Posting is a live pulse, so it refreshes status and clears any prior
@@ -7586,6 +7648,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .single();
           if (error) throw error;
 
+          await recordAutopilotEvents(
+            supabase,
+            apiKeyHash,
+            planTodoLedgerEvents({
+              todoId: data.id,
+              actorAgentId: agentId,
+              before: null,
+              after: data,
+            }),
+          );
+
           void postFishbowlEvent(
             supabase,
             apiKeyHash,
@@ -7648,6 +7721,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           const idRes = validateUuid(body.todo_id, "todo_id");
           if (typeof idRes !== "string") return res.status(400).json(idRes);
 
+          const { data: beforeTodo, error: beforeErr } = await supabase
+            .from("mc_fishbowl_todos")
+            .select("id,title,status,assigned_to_agent_id,priority")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .maybeSingle();
+          if (beforeErr) throw beforeErr;
+
           const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
           if (body.title != null) {
             const titleRes = validateTitle(body.title);
@@ -7689,12 +7770,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .maybeSingle();
           if (error) throw error;
           if (!data) return res.status(404).json({ error: "todo not found" });
+
+          await recordAutopilotEvents(
+            supabase,
+            apiKeyHash,
+            planTodoLedgerEvents({
+              todoId: data.id,
+              actorAgentId: agentId,
+              before: beforeTodo,
+              after: data,
+            }),
+          );
           return res.status(200).json({ todo: data });
         }
 
         if (action === "fishbowl_complete_todo") {
           const idRes = validateUuid(body.todo_id, "todo_id");
           if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const { data: beforeTodo, error: beforeErr } = await supabase
+            .from("mc_fishbowl_todos")
+            .select("id,title,status,assigned_to_agent_id,priority")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .maybeSingle();
+          if (beforeErr) throw beforeErr;
           const nowIso = new Date().toISOString();
           const { data, error } = await supabase
             .from("mc_fishbowl_todos")
@@ -7705,6 +7804,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .maybeSingle();
           if (error) throw error;
           if (!data) return res.status(404).json({ error: "todo not found" });
+
+          await recordAutopilotEvents(
+            supabase,
+            apiKeyHash,
+            planTodoLedgerEvents({
+              todoId: data.id,
+              actorAgentId: agentId,
+              before: beforeTodo,
+              after: data,
+            }),
+          );
 
           void postFishbowlEvent(
             supabase,
@@ -7719,6 +7829,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (action === "fishbowl_drop_todo") {
           const idRes = validateUuid(body.todo_id, "todo_id");
           if (typeof idRes !== "string") return res.status(400).json(idRes);
+          const { data: beforeTodo, error: beforeErr } = await supabase
+            .from("mc_fishbowl_todos")
+            .select("id,title,status,assigned_to_agent_id,priority")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", idRes)
+            .maybeSingle();
+          if (beforeErr) throw beforeErr;
           const { data, error } = await supabase
             .from("mc_fishbowl_todos")
             .update({ status: "dropped", updated_at: new Date().toISOString() })
@@ -7728,6 +7845,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .maybeSingle();
           if (error) throw error;
           if (!data) return res.status(404).json({ error: "todo not found" });
+
+          await recordAutopilotEvents(
+            supabase,
+            apiKeyHash,
+            planTodoLedgerEvents({
+              todoId: data.id,
+              actorAgentId: agentId,
+              before: beforeTodo,
+              after: data,
+            }),
+          );
           return res.status(200).json({ todo: data });
         }
 

--- a/supabase/migrations/20260509000000_autopilot_control_ledger.sql
+++ b/supabase/migrations/20260509000000_autopilot_control_ledger.sql
@@ -1,0 +1,66 @@
+-- Autopilot control ledger v1
+-- Append-only typed events for claim/build/proof/review/ship/close state.
+-- Boardroom posts and GitHub comments are mirrors; this table is the durable
+-- tenant-scoped state spine for automation readers.
+
+CREATE TABLE IF NOT EXISTS mc_autopilot_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  event_type text NOT NULL
+    CHECK (event_type IN (
+      'claim',
+      'lease_refresh',
+      'lease_expired',
+      'release',
+      'build_start',
+      'build_end',
+      'proof_request',
+      'proof_result',
+      'ack',
+      'blocker',
+      'merge_decision',
+      'watch_start',
+      'watch_end',
+      'dispatch',
+      'pick',
+      'todo_state_change'
+    )),
+  actor_agent_id text NOT NULL,
+  ref_kind text NOT NULL
+    CHECK (ref_kind IN ('todo', 'pr', 'dispatch', 'agent', 'run')),
+  ref_id text NOT NULL,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  seq bigserial UNIQUE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_autopilot_events_idempotency
+  ON mc_autopilot_events(api_key_hash, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_events_ref
+  ON mc_autopilot_events(api_key_hash, ref_kind, ref_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_events_type
+  ON mc_autopilot_events(api_key_hash, event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_events_actor
+  ON mc_autopilot_events(api_key_hash, actor_agent_id, created_at DESC);
+
+ALTER TABLE mc_autopilot_events ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'mc_autopilot_events'
+      AND policyname = 'mc_autopilot_events_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_autopilot_events_service_role_all"
+      ON mc_autopilot_events FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## SummaryAdds the first typed autopilot control ledger slice so automation can write durable state events instead of relying only on Boardroom/GitHub narration. This includes an append-only `mc_autopilot_events` table, an authenticated `autopilot_record_event` API action, and write-through event hooks for Fishbowl todo state/claim changes plus ACK/blocker/dispatch posts.Closes UnClick todo: faf225ff-c688-47f0-b6fd-853c2ba41469## Scope- Owned lane: autopilot control ledger / pipeline receipts- Added `api/lib/autopilot-control-ledger.ts`- Added `api/autopilot-control-ledger.test.ts`- Updated `api/memory-admin.ts`- Added `supabase/migrations/20260509000000_autopilot_control_ledger.sql`## Non-overlap- Does not change Runner claim selection or CAS locking.- Does not change Jobs page UI.- Does not backfill historical events.- Does not parse GitHub comments or Boardroom history into authoritative state.## Verification- `npx vitest run api/autopilot-control-ledger.test.ts`- `npx vitest run api/autopilot-control-ledger.test.ts api/fishbowl-todo-handoff.test.ts api/fishbowl-message-handoff.test.ts`- `npx eslint api/memory-admin.ts api/lib/autopilot-control-ledger.ts api/autopilot-control-ledger.test.ts`- `npm run build`- `git diff --cached --check`## Risk- Additive Supabase migration only: one new service-role-only append-only table and indexes.- Auth surface is limited to the existing `memory-admin` API key path.- Payload helper rejects obvious secret/token/API-key fields and token-shaped text.- Existing Boardroom/todo flows continue if best-effort ledger write-through skips.## Follow-up- Wire Runner, QueuePush, proof, review, ship, and reconciliation jobs to call `autopilot_record_event` directly for full end-to-end claim -> build -> proof -> review -> ship -> close receipts.
## Refresh Proof - 2026-05-09
- Merged current `main` into `codex/autopilot-control-ledger` to resolve the PR #588 conflict.
- Conflict was limited to `api/memory-admin.ts` imports; both ledger and UnClick Connect imports were preserved.
- Local focused proof passed: `npx vitest run api/autopilot-control-ledger.test.ts api/lib/route-packet-consumer.test.ts api/lib/tether-route-packet.test.ts api/lib/route-packet-dispatch.test.ts api/lib/unclick-connect-worker-discovery.test.ts` (17/17).
- Local build passed: `npm run build`.
- PR checks after push passed: Website, MCP server package, TestPass smoke, Vercel, Vercel Preview Comments.
- GitHub now reports the PR branch as mergeable.