### PR TITLE
feat(geopass): add chunk one scanner scaffold

### DIFF
--- a/docs/geopass-product-brief.md
+++ b/docs/geopass-product-brief.md
@@ -1,0 +1,31 @@
+# GEOPass Product Brief
+
+GEOPass is the Pass family product for generative-engine readiness. It diagnoses how prepared a public website is to be understood, cited, and represented by AI answer engines such as ChatGPT, Claude, Perplexity, Gemini, Copilot, Grok, and Meta AI.
+
+GEOPass does not promise rankings or citations. The correct promise is readiness: surface public gaps, explain why they matter, and give the user practical next steps that may increase the likelihood of accurate AI discovery.
+
+## Chunk 1 Scope
+
+This first scaffold creates a package-level contract only. It defines report, check, finding, evidence, severity, verdict, engine, bot, and cross-pass signal shapes. It also adds a scanner plan that documents the future shared scanner stack without running crawlers, using paid APIs, reading credentials, or writing production data.
+
+The v0 diagnostic hats are:
+
+- AI bot crawlability matrix across GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Bingbot, Twitterbot, and FacebookBot.
+- llms.txt presence and quality.
+- schema.org citation-grade validation.
+- Brand mention readiness across the seven answer engines.
+- Wikidata presence.
+- Common Crawl presence.
+- Aggregate AI engine readiness score.
+
+## Shared Scanner Relationship
+
+GEOPass owns the shared scanner contract for the Pass family. SEOPass should become a thin verdict pack on top of this package, reusing the same evidence and report language where possible. FlowPass, LegalPass, SlopPass, and UXPass can consume `cross_pass_signals` without each inventing a second scanner shape.
+
+## Safety Rules
+
+- No guaranteed citations, guaranteed rankings, or rank-one language.
+- No live crawler execution in this scaffold.
+- No paid API calls.
+- No credentials, auth, billing, domains, migrations, or production database writes.
+- Source-linked public evidence only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7847,6 +7847,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@unclick/geopass": {
+      "resolved": "packages/geopass",
+      "link": true
+    },
     "node_modules/@unclick/legalpass": {
       "resolved": "packages/legalpass",
       "link": true
@@ -21180,6 +21184,28 @@
         "sqlite3": {
           "optional": true
         }
+      }
+    },
+    "packages/geopass": {
+      "name": "@unclick/geopass",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+      }
+    },
+    "packages/geopass/node_modules/@types/node": {
+      "version": "20.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
+      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/legalpass": {

--- a/packages/geopass/package.json
+++ b/packages/geopass/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@unclick/geopass",
+  "version": "0.1.0",
+  "description": "GEOPass - generative-engine readiness diagnostics for public websites.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./schema": "./dist/schema.js",
+    "./scanner-plan": "./dist/scanner-plan.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/geopass/src/__tests__/scanner-plan.test.ts
+++ b/packages/geopass/src/__tests__/scanner-plan.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_GEOPASS_BOTS,
+  DEFAULT_GEOPASS_ENGINES,
+  createGeoPassScannerPlan,
+} from "../scanner-plan.js";
+
+describe("createGeoPassScannerPlan", () => {
+  it("creates a plan-only scanner blueprint for the seven target engines", () => {
+    const plan = createGeoPassScannerPlan({
+      targetUrl: "https://example.com",
+    });
+
+    expect(plan.mode).toBe("plan-only");
+    expect(plan.targetUrl).toBe("https://example.com/");
+    expect(plan.engines).toEqual(DEFAULT_GEOPASS_ENGINES);
+    expect(plan.bots).toEqual(DEFAULT_GEOPASS_BOTS);
+    expect(plan.steps.map((step) => step.id)).toContain("ai-bot-crawlability");
+    expect(plan.steps.map((step) => step.id)).toContain(
+      "aggregate-ai-engine-readiness",
+    );
+  });
+
+  it("allows a small scoped check subset", () => {
+    const plan = createGeoPassScannerPlan({
+      targetUrl: "https://example.com",
+      checks: ["llms-txt", "schema-org-citation-grade"],
+    });
+
+    expect(plan.steps.map((step) => step.id)).toEqual([
+      "llms-txt",
+      "schema-org-citation-grade",
+    ]);
+  });
+
+  it("records stop conditions for live crawler and paid API work", () => {
+    const plan = createGeoPassScannerPlan({
+      targetUrl: "https://example.com",
+    });
+
+    expect(plan.disallowedActions).toContain("live crawler execution");
+    expect(plan.disallowedActions).toContain("paid API calls");
+    expect(plan.disallowedActions).toContain("citation guarantees");
+  });
+
+  it("rejects invalid target URLs", () => {
+    expect(() =>
+      createGeoPassScannerPlan({
+        targetUrl: "not a url",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/geopass/src/__tests__/schema.test.ts
+++ b/packages/geopass/src/__tests__/schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { GeoPassReportSchema } from "../schema.js";
+
+const validReport = {
+  target_url: "https://example.com/",
+  generated_at: "2026-05-09T16:30:00.000Z",
+  mode: "plan-only",
+  engines: ["chatgpt", "claude", "perplexity", "gemini", "copilot", "grok", "meta-ai"],
+  aggregate_ai_engine_readiness_score: 74,
+  verdict: "needs-work",
+  checks: [
+    {
+      check_id: "llms-txt",
+      label: "llms.txt presence and quality",
+      score: 60,
+      verdict: "needs-work",
+      findings: [
+        {
+          id: "llms-txt-missing-summary",
+          check_id: "llms-txt",
+          severity: "medium",
+          title: "llms.txt needs a product summary",
+          summary: "The file exists but does not explain the product in plain public language.",
+          evidence: [
+            {
+              kind: "llms-txt",
+              label: "Public llms.txt",
+              source_url: "https://example.com/llms.txt",
+              summary: "Short file with links only.",
+            },
+          ],
+          recommendation:
+            "Add a short public summary that explains what the product does and who it serves.",
+        },
+      ],
+    },
+  ],
+  cross_pass_signals: [
+    {
+      pass: "seopass",
+      signal: "structured data quality affects both SEO and GEO citation readiness",
+      score: 70,
+    },
+  ],
+  notes: ["Diagnostic readiness only. It does not guarantee citation."],
+};
+
+describe("GeoPassReportSchema", () => {
+  it("accepts the chunk-1 public readiness report shape", () => {
+    const result = GeoPassReportSchema.safeParse(validReport);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid targets", () => {
+    const result = GeoPassReportSchema.safeParse({
+      ...validReport,
+      target_url: "not a url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects readiness scores outside 0 to 100", () => {
+    const result = GeoPassReportSchema.safeParse({
+      ...validReport,
+      aggregate_ai_engine_readiness_score: 101,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires at least one engine and one check", () => {
+    const noEngine = GeoPassReportSchema.safeParse({
+      ...validReport,
+      engines: [],
+    });
+    const noChecks = GeoPassReportSchema.safeParse({
+      ...validReport,
+      checks: [],
+    });
+    expect(noEngine.success).toBe(false);
+    expect(noChecks.success).toBe(false);
+  });
+
+  it("keeps the report public-safe with source-linked evidence only", () => {
+    const result = GeoPassReportSchema.parse(validReport);
+    expect(result.mode).toBe("plan-only");
+    expect(result.checks[0]?.findings[0]?.evidence[0]?.source_url).toBe(
+      "https://example.com/llms.txt",
+    );
+  });
+});

--- a/packages/geopass/src/index.ts
+++ b/packages/geopass/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./schema.js";
+export * from "./scanner-plan.js";

--- a/packages/geopass/src/scanner-plan.ts
+++ b/packages/geopass/src/scanner-plan.ts
@@ -1,0 +1,142 @@
+import {
+  GeoPassBotIdSchema,
+  GeoPassCheckIdSchema,
+  GeoPassEngineIdSchema,
+  type GeoPassBotId,
+  type GeoPassCheckId,
+  type GeoPassEngineId,
+} from "./schema.js";
+
+export type GeoPassScannerMode = "plan-only";
+
+export type GeoPassScannerStep = {
+  id: GeoPassCheckId;
+  label: string;
+  purpose: string;
+  evidenceKinds: string[];
+  sharedWith: Array<"seopass" | "flowpass" | "legalpass" | "sloppass" | "uxpass">;
+};
+
+export type GeoPassScannerPlan = {
+  targetUrl: string;
+  mode: GeoPassScannerMode;
+  engines: GeoPassEngineId[];
+  bots: GeoPassBotId[];
+  steps: GeoPassScannerStep[];
+  disallowedActions: string[];
+};
+
+export const DEFAULT_GEOPASS_ENGINES: GeoPassEngineId[] = [
+  "chatgpt",
+  "claude",
+  "perplexity",
+  "gemini",
+  "copilot",
+  "grok",
+  "meta-ai",
+];
+
+export const DEFAULT_GEOPASS_BOTS: GeoPassBotId[] = [
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+  "Twitterbot",
+  "FacebookBot",
+];
+
+export const DEFAULT_GEOPASS_SCANNER_STEPS: GeoPassScannerStep[] = [
+  {
+    id: "ai-bot-crawlability",
+    label: "AI bot crawlability matrix",
+    purpose:
+      "Plan robots.txt and public bot access checks for major generative engines.",
+    evidenceKinds: ["robots-txt", "manual-note"],
+    sharedWith: ["seopass"],
+  },
+  {
+    id: "llms-txt",
+    label: "llms.txt presence and quality",
+    purpose:
+      "Check whether the site publishes a useful llms.txt guide for AI readers.",
+    evidenceKinds: ["llms-txt"],
+    sharedWith: ["seopass", "sloppass"],
+  },
+  {
+    id: "schema-org-citation-grade",
+    label: "schema.org citation-grade validation",
+    purpose:
+      "Plan structured data checks that make public facts easier to cite accurately.",
+    evidenceKinds: ["schema-org"],
+    sharedWith: ["seopass", "legalpass"],
+  },
+  {
+    id: "brand-mention-readiness",
+    label: "Brand mention readiness",
+    purpose:
+      "Plan public-safe brand query fixtures without paid API calls or live prompts.",
+    evidenceKinds: ["brand-query"],
+    sharedWith: ["seopass", "uxpass"],
+  },
+  {
+    id: "wikidata-presence",
+    label: "Wikidata presence",
+    purpose:
+      "Plan public entity presence checks for citation context and disambiguation.",
+    evidenceKinds: ["wikidata"],
+    sharedWith: ["seopass"],
+  },
+  {
+    id: "common-crawl-presence",
+    label: "Common Crawl presence",
+    purpose:
+      "Plan public web corpus presence checks without fetching private content.",
+    evidenceKinds: ["common-crawl"],
+    sharedWith: ["seopass"],
+  },
+  {
+    id: "aggregate-ai-engine-readiness",
+    label: "Aggregate AI engine readiness score",
+    purpose:
+      "Combine public diagnostics into one readiness score and shared pass signals.",
+    evidenceKinds: ["lighthouse", "manual-note"],
+    sharedWith: ["seopass", "flowpass", "legalpass", "sloppass", "uxpass"],
+  },
+];
+
+const DISALLOWED_ACTIONS = [
+  "live crawler execution",
+  "paid API calls",
+  "credential access",
+  "production database writes",
+  "citation guarantees",
+];
+
+export function createGeoPassScannerPlan(input: {
+  targetUrl: string;
+  engines?: GeoPassEngineId[];
+  bots?: GeoPassBotId[];
+  checks?: GeoPassCheckId[];
+}): GeoPassScannerPlan {
+  const engines = (input.engines ?? DEFAULT_GEOPASS_ENGINES).map((engine) =>
+    GeoPassEngineIdSchema.parse(engine),
+  );
+  const bots = (input.bots ?? DEFAULT_GEOPASS_BOTS).map((bot) =>
+    GeoPassBotIdSchema.parse(bot),
+  );
+  const checks = new Set(
+    (input.checks ?? DEFAULT_GEOPASS_SCANNER_STEPS.map((step) => step.id)).map(
+      (check) => GeoPassCheckIdSchema.parse(check),
+    ),
+  );
+
+  return {
+    targetUrl: new URL(input.targetUrl).toString(),
+    mode: "plan-only",
+    engines,
+    bots,
+    steps: DEFAULT_GEOPASS_SCANNER_STEPS.filter((step) => checks.has(step.id)),
+    disallowedActions: DISALLOWED_ACTIONS,
+  };
+}

--- a/packages/geopass/src/schema.ts
+++ b/packages/geopass/src/schema.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+
+export const GeoPassSeveritySchema = z.enum([
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+]);
+
+export const GeoPassVerdictSchema = z.enum([
+  "ready",
+  "needs-work",
+  "blocked",
+  "unknown",
+]);
+
+export const GeoPassEngineIdSchema = z.enum([
+  "chatgpt",
+  "claude",
+  "perplexity",
+  "gemini",
+  "copilot",
+  "grok",
+  "meta-ai",
+]);
+
+export const GeoPassBotIdSchema = z.enum([
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+  "Twitterbot",
+  "FacebookBot",
+]);
+
+export const GeoPassCheckIdSchema = z.enum([
+  "ai-bot-crawlability",
+  "llms-txt",
+  "schema-org-citation-grade",
+  "brand-mention-readiness",
+  "wikidata-presence",
+  "common-crawl-presence",
+  "aggregate-ai-engine-readiness",
+]);
+
+export const GeoPassEvidenceSchema = z.object({
+  kind: z.enum([
+    "robots-txt",
+    "llms-txt",
+    "schema-org",
+    "wikidata",
+    "common-crawl",
+    "brand-query",
+    "lighthouse",
+    "manual-note",
+  ]),
+  label: z.string().min(1),
+  source_url: z.string().url().optional(),
+  summary: z.string().min(1),
+});
+
+export const GeoPassFindingSchema = z.object({
+  id: z.string().min(1),
+  check_id: GeoPassCheckIdSchema,
+  severity: GeoPassSeveritySchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  evidence: z.array(GeoPassEvidenceSchema).default([]),
+  recommendation: z.string().min(1).optional(),
+});
+
+export const GeoPassCheckResultSchema = z.object({
+  check_id: GeoPassCheckIdSchema,
+  label: z.string().min(1),
+  score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  findings: z.array(GeoPassFindingSchema).default([]),
+});
+
+export const GeoPassCrossPassSignalSchema = z.object({
+  pass: z.enum(["seopass", "flowpass", "legalpass", "sloppass", "uxpass"]),
+  signal: z.string().min(1),
+  score: z.number().min(0).max(100).optional(),
+});
+
+export const GeoPassReportSchema = z.object({
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).default("plan-only"),
+  engines: z.array(GeoPassEngineIdSchema).min(1),
+  aggregate_ai_engine_readiness_score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  checks: z.array(GeoPassCheckResultSchema).min(1),
+  cross_pass_signals: z.array(GeoPassCrossPassSignalSchema).default([]),
+  notes: z.array(z.string().min(1)).default([]),
+});
+
+export type GeoPassSeverity = z.infer<typeof GeoPassSeveritySchema>;
+export type GeoPassVerdict = z.infer<typeof GeoPassVerdictSchema>;
+export type GeoPassEngineId = z.infer<typeof GeoPassEngineIdSchema>;
+export type GeoPassBotId = z.infer<typeof GeoPassBotIdSchema>;
+export type GeoPassCheckId = z.infer<typeof GeoPassCheckIdSchema>;
+export type GeoPassEvidence = z.infer<typeof GeoPassEvidenceSchema>;
+export type GeoPassFinding = z.infer<typeof GeoPassFindingSchema>;
+export type GeoPassCheckResult = z.infer<typeof GeoPassCheckResultSchema>;
+export type GeoPassCrossPassSignal = z.infer<typeof GeoPassCrossPassSignalSchema>;
+export type GeoPassReport = z.infer<typeof GeoPassReportSchema>;

--- a/packages/geopass/tsconfig.json
+++ b/packages/geopass/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/geopass/vitest.config.ts
+++ b/packages/geopass/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false,
+    include: ["src/**/__tests__/**/*.{test,spec}.ts"],
+  },
+});


### PR DESCRIPTION
Summary:
- Adds the initial @unclick/geopass workspace package.
- Defines GEOPass report, finding, evidence, engine, bot, verdict, severity, and cross-pass signal schemas.
- Adds a plan-only scanner blueprint for the seven target answer engines and the v0 diagnostic hats.
- Adds focused tests and a public-facing GEOPass product brief.

Owner:
- chatgpt-codex-worker2 owns todo ea3ff0be-a6cb-4371-8dc5-56796ac92665 and branch codex/geopass-chunk-1-scaffold.

Status:
- Draft lifted after QueuePush packet queuepush:v3:pr-630:draft_green_needs_owner_lift:49968b4:ce212bf43f.
- PR checks are green and merge state is clean.

Scope:
- Lane: GEOPass chunk-1, shared scanner scaffold.
- Files: packages/geopass, docs/geopass-product-brief.md, package-lock.json.

Non-overlap:
- No live crawler execution, paid API calls, credentials, auth, billing, domains, migrations, or production data writes.
- No changes to UXPass, SEOPass, FlowPass, LegalPass, SlopPass, Jobs UI, Worker Registry, QueuePush, or PinballWake.
- No citation guarantees or ranking promises.

Verification:
- npm run test --workspace=@unclick/geopass, passed.
- From packages/geopass: npx vitest src/__tests__/schema.test.ts src/__tests__/scanner-plan.test.ts, passed.
- npm run build --workspace=@unclick/geopass, passed.
- npm run build, passed.
- PR checks green: Website (root package), MCP server package, TestPass smoke run, Vercel, Vercel Preview Comments.
- Existing root command npx vitest packages/geopass/src/__tests__/schema.test.ts packages/geopass/src/__tests__/scanner-plan.test.ts is blocked by root vitest.config.ts include paths that only cover src and api, so this package uses the existing Pass package-local Vitest config pattern.

Risk:
- Low. This is a new plan-only package and documentation scaffold.
- Package-lock changed only to register the new workspace package link and package-local @types/node dependency entry.

Follow-up:
- SEOPass can consume this contract as its thin verdict-pack base once this lands.