### PR TITLE
feat(admin): simplify jobs and show seat check-ins

### DIFF
--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -61,6 +61,18 @@ interface AgentDetail {
   memory_scope: Array<{ memory_layer: string; is_enabled: boolean }>;
 }
 
+interface FishbowlProfile {
+  agent_id: string;
+  emoji: string | null;
+  display_name: string | null;
+  user_agent_hint: string | null;
+  created_at: string;
+  last_seen_at: string | null;
+  current_status: string | null;
+  current_status_updated_at: string | null;
+  next_checkin_at: string | null;
+}
+
 const ROLE_OPTIONS = [
   { value: "researcher", label: "Researcher" },
   { value: "developer", label: "Developer" },
@@ -222,6 +234,21 @@ function loadSeatOverrides(): AISeat[] {
 function getApiKey(): string {
   if (typeof window === "undefined") return "";
   return window.localStorage.getItem("unclick_api_key") ?? "";
+}
+
+function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return "No check-in yet";
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return "Unknown";
+  const diffSec = Math.max(1, Math.floor((Date.now() - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 14) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString();
 }
 
 async function api<T>(action: string, opts: RequestInit = {}): Promise<T> {
@@ -662,10 +689,55 @@ function WorkerRolesPanel() {
   );
 }
 
+function profileDisplayName(profile: FishbowlProfile): string {
+  const name = profile.display_name?.trim();
+  if (name) return name;
+  return profile.agent_id
+    .replace(/^chatgpt[-_]/, "")
+    .replace(/^codex[-_]/, "")
+    .replace(/^claude[-_]/, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .replace(/\bAi\b/g, "AI");
+}
+
+function profileMatchesSeat(profile: FishbowlProfile, seat: AISeat): boolean {
+  const haystack = `${profile.agent_id} ${profile.display_name ?? ""} ${profile.user_agent_hint ?? ""}`.toLowerCase();
+  const needles = [seat.id, seat.name, seat.provider, seat.device]
+    .map((value) => value.toLowerCase().trim())
+    .filter((value) => value.length > 2 && !["unknown ai", "unknown device", "manual slot"].includes(value));
+  return needles.some((needle) => haystack.includes(needle));
+}
+
 function AISeatsPanel() {
   const [seats, setSeats] = useState<AISeat[]>(() => loadSeatOverrides());
+  const [profiles, setProfiles] = useState<FishbowlProfile[]>([]);
+  const [profilesLoading, setProfilesLoading] = useState(false);
   const [editingSeatId, setEditingSeatId] = useState<string | null>(null);
   const issues = seats.filter((seat) => seat.issue);
+
+  const loadProfiles = useCallback(async () => {
+    if (!getApiKey()) return;
+    setProfilesLoading(true);
+    try {
+      const res = await api<{ profiles?: FishbowlProfile[] }>("fishbowl_read", {
+        method: "POST",
+        body: JSON.stringify({
+          agent_id: "admin-agents-page",
+          limit: 1,
+        }),
+      });
+      setProfiles(
+        (res.profiles ?? [])
+          .filter((profile) => profile.user_agent_hint !== "admin-ui")
+          .sort((a, b) => new Date(b.last_seen_at ?? b.created_at).getTime() - new Date(a.last_seen_at ?? a.created_at).getTime()),
+      );
+    } catch {
+      setProfiles([]);
+    } finally {
+      setProfilesLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -684,6 +756,12 @@ function AISeatsPanel() {
     );
     window.localStorage.setItem(AI_SEAT_STORAGE_KEY, JSON.stringify(overrides));
   }, [seats]);
+
+  useEffect(() => {
+    void loadProfiles();
+    const id = window.setInterval(() => void loadProfiles(), 30_000);
+    return () => window.clearInterval(id);
+  }, [loadProfiles]);
 
   const updateSeat = (seatId: string, patch: Partial<AISeat>) => {
     setSeats((current) => current.map((seat) => (seat.id === seatId ? { ...seat, ...patch } : seat)));
@@ -718,7 +796,7 @@ function AISeatsPanel() {
             Manual mode
           </span>
         </div>
-        <div className="grid grid-cols-[minmax(210px,1.4fr)_110px_130px_minmax(180px,1.2fr)_minmax(190px,1fr)] gap-3 border-b border-border/40 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <div className="grid grid-cols-[minmax(210px,1.4fr)_110px_130px_minmax(150px,0.8fr)_minmax(180px,1.2fr)_minmax(190px,1fr)] gap-3 border-b border-border/40 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
           <span>Seat</span>
           <span>Status</span>
           <span className="flex items-center justify-between gap-2">
@@ -731,19 +809,21 @@ function AISeatsPanel() {
               Even split
             </button>
           </span>
+          <span>Last seen</span>
           <span>Assigned work</span>
           <span>Controls</span>
         </div>
         <div className="divide-y divide-border/30">
           {seats.map((seat) => {
             const editing = editingSeatId === seat.id;
+            const matchedProfile = profiles.find((profile) => profileMatchesSeat(profile, seat));
             const emojiOptions = AI_SEAT_EMOJI_OPTIONS.some((option) => option.emoji === seat.emoji)
               ? AI_SEAT_EMOJI_OPTIONS
               : [{ emoji: seat.emoji, label: "Custom" }, ...AI_SEAT_EMOJI_OPTIONS];
             return (
               <div
                 key={seat.id}
-                className="grid grid-cols-[minmax(210px,1.4fr)_110px_130px_minmax(180px,1.2fr)_minmax(190px,1fr)] items-center gap-3 px-4 py-3 text-xs"
+                className="grid grid-cols-[minmax(210px,1.4fr)_110px_130px_minmax(150px,0.8fr)_minmax(180px,1.2fr)_minmax(190px,1fr)] items-center gap-3 px-4 py-3 text-xs"
               >
                 <div className="min-w-0">
                   {editing ? (
@@ -817,6 +897,23 @@ function AISeatsPanel() {
                   />
                   <p className="mt-1 text-[10px] text-muted-foreground">{seat.load}%</p>
                 </div>
+                <div className="min-w-0">
+                  {matchedProfile ? (
+                    <>
+                      <p className="truncate text-xs font-medium text-heading" title={matchedProfile.agent_id}>
+                        {relativeTime(matchedProfile.last_seen_at)}
+                      </p>
+                      <p className="truncate text-[10px] text-muted-foreground">
+                        {profileDisplayName(matchedProfile)}
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-xs text-muted-foreground">No match</p>
+                      <p className="text-[10px] text-muted-foreground/70">Use recent check-ins below</p>
+                    </>
+                  )}
+                </div>
                 <input
                   value={seat.assigned}
                   onChange={(event) => updateSeat(seat.id, { assigned: event.target.value })}
@@ -844,6 +941,51 @@ function AISeatsPanel() {
             );
           })}
         </div>
+      </div>
+
+      <div className="rounded-xl border border-border/40 bg-card/20 p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-heading">Recent check-ins</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Live seats that have touched UnClick recently.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void loadProfiles()}
+            className="rounded-md border border-border/40 bg-card/40 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-primary/40 hover:text-heading"
+          >
+            {profilesLoading ? "Checking..." : "Refresh"}
+          </button>
+        </div>
+        {profiles.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No live seat check-ins found yet.</p>
+        ) : (
+          <div className="grid gap-2 md:grid-cols-2">
+            {profiles.slice(0, 8).map((profile) => (
+              <div key={profile.agent_id} className="rounded-lg border border-border/35 bg-card/30 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-semibold text-heading">
+                      <span className="mr-1.5" aria-hidden="true">{profile.emoji ?? "AI"}</span>
+                      {profileDisplayName(profile)}
+                    </p>
+                    <p className="truncate text-[10px] text-muted-foreground" title={profile.agent_id}>
+                      {profile.agent_id}
+                    </p>
+                  </div>
+                  <span className="shrink-0 rounded-full border border-primary/25 bg-primary/10 px-2 py-0.5 text-[10px] text-primary">
+                    {relativeTime(profile.last_seen_at)}
+                  </span>
+                </div>
+                <p className="mt-2 line-clamp-2 text-[11px] text-body">
+                  {profile.current_status || profile.user_agent_hint || "No status text"}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {issues.length > 0 && (

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -110,10 +110,85 @@ const TITLE_MAX_CHARS = 90;
 const JOB_ROW_GRID =
   "md:grid md:grid-cols-[48px_minmax(360px,1.25fr)_48px_58px_minmax(96px,0.35fr)_40px_minmax(200px,0.55fr)_30px_18px] md:items-center md:gap-1.5";
 
+interface JobDisplayCopy {
+  title: string;
+  summary: string;
+}
+
 function compactTitle(title: string): string {
   const cleaned = title.replace(/\s+/g, " ").trim();
   if (cleaned.length <= TITLE_MAX_CHARS) return cleaned;
   return `${cleaned.slice(0, TITLE_MAX_CHARS - 3).trimEnd()}...`;
+}
+
+function trimSentence(value: string, maxChars: number): string {
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= maxChars) return cleaned;
+  const cut = cleaned.slice(0, maxChars - 3);
+  const boundary = Math.max(cut.lastIndexOf("."), cut.lastIndexOf(","), cut.lastIndexOf(";"), cut.lastIndexOf(" "));
+  return `${cut.slice(0, boundary > 40 ? boundary : maxChars - 3).trimEnd()}...`;
+}
+
+function stripNoisyLead(value: string): string {
+  return value
+    .replace(/^\s*(urgent|bug|fix|feat|chore|docs|test|refactor|experiment|blocked|blocker)\s*[:\-]\s*/i, "")
+    .replace(/^\s*(fix|feat|chore|docs|test|refactor)\([^)]+\)\s*:\s*/i, "")
+    .replace(/^\s*(pr|pull request)\s*#?\d+\s*[:\-]\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function simplifyJobTitle(title: string): string {
+  const cleaned = stripNoisyLead(title)
+    .replace(/\bgreen-but-idle\b/gi, "idle")
+    .replace(/\bauto[- ]close\b/gi, "auto-close")
+    .replace(/\bunclick\b/gi, "UnClick")
+    .replace(/\bai\b/gi, "AI")
+    .replace(/\bmcp\b/gi, "MCP")
+    .replace(/\bpr\s*#\s*(\d+)/gi, "PR #$1")
+    .trim();
+
+  const dependencyMatch = cleaned.match(/^bump\s+(.+?)\s+from\s+.+?\s+to\s+(.+)$/i);
+  if (dependencyMatch) {
+    return compactTitle(`Update ${dependencyMatch[1]} to ${dependencyMatch[2]}`);
+  }
+
+  const schemaMatch = cleaned.match(/(.+?)\s+breaks\s+(.+)$/i);
+  if (schemaMatch) {
+    return compactTitle(`Fix ${schemaMatch[1]}`);
+  }
+
+  return compactTitle(cleaned || title);
+}
+
+function simplifyJobSummary(todo: JobTodo): string {
+  const rawDescription = todo.description?.trim();
+  const source = rawDescription && rawDescription.length > 0 ? rawDescription : todo.title;
+  const firstUsefulLine =
+    source
+      .split(/\r?\n/)
+      .map((line) => line.replace(/^[-*#>\s]+/, "").trim())
+      .find((line) => line.length > 0 && !/^https?:\/\//i.test(line)) ?? source;
+
+  const cleaned = stripNoisyLead(firstUsefulLine)
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\[[^\]]+\]\([^)]+\)/g, "")
+    .replace(/https?:\/\/\S+/gi, "")
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, "linked item")
+    .replace(/\b(api|mcp|ai|pr|ci)\b/gi, (match) => match.toUpperCase())
+    .replace(/\bunclick\b/gi, "UnClick")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return trimSentence(cleaned || simplifyJobTitle(todo.title), 130);
+}
+
+function displayCopyFor(todo: JobTodo): JobDisplayCopy {
+  return {
+    title: simplifyJobTitle(todo.title),
+    summary: simplifyJobSummary(todo),
+  };
 }
 
 function relativeTime(iso: string | null | undefined): string {
@@ -481,7 +556,7 @@ function JobRow({
   const rawOwner = todo.assigned_to_agent_id?.trim() || "unassigned";
   const alert = attention ? attentionCopy(todo) : null;
   const emoji = ownerEmoji(todo);
-  const visibleTitle = compactTitle(todo.title);
+  const displayCopy = displayCopyFor(todo);
 
   return (
     <li
@@ -530,7 +605,7 @@ function JobRow({
             )}
           </button>
         </div>
-        <p
+        <div
           role="button"
           tabIndex={0}
           aria-expanded={expanded}
@@ -541,11 +616,16 @@ function JobRow({
               onToggle();
             }
           }}
-          className={`min-w-0 cursor-pointer select-text truncate rounded-[3px] text-[10px] font-semibold leading-4 outline-none hover:text-white focus-visible:ring-1 focus-visible:ring-[#61C1C4]/50 ${todo.status === "done" ? "text-white/35 line-through" : "text-white/85"}`}
+          className="min-w-0 cursor-pointer select-text rounded-[3px] outline-none focus-visible:ring-1 focus-visible:ring-[#61C1C4]/50"
           title={todo.title}
         >
-          {visibleTitle}
-        </p>
+          <p className={`truncate text-[11px] font-semibold leading-4 hover:text-white ${todo.status === "done" ? "text-white/35 line-through" : "text-white/85"}`}>
+            {displayCopy.title}
+          </p>
+          <p className="truncate text-[10px] leading-4 text-white/35">
+            {displayCopy.summary}
+          </p>
+        </div>
 
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 md:contents">
           <span
@@ -630,22 +710,32 @@ function JobRow({
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div className="flex items-center gap-2 text-sm font-medium text-white/75">
                 <FileText className="h-3.5 w-3.5 text-[#61C1C4]" />
-                Job brief
+                Job context
               </div>
               <button
                 type="button"
                 onClick={() => setShowDetails((value) => !value)}
                 className="text-[11px] text-[#61C1C4]/80 hover:text-[#61C1C4]"
               >
-                {showDetails ? "See less" : "... See more"}
+                {showDetails ? "Hide original" : "Show original"}
               </button>
             </div>
-            {description ? (
-              <p className={`mt-2 whitespace-pre-wrap text-xs leading-5 text-white/60 ${showDetails ? "" : "max-h-20 overflow-hidden"}`}>
-                {description}
-              </p>
-            ) : (
-              <p className="mt-2 text-xs italic text-white/35">No description yet.</p>
+            <div className="mt-2 space-y-1.5">
+              <p className="text-xs font-medium text-white/70">{displayCopy.title}</p>
+              <p className="text-xs leading-5 text-white/50">{displayCopy.summary}</p>
+            </div>
+            {showDetails && (
+              <div className="mt-3 rounded-[5px] border border-white/[0.05] bg-black/20 p-2">
+                <p className="text-[10px] uppercase tracking-wide text-white/25">Original source</p>
+                <p className="mt-1 text-xs font-medium leading-5 text-white/60">{todo.title}</p>
+                {description ? (
+                  <p className="mt-2 whitespace-pre-wrap text-xs leading-5 text-white/45">
+                    {description}
+                  </p>
+                ) : (
+                  <p className="mt-2 text-xs italic text-white/30">No original description.</p>
+                )}
+              </div>
             )}
           </div>
 
@@ -698,6 +788,8 @@ function JobSection({
   visibleCount,
   onToggleSection,
   onShowMore,
+  hasMoreRemote,
+  showMoreLoading,
   loading,
 }: {
   sectionKey: JobSectionKey;
@@ -712,6 +804,8 @@ function JobSection({
   visibleCount?: number;
   onToggleSection?: () => void;
   onShowMore?: () => void;
+  hasMoreRemote?: boolean;
+  showMoreLoading?: boolean;
   loading?: boolean;
 }) {
   const [draggedId, setDraggedId] = useState<string | null>(null);
@@ -730,7 +824,7 @@ function JobSection({
   );
   const displayCount = Math.min(visibleCount ?? SECTION_PAGE_SIZE, cappedJobs.length);
   const visibleJobs = sortedJobs.slice(0, displayCount);
-  const canShowMore = displayCount < cappedJobs.length;
+  const canShowMore = displayCount < cappedJobs.length || hasMoreRemote === true;
   const showLoading = loading === true && jobs.length === 0;
   const sectionAccent: Record<JobSectionKey, string> = {
     active: "bg-[#E2B93B]",
@@ -773,7 +867,20 @@ function JobSection({
           Loading jobs
         </div>
       ) : jobs.length === 0 ? (
-        <p className="px-3 py-4 text-sm italic text-white/30">Empty</p>
+        <div className="px-3 py-4">
+          <p className="text-sm italic text-white/30">Empty</p>
+          {canShowMore && (
+            <button
+              type="button"
+              onClick={onShowMore}
+              disabled={showMoreLoading}
+              className="mt-3 inline-flex items-center gap-2 text-xs text-[#61C1C4]/80 hover:text-[#61C1C4] disabled:cursor-wait disabled:text-white/30"
+            >
+              {showMoreLoading && <Loader2 className="h-3 w-3 animate-spin" />}
+              Show completed history
+            </button>
+          )}
+        </div>
       ) : (
         <ul>
           <li className={`hidden border-b border-white/[0.05] bg-black/20 px-3 py-1.5 text-[10px] font-semibold uppercase text-white/30 ${JOB_ROW_GRID}`}>
@@ -812,9 +919,11 @@ function JobSection({
               <button
                 type="button"
                 onClick={onShowMore}
-                className="text-xs text-[#61C1C4]/80 hover:text-[#61C1C4]"
+                disabled={showMoreLoading}
+                className="inline-flex items-center gap-2 text-xs text-[#61C1C4]/80 hover:text-[#61C1C4] disabled:cursor-wait disabled:text-white/30"
               >
-                Show more
+                {showMoreLoading && <Loader2 className="h-3 w-3 animate-spin" />}
+                {sectionKey === "done" && hasMoreRemote ? "Show completed history" : "Show more"}
               </button>
             </li>
           )}
@@ -834,6 +943,9 @@ export default function AdminJobs() {
 
   const [humanAgentId, setHumanAgentId] = useState<string | null>(null);
   const [todos, setTodos] = useState<JobTodo[]>([]);
+  const [completedHistory, setCompletedHistory] = useState<JobTodo[]>([]);
+  const [completedHistoryLoaded, setCompletedHistoryLoaded] = useState(false);
+  const [completedHistoryLoading, setCompletedHistoryLoading] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [firstLoadDone, setFirstLoadDone] = useState(false);
@@ -928,8 +1040,13 @@ export default function AdminJobs() {
   }, [sectionPrefs]);
 
   const filteredTodos = useMemo(
-    () => todos.filter((todo) => matchesJobSearch(todo, searchQuery)),
-    [searchQuery, todos],
+    () => {
+      const byId = new Map<string, JobTodo>();
+      for (const todo of todos) byId.set(todo.id, todo);
+      for (const todo of completedHistory) byId.set(todo.id, todo);
+      return Array.from(byId.values()).filter((todo) => matchesJobSearch(todo, searchQuery));
+    },
+    [completedHistory, searchQuery, todos],
   );
   const grouped = useMemo(() => groupJobs(filteredTodos), [filteredTodos]);
   const orderedGrouped = useMemo(
@@ -945,6 +1062,7 @@ export default function AdminJobs() {
   const queueCount = grouped.next.length + grouped.inline.length;
   const alertCount = filteredTodos.filter(needsAttention).length;
   const initialLoading = !firstLoadDone && loading;
+  const visibleJobCount = todos.length + completedHistory.filter((historyJob) => !todos.some((todo) => todo.id === historyJob.id)).length;
 
   const toggleExpanded = (id: string) => {
     setExpanded((prev) => {
@@ -993,6 +1111,41 @@ export default function AdminJobs() {
           : prev.visible[sectionKey] + SECTION_PAGE_SIZE,
       },
     }));
+  };
+
+  const loadCompletedHistory = async () => {
+    if (!humanAgentId || completedHistoryLoading) return;
+    if (completedHistoryLoaded) {
+      showMore("done");
+      return;
+    }
+
+    setCompletedHistoryLoading(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_list_todos", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_id: humanAgentId,
+          include_description: true,
+          status: "done",
+          limit: 200,
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        todos?: JobTodo[];
+        error?: string;
+      };
+      if (!res.ok) throw new Error(body.error ?? "Failed to load completed jobs");
+      setCompletedHistory((body.todos ?? []).filter((todo) => todo.status === "done"));
+      setCompletedHistoryLoaded(true);
+      showMore("done");
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load completed jobs");
+    } finally {
+      setCompletedHistoryLoading(false);
+    }
   };
 
   return (
@@ -1063,8 +1216,8 @@ export default function AdminJobs() {
           {initialLoading && <Loader2 className="h-3.5 w-3.5 animate-spin text-[#61C1C4]" />}
           {firstLoadDone
             ? searchQuery.trim()
-              ? `${filteredTodos.length} of ${todos.length} jobs match`
-              : `${todos.length} visible jobs`
+              ? `${filteredTodos.length} of ${visibleJobCount} jobs match`
+              : `${visibleJobCount} visible jobs`
             : "Loading jobs"}
         </span>
         <span className="inline-flex items-center gap-1.5">
@@ -1131,7 +1284,9 @@ export default function AdminJobs() {
           sectionExpanded={sectionPrefs.expanded.done}
           visibleCount={sectionPrefs.visible.done}
           onToggleSection={() => toggleSection("done")}
-          onShowMore={() => showMore("done")}
+          onShowMore={loadCompletedHistory}
+          hasMoreRemote={!completedHistoryLoaded}
+          showMoreLoading={completedHistoryLoading}
           loading={initialLoading}
         />
       </div>


### PR DESCRIPTION
## Summary
- keep Jobs default view lightweight, but let Completed lazily fetch older done history on demand
- add display-only plain-English job titles and summaries while preserving original source text behind "Show original"
- add AI Seats last-seen visibility plus a Recent check-ins panel using live Fishbowl profile presence

## Proof
- npm run build
- npx vitest run src/pages/admin/fishbowl/messageLanes.test.ts src/pages/admin/pinballwakeJobRunners.test.ts src/pages/admin/pinballwakeLaunchpad.test.ts
- local browser smoke for /admin/jobs: no console errors; unauthenticated route correctly showed sign-in