### PR TITLE
feat(legalpass): add phase one hats

### DIFF
--- a/docs/legalpass-product-brief.md
+++ b/docs/legalpass-product-brief.md
@@ -142,3 +142,13 @@ jurisdiction-resolver, consent-ledger.
 Pricing experiments, marketplace economics, Phase 2 jurisdictions,
 Phase 2 hats (5 through 12), and the full bar-rule mapping per
 jurisdiction are covered in the long brief.
+
+## 12. Phase-1 package scaffold
+
+Chunk 1 keeps the code surface intentionally narrow:
+
+- `schema.ts` defines the advisory report, evidence, finding, hat, fixture document, and GEOPass adapter shapes for the three public-safe MVP hats.
+- `hat-library.ts` defines deterministic fixture checks for Privacy Policy, ToS and Unfair Terms, and OSS Licence.
+- `verdict-pack.ts` can emit a plan-only pack or evaluate public fixture text without live crawling, private uploads, production rows, paid calls, or legal instructions.
+
+Every report carries the issue-spotter disclaimer and stays framed as review input for a qualified practitioner.

--- a/packages/legalpass/package.json
+++ b/packages/legalpass/package.json
@@ -6,6 +6,9 @@
   "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./schema": "./dist/schema.js",
+    "./hat-library": "./dist/hat-library.js",
+    "./verdict-pack": "./dist/verdict-pack.js",
     "./types": "./dist/types.js",
     "./tools": "./dist/tools/index.js",
     "./passguard/verdict-linter": "./dist/passguard/verdict-linter.js",
@@ -13,6 +16,7 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/legalpass/src/__tests__/hat-library.test.ts
+++ b/packages/legalpass/src/__tests__/hat-library.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPhaseOneLegalPassHats,
+  PHASE_ONE_LEGALPASS_HATS,
+} from "../hat-library.js";
+
+describe("phase-one LegalPass hats", () => {
+  it("defines the three MVP hats", () => {
+    expect(PHASE_ONE_LEGALPASS_HATS.map((hat) => hat.id)).toEqual([
+      "privacy-policy",
+      "tos-unfair-terms",
+      "oss-licence",
+    ]);
+  });
+
+  it("keeps deterministic fixture checks on every hat", () => {
+    for (const hat of PHASE_ONE_LEGALPASS_HATS) {
+      expect(hat.checks.length).toBeGreaterThan(0);
+      expect(hat.checks.every((check) => check.fixture_terms.length > 0)).toBe(true);
+    }
+  });
+
+  it("filters hats by requested ids", () => {
+    const hats = getPhaseOneLegalPassHats({ hat_ids: ["oss-licence"] });
+
+    expect(hats).toHaveLength(1);
+    expect(hats[0]?.id).toBe("oss-licence");
+  });
+});

--- a/packages/legalpass/src/__tests__/schema.test.ts
+++ b/packages/legalpass/src/__tests__/schema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  LegalPassFixtureDocumentSchema,
+  LegalPassReportSchema,
+} from "../schema.js";
+
+describe("LegalPass phase-one schema", () => {
+  it("parses public fixture documents with safe defaults", () => {
+    const document = LegalPassFixtureDocumentSchema.parse({
+      id: "privacy-fixture",
+      kind: "privacy-policy",
+      title: "Privacy Policy Fixture",
+      text: "We collect account data and provide a privacy contact.",
+    });
+
+    expect(document.public_only).toBe(true);
+  });
+
+  it("requires report disclaimers", () => {
+    expect(() =>
+      LegalPassReportSchema.parse({
+        target: { name: "Example", url: "https://example.com" },
+        generated_at: "2026-05-09T18:10:00.000Z",
+        mode: "plan-only",
+        jurisdictions: ["AU"],
+        overall_score: 0,
+        verdict: "unknown",
+        hats: [],
+        scanner_source: {
+          kind: "manual",
+          mode: "plan-only",
+          shared_check_ids: [],
+        },
+        disclaimers: [],
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/legalpass/src/__tests__/verdict-pack.test.ts
+++ b/packages/legalpass/src/__tests__/verdict-pack.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  createFixtureLegalPassReport,
+  createLegalPassVerdictPack,
+} from "../verdict-pack.js";
+
+describe("LegalPass verdict pack", () => {
+  it("creates a plan-only advisory pack", () => {
+    const report = createLegalPassVerdictPack({
+      target: { name: "Example", url: "https://example.com" },
+      generated_at: "2026-05-09T18:10:00.000Z",
+    });
+
+    expect(report.mode).toBe("plan-only");
+    expect(report.verdict).toBe("unknown");
+    expect(report.hats).toHaveLength(3);
+    expect(report.disclaimers[0]).toContain("issue-spotter");
+  });
+
+  it("evaluates public fixture text deterministically", () => {
+    const report = createFixtureLegalPassReport({
+      target: { name: "Example", url: "https://example.com" },
+      generated_at: "2026-05-09T18:10:00.000Z",
+      documents: [
+        {
+          id: "privacy",
+          kind: "privacy-policy",
+          title: "Privacy Policy",
+          text: "Our privacy team provides contact details. We collect and use data, retain records, and share with a third party.",
+        },
+        {
+          id: "terms",
+          kind: "terms-of-service",
+          title: "Terms",
+          text: "The terms cover liability, indemnity, dispute support, and when we change or terminate access.",
+        },
+        {
+          id: "oss",
+          kind: "oss-manifest",
+          title: "OSS manifest",
+          text: "Each dependency has a license entry, attribution, copyleft marker, patent grant, and notice text.",
+        },
+      ],
+    });
+
+    expect(report.mode).toBe("fixture");
+    expect(report.verdict).toBe("ready");
+    expect(report.overall_score).toBe(100);
+  });
+
+  it("flags missing fixture signals without issuing legal instructions", () => {
+    const report = createFixtureLegalPassReport({
+      target: { name: "Example", url: "https://example.com" },
+      generated_at: "2026-05-09T18:10:00.000Z",
+      documents: [
+        {
+          id: "privacy",
+          kind: "privacy-policy",
+          title: "Privacy Policy",
+          text: "This page says hello.",
+        },
+      ],
+    });
+
+    expect(report.verdict).toBe("blocked");
+    expect(report.hats.some((hat) => hat.findings.length > 0)).toBe(true);
+    expect(JSON.stringify(report)).not.toContain("you should");
+  });
+});

--- a/packages/legalpass/src/hat-library.ts
+++ b/packages/legalpass/src/hat-library.ts
@@ -1,0 +1,149 @@
+import type { JurisdictionCode } from "./types.js";
+import type {
+  LegalPassHatDefinition,
+  LegalPassPhaseOneHatId,
+} from "./schema.js";
+
+export const PHASE_ONE_JURISDICTIONS: JurisdictionCode[] = [
+  "AU",
+  "EU",
+  "US-CA",
+];
+
+export const PHASE_ONE_LEGALPASS_HATS: LegalPassHatDefinition[] = [
+  {
+    id: "privacy-policy",
+    label: "Privacy Policy",
+    summary:
+      "Issue-spots whether a public privacy policy exposes basic identity, data-use, retention, transfer, and contact signals.",
+    target_documents: ["privacy-policy", "website"],
+    jurisdictions: PHASE_ONE_JURISDICTIONS,
+    checks: [
+      {
+        id: "privacy-controller-contact",
+        label: "Controller or operator contact path",
+        severity: "high",
+        evidence_kinds: ["policy-text", "public-page", "fixture"],
+        fixture_terms: ["contact", "privacy"],
+        issue_spotting_note:
+          "A privacy review often starts with whether a reader can identify a privacy contact path.",
+      },
+      {
+        id: "privacy-data-use",
+        label: "Data collection and use disclosure",
+        severity: "high",
+        evidence_kinds: ["policy-text", "fixture"],
+        fixture_terms: ["collect", "use"],
+        issue_spotting_note:
+          "The policy text warrants review when collection and use signals are absent from the public copy.",
+      },
+      {
+        id: "privacy-retention-transfer",
+        label: "Retention or transfer disclosure",
+        severity: "medium",
+        evidence_kinds: ["policy-text", "fixture"],
+        fixture_terms: ["retain", "third party"],
+        issue_spotting_note:
+          "Retention and third-party transfer language is a common issue-spotting input for privacy review.",
+      },
+    ],
+  },
+  {
+    id: "tos-unfair-terms",
+    label: "ToS and Unfair Terms",
+    summary:
+      "Issue-spots public terms for consumer-facing limitation, variation, termination, and dispute signals.",
+    target_documents: ["terms-of-service", "website"],
+    jurisdictions: PHASE_ONE_JURISDICTIONS,
+    checks: [
+      {
+        id: "tos-liability-indemnity",
+        label: "Liability and indemnity visibility",
+        severity: "high",
+        evidence_kinds: ["clause", "fixture"],
+        fixture_terms: ["liability", "indemnity"],
+        issue_spotting_note:
+          "Liability and indemnity clauses are common review targets in consumer and platform terms.",
+      },
+      {
+        id: "tos-variation-termination",
+        label: "Variation or termination signal",
+        severity: "medium",
+        evidence_kinds: ["clause", "fixture"],
+        fixture_terms: ["terminate", "change"],
+        issue_spotting_note:
+          "Variation and termination wording can affect unfair-terms review and warrants practitioner attention when unclear.",
+      },
+      {
+        id: "tos-dispute-contact",
+        label: "Dispute or support contact path",
+        severity: "medium",
+        evidence_kinds: ["clause", "fixture"],
+        fixture_terms: ["dispute", "support"],
+        issue_spotting_note:
+          "A dispute or support path helps route a reader before any formal action is considered.",
+      },
+    ],
+  },
+  {
+    id: "oss-licence",
+    label: "OSS Licence",
+    summary:
+      "Issue-spots repository or manifest fixtures for licence, attribution, copyleft, and patent-notice signals.",
+    target_documents: ["oss-manifest", "licence-file", "repository"],
+    jurisdictions: PHASE_ONE_JURISDICTIONS,
+    checks: [
+      {
+        id: "oss-manifest-licence",
+        label: "Dependency licence manifest",
+        severity: "high",
+        evidence_kinds: ["package-manifest", "licence-file", "fixture"],
+        fixture_terms: ["license", "dependency"],
+        issue_spotting_note:
+          "Licence and dependency manifests are baseline evidence for OSS review.",
+      },
+      {
+        id: "oss-attribution-copyleft",
+        label: "Attribution or copyleft marker",
+        severity: "medium",
+        evidence_kinds: ["licence-file", "fixture"],
+        fixture_terms: ["attribution", "copyleft"],
+        issue_spotting_note:
+          "Attribution and copyleft markers can change downstream notice obligations.",
+      },
+      {
+        id: "oss-patent-notice",
+        label: "Patent or notice signal",
+        severity: "low",
+        evidence_kinds: ["licence-file", "fixture"],
+        fixture_terms: ["patent", "notice"],
+        issue_spotting_note:
+          "Patent and notice language is a useful input for licence-compatibility review.",
+      },
+    ],
+  },
+];
+
+export interface GetPhaseOneLegalPassHatsInput {
+  hat_ids?: LegalPassPhaseOneHatId[];
+  jurisdictions?: JurisdictionCode[];
+}
+
+export function getPhaseOneLegalPassHats(
+  input: GetPhaseOneLegalPassHatsInput = {},
+): LegalPassHatDefinition[] {
+  const hatIdSet = input.hat_ids ? new Set(input.hat_ids) : null;
+  const jurisdictionSet = input.jurisdictions ? new Set(input.jurisdictions) : null;
+
+  return PHASE_ONE_LEGALPASS_HATS.filter((hat) => {
+    if (hatIdSet && !hatIdSet.has(hat.id)) {
+      return false;
+    }
+
+    if (!jurisdictionSet) {
+      return true;
+    }
+
+    return hat.jurisdictions.some((jurisdiction) => jurisdictionSet.has(jurisdiction));
+  });
+}

--- a/packages/legalpass/src/index.ts
+++ b/packages/legalpass/src/index.ts
@@ -7,6 +7,9 @@
 // for a qualified practitioner. See docs/legalpass-product-brief.md.
 
 export * from "./pack-schema.js";
+export * from "./schema.js";
+export * from "./hat-library.js";
+export * from "./verdict-pack.js";
 export type * from "./types.js";
 export {
   LEGALPASS_TOOLS,

--- a/packages/legalpass/src/schema.ts
+++ b/packages/legalpass/src/schema.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+import {
+  JurisdictionCodeSchema,
+  SeveritySchema,
+} from "./pack-schema.js";
+
+export const LegalPassPhaseOneHatIdSchema = z.enum([
+  "privacy-policy",
+  "tos-unfair-terms",
+  "oss-licence",
+]);
+
+export const LegalPassDocumentKindSchema = z.enum([
+  "privacy-policy",
+  "terms-of-service",
+  "oss-manifest",
+  "licence-file",
+  "repository",
+  "website",
+  "composite",
+]);
+
+export const LegalPassEvidenceKindSchema = z.enum([
+  "public-page",
+  "policy-text",
+  "clause",
+  "package-manifest",
+  "licence-file",
+  "fixture",
+  "primary-source",
+  "shared-scanner-signal",
+  "manual-note",
+]);
+
+export const LegalPassHatVerdictSchema = z.enum([
+  "pass",
+  "warn",
+  "fail",
+  "unknown",
+]);
+
+export const LegalPassReportVerdictSchema = z.enum([
+  "ready",
+  "needs-review",
+  "blocked",
+  "unknown",
+]);
+
+export const LegalPassModeSchema = z.enum([
+  "plan-only",
+  "fixture",
+  "live-readonly",
+]);
+
+export const LegalPassTargetSchema = z.object({
+  name: z.string().min(1),
+  url: z.string().url().optional(),
+});
+
+export const LegalPassEvidenceSchema = z.object({
+  kind: LegalPassEvidenceKindSchema,
+  label: z.string().min(1),
+  source_url: z.string().url().optional(),
+  summary: z.string().min(1),
+});
+
+export const LegalPassDocumentSchema = z.object({
+  id: z.string().min(1),
+  kind: LegalPassDocumentKindSchema,
+  title: z.string().min(1),
+  source_url: z.string().url().optional(),
+  content_ref: z.string().min(1).optional(),
+  public_only: z.boolean().default(true),
+});
+
+export const LegalPassFixtureDocumentSchema = LegalPassDocumentSchema.extend({
+  text: z.string().min(1),
+});
+
+export const LegalPassFindingSchema = z.object({
+  id: z.string().min(1),
+  hat_id: LegalPassPhaseOneHatIdSchema,
+  severity: SeveritySchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  evidence: z.array(LegalPassEvidenceSchema).default([]),
+  issue_spotting_note: z.string().min(1).optional(),
+  practitioner_review_flag: z.boolean().default(false),
+});
+
+export const LegalPassHatCheckSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  severity: SeveritySchema,
+  evidence_kinds: z.array(LegalPassEvidenceKindSchema).min(1),
+  fixture_terms: z.array(z.string().min(1)).default([]),
+  issue_spotting_note: z.string().min(1),
+});
+
+export const LegalPassHatDefinitionSchema = z.object({
+  id: LegalPassPhaseOneHatIdSchema,
+  label: z.string().min(1),
+  summary: z.string().min(1),
+  target_documents: z.array(LegalPassDocumentKindSchema).min(1),
+  jurisdictions: z.array(JurisdictionCodeSchema).min(1),
+  checks: z.array(LegalPassHatCheckSchema).min(1),
+});
+
+export const LegalPassHatResultSchema = z.object({
+  hat_id: LegalPassPhaseOneHatIdSchema,
+  label: z.string().min(1),
+  score: z.number().min(0).max(100),
+  verdict: LegalPassHatVerdictSchema,
+  findings: z.array(LegalPassFindingSchema).default([]),
+  comments: z.array(z.string().min(1)).default([]),
+});
+
+export const LegalPassScannerSourceSchema = z.object({
+  kind: z.enum(["geopass-plan", "fixture", "manual"]),
+  mode: LegalPassModeSchema.default("plan-only"),
+  target_url: z.string().url().optional(),
+  shared_check_ids: z.array(z.string().min(1)).default([]),
+});
+
+export const LegalPassReportSchema = z.object({
+  target: LegalPassTargetSchema,
+  generated_at: z.string().datetime(),
+  mode: LegalPassModeSchema.default("plan-only"),
+  jurisdictions: z.array(JurisdictionCodeSchema).min(1),
+  overall_score: z.number().min(0).max(100),
+  verdict: LegalPassReportVerdictSchema,
+  hats: z.array(LegalPassHatResultSchema).min(1),
+  scanner_source: LegalPassScannerSourceSchema,
+  disclaimers: z.array(z.string().min(1)).min(1),
+  notes: z.array(z.string().min(1)).default([]),
+});
+
+export const LegalPassGeoPassAdapterSchema = z.object({
+  source: z.literal("geopass"),
+  target_url: z.string().url(),
+  mode: LegalPassModeSchema.optional(),
+  shared_check_ids: z.array(z.string().min(1)).default([]),
+});
+
+export type LegalPassPhaseOneHatId = z.infer<typeof LegalPassPhaseOneHatIdSchema>;
+export type LegalPassDocumentKind = z.infer<typeof LegalPassDocumentKindSchema>;
+export type LegalPassEvidenceKind = z.infer<typeof LegalPassEvidenceKindSchema>;
+export type LegalPassHatVerdict = z.infer<typeof LegalPassHatVerdictSchema>;
+export type LegalPassReportVerdict = z.infer<typeof LegalPassReportVerdictSchema>;
+export type LegalPassMode = z.infer<typeof LegalPassModeSchema>;
+export type LegalPassTarget = z.infer<typeof LegalPassTargetSchema>;
+export type LegalPassEvidence = z.infer<typeof LegalPassEvidenceSchema>;
+export type LegalPassDocument = z.infer<typeof LegalPassDocumentSchema>;
+export type LegalPassFixtureDocument = z.infer<typeof LegalPassFixtureDocumentSchema>;
+export type LegalPassFixtureDocumentInput = z.input<typeof LegalPassFixtureDocumentSchema>;
+export type LegalPassFinding = z.infer<typeof LegalPassFindingSchema>;
+export type LegalPassHatCheck = z.infer<typeof LegalPassHatCheckSchema>;
+export type LegalPassHatDefinition = z.infer<typeof LegalPassHatDefinitionSchema>;
+export type LegalPassHatResult = z.infer<typeof LegalPassHatResultSchema>;
+export type LegalPassScannerSource = z.infer<typeof LegalPassScannerSourceSchema>;
+export type LegalPassReport = z.infer<typeof LegalPassReportSchema>;
+export type LegalPassGeoPassAdapter = z.infer<typeof LegalPassGeoPassAdapterSchema>;

--- a/packages/legalpass/src/verdict-pack.ts
+++ b/packages/legalpass/src/verdict-pack.ts
@@ -1,0 +1,190 @@
+import type { JurisdictionCode } from "./types.js";
+import { getPhaseOneLegalPassHats } from "./hat-library.js";
+import {
+  LegalPassFixtureDocumentSchema,
+  LegalPassReportSchema,
+  type LegalPassFixtureDocument,
+  type LegalPassFixtureDocumentInput,
+  type LegalPassGeoPassAdapter,
+  type LegalPassHatDefinition,
+  type LegalPassHatResult,
+  type LegalPassReport,
+  type LegalPassReportVerdict,
+  type LegalPassTarget,
+} from "./schema.js";
+
+const ISSUE_SPOTTER_DISCLAIMER =
+  "LegalPass is an issue-spotter only. It surfaces public signals for review and is not a lawyer, legal opinion, or substitute for a qualified practitioner.";
+
+export interface CreateLegalPassVerdictPackInput {
+  target: LegalPassTarget;
+  jurisdictions?: JurisdictionCode[];
+  generated_at?: string;
+  geo_pass?: LegalPassGeoPassAdapter;
+}
+
+export interface CreateFixtureLegalPassReportInput extends CreateLegalPassVerdictPackInput {
+  documents: LegalPassFixtureDocumentInput[];
+}
+
+export function createLegalPassVerdictPack(
+  input: CreateLegalPassVerdictPackInput,
+): LegalPassReport {
+  const jurisdictions = input.jurisdictions ?? ["AU", "EU", "US-CA"];
+  const hats = getPhaseOneLegalPassHats({ jurisdictions });
+  const report = {
+    target: input.target,
+    generated_at: input.generated_at ?? new Date().toISOString(),
+    mode: "plan-only" as const,
+    jurisdictions,
+    overall_score: 0,
+    verdict: "unknown" as const,
+    hats: hats.map(createPlanOnlyHatResult),
+    scanner_source: {
+      kind: input.geo_pass ? "geopass-plan" as const : "manual" as const,
+      mode: input.geo_pass?.mode ?? "plan-only" as const,
+      target_url: input.geo_pass?.target_url ?? input.target.url,
+      shared_check_ids: input.geo_pass?.shared_check_ids ?? [],
+    },
+    disclaimers: [ISSUE_SPOTTER_DISCLAIMER],
+    notes: [
+      "Plan-only LegalPass pack. No private contracts, production rows, paid calls, or live legal review were used.",
+    ],
+  };
+
+  return LegalPassReportSchema.parse(report);
+}
+
+export function createFixtureLegalPassReport(
+  input: CreateFixtureLegalPassReportInput,
+): LegalPassReport {
+  const jurisdictions = input.jurisdictions ?? ["AU", "EU", "US-CA"];
+  const documents = input.documents.map((document) =>
+    LegalPassFixtureDocumentSchema.parse(document),
+  );
+  const hats = getPhaseOneLegalPassHats({ jurisdictions });
+  const hatResults = hats.map((hat) => evaluateHatAgainstFixtures(hat, documents));
+  const overall_score = Math.round(
+    hatResults.reduce((total, result) => total + result.score, 0) / hatResults.length,
+  );
+  const report = {
+    target: input.target,
+    generated_at: input.generated_at ?? new Date().toISOString(),
+    mode: "fixture" as const,
+    jurisdictions,
+    overall_score,
+    verdict: toReportVerdict(hatResults),
+    hats: hatResults,
+    scanner_source: {
+      kind: "fixture" as const,
+      mode: "fixture" as const,
+      target_url: input.geo_pass?.target_url ?? input.target.url,
+      shared_check_ids: input.geo_pass?.shared_check_ids ?? [],
+    },
+    disclaimers: [ISSUE_SPOTTER_DISCLAIMER],
+    notes: [
+      "Fixture-only LegalPass report. Findings are deterministic text signals and require human practitioner review before action.",
+    ],
+  };
+
+  return LegalPassReportSchema.parse(report);
+}
+
+function createPlanOnlyHatResult(hat: LegalPassHatDefinition): LegalPassHatResult {
+  return {
+    hat_id: hat.id,
+    label: hat.label,
+    score: 0,
+    verdict: "unknown",
+    findings: [],
+    comments: [
+      `${hat.label} is configured for fixture and read-only evidence collection.`,
+    ],
+  };
+}
+
+function evaluateHatAgainstFixtures(
+  hat: LegalPassHatDefinition,
+  documents: LegalPassFixtureDocument[],
+): LegalPassHatResult {
+  const relevantDocuments = documents.filter((document) =>
+    (document.public_only ?? true) && hat.target_documents.includes(document.kind),
+  );
+  const searchableText = normalizeText(
+    relevantDocuments.map((document) => document.text).join(" "),
+  );
+  const findings = hat.checks.flatMap((check) => {
+    const matchedTerms = check.fixture_terms.filter((term) =>
+      searchableText.includes(normalizeText(term)),
+    );
+
+    if (matchedTerms.length > 0) {
+      return [];
+    }
+
+    return [
+      {
+        id: `${hat.id}.${check.id}.missing-fixture-signal`,
+        hat_id: hat.id,
+        severity: check.severity,
+        title: `${check.label} fixture signal missing`,
+        summary:
+          "The provided public fixture text did not include the configured issue-spotting signal.",
+        evidence: relevantDocuments.map((document) => ({
+          kind: "fixture" as const,
+          label: document.title,
+          source_url: document.source_url,
+          summary: `Checked public fixture document ${document.id}.`,
+        })),
+        issue_spotting_note: check.issue_spotting_note,
+        practitioner_review_flag: check.severity === "critical" || check.severity === "high",
+      },
+    ];
+  });
+
+  const passingChecks = hat.checks.length - findings.length;
+  const score = Math.round((passingChecks / hat.checks.length) * 100);
+
+  return {
+    hat_id: hat.id,
+    label: hat.label,
+    score,
+    verdict: toHatVerdict(score, findings.length),
+    findings,
+    comments: [
+      `Evaluated ${relevantDocuments.length} public fixture document(s) for ${hat.label}.`,
+    ],
+  };
+}
+
+function toHatVerdict(score: number, findingCount: number): LegalPassHatResult["verdict"] {
+  if (findingCount === 0) {
+    return "pass";
+  }
+
+  if (score >= 50) {
+    return "warn";
+  }
+
+  return "fail";
+}
+
+function toReportVerdict(hats: LegalPassHatResult[]): LegalPassReportVerdict {
+  if (hats.every((hat) => hat.verdict === "pass")) {
+    return "ready";
+  }
+
+  if (hats.some((hat) => hat.verdict === "fail")) {
+    return "blocked";
+  }
+
+  if (hats.some((hat) => hat.verdict === "warn")) {
+    return "needs-review";
+  }
+
+  return "unknown";
+}
+
+function normalizeText(value: string): string {
+  return value.toLocaleLowerCase("en-US").replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
## Summary
- Adds LegalPass Phase-1 advisory schemas for public-safe fixture documents, evidence, findings, hats, and reports.
- Adds the three MVP hats: Privacy Policy, ToS and Unfair Terms, and OSS Licence, with deterministic fixture checks.
- Adds a verdict-pack builder for plan-only reports and public fixture evaluation, plus focused tests and a brief update.

## Scope
- Owned files for todo `39fa6691`: LegalPass package schema, hat library, verdict pack, tests, package exports, and product brief.

## Non-overlap
- Does not inspect private contracts, private customer data, credentials, auth, billing, domains, or production rows.
- Does not add migrations, paid API calls, live crawlers, scheduled jobs, or production test rows.
- Does not claim lawyer review, generate binding legal terms, or issue legal instructions.

## Verification
- `npm run test --workspace=@unclick/legalpass -- --run src/__tests__/schema.test.ts src/__tests__/hat-library.test.ts src/__tests__/verdict-pack.test.ts`
- `npx vitest src/__tests__/schema.test.ts src/__tests__/hat-library.test.ts src/__tests__/verdict-pack.test.ts` from `packages/legalpass`
- `npm run test --workspace=@unclick/legalpass`
- `npm run typecheck --workspace=@unclick/legalpass`
- `npm run build --workspace=@unclick/legalpass`
- `npx eslint packages/legalpass/src/schema.ts packages/legalpass/src/hat-library.ts packages/legalpass/src/verdict-pack.ts packages/legalpass/src/index.ts packages/legalpass/src/__tests__/schema.test.ts packages/legalpass/src/__tests__/hat-library.test.ts packages/legalpass/src/__tests__/verdict-pack.test.ts`
- `npm run build`
- `git diff --check`

## Risk
- Low. This is an additive, advisory package slice with no runtime production side effects.

## Follow-up
- Later LegalPass chips can wire live read-only source collection, Citation Verifier receipts, and UI or MCP surfaces.
