### PR TITLE
feat(reliability): add fishbowl todo lease guard

### DIFF
--- a/api/fishbowl-todo-handoff.test.ts
+++ b/api/fishbowl-todo-handoff.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildFishbowlTodoHandoffDispatchRow,
+  buildFishbowlTodoClaimLease,
+  buildFishbowlTodoRefreshLease,
+  buildFishbowlTodoReleaseLease,
   FISHBOWL_TODO_HANDOFF_LEASE_SECONDS,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff";
@@ -74,5 +77,141 @@ describe("planFishbowlTodoHandoff", () => {
     expect(
       planFishbowlTodoHandoff({ ...baseInput, assignedToAgentId: baseInput.createdByAgentId }),
     ).toBeNull();
+  });
+});
+
+describe("Fishbowl todo claim leases", () => {
+  const now = new Date("2026-05-09T19:30:00.000Z");
+  const openTodo = {
+    id: "todo-lease-1",
+    status: "open",
+    assigned_to_agent_id: null,
+    lease_token: null,
+    lease_expires_at: null,
+    reclaim_count: 0,
+  };
+
+  it("builds a claim mutation for an open unassigned todo", () => {
+    const result = buildFishbowlTodoClaimLease({
+      todo: openTodo,
+      agentId: "runner-1",
+      leaseToken: "lease-1",
+      now,
+      leaseSeconds: 300,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      todo_id: "todo-lease-1",
+      action: "claim",
+      expected_lease_token: null,
+      update: {
+        status: "in_progress",
+        assigned_to_agent_id: "runner-1",
+        lease_token: "lease-1",
+        lease_expires_at: "2026-05-09T19:35:00.000Z",
+        reclaim_count: 0,
+        updated_at: "2026-05-09T19:30:00.000Z",
+      },
+    });
+  });
+
+  it("blocks stale claims when another active lease token owns the todo", () => {
+    const result = buildFishbowlTodoClaimLease({
+      todo: {
+        ...openTodo,
+        lease_token: "fresh-lease",
+        lease_expires_at: "2026-05-09T19:31:00.000Z",
+      },
+      agentId: "runner-2",
+      leaseToken: "stale-lease",
+      now,
+      leaseSeconds: 300,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "active_lease_token_mismatch",
+      lease_token: "fresh-lease",
+    });
+  });
+
+  it("allows reclaiming an expired open lease and increments reclaim count", () => {
+    const result = buildFishbowlTodoClaimLease({
+      todo: {
+        ...openTodo,
+        lease_token: "old-lease",
+        lease_expires_at: "2026-05-09T19:29:59.000Z",
+        reclaim_count: 2,
+      },
+      agentId: "runner-2",
+      leaseToken: "new-lease",
+      now,
+      leaseSeconds: 60,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      expected_lease_token: "old-lease",
+      update: {
+        lease_token: "new-lease",
+        lease_expires_at: "2026-05-09T19:31:00.000Z",
+        reclaim_count: 3,
+      },
+    });
+  });
+
+  it("refreshes and releases only with the matching lease token", () => {
+    const claimed = {
+      ...openTodo,
+      status: "in_progress",
+      assigned_to_agent_id: "runner-1",
+      lease_token: "lease-1",
+      lease_expires_at: "2026-05-09T19:31:00.000Z",
+    };
+
+    expect(
+      buildFishbowlTodoRefreshLease({
+        todo: claimed,
+        agentId: "runner-1",
+        leaseToken: "wrong",
+        now,
+        leaseSeconds: 60,
+      }),
+    ).toMatchObject({ ok: false, reason: "lease_token_mismatch" });
+
+    expect(
+      buildFishbowlTodoRefreshLease({
+        todo: claimed,
+        agentId: "runner-1",
+        leaseToken: "lease-1",
+        now,
+        leaseSeconds: 60,
+      }),
+    ).toMatchObject({
+      ok: true,
+      action: "refresh",
+      update: {
+        lease_expires_at: "2026-05-09T19:31:00.000Z",
+      },
+    });
+
+    expect(
+      buildFishbowlTodoReleaseLease({
+        todo: claimed,
+        agentId: "runner-1",
+        leaseToken: "lease-1",
+        now,
+      }),
+    ).toMatchObject({
+      ok: true,
+      action: "release",
+      update: {
+        status: "open",
+        assigned_to_agent_id: null,
+        lease_token: null,
+        lease_expires_at: null,
+      },
+    });
   });
 });

--- a/api/lib/fishbowl-todo-handoff.ts
+++ b/api/lib/fishbowl-todo-handoff.ts
@@ -44,6 +44,53 @@ export interface FishbowlTodoHandoffDispatchRow {
   updated_at: string;
 }
 
+export interface FishbowlTodoLeaseState {
+  id: string;
+  status: "open" | "in_progress" | "done" | "dropped" | string;
+  assigned_to_agent_id?: string | null;
+  lease_token?: string | null;
+  lease_expires_at?: string | null;
+  reclaim_count?: number | null;
+}
+
+export interface FishbowlTodoLeaseUpdate {
+  status?: "open" | "in_progress";
+  assigned_to_agent_id?: string | null;
+  lease_token?: string | null;
+  lease_expires_at?: string | null;
+  reclaim_count?: number;
+  updated_at: string;
+}
+
+export interface FishbowlTodoLeaseMutation {
+  ok: true;
+  todo_id: string;
+  action: "claim" | "refresh" | "release";
+  expected_lease_token: string | null;
+  update: FishbowlTodoLeaseUpdate;
+}
+
+export interface FishbowlTodoLeaseBlocked {
+  ok: false;
+  reason:
+    | "missing_todo"
+    | "missing_agent_id"
+    | "missing_lease_token"
+    | "todo_not_open"
+    | "todo_already_assigned"
+    | "active_lease_token_mismatch"
+    | "lease_token_mismatch"
+    | "lease_expired";
+  todo_id?: string;
+  assigned_to_agent_id?: string | null;
+  lease_token?: string | null;
+  lease_expires_at?: string | null;
+}
+
+export type FishbowlTodoLeaseResult =
+  | FishbowlTodoLeaseMutation
+  | FishbowlTodoLeaseBlocked;
+
 export function planFishbowlTodoHandoff(
   input: FishbowlTodoHandoffInput,
 ): FishbowlTodoHandoffPlan | null {
@@ -89,4 +136,173 @@ export function buildFishbowlTodoHandoffDispatchRow(params: {
     created_at: nowIso,
     updated_at: nowIso,
   };
+}
+
+export function buildFishbowlTodoClaimLease(params: {
+  todo: FishbowlTodoLeaseState | null | undefined;
+  agentId: string;
+  leaseToken: string;
+  now: Date;
+  leaseSeconds: number;
+}): FishbowlTodoLeaseResult {
+  const precheck = validateLeaseInput(params);
+  if (!precheck.ok) return precheck;
+
+  const todo = params.todo!;
+  const currentToken = normalizeLeaseToken(todo.lease_token);
+  const requestedToken = normalizeLeaseToken(params.leaseToken);
+  const assignee = normalizeAgentId(todo.assigned_to_agent_id);
+  const nowMs = params.now.getTime();
+
+  if (todo.status !== "open") {
+    return blockLease("todo_not_open", todo);
+  }
+
+  if (assignee && currentToken !== requestedToken) {
+    return blockLease("todo_already_assigned", todo);
+  }
+
+  if (
+    currentToken &&
+    currentToken !== requestedToken &&
+    !leaseIsExpired(todo.lease_expires_at, nowMs)
+  ) {
+    return blockLease("active_lease_token_mismatch", todo);
+  }
+
+  return {
+    ok: true,
+    todo_id: todo.id,
+    action: "claim",
+    expected_lease_token: currentToken || null,
+    update: {
+      status: "in_progress",
+      assigned_to_agent_id: normalizeAgentId(params.agentId),
+      lease_token: requestedToken,
+      lease_expires_at: addLeaseSeconds(params.now, params.leaseSeconds),
+      reclaim_count: leaseIsExpired(todo.lease_expires_at, nowMs)
+        ? Number(todo.reclaim_count || 0) + 1
+        : Number(todo.reclaim_count || 0),
+      updated_at: params.now.toISOString(),
+    },
+  };
+}
+
+export function buildFishbowlTodoRefreshLease(params: {
+  todo: FishbowlTodoLeaseState | null | undefined;
+  agentId: string;
+  leaseToken: string;
+  now: Date;
+  leaseSeconds: number;
+}): FishbowlTodoLeaseResult {
+  const precheck = validateLeaseInput(params);
+  if (!precheck.ok) return precheck;
+
+  const todo = params.todo!;
+  const currentToken = normalizeLeaseToken(todo.lease_token);
+  const requestedToken = normalizeLeaseToken(params.leaseToken);
+
+  if (currentToken !== requestedToken) {
+    return blockLease("lease_token_mismatch", todo);
+  }
+
+  if (leaseIsExpired(todo.lease_expires_at, params.now.getTime())) {
+    return blockLease("lease_expired", todo);
+  }
+
+  return {
+    ok: true,
+    todo_id: todo.id,
+    action: "refresh",
+    expected_lease_token: requestedToken,
+    update: {
+      lease_token: requestedToken,
+      lease_expires_at: addLeaseSeconds(params.now, params.leaseSeconds),
+      updated_at: params.now.toISOString(),
+    },
+  };
+}
+
+export function buildFishbowlTodoReleaseLease(params: {
+  todo: FishbowlTodoLeaseState | null | undefined;
+  agentId: string;
+  leaseToken: string;
+  now: Date;
+}): FishbowlTodoLeaseResult {
+  const precheck = validateLeaseInput({ ...params, leaseSeconds: 1 });
+  if (!precheck.ok) return precheck;
+
+  const todo = params.todo!;
+  const currentToken = normalizeLeaseToken(todo.lease_token);
+  const requestedToken = normalizeLeaseToken(params.leaseToken);
+
+  if (currentToken !== requestedToken) {
+    return blockLease("lease_token_mismatch", todo);
+  }
+
+  return {
+    ok: true,
+    todo_id: todo.id,
+    action: "release",
+    expected_lease_token: requestedToken,
+    update: {
+      status: "open",
+      assigned_to_agent_id: null,
+      lease_token: null,
+      lease_expires_at: null,
+      updated_at: params.now.toISOString(),
+    },
+  };
+}
+
+function validateLeaseInput(params: {
+  todo: FishbowlTodoLeaseState | null | undefined;
+  agentId: string;
+  leaseToken: string;
+}): FishbowlTodoLeaseBlocked | { ok: true } {
+  if (!params.todo) {
+    return { ok: false, reason: "missing_todo" };
+  }
+
+  if (!normalizeAgentId(params.agentId)) {
+    return blockLease("missing_agent_id", params.todo);
+  }
+
+  if (!normalizeLeaseToken(params.leaseToken)) {
+    return blockLease("missing_lease_token", params.todo);
+  }
+
+  return { ok: true };
+}
+
+function blockLease(
+  reason: FishbowlTodoLeaseBlocked["reason"],
+  todo: FishbowlTodoLeaseState,
+): FishbowlTodoLeaseBlocked {
+  return {
+    ok: false,
+    reason,
+    todo_id: todo.id,
+    assigned_to_agent_id: todo.assigned_to_agent_id ?? null,
+    lease_token: todo.lease_token ?? null,
+    lease_expires_at: todo.lease_expires_at ?? null,
+  };
+}
+
+function normalizeAgentId(value: string | null | undefined): string {
+  return String(value ?? "").trim();
+}
+
+function normalizeLeaseToken(value: string | null | undefined): string {
+  return String(value ?? "").trim();
+}
+
+function addLeaseSeconds(now: Date, leaseSeconds: number): string {
+  const seconds = Number.isFinite(leaseSeconds) ? Math.max(1, leaseSeconds) : 600;
+  return new Date(now.getTime() + seconds * 1000).toISOString();
+}
+
+function leaseIsExpired(value: string | null | undefined, nowMs: number): boolean {
+  const ms = Date.parse(String(value ?? ""));
+  return Number.isFinite(ms) && ms <= nowMs;
 }

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -422,6 +422,18 @@ function validateBoardroomClaimSourceState(job = {}) {
     };
   }
 
+  const sourceLeaseToken = String(state.lease_token || "").trim();
+  const jobClaimId = String(job?.claim_id || "").trim();
+  const sourceLeaseExpiresAt = Date.parse(String(state.lease_expires_at || ""));
+  const jobClaimedAt = Date.parse(String(job?.claimed_at || ""));
+  const sourceLeaseExpired =
+    Number.isFinite(sourceLeaseExpiresAt) &&
+    Number.isFinite(jobClaimedAt) &&
+    sourceLeaseExpiresAt <= jobClaimedAt;
+  if (sourceLeaseToken && sourceLeaseToken !== jobClaimId && !sourceLeaseExpired) {
+    return { ok: false, reason: "boardroom_todo_lease_token_mismatch" };
+  }
+
   return { ok: true };
 }
 
@@ -626,6 +638,9 @@ export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date
       todo_id: id || null,
       status: todo.status || null,
       assigned_to_agent_id: todo.assigned_to_agent_id || null,
+      lease_expires_at: todo.lease_expires_at || null,
+      lease_token: todo.lease_token || null,
+      reclaim_count: Number.isFinite(todo.reclaim_count) ? todo.reclaim_count : null,
       actionability_reason: todo.actionability_reason || null,
       updated_at: todo.updated_at || null,
     },

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -536,6 +536,83 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("blocks stale UnClick todo lease tokens before syncing ownership", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const calls = [];
+      const fetchImpl = async (_url, init = {}) => {
+        calls.push({ body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-stale-lease-1",
+                            title: "Scoped stale lease runner chip",
+                            status: "open",
+                            priority: "urgent",
+                            assigned_to_agent_id: null,
+                            lease_token: "other-active-lease",
+                            lease_expires_at: "2026-05-09T12:40:00.000Z",
+                            reclaim_count: 1,
+                            actionability_reason: "unassigned_open",
+                            created_at: "2026-05-08T05:00:00.000Z",
+                            updated_at: "2026-05-08T05:05:00.000Z",
+                            scope_pack: {
+                              owned_files: ["docs/stale-lease-chip.md"],
+                              patch: "diff --git a/docs/stale-lease-chip.md b/docs/stale-lease-chip.md\n--- a/docs/stale-lease-chip.md\n+++ b/docs/stale-lease-chip.md\n@@ -1 +1 @@\n-old\n+new\n",
+                              tests: [],
+                            },
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-09T12:35:00.000Z",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "todo_claim_sync_failed");
+      assert.equal(result.todo_claim_sync.reason, "claim_source_state_mismatch");
+      assert.equal(result.todo_claim_sync.detail, "boardroom_todo_lease_token_mismatch");
+      assert.deepEqual(calls.map((call) => call.body.params.name), ["list_actionable_todos"]);
+
+      const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
+      assert.equal(persisted.jobs.length, 0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reopens stale unscoped UnClick todos for scoping instead of idling forever", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");

--- a/supabase/migrations/20260509192800_fishbowl_todo_leases.sql
+++ b/supabase/migrations/20260509192800_fishbowl_todo_leases.sql
@@ -1,0 +1,24 @@
+-- Fishbowl todo claim leases v1.
+-- Adds conservative nullable lease columns so live runners can prove they
+-- still own a claim before mutating a Boardroom todo.
+
+ALTER TABLE IF EXISTS mc_fishbowl_todos
+  ADD COLUMN IF NOT EXISTS lease_expires_at timestamptz,
+  ADD COLUMN IF NOT EXISTS lease_token text,
+  ADD COLUMN IF NOT EXISTS reclaim_count integer NOT NULL DEFAULT 0
+    CHECK (reclaim_count >= 0);
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_todos_claimable_open
+  ON mc_fishbowl_todos(api_key_hash, status, assigned_to_agent_id, lease_expires_at)
+  WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_todos_lease_token
+  ON mc_fishbowl_todos(api_key_hash, lease_token)
+  WHERE lease_token IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_todos_stale_leases
+  ON mc_fishbowl_todos(api_key_hash, lease_expires_at)
+  WHERE lease_expires_at IS NOT NULL
+    AND status IN ('open', 'in_progress');
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Summary
- Adds nullable Fishbowl todo lease columns and conservative indexes for claim ownership checks.
- Adds pure claim, refresh, and release helpers for todo lease mutations.
- Carries todo lease state into PinballWake Boardroom job imports and blocks stale active lease-token claims before side effects.

Scope
- Linked todo: b744462e-8e50-4cad-babb-5468adc2a3d9.
- Owned files: supabase migration, api/lib/fishbowl-todo-handoff.ts, api/fishbowl-todo-handoff.test.ts, scripts/pinballwake-autonomous-runner.mjs, scripts/pinballwake-autonomous-runner.test.mjs.

Non-overlap
- Does not enable execute mode, merges, force-push, auto-merge, or broad queue draining.
- Does not touch secrets, auth, billing, DNS, customer data, Worker Registry, Jobs UI, QueuePush, WakePass, or XPass packages.

Verification
- npx vitest api/fishbowl-todo-handoff.test.ts
- node --test scripts/pinballwake-coding-room.test.mjs scripts/pinballwake-coding-room-runner.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- npx eslint scripts/pinballwake-coding-room.mjs scripts/pinballwake-coding-room-runner.mjs scripts/pinballwake-autonomous-runner.mjs
- npm run build
- git diff --check

Risk
- Additive migration only. Runtime behavior remains execute-off and only blocks stale active lease-token claims.

Follow-up
- After merge, prove via natural PinballWake Autonomous Runner schedule on merged SHA with AUTONOMOUS_RUNNER_ALLOW_EXECUTE=false.

Draft status
- Draft PR opened for checks.