### PR TITLE
Check worker lanes on todo claims

### DIFF
--- a/api/lib/worker-lanes.ts
+++ b/api/lib/worker-lanes.ts
@@ -27,6 +27,12 @@ export interface LaneClaimEvaluation {
   matched_token?: string;
 }
 
+export interface TodoLaneTokenInput {
+  title?: unknown;
+  priority?: unknown;
+  status?: unknown;
+}
+
 const MAX_TOKEN_LENGTH = 80;
 
 function compact(value: unknown, max = MAX_TOKEN_LENGTH): string {
@@ -100,5 +106,10 @@ export function evaluateLaneClaim(lane: WorkerLaneRow | null, todoTokens: unknow
     decision: lane.enforce_mode === "enforce" ? "reject" : "warn",
     reason: "scope_allowlist_miss",
   };
+}
+
+export function buildTodoLaneTokens(input: TodoLaneTokenInput): string[] {
+  const titleTokens = typeof input.title === "string" ? input.title.split(/[\s,]+/) : [];
+  return normalizeScopeTokens([input.priority, input.status, ...titleTokens]);
 }
 

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -127,6 +127,11 @@ import {
   recordAutopilotEvent,
   recordAutopilotEvents,
 } from "./lib/autopilot-control-ledger.js";
+import {
+  buildTodoLaneTokens,
+  evaluateLaneClaim,
+  type WorkerLaneRow,
+} from "./lib/worker-lanes.js";
 import { runRoutePacketConsumerDryRun, type VisibleWorker } from "./lib/route-packet-consumer.js";
 import { buildUnClickConnectDispatchRow } from "./lib/route-packet-dispatch.js";
 import { buildTetherRoutePacket } from "./lib/tether-route-packet.js";
@@ -7941,6 +7946,73 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             update.assigned_to_agent_id = a.length === 0 ? null : a;
           }
 
+          let laneCheck: {
+            decision: "allow" | "warn" | "reject";
+            reason: string;
+            matched_token?: string;
+          } | null = null;
+          const nextAssignee = typeof update.assigned_to_agent_id === "string" ? update.assigned_to_agent_id : null;
+          if (nextAssignee && beforeTodo) {
+            const { data: laneRow, error: laneErr } = await supabase
+              .from("worker_lanes")
+              .select("api_key_hash, agent_id, role, scope_allowlist, scope_denylist, enforce_mode")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("agent_id", nextAssignee)
+              .maybeSingle();
+            if (laneErr) throw laneErr;
+
+            const lane = laneRow as WorkerLaneRow | null;
+            const tokens = buildTodoLaneTokens({
+              title: update.title ?? beforeTodo.title,
+              priority: update.priority ?? beforeTodo.priority,
+              status: update.status ?? beforeTodo.status,
+            });
+            laneCheck = evaluateLaneClaim(lane, tokens);
+            await recordAutopilotEvents(supabase, apiKeyHash, [
+              {
+                apiKeyHash,
+                eventType: "lane_check",
+                actorAgentId: agentId,
+                refKind: "todo",
+                refId: idRes,
+                payload: {
+                  target_agent_id: nextAssignee,
+                  role: lane?.role ?? "unregistered",
+                  decision: laneCheck.decision,
+                  reason: laneCheck.reason,
+                  matched_token: laneCheck.matched_token ?? null,
+                  tokens,
+                },
+              },
+              ...(laneCheck.decision === "allow"
+                ? []
+                : [
+                    {
+                      apiKeyHash,
+                      eventType: "lane_violation",
+                      actorAgentId: agentId,
+                      refKind: "todo",
+                      refId: idRes,
+                      payload: {
+                        target_agent_id: nextAssignee,
+                        role: lane?.role ?? "unregistered",
+                        decision: laneCheck.decision,
+                        reason: laneCheck.reason,
+                        matched_token: laneCheck.matched_token ?? null,
+                      },
+                    },
+                  ]),
+            ]);
+
+            if (laneCheck.decision === "reject") {
+              return res.status(409).json({
+                error: "claim rejected by worker lane",
+                how_to_fix: "Choose a seat whose lane matches this job, or switch the lane to warn mode while tuning routing.",
+                lane_check: laneCheck,
+              });
+            }
+          }
+
           const { data, error } = await supabase
             .from("mc_fishbowl_todos")
             .update(update)
@@ -7961,7 +8033,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               after: data,
             }),
           );
-          return res.status(200).json({ todo: data });
+          return res.status(200).json({ todo: data, lane_check: laneCheck });
         }
 
         if (action === "fishbowl_complete_todo") {

--- a/api/worker-lanes.test.ts
+++ b/api/worker-lanes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildTodoLaneTokens,
   evaluateLaneClaim,
   normalizeScopeTokens,
   normalizeWorkerLane,
@@ -54,6 +55,16 @@ describe("worker lane helpers", () => {
       reason: "scope_allowlist_match",
       matched_token: "build",
     });
+  });
+
+  it("builds public-safe todo tokens for claim checks", () => {
+    expect(
+      buildTodoLaneTokens({
+        title: "Build F: Standing auto-merge bot + PR risk score",
+        priority: "urgent",
+        status: "open",
+      }),
+    ).toEqual(["urgent", "open", "build", "f:", "standing", "auto-merge", "bot", "pr", "risk", "score"]);
   });
 
   it("warns before enforcing allowlist misses", () => {


### PR DESCRIPTION
## Summary
- connect worker_lanes to fishbowl_update_todo assignment changes
- record lane_check events for claimed todos
- record lane_violation events for warn/reject lane mismatches
- reject mismatched claims only when a registered lane is in enforce mode
- keep legacy behavior for seats with no worker_lanes row

## Checks
- npx vitest run api/worker-lanes.test.ts api/autopilot-control-ledger.test.ts
- npx tsc --noEmit
- git diff --check