### PR TITLE
[codex] Allow actionable todo descriptions through MCP

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -721,6 +721,10 @@ const VISIBLE_TOOLS = [
       properties: {
         agent_id: { type: "string" },
         limit: { type: "number", minimum: 1, maximum: 50, default: 10 },
+        include_description: {
+          type: "boolean",
+          description: "Include compact job descriptions so runners can keep the source brief while routing.",
+        },
       },
       required: ["agent_id"],
     },


### PR DESCRIPTION
## Summary
- adds include_description to the list_actionable_todos MCP schema
- keeps the autonomous runner request accepted by the MCP doorway after PR #611

## Why
PR #611 taught the runner to request job descriptions, but the MCP schema still only listed agent_id and limit. This keeps the connector contract aligned so scheduled runners can ask for source briefs without schema friction.

## Checks
- npm run build --workspace=packages/mcp-server
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run build