### PR TITLE
Add GitHub OAuth login to Passport

### DIFF
--- a/api/oauth-callback.ts
+++ b/api/oauth-callback.ts
@@ -16,6 +16,7 @@
  * Adding a new OAuth platform = add an entry to PLATFORM_CONFIGS.
  *
  * Required env vars per platform:
+ *   GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_REDIRECT_URI
  *   XERO_CLIENT_ID, XERO_CLIENT_SECRET, XERO_REDIRECT_URI
  *   REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, REDDIT_REDIRECT_URI
  *   SHOPIFY_{STORE}_CLIENT_ID, etc. (Shopify is per-store, handled specially)
@@ -40,6 +41,18 @@ interface OAuthConfig {
 }
 
 const PLATFORM_CONFIGS: Record<string, OAuthConfig> = {
+
+  github: {
+    tokenUrl:        "https://github.com/login/oauth/access_token",
+    clientIdEnv:     "GITHUB_CLIENT_ID",
+    clientSecretEnv: "GITHUB_CLIENT_SECRET",
+    redirectUriEnv:  "GITHUB_REDIRECT_URI",
+    async extractCredentials(tokenResponse) {
+      const accessToken = String(tokenResponse.access_token ?? "");
+      if (!accessToken) throw new Error("No access_token in GitHub token response.");
+      return { api_key: accessToken };
+    },
+  },
 
   xero: {
     tokenUrl:         "https://identity.xero.com/connect/token",
@@ -141,7 +154,10 @@ async function exchangeCode(
 
   const res = await fetch(config.tokenUrl, {
     method:  "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept:         "application/json",
+    },
     body:    body.toString(),
   });
 

--- a/api/oauth-init.ts
+++ b/api/oauth-init.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createOAuthStateToken } from "./oauth-state";
 
-const ALLOWED_PLATFORMS = new Set(["xero", "reddit", "shopify"]);
+const ALLOWED_PLATFORMS = new Set(["github", "xero", "reddit", "shopify"]);
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader("Access-Control-Allow-Origin", "https://unclick.world");

--- a/api/oauth-state.test.ts
+++ b/api/oauth-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createOAuthStateToken, verifyOAuthStateToken } from "./oauth-state";
 
 const env = {
+  GITHUB_CLIENT_SECRET: "github-secret",
   XERO_CLIENT_SECRET: "xero-secret",
   REDDIT_CLIENT_SECRET: "reddit-secret",
   SHOPIFY_CLIENT_SECRET: "shopify-secret",
@@ -10,15 +11,15 @@ const env = {
 describe("oauth state token", () => {
   it("round-trips a valid token", () => {
     const token = createOAuthStateToken({
-      platform: "xero",
-      redirectPath: "/connect/xero",
+      platform: "github",
+      redirectPath: "/connect/github",
       env,
       nowSeconds: 1_000,
     });
 
     expect(verifyOAuthStateToken(token, env, 1_100)).toMatchObject({
-      platform: "xero",
-      redirectPath: "/connect/xero",
+      platform: "github",
+      redirectPath: "/connect/github",
       v: 1,
     });
   });

--- a/api/oauth-state.ts
+++ b/api/oauth-state.ts
@@ -20,6 +20,8 @@ function base64UrlDecode(value: string): string {
 
 function getPlatformSecret(platform: string, env: NodeJS.ProcessEnv): string {
   switch (platform) {
+    case "github":
+      return env.GITHUB_CLIENT_SECRET ?? "";
     case "xero":
       return env.XERO_CLIENT_SECRET ?? "";
     case "reddit":

--- a/src/__tests__/passport-core-connectors.test.ts
+++ b/src/__tests__/passport-core-connectors.test.ts
@@ -14,4 +14,12 @@ describe("Passport core connectors", () => {
     expect(CONNECTORS.vercel.credentialFields.find((field) => field.key === "api_key")?.secret).toBe(true);
     expect(CONNECTORS.supabase.credentialFields.find((field) => field.key === "service_role_key")?.secret).toBe(true);
   });
+
+  it("uses OAuth login for GitHub with manual token as fallback", () => {
+    expect(CONNECTORS.github.authType).toBe("oauth2");
+    expect(CONNECTORS.github.authUrl).toBe("https://github.com/login/oauth/authorize");
+    expect(CONNECTORS.github.tokenUrl).toBe("https://github.com/login/oauth/access_token");
+    expect(CONNECTORS.github.scopes).toEqual(expect.arrayContaining(["repo", "workflow"]));
+    expect(CONNECTORS.github.credentialFields.find((field) => field.key === "api_key")?.label).toContain("fallback");
+  });
 });

--- a/src/lib/connectors.ts
+++ b/src/lib/connectors.ts
@@ -32,13 +32,21 @@ export const CONNECTORS: Record<string, ConnectorConfig> = {
   github: {
     name:        "GitHub",
     slug:        "github",
-    authType:    "api_key",
+    authType:    "oauth2",
     description: "GitHub repositories, pull requests, issues, and workflow checks.",
+    scopes: [
+      "repo",
+      "workflow",
+      "read:user",
+      "user:email",
+    ],
+    authUrl:  "https://github.com/login/oauth/authorize",
+    tokenUrl: "https://github.com/login/oauth/access_token",
     credentialFields: [
       {
         key:          "api_key",
-        label:        "GitHub token",
-        description:  "Personal access token or fine-grained token with the repo and workflow access UnClick needs.",
+        label:        "GitHub token fallback",
+        description:  "Use only if GitHub login is unavailable. Token must include the repo and workflow access UnClick needs.",
         secret:       true,
         placeholder:  "ghp_... or github_pat_...",
         findGuideUrl: "https://github.com/settings/tokens",

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -92,11 +92,12 @@ function FieldInput({
   disabled: boolean;
 }) {
   const [revealed, setRevealed] = useState(false);
+  const fieldId = `credential_${field.key}`;
 
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <Label htmlFor={field.key} className="text-sm text-[#E8E8E8]">
+        <Label htmlFor={fieldId} className="text-sm text-[#E8E8E8]">
           {field.label}
         </Label>
         {field.findGuideUrl && (
@@ -115,7 +116,7 @@ function FieldInput({
       )}
       <div className="relative">
         <Input
-          id={field.key}
+          id={fieldId}
           type={field.secret && !revealed ? "password" : "text"}
           value={value}
           onChange={(e) => onChange(e.target.value)}
@@ -400,10 +401,10 @@ export default function ConnectPage() {
         {/* API key input (needed for all flows) */}
         <div className="space-y-1.5 border border-white/10 rounded-lg p-4 bg-white/[0.02]">
           <Label htmlFor="api_key" className="text-sm text-[#E8E8E8]">
-            Your UnClick API key
+            Your UnClick Passport key
           </Label>
           <p className="text-xs text-[#E8E8E8]/50">
-            Required to store credentials securely.{" "}
+            Needed once in this browser so Passport can store access securely.{" "}
             <Link to="/" className="text-[#E2B93B] hover:underline">Get one here.</Link>
           </p>
           <Input
@@ -447,7 +448,7 @@ export default function ConnectPage() {
             {oauthNotConfigured ? (
               <div className="bg-primary/10 border border-primary/20 rounded-lg p-4">
                 <p className="text-sm text-primary/80">
-                  OAuth2 setup pending for {connector.name}. Use the manual form below,
+                  Login setup is pending for {connector.name}. Use the manual fallback below,
                   or enter credentials directly in your MCP config.
                 </p>
               </div>
@@ -467,7 +468,7 @@ export default function ConnectPage() {
               </div>
               <div className="relative flex justify-center text-xs uppercase">
                 <span className="bg-[#0A0A0A] px-2 text-[#E8E8E8]/40">
-                  or enter token manually
+                  manual fallback
                 </span>
               </div>
             </div>
@@ -475,25 +476,52 @@ export default function ConnectPage() {
         )}
 
         {/* Manual form (always shown for non-oauth2; shown as fallback for oauth2) */}
-        <form onSubmit={handleManualSubmit} className="space-y-4">
-          {connector.credentialFields.map((field) => (
-            <FieldInput
-              key={field.key}
-              field={field}
-              value={fieldValues[field.key] ?? ""}
-              onChange={(v) => handleFieldChange(field.key, v)}
-              disabled={false}
-            />
-          ))}
+        {isOAuth2 ? (
+          <details className="rounded-lg border border-white/10 bg-white/[0.02] p-4">
+            <summary className="cursor-pointer text-sm font-medium text-[#E8E8E8]">
+              Use a token instead
+            </summary>
+            <form onSubmit={handleManualSubmit} className="mt-4 space-y-4">
+              {connector.credentialFields.map((field) => (
+                <FieldInput
+                  key={field.key}
+                  field={field}
+                  value={fieldValues[field.key] ?? ""}
+                  onChange={(v) => handleFieldChange(field.key, v)}
+                  disabled={false}
+                />
+              ))}
 
-          <Button
-            type="submit"
-            className="w-full bg-[#E2B93B] hover:bg-[#E2B93B]/90 text-black font-semibold"
-            disabled={!apiKey.trim() || !allFieldsFilled}
-          >
-            Save credentials
-          </Button>
-        </form>
+              <Button
+                type="submit"
+                className="w-full bg-[#E2B93B] hover:bg-[#E2B93B]/90 text-black font-semibold"
+                disabled={!apiKey.trim() || !allFieldsFilled}
+              >
+                Save token fallback
+              </Button>
+            </form>
+          </details>
+        ) : (
+          <form onSubmit={handleManualSubmit} className="space-y-4">
+            {connector.credentialFields.map((field) => (
+              <FieldInput
+                key={field.key}
+                field={field}
+                value={fieldValues[field.key] ?? ""}
+                onChange={(v) => handleFieldChange(field.key, v)}
+                disabled={false}
+              />
+            ))}
+
+            <Button
+              type="submit"
+              className="w-full bg-[#E2B93B] hover:bg-[#E2B93B]/90 text-black font-semibold"
+              disabled={!apiKey.trim() || !allFieldsFilled}
+            >
+              Save credentials
+            </Button>
+          </form>
+        )}
 
         {connector.docsUrl && (
           <p className="text-center text-xs text-[#E8E8E8]/40">


### PR DESCRIPTION
## Summary
- make GitHub Passport setup use OAuth login as the primary flow
- keep manual GitHub token entry as a collapsed fallback
- add GitHub OAuth state and token exchange support on the server
- fix duplicate form field ids on connect pages

## Proof
- npx vitest run src/__tests__/passport-core-connectors.test.ts api/oauth-state.test.ts
- npm run build
- Playwright smoke on /connect/github with VITE_GITHUB_CLIENT_ID set: login button visible, fallback closed, no console errors

## Env needed before full production login
- VITE_GITHUB_CLIENT_ID
- GITHUB_CLIENT_ID
- GITHUB_CLIENT_SECRET
- GITHUB_REDIRECT_URI=https://unclick.world/connect/github