### PR TITLE
fix(autopilot): add Jobs Worker handoff before PinballWake builds

### DIFF
--- a/scripts/pinballwake-jobs-room.mjs
+++ b/scripts/pinballwake-jobs-room.mjs
@@ -8,6 +8,20 @@ import {
 } from "./pinballwake-coding-room.mjs";
 import { DEFAULT_CODING_ROOM_RUNNER, createCodingRoomRunner } from "./pinballwake-coding-room-runner.mjs";
 
+export const DEFAULT_JOBS_WORKER = {
+  id: "pinballwake-jobs-worker",
+  name: "PinballWake Jobs Worker",
+  emoji: "📋",
+  readiness: "context_only",
+  capabilities: ["queue_management", "status_relay"],
+};
+
+const JOBS_WORKER_REASONS = new Set([
+  "boardroom_todo_missing_scopepack",
+  "missing_owned_files",
+  "owned_file_overlap",
+]);
+
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
   const found = process.argv.find((arg) => arg.startsWith(prefix));
@@ -53,15 +67,34 @@ function requestedWorker(job = {}) {
   return compactText(job.worker || "forge", 80);
 }
 
-function packetFor(job, nextAction, context, expectedProof, deadline = "next heartbeat") {
+function packetFor(job, nextAction, context, expectedProof, deadline = "next heartbeat", worker = requestedWorker(job)) {
   return {
-    worker: requestedWorker(job),
+    worker,
     chip: jobLabel(job),
     context: compactText(context || job.context || job.job_id),
     expected_proof: expectedProof,
     deadline,
     ack: "done/blocker",
   };
+}
+
+function jobsWorkerPacketFor(job, nextAction, reason, deadline = "next heartbeat") {
+  const sourceState = job.source_state || {};
+  const sourceText = sourceState.todo_id ? `Boardroom todo ${sourceState.todo_id}.` : "";
+  const overlapText = reason.file ? ` Overlap: ${reason.file}.` : "";
+  return packetFor(
+    job,
+    nextAction,
+    [
+      sourceText,
+      `Prepare this Job for PinballWake before a Builder claims it. Reason: ${reason.reason}.`,
+      overlapText,
+      "Add a narrow ScopePack comment with owned files, proof/tests, stop conditions, and whether the stale owner should be released.",
+    ].join(" "),
+    "Post one scoped Jobs comment or release/reroute receipt; do not edit product code.",
+    deadline,
+    DEFAULT_JOBS_WORKER.id,
+  );
 }
 
 function classifyJob({ job, ledger, runner, now }) {
@@ -94,6 +127,20 @@ function classifyJob({ job, ledger, runner, now }) {
             ? "Reply PASS/BLOCKER with latest-head proof."
             : "Claim the job, build only owned files, run listed proof, and report done/blocker.",
         ),
+      };
+    }
+
+    if (JOBS_WORKER_REASONS.has(claim.reason)) {
+      const action = claim.reason === "owned_file_overlap" ? "resolve_job_overlap" : "prepare_scopepack";
+      return {
+        job_id: job.job_id,
+        status: job.status,
+        job_type: type,
+        next_action: action,
+        priority: action === "resolve_job_overlap" ? 88 : 87,
+        reason: claim.reason,
+        file: claim.file || null,
+        packet: jobsWorkerPacketFor(job, action, claim, "next Jobs Worker pulse"),
       };
     }
 

--- a/scripts/pinballwake-jobs-room.test.mjs
+++ b/scripts/pinballwake-jobs-room.test.mjs
@@ -29,6 +29,7 @@ const qcRunner = {
 function codeJob(input = {}) {
   return createCodingRoomJob({
     jobId: input.jobId || "jobs-room:code",
+    source: input.source,
     prNumber: 528,
     worker: input.worker || "forge",
     chip: input.chip || "Jobs Room code chip",
@@ -83,6 +84,57 @@ describe("PinballWake Jobs Room", () => {
     assert.equal(result.next.priority, 80);
     assert.equal(result.packets[0].worker, "forge");
     assert.match(result.packets[0].expected_proof, /Claim the job/);
+  });
+
+  it("routes unscoped Boardroom jobs to the Jobs Worker before PinballWake builds", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({
+        jobs: [
+          codeJob({
+            jobId: "boardroom-todo:todo-missing-scope",
+            source: "unclick-boardroom-actionable-todo",
+            chip: "Stale vague Job needs a ScopePack",
+            files: [],
+            status: "queued",
+          }),
+        ],
+      }),
+      runner: builder,
+      now: "2026-05-04T00:01:00.000Z",
+    });
+
+    assert.equal(result.next.next_action, "prepare_scopepack");
+    assert.equal(result.next.priority, 87);
+    assert.equal(result.packets[0].worker, "pinballwake-jobs-worker");
+    assert.match(result.packets[0].context, /Prepare this Job for PinballWake/);
+    assert.match(result.packets[0].expected_proof, /scoped Jobs comment/);
+  });
+
+  it("routes owned-file overlaps to the Jobs Worker instead of a Builder", () => {
+    const active = claimCodingRoomJob({
+      runner: builder,
+      job: codeJob({ jobId: "jobs-room:active-overlap" }),
+      now: "2026-05-04T00:00:00.000Z",
+    }).job;
+
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({
+        jobs: [
+          active,
+          codeJob({
+            jobId: "jobs-room:queued-overlap",
+            chip: "Overlapping chip",
+          }),
+        ],
+      }),
+      runner: builder,
+      now: "2026-05-04T00:01:00.000Z",
+    });
+
+    assert.equal(result.next.next_action, "resolve_job_overlap");
+    assert.equal(result.next.priority, 88);
+    assert.equal(result.packets[0].worker, "pinballwake-jobs-worker");
+    assert.match(result.packets[0].context, /Overlap: scripts\/pinballwake-jobs-room\.mjs/);
   });
 
   it("turns queued review jobs into reviewer todos only for matching reviewer", () => {

--- a/src/pages/admin/pinballwakeJobRunners.test.ts
+++ b/src/pages/admin/pinballwakeJobRunners.test.ts
@@ -54,6 +54,19 @@ describe("PinballWake job runners", () => {
     expect(runner?.id).toBe("tester-product-context");
   });
 
+  it("routes Jobs queue cleanup to the Jobs Worker before builders", () => {
+    const runner = choosePinballWakeJobRunner({
+      kind: "queue_management",
+      lane: "jobs stale queue scopepack",
+      title: "Prepare stale Jobs for PinballWake",
+      requiresCode: false,
+    });
+
+    expect(runner?.id).toBe("jobs-worker");
+    expect(runner?.capabilities).toContain("queue_management");
+    expect(runner?.notFor).toContain("product code");
+  });
+
   it("summarizes runnable hands separately from probes", () => {
     const summary = summarizePinballWakeJobRunners();
 

--- a/src/pages/admin/pinballwakeJobRunners.ts
+++ b/src/pages/admin/pinballwakeJobRunners.ts
@@ -16,6 +16,7 @@ export type PinballWakeRunnerReadiness =
 
 export type PinballWakeJobKind =
   | "implementation"
+  | "queue_management"
   | "owner_decision"
   | "qc_review"
   | "merge_proof"
@@ -43,6 +44,19 @@ export interface PinballWakeJobRequest {
 }
 
 export const PINBALLWAKE_JOB_RUNNERS: PinballWakeJobRunner[] = [
+  {
+    id: "jobs-worker",
+    emoji: "📋",
+    name: "Jobs Worker",
+    kind: "local-runner",
+    host: "PinballWake Jobs lane",
+    readiness: "context_only",
+    capabilities: ["queue_management", "owner_decision", "status_relay"],
+    safeFor: ["jobs", "queue", "scopepack", "stale jobs", "boardroom", "pinballwake"],
+    notFor: ["product code", "branch edits", "merge execution", "secrets", "billing", "domains", "migrations"],
+    proof: "Keeps Jobs runnable by preparing ScopePacks, releasing stale claims, and reducing duplicate queue noise.",
+    nextProbe: "Use before PinballWake builder runs when a Job is stale, vague, duplicated, or missing a ScopePack.",
+  },
   {
     id: "coordinator-codex-desktop",
     emoji: "🧭",


### PR DESCRIPTION
## Summary
- add a dedicated PinballWake Jobs Worker lane for queue management
- route missing ScopePack and owned-file overlap cases to Jobs Worker before builders
- show Jobs Worker in the PinballWake runner registry

## Proof
- node --test scripts/pinballwake-jobs-room.test.mjs
- npx vitest run src/pages/admin/pinballwakeJobRunners.test.ts
- npm run build