### PR TITLE
feat(autopilot): add worker lanes foundation

### DIFF
--- a/api/lib/worker-lanes.ts
+++ b/api/lib/worker-lanes.ts
@@ -1,0 +1,104 @@
+export const WORKER_LANE_ENFORCE_MODES = ["warn", "enforce"] as const;
+
+export type WorkerLaneEnforceMode = (typeof WORKER_LANE_ENFORCE_MODES)[number];
+export type LaneClaimDecision = "allow" | "warn" | "reject";
+
+export interface WorkerLaneInput {
+  apiKeyHash: string;
+  agentId: string;
+  role: string;
+  scopeAllowlist?: unknown;
+  scopeDenylist?: unknown;
+  enforceMode?: string | null;
+}
+
+export interface WorkerLaneRow {
+  api_key_hash: string;
+  agent_id: string;
+  role: string;
+  scope_allowlist: string[];
+  scope_denylist: string[];
+  enforce_mode: WorkerLaneEnforceMode;
+}
+
+export interface LaneClaimEvaluation {
+  decision: LaneClaimDecision;
+  reason: string;
+  matched_token?: string;
+}
+
+const MAX_TOKEN_LENGTH = 80;
+
+function compact(value: unknown, max = MAX_TOKEN_LENGTH): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function normalizeToken(value: unknown): string {
+  return compact(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9:_/-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function normalizeScopeTokens(value: unknown): string[] {
+  const rawValues = Array.isArray(value) ? value : typeof value === "string" ? value.split(/[, ]+/) : [];
+  return Array.from(
+    new Set(
+      rawValues
+        .map((item) => normalizeToken(item))
+        .filter((item) => item.length > 0),
+    ),
+  );
+}
+
+export function normalizeWorkerLane(input: WorkerLaneInput): WorkerLaneRow {
+  const apiKeyHash = compact(input.apiKeyHash, 128);
+  const agentId = compact(input.agentId, 160);
+  const role = normalizeToken(input.role || "general");
+  const enforceMode = WORKER_LANE_ENFORCE_MODES.includes(input.enforceMode as WorkerLaneEnforceMode)
+    ? (input.enforceMode as WorkerLaneEnforceMode)
+    : "warn";
+
+  if (!apiKeyHash) throw new Error("api_key_hash required");
+  if (!agentId) throw new Error("agent_id required");
+  if (!role) throw new Error("role required");
+
+  return {
+    api_key_hash: apiKeyHash,
+    agent_id: agentId,
+    role,
+    scope_allowlist: normalizeScopeTokens(input.scopeAllowlist),
+    scope_denylist: normalizeScopeTokens(input.scopeDenylist),
+    enforce_mode: enforceMode,
+  };
+}
+
+export function evaluateLaneClaim(lane: WorkerLaneRow | null, todoTokens: unknown[]): LaneClaimEvaluation {
+  if (!lane) return { decision: "allow", reason: "unregistered_lane_legacy_allow" };
+
+  const tokens = normalizeScopeTokens(todoTokens);
+  const denied = tokens.find((token) => lane.scope_denylist.includes(token));
+  if (denied) {
+    return {
+      decision: lane.enforce_mode === "enforce" ? "reject" : "warn",
+      reason: "scope_denylist_match",
+      matched_token: denied,
+    };
+  }
+
+  if (lane.scope_allowlist.length === 0) {
+    return { decision: "allow", reason: "empty_allowlist_allows" };
+  }
+
+  const allowed = tokens.find((token) => lane.scope_allowlist.includes(token));
+  if (allowed) {
+    return { decision: "allow", reason: "scope_allowlist_match", matched_token: allowed };
+  }
+
+  return {
+    decision: lane.enforce_mode === "enforce" ? "reject" : "warn",
+    reason: "scope_allowlist_miss",
+  };
+}
+

--- a/api/worker-lanes.test.ts
+++ b/api/worker-lanes.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateLaneClaim,
+  normalizeScopeTokens,
+  normalizeWorkerLane,
+} from "./lib/worker-lanes";
+
+describe("worker lane helpers", () => {
+  it("normalizes scope tokens from public-safe labels", () => {
+    expect(normalizeScopeTokens(["Builder", "review ready", "PR:green", "Builder"])).toEqual([
+      "builder",
+      "review-ready",
+      "pr:green",
+    ]);
+  });
+
+  it("defaults registered lanes to warn mode", () => {
+    const lane = normalizeWorkerLane({
+      apiKeyHash: "hash_123",
+      agentId: "seat-1",
+      role: "Builder",
+      scopeAllowlist: ["build", "code"],
+    });
+
+    expect(lane).toMatchObject({
+      api_key_hash: "hash_123",
+      agent_id: "seat-1",
+      role: "builder",
+      scope_allowlist: ["build", "code"],
+      scope_denylist: [],
+      enforce_mode: "warn",
+    });
+  });
+
+  it("allows unregistered seats so legacy flows keep working", () => {
+    expect(evaluateLaneClaim(null, ["build"])).toEqual({
+      decision: "allow",
+      reason: "unregistered_lane_legacy_allow",
+    });
+  });
+
+  it("allows matching allowlist tokens", () => {
+    const lane = normalizeWorkerLane({
+      apiKeyHash: "hash_123",
+      agentId: "builder-seat",
+      role: "Builder",
+      scopeAllowlist: ["build"],
+      enforceMode: "enforce",
+    });
+
+    expect(evaluateLaneClaim(lane, ["build", "urgent"])).toEqual({
+      decision: "allow",
+      reason: "scope_allowlist_match",
+      matched_token: "build",
+    });
+  });
+
+  it("warns before enforcing allowlist misses", () => {
+    const lane = normalizeWorkerLane({
+      apiKeyHash: "hash_123",
+      agentId: "watcher-seat",
+      role: "Watcher",
+      scopeAllowlist: ["watch"],
+      enforceMode: "warn",
+    });
+
+    expect(evaluateLaneClaim(lane, ["build"])).toEqual({
+      decision: "warn",
+      reason: "scope_allowlist_miss",
+    });
+  });
+
+  it("rejects denylist matches only when enforce mode is active", () => {
+    const lane = normalizeWorkerLane({
+      apiKeyHash: "hash_123",
+      agentId: "watcher-seat",
+      role: "Watcher",
+      scopeAllowlist: ["watch"],
+      scopeDenylist: ["build"],
+      enforceMode: "enforce",
+    });
+
+    expect(evaluateLaneClaim(lane, ["build"])).toEqual({
+      decision: "reject",
+      reason: "scope_denylist_match",
+      matched_token: "build",
+    });
+  });
+});
+

--- a/supabase/migrations/20260509003000_worker_lanes.sql
+++ b/supabase/migrations/20260509003000_worker_lanes.sql
@@ -1,0 +1,37 @@
+-- Worker lanes foundation for role-fit routing.
+-- Rows are opt-in. If a seat has no row, legacy claim behavior remains valid.
+
+CREATE TABLE IF NOT EXISTS worker_lanes (
+  api_key_hash text NOT NULL,
+  agent_id text NOT NULL,
+  role text NOT NULL,
+  scope_allowlist jsonb NOT NULL DEFAULT '[]'::jsonb,
+  scope_denylist jsonb NOT NULL DEFAULT '[]'::jsonb,
+  enforce_mode text NOT NULL DEFAULT 'warn'
+    CHECK (enforce_mode IN ('warn', 'enforce')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (api_key_hash, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_worker_lanes_role
+  ON worker_lanes(api_key_hash, role);
+
+ALTER TABLE worker_lanes ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'worker_lanes'
+      AND policyname = 'worker_lanes_service_role_all'
+  ) THEN
+    CREATE POLICY "worker_lanes_service_role_all"
+      ON worker_lanes FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END$$;
+
+NOTIFY pgrst, 'reload schema';
+


### PR DESCRIPTION
Summary:
Adds the worker lanes foundation for Performance Monitor role-fit routing. This creates an opt-in worker_lanes table plus helper rules for allow, warn, and reject lane decisions.

Scope:
Performance Monitor routing foundation only. This does not enforce claim blocking yet and does not change live claim behavior. Seats with no lane row continue using legacy behavior.

Files:
- api/lib/worker-lanes.ts
- api/worker-lanes.test.ts
- supabase/migrations/20260509003000_worker_lanes.sql

Linked Job:
Refs UnClick todo: 9c6c6c4b-ddbf-4dc2-a3b8-8ca9549f061b

Verification:
- npx vitest run api/worker-lanes.test.ts api/autopilot-control-ledger.test.ts
- npm run build
- git diff --check

Cleanup:
No secrets, temp rows, leases, proof agents, or one-time schedules created.