### PR TITLE
feat(reliability): harden autonomous runner auto-claims

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -3,6 +3,10 @@ name: PinballWake Autonomous Runner
 on:
   schedule:
     - cron: "3,13,23,33,43,53 * * * *"
+  workflow_run:
+    workflows:
+      - Fleet Throughput Watch
+    types: [completed]
   workflow_dispatch:
     inputs:
       mode:
@@ -33,6 +37,7 @@ jobs:
   runner:
     name: Run autonomous queue cycle
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,11 +57,15 @@ jobs:
           CODING_ROOM_LEDGER_PATH: ${{ vars.CODING_ROOM_LEDGER_PATH || '.pinballwake/coding-room-ledger.json' }}
           CODING_ROOM_LEASE_SECONDS: ${{ vars.CODING_ROOM_LEASE_SECONDS || '1800' }}
           AUTONOMOUS_RUNNER_QUEUE_SOURCE: ${{ vars.AUTONOMOUS_RUNNER_QUEUE_SOURCE || 'unclick' }}
+          AUTONOMOUS_RUNNER_WAKE_SOURCE: ${{ github.event_name == 'workflow_run' && 'queuepush' || github.event_name }}
           AUTONOMOUS_RUNNER_TODO_LIMIT: ${{ vars.AUTONOMOUS_RUNNER_TODO_LIMIT || '10' }}
           AUTONOMOUS_RUNNER_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || vars.AUTONOMOUS_RUNNER_MODE || 'claim' }}
           AUTONOMOUS_RUNNER_DISABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.kill_switch == 'true' && 'true' || vars.AUTONOMOUS_RUNNER_DISABLED || 'false' }}
           AUTONOMOUS_RUNNER_ALLOW_EXECUTE: "false"
           AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES: "false"
+          AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES || 'urgent,high' }}
+          AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS || 'unassigned_open' }}
+          AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES || 'builder,plex-builder,implementation,test_fix,docs_update,code' }}
           AUTONOMOUS_RUNNER_MAX_CYCLES: ${{ github.event_name == 'workflow_dispatch' && inputs.max_cycles || vars.AUTONOMOUS_RUNNER_MAX_CYCLES || '1' }}
           UNCLICK_MCP_URL: ${{ vars.UNCLICK_MCP_URL || 'https://unclick.world/api/mcp' }}
           UNCLICK_API_KEY: ${{ secrets.UNCLICK_API_KEY || secrets.FISHBOWL_AUTOCLOSE_TOKEN || secrets.FISHBOWL_WAKE_TOKEN }}

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -28,9 +28,15 @@ export const DEFAULT_AUTONOMOUS_RUNNER_POLICY = {
   allowProtectedSurfaces: false,
   allowExecute: false,
   maxCycles: 1,
+  allowedPriorities: ["urgent", "high"],
+  allowedActionReasons: ["unassigned_open"],
+  allowedTodoRoles: ["builder", "plex-builder", "implementation", "test_fix", "docs_update", "code"],
 };
 
 export const DEFAULT_UNCLICK_MCP_URL = "https://unclick.world/api/mcp";
+
+const HOLD_TITLE_PATTERN = /\b(hold|blocker|blocked|dirty)\b/i;
+const HOLD_BODY_MARKER_PATTERN = /(?:^|\n)\s*(hold|blocker|blocked|dirty)\s*:/i;
 
 const PROTECTED_SURFACE_PATTERNS = [
   {
@@ -95,6 +101,10 @@ function normalizePath(value) {
   return String(value ?? "").replace(/\\/g, "/").trim();
 }
 
+function normalizeToken(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
 function compact(value, max = 240) {
   const text = String(value ?? "").replace(/\s+/g, " ").trim();
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
@@ -116,6 +126,49 @@ function priorityWeight(priority) {
   if (raw === "normal") return 50;
   if (raw === "low") return 20;
   return 0;
+}
+
+function tokenSet(value, fallback = []) {
+  return new Set(parseList(value, fallback).map(normalizeToken).filter(Boolean));
+}
+
+function listTodoRoleTokens(todo = {}, scopePack = {}) {
+  const raw = [
+    todo.worker,
+    todo.worker_role,
+    todo.role,
+    todo.lane,
+    todo.assigned_role,
+    todo.assigned_work,
+    scopePack.worker,
+    scopePack.worker_role,
+    scopePack.role,
+  ];
+
+  return raw
+    .flatMap((value) => parseList(value, []))
+    .map(normalizeToken)
+    .filter(Boolean);
+}
+
+function recentTodoCommentText(todo = {}) {
+  const comments = Array.isArray(todo.recent_comments)
+    ? todo.recent_comments
+    : Array.isArray(todo.comments)
+      ? todo.comments
+      : [];
+  const commentText = comments
+    .map((comment) => `${comment?.result || ""} ${comment?.status || ""} ${comment?.body || ""} ${comment?.text || ""}`)
+    .join("\n");
+
+  return [
+    todo.latest_comment_result,
+    todo.latest_comment_status,
+    todo.latest_comment_text,
+    todo.last_comment_text,
+    todo.recent_blocker_comment,
+    commentText,
+  ].join("\n");
 }
 
 function extractMcpTextJson(payload) {
@@ -246,6 +299,9 @@ function extractBoardroomTodoScopePack(todo = {}) {
     patch,
     tests,
     jobType: String(scope.job_type || scope.jobType || "code").trim() || "code",
+    worker: String(scope.worker || "").trim(),
+    worker_role: String(scope.worker_role || scope.workerRole || "").trim(),
+    role: String(scope.role || "").trim(),
   };
 }
 
@@ -499,7 +555,9 @@ export async function syncClaimedBoardroomTodoToUnClick({
           "Autonomous Runner claim synced: status open -> in_progress.",
           `owner=${agentId}.`,
           `dispatch=${job?.claim_id || "none"}.`,
+          `lease_token=${job?.claim_id || "none"}.`,
           `source=${job?.source || "unknown"}.`,
+          `wake_source=${job?.source_state?.wake_source || "unknown"}.`,
           `job=${job?.job_id || "unknown"}.`,
         ].join(" "),
         600,
@@ -643,6 +701,7 @@ export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date
       reclaim_count: Number.isFinite(todo.reclaim_count) ? todo.reclaim_count : null,
       actionability_reason: todo.actionability_reason || null,
       updated_at: todo.updated_at || null,
+      wake_source: todo.wake_source || todo.wakeSource || null,
     },
     worker: assignee || "builder",
     chip: title,
@@ -663,6 +722,70 @@ export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date
   });
 }
 
+export function evaluateBoardroomTodoAutoClaimEligibility(
+  todo = {},
+  {
+    scopePack = extractBoardroomTodoScopePack(todo),
+    allowedPriorities = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedPriorities,
+    allowedActionReasons = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons,
+    allowedTodoRoles = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles,
+    allowProtectedSurfaces = false,
+    now = new Date().toISOString(),
+  } = {},
+) {
+  if (!scopePack.hasScopePack) {
+    return { ok: true, reason: "missing_scopepack_kept_for_scoping" };
+  }
+
+  const priority = normalizeToken(todo.priority || "normal");
+  const safePriorities = tokenSet(allowedPriorities, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedPriorities);
+  if (!safePriorities.has(priority)) {
+    return { ok: false, reason: "boardroom_todo_priority_not_allowed", priority };
+  }
+
+  const status = normalizeToken(todo.status || "");
+  if (status !== "open") {
+    return { ok: false, reason: "boardroom_todo_not_open", status: status || null };
+  }
+
+  const assignedTo = String(todo.assigned_to_agent_id || "").trim();
+  if (assignedTo) {
+    return { ok: false, reason: "boardroom_todo_already_assigned", assigned_to_agent_id: assignedTo };
+  }
+
+  const actionReason = normalizeToken(todo.actionability_reason || "");
+  const safeActionReasons = tokenSet(allowedActionReasons, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons);
+  if (actionReason && safeActionReasons.size > 0 && !safeActionReasons.has(actionReason)) {
+    return { ok: false, reason: "boardroom_todo_action_reason_not_allowed", actionability_reason: actionReason };
+  }
+
+  const title = String(todo.title || "");
+  const description = String(todo.description || todo.body || todo.notes || "");
+  if (HOLD_TITLE_PATTERN.test(title) || HOLD_BODY_MARKER_PATTERN.test(description)) {
+    return { ok: false, reason: "boardroom_todo_hold_or_blocker_marker" };
+  }
+
+  if (/\b(blocker|blocked)\b/i.test(recentTodoCommentText(todo))) {
+    return { ok: false, reason: "boardroom_todo_recent_blocker_comment" };
+  }
+
+  const safeRoles = tokenSet(allowedTodoRoles, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles);
+  const roleTokens = listTodoRoleTokens(todo, scopePack);
+  const hasAllowedRole = roleTokens.length === 0 || roleTokens.some((role) => safeRoles.has(role));
+  if (!hasAllowedRole) {
+    return { ok: false, reason: "boardroom_todo_role_not_allowed", role: roleTokens[0] || null };
+  }
+
+  if (!allowProtectedSurfaces) {
+    const safety = inspectAutonomousRunnerJobSafety(createCodingRoomJobFromBoardroomTodo(todo, { now }));
+    if (!safety.ok) {
+      return { ok: false, reason: safety.reason, file: safety.file || null };
+    }
+  }
+
+  return { ok: true, reason: "boardroom_todo_claim_eligible" };
+}
+
 export async function hydrateAutonomousRunnerLedgerFromUnClick({
   ledger,
   runner = DEFAULT_AUTONOMOUS_RUNNER,
@@ -671,6 +794,11 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
   mcpUrl = DEFAULT_UNCLICK_MCP_URL,
   limit = 10,
   fetchImpl = globalThis.fetch,
+  wakeSource = "unknown",
+  allowedPriorities = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedPriorities,
+  allowedActionReasons = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons,
+  allowedTodoRoles = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles,
+  allowProtectedSurfaces = false,
 } = {}) {
   const fetched = await fetchUnClickActionableTodos({
     agentId: runner.agent_id || runner.id || DEFAULT_AUTONOMOUS_RUNNER.id,
@@ -699,10 +827,40 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
 
   let next = createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now });
   let imported = 0;
+  const skipped = [];
   for (const todo of ordered) {
+    const scopePack = extractBoardroomTodoScopePack(todo);
+    const eligibility = evaluateBoardroomTodoAutoClaimEligibility(todo, {
+      scopePack,
+      allowedPriorities,
+      allowedActionReasons,
+      allowedTodoRoles,
+      allowProtectedSurfaces,
+      now,
+    });
+    if (!eligibility.ok) {
+      skipped.push({
+        id: todo.id,
+        title: compact(todo.title, 140),
+        priority: todo.priority || null,
+        status: todo.status || null,
+        assigned_to_agent_id: todo.assigned_to_agent_id || null,
+        actionability_reason: todo.actionability_reason || null,
+        reason: eligibility.reason,
+        file: eligibility.file || null,
+      });
+      continue;
+    }
+
     const upserted = upsertCodingRoomJob({
       ledger: next,
-      job: createCodingRoomJobFromBoardroomTodo(todo, { now }),
+      job: createCodingRoomJobFromBoardroomTodo(
+        {
+          ...todo,
+          wake_source: wakeSource,
+        },
+        { now },
+      ),
       now,
     });
     if (upserted.ok) {
@@ -717,6 +875,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
     ledger: next,
     imported,
     seen: ordered.length,
+    skipped,
     todos: ordered.map((todo) => ({
       id: todo.id,
       title: compact(todo.title, 140),
@@ -761,6 +920,9 @@ export function createAutonomousRunnerPolicy(input = {}) {
     allowProtectedSurfaces: Boolean(input.allowProtectedSurfaces),
     allowExecute: Boolean(input.allowExecute),
     maxCycles: Math.max(1, Number.isFinite(input.maxCycles) ? input.maxCycles : DEFAULT_AUTONOMOUS_RUNNER_POLICY.maxCycles),
+    allowedPriorities: parseList(input.allowedPriorities, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedPriorities),
+    allowedActionReasons: parseList(input.allowedActionReasons, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons),
+    allowedTodoRoles: parseList(input.allowedTodoRoles, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles),
   };
 }
 
@@ -928,6 +1090,7 @@ export async function runAutonomousRunnerFile({
   fetchImpl = globalThis.fetch,
   now = new Date().toISOString(),
   leaseSeconds,
+  wakeSource = "unknown",
 } = {}) {
   if (!ledgerPath) {
     return { ok: false, reason: "missing_ledger_path" };
@@ -955,6 +1118,11 @@ export async function runAutonomousRunnerFile({
         mcpUrl: unclickMcpUrl,
         limit: todoLimit,
         fetchImpl,
+        wakeSource,
+        allowedPriorities: safePolicy.allowedPriorities,
+        allowedActionReasons: safePolicy.allowedActionReasons,
+        allowedTodoRoles: safePolicy.allowedTodoRoles,
+        allowProtectedSurfaces: safePolicy.allowProtectedSurfaces,
       })),
     };
     ledger = queueSourceResult.ledger || ledger;
@@ -1096,11 +1264,15 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
     unclickMcpUrl: getArg("unclick-mcp-url", process.env.UNCLICK_MCP_URL || DEFAULT_UNCLICK_MCP_URL),
     todoLimit: parseIntOption(getArg("todo-limit", process.env.AUTONOMOUS_RUNNER_TODO_LIMIT), 10),
     leaseSeconds: parseIntOption(getArg("lease-seconds", process.env.CODING_ROOM_LEASE_SECONDS), undefined),
+    wakeSource: getArg("wake-source", process.env.AUTONOMOUS_RUNNER_WAKE_SOURCE || process.env.GITHUB_EVENT_NAME || "unknown"),
     policy: createAutonomousRunnerPolicy({
       disabled: parseBoolean(process.env.AUTONOMOUS_RUNNER_DISABLED),
       allowProtectedSurfaces: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES),
       allowExecute: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_EXECUTE),
       maxCycles: parseIntOption(getArg("max-cycles", process.env.AUTONOMOUS_RUNNER_MAX_CYCLES), 1),
+      allowedPriorities: process.env.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES,
+      allowedActionReasons: process.env.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS,
+      allowedTodoRoles: process.env.AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES,
     }),
   })
     .then((result) => {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
+  evaluateBoardroomTodoAutoClaimEligibility,
   extractBoardroomTodoIdFromCodingRoomJob,
   fetchUnClickActionableTodos,
   inspectAutonomousRunnerJobSafety,
@@ -232,6 +233,140 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("quietly skips scoped UnClick todos that are not safe to auto-claim", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    const scopePack = {
+      owned_files: ["docs/safe-chip.md"],
+      patch: "diff --git a/docs/safe-chip.md b/docs/safe-chip.md\n--- a/docs/safe-chip.md\n+++ b/docs/safe-chip.md\n@@ -1 +1 @@\n-old\n+new\n",
+      tests: [],
+    };
+
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const fetchImpl = async () => ({
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    todos: [
+                      {
+                        id: "todo-low",
+                        title: "Low priority safe chip",
+                        status: "open",
+                        priority: "normal",
+                        assigned_to_agent_id: null,
+                        actionability_reason: "unassigned_open",
+                        scope_pack: scopePack,
+                      },
+                      {
+                        id: "todo-hold",
+                        title: "Builder HOLD on owner decision",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: null,
+                        actionability_reason: "unassigned_open",
+                        scope_pack: scopePack,
+                      },
+                      {
+                        id: "todo-auth",
+                        title: "Auth session hardening",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: null,
+                        actionability_reason: "unassigned_open",
+                        scope_pack: scopePack,
+                      },
+                      {
+                        id: "todo-assigned",
+                        title: "Assigned scoped chip",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: "other-seat",
+                        actionability_reason: "unassigned_open",
+                        scope_pack: scopePack,
+                      },
+                      {
+                        id: "todo-safe",
+                        title: "Safe docs chip",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: null,
+                        actionability_reason: "unassigned_open",
+                        scope_pack: scopePack,
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          };
+        },
+      });
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-09T11:00:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.queue_source.seen, 5);
+      assert.equal(result.queue_source.imported, 1);
+      assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-safe");
+      assert.deepEqual(
+        result.queue_source.skipped.map((skip) => skip.reason).sort(),
+        [
+          "boardroom_todo_already_assigned",
+          "boardroom_todo_hold_or_blocker_marker",
+          "boardroom_todo_priority_not_allowed",
+          "protected_surface_auth",
+        ].sort(),
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a scoped todo eligible only for the builder allowlist and open unassigned queue", () => {
+    const base = {
+      id: "todo-role",
+      title: "Safe docs chip",
+      status: "open",
+      priority: "urgent",
+      assigned_to_agent_id: null,
+      actionability_reason: "unassigned_open",
+      scope_pack: {
+        owned_files: ["docs/safe-chip.md"],
+        patch: "diff --git a/docs/safe-chip.md b/docs/safe-chip.md\n--- a/docs/safe-chip.md\n+++ b/docs/safe-chip.md\n@@ -1 +1 @@\n-old\n+new\n",
+        role: "builder",
+      },
+    };
+
+    assert.equal(evaluateBoardroomTodoAutoClaimEligibility(base).ok, true);
+    assert.equal(
+      evaluateBoardroomTodoAutoClaimEligibility({
+        ...base,
+        scope_pack: {
+          ...base.scope_pack,
+          role: "coordinator",
+        },
+      }).reason,
+      "boardroom_todo_role_not_allowed",
+    );
+  });
+
   it("does not pretend the queue is empty when UnClick queue auth is missing", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
@@ -431,6 +566,7 @@ describe("PinballWake autonomous Runner seat", () => {
         unclickMcpUrl: "https://unclick.test/api/mcp",
         fetchImpl,
         now: "2026-05-08T05:30:00.000Z",
+        wakeSource: "queuepush",
       });
 
       assert.equal(result.ok, true);
@@ -450,6 +586,8 @@ describe("PinballWake autonomous Runner seat", () => {
       });
       assert.equal(calls[2].body.params.arguments.target_id, "todo-claim-1");
       assert.match(calls[2].body.params.arguments.text, /dispatch=coding-room-claim:/);
+      assert.match(calls[2].body.params.arguments.text, /lease_token=coding-room-claim:/);
+      assert.match(calls[2].body.params.arguments.text, /wake_source=queuepush/);
       assert.equal(result.todo_claim_sync.ok, true);
       assert.equal(result.todo_claim_sync.todo_id, "todo-claim-1");
 
@@ -461,7 +599,7 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
-  it("blocks stale assigned UnClick todo claims before syncing ownership", async () => {
+  it("quietly skips stale assigned UnClick todo claims before syncing ownership", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
     try {
@@ -521,12 +659,11 @@ describe("PinballWake autonomous Runner seat", () => {
         now: "2026-05-09T12:35:00.000Z",
       });
 
-      assert.equal(result.ok, false);
-      assert.equal(result.action, "blocked");
-      assert.equal(result.reason, "todo_claim_sync_failed");
-      assert.equal(result.todo_claim_sync.reason, "claim_source_state_mismatch");
-      assert.equal(result.todo_claim_sync.detail, "boardroom_todo_not_open");
-      assert.equal(result.todo_claim_sync.source_status, "in_progress");
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "idle");
+      assert.equal(result.reason, "no_claimable_jobs");
+      assert.equal(result.queue_source.skipped[0].id, "todo-stale-scoped-1");
+      assert.equal(result.queue_source.skipped[0].reason, "boardroom_todo_not_open");
       assert.deepEqual(calls.map((call) => call.body.params.name), ["list_actionable_todos"]);
 
       const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
@@ -945,12 +1082,17 @@ describe("PinballWake autonomous Runner seat", () => {
     const workflow = await readFile(".github/workflows/autonomous-runner.yml", "utf8");
 
     assert.match(workflow, /cron:\s*"3,13,23,33,43,53 \* \* \* \*"/);
+    assert.match(workflow, /workflow_run:/);
+    assert.match(workflow, /Fleet Throughput Watch/);
     assert.match(workflow, /node scripts\/pinballwake-autonomous-runner\.mjs/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_QUEUE_SOURCE:.*'unclick'/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_WAKE_SOURCE:.*queuepush/);
     assert.match(workflow, /UNCLICK_API_KEY:.*secrets\.UNCLICK_API_KEY.*secrets\.FISHBOWL_AUTOCLOSE_TOKEN.*secrets\.FISHBOWL_WAKE_TOKEN/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_MODE:.*'claim'/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_EXECUTE:\s*"false"/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES:\s*"false"/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES:.*urgent,high/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS:.*unassigned_open/);
     assert.match(workflow, /kill_switch:/);
     assert.doesNotMatch(workflow, /^\s+- execute$/m);
   });


### PR DESCRIPTION
Summary:
Adds the first safer auto-claim guardrail layer for the PinballWake Autonomous Runner. The runner now filters scoped UnClick todos before local claim, records quiet skips, carries the wake source into claim receipts, and wakes after successful QueuePush runs as well as on the existing schedule.

Scope:
Owned files for todo 2cb86e47: .github/workflows/autonomous-runner.yml, scripts/pinballwake-autonomous-runner.mjs, scripts/pinballwake-autonomous-runner.test.mjs.

Non-overlap:
Did not enable execute mode, auto PR creation, merging, risk scoring, tier-2 auto-merge, QueuePush packet generation, Worker Registry, Jobs UI, WakePass, XPass, or the b744462e lease substrate.

Verification:
node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-build-executor.test.mjs scripts/pinballwake-jobs-room.test.mjs scripts/pinballwake-queue-health-room.test.mjs
npx eslint scripts/pinballwake-autonomous-runner.mjs scripts/pinballwake-build-executor.mjs scripts/pinballwake-jobs-room.mjs scripts/pinballwake-queue-health-room.mjs
npm run build
git diff --check

Risk:
Low to medium automation risk. The runner remains claim-only with AUTONOMOUS_RUNNER_ALLOW_EXECUTE=false and protected surfaces disabled. New workflow_run only fires after Fleet Throughput Watch succeeds.

Follow-up:
After merge, prove with a natural PinballWake Autonomous Runner schedule or QueuePush-triggered wake on the merged SHA with execute disabled.

Linked todo:
2cb86e47-5aea-406f-a5b7-be75bc61816a

Draft status:
Draft PR for checks first.