### PR TITLE
fix(wakepass): keep autoclose shell assignment on one YAML line

### DIFF
--- a/.github/workflows/auto-close-fishbowl-todo.yml
+++ b/.github/workflows/auto-close-fishbowl-todo.yml
@@ -122,8 +122,7 @@ jobs:
                   echo "::warning::Could not read commit messages for PR #${pr_number}: $(cat /tmp/gh-pr-view.err)"
                   pr_commits=""
                 }
-              pr_text="${pr_text}
-${pr_commits}"
+              pr_text="${pr_text}"$'\n'"${pr_commits}"
             fi
 
             if [ -z "${pr_text:-}" ]; then


### PR DESCRIPTION
Summary:
- fixes the actual YAML parse issue in the auto-close workflow
- keeps the shell string append on one YAML line so GitHub can create the job

Scope:
- .github/workflows/auto-close-fishbowl-todo.yml only

Verification:
- PyYAML safe_load passes
- git diff --check