### PR TITLE
feat(orchestrator): label seat freshness in compact context

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -154,6 +154,8 @@ export interface OrchestratorProfileCard {
   emoji?: string | null;
   device_hint?: string | null;
   last_seen_at?: string | null;
+  freshness_label: "Live" | "Recent" | "Missed check-in" | "Quiet";
+  checkin_age_minutes: number | null;
   current_status?: string | null;
   next_checkin_at?: string | null;
 }
@@ -238,7 +240,7 @@ export function compactText(input: unknown, maxChars = 220): string {
 export function buildOrchestratorContext(input: BuildOrchestratorContextInput): OrchestratorContext {
   const nowMs = Date.parse(input.generatedAt);
   const profiles = input.profiles
-    .map((profile) => buildProfileCard(profile))
+    .map((profile) => buildProfileCard(profile, nowMs))
     .sort((a, b) => compareIsoDesc(a.last_seen_at, b.last_seen_at));
   const activeSeatCount = profiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
 
@@ -339,19 +341,46 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   };
 }
 
-function buildProfileCard(profile: OrchestratorProfileRow): OrchestratorProfileCard {
+function buildProfileCard(profile: OrchestratorProfileRow, nowMs: number): OrchestratorProfileCard {
   const label = profile.display_name?.trim() || prettifyAgentId(profile.agent_id);
   const role = profile.user_agent_hint === "admin-ui" || profile.agent_id.startsWith("human-") ? "human" : "ai-seat";
+  const lastSeenAt = profile.last_seen_at ?? profile.created_at ?? null;
+  const freshness = getSeatFreshness(lastSeenAt, profile.next_checkin_at, nowMs);
   return {
     agent_id: profile.agent_id,
     label,
     role,
     emoji: profile.emoji ?? null,
     device_hint: profile.user_agent_hint ?? null,
-    last_seen_at: profile.last_seen_at ?? profile.created_at ?? null,
+    last_seen_at: lastSeenAt,
+    freshness_label: freshness.label,
+    checkin_age_minutes: freshness.ageMinutes,
     current_status: compactText(profile.current_status ?? "", 140) || null,
     next_checkin_at: profile.next_checkin_at ?? null,
   };
+}
+
+function getSeatFreshness(
+  lastSeenAt: string | null,
+  nextCheckinAt: string | null | undefined,
+  nowMs: number,
+): { label: OrchestratorProfileCard["freshness_label"]; ageMinutes: number | null } {
+  const seenMs = lastSeenAt ? Date.parse(lastSeenAt) : NaN;
+  const dueMs = nextCheckinAt ? Date.parse(nextCheckinAt) : NaN;
+  if (Number.isFinite(dueMs) && dueMs < nowMs && (!Number.isFinite(seenMs) || seenMs < dueMs)) {
+    return {
+      label: "Missed check-in",
+      ageMinutes: Number.isFinite(seenMs) ? Math.max(0, Math.floor((nowMs - seenMs) / 60_000)) : null,
+    };
+  }
+  if (!Number.isFinite(seenMs) || !Number.isFinite(nowMs)) {
+    return { label: "Quiet", ageMinutes: null };
+  }
+  const ageMs = Math.max(0, nowMs - seenMs);
+  const ageMinutes = Math.floor(ageMs / 60_000);
+  if (ageMs <= ACTIVE_WINDOW_MS) return { label: "Live", ageMinutes };
+  if (ageMs <= 24 * 60 * 60 * 1000) return { label: "Recent", ageMinutes };
+  return { label: "Quiet", ageMinutes };
 }
 
 function messageToEvent(message: OrchestratorMessageRow): OrchestratorContinuityEvent {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -141,11 +141,54 @@ describe("orchestrator context", () => {
     expect(context.current_state_card.blocker_count).toBe(1);
     expect(context.current_state_card.next_actions[0]).toContain("Orchestrator context layer");
     expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.role).toBe("human");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "chatgpt-codex-seat")?.freshness_label).toBe("Live");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.freshness_label).toBe("Recent");
     expect(context.continuity_events.some((event) => event.kind === "proof" && event.source_id === "msg-proof")).toBe(true);
     expect(context.continuity_events.some((event) => event.source_kind === "conversation_turn" && event.role === "user")).toBe(true);
     expect(context.library_snapshots.map((snapshot) => snapshot.source_kind)).toEqual(
       expect.arrayContaining(["library", "business_context", "session_summary"]),
     );
+  });
+
+  it("labels profile-card check-in freshness for AI seats", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-09T12:00:00.000Z",
+      profiles: [
+        {
+          agent_id: "live-seat",
+          last_seen_at: "2026-05-09T11:55:00.000Z",
+        },
+        {
+          agent_id: "recent-seat",
+          last_seen_at: "2026-05-09T09:30:00.000Z",
+        },
+        {
+          agent_id: "missed-seat",
+          last_seen_at: "2026-05-09T10:00:00.000Z",
+          next_checkin_at: "2026-05-09T11:00:00.000Z",
+        },
+        {
+          agent_id: "quiet-seat",
+          last_seen_at: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    const labels = new Map(context.profile_cards.map((profile) => [profile.agent_id, profile.freshness_label]));
+
+    expect(labels.get("live-seat")).toBe("Live");
+    expect(labels.get("recent-seat")).toBe("Recent");
+    expect(labels.get("missed-seat")).toBe("Missed check-in");
+    expect(labels.get("quiet-seat")).toBe("Quiet");
   });
 
   it("redacts sensitive auth and billing material before summaries leave the layer", () => {

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -70,6 +70,8 @@ interface OrchestratorContext {
     role: "human" | "ai-seat";
     emoji?: string | null;
     last_seen_at?: string | null;
+    freshness_label?: SeatFreshnessLabel | null;
+    checkin_age_minutes?: number | null;
     current_status?: string | null;
     next_checkin_at?: string | null;
   }>;
@@ -97,6 +99,14 @@ interface OrchestratorContext {
 }
 
 type ConnectionTier = "channel" | "gemini" | "unconfigured";
+type SeatFreshnessLabel = "Live" | "Recent" | "Missed check-in" | "Quiet";
+
+const FRESHNESS_STYLES: Record<SeatFreshnessLabel, string> = {
+  Live: "border-[#61C1C4]/35 bg-[#61C1C4]/10 text-[#61C1C4]",
+  Recent: "border-white/[0.08] bg-white/[0.04] text-white/60",
+  "Missed check-in": "border-[#E2B93B]/35 bg-[#E2B93B]/10 text-[#E2B93B]",
+  Quiet: "border-white/[0.06] bg-black/20 text-white/35",
+};
 
 function formatRelative(iso: string | null | undefined): string {
   if (!iso) return "never";
@@ -323,9 +333,12 @@ function OrchestratorContextCard({
 
         <ContextSection title="Profiles" icon={Users}>
           {context.profile_cards.slice(0, 5).map((profile) => (
-            <div key={profile.agent_id} className="flex items-center justify-between gap-2 text-xs">
+            <div key={profile.agent_id} className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-xs">
               <span className="min-w-0 truncate text-white/70">
                 {profile.emoji ? `${profile.emoji} ` : ""}{profile.label}
+              </span>
+              <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-medium ${FRESHNESS_STYLES[profile.freshness_label ?? "Quiet"]}`}>
+                {profile.freshness_label ?? "Quiet"}
               </span>
               <span className="shrink-0 text-white/35">{formatRelative(profile.last_seen_at)}</span>
             </div>


### PR DESCRIPTION
Summary:
- Adds derived freshness labels to Orchestrator profile cards: Live, Recent, Missed check-in, and Quiet.
- Renders the label beside each profile in the read-only Orchestrator context panel.

Scope:
- Owned files: api/lib/orchestrator-context.ts, api/orchestrator-context.test.ts, src/pages/admin/AdminOrchestrator.tsx.
- Linked todo: 04cd6e32-4187-4432-9353-eb4424a3c5ae.

Non-overlap:
- Does not change auth, secrets, billing, Passport storage, migrations, production config, or raw transcript capture.
- Does not add a second context source. The UI still reads orchestrator_context_read only.

Verification:
- npx vitest api/orchestrator-context.test.ts
- npm run build

Risk:
- Low UI and compact-context schema addition. Existing consumers keep existing fields, with two derived profile fields added.

Follow-up:
- None.

Draft status:
- Draft PR for checks and review.