### PR TITLE
fix(autopilot): read ScopePacks from job comments

### DIFF
--- a/api/lib/scope-pack-comments.ts
+++ b/api/lib/scope-pack-comments.ts
@@ -1,0 +1,80 @@
+export type ScopePackSource = {
+  scope_pack: Record<string, unknown>;
+  source: "comment" | "field";
+  comment_id?: string | null;
+};
+
+export type ScopePackCommentRow = {
+  id?: string | null;
+  text?: string | null;
+  created_at?: string | null;
+};
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseScopePackFromText(value: unknown): Record<string, unknown> | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return null;
+
+  const label = String.raw`(?:scope[_ -]?pack|scopepack|runner[_ -]?scope|autonomous[_ -]?scope|coding[_ -]?room[_ -]?scope)`;
+  const fencedPatterns = [
+    new RegExp(String.raw`(?:^|\n)\s*${label}\s*:?\s*\r?\n\s*` + "```(?:json)?\\s*([\\s\\S]*?)```", "gi"),
+    new RegExp(String.raw`(?:^|\n)\s*${label}\s*:\s*` + "```(?:json)?\\s*([\\s\\S]*?)```", "gi"),
+    /<scope_pack>\s*([\s\S]*?)\s*<\/scope_pack>/gi,
+  ];
+
+  for (const pattern of fencedPatterns) {
+    let match;
+    while ((match = pattern.exec(text))) {
+      const parsed = parseJsonObject(match[1]);
+      if (parsed) return parsed;
+    }
+  }
+
+  const inlinePattern = new RegExp(String.raw`(?:^|\n)\s*${label}\s*:\s*(\{[^\r\n]*\})`, "gi");
+  let match;
+  while ((match = inlinePattern.exec(text))) {
+    const parsed = parseJsonObject(match[1]);
+    if (parsed) return parsed;
+  }
+
+  return null;
+}
+
+export function pickScopePackFromComments(
+  comments: ScopePackCommentRow[] = [],
+): ScopePackSource | null {
+  const newestFirst = [...comments].sort((a, b) =>
+    String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")),
+  );
+
+  for (const comment of newestFirst) {
+    const scopePack = parseScopePackFromText(comment.text);
+    if (scopePack) {
+      return {
+        scope_pack: scopePack,
+        source: "comment",
+        comment_id: comment.id ?? null,
+      };
+    }
+  }
+
+  return null;
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -147,6 +147,10 @@ import {
   evaluateLaneClaim,
   type WorkerLaneRow,
 } from "./lib/worker-lanes.js";
+import {
+  pickScopePackFromComments,
+  type ScopePackCommentRow,
+} from "./lib/scope-pack-comments.js";
 import { runRoutePacketConsumerDryRun, type VisibleWorker } from "./lib/route-packet-consumer.js";
 import { buildUnClickConnectDispatchRow } from "./lib/route-packet-dispatch.js";
 import { buildTetherRoutePacket } from "./lib/tether-route-packet.js";
@@ -8555,11 +8559,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .slice(0, limit);
 
           let countMap: Record<string, number> = {};
+          let commentMap: Record<string, ScopePackCommentRow[]> = {};
           if (actionable.length > 0) {
             const ids = actionable.map((item) => item.todo.id);
             const { data: comments } = await supabase
               .from("mc_fishbowl_comments")
-              .select("target_id")
+              .select("id,target_id,text,created_at")
               .eq("api_key_hash", apiKeyHash)
               .eq("target_kind", "todo")
               .in("target_id", ids);
@@ -8568,26 +8573,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               acc[k] = (acc[k] ?? 0) + 1;
               return acc;
             }, {});
+            commentMap = (comments ?? []).reduce<Record<string, ScopePackCommentRow[]>>((acc, c) => {
+              const k = c.target_id as string;
+              acc[k] = [
+                ...(acc[k] ?? []),
+                {
+                  id: typeof c.id === "string" ? c.id : null,
+                  text: typeof c.text === "string" ? c.text : null,
+                  created_at: typeof c.created_at === "string" ? c.created_at : null,
+                },
+              ];
+              return acc;
+            }, {});
           }
 
-          const decorated = actionable.map(({ todo: t, actionability_reason }, index) => ({
-            id: t.id,
-            title: t.title,
-            ...(includeDescription ? { description: t.description } : {}),
-            status: t.status,
-            priority: t.priority,
-            assigned_to_agent_id: t.assigned_to_agent_id,
-            created_by_agent_id: t.created_by_agent_id,
-            created_at: t.created_at,
-            updated_at: t.updated_at,
-            completed_at: t.completed_at,
-            comment_count: countMap[t.id as string] ?? 0,
-            actionable_rank: index + 1,
-            actionability_reason,
-            owner_last_seen_at: t.assigned_to_agent_id
-              ? lastSeenByAgent.get(String(t.assigned_to_agent_id)) ?? null
-              : null,
-            scope_pack:
+          const decorated = actionable.map(({ todo: t, actionability_reason }, index) => {
+            const fieldScopePack =
               t.scope_pack ??
               t.scopePack ??
               t.runner_scope ??
@@ -8596,8 +8597,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               t.autonomousScope ??
               t.coding_room_scope ??
               t.codingRoomScope ??
-              null,
-          }));
+              null;
+            const commentScopePack = fieldScopePack
+              ? null
+              : pickScopePackFromComments(commentMap[t.id as string] ?? []);
+
+            return {
+              id: t.id,
+              title: t.title,
+              ...(includeDescription ? { description: t.description } : {}),
+              status: t.status,
+              priority: t.priority,
+              assigned_to_agent_id: t.assigned_to_agent_id,
+              created_by_agent_id: t.created_by_agent_id,
+              created_at: t.created_at,
+              updated_at: t.updated_at,
+              completed_at: t.completed_at,
+              comment_count: countMap[t.id as string] ?? 0,
+              actionable_rank: index + 1,
+              actionability_reason,
+              owner_last_seen_at: t.assigned_to_agent_id
+                ? lastSeenByAgent.get(String(t.assigned_to_agent_id)) ?? null
+                : null,
+              scope_pack: fieldScopePack ?? commentScopePack?.scope_pack ?? null,
+              scope_pack_source: fieldScopePack ? "field" : commentScopePack?.source ?? null,
+              scope_pack_comment_id: commentScopePack?.comment_id ?? null,
+            };
+          });
           return res.status(200).json({
             todos: decorated,
             response_bounds: {

--- a/api/scope-pack-comments.test.ts
+++ b/api/scope-pack-comments.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseScopePackFromText, pickScopePackFromComments } from "./lib/scope-pack-comments.js";
+
+describe("ScopePack comment parsing", () => {
+  it("parses an explicit fenced ScopePack from a job comment", () => {
+    const scopePack = parseScopePackFromText([
+      "Implementation-ready chip.",
+      "ScopePack:",
+      "```json",
+      JSON.stringify({
+        owned_files: ["scripts/pinballwake-autonomous-runner.mjs"],
+        tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+      }),
+      "```",
+    ].join("\n"));
+
+    expect(scopePack).toEqual({
+      owned_files: ["scripts/pinballwake-autonomous-runner.mjs"],
+      tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+    });
+  });
+
+  it("prefers the newest valid ScopePack comment", () => {
+    const picked = pickScopePackFromComments([
+      {
+        id: "old",
+        created_at: "2026-05-09T10:00:00Z",
+        text: 'ScopePack: {"owned_files":["old.ts"]}',
+      },
+      {
+        id: "new",
+        created_at: "2026-05-09T11:00:00Z",
+        text: 'ScopePack: {"owned_files":["new.ts"]}',
+      },
+    ]);
+
+    expect(picked).toEqual({
+      scope_pack: { owned_files: ["new.ts"] },
+      source: "comment",
+      comment_id: "new",
+    });
+  });
+
+  it("ignores prose that is not explicit JSON", () => {
+    expect(parseScopePackFromText("ScopePack needed: pick the right files later.")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- let actionable Jobs expose an explicit JSON ScopePack from the newest scoped comment when no todo field ScopePack exists
- keep field ScopePacks as the stronger source of truth
- add parser tests so prose does not accidentally become executable scope

## Proof
- npx vitest run api/scope-pack-comments.test.ts
- npm run build
- git diff --check

## Why
This helps the Jobs-to-PR handoff move without stuffing long ScopePacks into the main Job description. The runner can still require explicit JSON before claiming work.