### PR TITLE
[codex] Tune heartbeat progress summary prompt

### DIFF
--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -14,6 +14,8 @@ describe("AdminSeatHeartbeatPage", () => {
     expect(screen.getByLabelText("Public default heartbeat policy")).toHaveValue(HEARTBEAT_MASTER_PROMPT);
     expect(screen.getByLabelText("Short schedule message")).toHaveValue(HEARTBEAT_CONNECTION_PROMPT);
     expect(HEARTBEAT_CONNECTION_PROMPT).toContain("Run UnClick Heartbeat");
+    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("brief progress summary");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("include a brief progress summary");
     expect(HEARTBEAT_CONNECTION_PROMPT.length).toBeLessThan(HEARTBEAT_MASTER_PROMPT.length / 3);
   });
 });

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -7,13 +7,13 @@ Use UnClick as the source of truth first. Load memory and search active jobs whe
 
 Pick one clear, safe, useful live task. Do the smallest meaningful step. For code work: use a fresh branch, focused tests, a PR, and wait for checks. Use production state only when the task already requires it. Never print secrets. Clean up temporary rows, leases, proof agents, and one-time schedules.
 
-Output one line only. Do not repeat this prompt.
+Output one short line only. Do not repeat this prompt. Do not reply with only "tick", "PASS", or "BLOCKER"; include a brief progress summary.
 PASS: <changed>; proof: <link/id>; cleanup: done.
-BLOCKER: <safe reason>; next: <fix>.
-If no safe task is available: BLOCKER: no clear safe task available; next: add a scoped job.`;
+BLOCKER: <safe reason>; progress: <what was checked>; next: <fix>.
+If no safe task is available: BLOCKER: no clear safe task available; progress: checked live queue; next: add a scoped job.`;
 
 export const HEARTBEAT_CONNECTION_PROMPT =
-  "Run UnClick Heartbeat. Use the Seats > Heartbeat policy, do one safe useful step, and reply with PASS or BLOCKER only.";
+  "Run UnClick Heartbeat. Use the Seats > Heartbeat policy, do one safe useful step, and reply with PASS/BLOCKER plus a brief progress summary.";
 
 export default function AdminSeatHeartbeatPage() {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
## Summary
- Tune the Seats > Heartbeat public default policy so heartbeat replies include a brief progress summary.
- Update the short schedule message to ask for PASS/BLOCKER plus a brief progress summary.
- Add regression coverage for the summary wording.

## Checks
- npx vitest run src/pages/admin/AdminSeatHeartbeat.test.tsx
- npx eslint src/pages/admin/AdminSeatHeartbeat.tsx src/pages/admin/AdminSeatHeartbeat.test.tsx
- git diff --check
- npm run build
