### PR TITLE
feat(orchestrator): add human timezone context

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -109,6 +109,19 @@ export interface OrchestratorConversationTurnRow {
   created_at: string;
 }
 
+export type OrchestratorOperatorTimeSource = "browser" | "manual" | "unknown";
+
+export interface OrchestratorOperatorTimeContext {
+  timezone: string;
+  source: OrchestratorOperatorTimeSource;
+  local_date: string;
+  local_time: string;
+  utc_offset: string | null;
+  updated_at?: string | null;
+  privacy: "timezone-only";
+  summary: string;
+}
+
 export interface BuildOrchestratorContextInput {
   generatedAt: string;
   profiles: OrchestratorProfileRow[];
@@ -240,6 +253,7 @@ export interface OrchestratorContext {
     blockers: string[];
   };
   profile_cards: OrchestratorProfileCard[];
+  human_operator_time: OrchestratorOperatorTimeContext | null;
   continuity_events: OrchestratorContinuityEvent[];
   library_snapshots: OrchestratorLibrarySnapshot[];
   rolling_snapshot: OrchestratorRollingSnapshot;
@@ -309,6 +323,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     .map((profile) => buildProfileCard(profile, nowMs))
     .sort((a, b) => compareIsoDesc(a.last_seen_at, b.last_seen_at));
   const activeSeatCount = profiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
+  const humanOperatorTime = buildOperatorTimeContext(input.businessContext, input.generatedAt);
 
   const activeTodos = input.todos
     .filter((todo) => todo.status === "open" || todo.status === "in_progress")
@@ -377,6 +392,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     profiles,
     continuityEvents,
     rollingSnapshot,
+    humanOperatorTime,
   });
 
   return {
@@ -390,7 +406,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     },
     current_state_card: {
       summary: compactText(
-        `${activeTodos.length} active job${activeTodos.length === 1 ? "" : "s"}, ${activeSeatCount} active seat${activeSeatCount === 1 ? "" : "s"}, ${blockers.length} blocker signal${blockers.length === 1 ? "" : "s"}.`,
+        `${activeTodos.length} active job${activeTodos.length === 1 ? "" : "s"}, ${activeSeatCount} active seat${activeSeatCount === 1 ? "" : "s"}, ${blockers.length} blocker signal${blockers.length === 1 ? "" : "s"}.${humanOperatorTime ? ` Operator time: ${humanOperatorTime.summary}.` : ""}`,
         180,
       ),
       newest_activity_at: newestActivityAt,
@@ -414,6 +430,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
       blockers,
     },
     profile_cards: profiles,
+    human_operator_time: humanOperatorTime,
     continuity_events: continuityEvents,
     library_snapshots: librarySnapshots,
     rolling_snapshot: rollingSnapshot,
@@ -425,10 +442,12 @@ function buildSeatHandshake({
   profiles,
   continuityEvents,
   rollingSnapshot,
+  humanOperatorTime,
 }: {
   profiles: OrchestratorProfileCard[];
   continuityEvents: OrchestratorContinuityEvent[];
   rollingSnapshot: OrchestratorRollingSnapshot;
+  humanOperatorTime: OrchestratorOperatorTimeContext | null;
 }): OrchestratorSeatHandshake {
   const usefulEvents = continuityEvents.filter((event) => !isSnapshotNoise(event));
   const recentProof = usefulEvents.find((event) => event.kind === "proof") ?? null;
@@ -467,8 +486,50 @@ function buildSeatHandshake({
     recent_proof: recentProof?.summary ?? null,
     active_blocker: blocker?.summary ?? null,
     seat_freshness: seatFreshness,
-    next_prompt: "Use this compact handoff, inspect source pointers only as needed, do one safe useful step, then reply PASS or BLOCKER.",
+    next_prompt: humanOperatorTime
+      ? `Use this compact handoff. Human operator local time is ${humanOperatorTime.summary}. Inspect source pointers only as needed, do one safe useful step, then reply PASS or BLOCKER.`
+      : "Use this compact handoff, inspect source pointers only as needed, do one safe useful step, then reply PASS or BLOCKER.",
     source_pointers: sourcePointers,
+  };
+}
+
+function buildOperatorTimeContext(
+  rows: OrchestratorBusinessContextRow[],
+  generatedAt: string,
+): OrchestratorOperatorTimeContext | null {
+  const row = rows.find((item) => item.category === "preference" && item.key === "operator_timezone");
+  if (!row) return null;
+  const value = parseBusinessContextValue(row.value);
+  const timezone = typeof value.timezone === "string" ? value.timezone.trim() : "";
+  if (!isValidTimeZone(timezone)) return null;
+
+  const source = value.source === "manual" || value.source === "browser" ? value.source : "unknown";
+  const date = new Date(generatedAt);
+  const localDate = formatInTimeZone(date, timezone, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const localTime = formatInTimeZone(date, timezone, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  const utcOffset = formatUtcOffset(date, timezone);
+  const summary = compactText(
+    `${localTime} on ${localDate} ${timezone}${utcOffset ? ` (${utcOffset})` : ""}${source === "manual" ? ", manual override" : ""}`,
+    180,
+  );
+
+  return {
+    timezone,
+    source,
+    local_date: localDate,
+    local_time: localTime,
+    utc_offset: utcOffset,
+    updated_at: row.updated_at ?? (typeof value.updated_at === "string" ? value.updated_at : null),
+    privacy: "timezone-only",
+    summary,
   };
 }
 
@@ -849,6 +910,60 @@ function prettifyAgentId(agentId: string): string {
     .replace(/[-_]+/g, " ")
     .replace(/\b\w/g, (match) => match.toUpperCase())
     .replace(/\bAi\b/g, "AI");
+}
+
+function parseBusinessContextValue(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function isValidTimeZone(timezone: string): boolean {
+  if (!timezone || timezone.length > 80) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatInTimeZone(
+  date: Date,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    ...options,
+    timeZone: timezone,
+  }).formatToParts(date);
+  const byType = new Map(parts.map((part) => [part.type, part.value]));
+  if (options.hour) {
+    return `${byType.get("hour") ?? "00"}:${byType.get("minute") ?? "00"}`;
+  }
+  return `${byType.get("year") ?? "0000"}-${byType.get("month") ?? "00"}-${byType.get("day") ?? "00"}`;
+}
+
+function formatUtcOffset(date: Date, timezone: string): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortOffset",
+    }).formatToParts(date);
+    const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+    return name ? name.replace(/^GMT/, "UTC") : null;
+  } catch {
+    return null;
+  }
 }
 
 function safeJson(value: unknown): string {

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -203,6 +203,68 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+type OperatorTimeSource = "browser" | "manual";
+
+interface OperatorTimeContextValue {
+  timezone: string;
+  source: OperatorTimeSource;
+  detected_at?: string | null;
+  manual_override_at?: string | null;
+  updated_at: string;
+  privacy: "timezone-only";
+}
+
+const OPERATOR_TIME_CATEGORY = "preference";
+const OPERATOR_TIME_KEY = "operator_timezone";
+
+function isValidTimeZoneName(timezone: string): boolean {
+  if (!timezone || timezone.length > 80) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseOperatorTimeValue(value: unknown, updatedAt?: string | null): OperatorTimeContextValue | null {
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!isRecord(parsed)) return null;
+  const timezone = typeof parsed.timezone === "string" ? parsed.timezone.trim() : "";
+  if (!isValidTimeZoneName(timezone)) return null;
+  const source = parsed.source === "manual" || parsed.source === "browser" ? parsed.source : "browser";
+  return {
+    timezone,
+    source,
+    detected_at: typeof parsed.detected_at === "string" ? parsed.detected_at : null,
+    manual_override_at: typeof parsed.manual_override_at === "string" ? parsed.manual_override_at : null,
+    updated_at: typeof parsed.updated_at === "string" ? parsed.updated_at : updatedAt ?? new Date().toISOString(),
+    privacy: "timezone-only",
+  };
+}
+
+async function readOperatorTimeContext(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+): Promise<OperatorTimeContextValue | null> {
+  const { data, error } = await supabase
+    .from("mc_business_context")
+    .select("value, updated_at")
+    .eq("api_key_hash", apiKeyHash)
+    .eq("category", OPERATOR_TIME_CATEGORY)
+    .eq("key", OPERATOR_TIME_KEY)
+    .maybeSingle();
+  if (error) throw error;
+  return data ? parseOperatorTimeValue(data.value, data.updated_at as string | null) : null;
+}
+
 const RELIABILITY_SOURCES = [
   "fishbowl",
   "connectors",
@@ -3746,11 +3808,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         // Look up an existing api_keys row for this user.
         let keyRow = (await supabase
           .from("api_keys")
-          .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
+          .select("id, key_hash, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
           .eq("user_id", user.id)
           .maybeSingle()).data as
           | {
               id: string;
+              key_hash: string | null;
               key_prefix: string | null;
               label: string | null;
               tier: string | null;
@@ -3784,7 +3847,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               is_active: true,
               usage_count: 0,
             })
-            .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
+            .select("id, key_hash, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
             .maybeSingle();
 
           if (insertRes.error) {
@@ -3792,7 +3855,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             // user_id), re-read instead of failing.
             const retry = await supabase
               .from("api_keys")
-              .select("id, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
+              .select("id, key_hash, key_prefix, label, tier, is_active, usage_count, last_used_at, created_at")
               .eq("user_id", user.id)
               .maybeSingle();
             keyRow = retry.data as typeof keyRow;
@@ -3827,6 +3890,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const isAdmin = user.email
           ? adminEmails.includes(user.email.toLowerCase())
           : false;
+        const operatorTime = keyRow?.key_hash
+          ? await readOperatorTimeContext(supabase, keyRow.key_hash)
+          : null;
 
         return res.status(200).json({
           user_id: user.id,
@@ -3837,7 +3903,61 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           generated_api_key: generatedApiKey,
           is_admin: isAdmin,
           memory_quota_exempt: isMemoryQuotaExemptEmail(user.email),
+          operator_time: operatorTime,
         });
+      }
+
+      case "operator_timezone_update": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+        const keyRow = (await supabase
+          .from("api_keys")
+          .select("key_hash")
+          .eq("user_id", user.id)
+          .maybeSingle()).data as { key_hash: string | null } | null;
+        if (!keyRow?.key_hash) {
+          return res.status(404).json({ error: "No active UnClick key found for this user" });
+        }
+
+        const timezone = String(req.body?.timezone ?? "").trim();
+        if (!isValidTimeZoneName(timezone)) {
+          return res.status(400).json({ error: "timezone must be a valid IANA timezone" });
+        }
+        const source: OperatorTimeSource = req.body?.source === "manual" ? "manual" : "browser";
+        const nowIso = new Date().toISOString();
+        const existing = await readOperatorTimeContext(supabase, keyRow.key_hash);
+        if (existing?.source === "manual" && source === "browser") {
+          return res.status(200).json({ success: true, operator_time: existing, manual_override_preserved: true });
+        }
+
+        const value: OperatorTimeContextValue = {
+          timezone,
+          source,
+          detected_at: source === "browser" ? nowIso : existing?.detected_at ?? null,
+          manual_override_at: source === "manual" ? nowIso : existing?.manual_override_at ?? null,
+          updated_at: nowIso,
+          privacy: "timezone-only",
+        };
+
+        const { error } = await supabase
+          .from("mc_business_context")
+          .upsert(
+            {
+              api_key_hash: keyRow.key_hash,
+              category: OPERATOR_TIME_CATEGORY,
+              key: OPERATOR_TIME_KEY,
+              value,
+              priority: 98,
+              decay_tier: "hot",
+              updated_at: nowIso,
+              last_accessed: nowIso,
+            },
+            { onConflict: "api_key_hash,category,key" },
+          );
+        if (error) throw error;
+        return res.status(200).json({ success: true, operator_time: value });
       }
 
       case "generate_api_key": {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -158,6 +158,45 @@ describe("orchestrator context", () => {
     expect(context.rolling_snapshot.source_pointers.some((pointer) => pointer.source_id === "todo-1")).toBe(true);
   });
 
+  it("adds human operator timezone context to compact handoffs", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-10T01:00:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [
+        {
+          id: "bc-timezone",
+          category: "preference",
+          key: "operator_timezone",
+          value: {
+            timezone: "Australia/Sydney",
+            source: "manual",
+            updated_at: "2026-05-10T00:50:00.000Z",
+            privacy: "timezone-only",
+          },
+          priority: 98,
+          updated_at: "2026-05-10T00:50:00.000Z",
+        },
+      ],
+      conversationTurns: [],
+    });
+
+    expect(context.human_operator_time?.timezone).toBe("Australia/Sydney");
+    expect(context.human_operator_time?.source).toBe("manual");
+    expect(context.human_operator_time?.local_date).toBe("2026-05-10");
+    expect(context.human_operator_time?.local_time).toBe("11:00");
+    expect(context.human_operator_time?.privacy).toBe("timezone-only");
+    expect(context.human_operator_time?.summary).toContain("manual override");
+    expect(context.seat_handshake.next_prompt).toContain("Human operator local time");
+    expect(context.seat_handshake.next_prompt).toContain("Australia/Sydney");
+  });
+
   it("labels profile-card check-in freshness for AI seats", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-09T12:00:00.000Z",

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -78,6 +78,16 @@ interface OrchestratorContext {
     current_status?: string | null;
     next_checkin_at?: string | null;
   }>;
+  human_operator_time?: {
+    timezone: string;
+    source: "browser" | "manual" | "unknown";
+    local_date: string;
+    local_time: string;
+    utc_offset: string | null;
+    updated_at?: string | null;
+    privacy: "timezone-only";
+    summary: string;
+  } | null;
   continuity_events: Array<{
     source_kind: string;
     source_id: string;
@@ -313,6 +323,25 @@ function OrchestratorContextCard({
       </div>
 
       <div className="mt-4 space-y-3">
+        {context.human_operator_time && (
+          <ContextSection title="Human Time" icon={Clock}>
+            <div className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs font-medium text-white/75">
+                  {context.human_operator_time.local_time}
+                </span>
+                <span className="text-[10px] text-white/35">
+                  {context.human_operator_time.source === "manual" ? "Manual" : "Browser"}
+                </span>
+              </div>
+              <p className="mt-1 text-[11px] leading-4 text-white/45">
+                {context.human_operator_time.local_date} {context.human_operator_time.timezone}
+                {context.human_operator_time.utc_offset ? ` ${context.human_operator_time.utc_offset}` : ""}
+              </p>
+            </div>
+          </ContextSection>
+        )}
+
         <ContextSection title="Next" icon={ArrowRight}>
           {state.next_actions.length > 0 ? (
             state.next_actions.slice(0, 4).map((action) => (

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -156,6 +156,17 @@ interface ProfileData {
   } | null;
 }
 
+type OperatorTimezoneSource = "browser" | "manual";
+
+interface OperatorTimeContext {
+  timezone: string;
+  source: OperatorTimezoneSource;
+  detected_at?: string | null;
+  manual_override_at?: string | null;
+  updated_at?: string | null;
+  privacy: "timezone-only";
+}
+
 function timeAgo(iso: string | null | undefined): string {
   if (!iso) return "never";
   const diff = Date.now() - new Date(iso).getTime();
@@ -166,6 +177,27 @@ function timeAgo(iso: string | null | undefined): string {
   if (hrs < 24) return `${hrs}h ago`;
   const days = Math.floor(hrs / 24);
   return `${days}d ago`;
+}
+
+function getBrowserTimezone(): string | null {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function formatOperatorLocalTime(timezone: string | null | undefined): string {
+  if (!timezone) return "Unknown";
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      timeZone: timezone,
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date());
+  } catch {
+    return "Invalid timezone";
+  }
 }
 
 export default function AdminYou() {
@@ -189,7 +221,16 @@ export default function AdminYou() {
   const revealTimerRef = useRef<number | null>(null);
   const [reissuing, setReissuing] = useState(false);
   const [reissueError, setReissueError] = useState<string | null>(null);
+  const [operatorTime, setOperatorTime] = useState<OperatorTimeContext | null>(null);
+  const [detectedTimezone, setDetectedTimezone] = useState<string | null>(null);
+  const [timezoneInput, setTimezoneInput] = useState("");
+  const [timezoneSaving, setTimezoneSaving] = useState(false);
+  const [timezoneError, setTimezoneError] = useState<string | null>(null);
+  const timezoneAutoSyncRef = useRef<string | null>(null);
 
+  useEffect(() => {
+    setDetectedTimezone(getBrowserTimezone());
+  }, []);
 
   useEffect(() => {
     // Wait for Supabase to confirm the session state before firing
@@ -214,6 +255,7 @@ export default function AdminYou() {
         if (!cancelled && profileRes.ok) {
           const body = (await profileRes.json()) as ProfileData & {
             generated_api_key?: string | null;
+            operator_time?: OperatorTimeContext | null;
           };
           setProfile({
             user_id:   body.user_id,
@@ -222,6 +264,8 @@ export default function AdminYou() {
             needs_key: body.needs_key,
             api_key:   body.api_key,
           });
+          setOperatorTime(body.operator_time ?? null);
+          setTimezoneInput(body.operator_time?.timezone ?? "");
           // Two paths land here.
           //
           // 1. Fresh auto-provision on first visit: the backend returns the
@@ -271,6 +315,16 @@ export default function AdminYou() {
 
     return () => { cancelled = true; };
   }, [session, sessionLoading]);
+
+  useEffect(() => {
+    if (sessionLoading || loading || !session || !detectedTimezone) return;
+    if (operatorTime?.source === "manual") return;
+    if (operatorTime?.timezone === detectedTimezone) return;
+    const syncKey = `${detectedTimezone}:${operatorTime?.timezone ?? "none"}:${operatorTime?.source ?? "none"}`;
+    if (timezoneAutoSyncRef.current === syncKey) return;
+    timezoneAutoSyncRef.current = syncKey;
+    void saveOperatorTimezone(detectedTimezone, "browser", { quiet: true });
+  }, [detectedTimezone, loading, operatorTime?.source, operatorTime?.timezone, session, sessionLoading]);
 
   // Re-mask the api_key 60 seconds after the user reveals it. The raw
   // value stays in generatedKey state (and in localStorage) so the user
@@ -328,6 +382,47 @@ export default function AdminYou() {
     }
   }
 
+  async function saveOperatorTimezone(
+    timezone: string,
+    source: OperatorTimezoneSource,
+    options: { quiet?: boolean } = {},
+  ) {
+    if (!session) return;
+    const trimmed = timezone.trim();
+    if (!trimmed) {
+      setTimezoneError("Enter a timezone like Australia/Sydney.");
+      return;
+    }
+    if (!options.quiet) setTimezoneSaving(true);
+    setTimezoneError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=operator_timezone_update", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ timezone: trimmed, source }),
+      });
+      const body = await res.json() as {
+        operator_time?: OperatorTimeContext;
+        error?: string;
+      };
+      if (!res.ok) {
+        setTimezoneError(body.error ?? "Could not save timezone.");
+        return;
+      }
+      if (body.operator_time) {
+        setOperatorTime(body.operator_time);
+        setTimezoneInput(body.operator_time.timezone);
+      }
+    } catch (e) {
+      setTimezoneError((e as Error).message);
+    } finally {
+      if (!options.quiet) setTimezoneSaving(false);
+    }
+  }
+
   async function handleLogout() {
     await signOut();
     navigate("/login", { replace: true });
@@ -352,6 +447,12 @@ export default function AdminYou() {
     provider === "azure" ? "Microsoft" :
     provider === "email" ? "Magic link" :
     provider;
+  const timezonePreview = formatOperatorLocalTime(operatorTime?.timezone ?? detectedTimezone);
+  const timezoneSourceLabel =
+    operatorTime?.source === "manual" ? "Manual override" :
+    operatorTime?.source === "browser" ? "Browser detected" :
+    detectedTimezone ? "Browser available" :
+    "Not detected";
 
   return (
     <div>
@@ -430,6 +531,65 @@ export default function AdminYou() {
               <LogOut className="h-4 w-4" />
               Sign out
             </button>
+          </div>
+
+          {/* Local time card */}
+          <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
+            <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+              <Clock className="h-4 w-4 text-[#E2B93B]" />
+              Local Time
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-[#888]">
+              Used by Orchestrator so AI seats understand your working hours. Only timezone context is saved.
+            </p>
+            <div className="mt-4 rounded-lg border border-white/[0.06] bg-white/[0.03] p-3">
+              <div className="flex items-center justify-between gap-3 text-sm">
+                <span className="text-[#888]">Current local time</span>
+                <span className="text-right text-xs font-semibold text-white">{timezonePreview}</span>
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-3 text-sm">
+                <span className="text-[#888]">Timezone</span>
+                <span className="text-right font-mono text-xs text-white">
+                  {operatorTime?.timezone ?? detectedTimezone ?? "Unknown"}
+                </span>
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-3 text-sm">
+                <span className="text-[#888]">Source</span>
+                <span className="text-right text-xs text-white">{timezoneSourceLabel}</span>
+              </div>
+            </div>
+            <div className="mt-4 space-y-2">
+              <label className="block text-[11px] font-semibold uppercase tracking-wider text-white/40">
+                Manual timezone
+              </label>
+              <input
+                value={timezoneInput}
+                onChange={(event) => setTimezoneInput(event.target.value)}
+                placeholder={detectedTimezone ?? "Australia/Sydney"}
+                className="w-full rounded-lg border border-white/[0.08] bg-black/20 px-3 py-2 font-mono text-xs text-white outline-none transition-colors placeholder:text-white/25 focus:border-[#61C1C4]/50"
+              />
+              {timezoneError && <p className="text-[11px] text-red-400">{timezoneError}</p>}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => saveOperatorTimezone(timezoneInput, "manual")}
+                  disabled={timezoneSaving || !timezoneInput.trim()}
+                  className="rounded-md bg-[#61C1C4] px-3 py-1.5 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:opacity-50"
+                >
+                  {timezoneSaving ? "Saving..." : "Save override"}
+                </button>
+                {detectedTimezone && (
+                  <button
+                    type="button"
+                    onClick={() => saveOperatorTimezone(detectedTimezone, "manual")}
+                    disabled={timezoneSaving}
+                    className="rounded-md border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/70 hover:bg-white/[0.08] disabled:opacity-50"
+                  >
+                    Use detected
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
 
           {/* AI Style card */}


### PR DESCRIPTION
## Summary
- Adds timezone-only human operator time context to the You profile and Orchestrator compact context.
- Auto-detects browser timezone, lets Chris save a manual override, and preserves manual overrides against browser auto updates.
- Surfaces the operator local time in the Orchestrator admin context card and seat handoff prompt.

## Scope
- Owned files: `api/memory-admin.ts`, `api/lib/orchestrator-context.ts`, `api/orchestrator-context.test.ts`, `src/pages/admin/AdminYou.tsx`, `src/pages/admin/AdminOrchestrator.tsx`.
- Linked todo: `6cbbf1a8-9577-4c15-bc1d-cf03aa135027`.
- Product lane: Orchestrator context and You profile.

## Non-overlap
- Does not store precise location.
- Does not add migrations, change secrets, or touch auth policy.
- Does not perform the final Fleet Watch to PinballWake proof or parent card reconciliation.

## Verification
- `npm run test -- api/orchestrator-context.test.ts`
- `npm run build`
- `git diff --check` reports only existing CRLF working-copy warnings.

## Risk
- Adds one `mc_business_context` preference row, `operator_timezone`, scoped to the existing API key hash.
- Manual override wins over browser auto-detect.
- Timezone is stored as an IANA timezone string only.

## Follow-up
- Run the final post-d182594 Fleet Watch to PinballWake scheduled chain proof.
- Reconcile Orchestrator parent cards `b1334cae` and `2d31e79c` after final proof.

Draft PR: yes.
