### PR TITLE
fix(wakepass): move autoclose event gate into runner

### DIFF
--- a/.github/workflows/auto-close-fishbowl-todo.yml
+++ b/.github/workflows/auto-close-fishbowl-todo.yml
@@ -25,7 +25,6 @@ permissions:
 
 jobs:
   close-todos:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     name: Close linked Fishbowl todos
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +53,7 @@ jobs:
           MANUAL_PR_NUMBERS=$(jq -r '.inputs.pr_numbers // ""' "${GITHUB_EVENT_PATH}")
           PR_BODY=$(jq -r '.pull_request.body // ""' "${GITHUB_EVENT_PATH}")
           PR_NUMBER=$(jq -r '.pull_request.number // ""' "${GITHUB_EVENT_PATH}")
+          PR_MERGED=$(jq -r '.pull_request.merged // false' "${GITHUB_EVENT_PATH}")
 
           PR_NUMBERS=()
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
@@ -81,6 +81,10 @@ jobs:
               exit 0
             fi
           elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            if [ "${PR_MERGED}" != "true" ]; then
+              echo "Pull request was closed without merge - nothing to close."
+              exit 0
+            fi
             PR_NUMBERS=("${PR_NUMBER}")
           else
             echo "Unsupported event ${GITHUB_EVENT_NAME} - nothing to close."


### PR DESCRIPTION
Summary:
Move the auto-close workflow event gate out of the GitHub job-level `if` expression and into the runner script. Closed but unmerged pull requests now exit cleanly inside the job, while workflow dispatch and merge-push reconciliation still use the existing bounded close logic.

Scope:
.github/workflows/auto-close-fishbowl-todo.yml only.

Non-overlap:
Does not change memory-admin APIs, UnClick todo close semantics, credentials, or production data.

Verification:
- git diff --check

Risk:
Low. This is intended to stop pre-run zero-job failures. Runtime behavior remains fail-open for missing credentials and API failures.

Follow-up:
After merge, prove the fix with the resulting main push run for `.github/workflows/auto-close-fishbowl-todo.yml`.