### PR TITLE
feat(autopilot): discover live UnClick Connect workers

### DIFF
--- a/api/lib/unclick-connect-worker-discovery.test.ts
+++ b/api/lib/unclick-connect-worker-discovery.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkersToVisibleWorkers,
+  fishbowlProfilesToVisibleWorkers,
+} from "./unclick-connect-worker-discovery";
+
+describe("UnClick Connect worker discovery", () => {
+  it("maps available Build Desk workers into live visible workers", () => {
+    const workers = buildWorkersToVisibleWorkers([
+      {
+        id: "build-worker-1",
+        name: "Forge Builder",
+        worker_type: "builder",
+        status: "available",
+      },
+      {
+        id: "offline-worker",
+        name: "Offline Builder",
+        worker_type: "builder",
+        status: "offline",
+      },
+    ]);
+
+    expect(workers).toEqual([
+      {
+        worker_id: "build-worker-1",
+        lane: "Builder",
+        status: "available",
+        live: true,
+      },
+    ]);
+  });
+
+  it("maps fresh Builder-shaped Fishbowl profiles into live visible workers", () => {
+    const workers = fishbowlProfilesToVisibleWorkers(
+      [
+        {
+          agent_id: "scheduled-builder-tether",
+          emoji: "🛠️",
+          display_name: "Scheduled Builder Tether",
+          current_status: "ready for builder work",
+          last_seen_at: "2026-05-09T00:10:00.000Z",
+        },
+      ],
+      new Date("2026-05-09T00:30:00.000Z"),
+    );
+
+    expect(workers).toEqual([
+      {
+        agent_id: "scheduled-builder-tether",
+        lane: "Builder",
+        status: "active",
+        live: true,
+      },
+    ]);
+  });
+
+  it("does not treat unknown, stale, or blocked profiles as production workers", () => {
+    const workers = fishbowlProfilesToVisibleWorkers(
+      [
+        {
+          agent_id: "unknown-live-profile",
+          display_name: "General Profile",
+          last_seen_at: "2026-05-09T00:29:00.000Z",
+        },
+        {
+          agent_id: "stale-builder-profile",
+          display_name: "Builder",
+          last_seen_at: "2026-05-08T21:00:00.000Z",
+        },
+        {
+          agent_id: "blocked-builder-profile",
+          display_name: "Builder",
+          current_status: "blocked on setup",
+          last_seen_at: "2026-05-09T00:29:00.000Z",
+        },
+      ],
+      new Date("2026-05-09T00:30:00.000Z"),
+    );
+
+    expect(workers).toEqual([]);
+  });
+});

--- a/api/lib/unclick-connect-worker-discovery.ts
+++ b/api/lib/unclick-connect-worker-discovery.ts
@@ -1,0 +1,91 @@
+import { type RoutePacketLane, type VisibleWorker } from "./route-packet-consumer.js";
+
+export interface BuildWorkerDiscoveryRow {
+  id: string;
+  name?: string | null;
+  worker_type?: string | null;
+  status?: string | null;
+  last_health_check_at?: string | null;
+}
+
+export interface FishbowlProfileDiscoveryRow {
+  agent_id: string;
+  emoji?: string | null;
+  display_name?: string | null;
+  last_seen_at?: string | null;
+  current_status?: string | null;
+  current_status_updated_at?: string | null;
+}
+
+export const UNCLICK_CONNECT_WORKER_FRESH_MS = 2 * 60 * 60 * 1000;
+
+export function buildWorkersToVisibleWorkers(
+  rows: BuildWorkerDiscoveryRow[],
+): VisibleWorker[] {
+  return rows
+    .filter((row) => String(row.status ?? "").trim().toLowerCase() === "available")
+    .map((row) => ({
+      worker_id: row.id,
+      lane: inferLaneFromText(`${row.name ?? ""} ${row.worker_type ?? ""}`) ?? "Builder",
+      status: "available",
+      live: true,
+    }));
+}
+
+export function fishbowlProfilesToVisibleWorkers(
+  rows: FishbowlProfileDiscoveryRow[],
+  now = new Date(),
+): VisibleWorker[] {
+  return rows
+    .filter((row) => isFreshProfile(row, now))
+    .flatMap((row) => {
+      const lane = inferLaneFromText(
+        `${row.emoji ?? ""} ${row.display_name ?? ""} ${row.agent_id ?? ""} ${row.current_status ?? ""}`,
+      );
+      if (!lane) return [];
+      return [
+        {
+          agent_id: row.agent_id,
+          lane,
+          status: "active",
+          live: true,
+        },
+      ];
+    });
+}
+
+function isFreshProfile(row: FishbowlProfileDiscoveryRow, now: Date): boolean {
+  const lastSeenAtMs = Date.parse(String(row.last_seen_at ?? ""));
+  if (!Number.isFinite(lastSeenAtMs)) return false;
+  if (now.getTime() - lastSeenAtMs > UNCLICK_CONNECT_WORKER_FRESH_MS) return false;
+
+  const status = String(row.current_status ?? "").trim().toLowerCase();
+  if (status.includes("blocked") || status.includes("hold") || status.includes("offline")) {
+    return false;
+  }
+
+  return true;
+}
+
+function inferLaneFromText(text: string): RoutePacketLane | null {
+  const value = text.toLowerCase();
+  if (value.includes("🛠") || value.includes("builder") || value.includes("build") || value.includes("forge")) {
+    return "Builder";
+  }
+  if (value.includes("proof") || value.includes("prove")) {
+    return "Proof";
+  }
+  if (value.includes("🍿") || value.includes("review") || value.includes("qc") || value.includes("tester")) {
+    return "Reviewer";
+  }
+  if (value.includes("🛡") || value.includes("safety") || value.includes("gatekeeper")) {
+    return "Safety";
+  }
+  if (value.includes("coordinator") || value.includes("master")) {
+    return "Coordinator";
+  }
+  if (value.includes("watcher") || value.includes("relay")) {
+    return "Watcher";
+  }
+  return null;
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -121,9 +121,15 @@ import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
-import { runRoutePacketConsumerDryRun } from "./lib/route-packet-consumer.js";
+import { runRoutePacketConsumerDryRun, type VisibleWorker } from "./lib/route-packet-consumer.js";
 import { buildUnClickConnectDispatchRow } from "./lib/route-packet-dispatch.js";
 import { buildTetherRoutePacket } from "./lib/tether-route-packet.js";
+import {
+  buildWorkersToVisibleWorkers,
+  fishbowlProfilesToVisibleWorkers,
+  type BuildWorkerDiscoveryRow,
+  type FishbowlProfileDiscoveryRow,
+} from "./lib/unclick-connect-worker-discovery.js";
 import { buildCard, type ConversationalCard } from "../packages/mcp-server/src/cards/card.js";
 import {
   createDispatchId,
@@ -719,6 +725,87 @@ async function postFishbowlEvent(
   } catch (err) {
     console.error(`[fishbowl postEvent ${eventTag}] failed:`, (err as Error).message);
   }
+}
+
+type UnClickConnectWorkerSource = "client" | "server";
+
+interface UnClickConnectWorkerResolution {
+  visibleWorkers: VisibleWorker[];
+  workerSource: UnClickConnectWorkerSource;
+  discovery: {
+    build_workers_seen: number;
+    fishbowl_profiles_seen: number;
+    visible_workers_used: number;
+  };
+}
+
+async function resolveUnClickConnectVisibleWorkers(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+  body: Record<string, unknown>,
+): Promise<UnClickConnectWorkerResolution> {
+  const requestedSource = String(body.worker_source ?? "").trim().toLowerCase();
+  const workerSource: UnClickConnectWorkerSource = requestedSource === "client" ? "client" : "server";
+
+  if (workerSource === "client") {
+    const visibleWorkers = Array.isArray(body.visible_workers)
+      ? (body.visible_workers as VisibleWorker[])
+      : [];
+    return {
+      visibleWorkers,
+      workerSource,
+      discovery: {
+        build_workers_seen: 0,
+        fishbowl_profiles_seen: 0,
+        visible_workers_used: visibleWorkers.length,
+      },
+    };
+  }
+
+  const [buildWorkersResult, fishbowlProfilesResult] = await Promise.all([
+    supabase
+      .from("build_workers")
+      .select("id, name, worker_type, status, last_health_check_at")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("status", "available")
+      .limit(50),
+    supabase
+      .from("mc_fishbowl_profiles")
+      .select("agent_id, emoji, display_name, last_seen_at, current_status, current_status_updated_at")
+      .eq("api_key_hash", apiKeyHash)
+      .order("last_seen_at", { ascending: false })
+      .limit(50),
+  ]);
+
+  if (buildWorkersResult.error) throw buildWorkersResult.error;
+  if (fishbowlProfilesResult.error) throw fishbowlProfilesResult.error;
+
+  const buildWorkers = (buildWorkersResult.data ?? []) as BuildWorkerDiscoveryRow[];
+  const fishbowlProfiles = (fishbowlProfilesResult.data ?? []) as FishbowlProfileDiscoveryRow[];
+  const visibleWorkers = uniqueVisibleWorkers([
+    ...buildWorkersToVisibleWorkers(buildWorkers),
+    ...fishbowlProfilesToVisibleWorkers(fishbowlProfiles),
+  ]);
+
+  return {
+    visibleWorkers,
+    workerSource,
+    discovery: {
+      build_workers_seen: buildWorkers.length,
+      fishbowl_profiles_seen: fishbowlProfiles.length,
+      visible_workers_used: visibleWorkers.length,
+    },
+  };
+}
+
+function uniqueVisibleWorkers(workers: VisibleWorker[]): VisibleWorker[] {
+  const seen = new Set<string>();
+  return workers.filter((worker) => {
+    const workerId = String(worker.agent_id ?? worker.worker_id ?? worker.id ?? "").trim();
+    if (!workerId || seen.has(workerId)) return false;
+    seen.add(workerId);
+    return true;
+  });
 }
 
 // ─── Setup guide content ────────────────────────────────────────────────────
@@ -4869,15 +4956,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const body = (req.body ?? {}) as Record<string, unknown>;
         const intent = isRecord(body.intent) ? body.intent : body;
         const packet = buildTetherRoutePacket(intent);
-        const visibleWorkers = Array.isArray(body.visible_workers) ? body.visible_workers : [];
+        const workerResolution = await resolveUnClickConnectVisibleWorkers(supabase, apiKeyHash, body);
         const result = runRoutePacketConsumerDryRun({
           packet,
-          visibleWorkers,
+          visibleWorkers: workerResolution.visibleWorkers,
         });
 
         return res.status(200).json({
           ...result,
           tenant_scoped: true,
+          worker_source: workerResolution.workerSource,
+          discovery: workerResolution.discovery,
         });
       }
 
@@ -4896,7 +4985,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           });
         }
 
-        const visibleWorkers = Array.isArray(body.visible_workers) ? body.visible_workers : [];
+        const workerResolution = await resolveUnClickConnectVisibleWorkers(supabase, apiKeyHash, body);
         const idempotencyKey =
           typeof body.idempotency_key === "string" && body.idempotency_key.trim()
             ? body.idempotency_key.trim()
@@ -4904,7 +4993,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const row = buildUnClickConnectDispatchRow({
           apiKeyHash,
           packet,
-          visibleWorkers,
+          visibleWorkers: workerResolution.visibleWorkers,
           idempotencyKey,
         });
 
@@ -4931,6 +5020,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               data: existing.data,
               was_duplicate: true,
               tenant_scoped: true,
+              worker_source: workerResolution.workerSource,
+              discovery: workerResolution.discovery,
             });
           }
           throw error;
@@ -4940,6 +5031,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           data,
           was_duplicate: false,
           tenant_scoped: true,
+          worker_source: workerResolution.workerSource,
+          discovery: workerResolution.discovery,
         });
       }
 


### PR DESCRIPTION
## Summary
- make UnClick Connect dry-run and commit resolve workers from server-side Build Desk and Fishbowl state by default
- keep explicit client worker payloads available for controlled experiment tests with worker_source=client
- add focused discovery tests so unknown, stale, or blocked profiles do not count as live production workers

## Verification
- npx vitest run api/lib/route-packet-consumer.test.ts api/lib/tether-route-packet.test.ts api/lib/route-packet-dispatch.test.ts api/lib/unclick-connect-worker-discovery.test.ts
- npm run build