### PR TITLE
fix(wakepass): keep autoclose text join yaml-safe

### DIFF
--- a/.github/workflows/auto-close-fishbowl-todo.yml
+++ b/.github/workflows/auto-close-fishbowl-todo.yml
@@ -122,8 +122,7 @@ jobs:
                   echo "::warning::Could not read commit messages for PR #${pr_number}: $(cat /tmp/gh-pr-view.err)"
                   pr_commits=""
                 }
-              pr_text="${pr_text}
-${pr_commits}"
+              pr_text="${pr_text}"$'\n'"${pr_commits}"
             fi
 
             if [ -z "${pr_text:-}" ]; then


### PR DESCRIPTION
Summary:
Fix the auto-close workflow YAML parse failure by replacing a multiline shell assignment with a YAML-safe newline join.

Scope:
.github/workflows/auto-close-fishbowl-todo.yml only.

Non-overlap:
Does not change memory-admin APIs, credentials, trigger policy, or todo close semantics.

Verification:
- git diff --check
- npx --yes github-actionlint .github/workflows/auto-close-fishbowl-todo.yml

Risk:
Low. This repairs workflow syntax so the runner can start; runtime behavior is unchanged.

Follow-up:
After merge, prove the fix with the auto-close workflow run on the resulting main push.