### PR TITLE
feat(flowpass): add chunk one scaffold

### DIFF
--- a/docs/flowpass-product-brief.md
+++ b/docs/flowpass-product-brief.md
@@ -1,0 +1,30 @@
+# FlowPass Product Brief
+
+FlowPass checks whether an important product path can work end-to-end. It is the journey-completion member of the Pass family: TestPass checks tools, UXPass checks human experience, SEOPass checks search readiness, and FlowPass checks that a user can start, move through, recover from errors, and reach a handoff or receipt.
+
+## Chunk 1 Scope
+
+This chip is a scaffold only. It adds the FlowPass package, plan-only schemas, a fixture-driven flow plan, a verdict-pack helper, focused tests, and this brief.
+
+It does not run live signup, auth, checkout, billing, email, domains, production database writes, or destructive submissions. The first surface is intentionally static and fixture-driven so future runners can add live-readonly evidence without unsafe product actions.
+
+## Default Hats
+
+- Entry route loads.
+- Primary CTA is reachable.
+- Form is ready for fixture input.
+- Success state is represented.
+- Failure state is represented.
+- Navigation continuity is preserved.
+- Handoff proof is available.
+
+## Shared Scanner Boundary
+
+FlowPass consumes the shared GEOPass scanner contract only as source context. The current adapter records the target URL and shared check ids, especially aggregate AI engine readiness, but it does not duplicate GEOPass scanner internals.
+
+## Build Sequence
+
+1. Chunk 1: schema, flow plan, verdict pack, package scaffold, tests, brief.
+2. Chunk 2: fixture runner receipts for route, CTA, form, success, failure, navigation, and handoff proof.
+3. Chunk 3: admin report surface and Boardroom or Signals routing.
+4. Chunk 4: optional live-readonly runner with explicit protected-flow exclusions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7847,6 +7847,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@unclick/flowpass": {
+      "resolved": "packages/flowpass",
+      "link": true
+    },
     "node_modules/@unclick/geopass": {
       "resolved": "packages/geopass",
       "link": true
@@ -21188,6 +21192,28 @@
         "sqlite3": {
           "optional": true
         }
+      }
+    },
+    "packages/flowpass": {
+      "name": "@unclick/flowpass",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+      }
+    },
+    "packages/flowpass/node_modules/@types/node": {
+      "version": "20.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
+      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/geopass": {

--- a/packages/flowpass/package.json
+++ b/packages/flowpass/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@unclick/flowpass",
+  "version": "0.1.0",
+  "description": "FlowPass - fixture-driven end-to-end journey readiness diagnostics for products.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./schema": "./dist/schema.js",
+    "./flow-plan": "./dist/flow-plan.js",
+    "./verdict-pack": "./dist/verdict-pack.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/flowpass/src/__tests__/flow-plan.test.ts
+++ b/packages/flowpass/src/__tests__/flow-plan.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_FLOWPASS_STEPS, createFlowPassPlan } from "../flow-plan.js";
+
+describe("FlowPass plan", () => {
+  it("contains the default fixture-driven journey steps", () => {
+    expect(DEFAULT_FLOWPASS_STEPS.map((step) => step.id)).toEqual([
+      "entry-route",
+      "primary-cta",
+      "form-readiness",
+      "success-state",
+      "failure-state",
+      "navigation-continuity",
+      "handoff-proof",
+    ]);
+  });
+
+  it("creates a safe plan-only journey", () => {
+    const plan = createFlowPassPlan({
+      targetUrl: "https://example.com",
+      journeyId: "signup",
+      journeyName: "Signup journey",
+      journeyKind: "signup",
+      steps: ["entry-route", "primary-cta"],
+    });
+
+    expect(plan.targetUrl).toBe("https://example.com/");
+    expect(plan.mode).toBe("plan-only");
+    expect(plan.steps.map((step) => step.id)).toEqual([
+      "entry-route",
+      "primary-cta",
+    ]);
+    expect(plan.disallowedActions).toContain("live signup execution");
+    expect(plan.disallowedActions).toContain("production database writes");
+  });
+});

--- a/packages/flowpass/src/__tests__/schema.test.ts
+++ b/packages/flowpass/src/__tests__/schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FlowPassFindingSchema,
+  FlowPassGeoPassAdapterSchema,
+  FlowPassReportSchema,
+} from "../schema.js";
+
+describe("FlowPass schema", () => {
+  it("validates a fixture-safe flow finding", () => {
+    const finding = FlowPassFindingSchema.parse({
+      id: "primary-cta-missing",
+      step_id: "primary-cta",
+      severity: "high",
+      title: "Primary CTA is missing",
+      summary: "The fixture did not expose a clear primary action.",
+      evidence: [
+        {
+          kind: "fixture",
+          label: "Landing fixture",
+          source_url: "https://example.com/",
+          summary: "No button or link was marked as the primary CTA.",
+        },
+      ],
+      recommendation: "Expose one primary action for the journey.",
+    });
+
+    expect(finding.evidence).toHaveLength(1);
+  });
+
+  it("accepts a GEOPass source adapter for shared scanner context", () => {
+    const adapter = FlowPassGeoPassAdapterSchema.parse({
+      source: "geopass",
+      target_url: "https://example.com/",
+      mode: "plan-only",
+      shared_check_ids: ["aggregate-ai-engine-readiness"],
+    });
+
+    expect(adapter.shared_check_ids).toEqual([
+      "aggregate-ai-engine-readiness",
+    ]);
+  });
+
+  it("validates a plan-only FlowPass report", () => {
+    const report = FlowPassReportSchema.parse({
+      target_url: "https://example.com/",
+      generated_at: "2026-05-09T17:38:00.000Z",
+      mode: "plan-only",
+      journey: {
+        id: "signup",
+        name: "Signup journey",
+        kind: "signup",
+      },
+      journey_readiness_score: 0,
+      verdict: "unknown",
+      scanner_source: {
+        kind: "fixture",
+        mode: "plan-only",
+        target_url: "https://example.com/",
+      },
+      steps: [
+        {
+          step_id: "entry-route",
+          label: "Entry route loads",
+          score: 0,
+          verdict: "unknown",
+        },
+      ],
+    });
+
+    expect(report.steps[0]?.findings).toEqual([]);
+  });
+});

--- a/packages/flowpass/src/__tests__/verdict-pack.test.ts
+++ b/packages/flowpass/src/__tests__/verdict-pack.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createFlowPassVerdictPack,
+  createPlanOnlyFlowPassReport,
+} from "../verdict-pack.js";
+
+describe("FlowPass verdict pack", () => {
+  it("builds a verdict pack on the GEOPass source seam", () => {
+    const pack = createFlowPassVerdictPack({
+      targetUrl: "https://example.com/app",
+      journeyId: "checkout",
+      journeyName: "Checkout journey",
+      journeyKind: "checkout",
+      steps: ["entry-route", "form-readiness", "success-state"],
+    });
+
+    expect(pack.targetUrl).toBe("https://example.com/app");
+    expect(pack.scannerSource.source).toBe("geopass");
+    expect(pack.scannerSource.shared_check_ids).toEqual([
+      "aggregate-ai-engine-readiness",
+    ]);
+    expect(pack.steps).toHaveLength(3);
+  });
+
+  it("creates a typed plan-only report", () => {
+    const report = createPlanOnlyFlowPassReport({
+      targetUrl: "https://example.com/signup",
+      generatedAt: "2026-05-09T17:38:00.000Z",
+      journeyId: "signup",
+      journeyName: "Signup journey",
+      journeyKind: "signup",
+      scannerSource: {
+        source: "geopass",
+        target_url: "https://example.com/signup",
+        mode: "plan-only",
+        shared_check_ids: ["aggregate-ai-engine-readiness"],
+      },
+    });
+
+    expect(report.target_url).toBe("https://example.com/signup");
+    expect(report.verdict).toBe("unknown");
+    expect(report.steps).toHaveLength(7);
+    expect(report.scanner_source.kind).toBe("geopass-plan");
+  });
+});

--- a/packages/flowpass/src/flow-plan.ts
+++ b/packages/flowpass/src/flow-plan.ts
@@ -1,0 +1,108 @@
+import {
+  FlowPassJourneyKindSchema,
+  FlowPassStepIdSchema,
+  type FlowPassJourneyKind,
+  type FlowPassStep,
+  type FlowPassStepId,
+} from "./schema.js";
+
+export type FlowPassPlan = {
+  targetUrl: string;
+  mode: "plan-only";
+  journey: {
+    id: string;
+    name: string;
+    kind: FlowPassJourneyKind;
+  };
+  steps: FlowPassStep[];
+  disallowedActions: string[];
+};
+
+export const DEFAULT_FLOWPASS_STEPS: FlowPassStep[] = [
+  {
+    id: "entry-route",
+    label: "Entry route loads",
+    route: "/",
+    required: true,
+    fixtures: ["public route fixture"],
+    evidence_kinds: ["route", "fixture"],
+  },
+  {
+    id: "primary-cta",
+    label: "Primary CTA is reachable",
+    required: true,
+    fixtures: ["cta text fixture", "link target fixture"],
+    evidence_kinds: ["link", "fixture"],
+  },
+  {
+    id: "form-readiness",
+    label: "Form is ready for fixture input",
+    required: true,
+    fixtures: ["valid fixture input", "required field fixture"],
+    evidence_kinds: ["form", "fixture"],
+  },
+  {
+    id: "success-state",
+    label: "Success state is represented",
+    required: true,
+    fixtures: ["success copy fixture", "receipt fixture"],
+    evidence_kinds: ["route", "manual-note"],
+  },
+  {
+    id: "failure-state",
+    label: "Failure state is represented",
+    required: true,
+    fixtures: ["validation error fixture", "recoverable error fixture"],
+    evidence_kinds: ["form", "console-log", "manual-note"],
+  },
+  {
+    id: "navigation-continuity",
+    label: "Navigation continuity is preserved",
+    required: true,
+    fixtures: ["back link fixture", "next route fixture"],
+    evidence_kinds: ["link", "route"],
+  },
+  {
+    id: "handoff-proof",
+    label: "Handoff proof is available",
+    required: true,
+    fixtures: ["receipt fixture", "state handoff fixture"],
+    evidence_kinds: ["fixture", "manual-note"],
+  },
+];
+
+const DISALLOWED_ACTIONS = [
+  "live signup execution",
+  "live auth execution",
+  "live checkout or billing execution",
+  "email delivery",
+  "credential access",
+  "production database writes",
+  "destructive form submission",
+];
+
+export function createFlowPassPlan(input: {
+  targetUrl: string;
+  journeyId?: string;
+  journeyName?: string;
+  journeyKind?: FlowPassJourneyKind;
+  steps?: FlowPassStepId[];
+}): FlowPassPlan {
+  const selectedSteps = new Set(
+    (input.steps ?? DEFAULT_FLOWPASS_STEPS.map((step) => step.id)).map((step) =>
+      FlowPassStepIdSchema.parse(step),
+    ),
+  );
+
+  return {
+    targetUrl: new URL(input.targetUrl).toString(),
+    mode: "plan-only",
+    journey: {
+      id: input.journeyId ?? "primary-journey",
+      name: input.journeyName ?? "Primary product journey",
+      kind: FlowPassJourneyKindSchema.parse(input.journeyKind ?? "custom"),
+    },
+    steps: DEFAULT_FLOWPASS_STEPS.filter((step) => selectedSteps.has(step.id)),
+    disallowedActions: DISALLOWED_ACTIONS,
+  };
+}

--- a/packages/flowpass/src/index.ts
+++ b/packages/flowpass/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema.js";
+export * from "./flow-plan.js";
+export * from "./verdict-pack.js";

--- a/packages/flowpass/src/schema.ts
+++ b/packages/flowpass/src/schema.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+export const FlowPassStepIdSchema = z.enum([
+  "entry-route",
+  "primary-cta",
+  "form-readiness",
+  "success-state",
+  "failure-state",
+  "navigation-continuity",
+  "handoff-proof",
+]);
+
+export const FlowPassJourneyKindSchema = z.enum([
+  "signup",
+  "auth",
+  "checkout",
+  "onboarding",
+  "support",
+  "custom",
+]);
+
+export const FlowPassSeveritySchema = z.enum([
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+]);
+
+export const FlowPassStepVerdictSchema = z.enum([
+  "pass",
+  "warn",
+  "fail",
+  "unknown",
+]);
+
+export const FlowPassReportVerdictSchema = z.enum([
+  "ready",
+  "needs-work",
+  "blocked",
+  "unknown",
+]);
+
+export const FlowPassEvidenceSchema = z.object({
+  kind: z.enum([
+    "route",
+    "link",
+    "form",
+    "fixture",
+    "screenshot",
+    "console-log",
+    "network-log",
+    "accessibility-snapshot",
+    "geopass-signal",
+    "manual-note",
+  ]),
+  label: z.string().min(1),
+  source_url: z.string().url().optional(),
+  summary: z.string().min(1),
+});
+
+export const FlowPassFindingSchema = z.object({
+  id: z.string().min(1),
+  step_id: FlowPassStepIdSchema,
+  severity: FlowPassSeveritySchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  evidence: z.array(FlowPassEvidenceSchema).default([]),
+  recommendation: z.string().min(1).optional(),
+});
+
+export const FlowPassStepSchema = z.object({
+  id: FlowPassStepIdSchema,
+  label: z.string().min(1),
+  route: z.string().min(1).optional(),
+  required: z.boolean().default(true),
+  fixtures: z.array(z.string().min(1)).default([]),
+  evidence_kinds: z.array(z.string().min(1)).default([]),
+});
+
+export const FlowPassStepResultSchema = z.object({
+  step_id: FlowPassStepIdSchema,
+  label: z.string().min(1),
+  score: z.number().min(0).max(100),
+  verdict: FlowPassStepVerdictSchema,
+  findings: z.array(FlowPassFindingSchema).default([]),
+  comments: z.array(z.string().min(1)).default([]),
+});
+
+export const FlowPassScannerSourceSchema = z.object({
+  kind: z.enum(["geopass-plan", "fixture", "manual"]),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).default("plan-only"),
+  target_url: z.string().url(),
+  shared_check_ids: z.array(z.string().min(1)).default([]),
+});
+
+export const FlowPassReportSchema = z.object({
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).default("plan-only"),
+  journey: z.object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    kind: FlowPassJourneyKindSchema,
+  }),
+  journey_readiness_score: z.number().min(0).max(100),
+  verdict: FlowPassReportVerdictSchema,
+  steps: z.array(FlowPassStepResultSchema).min(1),
+  scanner_source: FlowPassScannerSourceSchema,
+  notes: z.array(z.string().min(1)).default([]),
+});
+
+export const FlowPassPackSchema = z.object({
+  name: z.string().min(1),
+  url: z.string().url(),
+  journey: z.object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    kind: FlowPassJourneyKindSchema.default("custom"),
+  }),
+  steps: z.array(FlowPassStepSchema).min(1),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export const FlowPassGeoPassAdapterSchema = z.object({
+  source: z.literal("geopass"),
+  target_url: z.string().url(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).optional(),
+  shared_check_ids: z.array(z.string().min(1)).default([]),
+});
+
+export type FlowPassStepId = z.infer<typeof FlowPassStepIdSchema>;
+export type FlowPassJourneyKind = z.infer<typeof FlowPassJourneyKindSchema>;
+export type FlowPassSeverity = z.infer<typeof FlowPassSeveritySchema>;
+export type FlowPassStepVerdict = z.infer<typeof FlowPassStepVerdictSchema>;
+export type FlowPassReportVerdict = z.infer<typeof FlowPassReportVerdictSchema>;
+export type FlowPassEvidence = z.infer<typeof FlowPassEvidenceSchema>;
+export type FlowPassFinding = z.infer<typeof FlowPassFindingSchema>;
+export type FlowPassStep = z.infer<typeof FlowPassStepSchema>;
+export type FlowPassStepResult = z.infer<typeof FlowPassStepResultSchema>;
+export type FlowPassScannerSource = z.infer<typeof FlowPassScannerSourceSchema>;
+export type FlowPassReport = z.infer<typeof FlowPassReportSchema>;
+export type FlowPassPack = z.infer<typeof FlowPassPackSchema>;
+export type FlowPassGeoPassAdapter = z.infer<typeof FlowPassGeoPassAdapterSchema>;

--- a/packages/flowpass/src/verdict-pack.ts
+++ b/packages/flowpass/src/verdict-pack.ts
@@ -1,0 +1,82 @@
+import {
+  FlowPassGeoPassAdapterSchema,
+  FlowPassReportSchema,
+  type FlowPassGeoPassAdapter,
+  type FlowPassReport,
+  type FlowPassStepId,
+  type FlowPassStepResult,
+} from "./schema.js";
+import { createFlowPassPlan } from "./flow-plan.js";
+
+export type FlowPassVerdictPack = ReturnType<typeof createFlowPassPlan> & {
+  scannerSource: FlowPassGeoPassAdapter;
+};
+
+function defaultScannerSource(targetUrl: string): FlowPassGeoPassAdapter {
+  return {
+    source: "geopass",
+    target_url: targetUrl,
+    mode: "plan-only",
+    shared_check_ids: ["aggregate-ai-engine-readiness"],
+  };
+}
+
+export function createFlowPassVerdictPack(input: {
+  targetUrl: string;
+  journeyId?: string;
+  journeyName?: string;
+  journeyKind?: "signup" | "auth" | "checkout" | "onboarding" | "support" | "custom";
+  steps?: FlowPassStepId[];
+  scannerSource?: FlowPassGeoPassAdapter;
+}): FlowPassVerdictPack {
+  const plan = createFlowPassPlan(input);
+
+  return {
+    ...plan,
+    scannerSource: FlowPassGeoPassAdapterSchema.parse(
+      input.scannerSource ?? defaultScannerSource(plan.targetUrl),
+    ),
+  };
+}
+
+export function createPlanOnlyFlowPassReport(input: {
+  targetUrl: string;
+  generatedAt?: string;
+  journeyId?: string;
+  journeyName?: string;
+  journeyKind?: "signup" | "auth" | "checkout" | "onboarding" | "support" | "custom";
+  steps?: FlowPassStepId[];
+  scannerSource?: FlowPassGeoPassAdapter;
+  notes?: string[];
+}): FlowPassReport {
+  const verdictPack = createFlowPassVerdictPack(input);
+  const stepResults: FlowPassStepResult[] = verdictPack.steps.map((step) => ({
+    step_id: step.id,
+    label: step.label,
+    score: 0,
+    verdict: "unknown",
+    findings: [],
+    comments: [
+      "Plan-only placeholder: run fixture-driven checks in a later chip.",
+    ],
+  }));
+
+  return FlowPassReportSchema.parse({
+    target_url: verdictPack.targetUrl,
+    generated_at: input.generatedAt ?? new Date(0).toISOString(),
+    mode: "plan-only",
+    journey: verdictPack.journey,
+    journey_readiness_score: 0,
+    verdict: "unknown",
+    steps: stepResults,
+    scanner_source: {
+      kind: "geopass-plan",
+      mode: verdictPack.scannerSource.mode ?? "plan-only",
+      target_url: verdictPack.scannerSource.target_url,
+      shared_check_ids: verdictPack.scannerSource.shared_check_ids,
+    },
+    notes: input.notes ?? [
+      "FlowPass is fixture-driven and does not execute live auth, checkout, billing, email, or destructive flows in this chip.",
+    ],
+  });
+}

--- a/packages/flowpass/tsconfig.json
+++ b/packages/flowpass/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/flowpass/vitest.config.ts
+++ b/packages/flowpass/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/__tests__/**/*.{test,spec}.ts"],
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds the first `@unclick/flowpass` package scaffold for plan-only product journey verdicts.
- Defines FlowPass schemas, safe default journey steps, and a verdict-pack builder that can reference upstream GEOPass posture without executing live flows.
- Adds a short product brief for the static and fixture-driven FlowPass slice.

## Scope
- Owned FlowPass chunk-1 files for todo `90b85c8e`.
- Package lock registration for the new workspace package.

## Non-overlap
- Does not run live signup, auth, checkout, billing, email, domain, or destructive production paths.
- Does not add production data, migrations, credentials, scheduled jobs, or GEOPass scanner rewrites.

## Verification
- `npm run test --workspace=@unclick/flowpass`
- `npm run typecheck --workspace=@unclick/flowpass`
- `(cd packages/flowpass && npx vitest src/__tests__/schema.test.ts src/__tests__/flow-plan.test.ts src/__tests__/verdict-pack.test.ts)`
- `npx eslint packages/flowpass/src/schema.ts packages/flowpass/src/flow-plan.ts packages/flowpass/src/verdict-pack.ts packages/flowpass/src/index.ts packages/flowpass/src/__tests__/schema.test.ts packages/flowpass/src/__tests__/flow-plan.test.ts packages/flowpass/src/__tests__/verdict-pack.test.ts`
- `npm run build`
- `git diff --check`

## Risk
- Low. This is a new plan-only package and documentation slice, with no runtime automation or live production effects.

## Follow-up
- Later chips can add fixture runners, UI/CLI surfaces, and shared Pass registry wiring.
