### PR TITLE
feat(workers): prefilter actionable todos by lane

### DIFF
--- a/api/lib/worker-lanes.ts
+++ b/api/lib/worker-lanes.ts
@@ -29,6 +29,7 @@ export interface LaneClaimEvaluation {
 
 export interface TodoLaneTokenInput {
   title?: unknown;
+  description?: unknown;
   priority?: unknown;
   status?: unknown;
 }
@@ -110,6 +111,7 @@ export function evaluateLaneClaim(lane: WorkerLaneRow | null, todoTokens: unknow
 
 export function buildTodoLaneTokens(input: TodoLaneTokenInput): string[] {
   const titleTokens = typeof input.title === "string" ? input.title.split(/[\s,]+/) : [];
-  return normalizeScopeTokens([input.priority, input.status, ...titleTokens]);
+  const descriptionTokens = typeof input.description === "string" ? input.description.split(/[\s,]+/).slice(0, 120) : [];
+  return normalizeScopeTokens([input.priority, input.status, ...titleTokens, ...descriptionTokens]);
 }
 

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -8489,6 +8489,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .limit(500);
           if (error) throw error;
 
+          const { data: callerLaneRow, error: callerLaneErr } = await supabase
+            .from("worker_lanes")
+            .select("api_key_hash, agent_id, role, scope_allowlist, scope_denylist, enforce_mode")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("agent_id", agentId)
+            .maybeSingle();
+          if (callerLaneErr) throw callerLaneErr;
+          const callerLane = callerLaneRow as WorkerLaneRow | null;
+
           const assigneeIds = Array.from(
             new Set(
               (data ?? [])
@@ -8526,11 +8535,28 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           };
 
           const actionable = (data ?? [])
-            .map((todo) => ({
-              todo,
-              actionability_reason: actionabilityFor(todo),
-            }))
+            .map((todo) => {
+              const tokens = buildTodoLaneTokens({
+                title: todo.title,
+                description: todo.description,
+                priority: todo.priority,
+                status: todo.status,
+              });
+              const laneCheck = evaluateLaneClaim(callerLane, tokens);
+              return {
+                todo,
+                actionability_reason: actionabilityFor(todo),
+                lane_check: callerLane
+                  ? {
+                      decision: laneCheck.decision,
+                      reason: laneCheck.reason,
+                      matched_token: laneCheck.matched_token ?? null,
+                    }
+                  : null,
+              };
+            })
             .filter((item) => item.actionability_reason)
+            .filter((item) => item.lane_check?.decision !== "reject")
             .sort((a, b) => {
               const todoA = a.todo;
               const todoB = b.todo;
@@ -8587,7 +8613,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             }, {});
           }
 
-          const decorated = actionable.map(({ todo: t, actionability_reason }, index) => {
+          const decorated = actionable.map(({ todo: t, actionability_reason, lane_check }, index) => {
             const fieldScopePack =
               t.scope_pack ??
               t.scopePack ??
@@ -8622,6 +8648,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               scope_pack: fieldScopePack ?? commentScopePack?.scope_pack ?? null,
               scope_pack_source: fieldScopePack ? "field" : commentScopePack?.source ?? null,
               scope_pack_comment_id: commentScopePack?.comment_id ?? null,
+              ...(lane_check ? { lane_check } : {}),
             };
           });
           return res.status(200).json({

--- a/api/worker-lanes.test.ts
+++ b/api/worker-lanes.test.ts
@@ -61,10 +61,27 @@ describe("worker lane helpers", () => {
     expect(
       buildTodoLaneTokens({
         title: "Build F: Standing auto-merge bot + PR risk score",
+        description: "ScopePack: safe code lane only",
         priority: "urgent",
         status: "open",
       }),
-    ).toEqual(["urgent", "open", "build", "f:", "standing", "auto-merge", "bot", "pr", "risk", "score"]);
+    ).toEqual([
+      "urgent",
+      "open",
+      "build",
+      "f:",
+      "standing",
+      "auto-merge",
+      "bot",
+      "pr",
+      "risk",
+      "score",
+      "scopepack:",
+      "safe",
+      "code",
+      "lane",
+      "only",
+    ]);
   });
 
   it("warns before enforcing allowlist misses", () => {


### PR DESCRIPTION
## Summary
- use worker_lanes when listing actionable todos for a caller agent
- hide out-of-lane jobs in enforce mode and expose compact lane_check metadata in warn mode
- include description tokens in todo lane classification so ScopePack/job hints can route better

## Proof
- npm run test -- api/worker-lanes.test.ts
- npm run build
- git diff --check

Closes child ScopePack todo cff8054d-a720-4864-aa96-3882f179ef6c when merged.