### PR TITLE
feat(autopilotkit): wire liveness advisories

### DIFF
--- a/scripts/pinballwake-ack-ledger-room.mjs
+++ b/scripts/pinballwake-ack-ledger-room.mjs
@@ -14,6 +14,38 @@ function safeList(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function firstArray(...values) {
+  return values.find((value) => Array.isArray(value)) || [];
+}
+
+function livenessSnapshotFrom(input = {}) {
+  const source = input.liveness || input.autopilotKit || input.autopilotkit_liveness || input.autopilotKitLiveness || {};
+  const profiles = firstArray(
+    source.profiles,
+    source.worker_profiles,
+    source.workerProfiles,
+    input.livenessProfiles,
+    input.worker_profiles,
+    input.workerProfiles,
+  );
+  const messages = firstArray(
+    source.messages,
+    source.fishbowlMessages,
+    source.fishbowl_messages,
+    input.livenessMessages,
+    input.liveness_messages,
+  );
+
+  if (profiles.length === 0 && messages.length === 0) return null;
+
+  return {
+    ...source,
+    now: source.now || input.now,
+    profiles,
+    messages,
+  };
+}
+
 function normalize(value) {
   return String(value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
 }
@@ -233,35 +265,32 @@ function latestClaimsByReviewer(claims = []) {
   return latest;
 }
 
-function evaluateAutoPilotKitSnapshot({
-  autopilotKit,
-  workerProfiles = [],
-  livenessMessages = [],
-  now,
-} = {}) {
-  const profiles = safeList(autopilotKit?.profiles ?? workerProfiles);
-  const messages = safeList(autopilotKit?.messages ?? livenessMessages);
-  if (profiles.length === 0 && messages.length === 0) return null;
-  return evaluateAutoPilotKitLiveness({
-    ...(autopilotKit || {}),
-    now: autopilotKit?.now || now,
-    profiles,
-    messages,
-  });
-}
+function reviewCoordinatorAdvisory(input = {}, output = {}) {
+  const snapshot = livenessSnapshotFrom(input);
+  if (!snapshot || output.result !== "missing_ack") return null;
 
-function reviewAdviceFromSnapshot(snapshot) {
-  const advice = snapshot?.adapter_examples?.review_coordinator;
-  if (!advice || safeList(advice.reason_codes).length === 0) return null;
+  const liveness = evaluateAutoPilotKitLiveness(snapshot);
+  const review = liveness.adapter_examples.review_coordinator;
+
   return {
-    ...advice,
-    safe_mode: snapshot.safe_mode,
-    generated_at: snapshot.generated_at,
+    ...review,
+    execute: false,
+    source: "autopilotkit_liveness",
+    ack_ledger_result: output.result,
+    missing_reviewers: output.missing_reviewers,
+    reason_codes: Array.from(new Set(["required_ack_missing", ...safeList(review.reason_codes)])).sort(),
+    generated_at: liveness.generated_at,
+    safe_mode: liveness.safe_mode,
   };
 }
 
-function withReviewAdvice(result, advice) {
-  return advice ? { ...result, autopilotkit_review_advice: advice } : result;
+function withReviewAdvisory(output, advisory) {
+  if (!advisory) return output;
+  return {
+    ...output,
+    autopilotkit_review_advisory: advisory,
+    autopilotkit_review_advice: advisory,
+  };
 }
 
 export function evaluateAckLedgerRoom({
@@ -272,10 +301,28 @@ export function evaluateAckLedgerRoom({
   reviews = [],
   requiredReviewers = ["gatekeeper", "popcorn", "forge"],
   autopilotKit = null,
-  workerProfiles = [],
-  livenessMessages = [],
+  liveness,
+  autopilotkit_liveness,
+  autopilotKitLiveness,
+  livenessProfiles,
+  livenessMessages,
+  worker_profiles,
+  workerProfiles,
+  liveness_messages,
   now,
 } = {}) {
+  const input = {
+    autopilotKit,
+    liveness,
+    autopilotkit_liveness,
+    autopilotKitLiveness,
+    livenessProfiles,
+    livenessMessages,
+    worker_profiles,
+    workerProfiles,
+    liveness_messages,
+    now,
+  };
   const number = prNumber(pr);
   if (!number) {
     return {
@@ -295,11 +342,9 @@ export function evaluateAckLedgerRoom({
     .filter((claim) => claim?.verdict === "BLOCKER");
   const missing_reviewers = required.filter((reviewer) => latest_by_reviewer[reviewer]?.verdict !== "PASS");
   const full_ack_set = blockers.length === 0 && missing_reviewers.length === 0;
-  const autopilotKitSnapshot = evaluateAutoPilotKitSnapshot({ autopilotKit, workerProfiles, livenessMessages, now });
-  const autopilotKitReviewAdvice = reviewAdviceFromSnapshot(autopilotKitSnapshot);
 
   if (blockers.length > 0) {
-    return withReviewAdvice({
+    return {
       ok: false,
       action: "ack_ledger_room",
       result: "blocked",
@@ -310,11 +355,11 @@ export function evaluateAckLedgerRoom({
       blockers,
       missing_reviewers,
       latest_by_reviewer,
-    }, autopilotKitReviewAdvice);
+    };
   }
 
   if (!full_ack_set) {
-    return withReviewAdvice({
+    const output = {
       ok: true,
       action: "ack_ledger_room",
       result: "missing_ack",
@@ -332,7 +377,9 @@ export function evaluateAckLedgerRoom({
         deadline: "next heartbeat",
         ack: "done/blocker",
       },
-    }, autopilotKitReviewAdvice);
+    };
+    const advisory = reviewCoordinatorAdvisory(input, output);
+    return withReviewAdvisory(output, advisory);
   }
 
   return {

--- a/scripts/pinballwake-ack-ledger-room.test.mjs
+++ b/scripts/pinballwake-ack-ledger-room.test.mjs
@@ -120,6 +120,7 @@ describe("PinballWake ACK ledger room", () => {
 
     assert.equal(result.result, "missing_ack");
     assert.deepEqual(result.missing_reviewers, ["popcorn"]);
+    assert.equal(result.autopilotkit_review_advisory, undefined);
   });
 
   it("keeps a newer reviewer blocker ahead of an older PASS", () => {
@@ -305,5 +306,41 @@ describe("PinballWake ACK ledger room", () => {
     });
 
     assert.equal(result.result, "full_pass");
+  });
+
+  it("adds advisory AutoPilotKit review reroute output only with liveness context", () => {
+    const result = evaluateAckLedgerRoom({
+      pr: pr(),
+      comments: [
+        comment("Gatekeeper PASS on #528.", "2026-05-05T00:00:00.000Z", "gatekeeper"),
+        comment("Forge PASS on #528.", "2026-05-05T00:00:00.000Z", "forge"),
+      ],
+      liveness: {
+        now: "2026-05-05T00:12:00.000Z",
+        profiles: [
+          {
+            agent_id: "review-seat",
+            display_name: "Review Coordinator",
+            current_status: "ACKed wake; actual diff pass deferred",
+            last_seen_at: "2026-05-05T00:10:00.000Z",
+            current_status_updated_at: "2026-05-05T00:10:00.000Z",
+          },
+        ],
+        messages: [
+          {
+            id: "wake-528",
+            tags: ["wakepass", "reroute"],
+            text: "WakePass auto-reroute. Reason: missed ACK for Review Coordinator.",
+          },
+        ],
+      },
+    });
+
+    assert.equal(result.result, "missing_ack");
+    assert.equal(result.autopilotkit_review_advisory.execute, false);
+    assert.equal(result.autopilotkit_review_advisory.safe_mode.read_only, true);
+    assert(result.autopilotkit_review_advisory.reason_codes.includes("required_ack_missing"));
+    assert(result.autopilotkit_review_advisory.reason_codes.includes("missed_ack_reroute_detected"));
+    assert(result.autopilotkit_review_advisory.reason_codes.includes("deferred_review_or_ack_only"));
   });
 });

--- a/scripts/pinballwake-jobs-room.mjs
+++ b/scripts/pinballwake-jobs-room.mjs
@@ -33,6 +33,38 @@ function safeList(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function firstArray(...values) {
+  return values.find((value) => Array.isArray(value)) || [];
+}
+
+function livenessSnapshotFrom(input = {}) {
+  const source = input.liveness || input.autopilotKit || input.autopilotkit_liveness || input.autopilotKitLiveness || {};
+  const profiles = firstArray(
+    source.profiles,
+    source.worker_profiles,
+    source.workerProfiles,
+    input.livenessProfiles,
+    input.worker_profiles,
+    input.workerProfiles,
+  );
+  const messages = firstArray(
+    source.messages,
+    source.fishbowlMessages,
+    source.fishbowl_messages,
+    input.livenessMessages,
+    input.liveness_messages,
+  );
+
+  if (profiles.length === 0 && messages.length === 0) return null;
+
+  return {
+    ...source,
+    now: source.now || input.now,
+    profiles,
+    messages,
+  };
+}
+
 function normalize(value) {
   return String(value ?? "").trim().toLowerCase();
 }
@@ -273,30 +305,29 @@ function countsBy(items, key) {
   }, {});
 }
 
-function evaluateAutoPilotKitSnapshot({
-  autopilotKit,
-  workerProfiles = [],
-  livenessMessages = [],
-  now,
-} = {}) {
-  const profiles = safeList(autopilotKit?.profiles ?? workerProfiles);
-  const messages = safeList(autopilotKit?.messages ?? livenessMessages);
-  if (profiles.length === 0 && messages.length === 0) return null;
-  return evaluateAutoPilotKitLiveness({
-    ...(autopilotKit || {}),
-    now: autopilotKit?.now || now,
-    profiles,
-    messages,
-  });
+function jobsManagerAdvisory(input = {}) {
+  const snapshot = livenessSnapshotFrom(input);
+  if (!snapshot) return null;
+
+  const liveness = evaluateAutoPilotKitLiveness(snapshot);
+  const jobs = liveness.adapter_examples.jobs_manager;
+  if (safeList(jobs.reason_codes).length === 0 && safeList(jobs.stale_agent_ids).length === 0) return null;
+
+  return {
+    ...jobs,
+    execute: false,
+    source: "autopilotkit_liveness",
+    generated_at: liveness.generated_at,
+    safe_mode: liveness.safe_mode,
+  };
 }
 
-function jobsAdviceFromSnapshot(snapshot) {
-  const advice = snapshot?.adapter_examples?.jobs_manager;
-  if (!advice || safeList(advice.reason_codes).length === 0) return null;
+function withJobsAdvisory(output, advisory) {
+  if (!advisory) return output;
   return {
-    ...advice,
-    safe_mode: snapshot.safe_mode,
-    generated_at: snapshot.generated_at,
+    ...output,
+    autopilotkit_jobs_advisory: advisory,
+    autopilotkit_jobs_advice: advisory,
   };
 }
 
@@ -307,9 +338,27 @@ export function evaluateJobsRoom({
   now = new Date().toISOString(),
   limit = 5,
   autopilotKit = null,
-  workerProfiles = [],
-  livenessMessages = [],
+  liveness,
+  autopilotkit_liveness,
+  autopilotKitLiveness,
+  livenessProfiles,
+  livenessMessages,
+  worker_profiles,
+  workerProfiles,
+  liveness_messages,
 } = {}) {
+  const input = {
+    now,
+    autopilotKit,
+    liveness,
+    autopilotkit_liveness,
+    autopilotKitLiveness,
+    livenessProfiles,
+    livenessMessages,
+    worker_profiles,
+    workerProfiles,
+    liveness_messages,
+  };
   const safeLedger = createCodingRoomJobLedger({
     jobs: jobs || ledger?.jobs || [],
     updatedAt: ledger?.updated_at || now,
@@ -321,10 +370,9 @@ export function evaluateJobsRoom({
 
   const actionable = decisions.filter((decision) => decision.priority > 0 && decision.next_action !== "none");
   const top = actionable.slice(0, limit);
-  const autopilotKitSnapshot = evaluateAutoPilotKitSnapshot({ autopilotKit, workerProfiles, livenessMessages, now });
-  const autopilotkitJobsAdvice = jobsAdviceFromSnapshot(autopilotKitSnapshot);
+  const advisory = jobsManagerAdvisory(input);
 
-  const result = {
+  const output = {
     ok: true,
     action: "jobs_room",
     result: actionable.length ? "todos" : "idle",
@@ -336,7 +384,7 @@ export function evaluateJobsRoom({
     packets: top.map((decision) => decision.packet).filter(Boolean),
   };
 
-  return autopilotkitJobsAdvice ? { ...result, autopilotkit_jobs_advice: autopilotkitJobsAdvice } : result;
+  return withJobsAdvisory(output, advisory);
 }
 
 export async function readJobsRoomInput(filePath) {

--- a/scripts/pinballwake-jobs-room.test.mjs
+++ b/scripts/pinballwake-jobs-room.test.mjs
@@ -84,6 +84,7 @@ describe("PinballWake Jobs Room", () => {
     assert.equal(result.next.priority, 80);
     assert.equal(result.packets[0].worker, "forge");
     assert.match(result.packets[0].expected_proof, /Claim the job/);
+    assert.equal(result.autopilotkit_jobs_advisory, undefined);
   });
 
   it("routes unscoped Boardroom jobs to the Jobs Worker before PinballWake builds", () => {
@@ -233,5 +234,35 @@ describe("PinballWake Jobs Room", () => {
     assert(result.autopilotkit_jobs_advice.reason_codes.includes("coordinator_fallback_needed"));
     assert(result.autopilotkit_jobs_advice.stale_agent_ids.includes("master"));
     assert.equal(result.autopilotkit_jobs_advice.safe_mode.no_secret_access, true);
+  });
+
+  it("adds advisory AutoPilotKit Jobs Manager output for stale liveness context", () => {
+    const result = evaluateJobsRoom({
+      ledger: createCodingRoomJobLedger({ jobs: [codeJob({ status: "done" })] }),
+      runner: builder,
+      now: "2026-05-05T00:12:00.000Z",
+      liveness: {
+        profiles: [
+          {
+            agent_id: "master",
+            display_name: "Master Coordinator",
+            last_seen_at: "2026-05-04T21:00:00.000Z",
+            current_status_updated_at: "2026-05-04T21:00:00.000Z",
+          },
+          {
+            agent_id: "builder-seat",
+            display_name: "Builder Seat",
+            last_seen_at: "2026-05-03T00:00:00.000Z",
+          },
+        ],
+        messages: [],
+      },
+    });
+
+    assert.equal(result.result, "idle");
+    assert.equal(result.autopilotkit_jobs_advisory.execute, false);
+    assert.equal(result.autopilotkit_jobs_advisory.safe_mode.no_merge_or_claim, true);
+    assert(result.autopilotkit_jobs_advisory.reason_codes.includes("coordinator_fallback_needed"));
+    assert.deepEqual(result.autopilotkit_jobs_advisory.stale_agent_ids, ["master", "builder-seat"]);
   });
 });


### PR DESCRIPTION
## Summary
- Wire the merged AutoPilotKit liveness helper into the ACK ledger room as advisory Review Coordinator output when required ACKs are missing.
- Wire the same helper into Jobs Room as advisory Jobs Manager output when supplied seat snapshots show stale, dormant, or unknown workers.
- Preserve existing room behavior when no liveness snapshot is supplied.
- Keep compatibility aliases for both `*_advisory` and `*_advice` outputs after rebasing over the prior AutoPilotKit advice work on `main`.

## Status
- Ready for review as of 2026-05-09T23:31Z.
- Head SHA: `e56fed7094c7eb2b18c12b43d35c0068a435a8bb`.
- Base observed at lift: `39ffb3eb737cef027e45bceedae86dd372f4da50`.
- Merge state observed at lift: `CLEAN`.
- QueuePush packet: `queuepush:v3:pr-646:draft_green_needs_owner_lift:e56fed7:915e333491`.

## Scope
- Owned files: `scripts/pinballwake-ack-ledger-room.mjs`, `scripts/pinballwake-ack-ledger-room.test.mjs`, `scripts/pinballwake-jobs-room.mjs`, `scripts/pinballwake-jobs-room.test.mjs`.
- Linked todo: `0e022045-134d-4516-af33-c327400b8a5f`.
- Parent AutoPilotKit todo: `40cbe6eb-baa9-41ea-930d-eb6d123e0e3c`.

## Non-overlap
- Does not add claims, merges, comments, scheduler mutations, or production writes.
- Does not touch worker registry UI, admin routing, secrets, billing, auth, or keychain paths.

## Verification
- `node --test scripts\pinballwake-ack-ledger-room.test.mjs scripts\pinballwake-jobs-room.test.mjs scripts\autopilotkit-liveness.test.mjs` = 25/25 pass.
- `git diff --check` passed.
- Live PR checks on `e56fed7`: CI Website, MCP server, TestPass smoke, Vercel, and Vercel Preview Comments all passed.

## Risk
- Low. The new output only appears when callers provide optional liveness context, and all advisory packets retain `execute=false` plus the helper safe-mode fields.

## Follow-up
- Move from adapter examples to live room inputs once production snapshots are available.

Ready for review for UnClick agent work; owned scope above. 🤖