### PR TITLE
feat(reliability): score tier-2 PR queue risk

### DIFF
--- a/scripts/tier2-auto-merge-queue-check.mjs
+++ b/scripts/tier2-auto-merge-queue-check.mjs
@@ -17,18 +17,78 @@ function normalizeMergeState(value) {
   return String(value ?? "").trim().toUpperCase() || "UNKNOWN";
 }
 
+function boundedNumber(value, fallback = 0) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, parsed);
+}
+
 function prNumber(pr = {}) {
   const parsed = Number.parseInt(String(pr.number ?? pr.pr_number ?? ""), 10);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+export function scoreTier2PullRequestRisk(pr = {}) {
+  const reasons = [];
+  let score = 0;
+  const mergeState = normalizeMergeState(pr.mergeStateStatus ?? pr.merge_state_status);
+  const changedFiles = boundedNumber(pr.changedFiles ?? pr.changed_files);
+  const changedLines = boundedNumber(pr.additions) + boundedNumber(pr.deletions);
+  const headRefName = String(pr.headRefName || pr.head?.ref || "").trim();
+
+  if (Boolean(pr.isDraft ?? pr.draft)) {
+    score += 35;
+    reasons.push("draft");
+  }
+
+  if (mergeState !== "CLEAN") {
+    score += 30;
+    reasons.push(`merge_state_${mergeState.toLowerCase()}`);
+  }
+
+  if (changedFiles > 30) {
+    score += 25;
+    reasons.push("many_files");
+  } else if (changedFiles > 12) {
+    score += 15;
+    reasons.push("several_files");
+  }
+
+  if (changedLines > 2000) {
+    score += 25;
+    reasons.push("large_diff");
+  } else if (changedLines > 500) {
+    score += 15;
+    reasons.push("medium_diff");
+  }
+
+  if (/\b(auth|billing|payment|stripe|secret|credential|migration|schema|rls|tenant)\b/i.test(headRefName)) {
+    score += 25;
+    reasons.push("sensitive_branch_name");
+  }
+
+  const boundedScore = Math.min(100, score);
+  return {
+    score: boundedScore,
+    level: boundedScore >= 60 ? "high" : boundedScore >= 30 ? "medium" : "low",
+    reasons,
+  };
+}
+
 function safePrSummary(pr = {}) {
+  const risk = scoreTier2PullRequestRisk(pr);
   return {
     number: prNumber(pr),
     isDraft: Boolean(pr.isDraft ?? pr.draft),
     mergeStateStatus: normalizeMergeState(pr.mergeStateStatus ?? pr.merge_state_status),
     url: String(pr.url || pr.html_url || "").trim(),
     headRefName: compact(pr.headRefName || pr.head?.ref || "", 120),
+    changedFiles: boundedNumber(pr.changedFiles ?? pr.changed_files),
+    additions: boundedNumber(pr.additions),
+    deletions: boundedNumber(pr.deletions),
+    risk_score: risk.score,
+    risk_level: risk.level,
+    risk_reasons: risk.reasons,
   };
 }
 
@@ -45,9 +105,14 @@ export function evaluateTier2AutoMergeQueue({ prs = [], now = new Date().toISOSt
       open_pr_count: 0,
       safe_to_merge_count: 0,
       execute: false,
+      low_risk_count: 0,
       summaries: [],
     };
   }
+
+  const lowRiskCount = summaries.filter((summary) =>
+    !summary.isDraft && summary.mergeStateStatus === "CLEAN" && summary.risk_level === "low",
+  ).length;
 
   return {
     ok: true,
@@ -58,6 +123,7 @@ export function evaluateTier2AutoMergeQueue({ prs = [], now = new Date().toISOSt
     open_pr_count: openPrs.length,
     safe_to_merge_count: 0,
     execute: false,
+    low_risk_count: lowRiskCount,
     summaries,
   };
 }
@@ -113,7 +179,7 @@ export async function fetchOpenPullRequests({
       "--limit",
       String(limit),
       "--json",
-      "number,isDraft,mergeStateStatus,url,headRefName",
+      "number,isDraft,mergeStateStatus,url,headRefName,changedFiles,additions,deletions",
     ],
     { cwd },
   );

--- a/scripts/tier2-auto-merge-queue-check.test.mjs
+++ b/scripts/tier2-auto-merge-queue-check.test.mjs
@@ -5,6 +5,7 @@ import {
   evaluateTier2AutoMergeQueue,
   fetchOpenPullRequests,
   runTier2AutoMergeQueueCheck,
+  scoreTier2PullRequestRisk,
 } from "./tier2-auto-merge-queue-check.mjs";
 
 describe("Tier-2 auto-merge queue check", () => {
@@ -18,6 +19,7 @@ describe("Tier-2 auto-merge queue check", () => {
     assert.equal(result.result, "idle");
     assert.equal(result.reason, "open_pr_queue_empty");
     assert.equal(result.open_pr_count, 0);
+    assert.equal(result.low_risk_count, 0);
     assert.equal(result.execute, false);
   });
 
@@ -30,6 +32,9 @@ describe("Tier-2 auto-merge queue check", () => {
           mergeStateStatus: "CLEAN",
           url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/604",
           headRefName: "codex/example",
+          changedFiles: 2,
+          additions: 80,
+          deletions: 20,
         },
       ],
       now: "2026-05-09T08:45:00.000Z",
@@ -40,6 +45,7 @@ describe("Tier-2 auto-merge queue check", () => {
     assert.equal(result.reason, "scheduled_noop_check_only");
     assert.equal(result.open_pr_count, 1);
     assert.equal(result.safe_to_merge_count, 0);
+    assert.equal(result.low_risk_count, 1);
     assert.equal(result.execute, false);
     assert.deepEqual(result.summaries[0], {
       number: 604,
@@ -47,7 +53,43 @@ describe("Tier-2 auto-merge queue check", () => {
       mergeStateStatus: "CLEAN",
       url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/604",
       headRefName: "codex/example",
+      changedFiles: 2,
+      additions: 80,
+      deletions: 20,
+      risk_score: 0,
+      risk_level: "low",
+      risk_reasons: [],
     });
+  });
+
+  it("adds a conservative PR risk score to queue summaries", () => {
+    const low = scoreTier2PullRequestRisk({
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      changedFiles: 2,
+      additions: 80,
+      deletions: 20,
+      headRefName: "codex/docs-chip",
+    });
+    const high = scoreTier2PullRequestRisk({
+      isDraft: true,
+      mergeStateStatus: "DIRTY",
+      changedFiles: 35,
+      additions: 1500,
+      deletions: 750,
+      headRefName: "codex/auth-migration",
+    });
+
+    assert.deepEqual(low, { score: 0, level: "low", reasons: [] });
+    assert.equal(high.level, "high");
+    assert.equal(high.score, 100);
+    assert.deepEqual(high.reasons, [
+      "draft",
+      "merge_state_dirty",
+      "many_files",
+      "large_diff",
+      "sensitive_branch_name",
+    ]);
   });
 
   it("fetches open PRs with gh without printing token-bearing environment values", async () => {
@@ -65,7 +107,7 @@ describe("Tier-2 auto-merge queue check", () => {
     assert.equal(result.prs.length, 1);
     assert.equal(calls[0].command, "gh");
     assert.deepEqual(calls[0].args.slice(0, 6), ["pr", "list", "--repo", "owner/repo", "--state", "open"]);
-    assert.equal(calls[0].args.includes("number,isDraft,mergeStateStatus,url,headRefName"), true);
+    assert.equal(calls[0].args.includes("number,isDraft,mergeStateStatus,url,headRefName,changedFiles,additions,deletions"), true);
     assert.equal(Object.hasOwn(calls[0].options, "env"), false);
   });
 


### PR DESCRIPTION
Summary:
Adds conservative PR risk metadata to the read-only Tier-2 Auto-Merge Queue Check. Queue summaries now include changed-file counts, line counts, risk score, risk level, and risk reasons, plus an informational low_risk_count. The workflow still never merges and keeps execute=false.

Scope:
Owned files: scripts/tier2-auto-merge-queue-check.mjs, scripts/tier2-auto-merge-queue-check.test.mjs. Product lane: reliability / tier-2 auto-merge queue risk scoring.

Non-overlap:
Did not enable merging, change workflow permissions, change cron, touch secrets, edit production data, or alter protected-surface gates.

Verification:
node --test scripts/tier2-auto-merge-queue-check.test.mjs
node scripts/tier2-auto-merge-queue-check.mjs

git diff --check

Risk:
Low. This is read-only metadata on an existing no-op scheduled checker. It expands gh PR fields but does not print credentials or execute merges.

Follow-up:
After merge, wait for the scheduled Tier-2 Auto-Merge Queue Check to prove the new risk fields from production GitHub state.

Linked todo:
46153e1d-e989-460d-a83f-ed4d80b14956

Draft status:
Draft PR for checks and review.