### PR TITLE
feat(seopass): add verdict pack scaffold

### DIFF
--- a/docs/seopass-product-brief.md
+++ b/docs/seopass-product-brief.md
@@ -10,6 +10,12 @@ Most SEO tooling is built for specialists and dashboards. SEOPass is built for a
 
 This chip is a scaffold only. It adds the SEOPass pack schema, a core pack, a Lighthouse execution-plan helper, four MCP tools, and this product brief. It does not run Lighthouse, write database rows, or create UI.
 
+## Verdict-pack scope
+
+This verdict-pack sits on the shared GEOPass scanner contract instead of creating a second crawler. It keeps SEOPass focused on search-engine readiness: indexability, metadata, canonical signals, structured data, internal links, and a Core Web Vitals placeholder.
+
+The current adapter is plan-only and public-safe. It accepts GEOPass-shaped source metadata and records which shared checks can feed SEO verdicts, but it does not execute Lighthouse, crawl live pages, call paid search APIs, write production rows, or claim ranking outcomes.
+
 ## MCP tools
 
 - `seopass_run` returns a planned run for a URL or registered pack.
@@ -20,9 +26,10 @@ This chip is a scaffold only. It adds the SEOPass pack schema, a core pack, a Li
 ## Build sequence
 
 1. Chunk 1: schema, pack, MCP tools, Lighthouse plan, brief.
-2. Chunk 2: execute Lighthouse and persist SEOPass runs/findings.
-3. Chunk 3: crawler checks for robots, sitemap, canonical, redirects, and internal links.
-4. Chunk 4: admin UI, reports, and Fishbowl/Signals routing.
+2. Verdict-pack: typed SEO report/finding/verdict shapes plus the shared GEOPass scanner adapter.
+3. Chunk 2: execute Lighthouse and persist SEOPass runs/findings.
+4. Chunk 3: crawler checks for robots, sitemap, canonical, redirects, and internal links.
+5. Chunk 4: admin UI, reports, and Fishbowl/Signals routing.
 
 ## Positioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7867,6 +7867,10 @@
       "resolved": "packages/securitypass",
       "link": true
     },
+    "node_modules/@unclick/seopass": {
+      "resolved": "packages/seopass",
+      "link": true
+    },
     "node_modules/@unclick/sloppass": {
       "resolved": "packages/sloppass",
       "link": true
@@ -21373,6 +21377,28 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/seopass": {
+      "name": "@unclick/seopass",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+      }
+    },
+    "packages/seopass/node_modules/@types/node": {
+      "version": "20.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
+      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/seopass/package.json
+++ b/packages/seopass/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@unclick/seopass",
+  "version": "0.1.0",
+  "description": "SEOPass - public-safe search-engine readiness verdicts for websites.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./schema": "./dist/schema.js",
+    "./verdict-pack": "./dist/verdict-pack.js",
+    "./lighthouse": "./dist/lighthouse.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/seopass/src/__tests__/schema.test.ts
+++ b/packages/seopass/src/__tests__/schema.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SeoPassFindingSchema,
+  SeoPassGeoPassAdapterSchema,
+  SeoPassReportSchema,
+} from "../schema.js";
+
+describe("SEOPass schema", () => {
+  it("validates a public-safe SEO finding", () => {
+    const finding = SeoPassFindingSchema.parse({
+      id: "metadata-title-missing",
+      check_id: "metadata",
+      severity: "high",
+      title: "Page title is missing",
+      summary: "The public HTML head did not provide a title.",
+      evidence: [
+        {
+          kind: "html-head",
+          label: "HTML head",
+          source_url: "https://example.com/",
+          summary: "No title element was present in the fixture.",
+        },
+      ],
+      recommendation: "Add a descriptive title for search snippets.",
+    });
+
+    expect(finding.evidence).toHaveLength(1);
+  });
+
+  it("accepts the GEOPass adapter seam without importing scanner internals", () => {
+    const adapter = SeoPassGeoPassAdapterSchema.parse({
+      source: "geopass",
+      target_url: "https://example.com/",
+      mode: "plan-only",
+      aggregate_ai_engine_readiness_score: 72,
+      verdict: "needs-work",
+      shared_check_ids: ["schema-org-citation-grade"],
+    });
+
+    expect(adapter.shared_check_ids).toEqual(["schema-org-citation-grade"]);
+  });
+
+  it("validates a plan-only report with scores and verdicts", () => {
+    const report = SeoPassReportSchema.parse({
+      target_url: "https://example.com/",
+      generated_at: "2026-05-09T16:58:00.000Z",
+      mode: "plan-only",
+      search_engine_readiness_score: 0,
+      verdict: "unknown",
+      scanner_source: {
+        kind: "geopass-plan",
+        mode: "plan-only",
+        target_url: "https://example.com/",
+        shared_check_ids: ["ai-bot-crawlability"],
+      },
+      checks: [
+        {
+          check_id: "indexability",
+          label: "Indexability",
+          score: 0,
+          verdict: "unknown",
+          comments: ["Awaiting read-only scanner evidence."],
+        },
+      ],
+    });
+
+    expect(report.checks[0]?.findings).toEqual([]);
+  });
+});

--- a/packages/seopass/src/__tests__/verdict-pack.test.ts
+++ b/packages/seopass/src/__tests__/verdict-pack.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SEOPASS_VERDICT_CHECKS,
+  createPlanOnlySeoPassReport,
+  createSeoPassVerdictPack,
+} from "../verdict-pack.js";
+
+describe("SEOPass verdict pack", () => {
+  it("contains the default search-engine readiness checks", () => {
+    expect(DEFAULT_SEOPASS_VERDICT_CHECKS.map((check) => check.id)).toEqual([
+      "indexability",
+      "metadata",
+      "canonical-signals",
+      "structured-data",
+      "internal-links",
+      "core-web-vitals",
+    ]);
+  });
+
+  it("builds a plan-only verdict pack on the GEOPass scanner seam", () => {
+    const pack = createSeoPassVerdictPack({
+      targetUrl: "https://example.com",
+      checks: ["metadata", "structured-data"],
+    });
+
+    expect(pack.targetUrl).toBe("https://example.com/");
+    expect(pack.mode).toBe("plan-only");
+    expect(pack.checks.map((check) => check.id)).toEqual([
+      "metadata",
+      "structured-data",
+    ]);
+    expect(pack.scannerSource.source).toBe("geopass");
+    expect(pack.disallowedActions).toContain("live crawler execution");
+  });
+
+  it("creates a typed plan-only report from the verdict pack", () => {
+    const report = createPlanOnlySeoPassReport({
+      targetUrl: "https://example.com/products",
+      generatedAt: "2026-05-09T16:58:00.000Z",
+      scannerSource: {
+        source: "geopass",
+        target_url: "https://example.com/products",
+        mode: "plan-only",
+        shared_check_ids: ["ai-bot-crawlability"],
+      },
+    });
+
+    expect(report.target_url).toBe("https://example.com/products");
+    expect(report.verdict).toBe("unknown");
+    expect(report.checks).toHaveLength(6);
+    expect(report.scanner_source.kind).toBe("geopass-plan");
+  });
+});

--- a/packages/seopass/src/index.ts
+++ b/packages/seopass/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema.js";
 export * from "./lighthouse.js";
+export * from "./verdict-pack.js";

--- a/packages/seopass/src/schema.ts
+++ b/packages/seopass/src/schema.ts
@@ -8,8 +8,94 @@ export const SeoPassCheckIdSchema = z.enum([
   "indexability",
   "canonical-signals",
   "internal-links",
+  "core-web-vitals",
   "ai-overview-readiness",
 ]);
+
+export const SeoPassSeveritySchema = z.enum([
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+]);
+
+export const SeoPassCheckVerdictSchema = z.enum([
+  "pass",
+  "warn",
+  "fail",
+  "unknown",
+]);
+
+export const SeoPassReportVerdictSchema = z.enum([
+  "ready",
+  "needs-work",
+  "blocked",
+  "unknown",
+]);
+
+export const SeoPassEvidenceSchema = z.object({
+  kind: z.enum([
+    "robots-txt",
+    "sitemap",
+    "html-head",
+    "canonical",
+    "structured-data",
+    "internal-link",
+    "lighthouse",
+    "geopass-signal",
+    "manual-note",
+  ]),
+  label: z.string().min(1),
+  source_url: z.string().url().optional(),
+  summary: z.string().min(1),
+});
+
+export const SeoPassFindingSchema = z.object({
+  id: z.string().min(1),
+  check_id: SeoPassCheckIdSchema,
+  severity: SeoPassSeveritySchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  evidence: z.array(SeoPassEvidenceSchema).default([]),
+  recommendation: z.string().min(1).optional(),
+});
+
+export const SeoPassCheckResultSchema = z.object({
+  check_id: SeoPassCheckIdSchema,
+  label: z.string().min(1),
+  score: z.number().min(0).max(100),
+  verdict: SeoPassCheckVerdictSchema,
+  findings: z.array(SeoPassFindingSchema).default([]),
+  comments: z.array(z.string().min(1)).default([]),
+});
+
+export const SeoPassScannerSourceSchema = z.object({
+  kind: z.enum(["geopass-plan", "fixture", "manual"]),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).default("plan-only"),
+  target_url: z.string().url(),
+  shared_check_ids: z.array(z.string().min(1)).default([]),
+});
+
+export const SeoPassReportSchema = z.object({
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).default("plan-only"),
+  search_engine_readiness_score: z.number().min(0).max(100),
+  verdict: SeoPassReportVerdictSchema,
+  checks: z.array(SeoPassCheckResultSchema).min(1),
+  scanner_source: SeoPassScannerSourceSchema,
+  notes: z.array(z.string().min(1)).default([]),
+});
+
+export const SeoPassGeoPassAdapterSchema = z.object({
+  source: z.literal("geopass"),
+  target_url: z.string().url(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).optional(),
+  aggregate_ai_engine_readiness_score: z.number().min(0).max(100).optional(),
+  verdict: z.enum(["ready", "needs-work", "blocked", "unknown"]).optional(),
+  shared_check_ids: z.array(z.string().min(1)).default([]),
+});
 
 export const SeoPassBudgetSchema = z
   .object({
@@ -44,3 +130,12 @@ export const SeoPassPackSchema = z.object({
 
 export type SeoPassPack = z.infer<typeof SeoPassPackSchema>;
 export type SeoPassCheckId = z.infer<typeof SeoPassCheckIdSchema>;
+export type SeoPassSeverity = z.infer<typeof SeoPassSeveritySchema>;
+export type SeoPassCheckVerdict = z.infer<typeof SeoPassCheckVerdictSchema>;
+export type SeoPassReportVerdict = z.infer<typeof SeoPassReportVerdictSchema>;
+export type SeoPassEvidence = z.infer<typeof SeoPassEvidenceSchema>;
+export type SeoPassFinding = z.infer<typeof SeoPassFindingSchema>;
+export type SeoPassCheckResult = z.infer<typeof SeoPassCheckResultSchema>;
+export type SeoPassScannerSource = z.infer<typeof SeoPassScannerSourceSchema>;
+export type SeoPassReport = z.infer<typeof SeoPassReportSchema>;
+export type SeoPassGeoPassAdapter = z.infer<typeof SeoPassGeoPassAdapterSchema>;

--- a/packages/seopass/src/verdict-pack.ts
+++ b/packages/seopass/src/verdict-pack.ts
@@ -1,0 +1,162 @@
+import {
+  SeoPassCheckIdSchema,
+  SeoPassGeoPassAdapterSchema,
+  SeoPassReportSchema,
+  type SeoPassCheckId,
+  type SeoPassCheckResult,
+  type SeoPassGeoPassAdapter,
+  type SeoPassReport,
+} from "./schema.js";
+
+export type SeoPassVerdictCheck = {
+  id: SeoPassCheckId;
+  label: string;
+  purpose: string;
+  evidenceKinds: string[];
+  sharedGeoPassCheckIds: string[];
+};
+
+export type SeoPassVerdictPack = {
+  targetUrl: string;
+  mode: "plan-only";
+  scannerSource: SeoPassGeoPassAdapter;
+  checks: SeoPassVerdictCheck[];
+  disallowedActions: string[];
+};
+
+export const DEFAULT_SEOPASS_VERDICT_CHECKS: SeoPassVerdictCheck[] = [
+  {
+    id: "indexability",
+    label: "Indexability",
+    purpose:
+      "Plan public robots, sitemap, and noindex checks before any search readiness verdict.",
+    evidenceKinds: ["robots-txt", "sitemap", "manual-note"],
+    sharedGeoPassCheckIds: ["ai-bot-crawlability", "common-crawl-presence"],
+  },
+  {
+    id: "metadata",
+    label: "Metadata",
+    purpose:
+      "Plan title, description, Open Graph, and search snippet checks from public HTML.",
+    evidenceKinds: ["html-head"],
+    sharedGeoPassCheckIds: ["brand-mention-readiness"],
+  },
+  {
+    id: "canonical-signals",
+    label: "Canonical signals",
+    purpose:
+      "Plan canonical URL, redirects, and alternate URL consistency checks.",
+    evidenceKinds: ["canonical", "html-head"],
+    sharedGeoPassCheckIds: [],
+  },
+  {
+    id: "structured-data",
+    label: "Structured data",
+    purpose:
+      "Plan schema.org presence checks that can also feed citation-grade AI answers.",
+    evidenceKinds: ["structured-data"],
+    sharedGeoPassCheckIds: ["schema-org-citation-grade"],
+  },
+  {
+    id: "internal-links",
+    label: "Internal links",
+    purpose:
+      "Plan basic public link graph checks without crawling private routes or forms.",
+    evidenceKinds: ["internal-link"],
+    sharedGeoPassCheckIds: [],
+  },
+  {
+    id: "core-web-vitals",
+    label: "Core Web Vitals placeholder",
+    purpose:
+      "Reserve the Lighthouse and field-data slot without executing a live crawler in this chip.",
+    evidenceKinds: ["lighthouse", "manual-note"],
+    sharedGeoPassCheckIds: ["aggregate-ai-engine-readiness"],
+  },
+];
+
+const DISALLOWED_ACTIONS = [
+  "live crawler execution",
+  "paid search API calls",
+  "credential access",
+  "production database writes",
+  "ranking guarantees",
+];
+
+function defaultScannerSource(targetUrl: string): SeoPassGeoPassAdapter {
+  return {
+    source: "geopass",
+    target_url: targetUrl,
+    mode: "plan-only",
+    shared_check_ids: [
+      "ai-bot-crawlability",
+      "schema-org-citation-grade",
+      "brand-mention-readiness",
+      "common-crawl-presence",
+      "aggregate-ai-engine-readiness",
+    ],
+  };
+}
+
+export function createSeoPassVerdictPack(input: {
+  targetUrl: string;
+  checks?: SeoPassCheckId[];
+  scannerSource?: SeoPassGeoPassAdapter;
+}): SeoPassVerdictPack {
+  const targetUrl = new URL(input.targetUrl).toString();
+  const selectedChecks = new Set(
+    (input.checks ?? DEFAULT_SEOPASS_VERDICT_CHECKS.map((check) => check.id)).map(
+      (check) => SeoPassCheckIdSchema.parse(check),
+    ),
+  );
+
+  return {
+    targetUrl,
+    mode: "plan-only",
+    scannerSource: SeoPassGeoPassAdapterSchema.parse(
+      input.scannerSource ?? defaultScannerSource(targetUrl),
+    ),
+    checks: DEFAULT_SEOPASS_VERDICT_CHECKS.filter((check) =>
+      selectedChecks.has(check.id),
+    ),
+    disallowedActions: DISALLOWED_ACTIONS,
+  };
+}
+
+export function createPlanOnlySeoPassReport(input: {
+  targetUrl: string;
+  generatedAt?: string;
+  checks?: SeoPassCheckId[];
+  scannerSource?: SeoPassGeoPassAdapter;
+  notes?: string[];
+}): SeoPassReport {
+  const verdictPack = createSeoPassVerdictPack(input);
+  const checkResults: SeoPassCheckResult[] = verdictPack.checks.map((check) => ({
+    check_id: check.id,
+    label: check.label,
+    score: 0,
+    verdict: "unknown",
+    findings: [],
+    comments: [
+      "Plan-only placeholder: execute read-only evidence collection in a later chip.",
+    ],
+  }));
+
+  return SeoPassReportSchema.parse({
+    target_url: verdictPack.targetUrl,
+    generated_at: input.generatedAt ?? new Date(0).toISOString(),
+    mode: "plan-only",
+    search_engine_readiness_score: 0,
+    verdict: "unknown",
+    checks: checkResults,
+    scanner_source: {
+      kind: "geopass-plan",
+      mode: verdictPack.scannerSource.mode ?? "plan-only",
+      target_url: verdictPack.scannerSource.target_url,
+      shared_check_ids: verdictPack.scannerSource.shared_check_ids,
+    },
+    notes: input.notes ?? [
+      "SEOPass verdict-pack consumes the shared GEOPass scanner contract through this adapter seam.",
+    ],
+  });
+}

--- a/packages/seopass/tsconfig.json
+++ b/packages/seopass/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/seopass/vitest.config.ts
+++ b/packages/seopass/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/__tests__/**/*.{test,spec}.ts"],
+    globals: false,
+  },
+});


### PR DESCRIPTION
Summary:
- Adds the @unclick/seopass workspace package scaffold with build, typecheck, and Vitest config.
- Adds typed SEOPass severity, verdict, finding, report, and GEOPass adapter schemas.
- Adds the plan-only verdict-pack module for indexability, metadata, canonical signals, structured data, internal links, and Core Web Vitals placeholders.
- Updates the SEOPass product brief with the shared GEOPass scanner boundary.

Scope:
- Owned files for UnClick todo 44a1edfc.
- Package lane: packages/seopass and docs/seopass-product-brief.md.

Non-overlap:
- Does not execute live crawlers or Lighthouse.
- Does not add database rows, migrations, credentials, billing, domains, or paid API calls.
- Does not touch GEOPass, UXPass, FlowPass, LegalPass, or SlopPass wrappers.

Verification:
- npm run test --workspace=@unclick/seopass
- npx vitest src/__tests__/schema.test.ts src/__tests__/verdict-pack.test.ts from packages/seopass
- npm run typecheck --workspace=@unclick/seopass
- npm run build --workspace=@unclick/seopass
- npm run build
- npx eslint packages/seopass/src/schema.ts packages/seopass/src/lighthouse.ts packages/seopass/src/verdict-pack.ts packages/seopass/src/index.ts packages/seopass/src/__tests__/schema.test.ts packages/seopass/src/__tests__/verdict-pack.test.ts
- git diff --check

Risk:
- Low. Plan-only schemas and tests; no runtime crawler, auth, cron, API, database, or secret handling.

Follow-up:
- Later chips can wire read-only evidence execution and persistence behind this typed verdict-pack surface.
