### PR TITLE
feat(autopilot): add UnClick Connect route packet proof

### DIFF
--- a/api/lib/route-packet-consumer.test.ts
+++ b/api/lib/route-packet-consumer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { runRoutePacketConsumerDryRun, type RoutePacket } from "./route-packet-consumer";
+
+const basePacket: RoutePacket = {
+  experiment: true,
+  lane: "Builder",
+  item: {
+    id: "experiment-route-packet-proof",
+    title: "Experiment: internal route packet proof",
+  },
+  needed_action: "Move one item forward.",
+  expected_receipt: ["proof", "HOLD", "BLOCKER"],
+  created_at: "2026-05-09T00:00:00.000Z",
+  ttl_seconds: 1200,
+};
+
+describe("route packet consumer dry run", () => {
+  it("assigns an experiment Builder packet to a live Builder", () => {
+    const result = runRoutePacketConsumerDryRun({
+      packet: basePacket,
+      visibleWorkers: [{ agent_id: "builder-live", lane: "Builder", status: "active" }],
+      now: new Date("2026-05-09T00:05:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      dry_run: true,
+      writes: [],
+      decision: {
+        status: "assigned",
+        receipt: "assigned",
+        target_agent_id: "builder-live",
+        reason: "live_worker_available",
+      },
+    });
+  });
+
+  it("returns an honest blocker when no live Builder is available", () => {
+    const result = runRoutePacketConsumerDryRun({
+      packet: basePacket,
+      visibleWorkers: [{ agent_id: "watcher-live", lane: "Watcher", status: "active" }],
+      now: new Date("2026-05-09T00:05:00.000Z"),
+    });
+
+    expect(result.decision).toEqual({
+      status: "BLOCKER",
+      receipt: "BLOCKER",
+      target_agent_id: "coordinator",
+      reason: "no_live_builder_available",
+    });
+  });
+
+  it("holds expired packets instead of assigning stale work", () => {
+    const result = runRoutePacketConsumerDryRun({
+      packet: basePacket,
+      visibleWorkers: [{ agent_id: "builder-live", lane: "Builder", status: "active" }],
+      now: new Date("2026-05-09T00:30:01.000Z"),
+    });
+
+    expect(result.decision).toEqual({
+      status: "HOLD",
+      receipt: "HOLD",
+      target_agent_id: "coordinator",
+      reason: "ttl_expired",
+    });
+  });
+});

--- a/api/lib/route-packet-consumer.ts
+++ b/api/lib/route-packet-consumer.ts
@@ -1,0 +1,168 @@
+export type RoutePacketLane =
+  | "Builder"
+  | "Proof"
+  | "Reviewer"
+  | "Safety"
+  | "Coordinator"
+  | "Watcher";
+
+export interface RoutePacket {
+  experiment: boolean;
+  lane: RoutePacketLane;
+  item: {
+    id: string;
+    title: string;
+  };
+  needed_action: string;
+  visible_blocker?: string | null;
+  expected_receipt: string[];
+  created_at: string;
+  ttl_seconds: number;
+  idempotency_key?: string;
+}
+
+export interface VisibleWorker {
+  id?: string;
+  agent_id?: string;
+  worker_id?: string;
+  lane?: string;
+  capabilities?: string[];
+  status?: string;
+  live?: boolean;
+}
+
+export type RoutePacketDecision =
+  | {
+      status: "assigned";
+      receipt: "assigned";
+      target_agent_id: string;
+      reason: "live_worker_available";
+    }
+  | {
+      status: "HOLD";
+      receipt: "HOLD";
+      target_agent_id: "coordinator";
+      reason: "ttl_expired";
+    }
+  | {
+      status: "BLOCKER";
+      receipt: "BLOCKER";
+      target_agent_id: "coordinator";
+      reason: "no_live_builder_available" | "no_live_worker_available";
+    };
+
+export interface RoutePacketConsumerResult {
+  dry_run: true;
+  writes: [];
+  packet: RoutePacket;
+  decision: RoutePacketDecision;
+}
+
+const LIVE_WORKER_STATUSES = new Set(["active", "available", "idle", "working", "live"]);
+
+export function normalizeRoutePacketLane(input: unknown): RoutePacketLane {
+  const value = String(input ?? "").trim().toLowerCase();
+  switch (value) {
+    case "builder":
+    case "build":
+    case "forge":
+      return "Builder";
+    case "proof":
+    case "prove":
+      return "Proof";
+    case "reviewer":
+    case "review":
+    case "tester":
+    case "qc":
+      return "Reviewer";
+    case "safety":
+    case "gatekeeper":
+      return "Safety";
+    case "coordinator":
+    case "master":
+      return "Coordinator";
+    case "watcher":
+    case "relay":
+      return "Watcher";
+    default:
+      return "Builder";
+  }
+}
+
+export function isRoutePacketExpired(packet: RoutePacket, now = new Date()): boolean {
+  const createdAtMs = Date.parse(packet.created_at);
+  if (!Number.isFinite(createdAtMs)) return false;
+  return now.getTime() - createdAtMs > packet.ttl_seconds * 1000;
+}
+
+export function findLiveWorkerForLane(
+  lane: RoutePacketLane,
+  workers: VisibleWorker[],
+): string | null {
+  const wanted = lane.toLowerCase();
+  for (const worker of workers) {
+    const workerId = String(worker.agent_id ?? worker.worker_id ?? worker.id ?? "").trim();
+    if (!workerId) continue;
+
+    const status = String(worker.status ?? "").trim().toLowerCase();
+    const isLive = worker.live === true || LIVE_WORKER_STATUSES.has(status);
+    if (!isLive) continue;
+
+    const workerLane = String(worker.lane ?? "").trim().toLowerCase();
+    const capabilities = Array.isArray(worker.capabilities)
+      ? worker.capabilities.map((capability) => String(capability).trim().toLowerCase())
+      : [];
+    if (workerLane === wanted || capabilities.includes(wanted)) {
+      return workerId;
+    }
+  }
+  return null;
+}
+
+export function runRoutePacketConsumerDryRun(params: {
+  packet: RoutePacket;
+  visibleWorkers?: VisibleWorker[];
+  now?: Date;
+}): RoutePacketConsumerResult {
+  const { packet } = params;
+  if (isRoutePacketExpired(packet, params.now)) {
+    return {
+      dry_run: true,
+      writes: [],
+      packet,
+      decision: {
+        status: "HOLD",
+        receipt: "HOLD",
+        target_agent_id: "coordinator",
+        reason: "ttl_expired",
+      },
+    };
+  }
+
+  const targetAgentId = findLiveWorkerForLane(packet.lane, params.visibleWorkers ?? []);
+  if (targetAgentId) {
+    return {
+      dry_run: true,
+      writes: [],
+      packet,
+      decision: {
+        status: "assigned",
+        receipt: "assigned",
+        target_agent_id: targetAgentId,
+        reason: "live_worker_available",
+      },
+    };
+  }
+
+  return {
+    dry_run: true,
+    writes: [],
+    packet,
+    decision: {
+      status: "BLOCKER",
+      receipt: "BLOCKER",
+      target_agent_id: "coordinator",
+      reason: packet.lane === "Builder" ? "no_live_builder_available" : "no_live_worker_available",
+    },
+  };
+}

--- a/api/lib/route-packet-dispatch.test.ts
+++ b/api/lib/route-packet-dispatch.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { buildTetherRoutePacket } from "./tether-route-packet";
+import { buildUnClickConnectDispatchRow } from "./route-packet-dispatch";
+
+const now = new Date("2026-05-09T00:20:00.000Z");
+
+describe("buildUnClickConnectDispatchRow", () => {
+  it("writes a leased dispatch when a live Builder exists", () => {
+    const packet = buildTetherRoutePacket(
+      { item_id: "todo-123", lane: "Builder", idempotency_key: "connect-1" },
+      new Date("2026-05-09T00:10:00.000Z"),
+    );
+    const row = buildUnClickConnectDispatchRow({
+      apiKeyHash: "hash-123",
+      packet,
+      visibleWorkers: [{ agent_id: "builder-live", lane: "Builder", status: "active" }],
+      now,
+    });
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash-123",
+      source: "connectors",
+      target_agent_id: "builder-live",
+      task_ref: "todo-123",
+      status: "leased",
+      lease_owner: "builder-live",
+      lease_expires_at: "2026-05-09T00:30:00.000Z",
+      payload: {
+        kind: "unclick_connect_route_packet",
+        receipt: {
+          status: "assigned",
+          receipt: "assigned",
+          target_agent_id: "builder-live",
+        },
+      },
+    });
+    expect(row.dispatch_id).toMatch(/^dispatch_/);
+  });
+
+  it("writes a failed dispatch with BLOCKER when no Builder exists", () => {
+    const packet = buildTetherRoutePacket(
+      { item_id: "todo-123", lane: "Builder", idempotency_key: "connect-1" },
+      new Date("2026-05-09T00:10:00.000Z"),
+    );
+    const row = buildUnClickConnectDispatchRow({
+      apiKeyHash: "hash-123",
+      packet,
+      visibleWorkers: [],
+      now,
+    });
+
+    expect(row).toMatchObject({
+      target_agent_id: "coordinator",
+      status: "failed",
+      lease_owner: null,
+      lease_expires_at: null,
+      payload: {
+        receipt: {
+          status: "BLOCKER",
+          receipt: "BLOCKER",
+          reason: "no_live_builder_available",
+        },
+      },
+    });
+  });
+
+  it("writes a stale dispatch with HOLD when packet TTL has expired", () => {
+    const packet = buildTetherRoutePacket(
+      { item_id: "todo-123", lane: "Builder", ttl_seconds: 60 },
+      new Date("2026-05-09T00:10:00.000Z"),
+    );
+    const row = buildUnClickConnectDispatchRow({
+      apiKeyHash: "hash-123",
+      packet,
+      visibleWorkers: [{ agent_id: "builder-live", lane: "Builder", status: "active" }],
+      now,
+    });
+
+    expect(row).toMatchObject({
+      target_agent_id: "coordinator",
+      status: "stale",
+      payload: {
+        receipt: {
+          status: "HOLD",
+          receipt: "HOLD",
+          reason: "ttl_expired",
+        },
+      },
+    });
+  });
+
+  it("rejects non-experiment commit rows", () => {
+    const packet = buildTetherRoutePacket({ experiment: false });
+    expect(() =>
+      buildUnClickConnectDispatchRow({
+        apiKeyHash: "hash-123",
+        packet,
+        visibleWorkers: [],
+        now,
+      }),
+    ).toThrow("experiment-only");
+  });
+});

--- a/api/lib/route-packet-dispatch.ts
+++ b/api/lib/route-packet-dispatch.ts
@@ -1,0 +1,104 @@
+import {
+  createDispatchId,
+  type DispatchSource,
+  type DispatchStatus,
+} from "../../packages/mcp-server/src/reliability.js";
+import {
+  runRoutePacketConsumerDryRun,
+  type RoutePacket,
+  type RoutePacketDecision,
+  type VisibleWorker,
+} from "./route-packet-consumer.js";
+
+export interface UnClickConnectDispatchRow {
+  api_key_hash: string;
+  dispatch_id: string;
+  source: DispatchSource;
+  target_agent_id: string;
+  task_ref: string;
+  status: DispatchStatus;
+  lease_owner: string | null;
+  lease_expires_at: string | null;
+  last_real_action_at?: string | null;
+  payload: {
+    kind: "unclick_connect_route_packet";
+    route_packet: RoutePacket;
+    receipt: RoutePacketDecision;
+    idempotency_key?: string;
+  };
+  created_at: string;
+  updated_at: string;
+}
+
+export function buildUnClickConnectDispatchRow(params: {
+  apiKeyHash: string;
+  packet: RoutePacket;
+  visibleWorkers?: VisibleWorker[];
+  idempotencyKey?: string;
+  now?: Date;
+  leaseSeconds?: number;
+}): UnClickConnectDispatchRow {
+  if (!params.packet.experiment) {
+    throw new Error("UnClick Connect commit is experiment-only");
+  }
+
+  const now = params.now ?? new Date();
+  const leaseSeconds = clampLeaseSeconds(params.leaseSeconds);
+  const decision = runRoutePacketConsumerDryRun({
+    packet: params.packet,
+    visibleWorkers: params.visibleWorkers,
+    now,
+  }).decision;
+  const targetAgentId = decision.target_agent_id;
+  const idempotencyKey = params.idempotencyKey ?? params.packet.idempotency_key;
+  const dispatchId = createDispatchId({
+    source: "connectors",
+    targetAgentId,
+    taskRef: params.packet.item.id,
+    promptHash: idempotencyKey,
+    payload: {
+      kind: "unclick_connect_route_packet",
+      lane: params.packet.lane,
+      item_id: params.packet.item.id,
+      created_at: params.packet.created_at,
+      receipt: decision.receipt,
+      reason: decision.reason,
+    },
+  });
+  const nowIso = now.toISOString();
+
+  return {
+    api_key_hash: params.apiKeyHash,
+    dispatch_id: dispatchId,
+    source: "connectors",
+    target_agent_id: targetAgentId,
+    task_ref: params.packet.item.id,
+    status: statusForDecision(decision),
+    lease_owner: decision.status === "assigned" ? targetAgentId : null,
+    lease_expires_at:
+      decision.status === "assigned"
+        ? new Date(now.getTime() + leaseSeconds * 1000).toISOString()
+        : null,
+    last_real_action_at: decision.status === "assigned" ? nowIso : null,
+    payload: {
+      kind: "unclick_connect_route_packet",
+      route_packet: params.packet,
+      receipt: decision,
+      ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
+    },
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+}
+
+function statusForDecision(decision: RoutePacketDecision): DispatchStatus {
+  if (decision.status === "assigned") return "leased";
+  if (decision.status === "HOLD") return "stale";
+  return "failed";
+}
+
+function clampLeaseSeconds(input: unknown): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 10 * 60;
+  return Math.min(Math.max(Math.floor(parsed), 60), 24 * 60 * 60);
+}

--- a/api/lib/tether-route-packet.test.ts
+++ b/api/lib/tether-route-packet.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildTetherRoutePacket } from "./tether-route-packet";
+
+describe("buildTetherRoutePacket", () => {
+  it("turns public-safe tether intent into an experiment route packet", () => {
+    const packet = buildTetherRoutePacket(
+      {
+        item_id: "todo-123",
+        item_title: "One live item is waiting",
+        lane: "builder",
+        needed_action: "Make the smallest useful change.",
+        visible_blocker: "Needs Builder help",
+        expected_receipt: "proof,HOLD,BLOCKER",
+        idempotency_key: "retry-1",
+      },
+      new Date("2026-05-09T00:10:00.000Z"),
+    );
+
+    expect(packet).toMatchObject({
+      experiment: true,
+      lane: "Builder",
+      item: {
+        id: "todo-123",
+        title: "One live item is waiting",
+      },
+      needed_action: "Make the smallest useful change.",
+      visible_blocker: "Needs Builder help",
+      expected_receipt: ["proof", "HOLD", "BLOCKER"],
+      created_at: "2026-05-09T00:10:00.000Z",
+      ttl_seconds: 1200,
+      idempotency_key: "retry-1",
+    });
+  });
+
+  it("keeps tether defaults generic and public-safe", () => {
+    const packet = buildTetherRoutePacket({}, new Date("2026-05-09T00:10:00.000Z"));
+
+    expect(packet.lane).toBe("Builder");
+    expect(packet.item.title).toBe("UnClick Connect experiment");
+    expect(packet.expected_receipt).toEqual(["proof", "HOLD", "BLOCKER"]);
+  });
+});

--- a/api/lib/tether-route-packet.ts
+++ b/api/lib/tether-route-packet.ts
@@ -1,0 +1,70 @@
+import {
+  normalizeRoutePacketLane,
+  type RoutePacket,
+  type RoutePacketLane,
+} from "./route-packet-consumer.js";
+
+export interface TetherRouteIntent {
+  item_id?: string;
+  item_title?: string;
+  lane?: string;
+  needed_action?: string;
+  visible_blocker?: string | null;
+  expected_receipt?: string[] | string;
+  ttl_seconds?: number;
+  idempotency_key?: string;
+  experiment?: boolean;
+}
+
+export function buildTetherRoutePacket(
+  intent: TetherRouteIntent,
+  now = new Date(),
+): RoutePacket {
+  const lane: RoutePacketLane = normalizeRoutePacketLane(intent.lane);
+  const itemId = String(intent.item_id ?? "unclick-connect-experiment").trim();
+  const title = String(intent.item_title ?? "UnClick Connect experiment").trim();
+  const neededAction = String(
+    intent.needed_action ?? "Move one live item to the next useful receipt.",
+  ).trim();
+  const expectedReceipt = normalizeExpectedReceipt(intent.expected_receipt);
+
+  return {
+    experiment: intent.experiment !== false,
+    lane,
+    item: {
+      id: itemId || "unclick-connect-experiment",
+      title: title || "UnClick Connect experiment",
+    },
+    needed_action: neededAction || "Move one live item to the next useful receipt.",
+    visible_blocker:
+      typeof intent.visible_blocker === "string" && intent.visible_blocker.trim()
+        ? intent.visible_blocker.trim()
+        : null,
+    expected_receipt: expectedReceipt.length > 0 ? expectedReceipt : ["proof", "HOLD", "BLOCKER"],
+    created_at: now.toISOString(),
+    ttl_seconds: clampTtlSeconds(intent.ttl_seconds),
+    idempotency_key:
+      typeof intent.idempotency_key === "string" && intent.idempotency_key.trim()
+        ? intent.idempotency_key.trim()
+        : undefined,
+  };
+}
+
+function normalizeExpectedReceipt(input: TetherRouteIntent["expected_receipt"]): string[] {
+  if (Array.isArray(input)) {
+    return input.map((value) => String(value).trim()).filter(Boolean);
+  }
+  if (typeof input === "string") {
+    return input
+      .split(/[,\|]/)
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function clampTtlSeconds(input: unknown): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 20 * 60;
+  return Math.min(Math.max(Math.floor(parsed), 60), 24 * 60 * 60);
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -35,6 +35,8 @@
  *   - admin_build_tasks: method=list|get|create|update_status|soft_delete
  *   - admin_build_workers: method=list|register|update|delete|health_check
  *   - admin_build_dispatch: POST with task_id + worker_id (same tenant) and optional idempotency_key
+ *   - admin_unclick_connect_dry_run: POST tether intent -> route packet -> assignment/HOLD/BLOCKER, no writes
+ *   - admin_unclick_connect_commit: POST experiment-only route packet -> mc_agent_dispatches row
  *   - reliability_dispatches: method=list|get|upsert|claim|release
  *   - reliability_heartbeats: method=list|publish
  *   - reliability_reclaim_stale: POST with optional { limit, dry_run }
@@ -119,6 +121,9 @@ import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
+import { runRoutePacketConsumerDryRun } from "./lib/route-packet-consumer.js";
+import { buildUnClickConnectDispatchRow } from "./lib/route-packet-dispatch.js";
+import { buildTetherRoutePacket } from "./lib/tether-route-packet.js";
 import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
 import {
   createDispatchId,
@@ -4854,6 +4859,88 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (updErr) throw updErr;
 
         return res.status(200).json({ data: eventData, was_duplicate: false });
+      }
+
+      case "admin_unclick_connect_dry_run": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const intent = isRecord(body.intent) ? body.intent : body;
+        const packet = buildTetherRoutePacket(intent);
+        const visibleWorkers = Array.isArray(body.visible_workers) ? body.visible_workers : [];
+        const result = runRoutePacketConsumerDryRun({
+          packet,
+          visibleWorkers,
+        });
+
+        return res.status(200).json({
+          ...result,
+          tenant_scoped: true,
+        });
+      }
+
+      case "admin_unclick_connect_commit": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const commitMode = String(body.commit_mode ?? body.mode ?? "").trim().toLowerCase();
+        const intent = isRecord(body.intent) ? body.intent : body;
+        const packet = buildTetherRoutePacket(intent);
+        if (commitMode !== "experiment" || !packet.experiment) {
+          return res.status(400).json({
+            error: "admin_unclick_connect_commit is experiment-only",
+          });
+        }
+
+        const visibleWorkers = Array.isArray(body.visible_workers) ? body.visible_workers : [];
+        const idempotencyKey =
+          typeof body.idempotency_key === "string" && body.idempotency_key.trim()
+            ? body.idempotency_key.trim()
+            : packet.idempotency_key;
+        const row = buildUnClickConnectDispatchRow({
+          apiKeyHash,
+          packet,
+          visibleWorkers,
+          idempotencyKey,
+        });
+
+        const { data, error } = await supabase
+          .from("mc_agent_dispatches")
+          .insert(row)
+          .select(
+            "id, api_key_hash, dispatch_id, source, target_agent_id, task_ref, status, lease_owner, lease_expires_at, last_real_action_at, payload, created_at, updated_at",
+          )
+          .single();
+
+        if (error) {
+          if ((error as { code?: string }).code === "23505") {
+            const existing = await supabase
+              .from("mc_agent_dispatches")
+              .select(
+                "id, api_key_hash, dispatch_id, source, target_agent_id, task_ref, status, lease_owner, lease_expires_at, last_real_action_at, payload, created_at, updated_at",
+              )
+              .eq("api_key_hash", apiKeyHash)
+              .eq("dispatch_id", row.dispatch_id)
+              .maybeSingle();
+            if (existing.error) throw existing.error;
+            return res.status(200).json({
+              data: existing.data,
+              was_duplicate: true,
+              tenant_scoped: true,
+            });
+          }
+          throw error;
+        }
+
+        return res.status(200).json({
+          data,
+          was_duplicate: false,
+          tenant_scoped: true,
+        });
       }
 
       case "reliability_dispatches": {


### PR DESCRIPTION
## Summary
- add UnClick Connect dry-run and experiment-only commit actions to `memory-admin`
- add route-packet consumer, tether-to-packet builder, and dispatch-row builder
- write dispatch rows to `mc_agent_dispatches` as leased, failed/BLOCKER, or stale/HOLD based on live worker and TTL state

## Proof
- PASS: `npx vitest run api/lib/route-packet-consumer.test.ts api/lib/tether-route-packet.test.ts api/lib/route-packet-dispatch.test.ts` (9/9)
- PASS: `npm run build`
- NOTE: `npm test` has an unrelated existing failure in `src/pages/admin/systemCredentialInventory.test.ts` expecting `metadata_only` while current code returns `untested`

## Safety
- experiment-only commit guard
- no migrations
- no secrets or env changes
- no production hosted insert attempted from this branch