### PR TITLE
Promote Orchestrator to root admin nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,10 +184,11 @@ const App = () => (
             <Route path="crews/runs"          element={<CrewsRuns />} />
             <Route path="crews/runs/:runId"  element={<CrewRun />} />
             <Route path="crews/settings"      element={<CrewsSettings />} />
+            {/* End-user visible read-only continuity surface */}
+            <Route path="orchestrator"   element={<AdminOrchestratorPage />} />
             {/* Admin-only surfaces (wrapped in RequireAdmin; also hidden from non-admin sidebar) */}
             <Route path="analytics"      element={<RequireAdmin><AdminAnalytics /></RequireAdmin>} />
             <Route path="codebase"       element={<RequireAdmin><AdminCodebase /></RequireAdmin>} />
-            <Route path="orchestrator"   element={<RequireAdmin><AdminOrchestratorPage /></RequireAdmin>} />
             <Route path="users"          element={<RequireAdmin><AdminUsers /></RequireAdmin>} />
             <Route path="system-health"  element={<RequireAdmin><AdminSystemHealth /></RequireAdmin>} />
             <Route path="pinballwake"    element={<RequireAdmin><AdminPinballWake /></RequireAdmin>} />

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -152,7 +152,6 @@ function AutopilotNavGroup({ onLinkClick }: { onLinkClick?: () => void }) {
 const ADMIN_SUBMENU = [
   { path: "/admin/analytics",     label: "Analytics",             icon: BarChart3   },
   { path: "/admin/codebase",      label: "Codebase",              icon: Code2       },
-  { path: "/admin/orchestrator",  label: "Orchestrator",          icon: Terminal    },
   { path: "/admin/users",         label: "User Management",       icon: UsersIcon   },
   { path: "/admin/system-health", label: "System Health",         icon: HeartPulse  },
   { path: "/admin/pinballwake",   label: "PinballWake",           icon: BellRing    },
@@ -305,6 +304,7 @@ function SidebarNav({
       <SurfaceLink path="/admin/dashboard" label="Dashboard"               icon={LayoutDashboard} onClick={onLinkClick} />
       <SurfaceLink path="/admin/you"      label="You"                      icon={User}    onClick={onLinkClick} />
       <MemoryNavItem onClick={onLinkClick} />
+      <SurfaceLink path="/admin/orchestrator" label="Orchestrator"          icon={Terminal} onClick={onLinkClick} />
       <SurfaceLink path="/admin/tools"    label="Apps"                     icon={AppWindow} onClick={onLinkClick} />
       <SurfaceLink path="/admin/keychain" label="Passport"                 icon={KeyRound} onClick={onLinkClick} />
       <SeatsNavItem onClick={onLinkClick} />


### PR DESCRIPTION
## Summary
- move Orchestrator out of the hidden Admin accordion and into the root admin sidebar near Memory
- make the Orchestrator route available to signed-in users instead of wrapping the whole page in RequireAdmin
- keep other admin-only surfaces gated as before

## Test
- npx eslint src/pages/admin/AdminShell.tsx src/App.tsx
- git diff --check
- npm run build

Closes UnClick todo: 4735c034-97b4-4cb2-bf88-be2907cb5634