### PR TITLE
Add header landmark to connect shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,9 @@
   <body>
     <div id="root">
       <main>
-        <h1>UnClick</h1>
+        <header>
+          <h1>UnClick</h1>
+        </header>
         <p>Loading UnClick.</p>
       </main>
     </div>

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -531,7 +531,7 @@ function ConnectShell({
     <main className="min-h-screen bg-[#0A0A0A] flex items-start justify-center pt-16 pb-24 px-4">
       <div className="w-full max-w-md space-y-6">
         {/* Header */}
-        <div className="text-center space-y-3">
+        <header className="text-center space-y-3">
           <Link
             to="/"
             className="inline-flex items-center gap-1.5 text-xs text-[#E8E8E8]/40 hover:text-[#E8E8E8]/70"
@@ -561,7 +561,7 @@ function ConnectShell({
           >
             {authLabel[connector.authType] ?? connector.authType}
           </Badge>
-        </div>
+        </header>
 
         {/* Card */}
         <div className="bg-white/[0.03] border border-white/10 rounded-xl p-6">


### PR DESCRIPTION
## Summary
- add a header landmark to the static shell fallback
- wrap the live Passport connect page header in a header element
- intended to clear the last UXPass agent-readability landmark finding after PR #619

## Proof
- npm run build
- npx vitest run src/__tests__/passport-core-connectors.test.ts src/__tests__/admin-keychain-last-check-display.test.ts src/pages/admin/tools/ConnectedServices.test.ts
- local Playwright smoke confirms /connect/github, /connect/vercel, and /connect/supabase render h1, main, and header