### PR TITLE
feat(orchestrator): add rolling snapshot plan

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -171,6 +171,31 @@ export interface OrchestratorLibrarySnapshot extends OrchestratorSourceLink {
   updated_at?: string | null;
 }
 
+export interface OrchestratorRollingSnapshotItem extends OrchestratorSourceLink {
+  kind: "decision" | "blocker" | "active_job" | "continuity";
+  summary: string;
+  actor_agent_id?: string | null;
+  tags?: string[];
+}
+
+export interface OrchestratorRollingSnapshot {
+  mode: "read-plan";
+  summary: string;
+  generated_at: string;
+  newest_source_at: string | null;
+  persistence_plan: {
+    recommended_key: string;
+    retention: string;
+    compaction: string;
+    raw_transcript_policy: string;
+  };
+  promoted_decisions: OrchestratorRollingSnapshotItem[];
+  active_blockers: OrchestratorRollingSnapshotItem[];
+  active_jobs: OrchestratorRollingSnapshotItem[];
+  recent_continuity: OrchestratorRollingSnapshotItem[];
+  source_pointers: OrchestratorSourceLink[];
+}
+
 export interface OrchestratorContext {
   version: "orchestrator-context-v1";
   generated_at: string;
@@ -205,6 +230,7 @@ export interface OrchestratorContext {
   profile_cards: OrchestratorProfileCard[];
   continuity_events: OrchestratorContinuityEvent[];
   library_snapshots: OrchestratorLibrarySnapshot[];
+  rolling_snapshot: OrchestratorRollingSnapshot;
 }
 
 const ACTIVE_WINDOW_MS = 30 * 60 * 1000;
@@ -302,6 +328,13 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     ...input.conversationTurns.map((row) => row.created_at),
   ]);
   const newestCheckinAt = newestIso(input.profiles.map((row) => row.last_seen_at));
+  const rollingSnapshot = buildRollingSnapshot({
+    generatedAt: input.generatedAt,
+    newestActivityAt,
+    activeTodos,
+    continuityEvents,
+    blockers,
+  });
 
   return {
     version: "orchestrator-context-v1",
@@ -340,7 +373,115 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     profile_cards: profiles,
     continuity_events: continuityEvents,
     library_snapshots: librarySnapshots,
+    rolling_snapshot: rollingSnapshot,
   };
+}
+
+function buildRollingSnapshot({
+  generatedAt,
+  newestActivityAt,
+  activeTodos,
+  continuityEvents,
+  blockers,
+}: {
+  generatedAt: string;
+  newestActivityAt: string | null;
+  activeTodos: OrchestratorTodoRow[];
+  continuityEvents: OrchestratorContinuityEvent[];
+  blockers: string[];
+}): OrchestratorRollingSnapshot {
+  const snapshotEvents = continuityEvents.filter((event) => !isSnapshotNoise(event));
+  const promotedDecisions = snapshotEvents
+    .filter((event) => event.kind === "decision")
+    .slice(0, 5)
+    .map((event) => eventToSnapshotItem(event, "decision"));
+  const activeBlockers = snapshotEvents
+    .filter((event) => event.kind === "blocker")
+    .slice(0, 5)
+    .map((event) => eventToSnapshotItem(event, "blocker"));
+  const activeJobs = activeTodos.slice(0, 6).map((todo) => ({
+    source_kind: "todo" as const,
+    source_id: todo.id,
+    deep_link: `/admin/jobs#todo-${todo.id}`,
+    created_at: todo.updated_at ?? todo.created_at,
+    kind: "active_job" as const,
+    actor_agent_id: todo.assigned_to_agent_id ?? todo.created_by_agent_id,
+    summary: compactText(`${todo.priority} ${todo.status}: ${todo.title}. ${todo.description ?? ""}`, 220),
+    tags: ["todo", todo.status, todo.priority],
+  }));
+  const recentContinuity = snapshotEvents
+    .filter((event) => event.kind !== "decision" && event.kind !== "blocker")
+    .slice(0, 8)
+    .map((event) => eventToSnapshotItem(event, "continuity"));
+  const sourcePointers = uniqueSourcePointers([
+    ...promotedDecisions,
+    ...activeBlockers,
+    ...activeJobs,
+    ...recentContinuity,
+  ]);
+
+  return {
+    mode: "read-plan",
+    summary: compactText(
+      [
+        `${activeJobs.length} active job${activeJobs.length === 1 ? "" : "s"}`,
+        `${promotedDecisions.length} promoted decision${promotedDecisions.length === 1 ? "" : "s"}`,
+        `${activeBlockers.length || blockers.length} blocker signal${(activeBlockers.length || blockers.length) === 1 ? "" : "s"}`,
+      ].join(", "),
+      180,
+    ),
+    generated_at: generatedAt,
+    newest_source_at: newestActivityAt,
+    persistence_plan: {
+      recommended_key: "orchestrator:rolling-current-state:v1",
+      retention: "Keep compact rolling snapshots and source pointers; refresh from live sources instead of storing duplicate raw rows.",
+      compaction: "Promote decisions, blockers, active jobs, and recent non-noise continuity only.",
+      raw_transcript_policy: "Do not persist raw transcripts, heartbeat noise, secret-shaped text, or bulk pasted content in the snapshot.",
+    },
+    promoted_decisions: promotedDecisions,
+    active_blockers: activeBlockers,
+    active_jobs: activeJobs,
+    recent_continuity: recentContinuity,
+    source_pointers: sourcePointers,
+  };
+}
+
+function eventToSnapshotItem(
+  event: OrchestratorContinuityEvent,
+  kind: OrchestratorRollingSnapshotItem["kind"],
+): OrchestratorRollingSnapshotItem {
+  return {
+    source_kind: event.source_kind,
+    source_id: event.source_id,
+    deep_link: event.deep_link ?? null,
+    created_at: event.created_at ?? null,
+    kind,
+    actor_agent_id: event.actor_agent_id ?? null,
+    summary: compactText(event.summary, 220),
+    tags: event.tags ?? [],
+  };
+}
+
+function uniqueSourcePointers(items: OrchestratorRollingSnapshotItem[]): OrchestratorSourceLink[] {
+  const seen = new Set<string>();
+  const pointers: OrchestratorSourceLink[] = [];
+  for (const item of items) {
+    const key = `${item.source_kind}:${item.source_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    pointers.push({
+      source_kind: item.source_kind,
+      source_id: item.source_id,
+      deep_link: item.deep_link ?? null,
+      created_at: item.created_at ?? null,
+    });
+  }
+  return pointers.slice(0, 18);
+}
+
+function isSnapshotNoise(event: OrchestratorContinuityEvent): boolean {
+  const text = `${event.summary} ${(event.tags ?? []).join(" ")}`.toLowerCase();
+  return /heartbeat|quiet-status|dont_notify|don't notify|no user action needed|unchanged ack|raw transcript/.test(text);
 }
 
 function buildProfileCard(profile: OrchestratorProfileRow, nowMs: number): OrchestratorProfileCard {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -151,6 +151,10 @@ describe("orchestrator context", () => {
     expect(context.library_snapshots.map((snapshot) => snapshot.source_kind)).toEqual(
       expect.arrayContaining(["library", "business_context", "session_summary"]),
     );
+    expect(context.rolling_snapshot.mode).toBe("read-plan");
+    expect(context.rolling_snapshot.active_jobs[0].source_id).toBe("todo-1");
+    expect(context.rolling_snapshot.promoted_decisions.some((item) => item.source_id === "msg-user")).toBe(true);
+    expect(context.rolling_snapshot.source_pointers.some((pointer) => pointer.source_id === "todo-1")).toBe(true);
   });
 
   it("labels profile-card check-in freshness for AI seats", () => {
@@ -210,5 +214,44 @@ describe("orchestrator context", () => {
 
     expect(compact.length).toBeLessThanOrEqual(80);
     expect(compact.endsWith("...")).toBe(true);
+  });
+
+  it("builds rolling snapshots without promoting heartbeat noise or secrets", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-09T13:00:00.000Z",
+      profiles: [],
+      messages: [
+        {
+          id: "msg-heartbeat",
+          author_agent_id: "heartbeat-seat",
+          text: "DONT_NOTIFY: quiet-status heartbeat, no user action needed.",
+          tags: ["heartbeat"],
+          created_at: "2026-05-09T12:59:00.000Z",
+        },
+        {
+          id: "msg-decision-secret",
+          author_agent_id: "chatgpt-codex-seat",
+          text: "Chris greenlit rolling snapshots with Authorization: Bearer sk-test-not-real-token in copied debug text.",
+          tags: ["decision"],
+          created_at: "2026-05-09T12:58:00.000Z",
+        },
+      ],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    const snapshotText = JSON.stringify(context.rolling_snapshot);
+
+    expect(snapshotText).not.toContain("sk-test-not-real-token");
+    expect(snapshotText).not.toContain("DONT_NOTIFY");
+    expect(context.rolling_snapshot.promoted_decisions.some((item) => item.source_id === "msg-decision-secret")).toBe(true);
+    expect(context.rolling_snapshot.source_pointers.some((pointer) => pointer.source_id === "msg-heartbeat")).toBe(false);
+    expect(context.rolling_snapshot.persistence_plan.raw_transcript_policy).toContain("Do not persist raw transcripts");
   });
 });


### PR DESCRIPTION
## Summary
- Add a read-only rolling snapshot section to orchestrator_context_read output.
- Promote decisions, blockers, active jobs, recent continuity, and source pointers from the existing Orchestrator model.
- Keep this as a plan/read model only: no migrations, no raw transcript persistence, no production writes.

## Links
- Primary Orchestrator todo: 2d31e79c-af77-436e-af80-0b834c86522c
- Visibility parent: b1334cae-bf0b-4460-b0f3-56bde7a6e1d6
- Child ScopePack: 1ebb7e53-942e-4ce0-abfe-7354a854a728

## Verification
- npm run test -- api/orchestrator-context.test.ts
- npm run build
- git diff --check