### PR TITLE
Allow Orchestrator proof from scheduled chain wake

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Prove Orchestrator seat handoff
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule')
         env:
           AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF: "true"
           AUTONOMOUS_RUNNER_TODO_LIMIT: ${{ vars.AUTONOMOUS_RUNNER_TODO_LIMIT || '10' }}

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1168,6 +1168,8 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /workflow_run:/);
     assert.match(workflow, /Fleet Throughput Watch/);
     assert.match(workflow, /Prove Orchestrator seat handoff/);
+    assert.match(workflow, /github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_run' && github\.event\.workflow_run\.event == 'schedule'\)/);
+    assert.doesNotMatch(workflow, /if:\s*github\.event_name == 'workflow_run'\s*$/m);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF:\s*"true"/);
     assert.match(workflow, /node scripts\/pinballwake-autonomous-runner\.mjs/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_QUEUE_SOURCE:.*'unclick'/);


### PR DESCRIPTION
## Summary
- run the Orchestrator seat handoff proof when PinballWake is triggered by a scheduled Fleet Throughput Watch chain reaction
- keep the proof read-only and still avoid counting ordinary non-scheduled workflow_run events
- cover the workflow gate in the autonomous runner test

Closes Boardroom todo 27738a50-71ca-4dbd-8ac5-c043a9e03c23.

## Tests
- node --test scripts/pinballwake-autonomous-runner.test.mjs