### PR TITLE
Reopen stale unscoped jobs for scoping

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -359,6 +359,12 @@ export function extractBoardroomTodoIdFromCodingRoomJob(job = {}) {
   return todoId && todoId !== "unknown" ? todoId : "";
 }
 
+const BOARDROOM_SCOPING_ACTION_REASONS = new Set([
+  "stale_in_progress",
+  "stale_assigned_open",
+  "role_assigned_open",
+]);
+
 function boardroomClaimAgentId(runner = {}) {
   const safeRunner = createAutonomousRunner(runner);
   return safeRunner.agent_id || safeRunner.id || DEFAULT_AUTONOMOUS_RUNNER.id;
@@ -442,6 +448,93 @@ export async function syncClaimedBoardroomTodoToUnClick({
     status: "in_progress",
     comment_ok: true,
     comment_id: comment.data?.comment?.id || null,
+  };
+}
+
+export function selectBoardroomTodoForScoping({ queueSourceResult = {}, lastResult = {} } = {}) {
+  if (queueSourceResult.source !== "unclick" || lastResult.action !== "idle") {
+    return null;
+  }
+
+  const missingScopepackIds = new Set(
+    (lastResult.skipped || [])
+      .filter((skip) => skip?.reason === "boardroom_todo_missing_scopepack")
+      .map((skip) => String(skip.job_id || "").replace(/^boardroom-todo:/, "").trim())
+      .filter(Boolean),
+  );
+  if (missingScopepackIds.size === 0) return null;
+
+  return (queueSourceResult.todos || []).find((todo) => (
+    missingScopepackIds.has(String(todo.id || "").trim()) &&
+    BOARDROOM_SCOPING_ACTION_REASONS.has(String(todo.actionability_reason || "").trim())
+  )) || null;
+}
+
+export async function syncBoardroomTodoScopingRequestToUnClick({
+  todo,
+  runner = DEFAULT_AUTONOMOUS_RUNNER,
+  mcpUrl = DEFAULT_UNCLICK_MCP_URL,
+  apiKey = "",
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const todoId = String(todo?.id || "").trim();
+  if (!todoId) {
+    return { ok: true, skipped: true, reason: "missing_todo_id" };
+  }
+
+  const agentId = boardroomClaimAgentId(runner);
+  const update = await callUnClickMcpTool({
+    mcpUrl,
+    apiKey,
+    fetchImpl,
+    toolName: "update_todo",
+    arguments: {
+      agent_id: agentId,
+      todo_id: todoId,
+      status: "open",
+      assigned_to_agent_id: "",
+    },
+  });
+
+  if (!update.ok) {
+    return {
+      ok: false,
+      reason: "scope_request_update_failed",
+      todo_id: todoId,
+      detail: update.reason || update.error || null,
+      status: update.status ?? null,
+    };
+  }
+
+  const comment = await callUnClickMcpTool({
+    mcpUrl,
+    apiKey,
+    fetchImpl,
+    toolName: "comment_on",
+    arguments: {
+      agent_id: agentId,
+      target_kind: "todo",
+      target_id: todoId,
+      text: compact(
+        [
+          "Autonomous Runner could not safely build this job yet because no ScopePack was attached.",
+          "Reopened for scoping instead of holding a stale active claim.",
+          "Next: attach exact owned files, proof/tests, and stop conditions, or split this into a smaller job.",
+          `reason=${todo.actionability_reason || "missing_scopepack"}.`,
+        ].join(" "),
+        700,
+      ),
+    },
+  });
+
+  return {
+    ok: true,
+    todo_id: todoId,
+    status: "open",
+    assigned_to_agent_id: null,
+    comment_ok: comment.ok,
+    comment_id: comment.ok ? comment.data?.comment?.id || null : null,
+    comment_detail: comment.ok ? null : comment.reason || comment.error || null,
   };
 }
 
@@ -541,6 +634,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
       priority: todo.priority || null,
       status: todo.status || null,
       assigned_to_agent_id: todo.assigned_to_agent_id || null,
+      actionability_reason: todo.actionability_reason || null,
     })),
   };
 }
@@ -815,6 +909,7 @@ export async function runAutonomousRunnerFile({
   const shouldPersist = safeMode !== "dry-run" && !safePolicy.disabled && !executeBlocked;
   const last = results[results.length - 1] || { ok: true, action: "idle", reason: "no_cycle_run", ledger };
   let todoClaimSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
+  let todoScopingSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
 
   if (
     shouldPersist &&
@@ -848,14 +943,44 @@ export async function runAutonomousRunnerFile({
     }
   }
 
+  const todoForScoping = selectBoardroomTodoForScoping({ queueSourceResult, lastResult: last });
+  if (shouldPersist && todoForScoping) {
+    todoScopingSync = await syncBoardroomTodoScopingRequestToUnClick({
+      todo: todoForScoping,
+      runner,
+      apiKey: unclickApiKey,
+      mcpUrl: unclickMcpUrl,
+      fetchImpl,
+    });
+
+    if (!todoScopingSync.ok) {
+      return {
+        ...last,
+        ok: false,
+        action: "blocked",
+        reason: "todo_scoping_sync_failed",
+        mode: safeMode,
+        dry_run: safeMode === "dry-run",
+        persisted: false,
+        cycles: results,
+        ledger,
+        ledger_path: ledgerPath,
+        queue_source: queueSourceResult,
+        todo_claim_sync: todoClaimSync,
+        todo_scoping_sync: todoScopingSync,
+      };
+    }
+  }
+
   if (shouldPersist) {
     await writeCodingRoomJobLedger(ledgerPath, ledger);
   }
 
   return {
     ...last,
-    ok: results.every((result) => result.ok) && todoClaimSync.ok,
-    action: last.action,
+    ok: results.every((result) => result.ok) && todoClaimSync.ok && todoScopingSync.ok,
+    action: todoForScoping && shouldPersist ? "scoping_requested" : last.action,
+    reason: todoForScoping && shouldPersist ? "boardroom_todo_reopened_for_scoping" : last.reason,
     mode: safeMode,
     dry_run: safeMode === "dry-run",
     persisted: shouldPersist,
@@ -864,6 +989,7 @@ export async function runAutonomousRunnerFile({
     ledger_path: ledgerPath,
     queue_source: queueSourceResult,
     todo_claim_sync: todoClaimSync,
+    todo_scoping_sync: todoScopingSync,
   };
 }
 

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -390,6 +390,127 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("reopens stale unscoped UnClick todos for scoping instead of idling forever", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const calls = [];
+      const fetchImpl = async (url, init = {}) => {
+        calls.push({ url, init, body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-stale-1",
+                            title: "Stale vague build job",
+                            status: "in_progress",
+                            priority: "urgent",
+                            assigned_to_agent_id: "old-worker",
+                            actionability_reason: "stale_in_progress",
+                            created_at: "2026-05-08T05:00:00.000Z",
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "update_todo") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todo: {
+                          id: "todo-stale-1",
+                          status: "open",
+                          assigned_to_agent_id: null,
+                        },
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "comment_on") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({ comment: { id: "comment-scope-1" } }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-08T05:30:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "scoping_requested");
+      assert.equal(result.reason, "boardroom_todo_reopened_for_scoping");
+      assert.deepEqual(calls.map((call) => call.body.params.name), [
+        "list_actionable_todos",
+        "update_todo",
+        "comment_on",
+      ]);
+      assert.deepEqual(calls[1].body.params.arguments, {
+        agent_id: "runner-plex-1",
+        todo_id: "todo-stale-1",
+        status: "open",
+        assigned_to_agent_id: "",
+      });
+      assert.match(calls[2].body.params.arguments.text, /Reopened for scoping/);
+      assert.equal(result.todo_scoping_sync.ok, true);
+      assert.equal(result.todo_scoping_sync.todo_id, "todo-stale-1");
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs[0].status, "queued");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("blocks and avoids persisting when UnClick todo claim sync fails", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");


### PR DESCRIPTION
## Summary
- when the autonomous runner finds stale UnClick Jobs with no safe ScopePack, reopen them for scoping instead of idling forever
- leave a Boardroom todo comment explaining the next safe action
- keep dry-run behavior non-mutating and add focused runner coverage

## Tests
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run build