### PR TITLE
Add static shell landmark for UXPass

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,12 @@
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main>
+        <h1>UnClick</h1>
+        <p>Loading UnClick.</p>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a tiny non-JS fallback inside the React root with a main landmark and h1
- keeps UXPass and agent-readability checks from seeing an empty shell before React paints

## Proof
- npm run build
- npx vitest run src/__tests__/passport-core-connectors.test.ts src/__tests__/admin-keychain-last-check-display.test.ts src/pages/admin/tools/ConnectedServices.test.ts

## Why
- UXPass on https://unclick.world/connect/github scored 89.19 after PR #616, with only two misses: no static h1 and no static landmark in the initial HTML response.