### PR TITLE
[codex] Add Jobs Manager worker role

### DIFF
--- a/api/lib/route-packet-consumer.test.ts
+++ b/api/lib/route-packet-consumer.test.ts
@@ -49,6 +49,31 @@ describe("route packet consumer dry run", () => {
     });
   });
 
+  it("assigns Jobs Manager queue packets only to a live Jobs Manager", () => {
+    const result = runRoutePacketConsumerDryRun({
+      packet: {
+        ...basePacket,
+        lane: "Jobs Manager",
+        item: {
+          id: "todo-jobs-manager",
+          title: "Worker Registry: add Jobs Manager",
+        },
+        needed_action: "Advise on queue health and routing.",
+      },
+      visibleWorkers: [
+        { agent_id: "builder-live", lane: "Builder", status: "active" },
+        { agent_id: "jobs-manager-live", lane: "Jobs Manager", status: "active" },
+      ],
+      now: new Date("2026-05-09T00:05:00.000Z"),
+    });
+
+    expect(result.decision).toMatchObject({
+      status: "assigned",
+      target_agent_id: "jobs-manager-live",
+      reason: "live_worker_available",
+    });
+  });
+
   it("holds expired packets instead of assigning stale work", () => {
     const result = runRoutePacketConsumerDryRun({
       packet: basePacket,

--- a/api/lib/route-packet-consumer.ts
+++ b/api/lib/route-packet-consumer.ts
@@ -4,6 +4,7 @@ export type RoutePacketLane =
   | "Reviewer"
   | "Safety"
   | "Coordinator"
+  | "Jobs Manager"
   | "Watcher";
 
 export interface RoutePacket {
@@ -81,6 +82,24 @@ export function normalizeRoutePacketLane(input: unknown): RoutePacketLane {
     case "coordinator":
     case "master":
       return "Coordinator";
+    case "jobs":
+    case "jobs manager":
+    case "jobs-manager":
+    case "job manager":
+    case "job-manager":
+    case "job scoping":
+    case "job-scoping":
+    case "queue manager":
+    case "queue-manager":
+    case "queue management":
+    case "queue-management":
+    case "scopepack":
+    case "scope pack":
+    case "stale ownership":
+    case "stale-ownership":
+    case "duplicate jobs":
+    case "duplicate-jobs":
+      return "Jobs Manager";
     case "watcher":
     case "relay":
       return "Watcher";

--- a/api/lib/tether-route-packet.test.ts
+++ b/api/lib/tether-route-packet.test.ts
@@ -39,4 +39,17 @@ describe("buildTetherRoutePacket", () => {
     expect(packet.item.title).toBe("UnClick Connect experiment");
     expect(packet.expected_receipt).toEqual(["proof", "HOLD", "BLOCKER"]);
   });
+
+  it("normalizes Jobs queue routing to the Jobs Manager lane", () => {
+    const packet = buildTetherRoutePacket(
+      {
+        item_id: "todo-jobs-manager",
+        item_title: "Worker Registry: add Jobs Manager",
+        lane: "stale ownership",
+      },
+      new Date("2026-05-09T00:10:00.000Z"),
+    );
+
+    expect(packet.lane).toBe("Jobs Manager");
+  });
 });

--- a/api/lib/unclick-connect-worker-discovery.test.ts
+++ b/api/lib/unclick-connect-worker-discovery.test.ts
@@ -55,6 +55,30 @@ describe("UnClick Connect worker discovery", () => {
     ]);
   });
 
+  it("maps Jobs Manager profiles into the Jobs Manager lane", () => {
+    const workers = fishbowlProfilesToVisibleWorkers(
+      [
+        {
+          agent_id: "jobs-manager-seat",
+          emoji: "📋",
+          display_name: "Jobs Manager",
+          current_status: "Watching queue management and ScopePack readiness",
+          last_seen_at: "2026-05-09T00:10:00.000Z",
+        },
+      ],
+      new Date("2026-05-09T00:30:00.000Z"),
+    );
+
+    expect(workers).toEqual([
+      {
+        agent_id: "jobs-manager-seat",
+        lane: "Jobs Manager",
+        status: "active",
+        live: true,
+      },
+    ]);
+  });
+
   it("does not treat unknown, stale, or blocked profiles as production workers", () => {
     const workers = fishbowlProfilesToVisibleWorkers(
       [

--- a/api/lib/unclick-connect-worker-discovery.ts
+++ b/api/lib/unclick-connect-worker-discovery.ts
@@ -84,6 +84,20 @@ function inferLaneFromText(text: string): RoutePacketLane | null {
   if (value.includes("coordinator") || value.includes("master")) {
     return "Coordinator";
   }
+  if (
+    value.includes("📋") ||
+    value.includes("jobs manager") ||
+    value.includes("job manager") ||
+    value.includes("job scoping") ||
+    value.includes("queue manager") ||
+    value.includes("queue management") ||
+    value.includes("scopepack") ||
+    value.includes("scope pack") ||
+    value.includes("stale ownership") ||
+    value.includes("duplicate jobs")
+  ) {
+    return "Jobs Manager";
+  }
   if (value.includes("watcher") || value.includes("relay")) {
     return "Watcher";
   }

--- a/src/pages/admin/AdminEcosystemPages.test.tsx
+++ b/src/pages/admin/AdminEcosystemPages.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { AdminWorkers } from "./AdminEcosystemPages";
+
+describe("AdminWorkers", () => {
+  it("shows Jobs Manager as a first-class worker role", () => {
+    render(React.createElement(AdminWorkers));
+
+    expect(screen.getByRole("heading", { name: "Workers" })).toBeInTheDocument();
+    expect(screen.getByText("📋 Jobs Manager")).toBeInTheDocument();
+    expect(screen.getByText(/coordinator escalation/i)).toBeInTheDocument();
+    expect(screen.getByText(/proof-to-done reconciliation/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -169,6 +169,7 @@ export function AdminWorkers() {
           { title: "🧪 Tester", body: "Runs proof, checks, and repeatable test commands.", icon: ClipboardCheck },
           { title: "🔍 Reviewer", body: "Reviews quality, clarity, and implementation shape.", icon: SearchCheck },
           { title: "🛡️ Safety Checker", body: "Protects releases from overlap, secrets, unsafe paths, and stale proof.", icon: ShieldCheck },
+          { title: "📋 Jobs Manager", body: "Keeps Jobs healthy with missing ScopePacks, stale ownership, duplicate detection, Coordinator escalation, routing advice, and proof-to-done reconciliation.", icon: ListTodo },
           { title: "🔬 Researcher", body: "Explores unknowns before a plan is made.", icon: Microscope },
           { title: "📋 Planner", body: "Creates the exact work packet and ownership boundaries.", icon: FileText },
           { title: "📣 Messenger", body: "Sends worker packets and chases missing ACKs.", icon: MessagesSquare },


### PR DESCRIPTION
## Summary

Adds Jobs Manager as a first-class AutoPilot worker role and gives routing code a Jobs Manager lane for queue-health work.

## What changed

- Shows `📋 Jobs Manager` on the Workers surface.
- Defines the role around missing ScopePacks, stale ownership, duplicate detection, Coordinator escalation, routing advice, and proof-to-done reconciliation.
- Adds `Jobs Manager` to route packet lane normalization.
- Lets live worker discovery recognize Jobs Manager profiles and queue-health wording.
- Covers the visible role and routing behavior with focused tests.

## Why

The runner loop is healthy, but the queue is under-scoped. Jobs Manager is the safe first slice for turning vague or stale Jobs into claimable packets without enabling execute powers or broad cleanup.

## Validation

- `npx vitest run src/pages/admin/AdminEcosystemPages.test.tsx api/lib/route-packet-consumer.test.ts api/lib/tether-route-packet.test.ts api/lib/unclick-connect-worker-discovery.test.ts`
- `npm run build`

## Notes

Draft PR because this is the first safe role and routing metadata slice only. No secrets, production config, migrations, auto-merge, mass job closure, or live automation side effects.