### PR TITLE
Add AutoPilotKit scheduler fallback gate

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -56,6 +56,7 @@ jobs:
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule')
         env:
           AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF: "true"
+          AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF_SOURCE: ${{ github.event_name == 'workflow_run' && 'workflow_run_schedule' || 'github_schedule' }}
           AUTONOMOUS_RUNNER_TODO_LIMIT: ${{ vars.AUTONOMOUS_RUNNER_TODO_LIMIT || '10' }}
           UNCLICK_MCP_URL: ${{ vars.UNCLICK_MCP_URL || 'https://unclick.world/api/mcp' }}
           UNCLICK_API_KEY: ${{ secrets.UNCLICK_API_KEY || secrets.FISHBOWL_AUTOCLOSE_TOKEN || secrets.FISHBOWL_WAKE_TOKEN }}

--- a/scripts/autopilotkit-liveness.test.mjs
+++ b/scripts/autopilotkit-liveness.test.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  evaluateAutoPilotKitSchedulerWatchdog,
   evaluateAutoPilotKitLiveness,
+  evaluateOrchestratorProofWakeGate,
   extractMissedAckSignals,
   normalizeSeatLiveness,
   parseMs,
@@ -72,5 +74,61 @@ describe("AutoPilotKit liveness helpers", () => {
 
     assert.equal(signals.length, 1);
     assert.equal(signals[0].excerpt, "[redacted-sensitive-text]");
+  });
+
+  it("turns stale scheduler evidence plus a fresh UnClick heartbeat into a safe fallback tap", () => {
+    const result = evaluateAutoPilotKitSchedulerWatchdog({
+      now: "2026-05-10T03:46:57.000Z",
+      expectedEveryMinutes: 15,
+      graceMinutes: 15,
+      trustedFallbackFreshMinutes: 10,
+      schedules: [
+        {
+          id: "fleet-throughput-watch",
+          name: "Fleet Throughput Watch",
+          last_scheduled_at: "2026-05-10T01:24:03.000Z",
+        },
+      ],
+      trustedFallback: {
+        source: "unclick_heartbeat",
+        source_id: "heartbeat-03-46",
+        created_at: "2026-05-10T03:46:00.000Z",
+      },
+    });
+
+    assert.equal(result.action, "tap_orchestrator_with_trusted_unclick_fallback");
+    assert.equal(result.reason, "schedule_stale_trusted_fallback_fresh");
+    assert.deepEqual(result.stale_schedule_ids, ["fleet-throughput-watch"]);
+    assert.equal(result.trusted_fallback.trusted, true);
+    assert.equal(result.safe_mode.no_manual_dispatch_as_schedule, true);
+  });
+
+  it("keeps fresh schedules in watch mode", () => {
+    const result = evaluateAutoPilotKitSchedulerWatchdog({
+      now: "2026-05-10T03:46:57.000Z",
+      expectedEveryMinutes: 15,
+      graceMinutes: 15,
+      schedules: [
+        {
+          id: "pinballwake",
+          last_scheduled_at: "2026-05-10T03:37:00.000Z",
+        },
+      ],
+    });
+
+    assert.equal(result.action, "watch");
+    assert.equal(result.reason, "schedules_fresh");
+    assert.deepEqual(result.stale_schedule_ids, []);
+  });
+
+  it("does not let manual workflow dispatch masquerade as scheduled Orchestrator proof", () => {
+    const gate = evaluateOrchestratorProofWakeGate({
+      now: "2026-05-10T03:46:57.000Z",
+      source: "workflow_dispatch",
+    });
+
+    assert.equal(gate.allow, false);
+    assert.equal(gate.reason, "manual_dispatch_is_not_scheduled_proof");
+    assert.equal(gate.safe_mode.no_manual_dispatch_as_schedule, true);
   });
 });

--- a/scripts/lib/autopilotkit-liveness.mjs
+++ b/scripts/lib/autopilotkit-liveness.mjs
@@ -2,10 +2,32 @@ const DEFAULT_ACTIVE_MS = 15 * 60 * 1000;
 const DEFAULT_WARM_MS = 60 * 60 * 1000;
 const DEFAULT_DORMANT_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_COORDINATOR_FALLBACK_MS = 2 * 60 * 60 * 1000;
+const DEFAULT_SCHEDULER_GRACE_MS = 15 * 60 * 1000;
+const DEFAULT_SCHEDULER_INTERVAL_MS = 15 * 60 * 1000;
+const DEFAULT_TRUSTED_FALLBACK_FRESH_MS = 10 * 60 * 1000;
 
 const SENSITIVE_KEY_RE = /(api[_-]?key|secret|token|password|credential|authorization|cookie)/i;
 const SENSITIVE_TEXT_RE =
   /(authorization:\s*bearer\s+\S+|uc_[a-f0-9]{16,}|sk-[a-z0-9_-]{12,}|gh[pousr]_[a-z0-9_]{20,})/i;
+const SCHEDULED_PROOF_SOURCES = new Set([
+  "schedule",
+  "scheduled",
+  "github_schedule",
+  "github_schedule_chain",
+  "workflow_run_schedule",
+]);
+const MANUAL_PROOF_SOURCES = new Set(["manual", "workflow_dispatch", "dispatch", "queuepush"]);
+const TRUSTED_UNCLICK_FALLBACK_SOURCES = new Set([
+  "unclick",
+  "unclick_heartbeat",
+  "unclick-heartbeat",
+  "unclick_chat_chain",
+  "unclick-chat-chain",
+  "unclick_seat_heartbeat",
+  "unclick-seat-heartbeat",
+  "boardroom_heartbeat",
+  "boardroom-heartbeat",
+]);
 
 function safeList(value) {
   return Array.isArray(value) ? value : [];
@@ -13,6 +35,10 @@ function safeList(value) {
 
 function normalize(value) {
   return String(value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function normalizeToken(value) {
+  return normalize(value).replace(/[\s-]+/g, "_");
 }
 
 export function sanitizeAdvisoryText(value, max = 500) {
@@ -35,6 +61,10 @@ export function parseMs(value) {
 function ageMs(nowMs, value) {
   const parsed = parseMs(value);
   return parsed === null ? null : Math.max(0, nowMs - parsed);
+}
+
+function isoFromMs(value) {
+  return Number.isFinite(value) ? new Date(value).toISOString() : null;
 }
 
 function minutes(value) {
@@ -248,5 +278,214 @@ export function evaluateAutoPilotKitLiveness(input = {}) {
   return {
     ...result,
     adapter_examples: buildAutoPilotKitAdapterExamples(result),
+  };
+}
+
+function normalizeSchedulerSchedule(schedule = {}, nowMs, defaults = {}) {
+  const lastRunAt =
+    schedule.last_scheduled_at ||
+    schedule.lastScheduledAt ||
+    schedule.last_success_at ||
+    schedule.lastSuccessAt ||
+    schedule.last_run_at ||
+    schedule.lastRunAt ||
+    "";
+  const lastRunMs = parseMs(lastRunAt);
+  const expectedMs =
+    Number.isFinite(schedule.expectedEveryMs) ? schedule.expectedEveryMs :
+    Number.isFinite(schedule.expected_every_ms) ? schedule.expected_every_ms :
+    Number.isFinite(schedule.expectedEveryMinutes) ? schedule.expectedEveryMinutes * 60 * 1000 :
+    Number.isFinite(schedule.expected_every_minutes) ? schedule.expected_every_minutes * 60 * 1000 :
+    defaults.expectedEveryMs;
+  const graceMs =
+    Number.isFinite(schedule.graceMs) ? schedule.graceMs :
+    Number.isFinite(schedule.grace_ms) ? schedule.grace_ms :
+    Number.isFinite(schedule.graceMinutes) ? schedule.graceMinutes * 60 * 1000 :
+    Number.isFinite(schedule.grace_minutes) ? schedule.grace_minutes * 60 * 1000 :
+    defaults.graceMs;
+  const dueMs = lastRunMs === null ? null : lastRunMs + expectedMs + graceMs;
+  const lastRunAgeMs = lastRunMs === null ? null : Math.max(0, nowMs - lastRunMs);
+  const stale = dueMs === null ? false : dueMs < nowMs;
+  const missing = lastRunMs === null;
+
+  return {
+    id: sanitizeAdvisoryText(schedule.id || schedule.name || "schedule", 120),
+    name: sanitizeAdvisoryText(schedule.name || schedule.id || "schedule", 160),
+    required: schedule.required !== false,
+    last_scheduled_at: lastRunMs === null ? null : new Date(lastRunMs).toISOString(),
+    last_scheduled_age_minutes: minutes(lastRunAgeMs),
+    expected_every_minutes: minutes(expectedMs),
+    grace_minutes: minutes(graceMs),
+    stale_after: isoFromMs(dueMs),
+    stale,
+    missing,
+  };
+}
+
+function normalizeTrustedFallbackSignal(input = {}, nowMs, freshnessMs) {
+  const source = input.source || input.source_kind || input.sourceKind || input.kind || "";
+  const createdAt = input.created_at || input.createdAt || input.at || "";
+  const createdAtMs = parseMs(createdAt);
+  const age = createdAtMs === null ? null : Math.max(0, nowMs - createdAtMs);
+  const sourceToken = normalizeToken(source);
+
+  return {
+    source: sanitizeAdvisoryText(source, 120),
+    source_token: sourceToken,
+    source_id: sanitizeAdvisoryText(input.source_id || input.sourceId || input.id || "", 160) || null,
+    created_at: createdAtMs === null ? null : new Date(createdAtMs).toISOString(),
+    age_minutes: minutes(age),
+    trusted: TRUSTED_UNCLICK_FALLBACK_SOURCES.has(sourceToken),
+    fresh: age !== null && age <= freshnessMs,
+  };
+}
+
+export function evaluateAutoPilotKitSchedulerWatchdog(input = {}) {
+  const now = input.now || new Date().toISOString();
+  const nowMs = parseMs(now);
+  if (nowMs === null) {
+    throw new Error(`Invalid now timestamp: ${now}`);
+  }
+
+  const defaults = {
+    expectedEveryMs: Number.isFinite(input.expectedEveryMs)
+      ? input.expectedEveryMs
+      : Number.isFinite(input.expectedEveryMinutes)
+        ? input.expectedEveryMinutes * 60 * 1000
+        : DEFAULT_SCHEDULER_INTERVAL_MS,
+    graceMs: Number.isFinite(input.graceMs)
+      ? input.graceMs
+      : Number.isFinite(input.graceMinutes)
+        ? input.graceMinutes * 60 * 1000
+        : DEFAULT_SCHEDULER_GRACE_MS,
+  };
+  const freshnessMs = Number.isFinite(input.trustedFallbackFreshMs)
+    ? input.trustedFallbackFreshMs
+    : Number.isFinite(input.trustedFallbackFreshMinutes)
+      ? input.trustedFallbackFreshMinutes * 60 * 1000
+      : DEFAULT_TRUSTED_FALLBACK_FRESH_MS;
+  const schedules = safeList(input.schedules).map((schedule) =>
+    normalizeSchedulerSchedule(schedule, nowMs, defaults),
+  );
+  const requiredSchedules = schedules.filter((schedule) => schedule.required);
+  const staleSchedules = requiredSchedules.filter((schedule) => schedule.stale);
+  const missingSchedules = requiredSchedules.filter((schedule) => schedule.missing);
+  const fallback = normalizeTrustedFallbackSignal(input.trustedFallback || input.trusted_fallback || {}, nowMs, freshnessMs);
+  const canTap = staleSchedules.length > 0 && missingSchedules.length === 0 && fallback.trusted && fallback.fresh;
+  const healthy = requiredSchedules.length > 0 && staleSchedules.length === 0 && missingSchedules.length === 0;
+
+  let action = "blocker";
+  let reason = "missing_schedule_evidence";
+  if (healthy) {
+    action = "watch";
+    reason = "schedules_fresh";
+  } else if (canTap) {
+    action = "tap_orchestrator_with_trusted_unclick_fallback";
+    reason = "schedule_stale_trusted_fallback_fresh";
+  } else if (staleSchedules.length > 0 && !fallback.trusted) {
+    reason = "schedule_stale_missing_trusted_fallback";
+  } else if (staleSchedules.length > 0 && !fallback.fresh) {
+    reason = "schedule_stale_fallback_not_fresh";
+  }
+
+  return {
+    generated_at: now,
+    action,
+    reason,
+    schedules,
+    stale_schedule_ids: staleSchedules.map((schedule) => schedule.id),
+    missing_schedule_ids: missingSchedules.map((schedule) => schedule.id),
+    trusted_fallback: fallback,
+    safe_mode: {
+      read_only: true,
+      no_secret_access: true,
+      no_manual_dispatch_as_schedule: true,
+    },
+  };
+}
+
+export function evaluateOrchestratorProofWakeGate(input = {}) {
+  const source = normalizeToken(input.source || input.proofSource || input.proof_source || "");
+  if (!source) {
+    return {
+      allow: true,
+      proof_source: "legacy_unlabeled",
+      reason: "legacy_unlabeled_proof_source",
+      safe_mode: {
+        read_only: true,
+        no_secret_access: true,
+        no_manual_dispatch_as_schedule: true,
+      },
+    };
+  }
+
+  if (SCHEDULED_PROOF_SOURCES.has(source)) {
+    return {
+      allow: true,
+      proof_source: source,
+      reason: "scheduled_proof_source",
+      safe_mode: {
+        read_only: true,
+        no_secret_access: true,
+        no_manual_dispatch_as_schedule: true,
+      },
+    };
+  }
+
+  if (MANUAL_PROOF_SOURCES.has(source)) {
+    return {
+      allow: false,
+      proof_source: source,
+      reason: "manual_dispatch_is_not_scheduled_proof",
+      next_action: "use a scheduled run or the trusted UnClick fallback gate",
+      safe_mode: {
+        read_only: true,
+        no_secret_access: true,
+        no_manual_dispatch_as_schedule: true,
+      },
+    };
+  }
+
+  if (source !== "trusted_unclick_fallback" && source !== "unclick_heartbeat_fallback") {
+    return {
+      allow: false,
+      proof_source: source,
+      reason: "unknown_orchestrator_proof_source",
+      next_action: "use github_schedule or trusted_unclick_fallback",
+      safe_mode: {
+        read_only: true,
+        no_secret_access: true,
+        no_manual_dispatch_as_schedule: true,
+      },
+    };
+  }
+
+  const watchdog = evaluateAutoPilotKitSchedulerWatchdog({
+    now: input.now,
+    expectedEveryMinutes: input.expectedEveryMinutes ?? 15,
+    graceMinutes: input.graceMinutes ?? 15,
+    trustedFallbackFreshMinutes: input.trustedFallbackFreshMinutes ?? 10,
+    schedules: [
+      {
+        id: "orchestrator_scheduled_proof",
+        name: "Orchestrator scheduled proof",
+        last_scheduled_at: input.lastScheduledProofAt || input.last_scheduled_proof_at || "",
+      },
+    ],
+    trustedFallback: {
+      source: input.trustedFallbackSource || input.trusted_fallback_source || "",
+      created_at: input.trustedFallbackAt || input.trusted_fallback_at || "",
+      source_id: input.trustedFallbackId || input.trusted_fallback_id || "",
+    },
+  });
+
+  const allow = watchdog.action === "tap_orchestrator_with_trusted_unclick_fallback";
+  return {
+    allow,
+    proof_source: "trusted_unclick_fallback",
+    reason: allow ? "trusted_unclick_fallback_due" : watchdog.reason,
+    next_action: allow ? "run read-only Orchestrator proof" : "wait for a scheduled proof or a fresh trusted UnClick fallback signal",
+    scheduler_watchdog: watchdog,
+    safe_mode: watchdog.safe_mode,
   };
 }

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -14,6 +14,7 @@ import {
   createCodingRoomRunnerFromEnv,
   runCodingRoomRunnerCycle,
 } from "./pinballwake-coding-room-runner.mjs";
+import { evaluateOrchestratorProofWakeGate } from "./lib/autopilotkit-liveness.mjs";
 
 export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
 
@@ -504,7 +505,45 @@ export async function runOrchestratorSeatHandshakeProof({
   apiKey = "",
   limit = 80,
   fetchImpl = globalThis.fetch,
+  now = new Date().toISOString(),
+  proofSource = "",
+  lastScheduledProofAt = "",
+  trustedFallbackSource = "",
+  trustedFallbackAt = "",
+  trustedFallbackId = "",
+  expectedEveryMinutes = 15,
+  graceMinutes = 15,
+  trustedFallbackFreshMinutes = 10,
 } = {}) {
+  const gate = evaluateOrchestratorProofWakeGate({
+    now,
+    source: proofSource,
+    lastScheduledProofAt,
+    trustedFallbackSource,
+    trustedFallbackAt,
+    trustedFallbackId,
+    expectedEveryMinutes,
+    graceMinutes,
+    trustedFallbackFreshMinutes,
+  });
+  if (!gate.allow) {
+    return {
+      ok: false,
+      action: "blocked",
+      mode: "orchestrator-proof",
+      reason: gate.reason,
+      proof_line: `BLOCKER: ${gate.reason}; next: ${gate.next_action}.`,
+      orchestrator_proof: {
+        ok: false,
+        result: "BLOCKER",
+        reason: gate.reason,
+        proof_source: gate.proof_source,
+        wake_gate: gate,
+      },
+      wake_gate: gate,
+    };
+  }
+
   const fetched = await fetchUnClickOrchestratorContext({ mcpUrl, apiKey, limit, fetchImpl });
   if (!fetched.ok) {
     return {
@@ -515,6 +554,7 @@ export async function runOrchestratorSeatHandshakeProof({
       status: fetched.status ?? null,
       proof_line: `BLOCKER: ${fetched.reason}; next: make orchestrator_context_read available to PinballWake.`,
       orchestrator_proof: fetched,
+      wake_gate: gate,
     };
   }
 
@@ -526,6 +566,7 @@ export async function runOrchestratorSeatHandshakeProof({
     reason: proof.reason,
     proof_line: proof.proof_line,
     orchestrator_proof: proof,
+    wake_gate: gate,
   };
 }
 
@@ -1216,6 +1257,14 @@ export async function runAutonomousRunnerFile({
   leaseSeconds,
   wakeSource = "unknown",
   orchestratorProof = false,
+  orchestratorProofSource = "",
+  lastScheduledProofAt = "",
+  trustedFallbackSource = "",
+  trustedFallbackAt = "",
+  trustedFallbackId = "",
+  proofExpectedEveryMinutes = 15,
+  proofGraceMinutes = 15,
+  trustedFallbackFreshMinutes = 10,
 } = {}) {
   if (orchestratorProof) {
     return runOrchestratorSeatHandshakeProof({
@@ -1223,6 +1272,15 @@ export async function runAutonomousRunnerFile({
       apiKey: unclickApiKey,
       limit: todoLimit,
       fetchImpl,
+      now,
+      proofSource: orchestratorProofSource,
+      lastScheduledProofAt,
+      trustedFallbackSource,
+      trustedFallbackAt,
+      trustedFallbackId,
+      expectedEveryMinutes: proofExpectedEveryMinutes,
+      graceMinutes: proofGraceMinutes,
+      trustedFallbackFreshMinutes,
     });
   }
 
@@ -1400,6 +1458,38 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
     leaseSeconds: parseIntOption(getArg("lease-seconds", process.env.CODING_ROOM_LEASE_SECONDS), undefined),
     wakeSource: getArg("wake-source", process.env.AUTONOMOUS_RUNNER_WAKE_SOURCE || process.env.GITHUB_EVENT_NAME || "unknown"),
     orchestratorProof: parseBoolean(getArg("orchestrator-proof", process.env.AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF)),
+    orchestratorProofSource: getArg(
+      "orchestrator-proof-source",
+      process.env.AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF_SOURCE || process.env.GITHUB_EVENT_NAME || "",
+    ),
+    lastScheduledProofAt: getArg(
+      "last-scheduled-proof-at",
+      process.env.AUTONOMOUS_RUNNER_LAST_SCHEDULED_PROOF_AT || "",
+    ),
+    trustedFallbackSource: getArg(
+      "trusted-fallback-source",
+      process.env.AUTONOMOUS_RUNNER_TRUSTED_FALLBACK_SOURCE || "",
+    ),
+    trustedFallbackAt: getArg(
+      "trusted-fallback-at",
+      process.env.AUTONOMOUS_RUNNER_TRUSTED_FALLBACK_AT || "",
+    ),
+    trustedFallbackId: getArg(
+      "trusted-fallback-id",
+      process.env.AUTONOMOUS_RUNNER_TRUSTED_FALLBACK_ID || "",
+    ),
+    proofExpectedEveryMinutes: parseIntOption(
+      getArg("proof-expected-every-minutes", process.env.AUTONOMOUS_RUNNER_PROOF_EXPECTED_EVERY_MINUTES),
+      15,
+    ),
+    proofGraceMinutes: parseIntOption(
+      getArg("proof-grace-minutes", process.env.AUTONOMOUS_RUNNER_PROOF_GRACE_MINUTES),
+      15,
+    ),
+    trustedFallbackFreshMinutes: parseIntOption(
+      getArg("trusted-fallback-fresh-minutes", process.env.AUTONOMOUS_RUNNER_TRUSTED_FALLBACK_FRESH_MINUTES),
+      10,
+    ),
     policy: createAutonomousRunnerPolicy({
       disabled: parseBoolean(process.env.AUTONOMOUS_RUNNER_DISABLED),
       allowProtectedSurfaces: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES),

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -464,6 +464,7 @@ describe("PinballWake autonomous Runner seat", () => {
     const calls = [];
     const result = await runAutonomousRunnerFile({
       orchestratorProof: true,
+      orchestratorProofSource: "github_schedule",
       unclickApiKey: "uc_test",
       unclickMcpUrl: "https://unclick.test/api/mcp",
       fetchImpl: async (url, init = {}) => {
@@ -497,6 +498,68 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.action, "orchestrator_proof_passed");
     assert.match(result.proof_line, /^PASS: Orchestrator seat_handshake readable/);
     assert.equal(result.orchestrator_proof.source_pointer_count, 1);
+    assert.equal(result.wake_gate.reason, "scheduled_proof_source");
+  });
+
+  it("blocks workflow_dispatch from counting as Orchestrator scheduled proof", async () => {
+    let called = false;
+    const result = await runAutonomousRunnerFile({
+      orchestratorProof: true,
+      orchestratorProofSource: "workflow_dispatch",
+      unclickApiKey: "uc_test",
+      unclickMcpUrl: "https://unclick.test/api/mcp",
+      fetchImpl: async () => {
+        called = true;
+        return { ok: false };
+      },
+    });
+
+    assert.equal(called, false);
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "manual_dispatch_is_not_scheduled_proof");
+    assert.match(result.proof_line, /^BLOCKER: manual_dispatch_is_not_scheduled_proof/);
+    assert.equal(result.wake_gate.safe_mode.no_manual_dispatch_as_schedule, true);
+  });
+
+  it("allows a trusted UnClick fallback proof only when the schedule is stale and the heartbeat is fresh", async () => {
+    const calls = [];
+    const result = await runAutonomousRunnerFile({
+      orchestratorProof: true,
+      orchestratorProofSource: "trusted_unclick_fallback",
+      lastScheduledProofAt: "2026-05-10T01:24:03.000Z",
+      trustedFallbackSource: "unclick_heartbeat",
+      trustedFallbackAt: "2026-05-10T03:46:00.000Z",
+      trustedFallbackId: "heartbeat-03-46",
+      now: "2026-05-10T03:46:57.000Z",
+      unclickApiKey: "uc_test",
+      unclickMcpUrl: "https://unclick.test/api/mcp",
+      fetchImpl: async (url, init = {}) => {
+        calls.push({ url, body: JSON.parse(init.body) });
+        return {
+          ok: true,
+          async json() {
+            return {
+              context: {
+                seat_handshake: {
+                  mode: "fresh-seat-pickup",
+                  active_decision: "Use trusted UnClick fallback if the schedule misses.",
+                  active_job: "Orchestrator proof via AutoPilotKit fallback.",
+                  recent_proof: "PASS: heartbeat fallback gate opened.",
+                  active_blocker: null,
+                  seat_freshness: ["PinballWake: Live"],
+                  source_pointers: [{ source_kind: "boardroom_message", source_id: "heartbeat-03-46" }],
+                },
+              },
+            };
+          },
+        };
+      },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(result.ok, true);
+    assert.equal(result.wake_gate.reason, "trusted_unclick_fallback_due");
+    assert.equal(result.wake_gate.scheduler_watchdog.action, "tap_orchestrator_with_trusted_unclick_fallback");
   });
 
   it("blocks empty or noisy Orchestrator seat_handshake proof packets", async () => {
@@ -1171,6 +1234,7 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_run' && github\.event\.workflow_run\.event == 'schedule'\)/);
     assert.doesNotMatch(workflow, /if:\s*github\.event_name == 'workflow_run'\s*$/m);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF:\s*"true"/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF_SOURCE:.*workflow_run_schedule.*github_schedule/);
     assert.match(workflow, /node scripts\/pinballwake-autonomous-runner\.mjs/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_QUEUE_SOURCE:.*'unclick'/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_WAKE_SOURCE:.*queuepush/);


### PR DESCRIPTION
## Summary
- add an AutoPilotKit scheduler watchdog that uses UTC timestamps to detect stale schedule proof
- add a trusted UnClick heartbeat fallback gate for read-only Orchestrator proof
- keep manual workflow_dispatch blocked from counting as scheduled proof

## Tests
- node --test scripts/autopilotkit-liveness.test.mjs
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npx eslint scripts/lib/autopilotkit-liveness.mjs scripts/pinballwake-autonomous-runner.mjs scripts/autopilotkit-liveness.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check
- npm run build

UnClick chip: 50aa0491-b6f7-4651-bb20-eb2d33274cfe