### PR TITLE
feat(memory): add orchestrator context layer

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -1,0 +1,555 @@
+export interface OrchestratorProfileRow {
+  agent_id: string;
+  emoji?: string | null;
+  display_name?: string | null;
+  user_agent_hint?: string | null;
+  created_at?: string | null;
+  last_seen_at?: string | null;
+  current_status?: string | null;
+  current_status_updated_at?: string | null;
+  next_checkin_at?: string | null;
+}
+
+export interface OrchestratorMessageRow {
+  id: string;
+  author_emoji?: string | null;
+  author_name?: string | null;
+  author_agent_id?: string | null;
+  recipients?: string[] | null;
+  text: string;
+  tags?: string[] | null;
+  thread_id?: string | null;
+  created_at: string;
+}
+
+export interface OrchestratorTodoRow {
+  id: string;
+  title: string;
+  description?: string | null;
+  status: "open" | "in_progress" | "done" | "dropped" | string;
+  priority: "low" | "normal" | "high" | "urgent" | string;
+  created_by_agent_id: string;
+  assigned_to_agent_id?: string | null;
+  source_idea_id?: string | null;
+  created_at: string;
+  updated_at?: string | null;
+  completed_at?: string | null;
+}
+
+export interface OrchestratorCommentRow {
+  id: string;
+  target_kind: "todo" | "idea" | string;
+  target_id: string;
+  author_agent_id: string;
+  text: string;
+  created_at: string;
+}
+
+export interface OrchestratorDispatchRow {
+  dispatch_id: string;
+  source: string;
+  target_agent_id: string;
+  task_ref?: string | null;
+  status: string;
+  lease_owner?: string | null;
+  lease_expires_at?: string | null;
+  last_real_action_at?: string | null;
+  payload?: Record<string, unknown> | null;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface OrchestratorSignalRow {
+  id: string;
+  tool: string;
+  action: string;
+  severity: string;
+  summary: string;
+  deep_link?: string | null;
+  payload?: Record<string, unknown> | null;
+  created_at: string;
+  read_at?: string | null;
+}
+
+export interface OrchestratorSessionRow {
+  id?: string;
+  session_id: string;
+  platform?: string | null;
+  summary: string;
+  decisions?: unknown;
+  open_loops?: unknown;
+  topics?: string[] | null;
+  created_at: string;
+}
+
+export interface OrchestratorLibraryRow {
+  slug: string;
+  title: string;
+  category: string;
+  tags?: string[] | null;
+  version?: number | null;
+  updated_at?: string | null;
+  created_at?: string | null;
+}
+
+export interface OrchestratorBusinessContextRow {
+  id: string;
+  category: string;
+  key: string;
+  value: unknown;
+  priority?: number | null;
+  updated_at?: string | null;
+}
+
+export interface OrchestratorConversationTurnRow {
+  id: string;
+  session_id: string;
+  role: "user" | "assistant" | "system" | "tool" | string;
+  content: string;
+  created_at: string;
+}
+
+export interface BuildOrchestratorContextInput {
+  generatedAt: string;
+  profiles: OrchestratorProfileRow[];
+  messages: OrchestratorMessageRow[];
+  todos: OrchestratorTodoRow[];
+  comments: OrchestratorCommentRow[];
+  dispatches: OrchestratorDispatchRow[];
+  signals: OrchestratorSignalRow[];
+  sessions: OrchestratorSessionRow[];
+  library: OrchestratorLibraryRow[];
+  businessContext: OrchestratorBusinessContextRow[];
+  conversationTurns: OrchestratorConversationTurnRow[];
+}
+
+export interface OrchestratorSourceLink {
+  source_kind:
+    | "boardroom_message"
+    | "todo"
+    | "todo_comment"
+    | "dispatch"
+    | "signal"
+    | "session_summary"
+    | "library"
+    | "business_context"
+    | "conversation_turn";
+  source_id: string;
+  deep_link?: string | null;
+  created_at?: string | null;
+}
+
+export interface OrchestratorContinuityEvent extends OrchestratorSourceLink {
+  kind: "handoff" | "claim" | "proof" | "blocker" | "ack" | "decision" | "status" | "context";
+  actor_agent_id?: string | null;
+  role?: string | null;
+  summary: string;
+  tags?: string[];
+}
+
+export interface OrchestratorProfileCard {
+  agent_id: string;
+  label: string;
+  role: "human" | "ai-seat";
+  emoji?: string | null;
+  device_hint?: string | null;
+  last_seen_at?: string | null;
+  current_status?: string | null;
+  next_checkin_at?: string | null;
+}
+
+export interface OrchestratorLibrarySnapshot extends OrchestratorSourceLink {
+  title: string;
+  category: string;
+  summary?: string;
+  tags?: string[];
+  version?: number | null;
+  updated_at?: string | null;
+}
+
+export interface OrchestratorContext {
+  version: "orchestrator-context-v1";
+  generated_at: string;
+  policy: {
+    mode: "read-only";
+    compaction: string;
+    raw_access: string;
+    redaction: string;
+  };
+  current_state_card: {
+    summary: string;
+    newest_activity_at: string | null;
+    newest_checkin_at: string | null;
+    active_todo_count: number;
+    blocker_count: number;
+    active_seat_count: number;
+    live_sources: {
+      profiles: number;
+      boardroom_messages: number;
+      todos: number;
+      comments: number;
+      dispatches: number;
+      signals: number;
+      sessions: number;
+      library: number;
+      business_context: number;
+      conversation_turns: number;
+    };
+    next_actions: string[];
+    blockers: string[];
+  };
+  profile_cards: OrchestratorProfileCard[];
+  continuity_events: OrchestratorContinuityEvent[];
+  library_snapshots: OrchestratorLibrarySnapshot[];
+}
+
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000;
+const PRIORITY_RANK: Record<string, number> = {
+  urgent: 4,
+  high: 3,
+  normal: 2,
+  low: 1,
+};
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\b(authorization\s*:\s*bearer)\s+[a-z0-9._~+/=-]+/gi, "$1 [redacted secret]"],
+  [/\b(bearer)\s+[a-z0-9._~+/=-]+/gi, "$1 [redacted secret]"],
+  [/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passwd|private[_-]?key)\s*[:=]\s*["']?[^"'\s,;]+/gi, "$1=[redacted secret]"],
+  [/\b(sk-[a-z0-9_-]{8,}|ghp_[a-z0-9_]{8,}|github_pat_[a-z0-9_]{8,}|xox[baprs]-[a-z0-9-]{8,})\b/gi, "[redacted secret]"],
+  [/\b(uc|agt)_[a-z0-9_-]{8,}\b/gi, "[redacted secret]"],
+  [/\b(?:\d[ -]*?){13,19}\b/g, "[redacted billing data]"],
+];
+
+export function redactSensitive(input: unknown): string {
+  if (input == null) return "";
+  let text = typeof input === "string" ? input : safeJson(input);
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    text = text.replace(pattern, replacement);
+  }
+  return text;
+}
+
+export function compactText(input: unknown, maxChars = 220): string {
+  const clean = redactSensitive(input).replace(/\s+/g, " ").trim();
+  if (clean.length <= maxChars) return clean;
+  return `${clean.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+export function buildOrchestratorContext(input: BuildOrchestratorContextInput): OrchestratorContext {
+  const nowMs = Date.parse(input.generatedAt);
+  const profiles = input.profiles
+    .map((profile) => buildProfileCard(profile))
+    .sort((a, b) => compareIsoDesc(a.last_seen_at, b.last_seen_at));
+  const activeSeatCount = profiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
+
+  const activeTodos = input.todos
+    .filter((todo) => todo.status === "open" || todo.status === "in_progress")
+    .sort(compareTodoPriorityThenUpdated)
+    .slice(0, 8);
+
+  const messageEvents = input.messages.map(messageToEvent);
+  const todoEvents = activeTodos.map(todoToEvent);
+  const commentEvents = input.comments.map(commentToEvent);
+  const dispatchEvents = input.dispatches.map(dispatchToEvent);
+  const signalEvents = input.signals.map(signalToEvent);
+  const conversationEvents = input.conversationTurns.map(conversationTurnToEvent);
+  const sessionEvents = input.sessions.map(sessionToEvent);
+
+  const continuityEvents = [
+    ...messageEvents,
+    ...todoEvents,
+    ...commentEvents,
+    ...dispatchEvents,
+    ...signalEvents,
+    ...conversationEvents,
+    ...sessionEvents,
+  ]
+    .filter((event) => event.summary.length > 0)
+    .sort((a, b) => compareIsoDesc(a.created_at, b.created_at))
+    .slice(0, 36);
+
+  const blockers = continuityEvents
+    .filter((event) => event.kind === "blocker")
+    .map((event) => event.summary)
+    .slice(0, 5);
+
+  const nextActions = activeTodos
+    .map((todo) => {
+      const owner = todo.assigned_to_agent_id ? ` -> ${todo.assigned_to_agent_id}` : "";
+      return compactText(`${todo.priority} ${todo.status}${owner}: ${todo.title}`, 160);
+    })
+    .slice(0, 6);
+
+  const librarySnapshots = [
+    ...input.library.map(libraryToSnapshot),
+    ...input.businessContext.map(businessContextToSnapshot),
+    ...input.sessions.map(sessionToSnapshot),
+  ]
+    .sort((a, b) => compareIsoDesc(a.updated_at ?? a.created_at, b.updated_at ?? b.created_at))
+    .slice(0, 24);
+
+  const newestActivityAt = newestIso([
+    ...input.messages.map((row) => row.created_at),
+    ...input.todos.map((row) => row.updated_at ?? row.created_at),
+    ...input.comments.map((row) => row.created_at),
+    ...input.dispatches.map((row) => row.updated_at ?? row.created_at),
+    ...input.signals.map((row) => row.created_at),
+    ...input.sessions.map((row) => row.created_at),
+    ...input.conversationTurns.map((row) => row.created_at),
+  ]);
+  const newestCheckinAt = newestIso(input.profiles.map((row) => row.last_seen_at));
+
+  return {
+    version: "orchestrator-context-v1",
+    generated_at: input.generatedAt,
+    policy: {
+      mode: "read-only",
+      compaction: "Small current-state, profile-card, continuity, and library-snapshot summaries are returned by default.",
+      raw_access: "Raw records stay in their source tables and are referenced by source_kind, source_id, and deep_link.",
+      redaction: "Auth, token, secret, password, API key, and billing-like values are redacted before summaries are returned.",
+    },
+    current_state_card: {
+      summary: compactText(
+        `${activeTodos.length} active job${activeTodos.length === 1 ? "" : "s"}, ${activeSeatCount} active seat${activeSeatCount === 1 ? "" : "s"}, ${blockers.length} blocker signal${blockers.length === 1 ? "" : "s"}.`,
+        180,
+      ),
+      newest_activity_at: newestActivityAt,
+      newest_checkin_at: newestCheckinAt,
+      active_todo_count: activeTodos.length,
+      blocker_count: blockers.length,
+      active_seat_count: activeSeatCount,
+      live_sources: {
+        profiles: input.profiles.length,
+        boardroom_messages: input.messages.length,
+        todos: input.todos.length,
+        comments: input.comments.length,
+        dispatches: input.dispatches.length,
+        signals: input.signals.length,
+        sessions: input.sessions.length,
+        library: input.library.length,
+        business_context: input.businessContext.length,
+        conversation_turns: input.conversationTurns.length,
+      },
+      next_actions: nextActions,
+      blockers,
+    },
+    profile_cards: profiles,
+    continuity_events: continuityEvents,
+    library_snapshots: librarySnapshots,
+  };
+}
+
+function buildProfileCard(profile: OrchestratorProfileRow): OrchestratorProfileCard {
+  const label = profile.display_name?.trim() || prettifyAgentId(profile.agent_id);
+  const role = profile.user_agent_hint === "admin-ui" || profile.agent_id.startsWith("human-") ? "human" : "ai-seat";
+  return {
+    agent_id: profile.agent_id,
+    label,
+    role,
+    emoji: profile.emoji ?? null,
+    device_hint: profile.user_agent_hint ?? null,
+    last_seen_at: profile.last_seen_at ?? profile.created_at ?? null,
+    current_status: compactText(profile.current_status ?? "", 140) || null,
+    next_checkin_at: profile.next_checkin_at ?? null,
+  };
+}
+
+function messageToEvent(message: OrchestratorMessageRow): OrchestratorContinuityEvent {
+  const tags = normalizeTags(message.tags);
+  return {
+    source_kind: "boardroom_message",
+    source_id: message.id,
+    deep_link: `/admin/boardroom#msg-${message.id}`,
+    created_at: message.created_at,
+    kind: classify(tags, message.text),
+    actor_agent_id: message.author_agent_id ?? null,
+    summary: compactText(message.text, 260),
+    tags,
+  };
+}
+
+function todoToEvent(todo: OrchestratorTodoRow): OrchestratorContinuityEvent {
+  return {
+    source_kind: "todo",
+    source_id: todo.id,
+    deep_link: `/admin/jobs#todo-${todo.id}`,
+    created_at: todo.updated_at ?? todo.created_at,
+    kind: todo.status === "in_progress" ? "claim" : classify([], `${todo.title} ${todo.description ?? ""}`),
+    actor_agent_id: todo.assigned_to_agent_id ?? todo.created_by_agent_id,
+    summary: compactText(`${todo.priority} ${todo.status}: ${todo.title}. ${todo.description ?? ""}`, 260),
+    tags: ["todo", todo.status, todo.priority],
+  };
+}
+
+function commentToEvent(comment: OrchestratorCommentRow): OrchestratorContinuityEvent {
+  return {
+    source_kind: "todo_comment",
+    source_id: comment.id,
+    deep_link: comment.target_kind === "todo" ? `/admin/jobs#todo-${comment.target_id}` : null,
+    created_at: comment.created_at,
+    kind: classify([], comment.text),
+    actor_agent_id: comment.author_agent_id,
+    summary: compactText(comment.text, 240),
+    tags: [comment.target_kind, "comment"],
+  };
+}
+
+function dispatchToEvent(dispatch: OrchestratorDispatchRow): OrchestratorContinuityEvent {
+  const detail = [
+    dispatch.source,
+    dispatch.status,
+    dispatch.task_ref,
+    dispatch.payload ? compactText(dispatch.payload, 140) : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return {
+    source_kind: "dispatch",
+    source_id: dispatch.dispatch_id,
+    deep_link: dispatch.task_ref?.startsWith("todo:") ? `/admin/jobs#${dispatch.task_ref}` : null,
+    created_at: dispatch.updated_at ?? dispatch.created_at,
+    kind: dispatch.status === "leased" ? "handoff" : dispatch.status === "failed" || dispatch.status === "stale" ? "blocker" : "status",
+    actor_agent_id: dispatch.lease_owner ?? dispatch.target_agent_id,
+    summary: compactText(detail, 240),
+    tags: ["dispatch", dispatch.source, dispatch.status],
+  };
+}
+
+function signalToEvent(signal: OrchestratorSignalRow): OrchestratorContinuityEvent {
+  return {
+    source_kind: "signal",
+    source_id: signal.id,
+    deep_link: signal.deep_link ?? null,
+    created_at: signal.created_at,
+    kind: signal.severity === "critical" || signal.severity === "action_needed" ? "blocker" : classify([signal.action], signal.summary),
+    summary: compactText(`${signal.tool} ${signal.action}: ${signal.summary}`, 240),
+    tags: ["signal", signal.tool, signal.action, signal.severity],
+  };
+}
+
+function sessionToEvent(session: OrchestratorSessionRow): OrchestratorContinuityEvent {
+  return {
+    source_kind: "session_summary",
+    source_id: session.session_id,
+    deep_link: `/admin/memory?session_id=${encodeURIComponent(session.session_id)}`,
+    created_at: session.created_at,
+    kind: "context",
+    role: session.platform ?? null,
+    summary: compactText(session.summary, 240),
+    tags: ["session", ...(session.topics ?? []).slice(0, 4)],
+  };
+}
+
+function conversationTurnToEvent(turn: OrchestratorConversationTurnRow): OrchestratorContinuityEvent {
+  return {
+    source_kind: "conversation_turn",
+    source_id: turn.id,
+    deep_link: `/admin/memory?session_id=${encodeURIComponent(turn.session_id)}`,
+    created_at: turn.created_at,
+    kind: classify([], turn.content),
+    role: turn.role,
+    summary: compactText(`${turn.role}: ${turn.content}`, 240),
+    tags: ["conversation", turn.role],
+  };
+}
+
+function libraryToSnapshot(row: OrchestratorLibraryRow): OrchestratorLibrarySnapshot {
+  return {
+    source_kind: "library",
+    source_id: row.slug,
+    deep_link: `/admin/memory?library=${encodeURIComponent(row.slug)}`,
+    title: row.title,
+    category: row.category,
+    tags: row.tags ?? [],
+    version: row.version ?? null,
+    updated_at: row.updated_at ?? row.created_at ?? null,
+    created_at: row.created_at ?? null,
+  };
+}
+
+function businessContextToSnapshot(row: OrchestratorBusinessContextRow): OrchestratorLibrarySnapshot {
+  return {
+    source_kind: "business_context",
+    source_id: row.id,
+    deep_link: "/admin/memory",
+    title: `${row.category}: ${row.key}`,
+    category: row.category,
+    summary: compactText(row.value, 220),
+    updated_at: row.updated_at ?? null,
+  };
+}
+
+function sessionToSnapshot(row: OrchestratorSessionRow): OrchestratorLibrarySnapshot {
+  return {
+    source_kind: "session_summary",
+    source_id: row.session_id,
+    deep_link: `/admin/memory?session_id=${encodeURIComponent(row.session_id)}`,
+    title: `Session ${row.session_id}`,
+    category: row.platform ?? "session",
+    summary: compactText(row.summary, 220),
+    tags: row.topics ?? [],
+    updated_at: row.created_at,
+    created_at: row.created_at,
+  };
+}
+
+function classify(tags: string[], text: string): OrchestratorContinuityEvent["kind"] {
+  const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
+  const lower = text.toLowerCase();
+  if (tagSet.has("blocker") || lower.startsWith("blocker:") || lower.includes(" blocked") || lower.includes(" blocker")) return "blocker";
+  if (tagSet.has("proof") || lower.startsWith("pass:") || lower.includes("proof:") || lower.includes(" pr #")) return "proof";
+  if (tagSet.has("handoff") || lower.includes("handoff") || lower.includes("assigned to")) return "handoff";
+  if (tagSet.has("ack") || lower.startsWith("ack ") || lower.includes(" ack ")) return "ack";
+  if (lower.includes("claimed") || lower.includes("claiming") || lower.includes("in_progress")) return "claim";
+  if (tagSet.has("decision") || lower.includes("decided") || lower.includes("greenlit")) return "decision";
+  return "status";
+}
+
+function normalizeTags(tags?: string[] | null): string[] {
+  return Array.isArray(tags)
+    ? tags.filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0).map((tag) => tag.trim())
+    : [];
+}
+
+function compareTodoPriorityThenUpdated(a: OrchestratorTodoRow, b: OrchestratorTodoRow): number {
+  const priorityDiff = (PRIORITY_RANK[b.priority] ?? 0) - (PRIORITY_RANK[a.priority] ?? 0);
+  if (priorityDiff !== 0) return priorityDiff;
+  return compareIsoDesc(a.updated_at ?? a.created_at, b.updated_at ?? b.created_at);
+}
+
+function compareIsoDesc(a?: string | null, b?: string | null): number {
+  const aMs = a ? Date.parse(a) : 0;
+  const bMs = b ? Date.parse(b) : 0;
+  return bMs - aMs;
+}
+
+function newestIso(values: Array<string | null | undefined>): string | null {
+  const best = values
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .sort((a, b) => Date.parse(b) - Date.parse(a))[0];
+  return best ?? null;
+}
+
+function isFresh(iso: string | null | undefined, nowMs: number): boolean {
+  if (!iso) return false;
+  const seenMs = Date.parse(iso);
+  return Number.isFinite(seenMs) && Number.isFinite(nowMs) && nowMs - seenMs <= ACTIVE_WINDOW_MS;
+}
+
+function prettifyAgentId(agentId: string): string {
+  return agentId
+    .replace(/^chatgpt[-_]/, "")
+    .replace(/^codex[-_]/, "")
+    .replace(/^claude[-_]/, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .replace(/\bAi\b/g, "AI");
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -77,6 +77,8 @@
  *                       for self-hosted export / portability.
  *   - admin_clear_all: POST with body.confirm === "DELETE", deletes every
  *                      memory row scoped to the user's api_key_hash.
+ *   - orchestrator_context_read: GET/POST read-only compact cross-seat state
+ *                                from Memory, Boardroom, dispatches, signals.
  *
  * Conflict detection actions (competing memory tools):
  *   - conflict_detect: POST with Bearer + { tool, platform? } -- log detection,
@@ -99,6 +101,19 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
+import {
+  buildOrchestratorContext,
+  type OrchestratorBusinessContextRow,
+  type OrchestratorCommentRow,
+  type OrchestratorConversationTurnRow,
+  type OrchestratorDispatchRow,
+  type OrchestratorLibraryRow,
+  type OrchestratorMessageRow,
+  type OrchestratorProfileRow,
+  type OrchestratorSessionRow,
+  type OrchestratorSignalRow,
+  type OrchestratorTodoRow,
+} from "./lib/orchestrator-context.js";
 import {
   createDispatchThroughputMetrics,
   decorateThroughputDispatch,
@@ -7698,6 +7713,125 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           room,
           messages: messages ?? [],
           profiles: profiles ?? [],
+        });
+      }
+
+      case "orchestrator_context_read": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'. Run the UnClick setup wizard if you do not have one.",
+          });
+        }
+
+        const body = (req.body ?? {}) as { limit?: number };
+        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 80) || 80, 20), 120);
+        const smallerLimit = Math.min(limit, 40);
+
+        const [
+          profilesResult,
+          messagesResult,
+          todosResult,
+          commentsResult,
+          dispatchesResult,
+          signalsResult,
+          sessionsResult,
+          libraryResult,
+          businessContextResult,
+          conversationTurnsResult,
+        ] = await Promise.all([
+          supabase
+            .from("mc_fishbowl_profiles")
+            .select("agent_id, emoji, display_name, user_agent_hint, created_at, last_seen_at, current_status, current_status_updated_at, next_checkin_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("last_seen_at", { ascending: false, nullsFirst: false })
+            .limit(smallerLimit),
+          supabase
+            .from("mc_fishbowl_messages")
+            .select("id, author_emoji, author_name, author_agent_id, recipients, text, tags, thread_id, created_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(limit),
+          supabase
+            .from("mc_fishbowl_todos")
+            .select("id, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, source_idea_id, created_at, updated_at, completed_at")
+            .eq("api_key_hash", apiKeyHash)
+            .neq("status", "dropped")
+            .order("updated_at", { ascending: false })
+            .limit(smallerLimit),
+          supabase
+            .from("mc_fishbowl_comments")
+            .select("id, target_kind, target_id, author_agent_id, text, created_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(smallerLimit),
+          supabase
+            .from("mc_agent_dispatches")
+            .select("dispatch_id, source, target_agent_id, task_ref, status, lease_owner, lease_expires_at, last_real_action_at, payload, created_at, updated_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("updated_at", { ascending: false })
+            .limit(smallerLimit),
+          supabase
+            .from("mc_signals")
+            .select("id, tool, action, severity, summary, deep_link, payload, created_at, read_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(smallerLimit),
+          supabase
+            .from("mc_session_summaries")
+            .select("id, session_id, platform, summary, decisions, open_loops, topics, created_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(12),
+          supabase
+            .from("mc_knowledge_library")
+            .select("slug, title, category, tags, version, updated_at, created_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("updated_at", { ascending: false })
+            .limit(16),
+          supabase
+            .from("mc_business_context")
+            .select("id, category, key, value, priority, updated_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("priority", { ascending: false })
+            .limit(16),
+          supabase
+            .from("mc_conversation_log")
+            .select("id, session_id, role, content, created_at")
+            .eq("api_key_hash", apiKeyHash)
+            .order("created_at", { ascending: false })
+            .limit(smallerLimit),
+        ]);
+
+        const errors = [
+          profilesResult.error,
+          messagesResult.error,
+          todosResult.error,
+          commentsResult.error,
+          dispatchesResult.error,
+          signalsResult.error,
+          sessionsResult.error,
+          libraryResult.error,
+          businessContextResult.error,
+          conversationTurnsResult.error,
+        ].filter(Boolean);
+        if (errors.length > 0) throw errors[0];
+
+        return res.status(200).json({
+          context: buildOrchestratorContext({
+            generatedAt: new Date().toISOString(),
+            profiles: (profilesResult.data ?? []) as OrchestratorProfileRow[],
+            messages: (messagesResult.data ?? []) as OrchestratorMessageRow[],
+            todos: (todosResult.data ?? []) as OrchestratorTodoRow[],
+            comments: (commentsResult.data ?? []) as OrchestratorCommentRow[],
+            dispatches: (dispatchesResult.data ?? []) as OrchestratorDispatchRow[],
+            signals: (signalsResult.data ?? []) as OrchestratorSignalRow[],
+            sessions: (sessionsResult.data ?? []) as OrchestratorSessionRow[],
+            library: (libraryResult.data ?? []) as OrchestratorLibraryRow[],
+            businessContext: (businessContextResult.data ?? []) as OrchestratorBusinessContextRow[],
+            conversationTurns: (conversationTurnsResult.data ?? []) as OrchestratorConversationTurnRow[],
+          }),
         });
       }
 

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOrchestratorContext,
+  compactText,
+  redactSensitive,
+} from "./lib/orchestrator-context";
+
+describe("orchestrator context", () => {
+  it("builds read-first cross-seat state from live source rows", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-09T11:00:00.000Z",
+      profiles: [
+        {
+          agent_id: "chatgpt-codex-seat",
+          display_name: "Codex Seat",
+          emoji: "C",
+          user_agent_hint: "codex-desktop",
+          last_seen_at: "2026-05-09T10:55:00.000Z",
+          current_status: "Building Orchestrator context",
+        },
+        {
+          agent_id: "human-chris",
+          display_name: "Chris",
+          user_agent_hint: "admin-ui",
+          last_seen_at: "2026-05-09T09:00:00.000Z",
+        },
+      ],
+      messages: [
+        {
+          id: "msg-proof",
+          author_agent_id: "chatgpt-codex-seat",
+          text: "PASS: PR #700 opened; proof: focused tests passed.",
+          tags: ["proof"],
+          created_at: "2026-05-09T10:50:00.000Z",
+        },
+        {
+          id: "msg-user",
+          author_agent_id: "human-chris",
+          text: "Chris greenlit the Orchestrator context layer.",
+          tags: ["decision"],
+          created_at: "2026-05-09T10:20:00.000Z",
+        },
+      ],
+      todos: [
+        {
+          id: "todo-1",
+          title: "Orchestrator context layer",
+          description: "Build compact shared state.",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "chatgpt-codex",
+          assigned_to_agent_id: "chatgpt-codex-seat",
+          created_at: "2026-05-09T09:00:00.000Z",
+          updated_at: "2026-05-09T10:30:00.000Z",
+        },
+      ],
+      comments: [
+        {
+          id: "comment-1",
+          target_kind: "todo",
+          target_id: "todo-1",
+          author_agent_id: "chatgpt-codex-seat",
+          text: "Claimed for first implementation slice.",
+          created_at: "2026-05-09T10:31:00.000Z",
+        },
+      ],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-1",
+          source: "fishbowl",
+          target_agent_id: "chatgpt-codex-seat",
+          task_ref: "todo:todo-1",
+          status: "leased",
+          lease_owner: "chatgpt-codex-seat",
+          created_at: "2026-05-09T10:32:00.000Z",
+          updated_at: "2026-05-09T10:32:00.000Z",
+        },
+      ],
+      signals: [
+        {
+          id: "signal-1",
+          tool: "github_action",
+          action: "access_token_invalid",
+          severity: "action_needed",
+          summary: "Rotate token in Passport/Keychain.",
+          deep_link: "/admin/keychain",
+          created_at: "2026-05-09T10:40:00.000Z",
+        },
+      ],
+      sessions: [
+        {
+          id: "session-row-1",
+          session_id: "session-1",
+          platform: "codex",
+          summary: "Planning Room packet inherits constraints and proof.",
+          topics: ["orchestrator", "memory"],
+          created_at: "2026-05-09T10:10:00.000Z",
+        },
+      ],
+      library: [
+        {
+          slug: "memory-research",
+          title: "Memory Research",
+          category: "research",
+          tags: ["memory"],
+          version: 2,
+          updated_at: "2026-05-09T10:00:00.000Z",
+        },
+      ],
+      businessContext: [
+        {
+          id: "bc-1",
+          category: "project",
+          key: "current_state_card",
+          value: { focus: "shared cross-seat story" },
+          priority: 10,
+          updated_at: "2026-05-09T09:50:00.000Z",
+        },
+      ],
+      conversationTurns: [
+        {
+          id: "turn-user",
+          session_id: "session-1",
+          role: "user",
+          content: "Please action the Orchestrator job.",
+          created_at: "2026-05-09T10:45:00.000Z",
+        },
+        {
+          id: "turn-ai",
+          session_id: "session-1",
+          role: "assistant",
+          content: "I will claim it and build the first slice.",
+          created_at: "2026-05-09T10:46:00.000Z",
+        },
+      ],
+    });
+
+    expect(context.version).toBe("orchestrator-context-v1");
+    expect(context.current_state_card.active_todo_count).toBe(1);
+    expect(context.current_state_card.active_seat_count).toBe(1);
+    expect(context.current_state_card.blocker_count).toBe(1);
+    expect(context.current_state_card.next_actions[0]).toContain("Orchestrator context layer");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.role).toBe("human");
+    expect(context.continuity_events.some((event) => event.kind === "proof" && event.source_id === "msg-proof")).toBe(true);
+    expect(context.continuity_events.some((event) => event.source_kind === "conversation_turn" && event.role === "user")).toBe(true);
+    expect(context.library_snapshots.map((snapshot) => snapshot.source_kind)).toEqual(
+      expect.arrayContaining(["library", "business_context", "session_summary"]),
+    );
+  });
+
+  it("redacts sensitive auth and billing material before summaries leave the layer", () => {
+    const raw = "Authorization: Bearer sk-test-not-real-token api_key=uc_fake_key_1234567890 card 4242 4242 4242 4242";
+
+    expect(redactSensitive(raw)).not.toContain("sk-test-not-real-token");
+    expect(redactSensitive(raw)).not.toContain("uc_fake_key_1234567890");
+    expect(redactSensitive(raw)).not.toContain("4242 4242 4242 4242");
+    expect(redactSensitive(raw)).toContain("[redacted secret]");
+    expect(redactSensitive(raw)).toContain("[redacted billing data]");
+  });
+
+  it("keeps compact text bounded for progressive memory reads", () => {
+    const compact = compactText("x ".repeat(300), 80);
+
+    expect(compact.length).toBeLessThanOrEqual(80);
+    expect(compact.endsWith("...")).toBe(true);
+  });
+});

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -122,6 +122,7 @@ export function AdminAutopilot() {
       <TileGrid
         items={[
           { title: "Boardroom", body: "Shared room for decisions, handoffs, and short updates from people and AI workers.", icon: MessagesSquare, href: "/admin/boardroom" },
+          { title: "Orchestrator", body: "Compact cross-seat context with profile cards, continuity, and memory snapshots.", icon: Brain, href: "/admin/orchestrator" },
           { title: "Jobs", body: "The live work queue. Pick, assign, complete, and prove the next safe step.", icon: ListTodo, href: "/admin/jobs" },
           { title: "XPass", body: "Proof and quality checks for work before it ships.", icon: ClipboardCheck, href: "/admin/checks" },
           { title: "Projects", body: "Containers for company, team, client, or personal work areas.", icon: FolderKanban, href: "/admin/projects" },

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -20,6 +20,9 @@ import {
   Clock,
   FileText,
   ArrowRight,
+  GitBranch,
+  ShieldCheck,
+  Users,
 } from "lucide-react";
 import AIChatPanel from "@/components/admin/AIChatPanel";
 import {
@@ -28,6 +31,7 @@ import {
   type AiChatTenantSettings,
   type ChannelStatus,
 } from "@/components/admin/aiChatConfig";
+import { useSession } from "@/lib/auth";
 
 interface MemoryStats {
   business_context?: number;
@@ -46,6 +50,52 @@ interface ConnectionCheck {
   last_used_at: string | null;
 }
 
+interface OrchestratorContext {
+  version: string;
+  generated_at: string;
+  current_state_card: {
+    summary: string;
+    newest_activity_at: string | null;
+    newest_checkin_at: string | null;
+    active_todo_count: number;
+    blocker_count: number;
+    active_seat_count: number;
+    next_actions: string[];
+    blockers: string[];
+    live_sources: Record<string, number>;
+  };
+  profile_cards: Array<{
+    agent_id: string;
+    label: string;
+    role: "human" | "ai-seat";
+    emoji?: string | null;
+    last_seen_at?: string | null;
+    current_status?: string | null;
+    next_checkin_at?: string | null;
+  }>;
+  continuity_events: Array<{
+    source_kind: string;
+    source_id: string;
+    deep_link?: string | null;
+    created_at?: string | null;
+    kind: string;
+    actor_agent_id?: string | null;
+    role?: string | null;
+    summary: string;
+    tags?: string[];
+  }>;
+  library_snapshots: Array<{
+    source_kind: string;
+    source_id: string;
+    deep_link?: string | null;
+    title: string;
+    category: string;
+    summary?: string;
+    tags?: string[];
+    updated_at?: string | null;
+  }>;
+}
+
 type ConnectionTier = "channel" | "gemini" | "unconfigured";
 
 function formatRelative(iso: string | null | undefined): string {
@@ -62,40 +112,47 @@ function formatRelative(iso: string | null | undefined): string {
 }
 
 export default function AdminOrchestratorPage() {
-  const [apiKey] = useState<string>(() => {
+  const [storedApiKey] = useState<string>(() => {
     try {
       return localStorage.getItem("unclick_api_key") ?? "";
     } catch {
       return "";
     }
   });
+  const { session, loading: sessionLoading } = useSession();
+  const authToken = session?.access_token ?? storedApiKey;
   const [channel, setChannel] = useState<ChannelStatus | null>(null);
   const [stats, setStats] = useState<MemoryStats | null>(null);
   const [connection, setConnection] = useState<ConnectionCheck | null>(null);
   const [tenant, setTenant] = useState<AiChatTenantSettings | null>(null);
+  const [orchestratorContext, setOrchestratorContext] = useState<OrchestratorContext | null>(null);
   const [loading, setLoading] = useState(true);
 
   const envEnabled = aiChatEnvEnabled();
 
   useEffect(() => {
-    if (!apiKey) {
-      setLoading(false);
+    if (sessionLoading) return;
+    if (!authToken) {
+      queueMicrotask(() => setLoading(false));
       return;
     }
     let cancelled = false;
     (async () => {
       try {
-        const [channelRes, statusRes, connRes, tenantRes] = await Promise.all([
+        const [channelRes, statusRes, connRes, contextRes, tenantRes] = await Promise.all([
           fetch("/api/memory-admin?action=admin_channel_status", {
-            headers: { Authorization: `Bearer ${apiKey}` },
+            headers: { Authorization: `Bearer ${authToken}` },
           }),
           fetch("/api/memory-admin?action=status", {
-            headers: { Authorization: `Bearer ${apiKey}` },
+            headers: { Authorization: `Bearer ${authToken}` },
           }),
           fetch(
-            `/api/memory-admin?action=admin_check_connection&api_key=${encodeURIComponent(apiKey)}`,
+            `/api/memory-admin?action=admin_check_connection&api_key=${encodeURIComponent(storedApiKey)}`,
           ),
-          fetchAiChatTenantSettings(apiKey),
+          fetch("/api/memory-admin?action=orchestrator_context_read&limit=80", {
+            headers: { Authorization: `Bearer ${authToken}` },
+          }),
+          fetchAiChatTenantSettings(authToken),
         ]);
         if (cancelled) return;
         if (channelRes.ok) setChannel((await channelRes.json()) as ChannelStatus);
@@ -104,6 +161,10 @@ export default function AdminOrchestratorPage() {
           setStats(body.data ?? body);
         }
         if (connRes.ok) setConnection((await connRes.json()) as ConnectionCheck);
+        if (contextRes.ok) {
+          const body = (await contextRes.json()) as { context?: OrchestratorContext };
+          setOrchestratorContext(body.context ?? null);
+        }
         if (tenantRes?.env_enabled) setTenant(tenantRes.settings);
       } finally {
         if (!cancelled) setLoading(false);
@@ -112,7 +173,7 @@ export default function AdminOrchestratorPage() {
     return () => {
       cancelled = true;
     };
-  }, [apiKey]);
+  }, [authToken, sessionLoading, storedApiKey]);
 
   const tier: ConnectionTier = useMemo(() => {
     if (channel?.channel_active) return "channel";
@@ -124,14 +185,14 @@ export default function AdminOrchestratorPage() {
     if (!envEnabled) {
       return "AI chat is disabled for this environment. Set VITE_AI_CHAT_ENABLED=true to turn it on.";
     }
-    if (!apiKey) {
+    if (!authToken) {
       return "Sign in with your UnClick API key to start chatting.";
     }
     if (tenant && !tenant.ai_chat_enabled) {
       return "AI chat is turned off in your tenant settings. Enable it in Settings to use the Orchestrator.";
     }
     return null;
-  }, [envEnabled, apiKey, tenant]);
+  }, [envEnabled, authToken, tenant]);
 
   return (
     <>
@@ -161,6 +222,10 @@ export default function AdminOrchestratorPage() {
 
         {/* Right rail */}
         <aside className="space-y-4">
+          <OrchestratorContextCard
+            context={orchestratorContext}
+            loading={loading || sessionLoading}
+          />
           <ConnectionCard
             tier={tier}
             channel={channel}
@@ -174,6 +239,201 @@ export default function AdminOrchestratorPage() {
       </div>
     </>
   );
+}
+
+function OrchestratorContextCard({
+  context,
+  loading,
+}: {
+  context: OrchestratorContext | null;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <section className="rounded-2xl border border-white/[0.08] bg-[#111111] p-4">
+        <div className="flex items-center gap-2 text-sm text-white/60">
+          <Brain className="h-4 w-4 text-[#61C1C4]" />
+          Loading Orchestrator context...
+        </div>
+      </section>
+    );
+  }
+
+  if (!context) {
+    return (
+      <section className="rounded-2xl border border-white/[0.08] bg-[#111111] p-4">
+        <header className="flex items-center gap-2">
+          <Brain className="h-4 w-4 text-[#61C1C4]" />
+          <h3 className="text-sm font-semibold text-white">Orchestrator Context</h3>
+        </header>
+        <p className="mt-3 text-xs leading-5 text-white/45">
+          No compact state is available yet.
+        </p>
+      </section>
+    );
+  }
+
+  const state = context.current_state_card;
+  const topSources = Object.entries(state.live_sources)
+    .filter(([, value]) => value > 0)
+    .slice(0, 4);
+
+  return (
+    <section className="rounded-2xl border border-[#61C1C4]/20 bg-[#101818] p-4">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <Brain className="h-4 w-4 text-[#61C1C4]" />
+            <h3 className="text-sm font-semibold text-white">Orchestrator Context</h3>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-white/55">{state.summary}</p>
+        </div>
+        <span className="shrink-0 rounded-md border border-[#61C1C4]/25 bg-[#61C1C4]/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-[#61C1C4]">
+          Read only
+        </span>
+      </header>
+
+      <div className="mt-4 grid grid-cols-3 gap-2">
+        <MiniMetric icon={FileText} label="Jobs" value={state.active_todo_count} />
+        <MiniMetric icon={Users} label="Seats" value={state.active_seat_count} />
+        <MiniMetric icon={ShieldCheck} label="Blocks" value={state.blocker_count} />
+      </div>
+
+      <div className="mt-4 space-y-3">
+        <ContextSection title="Next" icon={ArrowRight}>
+          {state.next_actions.length > 0 ? (
+            state.next_actions.slice(0, 4).map((action) => (
+              <p key={action} className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2 text-xs leading-5 text-white/65">
+                {action}
+              </p>
+            ))
+          ) : (
+            <p className="text-xs text-white/35">No active next action loaded.</p>
+          )}
+        </ContextSection>
+
+        <ContextSection title="Continuity" icon={GitBranch}>
+          {context.continuity_events.slice(0, 5).map((event) => (
+            <ContinuityRow key={`${event.source_kind}:${event.source_id}`} event={event} />
+          ))}
+          {context.continuity_events.length === 0 && (
+            <p className="text-xs text-white/35">No continuity events loaded.</p>
+          )}
+        </ContextSection>
+
+        <ContextSection title="Profiles" icon={Users}>
+          {context.profile_cards.slice(0, 5).map((profile) => (
+            <div key={profile.agent_id} className="flex items-center justify-between gap-2 text-xs">
+              <span className="min-w-0 truncate text-white/70">
+                {profile.emoji ? `${profile.emoji} ` : ""}{profile.label}
+              </span>
+              <span className="shrink-0 text-white/35">{formatRelative(profile.last_seen_at)}</span>
+            </div>
+          ))}
+          {context.profile_cards.length === 0 && (
+            <p className="text-xs text-white/35">No profile cards loaded.</p>
+          )}
+        </ContextSection>
+
+        <ContextSection title="Snapshots" icon={FileText}>
+          {context.library_snapshots.slice(0, 4).map((snapshot) => (
+            <SnapshotRow key={`${snapshot.source_kind}:${snapshot.source_id}`} snapshot={snapshot} />
+          ))}
+          {context.library_snapshots.length === 0 && (
+            <p className="text-xs text-white/35">No library snapshots loaded.</p>
+          )}
+        </ContextSection>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {topSources.map(([key, value]) => (
+          <span key={key} className="rounded-md border border-white/[0.06] bg-black/20 px-2 py-1 text-[10px] text-white/35">
+            {key.replace(/_/g, " ")} {value}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ContextSection({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: typeof Brain;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-white/40">
+        <Icon className="h-3 w-3 text-[#61C1C4]/70" />
+        {title}
+      </div>
+      <div className="space-y-2">{children}</div>
+    </div>
+  );
+}
+
+function MiniMetric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof Brain;
+  label: string;
+  value: number;
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-black/20 p-2">
+      <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-white/35">
+        <Icon className="h-3 w-3 text-[#61C1C4]/70" />
+        {label}
+      </div>
+      <div className="mt-1 font-mono text-lg font-semibold text-white">{value}</div>
+    </div>
+  );
+}
+
+function ContinuityRow({ event }: { event: OrchestratorContext["continuity_events"][number] }) {
+  const content = (
+    <div className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[#61C1C4]">
+          {event.kind}
+        </span>
+        <span className="shrink-0 text-[10px] text-white/30">{formatRelative(event.created_at)}</span>
+      </div>
+      <p className="line-clamp-2 text-xs leading-5 text-white/65">{event.summary}</p>
+    </div>
+  );
+
+  if (event.deep_link?.startsWith("/")) {
+    return <Link to={event.deep_link}>{content}</Link>;
+  }
+
+  return content;
+}
+
+function SnapshotRow({ snapshot }: { snapshot: OrchestratorContext["library_snapshots"][number] }) {
+  const content = (
+    <div className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-xs font-medium text-white/75">{snapshot.title}</p>
+        <span className="shrink-0 text-[10px] text-white/30">{snapshot.category}</span>
+      </div>
+      {snapshot.summary && (
+        <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-white/45">{snapshot.summary}</p>
+      )}
+    </div>
+  );
+
+  if (snapshot.deep_link?.startsWith("/")) {
+    return <Link to={snapshot.deep_link}>{content}</Link>;
+  }
+
+  return content;
 }
 
 function ConnectionCard({


### PR DESCRIPTION
Summary:
- Adds a read-only orchestrator_context_read API action that compacts live Memory, Boardroom, Job, dispatch, signal, profile, and conversation rows into a source-linked current state card.
- Adds redaction and bounded summaries for auth, token, secret, password, API key, and billing-shaped values before context leaves the layer.
- Adds an Orchestrator Context card to /admin/orchestrator and links it from AutoPilot.

Scope:
- api/lib/orchestrator-context.ts
- api/memory-admin.ts
- api/orchestrator-context.test.ts
- src/pages/admin/AdminOrchestrator.tsx
- src/pages/admin/AdminEcosystemPages.tsx
- UnClick todo 2d31e79c-af77-436e-af80-0b834c86522c

Non-overlap:
- Does not add a new persistence table or migrate raw chat storage.
- Does not change Boardroom write behavior, worker routing, or memory export format.
- Does not complete the full Orchestrator invention, only the first read-first compact context slice.

Verification:
- npm run test -- api/orchestrator-context.test.ts
- npx eslint api/lib/orchestrator-context.ts api/orchestrator-context.test.ts api/memory-admin.ts src/pages/admin/AdminOrchestrator.tsx src/pages/admin/AdminEcosystemPages.tsx
- npm run build
- npm run test:rotatepass-redaction
- npm run test:enterprisepass-receipt
- Whole-repo npm run lint is still blocked by pre-existing unrelated lint failures across older API/app files, so changed-file lint was used for this PR.

Risk:
- Read-only API path. It queries existing tenant-scoped tables through resolveApiKeyHash.
- No secrets are logged or printed. Compact summaries apply redaction before output.
- UI impact is limited to /admin/orchestrator and the AutoPilot tile list.

Follow-up:
- Add persisted rolling snapshots and a Data Island export mapping once this read model is accepted.
- Connect older todo b1334cae to the same model so connected-PC visibility does not drift.