### PR TITLE
feat(autopilotkit): surface review and jobs advice

### DIFF
--- a/scripts/pinballwake-ack-ledger-room.mjs
+++ b/scripts/pinballwake-ack-ledger-room.mjs
@@ -2,6 +2,8 @@
 
 import { readFile } from "node:fs/promises";
 
+import { evaluateAutoPilotKitLiveness } from "./lib/autopilotkit-liveness.mjs";
+
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
   const found = process.argv.find((arg) => arg.startsWith(prefix));
@@ -231,6 +233,37 @@ function latestClaimsByReviewer(claims = []) {
   return latest;
 }
 
+function evaluateAutoPilotKitSnapshot({
+  autopilotKit,
+  workerProfiles = [],
+  livenessMessages = [],
+  now,
+} = {}) {
+  const profiles = safeList(autopilotKit?.profiles ?? workerProfiles);
+  const messages = safeList(autopilotKit?.messages ?? livenessMessages);
+  if (profiles.length === 0 && messages.length === 0) return null;
+  return evaluateAutoPilotKitLiveness({
+    ...(autopilotKit || {}),
+    now: autopilotKit?.now || now,
+    profiles,
+    messages,
+  });
+}
+
+function reviewAdviceFromSnapshot(snapshot) {
+  const advice = snapshot?.adapter_examples?.review_coordinator;
+  if (!advice || safeList(advice.reason_codes).length === 0) return null;
+  return {
+    ...advice,
+    safe_mode: snapshot.safe_mode,
+    generated_at: snapshot.generated_at,
+  };
+}
+
+function withReviewAdvice(result, advice) {
+  return advice ? { ...result, autopilotkit_review_advice: advice } : result;
+}
+
 export function evaluateAckLedgerRoom({
   pr,
   comments = [],
@@ -238,6 +271,10 @@ export function evaluateAckLedgerRoom({
   messages = [],
   reviews = [],
   requiredReviewers = ["gatekeeper", "popcorn", "forge"],
+  autopilotKit = null,
+  workerProfiles = [],
+  livenessMessages = [],
+  now,
 } = {}) {
   const number = prNumber(pr);
   if (!number) {
@@ -258,9 +295,11 @@ export function evaluateAckLedgerRoom({
     .filter((claim) => claim?.verdict === "BLOCKER");
   const missing_reviewers = required.filter((reviewer) => latest_by_reviewer[reviewer]?.verdict !== "PASS");
   const full_ack_set = blockers.length === 0 && missing_reviewers.length === 0;
+  const autopilotKitSnapshot = evaluateAutoPilotKitSnapshot({ autopilotKit, workerProfiles, livenessMessages, now });
+  const autopilotKitReviewAdvice = reviewAdviceFromSnapshot(autopilotKitSnapshot);
 
   if (blockers.length > 0) {
-    return {
+    return withReviewAdvice({
       ok: false,
       action: "ack_ledger_room",
       result: "blocked",
@@ -271,11 +310,11 @@ export function evaluateAckLedgerRoom({
       blockers,
       missing_reviewers,
       latest_by_reviewer,
-    };
+    }, autopilotKitReviewAdvice);
   }
 
   if (!full_ack_set) {
-    return {
+    return withReviewAdvice({
       ok: true,
       action: "ack_ledger_room",
       result: "missing_ack",
@@ -293,7 +332,7 @@ export function evaluateAckLedgerRoom({
         deadline: "next heartbeat",
         ack: "done/blocker",
       },
-    };
+    }, autopilotKitReviewAdvice);
   }
 
   return {

--- a/scripts/pinballwake-ack-ledger-room.test.mjs
+++ b/scripts/pinballwake-ack-ledger-room.test.mjs
@@ -261,6 +261,39 @@ describe("PinballWake ACK ledger room", () => {
     assert.equal(result.blockers[0].reviewer, "gatekeeper");
   });
 
+  it("adds advisory AutoPilotKit review reroute output when ACK is missing", () => {
+    const result = evaluateAckLedgerRoom({
+      pr: pr(),
+      comments: [
+        comment("Gatekeeper PASS on #528.", "2026-05-05T00:00:00.000Z", "gatekeeper"),
+        comment("Forge PASS on #528.", "2026-05-05T00:00:00.000Z", "forge"),
+      ],
+      now: "2026-05-09T22:59:17.000Z",
+      workerProfiles: [
+        {
+          agent_id: "claude-cowork-seat",
+          display_name: "Reviewer Seat",
+          current_status: "ACKed PR #528 wake; actual diff pass deferred",
+          last_seen_at: "2026-05-09T22:50:00.000Z",
+          current_status_updated_at: "2026-05-09T22:50:00.000Z",
+        },
+      ],
+      livenessMessages: [
+        {
+          id: "wake-528",
+          tags: ["wakepass", "reroute"],
+          text: "WakePass auto-reroute. Reason: missed ACK for Review Coordinator.",
+        },
+      ],
+    });
+
+    assert.equal(result.result, "missing_ack");
+    assert.equal(result.autopilotkit_review_advice.execute, false);
+    assert(result.autopilotkit_review_advice.reason_codes.includes("missed_ack_reroute_detected"));
+    assert(result.autopilotkit_review_advice.reason_codes.includes("deferred_review_or_ack_only"));
+    assert.equal(result.autopilotkit_review_advice.safe_mode.no_merge_or_claim, true);
+  });
+
   it("accepts explicitly trusted structured lane ACK records", () => {
     const result = evaluateAckLedgerRoom({
       pr: pr(),

--- a/scripts/pinballwake-jobs-room.mjs
+++ b/scripts/pinballwake-jobs-room.mjs
@@ -6,6 +6,7 @@ import {
   createCodingRoomJobLedger,
   runnerCanClaimCodingRoomJob,
 } from "./pinballwake-coding-room.mjs";
+import { evaluateAutoPilotKitLiveness } from "./lib/autopilotkit-liveness.mjs";
 import { DEFAULT_CODING_ROOM_RUNNER, createCodingRoomRunner } from "./pinballwake-coding-room-runner.mjs";
 
 export const DEFAULT_JOBS_WORKER = {
@@ -272,12 +273,42 @@ function countsBy(items, key) {
   }, {});
 }
 
+function evaluateAutoPilotKitSnapshot({
+  autopilotKit,
+  workerProfiles = [],
+  livenessMessages = [],
+  now,
+} = {}) {
+  const profiles = safeList(autopilotKit?.profiles ?? workerProfiles);
+  const messages = safeList(autopilotKit?.messages ?? livenessMessages);
+  if (profiles.length === 0 && messages.length === 0) return null;
+  return evaluateAutoPilotKitLiveness({
+    ...(autopilotKit || {}),
+    now: autopilotKit?.now || now,
+    profiles,
+    messages,
+  });
+}
+
+function jobsAdviceFromSnapshot(snapshot) {
+  const advice = snapshot?.adapter_examples?.jobs_manager;
+  if (!advice || safeList(advice.reason_codes).length === 0) return null;
+  return {
+    ...advice,
+    safe_mode: snapshot.safe_mode,
+    generated_at: snapshot.generated_at,
+  };
+}
+
 export function evaluateJobsRoom({
   ledger,
   jobs,
   runner = DEFAULT_CODING_ROOM_RUNNER,
   now = new Date().toISOString(),
   limit = 5,
+  autopilotKit = null,
+  workerProfiles = [],
+  livenessMessages = [],
 } = {}) {
   const safeLedger = createCodingRoomJobLedger({
     jobs: jobs || ledger?.jobs || [],
@@ -290,8 +321,10 @@ export function evaluateJobsRoom({
 
   const actionable = decisions.filter((decision) => decision.priority > 0 && decision.next_action !== "none");
   const top = actionable.slice(0, limit);
+  const autopilotKitSnapshot = evaluateAutoPilotKitSnapshot({ autopilotKit, workerProfiles, livenessMessages, now });
+  const autopilotkitJobsAdvice = jobsAdviceFromSnapshot(autopilotKitSnapshot);
 
-  return {
+  const result = {
     ok: true,
     action: "jobs_room",
     result: actionable.length ? "todos" : "idle",
@@ -302,6 +335,8 @@ export function evaluateJobsRoom({
     todos: top,
     packets: top.map((decision) => decision.packet).filter(Boolean),
   };
+
+  return autopilotkitJobsAdvice ? { ...result, autopilotkit_jobs_advice: autopilotkitJobsAdvice } : result;
 }
 
 export async function readJobsRoomInput(filePath) {

--- a/scripts/pinballwake-jobs-room.test.mjs
+++ b/scripts/pinballwake-jobs-room.test.mjs
@@ -210,5 +210,28 @@ describe("PinballWake Jobs Room", () => {
     assert.equal(result.result, "idle");
     assert.equal(result.reason, "no_actionable_jobs");
     assert.equal(result.packets.length, 0);
+    assert.equal(result.autopilotkit_jobs_advice, undefined);
+  });
+
+  it("adds advisory AutoPilotKit Jobs Manager output for dormant coordination context", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [codeJob({ status: "done" })] }),
+      runner: builder,
+      now: "2026-05-09T22:59:17.000Z",
+      workerProfiles: [
+        {
+          agent_id: "master",
+          display_name: "Master Coordinator",
+          user_agent_hint: "unclick-master/coordinator",
+          last_seen_at: "2026-05-06T03:59:07.640Z",
+        },
+      ],
+    });
+
+    assert.equal(result.result, "idle");
+    assert.equal(result.autopilotkit_jobs_advice.execute, false);
+    assert(result.autopilotkit_jobs_advice.reason_codes.includes("coordinator_fallback_needed"));
+    assert(result.autopilotkit_jobs_advice.stale_agent_ids.includes("master"));
+    assert.equal(result.autopilotkit_jobs_advice.safe_mode.no_secret_access, true);
   });
 });


### PR DESCRIPTION
## Summary
- Wire the shared AutoPilotKit liveness helper into ACK Ledger / Review Coordinator output as advisory review reroute advice.
- Wire the same helper into Jobs Room output as advisory Jobs Manager coordination advice.
- Preserve existing behavior when no liveness snapshot is supplied, and keep outputs execute=false/read-only.

## Links
- Parent AutoPilotKit todo: 40cbe6eb-baa9-41ea-930d-eb6d123e0e3c
- ScopePack todo: 0e022045-134d-4516-af33-c327400b8a5f
- Merged helper PR: #644 / 44432f8c506c934fa6727649dc5bf8b4a23d4d3b

## Verification
- node --test scripts\\pinballwake-ack-ledger-room.test.mjs scripts\\pinballwake-jobs-room.test.mjs scripts\\autopilotkit-liveness.test.mjs
- git diff --check