### PR TITLE
fix(memory): keep orchestrator handoff decision populated

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -454,6 +454,15 @@ function buildSeatHandshake({
   const decision = rollingSnapshot.promoted_decisions[0] ?? null;
   const job = rollingSnapshot.active_jobs[0] ?? null;
   const blocker = rollingSnapshot.active_blockers[0] ?? null;
+  const activeDecision =
+    decision?.summary ??
+    (job
+      ? `Continue current priority job: ${job.summary}`
+      : recentProof
+        ? `Continue from latest proof: ${recentProof.summary}`
+        : blocker
+          ? `Resolve current blocker: ${blocker.summary}`
+          : null);
   const seatFreshness = profiles
     .slice(0, 6)
     .map((profile) => `${profile.label}: ${profile.freshness_label}`)
@@ -472,7 +481,7 @@ function buildSeatHandshake({
     mode: "fresh-seat-pickup",
     summary: compactText(
       [
-        decision ? `Decision: ${decision.summary}` : "",
+        activeDecision ? `Decision: ${activeDecision}` : "",
         job ? `Job: ${job.summary}` : "",
         recentProof ? `Proof: ${recentProof.summary}` : "",
         blocker ? `Blocker: ${blocker.summary}` : "",
@@ -481,7 +490,7 @@ function buildSeatHandshake({
         .join(" "),
       320,
     ),
-    active_decision: decision?.summary ?? null,
+    active_decision: activeDecision,
     active_job: job?.summary ?? null,
     recent_proof: recentProof?.summary ?? null,
     active_blocker: blocker?.summary ?? null,

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -344,6 +344,66 @@ describe("orchestrator context", () => {
     expect(context.rolling_snapshot.source_pointers.some((pointer) => pointer.source_id === "turn-heartbeat")).toBe(false);
   });
 
+  it("keeps fresh-seat active_decision populated from active work when no decision event is live", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-10T04:16:00.000Z",
+      profiles: [
+        {
+          agent_id: "pinballwake-autonomous-runner",
+          display_name: "PinballWake",
+          user_agent_hint: "github-action scheduled heartbeat",
+          last_seen_at: "2026-05-10T04:14:00.000Z",
+        },
+      ],
+      messages: [
+        {
+          id: "msg-noise",
+          author_agent_id: "heartbeat-seat",
+          text: "DONT_NOTIFY: quiet-status heartbeat, no user action needed.",
+          tags: ["heartbeat"],
+          created_at: "2026-05-10T04:15:00.000Z",
+        },
+      ],
+      todos: [
+        {
+          id: "todo-orchestrator-finish-line",
+          title: "Orchestrator finish line proof",
+          description: "Get a scheduled proof green after the trusted fallback merge.",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "codex",
+          created_at: "2026-05-10T03:40:00.000Z",
+          updated_at: "2026-05-10T04:10:00.000Z",
+        },
+      ],
+      comments: [
+        {
+          id: "comment-trusted-fallback-proof",
+          target_kind: "todo",
+          target_id: "todo-orchestrator-finish-line",
+          author_agent_id: "chatgpt-codex-worker2",
+          text: "PASS: trusted fallback gate shipped; proof: PR #659; cleanup: done.",
+          created_at: "2026-05-10T04:12:00.000Z",
+        },
+      ],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.rolling_snapshot.promoted_decisions).toHaveLength(0);
+    expect(context.seat_handshake.active_decision).toContain("Continue current priority job");
+    expect(context.seat_handshake.active_decision).toContain("Orchestrator finish line proof");
+    expect(context.seat_handshake.active_job).toContain("Orchestrator finish line proof");
+    expect(context.seat_handshake.recent_proof).toContain("trusted fallback gate shipped");
+    expect(context.seat_handshake.source_pointers.map((pointer) => pointer.source_id)).toEqual(
+      expect.arrayContaining(["todo-orchestrator-finish-line", "comment-trusted-fallback-proof"]),
+    );
+  });
+
   it("builds a fresh-seat handshake from compact rolling context only", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-10T00:20:00.000Z",


### PR DESCRIPTION
Summary:
- Keeps Orchestrator fresh-seat handoff `active_decision` populated from the active priority job, latest proof, or blocker when no explicit decision event survives compacting.
- Adds a regression test for the scheduled proof failure mode where heartbeat noise is present but the active Orchestrator job is enough context to continue.

Scope:
- Owned files: `api/lib/orchestrator-context.ts`, `api/orchestrator-context.test.ts`.
- Lane: Orchestrator compact context and scheduled proof reliability.

Non-overlap:
- Does not change proof trust policy, scheduled trigger rules, secrets handling, or GitHub workflow configuration.
- Does not close or downgrade parent Orchestrator cards yet; that still waits on a fresh scheduled proof pass.

Verification:
- `npm run test -- api/orchestrator-context.test.ts`
- `npm run build`
- `npx eslint api/lib/orchestrator-context.ts api/orchestrator-context.test.ts`
- `git diff --check`
- `npm run lint` was attempted and remains blocked by existing repo-wide lint errors outside this PR.

Risk:
- Low. Read-only context shaping only. No database migration, auth, secrets, cron, or workflow mutation.

Follow-up:
- After this reaches main, wait for the next scheduled PinballWake proof and then reconcile Orchestrator parent cards `b1334cae` and `2d31e79c`.