### PR TITLE
[codex] Add Jobs GitHub sync guard

### DIFF
--- a/scripts/fishbowl-todo-reconciliation.mjs
+++ b/scripts/fishbowl-todo-reconciliation.mjs
@@ -11,6 +11,8 @@ const TODO_REFERENCE_RE = new RegExp(
 );
 
 const NO_TODO_RE = /^no-todo:\s*(\S.*)$/gim;
+const PR_URL_RE = /github\.com\/[^\s/)]+\/[^\s/)]+\/pull\/(\d+)/gi;
+const PR_NUMBER_RE = /\bPR\s*#(\d{1,7})\b/gi;
 
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -48,6 +50,23 @@ function prText(pr = {}) {
       commit.commit?.message,
     ]),
   ).join("\n");
+}
+
+function todoText(todo = {}) {
+  return textParts(
+    todo.title,
+    todo.description,
+    todo.pipeline_evidence,
+    todo.pipelineEvidence,
+  ).join("\n");
+}
+
+export function extractPullRequestNumbers(...parts) {
+  const text = textParts(...parts).join("\n");
+  const numbers = new Set();
+  for (const match of text.matchAll(PR_URL_RE)) numbers.add(Number(match[1]));
+  for (const match of text.matchAll(PR_NUMBER_RE)) numbers.add(Number(match[1]));
+  return [...numbers].filter(Number.isFinite).sort((a, b) => a - b);
 }
 
 export function extractTodoReferenceIds(...parts) {
@@ -162,6 +181,118 @@ export function buildInProgressReconciliationPlan({
   };
 }
 
+export function buildJobsGithubSyncPlan({
+  todos = [],
+  pullRequests = [],
+} = {}) {
+  const safeTodos = Array.isArray(todos) ? todos : [];
+  const safePrs = Array.isArray(pullRequests) ? pullRequests : [];
+  const todoById = new Map(
+    safeTodos
+      .map((todo) => [String(todo?.id ?? "").toLowerCase(), todo])
+      .filter(([id]) => id),
+  );
+  const prByNumber = new Map(
+    safePrs
+      .map((pr) => [Number(pr?.number ?? pr?.pr_number), pr])
+      .filter(([number]) => Number.isFinite(number)),
+  );
+  const prsByTodo = new Map();
+  const issues = [];
+  const linked = [];
+
+  for (const pr of safePrs) {
+    const number = Number(pr?.number ?? pr?.pr_number);
+    if (!Number.isFinite(number)) continue;
+
+    const text = prText(pr);
+    const todoIds = extractTodoReferenceIds(text);
+    const noTodoReason = findNoTodoReason(text);
+
+    if (todoIds.length === 0 && !noTodoReason) {
+      issues.push({
+        kind: "pr_needs_job_link",
+        severity: "high",
+        pr_number: number,
+        message: `PR #${number} is not linked to an UnClick Job.`,
+        next: "Add `Closes UnClick todo: <job id>` to the PR body, or add `no-todo: <reason>` for tiny safe changes.",
+      });
+      continue;
+    }
+
+    for (const todoId of todoIds) {
+      const list = prsByTodo.get(todoId) ?? [];
+      list.push(number);
+      prsByTodo.set(todoId, list);
+
+      if (!todoById.has(todoId)) {
+        issues.push({
+          kind: "pr_points_to_missing_job",
+          severity: "medium",
+          pr_number: number,
+          todo_id: todoId,
+          message: `PR #${number} points to a Job ID that is not visible in the current Jobs list.`,
+          next: "Confirm the Job exists, then refresh the Jobs list or correct the PR marker.",
+        });
+      } else {
+        linked.push({ pr_number: number, todo_id: todoId });
+      }
+    }
+  }
+
+  for (const todo of safeTodos) {
+    const todoId = String(todo?.id ?? "").toLowerCase();
+    if (!todoId || todo?.status === "dropped") continue;
+
+    const mentionedPrs = extractPullRequestNumbers(todoText(todo));
+    const markedPrs = new Set(prsByTodo.get(todoId) ?? []);
+
+    for (const prNumber of mentionedPrs) {
+      if (markedPrs.has(prNumber)) continue;
+      if (!prByNumber.has(prNumber)) continue;
+      issues.push({
+        kind: "job_mentions_pr_without_marker",
+        severity: "high",
+        todo_id: todo.id,
+        pr_number: prNumber,
+        message: `Job ${todo.id} mentions PR #${prNumber}, but the PR does not carry this Job ID.`,
+        next: `Add \`Closes UnClick todo: ${todo.id}\` to PR #${prNumber} before merge.`,
+      });
+    }
+
+    const mergedMarkedPr = [...markedPrs]
+      .map((number) => prByNumber.get(number))
+      .find((pr) => parseTime(pr?.merged_at ?? pr?.mergedAt) !== null);
+    if (todo.status === "in_progress" && mergedMarkedPr) {
+      issues.push({
+        kind: "job_ready_to_complete",
+        severity: "high",
+        todo_id: todo.id,
+        pr_number: Number(mergedMarkedPr.number ?? mergedMarkedPr.pr_number),
+        message: `Job ${todo.id} has a merged linked PR but is still active.`,
+        next: "Run the auto-close reconciliation or complete the Job with the linked PR as proof.",
+      });
+    }
+
+    if (todo.status === "done" && markedPrs.size === 0 && mentionedPrs.length === 0) {
+      issues.push({
+        kind: "done_job_missing_proof",
+        severity: "medium",
+        todo_id: todo.id,
+        message: `Completed Job ${todo.id} has no visible GitHub proof link.`,
+        next: "Add the PR, run, or deployment link to the Job proof so future seats can audit it.",
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    reason: "jobs_github_sync_plan",
+    issues,
+    linked,
+  };
+}
+
 export async function readReconciliationInput(filePath) {
   if (!filePath) return { ok: false, reason: "missing_input_path" };
   return JSON.parse(await readFile(filePath, "utf8"));
@@ -171,6 +302,12 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
   readReconciliationInput(getArg("input", process.env.FISHBOWL_RECONCILIATION_INPUT || ""))
     .then((input) => {
       if (Array.isArray(input.todos) || Array.isArray(input.pullRequests) || Array.isArray(input.pull_requests)) {
+        if (input.mode === "jobs_github_sync") {
+          return buildJobsGithubSyncPlan({
+            todos: input.todos,
+            pullRequests: input.pullRequests ?? input.pull_requests,
+          });
+        }
         return buildInProgressReconciliationPlan({
           todos: input.todos,
           pullRequests: input.pullRequests ?? input.pull_requests,

--- a/scripts/fishbowl-todo-reconciliation.test.mjs
+++ b/scripts/fishbowl-todo-reconciliation.test.mjs
@@ -3,7 +3,9 @@ import { describe, it } from "node:test";
 
 import {
   buildInProgressReconciliationPlan,
+  buildJobsGithubSyncPlan,
   evaluatePrTodoReference,
+  extractPullRequestNumbers,
   extractTodoReferenceIds,
   findNoTodoReason,
 } from "./fishbowl-todo-reconciliation.mjs";
@@ -94,5 +96,54 @@ describe("fishbowl todo reconciliation helpers", () => {
     assert.equal(plan.stale.length, 1);
     assert.equal(plan.stale[0].todo_id, TODO_A);
     assert.equal(plan.stale[0].assigned_to_agent_id, "builder-seat");
+  });
+
+  it("extracts pull request numbers from job proof text", () => {
+    assert.deepEqual(
+      extractPullRequestNumbers(
+        "Proof: PR #594",
+        "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/589",
+      ),
+      [589, 594],
+    );
+  });
+
+  it("flags PRs that are not linked back to a Job", () => {
+    const plan = buildJobsGithubSyncPlan({
+      todos: [{ id: TODO_A, title: "Jobs sync", status: "in_progress" }],
+      pullRequests: [{ number: 700, body: "Small change with no job marker" }],
+    });
+
+    assert.equal(plan.ok, true);
+    assert.deepEqual(plan.issues.map((issue) => issue.kind), ["pr_needs_job_link"]);
+    assert.equal(plan.issues[0].severity, "high");
+  });
+
+  it("flags a Job that mentions a PR when the PR lacks the Job marker", () => {
+    const plan = buildJobsGithubSyncPlan({
+      todos: [{ id: TODO_A, title: "Jobs sync PR #701", status: "in_progress" }],
+      pullRequests: [{ number: 701, body: "Build proof, but no marker" }],
+    });
+
+    assert.equal(
+      plan.issues.some((issue) => issue.kind === "job_mentions_pr_without_marker" && issue.pr_number === 701),
+      true,
+    );
+  });
+
+  it("flags active Jobs whose linked PR has already merged", () => {
+    const plan = buildJobsGithubSyncPlan({
+      todos: [{ id: TODO_A, title: "linked shipped work", status: "in_progress" }],
+      pullRequests: [
+        {
+          number: 702,
+          merged_at: "2026-05-09T02:00:00.000Z",
+          body: `Closes UnClick todo: ${TODO_A}`,
+        },
+      ],
+    });
+
+    assert.equal(plan.linked.length, 1);
+    assert.equal(plan.issues.some((issue) => issue.kind === "job_ready_to_complete"), true);
   });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -5,7 +5,9 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   FileText,
+  GitPullRequest,
   GripVertical,
   Loader2,
   MessageSquare,
@@ -14,6 +16,7 @@ import {
 } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import Comments from "./fishbowl/Comments";
+import { buildJobGithubSyncSignal, type JobGithubSyncSignal } from "./jobsGithubSync";
 
 interface FishbowlProfile {
   agent_id: string;
@@ -108,11 +111,12 @@ const STAGES = ["Brief", "Build", "Proof", "Review", "Ship"] as const;
 const TITLE_MAX_CHARS = 90;
 
 const JOB_ROW_GRID =
-  "md:grid md:grid-cols-[48px_minmax(360px,1.25fr)_48px_58px_minmax(96px,0.35fr)_40px_minmax(200px,0.55fr)_30px_18px] md:items-center md:gap-1.5";
+  "md:grid md:grid-cols-[48px_minmax(320px,1.2fr)_48px_58px_minmax(96px,0.35fr)_40px_minmax(190px,0.5fr)_78px_30px_18px] md:items-center md:gap-1.5";
 
 interface JobDisplayCopy {
   title: string;
   summary: string;
+  context: string;
 }
 
 function compactTitle(title: string): string {
@@ -161,16 +165,8 @@ function simplifyJobTitle(title: string): string {
   return compactTitle(cleaned || title);
 }
 
-function simplifyJobSummary(todo: JobTodo): string {
-  const rawDescription = todo.description?.trim();
-  const source = rawDescription && rawDescription.length > 0 ? rawDescription : todo.title;
-  const firstUsefulLine =
-    source
-      .split(/\r?\n/)
-      .map((line) => line.replace(/^[-*#>\s]+/, "").trim())
-      .find((line) => line.length > 0 && !/^https?:\/\//i.test(line)) ?? source;
-
-  const cleaned = stripNoisyLead(firstUsefulLine)
+function cleanJobCopy(value: string): string {
+  return stripNoisyLead(value)
     .replace(/`([^`]+)`/g, "$1")
     .replace(/\*\*([^*]+)\*\*/g, "$1")
     .replace(/\[[^\]]+\]\([^)]+\)/g, "")
@@ -180,14 +176,35 @@ function simplifyJobSummary(todo: JobTodo): string {
     .replace(/\bunclick\b/gi, "UnClick")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function usefulJobLines(todo: JobTodo): string[] {
+  const rawDescription = todo.description?.trim();
+  const source = rawDescription && rawDescription.length > 0 ? rawDescription : todo.title;
+  return source
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^[-*#>\s]+/, "").trim())
+    .filter((line) => line.length > 0 && !/^https?:\/\//i.test(line));
+}
+
+function simplifyJobSummary(todo: JobTodo): string {
+  const firstUsefulLine = usefulJobLines(todo)[0] ?? todo.title;
+  const cleaned = cleanJobCopy(firstUsefulLine);
 
   return trimSentence(cleaned || simplifyJobTitle(todo.title), 130);
+}
+
+function simplifyJobContext(todo: JobTodo): string {
+  const usefulLines = usefulJobLines(todo);
+  const cleaned = cleanJobCopy(usefulLines.join(" ") || todo.title);
+  return cleaned || simplifyJobTitle(todo.title);
 }
 
 function displayCopyFor(todo: JobTodo): JobDisplayCopy {
   return {
     title: simplifyJobTitle(todo.title),
     summary: simplifyJobSummary(todo),
+    context: simplifyJobContext(todo),
   };
 }
 
@@ -279,6 +296,44 @@ function StageStrip({ todo }: { todo: JobTodo }) {
         ))}
       </div>
     </div>
+  );
+}
+
+const SYNC_SIGNAL_STYLE: Record<JobGithubSyncSignal["tone"], string> = {
+  quiet: "border-white/[0.08] bg-white/[0.025] text-white/40",
+  linked: "border-[#61C1C4]/30 bg-[#61C1C4]/10 text-[#8EE8EB]",
+  done: "border-green-400/25 bg-green-400/10 text-green-300",
+  alert: "border-red-300/30 bg-red-500/10 text-red-200",
+};
+
+function SyncSignalPill({ signal }: { signal: JobGithubSyncSignal }) {
+  const content = (
+    <>
+      <GitPullRequest className="h-3 w-3 shrink-0" aria-hidden="true" />
+      <span className="min-w-0 truncate">{signal.label}</span>
+      {signal.href && <ExternalLink className="h-2.5 w-2.5 shrink-0 opacity-70" aria-hidden="true" />}
+    </>
+  );
+  const className = `inline-flex max-w-[78px] items-center gap-1 rounded-[4px] border px-1 py-px text-[9px] font-semibold ${SYNC_SIGNAL_STYLE[signal.tone]}`;
+
+  if (signal.href) {
+    return (
+      <a
+        href={signal.href}
+        target="_blank"
+        rel="noreferrer"
+        className={`${className} hover:border-[#61C1C4]/45 hover:bg-[#61C1C4]/15`}
+        title={signal.detail}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <span className={className} title={signal.detail}>
+      {content}
+    </span>
   );
 }
 
@@ -557,6 +612,7 @@ function JobRow({
   const alert = attention ? attentionCopy(todo) : null;
   const emoji = ownerEmoji(todo);
   const displayCopy = displayCopyFor(todo);
+  const syncSignal = buildJobGithubSyncSignal(todo);
 
   return (
     <li
@@ -655,6 +711,7 @@ function JobRow({
           <span className="text-[11px] font-medium text-white/55">
             <StageStrip todo={todo} />
           </span>
+          <SyncSignalPill signal={syncSignal} />
           <span className="flex items-center gap-0.5 text-[11px] text-white/45">
             <MessageSquare className="h-3 w-3" />
             {todo.comment_count ?? 0}
@@ -685,7 +742,7 @@ function JobRow({
               <span className="text-red-100/45">Fallback: {alert.actions.join(" / ")}</span>
             </div>
           )}
-          <div className="grid gap-3 text-xs text-white/50 sm:grid-cols-4">
+          <div className="grid gap-3 text-xs text-white/50 sm:grid-cols-5">
             <div>
               <span className="block text-[10px] uppercase tracking-wide text-white/30">Created</span>
               <span>{relativeTime(todo.created_at)}</span>
@@ -703,6 +760,12 @@ function JobRow({
             <div>
               <span className="block text-[10px] uppercase tracking-wide text-white/30">Pipeline</span>
               <StageStrip todo={todo} />
+            </div>
+            <div>
+              <span className="block text-[10px] uppercase tracking-wide text-white/30">Proof</span>
+              <div className="mt-0.5">
+                <SyncSignalPill signal={syncSignal} />
+              </div>
             </div>
           </div>
 
@@ -722,7 +785,7 @@ function JobRow({
             </div>
             <div className="mt-2 space-y-1.5">
               <p className="text-xs font-medium text-white/70">{displayCopy.title}</p>
-              <p className="text-xs leading-5 text-white/50">{displayCopy.summary}</p>
+              <p className="text-xs leading-5 text-white/50">{displayCopy.context}</p>
             </div>
             {showDetails && (
               <div className="mt-3 rounded-[5px] border border-white/[0.05] bg-black/20 p-2">
@@ -891,6 +954,7 @@ function JobSection({
             <SortHeader label="Worker" value="worker" sortKey={sortKey} sortDirection={sortDirection} onSort={setSort} />
             <SortHeader label="Live" value="live" sortKey={sortKey} sortDirection={sortDirection} onSort={setSort} />
             <SortHeader label="Progress" value="progress" sortKey={sortKey} sortDirection={sortDirection} onSort={setSort} />
+            <span>Proof</span>
             <SortHeader label="Notes" value="notes" sortKey={sortKey} sortDirection={sortDirection} onSort={setSort} />
             <span className="text-right">!</span>
           </li>
@@ -1153,11 +1217,11 @@ export default function AdminJobs() {
       <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div>
           <div className="mb-3 inline-flex items-center rounded-full border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-1 text-xs font-medium text-[#61C1C4]">
-            Jobs source of truth
+            Work board
           </div>
           <h1 className="text-2xl font-semibold tracking-tight text-white">Jobs</h1>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
-            One work list for active, next, queued, and completed UnClick jobs.
+            One work list for active, next, queued, and completed jobs. GitHub and deployment links appear as proof when code work moves.
           </p>
         </div>
         <div className="grid grid-cols-3 gap-2 text-center sm:min-w-[360px]">

--- a/src/pages/admin/jobsGithubSync.test.ts
+++ b/src/pages/admin/jobsGithubSync.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildJobGithubSyncSignal,
+  extractJobGithubReferences,
+  jobHasDeploymentFailure,
+  type JobGithubSyncInput,
+} from "./jobsGithubSync";
+
+const baseJob: JobGithubSyncInput = {
+  id: "4e9c7f73-5a67-4b50-a02a-9e2adcb8e3e0",
+  title: "Jobs and GitHub sync",
+  status: "open",
+};
+
+describe("Jobs and GitHub sync helpers", () => {
+  it("keeps a job-first label when no GitHub proof is linked yet", () => {
+    expect(buildJobGithubSyncSignal(baseJob)).toEqual({
+      label: "Job first",
+      detail: "Work starts here. Add a PR, run, or deployment link when code ships.",
+      tone: "quiet",
+    });
+  });
+
+  it("extracts a pull request URL as the linked proof", () => {
+    const job = {
+      ...baseJob,
+      description: "Proof: https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/594",
+    };
+
+    expect(extractJobGithubReferences(job)).toEqual([
+      {
+        kind: "pull_request",
+        label: "PR #594",
+        url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/594",
+      },
+    ]);
+    expect(buildJobGithubSyncSignal(job)).toMatchObject({
+      label: "PR #594",
+      detail: "GitHub PR is linked to this job.",
+      tone: "linked",
+    });
+  });
+
+  it("uses PR number references when a URL is not available", () => {
+    expect(buildJobGithubSyncSignal({ ...baseJob, title: "Finish PR #589 reconciliation" })).toMatchObject({
+      label: "PR #589",
+      tone: "linked",
+    });
+  });
+
+  it("surfaces failed preview deployments as an action item", () => {
+    const job = {
+      ...baseJob,
+      description: "Failed preview deployment on https://vercel.com/chris/unclick-agent-native-endpoints/abc123",
+    };
+
+    expect(jobHasDeploymentFailure(job)).toBe(true);
+    expect(buildJobGithubSyncSignal(job)).toEqual({
+      label: "Deploy issue",
+      detail: "A linked deployment needs attention.",
+      tone: "alert",
+      href: "https://vercel.com/chris/unclick-agent-native-endpoints/abc123",
+    });
+  });
+
+  it("expects completed jobs to keep proof attached", () => {
+    expect(buildJobGithubSyncSignal({ ...baseJob, status: "done" })).toEqual({
+      label: "Proof missing",
+      detail: "Completed job needs a PR, run, or deployment link.",
+      tone: "alert",
+    });
+    expect(
+      buildJobGithubSyncSignal({
+        ...baseJob,
+        status: "done",
+        pipeline_evidence: ["https://github.com/malamutemayhem/unclick-agent-native-endpoints/actions/runs/25590447727"],
+      }),
+    ).toMatchObject({
+      label: "Proof saved",
+      detail: "Run 25590447727 is linked to this completed job.",
+      tone: "done",
+    });
+  });
+});

--- a/src/pages/admin/jobsGithubSync.ts
+++ b/src/pages/admin/jobsGithubSync.ts
@@ -1,0 +1,155 @@
+export type JobSyncStatus = "open" | "in_progress" | "done" | "dropped";
+
+export interface JobGithubSyncInput {
+  id: string;
+  title: string;
+  description?: string | null;
+  status: JobSyncStatus;
+  pipeline_evidence?: string[];
+}
+
+export interface JobGithubReference {
+  kind: "pull_request" | "action_run" | "deployment";
+  label: string;
+  url?: string;
+}
+
+export interface JobGithubSyncSignal {
+  label: string;
+  detail: string;
+  tone: "quiet" | "linked" | "done" | "alert";
+  href?: string;
+}
+
+const GITHUB_PULL_URL_RE = /https:\/\/github\.com\/([^\s/)]+\/[^\s/)]+)\/pull\/(\d+)/gi;
+const GITHUB_RUN_URL_RE = /https:\/\/github\.com\/([^\s/)]+\/[^\s/)]+)\/actions\/runs\/(\d+)/gi;
+const VERCEL_URL_RE = /https:\/\/(?:vercel\.com|[^\s/)]+\.vercel\.app)[^\s)]*/gi;
+const PR_NUMBER_RE = /\bPR\s*#(\d{1,7})\b/gi;
+const FAILED_DEPLOY_RE = /\b(failed preview deployment|deployment failed|failed deployment|preview deployment failed|vercel failed)\b/i;
+
+function uniqueByLabel(refs: JobGithubReference[]): JobGithubReference[] {
+  const seen = new Set<string>();
+  return refs.filter((ref) => {
+    const key = `${ref.kind}:${ref.label}:${ref.url ?? ""}`.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function jobSyncText(job: JobGithubSyncInput): string {
+  return [job.id, job.title, job.description, ...(job.pipeline_evidence ?? [])]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function extractJobGithubReferences(job: JobGithubSyncInput): JobGithubReference[] {
+  const text = jobSyncText(job);
+  const refs: JobGithubReference[] = [];
+
+  for (const match of text.matchAll(GITHUB_PULL_URL_RE)) {
+    refs.push({
+      kind: "pull_request",
+      label: `PR #${match[2]}`,
+      url: match[0],
+    });
+  }
+
+  for (const match of text.matchAll(GITHUB_RUN_URL_RE)) {
+    refs.push({
+      kind: "action_run",
+      label: `Run ${match[2]}`,
+      url: match[0],
+    });
+  }
+
+  for (const match of text.matchAll(VERCEL_URL_RE)) {
+    refs.push({
+      kind: "deployment",
+      label: "Deploy",
+      url: match[0],
+    });
+  }
+
+  const hasPullUrl = refs.some((ref) => ref.kind === "pull_request");
+  if (!hasPullUrl) {
+    for (const match of text.matchAll(PR_NUMBER_RE)) {
+      refs.push({
+        kind: "pull_request",
+        label: `PR #${match[1]}`,
+      });
+    }
+  }
+
+  return uniqueByLabel(refs);
+}
+
+export function jobHasDeploymentFailure(job: JobGithubSyncInput): boolean {
+  return FAILED_DEPLOY_RE.test(jobSyncText(job));
+}
+
+export function buildJobGithubSyncSignal(job: JobGithubSyncInput): JobGithubSyncSignal {
+  const refs = extractJobGithubReferences(job);
+  const firstPr = refs.find((ref) => ref.kind === "pull_request");
+  const firstRun = refs.find((ref) => ref.kind === "action_run");
+  const firstDeploy = refs.find((ref) => ref.kind === "deployment");
+  const firstLink = firstPr ?? firstRun ?? firstDeploy;
+
+  if (jobHasDeploymentFailure(job)) {
+    return {
+      label: "Deploy issue",
+      detail: "A linked deployment needs attention.",
+      tone: "alert",
+      href: firstLink?.url,
+    };
+  }
+
+  if (job.status === "done") {
+    if (firstLink) {
+      return {
+        label: "Proof saved",
+        detail: `${firstLink.label} is linked to this completed job.`,
+        tone: "done",
+        href: firstLink.url,
+      };
+    }
+    return {
+      label: "Proof missing",
+      detail: "Completed job needs a PR, run, or deployment link.",
+      tone: "alert",
+    };
+  }
+
+  if (firstPr) {
+    return {
+      label: firstPr.label,
+      detail: "GitHub PR is linked to this job.",
+      tone: "linked",
+      href: firstPr.url,
+    };
+  }
+
+  if (firstRun) {
+    return {
+      label: "Run linked",
+      detail: "GitHub run is linked to this job.",
+      tone: "linked",
+      href: firstRun.url,
+    };
+  }
+
+  if (firstDeploy) {
+    return {
+      label: "Deploy linked",
+      detail: "Deployment proof is linked to this job.",
+      tone: "linked",
+      href: firstDeploy.url,
+    };
+  }
+
+  return {
+    label: "Job first",
+    detail: "Work starts here. Add a PR, run, or deployment link when code ships.",
+    tone: "quiet",
+  };
+}


### PR DESCRIPTION
## What changed

- Adds a Jobs/GitHub sync guard so automation can flag PRs without a linked UnClick Job, Jobs that mention a PR without the matching PR marker, and active Jobs whose linked PR already merged.
- Adds a friendly Proof column to the public Jobs board so people can see whether a Job is still job-first, has a PR linked, has deployment/run proof, or has a deployment issue.
- Shows the full cleaned Job context in the expanded Job panel while keeping the table row compact.

## Why

Jobs are the work board. GitHub PRs, runs, and deployments are proof. This keeps seats from confusing an empty PR queue with an empty UnClick work queue.

## Proof

- `npx vitest run src/pages/admin/jobsGithubSync.test.ts`
- `node --test scripts/fishbowl-todo-reconciliation.test.mjs`
- `npm run build`
- Local browser smoke: `/admin/jobs` loads and redirects to login with no console errors.

Closes UnClick todo: c852149d-2155-4554-978e-0dd9e91b545a