### PR TITLE
feat(uxpass): enrich site sweep receipt

### DIFF
--- a/public/dogfood/uxpass-site-sweep.json
+++ b/public/dogfood/uxpass-site-sweep.json
@@ -1,37 +1,154 @@
 {
   "kind": "uxpass_site_sweep_receipt",
-  "generated_at": "2026-05-09T17:15:19.132Z",
+  "check": "uxpass",
+  "name": "UXPass",
+  "generated_at": "2026-05-09T20:50:42.979Z",
+  "run_id": "uxpass-site-sweep-3d7a9c6519a0fe59",
   "status": "blocked",
-  "target_sha": "eaa001e4e8013a2bfa47c0b846de875a3ac1c3a6",
+  "target_sha": "6aadc437a0aafbd0a24c9aedfc496b766e05d745",
   "min_score": 80,
   "allowed_origins": [
     "https://unclick.world",
     "https://www.unclick.world"
   ],
+  "viewports": [
+    {
+      "name": "desktop",
+      "width": 1440,
+      "height": 1000
+    },
+    {
+      "name": "mobile",
+      "width": 390,
+      "height": 844
+    }
+  ],
   "targets": [
     {
       "url": "https://unclick.world/",
+      "route_target": {
+        "url": "https://unclick.world/",
+        "origin": "https://unclick.world",
+        "path": "/"
+      },
       "status": "blocked",
       "run_id": null,
       "ux_score": null,
       "summary": "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
-      "proof": null
+      "proof": {
+        "kind": "safe_fallback_receipt",
+        "reason": "missing_credential",
+        "targetUrl": "https://unclick.world/",
+        "target_sha": "6aadc437a0aafbd0a24c9aedfc496b766e05d745"
+      },
+      "evidence": {
+        "viewports": [
+          {
+            "name": "desktop",
+            "width": 1440,
+            "height": 1000,
+            "capture_status": "skipped_missing_credential",
+            "screenshot_url": null,
+            "console_issues": [],
+            "layout_issues": []
+          },
+          {
+            "name": "mobile",
+            "width": 390,
+            "height": 844,
+            "capture_status": "skipped_missing_credential",
+            "screenshot_url": null,
+            "console_issues": [],
+            "layout_issues": []
+          }
+        ],
+        "console_issues": [],
+        "layout_issues": []
+      }
     },
     {
       "url": "https://unclick.world/dashboard",
+      "route_target": {
+        "url": "https://unclick.world/dashboard",
+        "origin": "https://unclick.world",
+        "path": "/dashboard"
+      },
       "status": "blocked",
       "run_id": null,
       "ux_score": null,
       "summary": "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
-      "proof": null
+      "proof": {
+        "kind": "safe_fallback_receipt",
+        "reason": "missing_credential",
+        "targetUrl": "https://unclick.world/dashboard",
+        "target_sha": "6aadc437a0aafbd0a24c9aedfc496b766e05d745"
+      },
+      "evidence": {
+        "viewports": [
+          {
+            "name": "desktop",
+            "width": 1440,
+            "height": 1000,
+            "capture_status": "skipped_missing_credential",
+            "screenshot_url": null,
+            "console_issues": [],
+            "layout_issues": []
+          },
+          {
+            "name": "mobile",
+            "width": 390,
+            "height": 844,
+            "capture_status": "skipped_missing_credential",
+            "screenshot_url": null,
+            "console_issues": [],
+            "layout_issues": []
+          }
+        ],
+        "console_issues": [],
+        "layout_issues": []
+      }
     },
     {
       "url": "https://unclick.world/admin/you",
+      "route_target": {
+        "url": "https://unclick.world/admin/you",
+        "origin": "https://unclick.world",
+        "path": "/admin/you"
+      },
       "status": "blocked",
       "run_id": null,
       "ux_score": null,
       "summary": "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
-      "proof": null
+      "proof": {
+        "kind": "safe_fallback_receipt",
+        "reason": "missing_credential",
+        "targetUrl": "https://unclick.world/admin/you",
+        "target_sha": "6aadc437a0aafbd0a24c9aedfc496b766e05d745"
+      },
+      "evidence": {
+        "viewports": [
+          {
+            "name": "desktop",
+            "width": 1440,
+            "height": 1000,
+            "capture_status": "skipped_missing_credential",
+            "screenshot_url": null,
+            "console_issues": [],
+            "layout_issues": []
+          },
+          {
+            "name": "mobile",
+            "width": 390,
+            "height": 844,
+            "capture_status": "skipped_missing_credential",
+            "screenshot_url": null,
+            "console_issues": [],
+            "layout_issues": []
+          }
+        ],
+        "console_issues": [],
+        "layout_issues": []
+      }
     }
   ],
   "action_needed": [
@@ -39,5 +156,15 @@
     "https://unclick.world/dashboard: Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
     "https://unclick.world/admin/you: Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET."
   ],
-  "summary": "UXPass site sweep could not run because no token was available."
+  "summary": "UXPass site sweep could not run because no token was available.",
+  "xpass_gate_result": {
+    "check": "uxpass",
+    "name": "UXPass",
+    "status": "blocked",
+    "run_id": "uxpass-site-sweep-3d7a9c6519a0fe59",
+    "target_sha": "6aadc437a0aafbd0a24c9aedfc496b766e05d745",
+    "url": "https://unclick.world",
+    "summary": "UXPass site sweep could not run because no token was available.",
+    "generated_at": "2026-05-09T20:50:42.979Z"
+  }
 }

--- a/scripts/uxpass-site-sweep.mjs
+++ b/scripts/uxpass-site-sweep.mjs
@@ -2,10 +2,16 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createHash } from "node:crypto";
 
 const DEFAULT_PATHS = ["/", "/dashboard", "/admin/you"];
 const DEFAULT_MIN_SCORE = 80;
 const DEFAULT_ALLOWED_ORIGINS = ["https://unclick.world", "https://www.unclick.world"];
+const DEFAULT_VIEWPORTS = [
+  { name: "desktop", width: 1440, height: 1000 },
+  { name: "mobile", width: 390, height: 844 },
+];
+const ISSUE_LIMIT = 20;
 
 function argValue(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -54,6 +60,135 @@ function normalizeOrigin(value) {
   }
 }
 
+function normalizeRouteTarget(url) {
+  try {
+    const parsed = new URL(url);
+    return {
+      url: parsed.toString(),
+      origin: parsed.origin,
+      path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+    };
+  } catch {
+    return {
+      url: compactText(url, 500),
+      origin: "",
+      path: "",
+    };
+  }
+}
+
+function normalizeViewport(value) {
+  if (value && typeof value === "object") {
+    const width = Number(value.width);
+    const height = Number(value.height);
+    if (Number.isFinite(width) && Number.isFinite(height)) {
+      return {
+        name: compactText(value.name || `${width}x${height}`, 80),
+        width,
+        height,
+      };
+    }
+  }
+
+  const text = String(value ?? "").trim();
+  const named = text.match(/^([a-z0-9_-]+):(\d{2,5})x(\d{2,5})$/i);
+  if (named) {
+    return {
+      name: named[1].toLowerCase(),
+      width: Number(named[2]),
+      height: Number(named[3]),
+    };
+  }
+
+  const sized = text.match(/^(\d{2,5})x(\d{2,5})$/);
+  if (sized) {
+    return {
+      name: text.toLowerCase(),
+      width: Number(sized[1]),
+      height: Number(sized[2]),
+    };
+  }
+
+  return null;
+}
+
+export function resolveSweepViewports(values = []) {
+  const source = values.length > 0 ? values : DEFAULT_VIEWPORTS;
+  const normalized = source.map(normalizeViewport).filter(Boolean);
+  return normalized.length > 0 ? normalized : DEFAULT_VIEWPORTS;
+}
+
+function normalizeIssue(issue) {
+  if (!issue) return null;
+  if (typeof issue === "string") {
+    return { message: compactText(issue, 500) };
+  }
+
+  return {
+    type: compactText(issue.type || issue.kind || "", 80) || null,
+    severity: compactText(issue.severity || issue.level || "", 80) || null,
+    message: compactText(issue.message || issue.text || issue.summary || JSON.stringify(issue), 500),
+    source: compactText(issue.source || issue.url || "", 500) || null,
+    viewport: compactText(issue.viewport || issue.viewport_name || "", 80) || null,
+  };
+}
+
+function normalizeIssues(value) {
+  const list = Array.isArray(value) ? value : value ? [value] : [];
+  return list
+    .map(normalizeIssue)
+    .filter((issue) => issue && issue.message)
+    .slice(0, ISSUE_LIMIT);
+}
+
+function issuesSummary(consoleIssues, layoutIssues) {
+  const parts = [];
+  if (consoleIssues.length > 0) parts.push(`${consoleIssues.length} console issue(s)`);
+  if (layoutIssues.length > 0) parts.push(`${layoutIssues.length} layout issue(s)`);
+  return parts.join(", ");
+}
+
+function viewportEvidence(viewports, captureStatus, { consoleIssues = [], layoutIssues = [], screenshotUrl = null } = {}) {
+  return viewports.map((viewport) => ({
+    name: viewport.name,
+    width: viewport.width,
+    height: viewport.height,
+    capture_status: captureStatus,
+    screenshot_url: screenshotUrl,
+    console_issues: consoleIssues.filter((issue) => !issue.viewport || issue.viewport === viewport.name),
+    layout_issues: layoutIssues.filter((issue) => !issue.viewport || issue.viewport === viewport.name),
+  }));
+}
+
+function makeTarget({
+  url,
+  status,
+  runId = null,
+  uxScore = null,
+  summary,
+  proof = null,
+  viewports,
+  captureStatus,
+  consoleIssues = [],
+  layoutIssues = [],
+  screenshotUrl = null,
+}) {
+  return {
+    url,
+    route_target: normalizeRouteTarget(url),
+    status,
+    run_id: runId,
+    ux_score: uxScore,
+    summary,
+    proof,
+    evidence: {
+      viewports: viewportEvidence(viewports, captureStatus, { consoleIssues, layoutIssues, screenshotUrl }),
+      console_issues: consoleIssues,
+      layout_issues: layoutIssues,
+    },
+  };
+}
+
 function resolveAllowedOrigins(values = []) {
   return unique((values.length > 0 ? values : DEFAULT_ALLOWED_ORIGINS).map(normalizeOrigin));
 }
@@ -69,21 +204,24 @@ export function resolveSweepTargets({ publicUrl, urls = [] } = {}) {
   return requested.map((url) => new URL(url, `${base}/`).toString());
 }
 
-export function splitAllowedSweepTargets(targets, allowedOrigins) {
+function blockedOriginTarget(target, allowedOrigins, viewports = DEFAULT_VIEWPORTS) {
+  return makeTarget({
+    url: target,
+    status: "blocked",
+    summary: `Target origin is outside the owned-origin allowlist: ${allowedOrigins.join(", ")}.`,
+    viewports: resolveSweepViewports(viewports),
+    captureStatus: "blocked_off_origin",
+  });
+}
+
+export function splitAllowedSweepTargets(targets, allowedOrigins, viewports = DEFAULT_VIEWPORTS) {
   const allowed = [];
   const blocked = [];
   for (const target of targets) {
     if (isAllowedOrigin(target, allowedOrigins)) {
       allowed.push(target);
     } else {
-      blocked.push({
-        url: target,
-        status: "blocked",
-        run_id: null,
-        ux_score: null,
-        summary: `Target origin is outside the owned-origin allowlist: ${allowedOrigins.join(", ")}.`,
-        proof: null,
-      });
+      blocked.push(blockedOriginTarget(target, allowedOrigins, viewports));
     }
   }
   return { allowed, blocked };
@@ -139,6 +277,55 @@ function dryRunTarget(url, targetSha) {
   };
 }
 
+function gateStatus(status) {
+  if (status === "passing") return "passed";
+  if (status === "failing") return "failed";
+  if (status === "blocked") return "blocked";
+  if (status === "pending") return "skipped";
+  return "missing";
+}
+
+function receiptRunId({ status, targetSha, now }) {
+  const source = `${status}:${targetSha || "no-sha"}:${now}`;
+  return `uxpass-site-sweep-${createHash("sha256").update(source).digest("hex").slice(0, 16)}`;
+}
+
+function withGateResult(receipt, { publicUrl }) {
+  return {
+    ...receipt,
+    check: "uxpass",
+    name: "UXPass",
+    xpass_gate_result: {
+      check: "uxpass",
+      name: "UXPass",
+      status: gateStatus(receipt.status),
+      run_id: receipt.run_id,
+      target_sha: receipt.target_sha || null,
+      url: publicUrl,
+      summary: receipt.summary,
+      generated_at: receipt.generated_at,
+    },
+  };
+}
+
+function makeReceipt({ now, status, targetSha, minScore, allowedOrigins, viewports, targets, summary, publicUrl }) {
+  return withGateResult({
+    kind: "uxpass_site_sweep_receipt",
+    check: "uxpass",
+    name: "UXPass",
+    generated_at: now,
+    run_id: receiptRunId({ status, targetSha, now }),
+    status,
+    target_sha: targetSha || null,
+    min_score: minScore,
+    allowed_origins: allowedOrigins,
+    viewports,
+    targets,
+    action_needed: actionNeeded(targets),
+    summary,
+  }, { publicUrl });
+}
+
 export async function runUxPassSiteSweep({
   apiBase = "https://unclick.world",
   publicUrl = "https://unclick.world",
@@ -148,84 +335,103 @@ export async function runUxPassSiteSweep({
   minScore = DEFAULT_MIN_SCORE,
   dryRun = false,
   allowedOrigins = DEFAULT_ALLOWED_ORIGINS,
+  viewports = DEFAULT_VIEWPORTS,
   now = new Date().toISOString(),
   fetchImpl = fetch,
 } = {}) {
   const targets = resolveSweepTargets({ publicUrl, urls });
   const ownedOrigins = resolveAllowedOrigins(allowedOrigins);
+  const sweepViewports = resolveSweepViewports(viewports);
   const apiUrl = `${trimTrailingSlash(apiBase)}/api/uxpass-run`;
 
   if (dryRun) {
-    const dryTargets = targets.map((url) => dryRunTarget(url, targetSha));
-    return {
-      kind: "uxpass_site_sweep_receipt",
-      generated_at: now,
+    const dryTargets = targets.map((url) => {
+      const dryTarget = dryRunTarget(url, targetSha);
+      return makeTarget({
+        url: dryTarget.url,
+        status: dryTarget.status,
+        runId: dryTarget.run_id,
+        uxScore: dryTarget.ux_score,
+        summary: dryTarget.summary,
+        proof: dryTarget.proof,
+        viewports: sweepViewports,
+        captureStatus: "dry_run",
+      });
+    });
+    return makeReceipt({
+      now,
       status: "passing",
-      target_sha: targetSha || null,
-      min_score: minScore,
+      targetSha,
+      minScore,
+      allowedOrigins: ownedOrigins,
+      viewports: sweepViewports,
       targets: dryTargets,
-      action_needed: [],
       summary: `Dry-run UXPass site sweep covered ${dryTargets.length} URL(s).`,
-    };
+      publicUrl,
+    });
   }
 
-  const { allowed: allowedTargets, blocked: blockedTargets } = splitAllowedSweepTargets(targets, ownedOrigins);
+  const { allowed: allowedTargets, blocked: blockedTargets } = splitAllowedSweepTargets(targets, ownedOrigins, sweepViewports);
   if (!isAllowedOrigin(apiUrl, ownedOrigins)) {
-    const apiBlockedTargets = targets.map((url) => ({
+    const apiBlockedTargets = targets.map((url) => makeTarget({
       url,
       status: "blocked",
-      run_id: null,
-      ux_score: null,
       summary: `UXPass API origin is outside the owned-origin allowlist: ${ownedOrigins.join(", ")}.`,
-      proof: null,
+      viewports: sweepViewports,
+      captureStatus: "blocked_api_origin",
     }));
-    return {
-      kind: "uxpass_site_sweep_receipt",
-      generated_at: now,
+    return makeReceipt({
+      now,
       status: "blocked",
-      target_sha: targetSha || null,
-      min_score: minScore,
-      allowed_origins: ownedOrigins,
+      targetSha,
+      minScore,
+      allowedOrigins: ownedOrigins,
+      viewports: sweepViewports,
       targets: apiBlockedTargets,
-      action_needed: actionNeeded(apiBlockedTargets),
       summary: "UXPass site sweep could not run because the API origin is not allowed.",
-    };
+      publicUrl,
+    });
   }
 
   if (allowedTargets.length === 0) {
-    return {
-      kind: "uxpass_site_sweep_receipt",
-      generated_at: now,
+    return makeReceipt({
+      now,
       status: "blocked",
-      target_sha: targetSha || null,
-      min_score: minScore,
-      allowed_origins: ownedOrigins,
+      targetSha,
+      minScore,
+      allowedOrigins: ownedOrigins,
+      viewports: sweepViewports,
       targets: blockedTargets,
-      action_needed: actionNeeded(blockedTargets),
       summary: "UXPass site sweep did not run because every target was outside the owned-origin allowlist.",
-    };
+      publicUrl,
+    });
   }
 
   if (!token) {
-    const missingTokenTargets = allowedTargets.map((url) => ({
+    const missingTokenTargets = allowedTargets.map((url) => makeTarget({
       url,
       status: "blocked",
-      run_id: null,
-      ux_score: null,
       summary: "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
-      proof: null,
+      proof: {
+        kind: "safe_fallback_receipt",
+        reason: "missing_credential",
+        targetUrl: url,
+        target_sha: targetSha || null,
+      },
+      viewports: sweepViewports,
+      captureStatus: "skipped_missing_credential",
     }));
-    return {
-      kind: "uxpass_site_sweep_receipt",
-      generated_at: now,
+    return makeReceipt({
+      now,
       status: "blocked",
-      target_sha: targetSha || null,
-      min_score: minScore,
-      allowed_origins: ownedOrigins,
+      targetSha,
+      minScore,
+      allowedOrigins: ownedOrigins,
+      viewports: sweepViewports,
       targets: [...missingTokenTargets, ...blockedTargets],
-      action_needed: actionNeeded([...missingTokenTargets, ...blockedTargets]),
       summary: "UXPass site sweep could not run because no token was available.",
-    };
+      publicUrl,
+    });
   }
 
   const sweptTargets = [...blockedTargets];
@@ -240,15 +446,22 @@ export async function runUxPassSiteSweep({
 
       const runId = compactText(json.run_id || "", 160);
       const uxScore = typeof json.ux_score === "number" ? json.ux_score : null;
-      const passed = ok && json.status === "complete" && (uxScore === null || uxScore >= minScore);
-      sweptTargets.push({
+      const consoleIssues = normalizeIssues(json.console_issues || json.consoleIssues);
+      const layoutIssues = normalizeIssues(json.layout_issues || json.layoutIssues);
+      const issueSummary = issuesSummary(consoleIssues, layoutIssues);
+      const passed = ok
+        && json.status === "complete"
+        && (uxScore === null || uxScore >= minScore)
+        && consoleIssues.length === 0
+        && layoutIssues.length === 0;
+      sweptTargets.push(makeTarget({
         url,
         status: passed ? "passing" : "failing",
-        run_id: runId || null,
-        ux_score: uxScore,
+        runId: runId || null,
+        uxScore,
         summary: passed
           ? `UXPass completed${uxScore === null ? "" : ` with score ${uxScore}`}.`
-          : `UXPass returned HTTP ${status}, status ${json.status || "unknown"}${uxScore === null ? "" : `, score ${uxScore}`}.`,
+          : `UXPass returned HTTP ${status}, status ${json.status || "unknown"}${uxScore === null ? "" : `, score ${uxScore}`}${issueSummary ? `, ${issueSummary}` : ""}.`,
         proof: runId
           ? {
               kind: "uxpass_run",
@@ -257,31 +470,35 @@ export async function runUxPassSiteSweep({
               target_sha: targetSha || null,
             }
           : null,
-      });
+        viewports: sweepViewports,
+        captureStatus: "api_receipt",
+        consoleIssues,
+        layoutIssues,
+        screenshotUrl: compactText(json.screenshot_url || json.screenshotUrl || "", 500) || null,
+      }));
     } catch (error) {
-      sweptTargets.push({
+      sweptTargets.push(makeTarget({
         url,
         status: "failing",
-        run_id: null,
-        ux_score: null,
         summary: `UXPass site sweep could not reach the API: ${error instanceof Error ? error.message : String(error)}`,
-        proof: null,
-      });
+        viewports: sweepViewports,
+        captureStatus: "api_unreachable",
+      }));
     }
   }
 
   const status = statusFromTargets(sweptTargets);
-  return {
-    kind: "uxpass_site_sweep_receipt",
-    generated_at: now,
+  return makeReceipt({
+    now,
     status,
-    target_sha: targetSha || null,
-    min_score: minScore,
-    allowed_origins: ownedOrigins,
+    targetSha,
+    minScore,
+    allowedOrigins: ownedOrigins,
+    viewports: sweepViewports,
     targets: sweptTargets,
-    action_needed: actionNeeded(sweptTargets),
     summary: `UXPass site sweep ${status} across ${sweptTargets.length} URL(s).`,
-  };
+    publicUrl,
+  });
 }
 
 if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
@@ -292,6 +509,10 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
   const urls = [
     ...splitList(process.env.UXPASS_SITE_SWEEP_URLS),
     ...argValues("url"),
+  ];
+  const viewports = [
+    ...splitList(process.env.UXPASS_SITE_SWEEP_VIEWPORTS),
+    ...argValues("viewport"),
   ];
   const receipt = await runUxPassSiteSweep({
     apiBase: argValue("api-base", process.env.DOGFOOD_API_BASE || "https://unclick.world"),
@@ -305,6 +526,7 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
     targetSha: argValue("target-sha", process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || ""),
     minScore: Number(argValue("min-score", process.env.UXPASS_SITE_SWEEP_MIN_SCORE || DEFAULT_MIN_SCORE)),
     allowedOrigins: splitList(process.env.UXPASS_SITE_SWEEP_ALLOWED_ORIGINS),
+    viewports,
     dryRun,
   });
 

--- a/scripts/uxpass-site-sweep.test.mjs
+++ b/scripts/uxpass-site-sweep.test.mjs
@@ -9,6 +9,7 @@ import { test } from "node:test";
 
 import {
   resolveSweepTargets,
+  resolveSweepViewports,
   runUxPassSiteSweep,
   splitAllowedSweepTargets,
 } from "./uxpass-site-sweep.mjs";
@@ -31,6 +32,13 @@ test("resolves default site sweep targets from the public URL", () => {
   ]);
 });
 
+test("resolves desktop and mobile viewport evidence targets", () => {
+  assert.deepEqual(resolveSweepViewports(["desktop:1440x1000", "mobile:390x844"]), [
+    { name: "desktop", width: 1440, height: 1000 },
+    { name: "mobile", width: 390, height: 844 },
+  ]);
+});
+
 test("returns a blocked receipt when no token is available", async () => {
   const receipt = await runUxPassSiteSweep({
     publicUrl: "https://unclick.world",
@@ -45,6 +53,10 @@ test("returns a blocked receipt when no token is available", async () => {
   assert.equal(receipt.targets.length, 2);
   assert.equal(receipt.action_needed.length, 2);
   assert.match(receipt.summary, /no token/i);
+  assert.equal(receipt.xpass_gate_result.status, "blocked");
+  assert.equal(receipt.targets[0].proof.kind, "safe_fallback_receipt");
+  assert.equal(receipt.targets[0].evidence.viewports.length, 2);
+  assert.equal(receipt.targets[0].evidence.viewports[0].capture_status, "skipped_missing_credential");
 });
 
 test("runs every target through the UXPass API and writes scoped proof", async () => {
@@ -89,6 +101,9 @@ test("runs every target through the UXPass API and writes scoped proof", async (
       targetUrl: "https://unclick.world/",
       target_sha: "head-sha",
     });
+    assert.equal(receipt.xpass_gate_result.status, "passed");
+    assert.equal(receipt.targets[0].route_target.path, "/");
+    assert.equal(receipt.targets[0].evidence.viewports.length, 2);
   } finally {
     await close(server);
   }
@@ -213,6 +228,43 @@ test("fails the sweep when a target is below the UX score floor", async () => {
   }
 });
 
+test("fails the sweep when UXPass reports console or layout issues", async () => {
+  const server = http.createServer((_req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({
+      run_id: "run-issues",
+      status: "complete",
+      ux_score: 95,
+      console_issues: [{ severity: "error", message: "Hydration mismatch", viewport: "desktop" }],
+      layout_issues: [{ type: "overflow", message: "Mobile header overflows", viewport: "mobile" }],
+    }));
+  });
+
+  try {
+    await listen(server);
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    const receipt = await runUxPassSiteSweep({
+      apiBase: `http://127.0.0.1:${address.port}`,
+      publicUrl: "https://unclick.world",
+      urls: ["/"],
+      token: "ux-token",
+      allowedOrigins: ["https://unclick.world", `http://127.0.0.1:${address.port}`],
+    });
+
+    assert.equal(receipt.status, "failing");
+    assert.equal(receipt.xpass_gate_result.status, "failed");
+    assert.match(receipt.targets[0].summary, /console issue/i);
+    assert.equal(receipt.targets[0].evidence.console_issues.length, 1);
+    assert.equal(receipt.targets[0].evidence.layout_issues.length, 1);
+    assert.equal(receipt.targets[0].evidence.viewports[0].console_issues.length, 1);
+    assert.equal(receipt.targets[0].evidence.viewports[1].layout_issues.length, 1);
+  } finally {
+    await close(server);
+  }
+});
+
 test("CLI dry-run writes the sweep receipt to disk", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "uxpass-site-sweep-"));
   const output = path.join(dir, "receipt.json");
@@ -233,6 +285,7 @@ test("CLI dry-run writes the sweep receipt to disk", async () => {
     assert.equal(receipt.status, "passing");
     assert.equal(receipt.target_sha, "dry-sha");
     assert.equal(receipt.targets.length, 1);
+    assert.equal(receipt.xpass_gate_result.status, "passed");
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Summary: Adds route-target metadata, desktop and mobile viewport evidence shells, console and layout issue capture from UXPass API responses, and a structured no-token fallback receipt. The receipt now also includes an `xpass_gate_result` object that XPass Gate can consume without guessing status names.

Scope: UXPass site sweep runner, focused Node test, and public dogfood receipt only.

Owned files: `scripts/uxpass-site-sweep.mjs`, `scripts/uxpass-site-sweep.test.mjs`, `public/dogfood/uxpass-site-sweep.json`.

Linked todo: `d4c35fdb-7bd3-4b99-981a-ac8d945f23e6`.

Non-overlap: Does not make UXPass block merges, does not touch secrets, auth, billing, domains, migrations, XPass Gate internals, or workflows.

Verification: `node --test scripts/uxpass-site-sweep.test.mjs`; `npm run build`; generated a safe no-token fallback receipt with `--allow-non-passing`.

Risk: Low. Advisory receipt shape expands but keeps existing top-level `status` vocabulary for the current dogfood workflow.

Follow-up: Wire `xpass_gate_result` into any future enforced Gate caller when UXPass graduates from advisory to blocking.