### PR TITLE
Add Performance Monitor worker role card

### DIFF
--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -108,6 +108,7 @@ const WORKER_ROLES = [
   { name: "Messenger", emoji: "📣", summary: "Posts clean handoffs and status packets.", required: false },
   { name: "Watcher", emoji: "👁️", summary: "Keeps an eye on stale queues and missed signals.", required: false },
   { name: "Publisher", emoji: "🚀", summary: "Handles publish proof after work lands.", required: false },
+  { name: "Performance Monitor", emoji: "📈", summary: "Scores seat outcomes so routing picks the best fit.", required: false },
   { name: "Repairer", emoji: "🩹", summary: "Fixes small blockers found by checks.", required: false },
   { name: "Improver", emoji: "♻️", summary: "Turns repeated friction into new build work.", required: false },
 ] as const;


### PR DESCRIPTION
Summary:
- Added the Performance Monitor built-in worker role card on the Workers page.
- Keeps the role public-facing and simple: scores seat outcomes so routing can pick the best fit.

Scope:
- Owned file: src/pages/admin/AdminAgents.tsx
- Lane: Performance Monitor role visibility
- Refs UnClick todo: 9c6c6c4b-ddbf-4dc2-a3b8-8ca9549f061b

Non-overlap:
- Does not implement scoring, lane enforcement, routing behavior, secrets, auth, migrations, or background jobs.

Verification:
- npm run build
- git diff --check

Risk:
- Low. Adds one built-in role card only.

PR status:
- Draft by default.