### PR TITLE
Allow trusted chat messages for Orchestrator fallback

### DIFF
--- a/scripts/autopilotkit-liveness.test.mjs
+++ b/scripts/autopilotkit-liveness.test.mjs
@@ -103,6 +103,26 @@ describe("AutoPilotKit liveness helpers", () => {
     assert.equal(result.safe_mode.no_manual_dispatch_as_schedule, true);
   });
 
+  it("turns stale scheduler evidence plus a fresh trusted chat message into a safe fallback tap", () => {
+    const gate = evaluateOrchestratorProofWakeGate({
+      now: "2026-05-10T05:03:59.000Z",
+      source: "trusted_unclick_fallback",
+      lastScheduledProofAt: "2026-05-10T04:09:24.000Z",
+      trustedFallbackSource: "trusted_chat_message",
+      trustedFallbackAt: "2026-05-10T05:03:20.000Z",
+      trustedFallbackId: "chat-message-fallback-probe-1",
+      expectedEveryMinutes: 1,
+      graceMinutes: 0,
+      trustedFallbackFreshMinutes: 2,
+    });
+
+    assert.equal(gate.allow, true);
+    assert.equal(gate.reason, "trusted_unclick_fallback_due");
+    assert.equal(gate.scheduler_watchdog.trusted_fallback.source_token, "trusted_chat_message");
+    assert.equal(gate.scheduler_watchdog.trusted_fallback.trusted, true);
+    assert.equal(gate.safe_mode.no_manual_dispatch_as_schedule, true);
+  });
+
   it("keeps fresh schedules in watch mode", () => {
     const result = evaluateAutoPilotKitSchedulerWatchdog({
       now: "2026-05-10T03:46:57.000Z",

--- a/scripts/lib/autopilotkit-liveness.mjs
+++ b/scripts/lib/autopilotkit-liveness.mjs
@@ -27,6 +27,10 @@ const TRUSTED_UNCLICK_FALLBACK_SOURCES = new Set([
   "unclick-seat-heartbeat",
   "boardroom_heartbeat",
   "boardroom-heartbeat",
+  "trusted_chat_message",
+  "trusted-chat-message",
+  "chat_message_pulse",
+  "chat-message-pulse",
 ]);
 
 function safeList(value) {


### PR DESCRIPTION
## Summary
- allow trusted chat-message pulse sources as safe Orchestrator fallback evidence
- add a focused AutoPilotKit liveness test for stale schedule plus fresh trusted_chat_message
- keep manual workflow_dispatch rejection covered by the existing guard test

## Test
- node --test scripts/autopilotkit-liveness.test.mjs

UnClick Job: 12fad7c1-8bdb-4462-8e8e-833e6226dd9d