### PR TITLE
feat(autopilotkit): plan advisory ledger events

### DIFF
--- a/api/autopilot-control-ledger.test.ts
+++ b/api/autopilot-control-ledger.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildAutopilotEventRow,
+  planAutoPilotKitRecommendationLedgerEvents,
   planFishbowlPostLedgerEvent,
   planTodoLedgerEvents,
 } from "./lib/autopilot-control-ledger";
@@ -160,5 +161,90 @@ describe("autopilot control ledger helpers", () => {
         payload: { api_key: "uc_abc1234567890def" },
       }),
     ).toThrow(/sensitive key/);
+  });
+
+  it("plans advisory AutoPilotKit reroute recommendations as lane check ledger events", () => {
+    const events = planAutoPilotKitRecommendationLedgerEvents({
+      actorAgentId: "autopilotkit",
+      refKind: "run",
+      refId: "wake-528",
+      source: "review_coordinator",
+      now,
+      recommendations: [
+        {
+          action: "reroute_missed_ack_to_live_worker",
+          reason: "missed_ack_reroute_detected",
+          target_lane: "reviewer",
+          proof_message_id: "msg-528",
+        },
+        {
+          action: "activate_second_tier_coordinator",
+          reason: "coordinator_fallback_needed",
+          target_lane: "coordinator",
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      eventType: "lane_check",
+      actorAgentId: "autopilotkit",
+      refKind: "run",
+      refId: "wake-528",
+      payload: {
+        source: "review_coordinator",
+        decision: "advisory",
+        advisory: true,
+        execute: false,
+        recommendation_action: "reroute_missed_ack_to_live_worker",
+        reason_code: "missed_ack_reroute_detected",
+        target_lane: "reviewer",
+        proof_message_id: "msg-528",
+      },
+    });
+  });
+
+  it("keeps AutoPilotKit recommendation rows idempotent and sanitized", () => {
+    const event = planAutoPilotKitRecommendationLedgerEvents({
+      actorAgentId: "autopilotkit",
+      refId: "run-123",
+      now,
+      recommendations: [
+        {
+          action: "separate_ack_from_diff_review",
+          reason: "deferred_review_or_ack_only",
+          target_lane: "reviewer",
+          affected_agent_ids: ["review-seat", "review-seat-2"],
+        },
+      ],
+    })[0];
+
+    const first = buildAutopilotEventRow({ ...event, apiKeyHash: "hash_123" });
+    const second = buildAutopilotEventRow({ ...event, apiKeyHash: "hash_123" });
+
+    expect(first.idempotency_key).toBe(second.idempotency_key);
+    expect(first.payload).toMatchObject({
+      decision: "advisory",
+      execute: false,
+      affected_agent_ids: ["review-seat", "review-seat-2"],
+    });
+    expect(JSON.stringify(first.payload)).not.toContain("undefined");
+  });
+
+  it("rejects secret-looking AutoPilotKit recommendation text at row build time", () => {
+    const event = planAutoPilotKitRecommendationLedgerEvents({
+      actorAgentId: "autopilotkit",
+      refId: "run-123",
+      now,
+      recommendations: [
+        {
+          action: "reroute_missed_ack_to_live_worker",
+          reason: "authorization: bearer sk-test-not-real-secret",
+          target_lane: "reviewer",
+        },
+      ],
+    })[0];
+
+    expect(() => buildAutopilotEventRow({ ...event, apiKeyHash: "hash_123" })).toThrow(/sensitive text/);
   });
 });

--- a/api/lib/autopilot-control-ledger.ts
+++ b/api/lib/autopilot-control-ledger.ts
@@ -67,6 +67,15 @@ export interface FishbowlPostLedgerInput {
   now?: Date;
 }
 
+export interface AutoPilotKitRecommendationLedgerInput {
+  actorAgentId: string;
+  refId: string;
+  refKind?: AutopilotRefKind | string;
+  source?: string;
+  recommendations?: Array<Record<string, unknown>> | null;
+  now?: Date;
+}
+
 const EVENT_TYPE_SET = new Set<string>(AUTOPILOT_EVENT_TYPES);
 const REF_KIND_SET = new Set<string>(AUTOPILOT_REF_KINDS);
 const SENSITIVE_KEY_RE = /(api[_-]?key|secret|token|password|credential|authorization|cookie)/i;
@@ -304,6 +313,44 @@ export function planFishbowlPostLedgerEvent(input: FishbowlPostLedgerInput): Aut
   }
 
   return null;
+}
+
+export function planAutoPilotKitRecommendationLedgerEvents(
+  input: AutoPilotKitRecommendationLedgerInput,
+): AutopilotEventInput[] {
+  const recommendations = Array.isArray(input.recommendations) ? input.recommendations : [];
+  return recommendations
+    .map((recommendation) => {
+      const action = compact(recommendation.action, 120);
+      const reason = compact(recommendation.reason, 160);
+      if (!action || !reason) return null;
+      const targetLane = compact(recommendation.target_lane, 120);
+      const proofMessageId = compact(recommendation.proof_message_id, 160);
+      const affectedAgentIds = Array.isArray(recommendation.affected_agent_ids)
+        ? recommendation.affected_agent_ids.map((agentId) => compact(agentId, 128)).filter(Boolean).slice(0, 12)
+        : [];
+
+      return {
+        apiKeyHash: "",
+        eventType: "lane_check",
+        actorAgentId: input.actorAgentId,
+        refKind: input.refKind ?? "run",
+        refId: input.refId,
+        now: input.now,
+        payload: {
+          source: compact(input.source ?? "autopilotkit", 120),
+          decision: "advisory",
+          advisory: true,
+          execute: false,
+          recommendation_action: action,
+          reason_code: reason,
+          target_lane: targetLane || null,
+          proof_message_id: proofMessageId || null,
+          affected_agent_ids: affectedAgentIds,
+        },
+      } satisfies AutopilotEventInput;
+    })
+    .filter((event): event is AutopilotEventInput => event !== null);
 }
 
 export async function recordAutopilotEvent(


### PR DESCRIPTION
## Summary
- Add an advisory-only AutoPilotKit recommendation ledger planner.
- Reuse existing lane_check event type with dvisory=true and xecute=false payloads.
- Cover missed ACK reroute, dormant coordinator fallback, idempotency, and sensitive-text rejection.

## Links
- Parent AutoPilotKit todo: 40cbe6eb-baa9-41ea-930d-eb6d123e0e3c
- ScopePack todo: bc34717c-2a0f-4726-912d-e2c7d59b9606
- Merged helper PR: #644 / 44432f8c506c934fa6727649dc5bf8b4a23d4d3b
- Merged wiring PR: #645 / 4dddf51ec40545225af5b5189559be7ef86202dc

## Verification
- npm run test -- api/autopilot-control-ledger.test.ts
- npm run build
- git diff --check