### PR TITLE
[codex] Add tier-2 auto-merge candidate audit

### DIFF
--- a/scripts/tier2-auto-merge-queue-check.mjs
+++ b/scripts/tier2-auto-merge-queue-check.mjs
@@ -92,6 +92,25 @@ function safePrSummary(pr = {}) {
   };
 }
 
+function auditReasons(summary = {}) {
+  const reasons = [];
+  if (summary.isDraft) reasons.push("draft");
+  if (summary.mergeStateStatus !== "CLEAN") {
+    reasons.push(`merge_state_${String(summary.mergeStateStatus || "UNKNOWN").toLowerCase()}`);
+  }
+  if (summary.risk_level !== "low") {
+    reasons.push(`risk_${summary.risk_level || "unknown"}`);
+  }
+  for (const reason of summary.risk_reasons || []) {
+    if (!reasons.includes(reason)) reasons.push(reason);
+  }
+  return reasons;
+}
+
+function auditKey(summary = {}, index = 0) {
+  return summary.number ? `#${summary.number}` : `unknown-${index + 1}`;
+}
+
 export function evaluateTier2AutoMergeQueue({ prs = [], now = new Date().toISOString() } = {}) {
   const openPrs = Array.isArray(prs) ? prs : [];
   const summaries = openPrs.map(safePrSummary);
@@ -105,14 +124,30 @@ export function evaluateTier2AutoMergeQueue({ prs = [], now = new Date().toISOSt
       open_pr_count: 0,
       safe_to_merge_count: 0,
       execute: false,
+      no_execute_reason: "audit_only_no_merge_execution",
       low_risk_count: 0,
+      candidate_count: 0,
+      candidate_pr_numbers: [],
+      blocked_prs: [],
+      blocked_reasons_by_pr: {},
       summaries: [],
     };
   }
 
-  const lowRiskCount = summaries.filter((summary) =>
-    !summary.isDraft && summary.mergeStateStatus === "CLEAN" && summary.risk_level === "low",
-  ).length;
+  const candidates = [];
+  const blockedPrs = [];
+  const blockedReasonsByPr = {};
+
+  for (const [index, summary] of summaries.entries()) {
+    const reasons = auditReasons(summary);
+    if (reasons.length === 0) {
+      candidates.push(summary);
+      continue;
+    }
+    const key = auditKey(summary, index);
+    blockedPrs.push({ number: summary.number, reasons });
+    blockedReasonsByPr[key] = reasons;
+  }
 
   return {
     ok: true,
@@ -123,7 +158,12 @@ export function evaluateTier2AutoMergeQueue({ prs = [], now = new Date().toISOSt
     open_pr_count: openPrs.length,
     safe_to_merge_count: 0,
     execute: false,
-    low_risk_count: lowRiskCount,
+    no_execute_reason: "audit_only_no_merge_execution",
+    low_risk_count: candidates.length,
+    candidate_count: candidates.length,
+    candidate_pr_numbers: candidates.map((summary) => summary.number).filter(Number.isFinite),
+    blocked_prs: blockedPrs,
+    blocked_reasons_by_pr: blockedReasonsByPr,
     summaries,
   };
 }

--- a/scripts/tier2-auto-merge-queue-check.test.mjs
+++ b/scripts/tier2-auto-merge-queue-check.test.mjs
@@ -21,6 +21,10 @@ describe("Tier-2 auto-merge queue check", () => {
     assert.equal(result.open_pr_count, 0);
     assert.equal(result.low_risk_count, 0);
     assert.equal(result.execute, false);
+    assert.equal(result.no_execute_reason, "audit_only_no_merge_execution");
+    assert.equal(result.candidate_count, 0);
+    assert.deepEqual(result.candidate_pr_numbers, []);
+    assert.deepEqual(result.blocked_prs, []);
   });
 
   it("fails closed when open PRs exist because this check never merges", () => {
@@ -47,6 +51,10 @@ describe("Tier-2 auto-merge queue check", () => {
     assert.equal(result.safe_to_merge_count, 0);
     assert.equal(result.low_risk_count, 1);
     assert.equal(result.execute, false);
+    assert.equal(result.no_execute_reason, "audit_only_no_merge_execution");
+    assert.equal(result.candidate_count, 1);
+    assert.deepEqual(result.candidate_pr_numbers, [604]);
+    assert.deepEqual(result.blocked_prs, []);
     assert.deepEqual(result.summaries[0], {
       number: 604,
       isDraft: false,
@@ -60,6 +68,60 @@ describe("Tier-2 auto-merge queue check", () => {
       risk_level: "low",
       risk_reasons: [],
     });
+  });
+
+  it("audits candidates and blocked PRs without granting merge execution", () => {
+    const result = evaluateTier2AutoMergeQueue({
+      prs: [
+        {
+          number: 640,
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/640",
+          headRefName: "codex/docs-chip",
+          changedFiles: 2,
+          additions: 20,
+          deletions: 5,
+        },
+        {
+          number: 641,
+          isDraft: true,
+          mergeStateStatus: "DIRTY",
+          url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/641",
+          headRefName: "codex/auth-migration",
+          changedFiles: 35,
+          additions: 1500,
+          deletions: 750,
+        },
+      ],
+      now: "2026-05-09T08:45:00.000Z",
+    });
+
+    assert.equal(result.execute, false);
+    assert.equal(result.safe_to_merge_count, 0);
+    assert.equal(result.candidate_count, 1);
+    assert.deepEqual(result.candidate_pr_numbers, [640]);
+    assert.deepEqual(result.blocked_reasons_by_pr["#641"], [
+      "draft",
+      "merge_state_dirty",
+      "risk_high",
+      "many_files",
+      "large_diff",
+      "sensitive_branch_name",
+    ]);
+    assert.deepEqual(result.blocked_prs, [
+      {
+        number: 641,
+        reasons: [
+          "draft",
+          "merge_state_dirty",
+          "risk_high",
+          "many_files",
+          "large_diff",
+          "sensitive_branch_name",
+        ],
+      },
+    ]);
   });
 
   it("adds a conservative PR risk score to queue summaries", () => {


### PR DESCRIPTION
## What changed

- Added audit-only candidate output to the tier-2 auto-merge queue checker.
- Reports `candidate_count`, `candidate_pr_numbers`, `blocked_prs`, `blocked_reasons_by_pr`, and `no_execute_reason`.
- Preserves the hard safety stop: `execute` stays `false` and `safe_to_merge_count` stays `0`.

## Why

Jobs Manager split the canonical tier-2 auto-merge parent into a safer first child: improve visibility before any merge execution exists. This lets scheduled runs show which PRs look low risk and why others are blocked, without writing to GitHub.

## Validation

- `node --test scripts/tier2-auto-merge-queue-check.test.mjs`
- `git diff --check`

## Safety

No merge execution, no draft lift, no PR comments, no labels, no write permissions, no secrets or production config changes.

Closes UnClick todo: 09f6b7ab-b5ab-48b4-84ed-8e7d71debb16