### PR TITLE
fix(reliability): import description scopepacks for autonomous runner

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -154,6 +154,35 @@ function firstPresentObject(...values) {
   return null;
 }
 
+function parseLabeledJsonObjectFromText(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+
+  const label = String.raw`(?:scope[_ -]?pack|scopepack|runner[_ -]?scope|autonomous[_ -]?scope|coding[_ -]?room[_ -]?scope)`;
+  const fencedPatterns = [
+    new RegExp(String.raw`(?:^|\n)\s*${label}\s*:?\s*\r?\n\s*` + "```(?:json)?\\s*([\\s\\S]*?)```", "gi"),
+    new RegExp(String.raw`(?:^|\n)\s*${label}\s*:\s*` + "```(?:json)?\\s*([\\s\\S]*?)```", "gi"),
+    /<scope_pack>\s*([\s\S]*?)\s*<\/scope_pack>/gi,
+  ];
+
+  for (const pattern of fencedPatterns) {
+    let match;
+    while ((match = pattern.exec(text))) {
+      const parsed = parseJsonObject(match[1]);
+      if (parsed) return parsed;
+    }
+  }
+
+  const inlinePattern = new RegExp(String.raw`(?:^|\n)\s*${label}\s*:\s*(\{[^\r\n]*\})`, "gi");
+  let match;
+  while ((match = inlinePattern.exec(text))) {
+    const parsed = parseJsonObject(match[1]);
+    if (parsed) return parsed;
+  }
+
+  return null;
+}
+
 function listFromUnknown(value) {
   if (Array.isArray(value)) {
     return value.map((item) => normalizePath(item)).filter(Boolean);
@@ -177,6 +206,9 @@ function extractBoardroomTodoScopePack(todo = {}) {
     todo.autonomousScope,
     todo.coding_room_scope,
     todo.codingRoomScope,
+    parseLabeledJsonObjectFromText(todo.description),
+    parseLabeledJsonObjectFromText(todo.body),
+    parseLabeledJsonObjectFromText(todo.notes),
   );
 
   if (!scope) {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -161,6 +161,77 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("imports a ScopePack embedded in an UnClick todo description", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const scopePack = {
+        owned_files: ["docs/autonomous-runner-scopepack.md"],
+        patch: "diff --git a/docs/autonomous-runner-scopepack.md b/docs/autonomous-runner-scopepack.md\n--- a/docs/autonomous-runner-scopepack.md\n+++ b/docs/autonomous-runner-scopepack.md\n@@ -1 +1 @@\n-old\n+new\n",
+        tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+      };
+
+      const fetchImpl = async () => ({
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    todos: [
+                      {
+                        id: "todo-description-scopepack",
+                        title: "Document autonomous runner ScopePack parsing",
+                        status: "open",
+                        priority: "high",
+                        assigned_to_agent_id: null,
+                        description: [
+                          "Small safe implementation chip.",
+                          "ScopePack:",
+                          "```json",
+                          JSON.stringify(scopePack, null, 2),
+                          "```",
+                        ].join("\n"),
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          };
+        },
+      });
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-09T10:30:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.persisted, false);
+      assert.equal(result.queue_source.imported, 1);
+      assert.deepEqual(result.ledger.jobs[0].owned_files, ["docs/autonomous-runner-scopepack.md"]);
+      assert.match(result.ledger.jobs[0].build.patch, /docs\/autonomous-runner-scopepack\.md/);
+      assert.deepEqual(result.ledger.jobs[0].expected_proof.tests, [
+        "node --test scripts/pinballwake-autonomous-runner.test.mjs",
+      ]);
+      assert.match(result.ledger.jobs[0].context, /scopepack=present/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not pretend the queue is empty when UnClick queue auth is missing", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");


### PR DESCRIPTION
Summary:
Autonomous Runner now recognizes labeled JSON ScopePack blocks embedded in UnClick todo descriptions, body, or notes, so todos surfaced through include_description can carry owned files, patch text, and focused tests without relying only on structured scope_pack fields. Added a focused import test for a description-embedded ScopePack.

Scope:
Owned files: scripts/pinballwake-autonomous-runner.mjs, scripts/pinballwake-autonomous-runner.test.mjs. Product lane: reliability / autonomous runner ScopePack ingestion.

Non-overlap:
Did not change MCP schemas, schedulers, GitHub workflows, claim sync, protected-surface rules, secrets, or live UnClick data.

Verification:
node --test scripts/pinballwake-autonomous-runner.test.mjs

git diff --check

Risk:
Low. Parsing is limited to explicitly labeled ScopePack JSON blocks or scope_pack tags, and existing safety gates still require owned files, patch text, tests when present, and protected-surface checks before claim.

Follow-up:
Populate ScopePack blocks on the stale urgent UnClick jobs, then rerun PinballWake dry-run to prove they become claimable.

Linked todo:
07939e9a-f139-47bc-8691-90ed8b16cddb

Draft status:
Draft PR for checks and review.