### PR TITLE
feat(orchestrator): label seat freshness

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -156,6 +156,8 @@ export interface OrchestratorProfileCard {
   last_seen_at?: string | null;
   current_status?: string | null;
   next_checkin_at?: string | null;
+  freshness_state: "live" | "recent" | "missed_checkin" | "quiet" | "unknown";
+  freshness_label: string;
 }
 
 export interface OrchestratorLibrarySnapshot extends OrchestratorSourceLink {
@@ -204,6 +206,7 @@ export interface OrchestratorContext {
 }
 
 const ACTIVE_WINDOW_MS = 30 * 60 * 1000;
+const RECENT_WINDOW_MS = 6 * 60 * 60 * 1000;
 const PRIORITY_RANK: Record<string, number> = {
   urgent: 4,
   high: 3,
@@ -238,7 +241,7 @@ export function compactText(input: unknown, maxChars = 220): string {
 export function buildOrchestratorContext(input: BuildOrchestratorContextInput): OrchestratorContext {
   const nowMs = Date.parse(input.generatedAt);
   const profiles = input.profiles
-    .map((profile) => buildProfileCard(profile))
+    .map((profile) => buildProfileCard(profile, nowMs))
     .sort((a, b) => compareIsoDesc(a.last_seen_at, b.last_seen_at));
   const activeSeatCount = profiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
 
@@ -339,19 +342,47 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   };
 }
 
-function buildProfileCard(profile: OrchestratorProfileRow): OrchestratorProfileCard {
+function buildProfileCard(profile: OrchestratorProfileRow, nowMs: number): OrchestratorProfileCard {
   const label = profile.display_name?.trim() || prettifyAgentId(profile.agent_id);
   const role = profile.user_agent_hint === "admin-ui" || profile.agent_id.startsWith("human-") ? "human" : "ai-seat";
+  const lastSeenAt = profile.last_seen_at ?? profile.created_at ?? null;
+  const freshness = profileFreshness(lastSeenAt, profile.next_checkin_at ?? null, nowMs);
   return {
     agent_id: profile.agent_id,
     label,
     role,
     emoji: profile.emoji ?? null,
     device_hint: profile.user_agent_hint ?? null,
-    last_seen_at: profile.last_seen_at ?? profile.created_at ?? null,
+    last_seen_at: lastSeenAt,
     current_status: compactText(profile.current_status ?? "", 140) || null,
     next_checkin_at: profile.next_checkin_at ?? null,
+    freshness_state: freshness.freshness_state,
+    freshness_label: freshness.freshness_label,
   };
+}
+
+function profileFreshness(
+  lastSeenAt: string | null,
+  nextCheckinAt: string | null,
+  nowMs: number,
+): Pick<OrchestratorProfileCard, "freshness_state" | "freshness_label"> {
+  const lastSeenMs = lastSeenAt ? Date.parse(lastSeenAt) : NaN;
+  const nextCheckinMs = nextCheckinAt ? Date.parse(nextCheckinAt) : NaN;
+
+  if (Number.isFinite(nextCheckinMs) && Number.isFinite(nowMs) && nextCheckinMs < nowMs) {
+    if (!Number.isFinite(lastSeenMs) || lastSeenMs < nextCheckinMs) {
+      return { freshness_state: "missed_checkin", freshness_label: "Missed check-in" };
+    }
+  }
+
+  if (!Number.isFinite(lastSeenMs) || !Number.isFinite(nowMs)) {
+    return { freshness_state: "unknown", freshness_label: "No check-in yet" };
+  }
+
+  const ageMs = nowMs - lastSeenMs;
+  if (ageMs <= ACTIVE_WINDOW_MS) return { freshness_state: "live", freshness_label: "Live" };
+  if (ageMs <= RECENT_WINDOW_MS) return { freshness_state: "recent", freshness_label: "Recent" };
+  return { freshness_state: "quiet", freshness_label: "Quiet" };
 }
 
 function messageToEvent(message: OrchestratorMessageRow): OrchestratorContinuityEvent {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -24,6 +24,13 @@ describe("orchestrator context", () => {
           user_agent_hint: "admin-ui",
           last_seen_at: "2026-05-09T09:00:00.000Z",
         },
+        {
+          agent_id: "quiet-seat",
+          display_name: "Quiet Seat",
+          user_agent_hint: "codex-desktop",
+          last_seen_at: "2026-05-09T08:00:00.000Z",
+          next_checkin_at: "2026-05-09T10:00:00.000Z",
+        },
       ],
       messages: [
         {
@@ -141,6 +148,9 @@ describe("orchestrator context", () => {
     expect(context.current_state_card.blocker_count).toBe(1);
     expect(context.current_state_card.next_actions[0]).toContain("Orchestrator context layer");
     expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.role).toBe("human");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "chatgpt-codex-seat")?.freshness_label).toBe("Live");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.freshness_label).toBe("Recent");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "quiet-seat")?.freshness_label).toBe("Missed check-in");
     expect(context.continuity_events.some((event) => event.kind === "proof" && event.source_id === "msg-proof")).toBe(true);
     expect(context.continuity_events.some((event) => event.source_kind === "conversation_turn" && event.role === "user")).toBe(true);
     expect(context.library_snapshots.map((snapshot) => snapshot.source_kind)).toEqual(

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -72,6 +72,8 @@ interface OrchestratorContext {
     last_seen_at?: string | null;
     current_status?: string | null;
     next_checkin_at?: string | null;
+    freshness_state?: "live" | "recent" | "missed_checkin" | "quiet" | "unknown";
+    freshness_label?: string;
   }>;
   continuity_events: Array<{
     source_kind: string;
@@ -327,7 +329,12 @@ function OrchestratorContextCard({
               <span className="min-w-0 truncate text-white/70">
                 {profile.emoji ? `${profile.emoji} ` : ""}{profile.label}
               </span>
-              <span className="shrink-0 text-white/35">{formatRelative(profile.last_seen_at)}</span>
+              <span className="flex shrink-0 items-center gap-2">
+                <span className={profileFreshnessClass(profile.freshness_state)}>
+                  {profile.freshness_label ?? "Quiet"}
+                </span>
+                <span className="text-white/35">{formatRelative(profile.last_seen_at)}</span>
+              </span>
             </div>
           ))}
           {context.profile_cards.length === 0 && (
@@ -354,6 +361,14 @@ function OrchestratorContextCard({
       </div>
     </section>
   );
+}
+
+function profileFreshnessClass(state: OrchestratorContext["profile_cards"][number]["freshness_state"]): string {
+  const base = "rounded-md border px-1.5 py-0.5 text-[10px] font-medium";
+  if (state === "live") return `${base} border-emerald-400/25 bg-emerald-400/10 text-emerald-200`;
+  if (state === "recent") return `${base} border-[#61C1C4]/25 bg-[#61C1C4]/10 text-[#9FE3E5]`;
+  if (state === "missed_checkin") return `${base} border-amber-300/25 bg-amber-300/10 text-amber-200`;
+  return `${base} border-white/[0.08] bg-white/[0.03] text-white/35`;
 }
 
 function ContextSection({


### PR DESCRIPTION
## Summary
- add derived Orchestrator profile freshness labels: Live, Recent, Missed check-in, Quiet, or No check-in yet
- show the label beside each compact Profile row in the read-only Orchestrator panel
- cover the derived labels in the focused Orchestrator context test

## Proof
- npx vitest api/orchestrator-context.test.ts
- npm run build

Job: 04cd6e32-4187-4432-9353-eb4424a3c5ae