### PR TITLE
fix(reliability): guard stale runner todo claims

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -402,6 +402,29 @@ function boardroomClaimAgentId(runner = {}) {
   return safeRunner.agent_id || safeRunner.id || DEFAULT_AUTONOMOUS_RUNNER.id;
 }
 
+function validateBoardroomClaimSourceState(job = {}) {
+  const state = job?.source_state || {};
+  if (!state || typeof state !== "object") {
+    return { ok: false, reason: "missing_boardroom_claim_source_state" };
+  }
+
+  const sourceStatus = String(state.status || "").trim();
+  if (sourceStatus !== "open") {
+    return { ok: false, reason: "boardroom_todo_not_open", source_status: sourceStatus || null };
+  }
+
+  const sourceAssignee = String(state.assigned_to_agent_id || "").trim();
+  if (sourceAssignee) {
+    return {
+      ok: false,
+      reason: "boardroom_todo_already_assigned",
+      source_assigned_to_agent_id: sourceAssignee,
+    };
+  }
+
+  return { ok: true };
+}
+
 export async function syncClaimedBoardroomTodoToUnClick({
   job,
   runner = DEFAULT_AUTONOMOUS_RUNNER,
@@ -415,6 +438,18 @@ export async function syncClaimedBoardroomTodoToUnClick({
   }
 
   const agentId = boardroomClaimAgentId(runner);
+  const sourceState = validateBoardroomClaimSourceState(job);
+  if (!sourceState.ok) {
+    return {
+      ok: false,
+      reason: "claim_source_state_mismatch",
+      todo_id: todoId,
+      detail: sourceState.reason,
+      source_status: sourceState.source_status ?? null,
+      source_assigned_to_agent_id: sourceState.source_assigned_to_agent_id ?? null,
+    };
+  }
+
   const update = await callUnClickMcpTool({
     mcpUrl,
     apiKey,
@@ -587,6 +622,13 @@ export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date
   return createCodingRoomJob({
     jobId: stableTodoJobId(todo),
     source: "unclick-boardroom-actionable-todo",
+    sourceState: {
+      todo_id: id || null,
+      status: todo.status || null,
+      assigned_to_agent_id: todo.assigned_to_agent_id || null,
+      actionability_reason: todo.actionability_reason || null,
+      updated_at: todo.updated_at || null,
+    },
     worker: assignee || "builder",
     chip: title,
     context: `${contextParts.join("; ")}. Imported for autonomous claim/routing; claim only when a ScopePack names owned files and an executable patch.`,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -461,6 +461,81 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("blocks stale assigned UnClick todo claims before syncing ownership", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const calls = [];
+      const fetchImpl = async (_url, init = {}) => {
+        calls.push({ body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-stale-scoped-1",
+                            title: "Scoped but stale runner chip",
+                            status: "in_progress",
+                            priority: "urgent",
+                            assigned_to_agent_id: "old-worker",
+                            actionability_reason: "stale_in_progress",
+                            created_at: "2026-05-08T05:00:00.000Z",
+                            updated_at: "2026-05-08T05:05:00.000Z",
+                            scope_pack: {
+                              owned_files: ["docs/stale-scoped-chip.md"],
+                              patch: "diff --git a/docs/stale-scoped-chip.md b/docs/stale-scoped-chip.md\n--- a/docs/stale-scoped-chip.md\n+++ b/docs/stale-scoped-chip.md\n@@ -1 +1 @@\n-old\n+new\n",
+                              tests: [],
+                            },
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-09T12:35:00.000Z",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "todo_claim_sync_failed");
+      assert.equal(result.todo_claim_sync.reason, "claim_source_state_mismatch");
+      assert.equal(result.todo_claim_sync.detail, "boardroom_todo_not_open");
+      assert.equal(result.todo_claim_sync.source_status, "in_progress");
+      assert.deepEqual(calls.map((call) => call.body.params.name), ["list_actionable_todos"]);
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs.length, 0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reopens stale unscoped UnClick todos for scoping instead of idling forever", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");

--- a/scripts/pinballwake-coding-room.mjs
+++ b/scripts/pinballwake-coding-room.mjs
@@ -120,6 +120,7 @@ export function createCodingRoomJob(input = {}) {
         worker: input.worker,
       }),
     source: compactText(input.source || "manual", 80),
+    source_state: input.sourceState || input.source_state || null,
     pr_number: input.prNumber ?? null,
     worker: compactText(input.worker || "", 80),
     chip: compactText(input.chip || "", 180),


### PR DESCRIPTION
Summary:
Adds a source-state guard to the PinballWake autonomous runner so imported Boardroom todo claims only sync back to UnClick when the queue snapshot says the todo is still open and unassigned. Stale assigned rows now block before ownership sync, preserving the live queue instead of re-owning stale work.

Scope:
Owned files for this PR are `scripts/pinballwake-autonomous-runner.mjs`, `scripts/pinballwake-coding-room.mjs`, and `scripts/pinballwake-autonomous-runner.test.mjs`. Linked todo: b744462e, Coding Room live runner with CAS/lock for safe racing.

Non-overlap:
No migrations, auth, secrets, billing, DNS, execute mode, merge automation, QueuePush routing, Jobs UI, or broad runner refactor. This is only the claim-source guard around Boardroom todo sync.

Verification:
`node --test scripts/pinballwake-autonomous-runner.test.mjs`
`node --test scripts/pinballwake-coding-room.test.mjs scripts/pinballwake-coding-room-runner.test.mjs scripts/pinballwake-autonomous-runner.test.mjs`
`npx eslint scripts/pinballwake-coding-room.mjs scripts/pinballwake-autonomous-runner.mjs scripts/pinballwake-autonomous-runner.test.mjs`
`git diff --check`

Risk:
Low. Claim mode remains advisory and execute mode remains locked off. The new guard may block a stale imported claim if source state is missing or no longer open, which is intentional for this safety slice.

Follow-up:
DB-backed CAS and lease columns are still needed for the full b744462e contract.