### PR TITLE
fix(seats): show unmatched live check-ins

### DIFF
--- a/src/pages/admin/AdminAgents.test.ts
+++ b/src/pages/admin/AdminAgents.test.ts
@@ -6,6 +6,7 @@ import {
   latestProfileCheckInAt,
   mapProfilesToSeats,
   profileMatchesSeat,
+  unmatchedRecentProfiles,
   type AISeat,
   type FishbowlProfile,
 } from "./AdminAgentsSeatUtils";
@@ -92,5 +93,27 @@ describe("AdminAgents seat check-ins", () => {
         }),
       ),
     ).toBe("2026-05-09T04:00:00.000Z");
+  });
+
+  it("keeps recent unmatched live seats visible beyond manual slots", () => {
+    const windsurf = profile({
+      agent_id: "cascade-windsurf-seat",
+      display_name: "Cascade Windsurf",
+      user_agent_hint: "windsurf/cascade",
+      last_seen_at: "2026-05-09T10:54:57.440Z",
+      current_status_updated_at: "2026-05-09T11:30:20.312Z",
+    });
+    const matched = profile({
+      agent_id: "chatgpt-codex-worker2",
+      last_seen_at: "2026-05-09T15:05:20.120Z",
+    });
+
+    expect(
+      unmatchedRecentProfiles(
+        [matched, windsurf],
+        [matched],
+        Date.parse("2026-05-09T15:10:00.000Z"),
+      ).map((p) => p.agent_id),
+    ).toEqual(["cascade-windsurf-seat"]);
   });
 });

--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -22,6 +22,7 @@ import {
 import {
   latestProfileCheckInAt,
   mapProfilesToSeats,
+  unmatchedRecentProfiles,
   type AISeat,
   type FishbowlProfile,
 } from "./AdminAgentsSeatUtils";
@@ -253,6 +254,10 @@ function AISeatsPanel() {
   const [editingSeatId, setEditingSeatId] = useState<string | null>(null);
   const issues = seats.filter((seat) => seat.issue);
   const seatProfiles = useMemo(() => mapProfilesToSeats(seats, profiles), [profiles, seats]);
+  const extraProfiles = useMemo(
+    () => unmatchedRecentProfiles(profiles, seatProfiles.values()),
+    [profiles, seatProfiles],
+  );
   const matchedProfileCount = seatProfiles.size;
   const checkInSummary = profilesError
     ? profilesError
@@ -526,6 +531,54 @@ function AISeatsPanel() {
                     <span className="text-[10px] text-muted-foreground">Manual</span>
                   )}
                 </div>
+              </div>
+            );
+          })}
+          {extraProfiles.map((profile) => {
+            const checkedInAt = latestProfileCheckInAt(profile);
+            const checkedInMs = checkedInAt ? Date.parse(checkedInAt) : NaN;
+            const isReady = Number.isFinite(checkedInMs) && Date.now() - checkedInMs < 15 * 60 * 1000;
+            return (
+              <div
+                key={`live-${profile.agent_id}`}
+                className="grid grid-cols-[minmax(210px,1.4fr)_110px_130px_minmax(150px,0.8fr)_minmax(180px,1.2fr)_minmax(190px,1fr)] items-center gap-3 bg-primary/[0.025] px-4 py-3 text-xs"
+              >
+                <div className="min-w-0">
+                  <p className="truncate font-semibold text-heading">
+                    <span className="mr-1.5" aria-hidden="true">{profile.emoji ?? "💻"}</span>
+                    {profileDisplayName(profile)}
+                  </p>
+                  <p className="truncate text-[10px] text-muted-foreground">{profile.agent_id}</p>
+                  <p className="truncate text-[10px] text-muted-foreground">{profile.user_agent_hint ?? "Live seat"}</p>
+                </div>
+                <div>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] ${
+                      isReady
+                        ? "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+                        : "border-amber-400/30 bg-amber-400/10 text-amber-300"
+                    }`}
+                  >
+                    {isReady ? "Ready" : "Seen"}
+                  </span>
+                  <p className="mt-1 text-[10px] text-muted-foreground">Auto-detected</p>
+                </div>
+                <div>
+                  <div className="h-1.5 w-full rounded-full bg-border/60">
+                    <div className="h-1.5 w-1/4 rounded-full bg-primary" />
+                  </div>
+                  <p className="mt-1 text-[10px] text-muted-foreground">Auto</p>
+                </div>
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-medium text-heading" title={profile.agent_id}>
+                    {relativeTime(checkedInAt)}
+                  </p>
+                  <p className="truncate text-[10px] text-muted-foreground">
+                    {profile.current_status ? "Status updated" : "Checked in"}
+                  </p>
+                </div>
+                <p className="text-body">General capacity</p>
+                <p className="text-[10px] text-primary">Live seat</p>
               </div>
             );
           })}

--- a/src/pages/admin/AdminAgentsSeatUtils.ts
+++ b/src/pages/admin/AdminAgentsSeatUtils.ts
@@ -62,3 +62,19 @@ export function mapProfilesToSeats(seats: AISeat[], profiles: FishbowlProfile[])
 
   return seatProfiles;
 }
+
+export function unmatchedRecentProfiles(
+  profiles: FishbowlProfile[],
+  matchedProfiles: Iterable<FishbowlProfile>,
+  nowMs = Date.now(),
+  windowMs = 24 * 60 * 60 * 1000,
+): FishbowlProfile[] {
+  const matchedIds = new Set(Array.from(matchedProfiles).map((profile) => profile.agent_id));
+  return profiles.filter((profile) => {
+    if (matchedIds.has(profile.agent_id)) return false;
+    const checkedInAt = latestProfileCheckInAt(profile);
+    if (!checkedInAt) return false;
+    const checkedInMs = Date.parse(checkedInAt);
+    return Number.isFinite(checkedInMs) && nowMs - checkedInMs <= windowMs;
+  });
+}


### PR DESCRIPTION
## Summary
- show recent live AI check-ins as extra rows when the four manual seat slots are already filled
- keep Windsurf/Cascade visible as a live seat instead of hiding it behind newer check-ins
- add a focused regression test for unmatched recent profiles

## Tests
- npx vitest run src/pages/admin/AdminAgents.test.ts
- npm run build