### PR TITLE
Make AutoPilot the engine room hub

### DIFF
--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -430,9 +430,9 @@ export default function AdminAgentsPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-heading">Workers</h1>
+        <h1 className="text-2xl font-semibold tracking-tight text-heading">Seats</h1>
         <p className="mt-1 text-sm text-body">
-          UnClick Workers are the roles. AI Seats are the connected AI capacity behind them.
+          Seats are the connected AI capacity across UnClick. Workers are the AutoPilot roles those seats can power.
         </p>
       </header>
 

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -115,25 +115,41 @@ export function AdminProjects() {
 export function AdminAutopilot() {
   return (
     <PageShell
-      kicker="Development and work assembly line"
-      title="Autopilot"
-      subtitle="Autopilot turns a request into a controlled path: research, plan, build, test, review, safety, merge, publish, repair, and improvement."
+      kicker="Engine room"
+      title="AutoPilot"
+      subtitle="AutoPilot is the controlled work hub for projects. It gives people and companies a safe bubble to plan, build, check, route, and prove work using UnClick's tools and automation."
     >
       <TileGrid
         items={[
-          { title: "Research Room", body: "Explores the idea, market, risks, options, and low-hanging fruit before work begins.", icon: Microscope },
-          { title: "Plan Room", body: "Turns research into an exact ScopePack: owned files, proof, risk, and handoff.", icon: FileText },
-          { title: "Build Room", body: "Applies tightly scoped code or content changes with ownership declared first.", icon: Hammer },
-          { title: "Test Room", body: "Runs the proof commands and records whether they passed.", icon: ClipboardCheck },
-          { title: "Review Room", body: "Checks shape, quality, clarity, and whether the change matches the request.", icon: SearchCheck },
-          { title: "Safety Room", body: "Looks for protected surfaces, stomp risk, unsafe merge state, and release blockers.", icon: ShieldCheck },
-          { title: "Merge Room", body: "Decides whether a clean, approved change can leave draft and merge.", icon: BadgeCheck },
-          { title: "Publish Room", body: "Watches deployment and publish proof after merge.", icon: Rocket },
-          { title: "Repair Room", body: "Routes failures into small repair chips instead of broad panic fixes.", icon: Wrench },
-          { title: "Improve Room", body: "Turns repeated resistance into a front-of-line improvement job.", icon: RefreshCw },
-          { title: "Wake & Retry", body: "Keeps stale jobs moving with retries, nudges, and fallback rules.", icon: BellRing, mote: "PinballWake plumbing stays internal" },
+          { title: "Boardroom", body: "Shared room for decisions, handoffs, and short updates from people and AI workers.", icon: MessagesSquare, href: "/admin/boardroom" },
+          { title: "Jobs", body: "The live work queue. Pick, assign, complete, and prove the next safe step.", icon: ListTodo, href: "/admin/jobs" },
+          { title: "XPass", body: "Proof and quality checks for work before it ships.", icon: ClipboardCheck, href: "/admin/checks" },
+          { title: "Projects", body: "Containers for company, team, client, or personal work areas.", icon: FolderKanban, href: "/admin/projects" },
+          { title: "Ledger", body: "Receipts, approvals, blockers, and recovery history for trusted work.", icon: ReceiptText, href: "/admin/ledger" },
+          { title: "Workers", body: "The roles AutoPilot can route work through: planner, builder, tester, reviewer, safety, and more.", icon: Users, href: "/admin/workers" },
         ]}
       />
+      <div className="mt-8">
+        <div className="mb-3">
+          <h2 className="text-sm font-semibold text-white">Controlled assembly line</h2>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-white/50">
+            AutoPilot stays flexible, but it keeps order by moving work through clear roles and proof.
+          </p>
+        </div>
+        <TileGrid
+          items={[
+            { title: "Research", body: "Explore the idea, risks, options, and useful shortcuts before work begins.", icon: Microscope },
+            { title: "Plan", body: "Turn intent into a small work packet with clear ownership and proof.", icon: FileText },
+            { title: "Build", body: "Make focused changes inside agreed boundaries.", icon: Hammer },
+            { title: "Test", body: "Run checks and record whether they passed.", icon: ClipboardCheck },
+            { title: "Review", body: "Check quality, clarity, and fit before work moves on.", icon: SearchCheck },
+            { title: "Safety", body: "Protect secrets, releases, permissions, and shared work.", icon: ShieldCheck },
+            { title: "Publish", body: "Watch deploys, receipts, and final proof after release.", icon: Rocket },
+            { title: "Repair", body: "Route failures into exact fixes instead of broad rewrites.", icon: Wrench },
+            { title: "Improve", body: "Turn repeated friction into a better system.", icon: RefreshCw },
+          ]}
+        />
+      </div>
     </PageShell>
   );
 }
@@ -187,7 +203,7 @@ export function AdminChecks() {
   return (
     <PageShell
       kicker="Proof and quality checks"
-      title="XPass / Checks"
+      title="XPass"
       subtitle="XPass is the check family. It proves work with receipts instead of relying on a worker saying 'done'."
     >
       <TileGrid

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -90,6 +90,40 @@ function SurfaceLink({ path, label, icon: Icon, onClick, badge }: {
   );
 }
 
+const AUTOPILOT_LINKS = [
+  { path: "/admin/boardroom", label: "Boardroom", icon: MessagesSquare },
+  { path: "/admin/jobs", label: "Jobs", icon: ListTodo },
+  { path: "/admin/checks", label: "XPass", icon: ClipboardCheck },
+  { path: "/admin/projects", label: "Projects", icon: FolderKanban },
+  { path: "/admin/ledger", label: "Ledger", icon: ReceiptText },
+  { path: "/admin/workers", label: "Workers", icon: Bot },
+] as const;
+
+function AutopilotNavGroup({ onLinkClick }: { onLinkClick?: () => void }) {
+  const location = useLocation();
+  const open = location.pathname.startsWith("/admin/autopilot") ||
+    AUTOPILOT_LINKS.some((item) => location.pathname.startsWith(item.path));
+
+  return (
+    <div className="rounded-lg border border-[#61C1C4]/15 bg-[#61C1C4]/[0.03] p-1">
+      <SurfaceLink path="/admin/autopilot" label="AutoPilot" icon={Plane} onClick={onLinkClick} />
+      {open && (
+        <div className="mt-1 space-y-0.5 border-l border-[#61C1C4]/20 pl-3">
+          {AUTOPILOT_LINKS.map((item) => (
+            <SurfaceLink
+              key={item.path}
+              path={item.path}
+              label={item.label}
+              icon={item.icon}
+              onClick={onLinkClick}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 const ADMIN_SUBMENU = [
   { path: "/admin/analytics",     label: "Analytics",             icon: BarChart3   },
   { path: "/admin/codebase",      label: "Codebase",              icon: Code2       },
@@ -204,6 +238,33 @@ function MemoryNavItem({ onClick }: { onClick?: () => void }) {
   );
 }
 
+function SidebarNav({
+  isAdmin,
+  signalsUnread,
+  onLinkClick,
+}: {
+  isAdmin: boolean;
+  signalsUnread: number;
+  onLinkClick?: () => void;
+}) {
+  return (
+    <>
+      <SurfaceLink path="/admin/dashboard" label="Dashboard"               icon={LayoutDashboard} onClick={onLinkClick} />
+      <SurfaceLink path="/admin/you"      label="You"                      icon={User}    onClick={onLinkClick} />
+      <MemoryNavItem onClick={onLinkClick} />
+      <SurfaceLink path="/admin/tools"    label="Apps"                     icon={AppWindow} onClick={onLinkClick} />
+      <SurfaceLink path="/admin/keychain" label="Passport"                 icon={KeyRound} onClick={onLinkClick} />
+      <SurfaceLink path="/admin/agents"    label="Seats"                   icon={Bot} onClick={onLinkClick} />
+      <AutopilotNavGroup onLinkClick={onLinkClick} />
+      <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />
+      {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}
+      <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />
+      <SurfaceLink path="/admin/billing"  label="Billing"                  icon={CreditCard} onClick={onLinkClick} />
+      {isAdmin && <AdminSubmenu onLinkClick={onLinkClick} />}
+    </>
+  );
+}
+
 export default function AdminShell() {
   const { user, session } = useSession();
   const navigate = useNavigate();
@@ -241,7 +302,9 @@ export default function AdminShell() {
         if (!res.ok) return;
         const body = await res.json();
         if (!cancelled) setSignalsUnread((body.signals ?? []).length);
-      } catch {}
+      } catch {
+        if (!cancelled) setSignalsUnread(0);
+      }
     }
 
     void fetchUnread();
@@ -252,30 +315,6 @@ export default function AdminShell() {
   async function handleLogout() {
     await signOut();
     navigate("/login", { replace: true });
-  }
-
-  function SidebarNav({ onLinkClick }: { onLinkClick?: () => void }) {
-    return (
-      <>
-        <SurfaceLink path="/admin/dashboard" label="Dashboard"               icon={LayoutDashboard} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/you"      label="You"                      icon={User}    onClick={onLinkClick} />
-        <MemoryNavItem onClick={onLinkClick} />
-        <SurfaceLink path="/admin/tools"    label="Apps"                     icon={AppWindow} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/keychain" label="Passport"                 icon={KeyRound} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/projects" label="Projects"                 icon={FolderKanban} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/autopilot" label="Autopilot"               icon={Plane} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/agents"    label="Workers"                 icon={Bot} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/boardroom" label="Boardroom"               icon={MessagesSquare} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/jobs"      label="Jobs"                    icon={ListTodo} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/checks"    label="XPass / Checks"          icon={ClipboardCheck} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/ledger"    label="Ledger"                  icon={ReceiptText} onClick={onLinkClick} />
-        <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />
-        {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}
-        <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />
-        <SurfaceLink path="/admin/billing"  label="Billing"                  icon={CreditCard} onClick={onLinkClick} />
-        {isAdmin && <AdminSubmenu onLinkClick={onLinkClick} />}
-      </>
-    );
   }
 
   return (
@@ -294,7 +333,7 @@ export default function AdminShell() {
         </div>
 
         <nav className="mt-4 flex flex-1 flex-col gap-1 overflow-y-auto px-3">
-          <SidebarNav />
+          <SidebarNav isAdmin={isAdmin} signalsUnread={signalsUnread} />
           <a
             href="/memory"
             className="text-white/30 hover:text-white/50 text-xs block px-3 py-2"
@@ -372,7 +411,11 @@ export default function AdminShell() {
             <AdminSearchBar />
           </div>
           <nav className="flex flex-col gap-1">
-            <SidebarNav onLinkClick={() => setMobileNavOpen(false)} />
+            <SidebarNav
+              isAdmin={isAdmin}
+              signalsUnread={signalsUnread}
+              onLinkClick={() => setMobileNavOpen(false)}
+            />
           </nav>
           <div className="mt-3 border-t border-white/[0.06] pt-3">
             <BugReportButton />

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -28,7 +28,7 @@ export default function AdminToolsPage() {
 
   useEffect(() => {
     if (!session) {
-      setLoading(false);
+      queueMicrotask(() => setLoading(false));
       return;
     }
     (async () => {
@@ -106,7 +106,7 @@ export default function AdminToolsPage() {
                 <PenSquare className="h-4 w-4 text-fuchsia-300" />
                 <h3 className="text-sm font-semibold text-white">CopyPass</h3>
                 <span className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-fuchsia-500/10 text-fuchsia-300">
-                  XPass / Checks
+                  XPass
                 </span>
               </div>
               <p className="mt-2 text-xs text-white/50">


### PR DESCRIPTION
## Summary
- make AutoPilot the sidebar hub for Boardroom, Jobs, XPass, Projects, Ledger, and Workers
- keep Seats as a root-level area because seats are platform capacity, not only AutoPilot
- update AutoPilot page copy to explain the engine-room model in public-friendly language
- rename the checks surface from 'XPass / Checks' to 'XPass'

## Checks
- npx eslint src/pages/admin/AdminShell.tsx src/pages/admin/AdminEcosystemPages.tsx src/pages/admin/AdminAgents.tsx src/pages/admin/AdminTools.tsx
- npm run build
- git diff --check