### PR TITLE
fix(wakepass): accept threaded QueuePush ACKs

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -222,6 +222,29 @@ describe("fishbowl watcher PinballWake ACK coverage", () => {
     expect(messageAcknowledgesDispatch(dispatch, message)).toBe(true);
   });
 
+  it("matches threaded QueuePush ACK replies without requiring repeated packet text", () => {
+    const dispatch: DispatchRow = {
+      ...baseDispatch,
+      task_ref: "fishbowl-message:msg-queuepush",
+      payload: {
+        kind: "message_handoff",
+        ack_required: true,
+        handoff_message_id: "msg-queuepush",
+        summary:
+          "QueuePush ID: queuepush:v3:pr-544:blocked_chris_only:caef570:e53888490d",
+      },
+    };
+    const message: FishbowlMessageAckRow = {
+      id: "msg-ack",
+      text: "ACK. BLOCKER: exact Chris decision still required.",
+      thread_id: "msg-queuepush",
+      created_at: "2026-05-01T01:12:00.000Z",
+      author_agent_id: "chatgpt-codex-heartbeat",
+    };
+
+    expect(messageAcknowledgesDispatch(dispatch, message)).toBe(true);
+  });
+
   it("does not count wake prompt copy as an ACK reply", () => {
     const wakeEventId = "wake-pull_request-pr-508-5e6cd76ba13e";
     const message: FishbowlMessageAckRow = {

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -198,17 +198,19 @@ export function messageAcknowledgesDispatch(
   row: DispatchRow,
   message: FishbowlMessageAckRow,
 ): boolean {
-  const ackToken = ackTokenForDispatch(row);
-  if (!ackToken) return false;
-
   const text = String(message.text ?? "").trim();
   if (!/^ACK\b/i.test(text)) return false;
-  if (!text.includes(ackToken)) return false;
 
   const handoffMessageId = nonEmptyString(row.payload?.handoff_message_id);
+  if (handoffMessageId && message.thread_id === handoffMessageId) return true;
+
+  const ackToken = ackTokenForDispatch(row);
+  if (!ackToken) return false;
+  if (!text.includes(ackToken)) return false;
+
   if (!handoffMessageId) return true;
 
-  return message.thread_id === handoffMessageId || message.thread_id === null;
+  return message.thread_id === null;
 }
 
 function newestFirst(a: ProfileRow, b: ProfileRow): number {
@@ -455,9 +457,6 @@ async function findDispatchAckMessage(
   supabase: ReturnType<typeof createClient>,
   row: DispatchRow,
 ): Promise<FishbowlMessageAckRow | null> {
-  const ackToken = ackTokenForDispatch(row);
-  if (!ackToken) return null;
-
   const createdMs = Date.parse(String(row.created_at ?? ""));
   let query = supabase
     .from("mc_fishbowl_messages")


### PR DESCRIPTION
Summary:
- Extend the WakePass ACK matcher so a threaded Boardroom reply that starts with ACK satisfies the original Fishbowl message handoff lease.
- Keep the exact wake_event_id path from PR #597 for non-threaded/manual ACKs.

Scope:
- WakePass/Fishbowl watcher ACK detection in api/fishbowl-watcher.ts.
- Focused watcher regression coverage in api/fishbowl-watcher.test.ts.
- Linked todo: 5a6c8369-41eb-40e7-9744-b2fa282a2247.

Non-overlap:
- Does not change QueuePush packet emission, PR state hashing, React dependency work, merge policy, or database schema.

Verification:
- npm run test -- api/fishbowl-watcher.test.ts
- git diff --check

Risk:
- Low. The broad ACK shortcut only applies when the reply is threaded under the exact original handoff message id and begins with ACK. Other paths still require the exact wake event, dispatch id, or task ref token.

Follow-up:
- A later QueuePush-side suppressor can skip re-dispatch when the PR state tuple is unchanged, but this prevents already-threaded ACKs from becoming WakePass misses.