### PR TITLE
feat(copypass): add fixture copy review scaffold

### DIFF
--- a/docs/copypass-product-brief.md
+++ b/docs/copypass-product-brief.md
@@ -1,0 +1,18 @@
+# CopyPass Product Brief
+
+CopyPass is a fixture-first product-copy review pass for UnClick. It flags copy that is unclear, overconfident, stale, or missing a direct next action before the wording reaches a public surface.
+
+## First Slice
+
+- Run only on caller-provided fixture text.
+- Detect vague hero language, missing CTAs, missing trust signals, unsupported superiority claims, placeholder copy, and risky guarantee language.
+- Return a structured advisory verdict pack with findings, evidence, not-checked boundaries, and disclaimers.
+- Avoid paid model calls, production crawls, private customer copy, live analytics writes, migrations, scheduled jobs, and production test rows.
+
+## Product Guardrails
+
+CopyPass is advisory. It does not promise legal, compliance, revenue, ranking, conversion, accessibility, or safety outcomes. Its job is to make the next human copy review sharper and easier to audit.
+
+## Future Fit
+
+The package is intentionally small so it can later consume shared scanner output from the Pass family without coupling this first slice to GEOPass, SEOPass, FlowPass, LegalPass, SlopPass, UXPass, SecurityPass, or TestPass internals.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7843,6 +7843,10 @@
       "resolved": "packages/channel-plugin",
       "link": true
     },
+    "node_modules/@unclick/copypass": {
+      "resolved": "packages/copypass",
+      "link": true
+    },
     "node_modules/@unclick/core": {
       "resolved": "packages/core",
       "link": true
@@ -21046,6 +21050,22 @@
       },
       "bin": {
         "unclick-channel": "index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/copypass": {
+      "name": "@unclick/copypass",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=18"

--- a/packages/copypass/package.json
+++ b/packages/copypass/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@unclick/copypass",
+  "version": "0.1.0",
+  "description": "CopyPass - fixture-only product-copy review with advisory verdict packs.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./copy-library": "./dist/copy-library.js",
+    "./schema": "./dist/schema.js",
+    "./verdict-pack": "./dist/verdict-pack.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/packages/copypass/src/__tests__/copy-library.test.ts
+++ b/packages/copypass/src/__tests__/copy-library.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { detectCopyPassFindings } from "../copy-library.js";
+import type { CopyPassCopyBlock } from "../schema.js";
+
+describe("CopyPass copy library", () => {
+  it("flags vague hero copy, missing CTA, trust gaps, unsupported claims, and placeholders", () => {
+    const blocks: CopyPassCopyBlock[] = [
+      {
+        id: "hero",
+        kind: "hero",
+        text: "Welcome to the best all-in-one solution. Coming soon.",
+        public_only: true,
+      },
+    ];
+
+    const checkIds = detectCopyPassFindings(blocks).map((finding) => finding.check_id);
+
+    expect(checkIds).toContain("value-prop-clarity");
+    expect(checkIds).toContain("cta-presence");
+    expect(checkIds).toContain("proof-trust-gap");
+    expect(checkIds).toContain("unsupported-superiority");
+    expect(checkIds).toContain("placeholder-copy");
+  });
+
+  it("redacts sensitive fixture fragments from evidence", () => {
+    const blocks: CopyPassCopyBlock[] = [
+      {
+        id: "feature",
+        kind: "feature",
+        text: "TODO: replace this API key sk-test-secret-value with final copy.",
+        public_only: true,
+      },
+    ];
+
+    const [finding] = detectCopyPassFindings(blocks);
+
+    expect(finding.evidence).toBe("[redacted-sensitive-copy-fragment]");
+  });
+});

--- a/packages/copypass/src/__tests__/schema.test.ts
+++ b/packages/copypass/src/__tests__/schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  CopyPassCopyBlockSchema,
+  CopyPassReportSchema,
+} from "../schema.js";
+
+describe("CopyPass schemas", () => {
+  it("accepts a minimal fixture report", () => {
+    const report = CopyPassReportSchema.parse({
+      target: {
+        kind: "page",
+        label: "UnClick home",
+        url: "https://unclick.world/",
+      },
+      generated_at: "2026-05-09T19:00:00.000Z",
+      mode: "fixture",
+      overall_score: 100,
+      verdict: "pass",
+      checks_attempted: ["value-prop-clarity", "cta-presence"],
+      blocks_reviewed: ["hero"],
+      findings: [],
+      not_checked: [
+        {
+          label: "Production crawl",
+          reason: "Fixture-only scaffold.",
+        },
+      ],
+      scanner_source: {
+        kind: "fixture",
+        mode: "fixture",
+        target_url: "https://unclick.world/",
+        shared_check_ids: ["value-prop-clarity"],
+      },
+      disclaimers: ["Advisory fixture check."],
+      notes: [],
+    });
+
+    expect(report.verdict).toBe("pass");
+  });
+
+  it("rejects empty copy block text", () => {
+    expect(() =>
+      CopyPassCopyBlockSchema.parse({
+        id: "hero",
+        kind: "hero",
+        text: "",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/copypass/src/__tests__/verdict-pack.test.ts
+++ b/packages/copypass/src/__tests__/verdict-pack.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCopyPassVerdictPack,
+  createFixtureCopyPassReport,
+} from "../verdict-pack.js";
+
+describe("CopyPass verdict pack", () => {
+  it("creates a plan-only pack without scanning production", () => {
+    const report = createCopyPassVerdictPack({
+      target: {
+        kind: "page",
+        label: "UnClick home",
+        url: "https://unclick.world/",
+      },
+      generated_at: "2026-05-09T19:00:00.000Z",
+    });
+
+    expect(report.mode).toBe("plan-only");
+    expect(report.verdict).toBe("unknown");
+    expect(report.not_checked.map((item) => item.label)).toContain("Production crawl");
+  });
+
+  it("fails a fixture with unsupported outcome language", () => {
+    const report = createFixtureCopyPassReport({
+      target: {
+        kind: "page",
+        label: "CopyPass fixture",
+      },
+      generated_at: "2026-05-09T19:00:00.000Z",
+      blocks: [
+        {
+          id: "hero",
+          kind: "hero",
+          text: "The best platform with guaranteed instant revenue. Coming soon.",
+        },
+      ],
+    });
+
+    expect(report.verdict).toBe("fail");
+    expect(report.overall_score).toBeLessThan(100);
+    expect(report.findings.map((finding) => finding.check_id)).toContain(
+      "risky-guarantee-language",
+    );
+  });
+
+  it("passes a clean public fixture", () => {
+    const report = createFixtureCopyPassReport({
+      target: {
+        kind: "page",
+        label: "CopyPass fixture",
+      },
+      generated_at: "2026-05-09T19:00:00.000Z",
+      blocks: [
+        {
+          id: "hero",
+          kind: "hero",
+          text:
+            "UnClick helps teams review AI work with shared context, public proof, and green checks. Start a free review.",
+        },
+        {
+          id: "proof",
+          kind: "proof",
+          text: "Public receipts and privacy notes show what was checked.",
+        },
+      ],
+    });
+
+    expect(report.verdict).toBe("pass");
+    expect(report.overall_score).toBe(100);
+    expect(report.findings).toEqual([]);
+  });
+});

--- a/packages/copypass/src/copy-library.ts
+++ b/packages/copypass/src/copy-library.ts
@@ -1,0 +1,314 @@
+import {
+  CopyPassCheckDefinitionSchema,
+  type CopyPassCheckDefinition,
+  type CopyPassCheckId,
+  type CopyPassCopyBlock,
+  type CopyPassFinding,
+} from "./schema.js";
+
+export const DEFAULT_COPYPASS_CHECKS: CopyPassCheckDefinition[] = [
+  {
+    id: "value-prop-clarity",
+    label: "Value prop clarity",
+    goal: "Hero and headline copy should say who it helps and what changes for them.",
+    severity: "medium",
+    recommended_fix:
+      "Rewrite the line with a concrete audience, action, and outcome instead of broad platform language.",
+  },
+  {
+    id: "cta-presence",
+    label: "CTA presence",
+    goal: "Hero and CTA blocks should include a clear next action.",
+    severity: "medium",
+    recommended_fix:
+      "Add one direct call to action, such as Start, Try, Connect, Run, Book, or Open.",
+  },
+  {
+    id: "proof-trust-gap",
+    label: "Proof or trust signal",
+    goal: "Primary copy should include a proof, safety, privacy, receipt, or trust signal.",
+    severity: "low",
+    recommended_fix:
+      "Add a concrete receipt, customer proof, safety note, privacy note, or public evidence signal.",
+  },
+  {
+    id: "unsupported-superiority",
+    label: "Unsupported superiority",
+    goal: "Absolute or superiority claims should have public proof before they ship.",
+    severity: "high",
+    recommended_fix:
+      "Replace the absolute claim with a qualified claim, or attach public proof in nearby copy.",
+  },
+  {
+    id: "placeholder-copy",
+    label: "Placeholder language",
+    goal: "Shipped copy should not contain stale placeholders or drafting markers.",
+    severity: "medium",
+    recommended_fix:
+      "Replace the placeholder with final copy or remove the block until the message is ready.",
+  },
+  {
+    id: "risky-guarantee-language",
+    label: "Risky guarantee language",
+    goal: "Copy should avoid guarantees around revenue, rankings, compliance, access, or outcomes.",
+    severity: "high",
+    recommended_fix:
+      "Use advisory, evidence-backed language and remove outcome guarantees.",
+  },
+].map((check) => CopyPassCheckDefinitionSchema.parse(check));
+
+const VALUE_TERMS = [
+  "helps",
+  "ship",
+  "review",
+  "scan",
+  "find",
+  "reduce",
+  "save",
+  "protect",
+  "connect",
+  "context",
+  "proof",
+  "receipts",
+  "checks",
+  "workflow",
+];
+
+const VAGUE_TERMS = [
+  "all-in-one",
+  "game changing",
+  "next generation",
+  "next-gen",
+  "powerful",
+  "revolutionary",
+  "simple",
+  "smart",
+  "solution",
+  "transform",
+  "world class",
+];
+
+const CTA_TERMS = [
+  "book",
+  "connect",
+  "create",
+  "get",
+  "join",
+  "open",
+  "run",
+  "scan",
+  "start",
+  "try",
+];
+
+const PROOF_TERMS = [
+  "audit",
+  "case study",
+  "check",
+  "customer",
+  "evidence",
+  "privacy",
+  "proof",
+  "receipt",
+  "security",
+  "trusted",
+  "verified",
+];
+
+const SUPERIORITY_TERMS = [
+  "#1",
+  "best",
+  "industry leading",
+  "leading",
+  "most advanced",
+  "number one",
+  "revolutionary",
+  "ultimate",
+];
+
+const PLACEHOLDER_TERMS = [
+  "coming soon",
+  "copy goes here",
+  "insert copy",
+  "lorem ipsum",
+  "placeholder",
+  "tbd",
+  "todo",
+];
+
+const GUARANTEE_TERMS = [
+  "100%",
+  "always",
+  "compliance guaranteed",
+  "guaranteed",
+  "instant revenue",
+  "never fail",
+  "rank #1",
+  "risk-free",
+];
+
+const SENSITIVE_COPY_PATTERN =
+  /\b(api[_ -]?key|bearer|password|secret|sk-[a-z0-9_-]{8,}|token)\b/i;
+
+export function getDefaultCopyPassChecks(): CopyPassCheckDefinition[] {
+  return DEFAULT_COPYPASS_CHECKS.map((check) => ({ ...check }));
+}
+
+export function detectCopyPassFindings(
+  blocks: CopyPassCopyBlock[],
+  checks: CopyPassCheckDefinition[] = DEFAULT_COPYPASS_CHECKS,
+): CopyPassFinding[] {
+  const activeCheckIds = new Set(checks.map((check) => check.id));
+  const checkById = new Map(checks.map((check) => [check.id, check]));
+
+  return blocks.flatMap((block) => {
+    const normalized = normalizeCopy(block.text);
+    const findings: CopyPassFinding[] = [];
+
+    if (
+      isActive(activeCheckIds, "value-prop-clarity") &&
+      isPrimaryBlock(block) &&
+      containsAny(normalized, VAGUE_TERMS) &&
+      !containsAny(normalized, VALUE_TERMS)
+    ) {
+      findings.push(
+        createFinding(
+          block,
+          requireCheck(checkById, "value-prop-clarity"),
+          "Primary copy lacks a concrete value prop",
+          "The copy leans on broad language without clearly naming the user, action, and outcome.",
+        ),
+      );
+    }
+
+    if (
+      isActive(activeCheckIds, "cta-presence") &&
+      (block.kind === "hero" || block.kind === "cta") &&
+      !containsAny(normalized, CTA_TERMS)
+    ) {
+      findings.push(
+        createFinding(
+          block,
+          requireCheck(checkById, "cta-presence"),
+          "Primary copy is missing a clear CTA",
+          "The block does not include a direct next action.",
+        ),
+      );
+    }
+
+    if (
+      isActive(activeCheckIds, "proof-trust-gap") &&
+      (block.kind === "hero" || block.kind === "proof" || block.kind === "pricing") &&
+      !containsAny(normalized, PROOF_TERMS)
+    ) {
+      findings.push(
+        createFinding(
+          block,
+          requireCheck(checkById, "proof-trust-gap"),
+          "Primary copy is missing a trust signal",
+          "The block does not show proof, safety, privacy, receipt, or public evidence language.",
+        ),
+      );
+    }
+
+    if (
+      isActive(activeCheckIds, "unsupported-superiority") &&
+      containsAny(normalized, SUPERIORITY_TERMS) &&
+      !containsAny(normalized, PROOF_TERMS)
+    ) {
+      findings.push(
+        createFinding(
+          block,
+          requireCheck(checkById, "unsupported-superiority"),
+          "Superiority claim needs proof",
+          "The copy uses an absolute or superiority phrase without a nearby proof signal.",
+        ),
+      );
+    }
+
+    if (
+      isActive(activeCheckIds, "placeholder-copy") &&
+      containsAny(normalized, PLACEHOLDER_TERMS)
+    ) {
+      findings.push(
+        createFinding(
+          block,
+          requireCheck(checkById, "placeholder-copy"),
+          "Placeholder copy detected",
+          "The block contains drafting language that should not ship.",
+        ),
+      );
+    }
+
+    if (
+      isActive(activeCheckIds, "risky-guarantee-language") &&
+      containsAny(normalized, GUARANTEE_TERMS)
+    ) {
+      findings.push(
+        createFinding(
+          block,
+          requireCheck(checkById, "risky-guarantee-language"),
+          "Outcome guarantee language detected",
+          "The copy appears to promise a fixed result, access, compliance, revenue, or ranking outcome.",
+        ),
+      );
+    }
+
+    return findings;
+  });
+}
+
+export function normalizeCopy(value: string): string {
+  return value.toLocaleLowerCase("en-US").replace(/\s+/g, " ").trim();
+}
+
+function isPrimaryBlock(block: CopyPassCopyBlock): boolean {
+  return block.kind === "hero" || block.kind === "headline";
+}
+
+function isActive(activeCheckIds: Set<CopyPassCheckId>, checkId: CopyPassCheckId): boolean {
+  return activeCheckIds.has(checkId);
+}
+
+function containsAny(value: string, terms: string[]): boolean {
+  return terms.some((term) => value.includes(term));
+}
+
+function requireCheck(
+  checkById: Map<CopyPassCheckId, CopyPassCheckDefinition>,
+  checkId: CopyPassCheckId,
+): CopyPassCheckDefinition {
+  const check = checkById.get(checkId);
+  if (!check) {
+    throw new Error(`CopyPass check ${checkId} is not configured.`);
+  }
+  return check;
+}
+
+function createFinding(
+  block: CopyPassCopyBlock,
+  check: CopyPassCheckDefinition,
+  title: string,
+  summary: string,
+): CopyPassFinding {
+  return {
+    id: `${block.id}.${check.id}`,
+    check_id: check.id,
+    severity: check.severity,
+    title,
+    summary,
+    evidence: redactEvidence(block.text),
+    suggested_fix: check.recommended_fix,
+    block_id: block.id,
+    source_path: block.source_path,
+    source_url: block.source_url,
+  };
+}
+
+function redactEvidence(value: string): string {
+  if (SENSITIVE_COPY_PATTERN.test(value)) {
+    return "[redacted-sensitive-copy-fragment]";
+  }
+
+  return value.replace(/\s+/g, " ").trim().slice(0, 220);
+}

--- a/packages/copypass/src/index.ts
+++ b/packages/copypass/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./copy-library.js";
+export * from "./schema.js";
+export * from "./verdict-pack.js";

--- a/packages/copypass/src/schema.ts
+++ b/packages/copypass/src/schema.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+export const CopyPassSeveritySchema = z.enum([
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+]);
+
+export const CopyPassCheckIdSchema = z.enum([
+  "value-prop-clarity",
+  "cta-presence",
+  "proof-trust-gap",
+  "unsupported-superiority",
+  "placeholder-copy",
+  "risky-guarantee-language",
+]);
+
+export const CopyPassBlockKindSchema = z.enum([
+  "hero",
+  "headline",
+  "cta",
+  "feature",
+  "proof",
+  "pricing",
+  "legal",
+  "email",
+  "ad",
+  "other",
+]);
+
+export const CopyPassTargetSchema = z.object({
+  kind: z.enum(["page", "component", "campaign", "email", "ad", "doc", "artifact"]),
+  label: z.string().min(1),
+  url: z.string().url().optional(),
+  source: z.string().min(1).optional(),
+});
+
+export const CopyPassCopyBlockSchema = z.object({
+  id: z.string().min(1),
+  kind: CopyPassBlockKindSchema,
+  label: z.string().min(1).optional(),
+  text: z.string().min(1),
+  source_path: z.string().min(1).optional(),
+  source_url: z.string().url().optional(),
+  public_only: z.boolean().default(true),
+});
+
+export const CopyPassCheckDefinitionSchema = z.object({
+  id: CopyPassCheckIdSchema,
+  label: z.string().min(1),
+  goal: z.string().min(1),
+  severity: CopyPassSeveritySchema,
+  recommended_fix: z.string().min(1),
+});
+
+export const CopyPassFindingSchema = z.object({
+  id: z.string().min(1),
+  check_id: CopyPassCheckIdSchema,
+  severity: CopyPassSeveritySchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  evidence: z.string().min(1),
+  suggested_fix: z.string().min(1),
+  block_id: z.string().min(1).optional(),
+  source_path: z.string().min(1).optional(),
+  source_url: z.string().url().optional(),
+});
+
+export const CopyPassVerdictSchema = z.enum(["pass", "warn", "fail", "unknown"]);
+
+export const CopyPassNotCheckedSchema = z.object({
+  label: z.string().min(1),
+  reason: z.string().min(1),
+});
+
+export const CopyPassScannerSourceSchema = z.object({
+  kind: z.enum(["fixture", "manual", "shared-scanner-plan"]),
+  mode: z.enum(["plan-only", "fixture"]),
+  target_url: z.string().url().optional(),
+  shared_check_ids: z.array(z.string().min(1)).default([]),
+});
+
+export const CopyPassReportSchema = z.object({
+  target: CopyPassTargetSchema,
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture"]),
+  overall_score: z.number().int().min(0).max(100),
+  verdict: CopyPassVerdictSchema,
+  checks_attempted: z.array(CopyPassCheckIdSchema),
+  blocks_reviewed: z.array(z.string().min(1)),
+  findings: z.array(CopyPassFindingSchema),
+  not_checked: z.array(CopyPassNotCheckedSchema),
+  scanner_source: CopyPassScannerSourceSchema,
+  disclaimers: z.array(z.string().min(1)),
+  notes: z.array(z.string().min(1)).default([]),
+});
+
+export type CopyPassSeverity = z.output<typeof CopyPassSeveritySchema>;
+export type CopyPassCheckId = z.output<typeof CopyPassCheckIdSchema>;
+export type CopyPassBlockKind = z.output<typeof CopyPassBlockKindSchema>;
+export type CopyPassTarget = z.output<typeof CopyPassTargetSchema>;
+export type CopyPassTargetInput = z.input<typeof CopyPassTargetSchema>;
+export type CopyPassCopyBlock = z.output<typeof CopyPassCopyBlockSchema>;
+export type CopyPassCopyBlockInput = z.input<typeof CopyPassCopyBlockSchema>;
+export type CopyPassCheckDefinition = z.output<typeof CopyPassCheckDefinitionSchema>;
+export type CopyPassFinding = z.output<typeof CopyPassFindingSchema>;
+export type CopyPassVerdict = z.output<typeof CopyPassVerdictSchema>;
+export type CopyPassNotChecked = z.output<typeof CopyPassNotCheckedSchema>;
+export type CopyPassReport = z.output<typeof CopyPassReportSchema>;

--- a/packages/copypass/src/verdict-pack.ts
+++ b/packages/copypass/src/verdict-pack.ts
@@ -1,0 +1,147 @@
+import {
+  CopyPassCopyBlockSchema,
+  CopyPassReportSchema,
+  type CopyPassCheckDefinition,
+  type CopyPassCopyBlockInput,
+  type CopyPassFinding,
+  type CopyPassNotChecked,
+  type CopyPassReport,
+  type CopyPassTargetInput,
+  type CopyPassVerdict,
+} from "./schema.js";
+import {
+  DEFAULT_COPYPASS_CHECKS,
+  detectCopyPassFindings,
+} from "./copy-library.js";
+
+const COPYPASS_ADVISORY_DISCLAIMER =
+  "CopyPass is advisory. It flags deterministic copy signals for review and does not guarantee legal, ranking, conversion, revenue, accessibility, or compliance outcomes.";
+
+const FIXTURE_NOT_CHECKED: CopyPassNotChecked[] = [
+  {
+    label: "Production crawl",
+    reason: "This scaffold only evaluates provided fixture copy.",
+  },
+  {
+    label: "Paid model review",
+    reason: "This scaffold uses deterministic local checks and does not call paid LLMs.",
+  },
+  {
+    label: "Private customer copy",
+    reason: "Only caller-provided public fixtures should be passed to CopyPass.",
+  },
+];
+
+export interface CreateCopyPassVerdictPackInput {
+  target: CopyPassTargetInput;
+  generated_at?: string;
+  checks?: CopyPassCheckDefinition[];
+}
+
+export interface CreateFixtureCopyPassReportInput
+  extends CreateCopyPassVerdictPackInput {
+  blocks: CopyPassCopyBlockInput[];
+}
+
+export function createCopyPassVerdictPack(
+  input: CreateCopyPassVerdictPackInput,
+): CopyPassReport {
+  const checks = input.checks ?? DEFAULT_COPYPASS_CHECKS;
+  const report = {
+    target: input.target,
+    generated_at: input.generated_at ?? new Date().toISOString(),
+    mode: "plan-only" as const,
+    overall_score: 0,
+    verdict: "unknown" as const,
+    checks_attempted: checks.map((check) => check.id),
+    blocks_reviewed: [],
+    findings: [],
+    not_checked: FIXTURE_NOT_CHECKED,
+    scanner_source: {
+      kind: "shared-scanner-plan" as const,
+      mode: "plan-only" as const,
+      target_url: input.target.url,
+      shared_check_ids: checks.map((check) => check.id),
+    },
+    disclaimers: [COPYPASS_ADVISORY_DISCLAIMER],
+    notes: [
+      "Plan-only CopyPass pack. No production crawl, paid call, private copy, or live analytics write was used.",
+    ],
+  };
+
+  return CopyPassReportSchema.parse(report);
+}
+
+export function createFixtureCopyPassReport(
+  input: CreateFixtureCopyPassReportInput,
+): CopyPassReport {
+  const checks = input.checks ?? DEFAULT_COPYPASS_CHECKS;
+  const blocks = input.blocks.map((block) => CopyPassCopyBlockSchema.parse(block));
+  const findings = detectCopyPassFindings(blocks, checks);
+  const overall_score = scoreCopyPassFindings(findings);
+  const report = {
+    target: input.target,
+    generated_at: input.generated_at ?? new Date().toISOString(),
+    mode: "fixture" as const,
+    overall_score,
+    verdict: toCopyPassVerdict(findings, overall_score),
+    checks_attempted: checks.map((check) => check.id),
+    blocks_reviewed: blocks.map((block) => block.id),
+    findings,
+    not_checked: FIXTURE_NOT_CHECKED,
+    scanner_source: {
+      kind: "fixture" as const,
+      mode: "fixture" as const,
+      target_url: input.target.url,
+      shared_check_ids: checks.map((check) => check.id),
+    },
+    disclaimers: [COPYPASS_ADVISORY_DISCLAIMER],
+    notes: [
+      "Fixture-only CopyPass report. Findings are deterministic text signals for human copy review.",
+    ],
+  };
+
+  return CopyPassReportSchema.parse(report);
+}
+
+export function scoreCopyPassFindings(findings: CopyPassFinding[]): number {
+  const penalty = findings.reduce((total, finding) => {
+    switch (finding.severity) {
+      case "critical":
+        return total + 30;
+      case "high":
+        return total + 20;
+      case "medium":
+        return total + 12;
+      case "low":
+        return total + 6;
+      case "info":
+        return total + 2;
+    }
+  }, 0);
+
+  return Math.max(0, 100 - penalty);
+}
+
+export function toCopyPassVerdict(
+  findings: CopyPassFinding[],
+  overallScore: number,
+): CopyPassVerdict {
+  if (findings.length === 0) {
+    return "pass";
+  }
+
+  if (
+    findings.some(
+      (finding) => finding.severity === "critical" || finding.severity === "high",
+    )
+  ) {
+    return "fail";
+  }
+
+  if (overallScore < 100) {
+    return "warn";
+  }
+
+  return "unknown";
+}

--- a/packages/copypass/tsconfig.json
+++ b/packages/copypass/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/copypass/vitest.config.ts
+++ b/packages/copypass/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.{test,spec}.ts"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}", "api/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      "api/**/*.{test,spec}.{ts,tsx}",
+      "packages/copypass/src/**/*.{test,spec}.ts",
+    ],
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },


### PR DESCRIPTION
Summary
- Adds @unclick/copypass as a fixture-only product-copy review package.
- Defines schemas, deterministic copy checks, advisory verdict reports, tests, and a concise CopyPass product brief.

Scope
- Linked todo: dbbc3b8e-7885-4f8d-a0f8-540738fdb9a5.
- Owned files: packages/copypass, docs/copypass-product-brief.md, package-lock.json, and root Vitest include for the requested package test command.

Non-overlap
- No paid LLM calls, production crawls, private customer copy, migrations, scheduled jobs, live analytics writes, or production test rows.
- Does not rewrite GEOPass, SEOPass, FlowPass, LegalPass, SlopPass, UXPass, SecurityPass, or TestPass internals.

Verification
- npx vitest packages/copypass/src/__tests__/schema.test.ts packages/copypass/src/__tests__/copy-library.test.ts packages/copypass/src/__tests__/verdict-pack.test.ts
- npm run build --workspace=@unclick/copypass
- npm ci --dry-run --ignore-scripts
- npm run build
- git diff --check

Risk
- Low. New isolated package and test include only, with advisory output and no external calls.

Follow-up
- Later slices can feed CopyPass from the shared scanner once the Pass family wiring is ready.

Draft status
- Draft PR opened for checks.