### PR TITLE
Restore Orchestrator active decision handoff

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -638,6 +638,9 @@ function uniqueSourcePointers(items: OrchestratorRollingSnapshotItem[]): Orchest
 function isSnapshotNoise(event: OrchestratorContinuityEvent): boolean {
   const summary = event.summary.toLowerCase();
   const tags = (event.tags ?? []).map((tag) => tag.toLowerCase());
+  if (event.kind === "decision" && !tags.includes("heartbeat")) {
+    return false;
+  }
   if (event.kind === "proof" && !tags.includes("heartbeat") && !summary.startsWith("heartbeat result:")) {
     return false;
   }
@@ -791,16 +794,44 @@ function signalToEvent(signal: OrchestratorSignalRow): OrchestratorContinuityEve
 }
 
 function sessionToEvent(session: OrchestratorSessionRow): OrchestratorContinuityEvent {
+  const decisionSummary = sessionDecisionSummary(session.decisions);
+  const summary = decisionSummary
+    ? compactText(`Decision memory: ${decisionSummary}. Session: ${session.summary}`, 240)
+    : compactText(session.summary, 240);
+
   return {
     source_kind: "session_summary",
     source_id: session.session_id,
     deep_link: `/admin/memory?session_id=${encodeURIComponent(session.session_id)}`,
     created_at: session.created_at,
-    kind: "context",
+    kind: decisionSummary ? "decision" : "context",
     role: session.platform ?? null,
-    summary: compactText(session.summary, 240),
+    summary,
     tags: ["session", ...(session.topics ?? []).slice(0, 4)],
   };
+}
+
+function sessionDecisionSummary(decisions: unknown): string {
+  const values = Array.isArray(decisions)
+    ? decisions
+    : typeof decisions === "string" && decisions.trim().startsWith("[")
+      ? parseJsonArray(decisions)
+      : [];
+
+  return values
+    .map((value) => compactText(typeof value === "string" ? value : safeJson(value), 140))
+    .filter(Boolean)
+    .slice(0, 3)
+    .join("; ");
+}
+
+function parseJsonArray(value: string): unknown[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 }
 
 function conversationTurnToEvent(turn: OrchestratorConversationTurnRow): OrchestratorContinuityEvent {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -438,4 +438,57 @@ describe("orchestrator context", () => {
       expect.arrayContaining(["msg-decision", "todo-orchestrator-proof", "msg-proof", "signal-blocker"]),
     );
   });
+
+  it("uses saved session decisions when recent boardroom chatter has no decision event", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-10T04:15:00.000Z",
+      profiles: [],
+      messages: [
+        {
+          id: "msg-proof",
+          author_agent_id: "pinballwake-autonomous-runner",
+          text: "PASS: AutoPilotKit fallback gate shipped; proof: PR #659.",
+          tags: ["proof"],
+          created_at: "2026-05-10T04:00:00.000Z",
+        },
+      ],
+      todos: [
+        {
+          id: "todo-active",
+          title: "Orchestrator scheduled proof",
+          description: "Keep compact handoff proof readable.",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "chatgpt-codex-seat",
+          created_at: "2026-05-10T03:50:00.000Z",
+          updated_at: "2026-05-10T04:10:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [
+        {
+          id: "session-row",
+          session_id: "session-orchestrator-fallback",
+          platform: "codex",
+          summary: "AutoPilotKit scheduler fallback shipped and awaits scheduled proof.",
+          decisions: [
+            "Use UTC for proof math and allow trusted UnClick heartbeat fallback only when GitHub schedule evidence is stale.",
+          ],
+          topics: ["orchestrator", "autopilotkit"],
+          created_at: "2026-05-10T04:01:00.000Z",
+        },
+      ],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.rolling_snapshot.promoted_decisions[0].source_id).toBe("session-orchestrator-fallback");
+    expect(context.seat_handshake.active_decision).toContain("Use UTC for proof math");
+    expect(context.seat_handshake.source_pointers.map((pointer) => pointer.source_id)).toEqual(
+      expect.arrayContaining(["session-orchestrator-fallback", "todo-active", "msg-proof"]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- keep legitimate decision events that mention heartbeat from being filtered as snapshot noise
- promote saved session decisions into Orchestrator continuity so `seat_handshake.active_decision` stays populated
- add focused coverage for scheduled proof context with no recent boardroom decision event

## Tests
- npx vitest run api/orchestrator-context.test.ts
- npx eslint api/lib/orchestrator-context.ts api/orchestrator-context.test.ts
- git diff --check

UnClick chip: a6c556b4-e6ed-47fa-93f8-98190899c900