### PR TITLE
feat(pinballwake): prove orchestrator seat handoff

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -52,6 +52,15 @@ jobs:
             printf '{"version":1,"updated_at":"%s","jobs":[]}\n' "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" > "${CODING_ROOM_LEDGER_PATH}"
           fi
 
+      - name: Prove Orchestrator seat handoff
+        if: github.event_name == 'schedule'
+        env:
+          AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF: "true"
+          AUTONOMOUS_RUNNER_TODO_LIMIT: ${{ vars.AUTONOMOUS_RUNNER_TODO_LIMIT || '10' }}
+          UNCLICK_MCP_URL: ${{ vars.UNCLICK_MCP_URL || 'https://unclick.world/api/mcp' }}
+          UNCLICK_API_KEY: ${{ secrets.UNCLICK_API_KEY || secrets.FISHBOWL_AUTOCLOSE_TOKEN || secrets.FISHBOWL_WAKE_TOKEN }}
+        run: node scripts/pinballwake-autonomous-runner.mjs
+
       - name: Run autonomous Runner
         env:
           CODING_ROOM_LEDGER_PATH: ${{ vars.CODING_ROOM_LEDGER_PATH || '.pinballwake/coding-room-ledger.json' }}

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -115,6 +115,14 @@ function compactMultiline(value, max = 12000) {
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
 }
 
+function memoryAdminActionUrlFromMcpUrl(mcpUrl = DEFAULT_UNCLICK_MCP_URL, action = "") {
+  const url = new URL(mcpUrl || DEFAULT_UNCLICK_MCP_URL);
+  url.pathname = "/api/memory-admin";
+  url.search = "";
+  url.searchParams.set("action", action);
+  return url.toString();
+}
+
 function stableTodoJobId(todo = {}) {
   return `boardroom-todo:${String(todo.id || todo.todo_id || "unknown").trim()}`;
 }
@@ -402,6 +410,122 @@ async function callUnClickMcpTool({
   return {
     ok: true,
     data: extractMcpTextJson(payload),
+  };
+}
+
+export async function fetchUnClickOrchestratorContext({
+  mcpUrl = DEFAULT_UNCLICK_MCP_URL,
+  apiKey = "",
+  limit = 80,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (!apiKey) {
+    return { ok: false, reason: "missing_unclick_api_key" };
+  }
+  if (typeof fetchImpl !== "function") {
+    return { ok: false, reason: "missing_fetch_impl" };
+  }
+
+  const response = await fetchImpl(memoryAdminActionUrlFromMcpUrl(mcpUrl, "orchestrator_context_read"), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ limit }),
+  });
+
+  if (!response?.ok) {
+    return {
+      ok: false,
+      reason: "orchestrator_context_http_error",
+      status: response?.status ?? null,
+    };
+  }
+
+  const payload = await response.json().catch(() => ({}));
+  return {
+    ok: true,
+    context: payload?.context ?? null,
+  };
+}
+
+export function evaluateOrchestratorSeatHandshakeProof(context = {}) {
+  const handshake = context?.seat_handshake;
+  if (!handshake || typeof handshake !== "object") {
+    return {
+      ok: false,
+      result: "BLOCKER",
+      reason: "missing_seat_handshake",
+      proof_line: "BLOCKER: missing Orchestrator seat_handshake; next: deploy PR #653 or expose orchestrator_context_read.",
+    };
+  }
+
+  const handoffText = JSON.stringify(handshake);
+  const noisy = /<heartbeat\b|current_time_iso|unclick-heartbeat|run unclick heartbeat|dont_notify/i.test(handoffText);
+  const sourcePointers = Array.isArray(handshake.source_pointers) ? handshake.source_pointers : [];
+  const seatFreshness = Array.isArray(handshake.seat_freshness) ? handshake.seat_freshness : [];
+  const missing = [];
+  if (!String(handshake.active_decision || "").trim()) missing.push("active_decision");
+  if (!String(handshake.active_job || "").trim()) missing.push("active_job");
+  if (!String(handshake.recent_proof || "").trim()) missing.push("recent_proof");
+  if (sourcePointers.length === 0) missing.push("source_pointers");
+  if (seatFreshness.length === 0) missing.push("seat_freshness");
+  if (noisy) missing.push("noise_free_handoff");
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      result: "BLOCKER",
+      reason: "seat_handshake_incomplete",
+      missing,
+      proof_line: `BLOCKER: Orchestrator seat_handshake incomplete (${missing.join(", ")}); next: fix compact context proof source.`,
+    };
+  }
+
+  const proofIds = sourcePointers
+    .map((pointer) => String(pointer?.source_id || "").trim())
+    .filter(Boolean)
+    .slice(0, 4)
+    .join(",");
+
+  return {
+    ok: true,
+    result: "PASS",
+    reason: "seat_handshake_ready",
+    source_pointer_count: sourcePointers.length,
+    seat_freshness_count: seatFreshness.length,
+    proof_line: `PASS: Orchestrator seat_handshake readable; proof: ${proofIds || "source_pointers"}; cleanup: done.`,
+  };
+}
+
+export async function runOrchestratorSeatHandshakeProof({
+  mcpUrl = DEFAULT_UNCLICK_MCP_URL,
+  apiKey = "",
+  limit = 80,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const fetched = await fetchUnClickOrchestratorContext({ mcpUrl, apiKey, limit, fetchImpl });
+  if (!fetched.ok) {
+    return {
+      ok: false,
+      action: "blocked",
+      mode: "orchestrator-proof",
+      reason: fetched.reason,
+      status: fetched.status ?? null,
+      proof_line: `BLOCKER: ${fetched.reason}; next: make orchestrator_context_read available to PinballWake.`,
+      orchestrator_proof: fetched,
+    };
+  }
+
+  const proof = evaluateOrchestratorSeatHandshakeProof(fetched.context);
+  return {
+    ok: proof.ok,
+    action: proof.ok ? "orchestrator_proof_passed" : "blocked",
+    mode: "orchestrator-proof",
+    reason: proof.reason,
+    proof_line: proof.proof_line,
+    orchestrator_proof: proof,
   };
 }
 
@@ -1091,7 +1215,17 @@ export async function runAutonomousRunnerFile({
   now = new Date().toISOString(),
   leaseSeconds,
   wakeSource = "unknown",
+  orchestratorProof = false,
 } = {}) {
+  if (orchestratorProof) {
+    return runOrchestratorSeatHandshakeProof({
+      mcpUrl: unclickMcpUrl,
+      apiKey: unclickApiKey,
+      limit: todoLimit,
+      fetchImpl,
+    });
+  }
+
   if (!ledgerPath) {
     return { ok: false, reason: "missing_ledger_path" };
   }
@@ -1265,6 +1399,7 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
     todoLimit: parseIntOption(getArg("todo-limit", process.env.AUTONOMOUS_RUNNER_TODO_LIMIT), 10),
     leaseSeconds: parseIntOption(getArg("lease-seconds", process.env.CODING_ROOM_LEASE_SECONDS), undefined),
     wakeSource: getArg("wake-source", process.env.AUTONOMOUS_RUNNER_WAKE_SOURCE || process.env.GITHUB_EVENT_NAME || "unknown"),
+    orchestratorProof: parseBoolean(getArg("orchestrator-proof", process.env.AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF)),
     policy: createAutonomousRunnerPolicy({
       disabled: parseBoolean(process.env.AUTONOMOUS_RUNNER_DISABLED),
       allowProtectedSurfaces: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES),

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -13,8 +13,10 @@ import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
   evaluateBoardroomTodoAutoClaimEligibility,
+  evaluateOrchestratorSeatHandshakeProof,
   extractBoardroomTodoIdFromCodingRoomJob,
   fetchUnClickActionableTodos,
+  fetchUnClickOrchestratorContext,
   inspectAutonomousRunnerJobSafety,
   markUnsafeJobsBlockedForAutonomousRunner,
   normalizeAutonomousRunnerMode,
@@ -456,6 +458,87 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.ok, true);
     assert.equal(result.todos.length, 1);
     assert.equal(result.todos[0].id, "todo-sse");
+  });
+
+  it("reads Orchestrator context for a scheduled seat_handshake proof", async () => {
+    const calls = [];
+    const result = await runAutonomousRunnerFile({
+      orchestratorProof: true,
+      unclickApiKey: "uc_test",
+      unclickMcpUrl: "https://unclick.test/api/mcp",
+      fetchImpl: async (url, init = {}) => {
+        calls.push({ url, body: JSON.parse(init.body), auth: init.headers.authorization });
+        return {
+          ok: true,
+          async json() {
+            return {
+              context: {
+                seat_handshake: {
+                  mode: "fresh-seat-pickup",
+                  active_decision: "Chris greenlit Orchestrator V1 proof with AutoPilotKit and PinballWake.",
+                  active_job: "urgent open: Orchestrator chip: PinballWake scheduled proof reads seat_handshake.",
+                  recent_proof: "PASS: PR #653 shipped seat_handshake.",
+                  active_blocker: null,
+                  seat_freshness: ["PinballWake: Live"],
+                  source_pointers: [{ source_kind: "todo", source_id: "fa3801d1" }],
+                },
+              },
+            };
+          },
+        };
+      },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://unclick.test/api/memory-admin?action=orchestrator_context_read");
+    assert.equal(calls[0].body.limit, 10);
+    assert.equal(calls[0].auth, "Bearer uc_test");
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "orchestrator_proof_passed");
+    assert.match(result.proof_line, /^PASS: Orchestrator seat_handshake readable/);
+    assert.equal(result.orchestrator_proof.source_pointer_count, 1);
+  });
+
+  it("blocks empty or noisy Orchestrator seat_handshake proof packets", async () => {
+    const direct = evaluateOrchestratorSeatHandshakeProof({
+      seat_handshake: {
+        active_decision: "Chris greenlit Orchestrator V1.",
+        active_job: "",
+        recent_proof: "PASS: proof exists.",
+        seat_freshness: ["PinballWake: Live"],
+        source_pointers: [{ source_id: "todo-1" }],
+      },
+    });
+
+    assert.equal(direct.ok, false);
+    assert(direct.missing.includes("active_job"));
+
+    const fetched = await fetchUnClickOrchestratorContext({
+      apiKey: "uc_test",
+      mcpUrl: "https://unclick.test/api/mcp",
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return {
+            context: {
+              seat_handshake: {
+                active_decision: "Chris greenlit Orchestrator V1.",
+                active_job: "Orchestrator proof",
+                recent_proof: "PASS: proof exists.",
+                seat_freshness: ["PinballWake: Live"],
+                source_pointers: [{ source_id: "todo-1" }],
+                next_prompt: "Run UnClick Heartbeat. Use the Seats > Heartbeat policy.",
+              },
+            },
+          };
+        },
+      }),
+    });
+    const noisy = evaluateOrchestratorSeatHandshakeProof(fetched.context);
+
+    assert.equal(noisy.ok, false);
+    assert(noisy.missing.includes("noise_free_handoff"));
+    assert.match(noisy.proof_line, /^BLOCKER:/);
   });
 
   it("extracts Boardroom todo ids only from imported UnClick jobs", () => {
@@ -1084,6 +1167,8 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /cron:\s*"3,13,23,33,43,53 \* \* \* \*"/);
     assert.match(workflow, /workflow_run:/);
     assert.match(workflow, /Fleet Throughput Watch/);
+    assert.match(workflow, /Prove Orchestrator seat handoff/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF:\s*"true"/);
     assert.match(workflow, /node scripts\/pinballwake-autonomous-runner\.mjs/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_QUEUE_SOURCE:.*'unclick'/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_WAKE_SOURCE:.*queuepush/);


### PR DESCRIPTION
## Summary
- add a read-only PinballWake Orchestrator proof mode that reads orchestrator_context_read
- validate the compact seat_handshake has decision, job, recent proof, source pointers, seat freshness, and no heartbeat prompt noise
- run the proof as a scheduled workflow step before the normal autonomous runner cycle

## Verification
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run build
- git diff --check

Closes UnClick todo: fa3801d1-cc44-4bb3-83c9-478cd7a88493