### PR TITLE
Add lane check ledger events

### DIFF
--- a/api/autopilot-control-ledger.test.ts
+++ b/api/autopilot-control-ledger.test.ts
@@ -52,6 +52,35 @@ describe("autopilot control ledger helpers", () => {
     expect(row.idempotency_key).toContain("lease_grant:dispatch:dispatch-123:runner:");
   });
 
+  it("records lane check decisions for role-fit routing", () => {
+    const row = buildAutopilotEventRow({
+      apiKeyHash: "hash_123",
+      eventType: "lane_check",
+      actorAgentId: "watcher-seat",
+      refKind: "todo",
+      refId: "todo-123",
+      now,
+      payload: {
+        decision: "reject",
+        reason: "Builder lane task assigned to Watcher seat",
+        suggested_recipient: "builder-seat",
+      },
+    });
+
+    expect(row).toMatchObject({
+      event_type: "lane_check",
+      actor_agent_id: "watcher-seat",
+      ref_kind: "todo",
+      ref_id: "todo-123",
+      payload: {
+        decision: "reject",
+        reason: "Builder lane task assigned to Watcher seat",
+        suggested_recipient: "builder-seat",
+      },
+    });
+    expect(row.idempotency_key).toContain("lane_check:todo:todo-123:watcher-seat:");
+  });
+
   it("plans todo state and claim events from before/after rows", () => {
     const events = planTodoLedgerEvents({
       todoId: "todo-123",

--- a/api/lib/autopilot-control-ledger.ts
+++ b/api/lib/autopilot-control-ledger.ts
@@ -6,6 +6,8 @@ export const AUTOPILOT_EVENT_TYPES = [
   "lease_grant",
   "lease_refresh",
   "lease_expired",
+  "lane_check",
+  "lane_violation",
   "release",
   "build_start",
   "build_end",

--- a/supabase/migrations/20260509000000_autopilot_control_ledger.sql
+++ b/supabase/migrations/20260509000000_autopilot_control_ledger.sql
@@ -12,6 +12,8 @@ CREATE TABLE IF NOT EXISTS mc_autopilot_events (
       'lease_grant',
       'lease_refresh',
       'lease_expired',
+      'lane_check',
+      'lane_violation',
       'release',
       'build_start',
       'build_end',

--- a/supabase/migrations/20260509002000_autopilot_control_ledger_lane_events.sql
+++ b/supabase/migrations/20260509002000_autopilot_control_ledger_lane_events.sql
@@ -1,0 +1,31 @@
+-- Add lane-check event types for role-fit routing and Performance Monitor work.
+-- This only widens the existing ledger event_type check.
+
+ALTER TABLE mc_autopilot_events
+  DROP CONSTRAINT IF EXISTS mc_autopilot_events_event_type_check;
+
+ALTER TABLE mc_autopilot_events
+  ADD CONSTRAINT mc_autopilot_events_event_type_check
+  CHECK (event_type IN (
+    'claim',
+    'lease_grant',
+    'lease_refresh',
+    'lease_expired',
+    'lane_check',
+    'lane_violation',
+    'release',
+    'build_start',
+    'build_end',
+    'proof_request',
+    'proof_result',
+    'ack',
+    'blocker',
+    'merge_decision',
+    'watch_start',
+    'watch_end',
+    'dispatch',
+    'pick',
+    'todo_state_change'
+  ));
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Summary:
- Added explicit `lane_check` and `lane_violation` event types to the Autopilot control ledger.
- Added a forward migration for existing databases and kept the original create migration aligned for fresh installs.
- Covered `lane_check` row creation with a focused regression test.

Scope:
- Owned files: api/lib/autopilot-control-ledger.ts, api/autopilot-control-ledger.test.ts, supabase/migrations/20260509000000_autopilot_control_ledger.sql, supabase/migrations/20260509002000_autopilot_control_ledger_lane_events.sql
- Lane: Performance Monitor / role-fit routing audit spine
- Linked todo: 9c6c6c4b-ddbf-4dc2-a3b8-8ca9549f061b

Non-overlap:
- Does not implement lane enforcement, worker scoring, routing changes, UI, auth, secrets, billing, or destructive cleanup.
- Only widens the existing ledger event type allowlist.

Verification:
- npx vitest run api/autopilot-control-ledger.test.ts
- npm run build
- git diff --check

Risk:
- Low. This is additive ledger vocabulary plus test coverage. Existing event rows and callers keep working.

Follow-up:
- Wire lane_check and lane_violation events into claim filtering and Performance Monitor scoring.

Refs UnClick todo: 9c6c6c4b-ddbf-4dc2-a3b8-8ca9549f061b

PR status:
- Draft by default.
