### PR TITLE
Allow Orchestrator chat with session auth

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -1689,22 +1689,28 @@ function buildAdminChatTools(supabase: SupabaseClient, apiKeyHash: string | null
   };
 }
 
-async function buildAdminChatSystemPrompt(supabase: SupabaseClient): Promise<string> {
+async function buildAdminChatSystemPrompt(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+): Promise<string> {
   const [bcRes, sessRes, factsRes] = await Promise.all([
     supabase
-      .from("business_context")
+      .from("mc_business_context")
       .select("category, key, value, priority")
+      .eq("api_key_hash", apiKeyHash)
       .in("decay_tier", ["hot", "warm"])
       .order("priority", { ascending: false })
       .limit(40),
     supabase
-      .from("session_summaries")
+      .from("mc_session_summaries")
       .select("session_id, platform, summary, topics, created_at")
+      .eq("api_key_hash", apiKeyHash)
       .order("created_at", { ascending: false })
       .limit(5),
     supabase
-      .from("extracted_facts")
+      .from("mc_extracted_facts")
       .select("fact, category, confidence")
+      .eq("api_key_hash", apiKeyHash)
       .eq("status", "active")
       .in("decay_tier", ["hot", "warm"])
       .order("confidence", { ascending: false })
@@ -5952,10 +5958,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(400).json({ error: "messages array is required" });
         }
 
-        const rawApiKey = (body?.api_key ?? bearerFrom(req)).trim();
-        const apiKeyHash = rawApiKey ? sha256hex(rawApiKey) : null;
+        const rawApiKey = (body?.api_key ?? "").trim();
+        const apiKeyHash =
+          (await resolveApiKeyHash(req, supabaseUrl, supabaseKey)) ||
+          (rawApiKey ? sha256hex(rawApiKey) : null);
+        if (!apiKeyHash) {
+          return res.status(401).json({ error: "Authorization header required" });
+        }
 
-        const systemPrompt = await buildAdminChatSystemPrompt(supabase);
+        const systemPrompt = await buildAdminChatSystemPrompt(supabase, apiKeyHash);
         const tools = buildAdminChatTools(supabase, apiKeyHash, req);
 
         const modelMessages = await convertToModelMessages(messages);

--- a/src/components/admin/AIChatPanel.test.tsx
+++ b/src/components/admin/AIChatPanel.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AIChatPanel from "./AIChatPanel";
+
+describe("AIChatPanel auth", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          channel_active: false,
+          last_seen: null,
+          client_info: null,
+        }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it("uses the signed-in session token when no raw API key is saved", async () => {
+    render(<AIChatPanel authToken="session-jwt-token" />);
+
+    expect(screen.queryByText("Sign in to use the Orchestrator chat.")).not.toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Ask your agent anything. Connect Claude Code for a free bridge via your own session.",
+      ),
+    ).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/memory-admin?action=admin_channel_status",
+      {
+        headers: { Authorization: "Bearer session-jwt-token" },
+      },
+    );
+  });
+
+  it("still asks the user to sign in when neither session nor API key is available", () => {
+    render(<AIChatPanel />);
+
+    expect(screen.getByText("Sign in to use the Orchestrator chat.")).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/AIChatPanel.tsx
+++ b/src/components/admin/AIChatPanel.tsx
@@ -29,8 +29,12 @@ interface PendingNotice {
   message: string;
 }
 
-export default function AIChatPanel() {
-  const [apiKey, setApiKey] = useState<string>("");
+interface AIChatPanelProps {
+  authToken?: string;
+}
+
+export default function AIChatPanel({ authToken = "" }: AIChatPanelProps) {
+  const [storedApiKey, setStoredApiKey] = useState<string>("");
   const [sessionId, setSessionId] = useState<string>("");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState<string>("");
@@ -42,10 +46,14 @@ export default function AIChatPanel() {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const channelActive = channelInfo?.channel_active === true;
+  const effectiveAuthToken = authToken || storedApiKey;
+  const rawApiKey = storedApiKey.startsWith("uc_") || storedApiKey.startsWith("agt_")
+    ? storedApiKey
+    : "";
 
   useEffect(() => {
     try {
-      setApiKey(localStorage.getItem(API_KEY_STORAGE) ?? "");
+      setStoredApiKey(localStorage.getItem(API_KEY_STORAGE) ?? "");
       const existing = localStorage.getItem(SESSION_STORAGE_KEY);
       if (existing) {
         setSessionId(existing);
@@ -61,10 +69,10 @@ export default function AIChatPanel() {
 
   // ── Channel presence polling ─────────────────────────────────────────────
   const checkChannel = useCallback(async () => {
-    if (!apiKey) return;
+    if (!effectiveAuthToken) return;
     try {
       const res = await fetch("/api/memory-admin?action=admin_channel_status", {
-        headers: { Authorization: `Bearer ${apiKey}` },
+        headers: { Authorization: `Bearer ${effectiveAuthToken}` },
       });
       if (!res.ok) return;
       const data = (await res.json()) as ChannelStatus;
@@ -90,14 +98,14 @@ export default function AIChatPanel() {
     } catch {
       // network hiccup, ignore
     }
-  }, [apiKey]);
+  }, [effectiveAuthToken]);
 
   useEffect(() => {
-    if (!apiKey) return;
+    if (!effectiveAuthToken) return;
     checkChannel();
     const id = window.setInterval(checkChannel, CHANNEL_STATUS_POLL_MS);
     return () => window.clearInterval(id);
-  }, [apiKey, checkChannel]);
+  }, [effectiveAuthToken, checkChannel]);
 
   // ── Scroll on new messages ───────────────────────────────────────────────
   useEffect(() => {
@@ -118,7 +126,7 @@ export default function AIChatPanel() {
           after: afterIso,
         }).toString();
         const res = await fetch(`/api/memory-admin?${qs}`, {
-          headers: { Authorization: `Bearer ${apiKey}` },
+          headers: { Authorization: `Bearer ${effectiveAuthToken}` },
         });
         if (!res.ok) continue;
         const body = (await res.json()) as { data: ChatMessage[] };
@@ -136,7 +144,7 @@ export default function AIChatPanel() {
   // ── Send ─────────────────────────────────────────────────────────────────
   async function handleSend() {
     const text = input.trim();
-    if (!text || sending || !apiKey || !sessionId) return;
+    if (!text || sending || !effectiveAuthToken || !sessionId) return;
     setSending(true);
     setInput("");
 
@@ -155,7 +163,7 @@ export default function AIChatPanel() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${apiKey}`,
+            Authorization: `Bearer ${effectiveAuthToken}`,
           },
           body: JSON.stringify({ session_id: sessionId, content: text }),
         });
@@ -193,9 +201,12 @@ export default function AIChatPanel() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${apiKey}`,
+            Authorization: `Bearer ${effectiveAuthToken}`,
           },
-          body: JSON.stringify({ messages: uiMessages, api_key: apiKey }),
+          body: JSON.stringify({
+            messages: uiMessages,
+            ...(rawApiKey ? { api_key: rawApiKey } : {}),
+          }),
         });
 
         if (!res.ok) {
@@ -313,10 +324,10 @@ export default function AIChatPanel() {
     };
   }, [channelActive]);
 
-  if (!apiKey) {
+  if (!effectiveAuthToken) {
     return (
       <div className="rounded-xl border border-border/40 bg-card/20 p-6 text-xs text-muted-foreground">
-        Sign in with your UnClick API key to use the admin chat.
+        Sign in to use the Orchestrator chat.
       </div>
     );
   }

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -239,7 +239,7 @@ export default function AdminOrchestratorPage() {
               {chatDisabledReason}
             </div>
           ) : (
-            <AIChatPanel />
+            <AIChatPanel authToken={authToken} />
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- let Orchestrator's chat panel use the signed-in session token instead of requiring localStorage.unclick_api_key
- keep raw UnClick API keys as a fallback for older/local setups
- resolve admin_ai_chat tenant scope from the Authorization session/API key instead of hashing session JWTs
- scope the admin chat memory snapshot to the resolved tenant
- add a focused component test for signed-in users without a saved local API key

Closes UnClick todo: 83fc16d6-564c-4076-b5b9-653334c0780e

## Tests
- npx eslint src/components/admin/AIChatPanel.tsx src/components/admin/AIChatPanel.test.tsx src/pages/admin/AdminOrchestrator.tsx api/memory-admin.ts
- npx vitest run src/components/admin/AIChatPanel.test.tsx
- git diff --check
- npm run build