### PR TITLE
Use main landmark on connect pages

### DIFF
--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -528,7 +528,7 @@ function ConnectShell({
   };
 
   return (
-    <div className="min-h-screen bg-[#0A0A0A] flex items-start justify-center pt-16 pb-24 px-4">
+    <main className="min-h-screen bg-[#0A0A0A] flex items-start justify-center pt-16 pb-24 px-4">
       <div className="w-full max-w-md space-y-6">
         {/* Header */}
         <div className="text-center space-y-3">
@@ -572,6 +572,6 @@ function ConnectShell({
           Credentials are encrypted with AES-256-GCM using your API key before storage.
         </p>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- render Passport connect pages inside a real main landmark after React loads
- keeps the existing h1 and static shell fallback from PR #618 aligned with the live app DOM

## Proof
- npm run build
- npx vitest run src/__tests__/passport-core-connectors.test.ts src/__tests__/admin-keychain-last-check-display.test.ts src/pages/admin/tools/ConnectedServices.test.ts
- local Playwright smoke confirms /connect/github, /connect/vercel, and /connect/supabase have h1 and main after app render