### PR TITLE
[codex] Add explicit autopilot lease grant event

### DIFF
--- a/api/autopilot-control-ledger.test.ts
+++ b/api/autopilot-control-ledger.test.ts
@@ -31,6 +31,27 @@ describe("autopilot control ledger helpers", () => {
     expect(row.idempotency_key).toContain("claim:todo:todo-123:runner:");
   });
 
+  it("records explicit lease grant events", () => {
+    const row = buildAutopilotEventRow({
+      apiKeyHash: "hash_123",
+      eventType: "lease_grant",
+      actorAgentId: "runner",
+      refKind: "dispatch",
+      refId: "dispatch-123",
+      now,
+      payload: { lease_owner: "runner", lease_minutes: 10 },
+    });
+
+    expect(row).toMatchObject({
+      event_type: "lease_grant",
+      actor_agent_id: "runner",
+      ref_kind: "dispatch",
+      ref_id: "dispatch-123",
+      payload: { lease_owner: "runner", lease_minutes: 10 },
+    });
+    expect(row.idempotency_key).toContain("lease_grant:dispatch:dispatch-123:runner:");
+  });
+
   it("plans todo state and claim events from before/after rows", () => {
     const events = planTodoLedgerEvents({
       todoId: "todo-123",

--- a/api/lib/autopilot-control-ledger.ts
+++ b/api/lib/autopilot-control-ledger.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 export const AUTOPILOT_EVENT_TYPES = [
   "claim",
+  "lease_grant",
   "lease_refresh",
   "lease_expired",
   "release",

--- a/supabase/migrations/20260509000000_autopilot_control_ledger.sql
+++ b/supabase/migrations/20260509000000_autopilot_control_ledger.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS mc_autopilot_events (
   event_type text NOT NULL
     CHECK (event_type IN (
       'claim',
+      'lease_grant',
       'lease_refresh',
       'lease_expired',
       'release',

--- a/supabase/migrations/20260509001000_autopilot_control_ledger_lease_grant.sql
+++ b/supabase/migrations/20260509001000_autopilot_control_ledger_lease_grant.sql
@@ -1,0 +1,30 @@
+-- Add explicit lease grant events to the Autopilot control ledger.
+-- Existing deployments already have mc_autopilot_events, so this migration
+-- updates the event_type check instead of relying on the original create file.
+
+ALTER TABLE mc_autopilot_events
+  DROP CONSTRAINT IF EXISTS mc_autopilot_events_event_type_check;
+
+ALTER TABLE mc_autopilot_events
+  ADD CONSTRAINT mc_autopilot_events_event_type_check
+  CHECK (event_type IN (
+    'claim',
+    'lease_grant',
+    'lease_refresh',
+    'lease_expired',
+    'release',
+    'build_start',
+    'build_end',
+    'proof_request',
+    'proof_result',
+    'ack',
+    'blocker',
+    'merge_decision',
+    'watch_start',
+    'watch_end',
+    'dispatch',
+    'pick',
+    'todo_state_change'
+  ));
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- Adds explicit `lease_grant` as a typed Autopilot control ledger event.
- Updates the original ledger migration and adds a follow-up migration for already-created `mc_autopilot_events` tables.
- Covers the event builder with a focused regression test.

## Why

The live Job asks for job claim, lease grant, build, proof, ACK, blocker, merge, watch, and dispatch events to be real typed state. `lease_grant` was the missing lease event between claim and refresh/expiry.

## Proof

- `npx vitest run api/autopilot-control-ledger.test.ts`
- `npm run build`
- `git diff --check`

Closes UnClick todo: faf225ff-c688-47f0-b6fd-853c2ba41469