### PR TITLE
feat(seats): add heartbeat prompt page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,7 @@ import AdminTools from "./pages/admin/AdminTools.tsx";
 import AdminActivity from "./pages/admin/AdminActivity.tsx";
 import AdminSettings from "./pages/admin/AdminSettings.tsx";
 import AdminAgentsPage from "./pages/admin/AdminAgents.tsx";
+import AdminSeatHeartbeatPage from "./pages/admin/AdminSeatHeartbeat.tsx";
 import AdminAnalytics from "./pages/admin/AdminAnalytics.tsx";
 import AdminCodebase from "./pages/admin/AdminCodebase.tsx";
 import AdminOrchestratorPage from "./pages/admin/AdminOrchestrator.tsx";
@@ -163,6 +164,7 @@ const App = () => (
             <Route path="projects" element={<AdminProjects />} />
             <Route path="autopilot" element={<AdminAutopilot />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
+            <Route path="agents/heartbeat" element={<AdminSeatHeartbeatPage />} />
             <Route path="workers" element={<AdminWorkers />} />
             <Route path="jobs" element={<AdminJobs />} />
             <Route path="todos" element={<Navigate to="/admin/jobs" replace />} />

--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import AdminSeatHeartbeatPage, {
+  HEARTBEAT_CONNECTION_PROMPT,
+  HEARTBEAT_MASTER_PROMPT,
+} from "./AdminSeatHeartbeat";
+
+describe("AdminSeatHeartbeatPage", () => {
+  it("shows the canonical policy and short schedule message", () => {
+    render(React.createElement(AdminSeatHeartbeatPage));
+
+    expect(screen.getByRole("heading", { name: "Heartbeat" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Public default heartbeat policy")).toHaveValue(HEARTBEAT_MASTER_PROMPT);
+    expect(screen.getByLabelText("Short schedule message")).toHaveValue(HEARTBEAT_CONNECTION_PROMPT);
+    expect(HEARTBEAT_CONNECTION_PROMPT.length).toBeLessThan(HEARTBEAT_MASTER_PROMPT.length / 3);
+  });
+});

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useState } from "react";
+import { Check, Copy, HeartPulse } from "lucide-react";
+
+export const HEARTBEAT_MASTER_PROMPT = `You are an UnClick AI Seat. Use UnClick as source of truth via available UnClick MCP/tools first, especially load_memory/search_memory or equivalent.
+
+Pick one clear, safe, useful live task. Do the smallest meaningful step. For code: fresh branch, focused tests, PR, wait for checks. Prove automation only with a scheduled run. Use production state only. Never print secrets. Clean up temp rows, leases, proof agents, and one-time schedules.
+
+Output one line only. Do not repeat this prompt.
+PASS: <changed>; proof: <link/id>; cleanup: <done>.
+BLOCKER: <safe reason>; next: <fix>.
+If no safe task: BLOCKER: no clear safe task available.`;
+
+export const HEARTBEAT_CONNECTION_PROMPT =
+  "Load UnClick Seats > Heartbeat: public default policy. Then pick one clear safe live task from UnClick and reply only PASS/BLOCKER per that policy.";
+
+export default function AdminSeatHeartbeatPage() {
+  const [copied, setCopied] = useState(false);
+
+  const copyConnectionPrompt = useCallback(() => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(HEARTBEAT_CONNECTION_PROMPT).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    });
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="mb-2 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-primary/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-primary">
+            <HeartPulse className="h-3.5 w-3.5" />
+            Seats
+          </div>
+          <h1 className="text-2xl font-semibold tracking-tight text-heading">Heartbeat</h1>
+          <p className="mt-1 max-w-2xl text-sm text-body">
+            Canonical policy for scheduled AI Seat runs.
+          </p>
+        </div>
+      </header>
+
+      <section className="space-y-3 rounded-xl border border-border/40 bg-card/20 p-4">
+        <label htmlFor="heartbeat-master-prompt" className="block text-sm font-semibold text-heading">
+          Public default heartbeat policy
+        </label>
+        <textarea
+          id="heartbeat-master-prompt"
+          aria-label="Public default heartbeat policy"
+          readOnly
+          value={HEARTBEAT_MASTER_PROMPT}
+          rows={13}
+          className="min-h-[320px] w-full resize-y rounded-md border border-border/40 bg-black/20 px-3 py-3 font-mono text-xs leading-5 text-body outline-none focus:border-primary/40"
+        />
+      </section>
+
+      <section className="space-y-3 rounded-xl border border-border/40 bg-card/20 p-4">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <label htmlFor="heartbeat-connection-prompt" className="text-sm font-semibold text-heading">
+            Short schedule message
+          </label>
+          <button
+            type="button"
+            onClick={copyConnectionPrompt}
+            title="Copy short schedule message"
+            aria-label="Copy short schedule message"
+            className="inline-flex w-fit items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary transition-colors hover:bg-primary/15"
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+        <textarea
+          id="heartbeat-connection-prompt"
+          aria-label="Short schedule message"
+          readOnly
+          value={HEARTBEAT_CONNECTION_PROMPT}
+          rows={3}
+          className="w-full resize-none rounded-md border border-border/40 bg-black/20 px-3 py-2 font-mono text-xs leading-5 text-body outline-none focus:border-primary/40"
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -238,6 +238,34 @@ function MemoryNavItem({ onClick }: { onClick?: () => void }) {
   );
 }
 
+function SeatsNavItem({ onClick }: { onClick?: () => void }) {
+  const location = useLocation();
+  const isSeats = location.pathname === "/admin/agents" || location.pathname.startsWith("/admin/agents/");
+  const heartbeatActive = location.pathname === "/admin/agents/heartbeat";
+
+  return (
+    <div>
+      <SurfaceLink path="/admin/agents" label="Seats" icon={Bot} onClick={onClick} />
+      {isSeats && (
+        <div className="ml-7 mt-0.5 flex flex-col gap-0.5">
+          <Link
+            to="/admin/agents/heartbeat"
+            onClick={onClick}
+            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              heartbeatActive
+                ? "bg-[#61C1C4]/10 text-[#61C1C4]"
+                : "text-[#666] hover:bg-white/[0.04] hover:text-[#aaa]"
+            }`}
+          >
+            <HeartPulse className="h-3 w-3 shrink-0" />
+            Heartbeat
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function SidebarNav({
   isAdmin,
   signalsUnread,
@@ -254,7 +282,7 @@ function SidebarNav({
       <MemoryNavItem onClick={onLinkClick} />
       <SurfaceLink path="/admin/tools"    label="Apps"                     icon={AppWindow} onClick={onLinkClick} />
       <SurfaceLink path="/admin/keychain" label="Passport"                 icon={KeyRound} onClick={onLinkClick} />
-      <SurfaceLink path="/admin/agents"    label="Seats"                   icon={Bot} onClick={onLinkClick} />
+      <SeatsNavItem onClick={onLinkClick} />
       <AutopilotNavGroup onLinkClick={onLinkClick} />
       <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />
       {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}


### PR DESCRIPTION
## Summary
- add a Seats > Heartbeat route with the public default heartbeat policy prefilled
- add a short schedule-message copy box that references the canonical policy instead of repeating it
- expose Heartbeat as a Seats submenu item in the admin shell

## Proof
- npm run test -- src/pages/admin/AdminSeatHeartbeat.test.tsx
- npm run build
- git diff --check