### PR TITLE
fix(memory): suppress stale load-memory hint

### DIFF
--- a/packages/mcp-server/src/__tests__/memory-load-hint.test.ts
+++ b/packages/mcp-server/src/__tests__/memory-load-hint.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { sessionState } from "../memory/session-state.js";
+import { memoryToolText } from "../server.js";
+
+describe("memory tool response formatting", () => {
+  it("does not prepend a stale load_memory hint when session tracking is unset", () => {
+    sessionState.contextLoaded = false;
+    sessionState.contextLoadMethod = null;
+
+    const text = memoryToolText("search_memory", [{ content: "ok" }]);
+
+    expect(text).toBe(JSON.stringify([{ content: "ok" }], null, 2));
+    expect(text).not.toContain("No load_memory call detected");
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -11,7 +11,7 @@ import { createClient, type UnClickClient } from "./client.js";
 import { ADDITIONAL_TOOLS, ADDITIONAL_HANDLERS } from "./tool-wiring.js";
 import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
-import { markContextLoaded, recordToolCall, sessionState } from "./memory/session-state.js";
+import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
 import { emitSignal } from "./signals/emit.js";
 import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
 import { createHash } from "node:crypto";
@@ -884,16 +884,12 @@ const MEMORY_TOOL_ALIASES: Record<string, string> = {
   // search_memory and invalidate_fact keep their names
 };
 
-const LOAD_MEMORY_HINT =
-  "[hint] No load_memory call detected this session -- call it for personalised context.\n\n";
-
-function memoryToolText(memoryKey: string, result: unknown): string {
+export function memoryToolText(memoryKey: string, result: unknown): string {
   if (memoryKey === "get_startup_context") {
     markContextLoaded("manual");
     return JSON.stringify(result, null, 2);
   }
-  const text = JSON.stringify(result, null, 2);
-  return sessionState.contextLoaded ? text : `${LOAD_MEMORY_HINT}${text}`;
+  return JSON.stringify(result, null, 2);
 }
 
 const DIRECT_TOOLS = [


### PR DESCRIPTION
Summary:
- Removed the per-process load_memory hint prefix from non-load memory tool responses because live MCP invocations can be stateless and falsely warn after load_memory already ran.
- Added a regression test that keeps search_memory response text clean when session tracking is unset.

Scope:
- Owned files: packages/mcp-server/src/server.ts, packages/mcp-server/src/__tests__/memory-load-hint.test.ts
- Lane: memory, MCP server response formatting
- Linked todo: b0a35d4d-1e54-453c-afac-8bbcf7045222

Non-overlap:
- Does not change memory retrieval, storage, identity rules, or load event persistence.
- Does not touch production secrets, migrations, or client UI.

Verification:
- npx vitest run src/__tests__/memory-load-hint.test.ts
- npm run build
- npm test
- git diff --check

Risk:
- Low. Removes advisory text only. Agents may receive fewer reminders, but tool descriptions and startup instructions still tell them to call load_memory.

Follow-up:
- A persisted per-session load tracker can restore this hint later if the MCP runtime exposes a reliable session key.

PR status:
- Draft by default.