### PR TITLE
feat(orchestrator): add connected PC visibility card

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -153,6 +153,8 @@ export interface OrchestratorProfileCard {
   role: "human" | "ai-seat";
   emoji?: string | null;
   device_hint?: string | null;
+  source_app_label: string;
+  connection_label: string;
   last_seen_at?: string | null;
   freshness_label: "Live" | "Recent" | "Missed check-in" | "Quiet";
   checkin_age_minutes: number | null;
@@ -346,12 +348,15 @@ function buildProfileCard(profile: OrchestratorProfileRow, nowMs: number): Orche
   const role = profile.user_agent_hint === "admin-ui" || profile.agent_id.startsWith("human-") ? "human" : "ai-seat";
   const lastSeenAt = profile.last_seen_at ?? profile.created_at ?? null;
   const freshness = getSeatFreshness(lastSeenAt, profile.next_checkin_at, nowMs);
+  const sourceAppLabel = getSourceAppLabel(profile);
   return {
     agent_id: profile.agent_id,
     label,
     role,
     emoji: profile.emoji ?? null,
     device_hint: profile.user_agent_hint ?? null,
+    source_app_label: sourceAppLabel,
+    connection_label: getConnectionLabel(freshness.label, role),
     last_seen_at: lastSeenAt,
     freshness_label: freshness.label,
     checkin_age_minutes: freshness.ageMinutes,
@@ -381,6 +386,30 @@ function getSeatFreshness(
   if (ageMs <= ACTIVE_WINDOW_MS) return { label: "Live", ageMinutes };
   if (ageMs <= 24 * 60 * 60 * 1000) return { label: "Recent", ageMinutes };
   return { label: "Quiet", ageMinutes };
+}
+
+function getSourceAppLabel(profile: OrchestratorProfileRow): string {
+  const hint = `${profile.user_agent_hint ?? ""} ${profile.agent_id}`.toLowerCase();
+  if (hint.includes("admin-ui") || profile.agent_id.startsWith("human-")) return "Admin UI";
+  if (hint.includes("windsurf") || hint.includes("cascade")) return "Windsurf";
+  if (hint.includes("claude")) return "Claude";
+  if (hint.includes("github-action") || hint.includes("github_action")) return "GitHub Action";
+  if (hint.includes("scheduled") || hint.includes("heartbeat")) return "Scheduled";
+  if (hint.includes("codex")) return "Codex";
+  return "AI Seat";
+}
+
+function getConnectionLabel(
+  freshnessLabel: OrchestratorProfileCard["freshness_label"],
+  role: OrchestratorProfileCard["role"],
+): string {
+  if (role === "human") {
+    return freshnessLabel === "Live" || freshnessLabel === "Recent" ? "Admin present" : "Admin quiet";
+  }
+  if (freshnessLabel === "Live") return "Connected";
+  if (freshnessLabel === "Recent") return "Seen recently";
+  if (freshnessLabel === "Missed check-in") return "Check-in overdue";
+  return "No recent check-in";
 }
 
 function messageToEvent(message: OrchestratorMessageRow): OrchestratorContinuityEvent {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -142,6 +142,9 @@ describe("orchestrator context", () => {
     expect(context.current_state_card.next_actions[0]).toContain("Orchestrator context layer");
     expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.role).toBe("human");
     expect(context.profile_cards.find((profile) => profile.agent_id === "chatgpt-codex-seat")?.freshness_label).toBe("Live");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "chatgpt-codex-seat")?.source_app_label).toBe("Codex");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "chatgpt-codex-seat")?.connection_label).toBe("Connected");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.source_app_label).toBe("Admin UI");
     expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.freshness_label).toBe("Recent");
     expect(context.continuity_events.some((event) => event.kind === "proof" && event.source_id === "msg-proof")).toBe(true);
     expect(context.continuity_events.some((event) => event.source_kind === "conversation_turn" && event.role === "user")).toBe(true);
@@ -189,6 +192,7 @@ describe("orchestrator context", () => {
     expect(labels.get("recent-seat")).toBe("Recent");
     expect(labels.get("missed-seat")).toBe("Missed check-in");
     expect(labels.get("quiet-seat")).toBe("Quiet");
+    expect(context.profile_cards.find((profile) => profile.agent_id === "missed-seat")?.connection_label).toBe("Check-in overdue");
   });
 
   it("redacts sensitive auth and billing material before summaries leave the layer", () => {

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -69,6 +69,9 @@ interface OrchestratorContext {
     label: string;
     role: "human" | "ai-seat";
     emoji?: string | null;
+    device_hint?: string | null;
+    source_app_label?: string | null;
+    connection_label?: string | null;
     last_seen_at?: string | null;
     freshness_label?: SeatFreshnessLabel | null;
     checkin_age_minutes?: number | null;
@@ -331,16 +334,23 @@ function OrchestratorContextCard({
           )}
         </ContextSection>
 
-        <ContextSection title="Profiles" icon={Users}>
+        <ContextSection title="Connected PCs" icon={Terminal}>
           {context.profile_cards.slice(0, 5).map((profile) => (
-            <div key={profile.agent_id} className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-xs">
-              <span className="min-w-0 truncate text-white/70">
-                {profile.emoji ? `${profile.emoji} ` : ""}{profile.label}
-              </span>
-              <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-medium ${FRESHNESS_STYLES[profile.freshness_label ?? "Quiet"]}`}>
-                {profile.freshness_label ?? "Quiet"}
-              </span>
-              <span className="shrink-0 text-white/35">{formatRelative(profile.last_seen_at)}</span>
+            <div key={profile.agent_id} className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2">
+              <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+                <span className="min-w-0 truncate text-xs font-medium text-white/75">
+                  {profile.emoji ? `${profile.emoji} ` : ""}{profile.label}
+                </span>
+                <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-medium ${FRESHNESS_STYLES[profile.freshness_label ?? "Quiet"]}`}>
+                  {profile.freshness_label ?? "Quiet"}
+                </span>
+              </div>
+              <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-white/35">
+                <span className="font-medium text-white/50">{profile.connection_label ?? "No recent check-in"}</span>
+                <span>{profile.source_app_label ?? "AI Seat"}</span>
+                <span>{formatRelative(profile.last_seen_at)}</span>
+                {profile.device_hint && <span className="max-w-full truncate font-mono">{profile.device_hint}</span>}
+              </div>
             </div>
           ))}
           {context.profile_cards.length === 0 && (


### PR DESCRIPTION
Summary:
Adds compact connected-PC visibility to the read-only Orchestrator context card. Profile Cards now include derived source-app and connection labels, and `/admin/orchestrator` renders them with freshness, last-seen timing, and device hint.

Scope:
Owned files for todo `44b84854-3eec-40f3-8397-0bfcdb4482ec`:
- `api/lib/orchestrator-context.ts`
- `api/orchestrator-context.test.ts`
- `src/pages/admin/AdminOrchestrator.tsx`

Non-overlap:
This PR does not touch auth, secrets, billing, Passport storage, migrations, production config, raw transcript capture, or any second Orchestrator data model.

Verification:
- `npx vitest api/orchestrator-context.test.ts`
- `npm run build`

Risk:
Low. The change is read-only UI and derived labels from existing profile state. No new storage or permissions.

Follow-up:
After merge, parent Orchestrator visibility todo `b1334cae` can be reassessed for remaining turn-logging polish.

PR status:
Draft for normal review. 🤖