### PR TITLE
feat(reliability): add tier-2 auto-merge queue check

### DIFF
--- a/.github/workflows/tier2-auto-merge-queue-check.yml
+++ b/.github/workflows/tier2-auto-merge-queue-check.yml
@@ -1,0 +1,26 @@
+name: Tier-2 Auto-Merge Queue Check
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+
+jobs:
+  queue-check:
+    name: Scheduled tier-2 merge no-op check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check live open PR queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TIER2_AUTOMERGE_PR_LIMIT: "30"
+        run: node scripts/tier2-auto-merge-queue-check.mjs

--- a/scripts/tier2-auto-merge-queue-check.mjs
+++ b/scripts/tier2-auto-merge-queue-check.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+function parseBoundedInt(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function compact(value, max = 160) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function normalizeMergeState(value) {
+  return String(value ?? "").trim().toUpperCase() || "UNKNOWN";
+}
+
+function prNumber(pr = {}) {
+  const parsed = Number.parseInt(String(pr.number ?? pr.pr_number ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function safePrSummary(pr = {}) {
+  return {
+    number: prNumber(pr),
+    isDraft: Boolean(pr.isDraft ?? pr.draft),
+    mergeStateStatus: normalizeMergeState(pr.mergeStateStatus ?? pr.merge_state_status),
+    url: String(pr.url || pr.html_url || "").trim(),
+    headRefName: compact(pr.headRefName || pr.head?.ref || "", 120),
+  };
+}
+
+export function evaluateTier2AutoMergeQueue({ prs = [], now = new Date().toISOString() } = {}) {
+  const openPrs = Array.isArray(prs) ? prs : [];
+  const summaries = openPrs.map(safePrSummary);
+  if (openPrs.length === 0) {
+    return {
+      ok: true,
+      action: "tier2_auto_merge_queue_check",
+      result: "idle",
+      reason: "open_pr_queue_empty",
+      now,
+      open_pr_count: 0,
+      safe_to_merge_count: 0,
+      execute: false,
+      summaries: [],
+    };
+  }
+
+  return {
+    ok: true,
+    action: "tier2_auto_merge_queue_check",
+    result: "queue_not_empty",
+    reason: "scheduled_noop_check_only",
+    now,
+    open_pr_count: openPrs.length,
+    safe_to_merge_count: 0,
+    execute: false,
+    summaries,
+  };
+}
+
+export async function runCommandJson(command, args, { cwd = process.cwd(), env = process.env } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      shell: false,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({ ok: false, exit_code: null, reason: "command_failed", output: compact(error.message, 500) });
+    });
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolve({ ok: false, exit_code: code, reason: "command_failed", output: compact(stderr || stdout, 500) });
+        return;
+      }
+      try {
+        resolve({ ok: true, value: JSON.parse(stdout || "[]") });
+      } catch {
+        resolve({ ok: false, exit_code: code, reason: "invalid_json", output: compact(stdout, 500) });
+      }
+    });
+  });
+}
+
+export async function fetchOpenPullRequests({
+  repo = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick-agent-native-endpoints",
+  limit = parseBoundedInt(process.env.TIER2_AUTOMERGE_PR_LIMIT, 30, 1, 100),
+  cwd = process.cwd(),
+  runJson = runCommandJson,
+} = {}) {
+  const result = await runJson(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--state",
+      "open",
+      "--limit",
+      String(limit),
+      "--json",
+      "number,isDraft,mergeStateStatus,url,headRefName",
+    ],
+    { cwd },
+  );
+  if (!result.ok) return result;
+  return { ok: true, prs: Array.isArray(result.value) ? result.value : [] };
+}
+
+export async function runTier2AutoMergeQueueCheck(options = {}) {
+  const fetched = await fetchOpenPullRequests(options);
+  if (!fetched.ok) {
+    return {
+      ok: false,
+      action: "tier2_auto_merge_queue_check",
+      result: "blocker",
+      reason: fetched.reason || "fetch_open_prs_failed",
+      execute: false,
+      output: fetched.output || "",
+    };
+  }
+
+  return evaluateTier2AutoMergeQueue({
+    prs: fetched.prs,
+    now: options.now || new Date().toISOString(),
+  });
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  runTier2AutoMergeQueueCheck()
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(compact(error?.message || error, 500));
+      process.exitCode = 1;
+    });
+}

--- a/scripts/tier2-auto-merge-queue-check.test.mjs
+++ b/scripts/tier2-auto-merge-queue-check.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  evaluateTier2AutoMergeQueue,
+  fetchOpenPullRequests,
+  runTier2AutoMergeQueueCheck,
+} from "./tier2-auto-merge-queue-check.mjs";
+
+describe("Tier-2 auto-merge queue check", () => {
+  it("reports a scheduled no-op when the live PR queue is empty", () => {
+    const result = evaluateTier2AutoMergeQueue({
+      prs: [],
+      now: "2026-05-09T08:45:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "idle");
+    assert.equal(result.reason, "open_pr_queue_empty");
+    assert.equal(result.open_pr_count, 0);
+    assert.equal(result.execute, false);
+  });
+
+  it("fails closed when open PRs exist because this check never merges", () => {
+    const result = evaluateTier2AutoMergeQueue({
+      prs: [
+        {
+          number: 604,
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/604",
+          headRefName: "codex/example",
+        },
+      ],
+      now: "2026-05-09T08:45:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.result, "queue_not_empty");
+    assert.equal(result.reason, "scheduled_noop_check_only");
+    assert.equal(result.open_pr_count, 1);
+    assert.equal(result.safe_to_merge_count, 0);
+    assert.equal(result.execute, false);
+    assert.deepEqual(result.summaries[0], {
+      number: 604,
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/604",
+      headRefName: "codex/example",
+    });
+  });
+
+  it("fetches open PRs with gh without printing token-bearing environment values", async () => {
+    const calls = [];
+    const result = await fetchOpenPullRequests({
+      repo: "owner/repo",
+      limit: 5,
+      runJson: async (command, args, options) => {
+        calls.push({ command, args, options });
+        return { ok: true, value: [{ number: 1, isDraft: true }] };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.prs.length, 1);
+    assert.equal(calls[0].command, "gh");
+    assert.deepEqual(calls[0].args.slice(0, 6), ["pr", "list", "--repo", "owner/repo", "--state", "open"]);
+    assert.equal(calls[0].args.includes("number,isDraft,mergeStateStatus,url,headRefName"), true);
+    assert.equal(Object.hasOwn(calls[0].options, "env"), false);
+  });
+
+  it("returns a blocker if the scheduled live fetch fails", async () => {
+    const result = await runTier2AutoMergeQueueCheck({
+      runJson: async () => ({ ok: false, reason: "command_failed", output: "gh auth missing" }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.result, "blocker");
+    assert.equal(result.reason, "command_failed");
+    assert.equal(result.execute, false);
+  });
+});


### PR DESCRIPTION
Summary:
Adds a scheduled tier-2 auto-merge queue check that proves the PR queue is observed from live GitHub state and fails closed. Empty queues report an explicit no-op. Non-empty queues report summaries and never merge.

Scope:
Reliability lane. Owned files: .github/workflows/tier2-auto-merge-queue-check.yml, scripts/tier2-auto-merge-queue-check.mjs, scripts/tier2-auto-merge-queue-check.test.mjs. Linked todo: 7bcb1746-15ee-4e61-911d-b2269bcb2235.

Non-overlap:
Does not merge PRs, lift drafts, change QueuePush routing, or touch Performance Monitor PR #604.

Verification:
node --test scripts/tier2-auto-merge-queue-check.test.mjs
node scripts/tier2-auto-merge-queue-check.mjs against live GitHub state, which reported open draft PR #604 and execute=false
git diff --check

Risk:
Low. Read-only GitHub permissions, no secrets printed, scheduled workflow is no-op only.

Follow-up:
After this lands, wait for the first scheduled run on main before claiming scheduled automation proof. A later PR can add gated merge execution.