### PR TITLE
Add Orchestrator easy-read filtering

### DIFF
--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -17,6 +17,7 @@ import {
 import { useSession } from "@/lib/auth";
 import Comments from "./fishbowl/Comments";
 import { buildJobGithubSyncSignal, type JobGithubSyncSignal } from "./jobsGithubSync";
+import { highlightSearchText } from "./searchHighlight";
 
 interface FishbowlProfile {
   agent_id: string;
@@ -135,9 +136,9 @@ function trimSentence(value: string, maxChars: number): string {
 
 function stripNoisyLead(value: string): string {
   return value
-    .replace(/^\s*(urgent|bug|fix|feat|chore|docs|test|refactor|experiment|blocked|blocker)\s*[:\-]\s*/i, "")
+    .replace(/^\s*(urgent|bug|fix|feat|chore|docs|test|refactor|experiment|blocked|blocker)\s*[:-]\s*/i, "")
     .replace(/^\s*(fix|feat|chore|docs|test|refactor)\([^)]+\)\s*:\s*/i, "")
-    .replace(/^\s*(pr|pull request)\s*#?\d+\s*[:\-]\s*/i, "")
+    .replace(/^\s*(pr|pull request)\s*#?\d+\s*[:-]\s*/i, "")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -592,6 +593,7 @@ function JobRow({
   onDragStart,
   onDragEnd,
   onDrop,
+  searchQuery,
 }: {
   todo: JobTodo;
   queueRank: number;
@@ -603,6 +605,7 @@ function JobRow({
   onDragStart: (id: string) => void;
   onDragEnd: () => void;
   onDrop: (id: string) => void;
+  searchQuery: string;
 }) {
   const attention = needsAttention(todo);
   const description = todo.description?.trim();
@@ -676,10 +679,10 @@ function JobRow({
           title={todo.title}
         >
           <p className={`truncate text-[11px] font-semibold leading-4 hover:text-white ${todo.status === "done" ? "text-white/35 line-through" : "text-white/85"}`}>
-            {displayCopy.title}
+            {highlightSearchText(displayCopy.title, searchQuery)}
           </p>
           <p className="truncate text-[10px] leading-4 text-white/35">
-            {displayCopy.summary}
+            {highlightSearchText(displayCopy.summary, searchQuery)}
           </p>
         </div>
 
@@ -699,7 +702,7 @@ function JobRow({
               {emoji ?? "AI"}
             </span>
             <span className="max-w-[130px] truncate" title={ownerLabel(todo)}>
-              {ownerLabel(todo)}
+              {highlightSearchText(ownerLabel(todo), searchQuery)}
             </span>
           </span>
           <span className="flex items-center gap-1 text-[11px] text-white/45">
@@ -784,16 +787,16 @@ function JobRow({
               </button>
             </div>
             <div className="mt-2 space-y-1.5">
-              <p className="text-xs font-medium text-white/70">{displayCopy.title}</p>
-              <p className="text-xs leading-5 text-white/50">{displayCopy.context}</p>
+              <p className="text-xs font-medium text-white/70">{highlightSearchText(displayCopy.title, searchQuery)}</p>
+              <p className="text-xs leading-5 text-white/50">{highlightSearchText(displayCopy.context, searchQuery)}</p>
             </div>
             {showDetails && (
               <div className="mt-3 rounded-[5px] border border-white/[0.05] bg-black/20 p-2">
                 <p className="text-[10px] uppercase tracking-wide text-white/25">Original source</p>
-                <p className="mt-1 text-xs font-medium leading-5 text-white/60">{todo.title}</p>
+                <p className="mt-1 text-xs font-medium leading-5 text-white/60">{highlightSearchText(todo.title, searchQuery)}</p>
                 {description ? (
                   <p className="mt-2 whitespace-pre-wrap text-xs leading-5 text-white/45">
-                    {description}
+                    {highlightSearchText(description, searchQuery)}
                   </p>
                 ) : (
                   <p className="mt-2 text-xs italic text-white/30">No original description.</p>
@@ -854,6 +857,7 @@ function JobSection({
   hasMoreRemote,
   showMoreLoading,
   loading,
+  searchQuery,
 }: {
   sectionKey: JobSectionKey;
   jobs: JobTodo[];
@@ -870,6 +874,7 @@ function JobSection({
   hasMoreRemote?: boolean;
   showMoreLoading?: boolean;
   loading?: boolean;
+  searchQuery: string;
 }) {
   const [draggedId, setDraggedId] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("queue");
@@ -976,6 +981,7 @@ function JobSection({
                 }
                 setDraggedId(null);
               }}
+              searchQuery={searchQuery}
             />
           ))}
           {canShowMore && (
@@ -1305,6 +1311,7 @@ export default function AdminJobs() {
           onToggleSection={() => toggleSection("active")}
           onShowMore={() => showMore("active")}
           loading={initialLoading}
+          searchQuery={searchQuery}
         />
         <JobSection
           sectionKey="next"
@@ -1320,6 +1327,7 @@ export default function AdminJobs() {
           onToggleSection={() => toggleSection("next")}
           onShowMore={() => showMore("next")}
           loading={initialLoading}
+          searchQuery={searchQuery}
         />
         <JobSection
           sectionKey="inline"
@@ -1335,6 +1343,7 @@ export default function AdminJobs() {
           onToggleSection={() => toggleSection("inline")}
           onShowMore={() => showMore("inline")}
           loading={initialLoading}
+          searchQuery={searchQuery}
         />
         <JobSection
           sectionKey="done"
@@ -1352,6 +1361,7 @@ export default function AdminJobs() {
           hasMoreRemote={!completedHistoryLoaded}
           showMoreLoading={completedHistoryLoading}
           loading={initialLoading}
+          searchQuery={searchQuery}
         />
       </div>
 

--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AdminOrchestratorPage from "./AdminOrchestrator";
@@ -13,6 +13,7 @@ vi.mock("@/lib/auth", () => ({
 
 describe("AdminOrchestratorPage", () => {
   beforeEach(() => {
+    localStorage.clear();
     vi.stubEnv("VITE_AI_CHAT_ENABLED", "true");
     vi.stubGlobal(
       "fetch",
@@ -126,6 +127,10 @@ describe("AdminOrchestratorPage", () => {
     );
 
     expect(await screen.findByText("Continuity Feed")).toBeInTheDocument();
+    expect(screen.getByLabelText("Easy reading for humans")).toBeChecked();
+    expect(screen.getByLabelText("Dripfeed Education")).toBeChecked();
+    expect(screen.getByLabelText("Analogies")).toBeChecked();
+    expect(screen.getByPlaceholderText("Filter Orchestrator feed")).toBeInTheDocument();
     expect(
       (await screen.findAllByText("user: Orchestrator context should show subscription messages."))
         .length,
@@ -135,5 +140,20 @@ describe("AdminOrchestratorPage", () => {
     expect(screen.getAllByText("Human").length).toBeGreaterThan(0);
     expect(screen.queryByPlaceholderText("Message the AI assistant...")).not.toBeInTheDocument();
     expect(screen.queryByText("Using AI Assistant")).not.toBeInTheDocument();
+  });
+
+  it("filters the Orchestrator feed as the user types", async () => {
+    render(
+      <MemoryRouter>
+        <AdminOrchestratorPage />
+      </MemoryRouter>,
+    );
+
+    const filter = await screen.findByPlaceholderText("Filter Orchestrator feed");
+    fireEvent.change(filter, { target: { value: "proof" } });
+
+    expect(screen.getByText("1 of 2 events match")).toBeInTheDocument();
+    expect(screen.getAllByText(/Orchestrator continuity proof landed/i).length).toBeGreaterThan(0);
+    expect(document.querySelector("mark")?.textContent?.toLowerCase()).toContain("proof");
   });
 });

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -23,6 +23,7 @@ import {
   ShieldCheck,
   Users,
   MessageSquareText,
+  X,
 } from "lucide-react";
 import {
   aiChatEnvEnabled,
@@ -31,6 +32,7 @@ import {
   type ChannelStatus,
 } from "@/components/admin/aiChatConfig";
 import { useSession } from "@/lib/auth";
+import { highlightSearchText } from "./searchHighlight";
 
 interface MemoryStats {
   business_context?: number;
@@ -137,6 +139,10 @@ const ACTOR_TONE_STYLES: Record<ActorTone, string> = {
   work: "border-[#8EC5FF]/25 bg-[#8EC5FF]/10 text-[#8EC5FF]",
 };
 
+const EASY_READ_STORAGE_KEY = "unclick_orchestrator_easy_read_v1";
+const DRIPFEED_EDUCATION_STORAGE_KEY = "unclick_orchestrator_dripfeed_education_v1";
+const ANALOGY_STORAGE_KEY = "unclick_orchestrator_analogy_v1";
+
 function formatRelative(iso: string | null | undefined): string {
   if (!iso) return "never";
   const ts = new Date(iso).getTime();
@@ -148,6 +154,38 @@ function formatRelative(iso: string | null | undefined): string {
   if (hrs < 24) return `${hrs}h ago`;
   const days = Math.floor(hrs / 24);
   return `${days}d ago`;
+}
+
+function formatAbsolute(iso: string | null | undefined): string {
+  if (!iso) return "No date";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "No date";
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(date);
+}
+
+function normalizeSearch(value: string): string {
+  return value.toLowerCase().trim().replace(/\s+/g, " ");
+}
+
+function compactSearch(value: string): string {
+  return normalizeSearch(value).replace(/[\s:_-]+/g, "");
+}
+
+function isSubsequence(needle: string, haystack: string): boolean {
+  if (!needle) return true;
+  let index = 0;
+  for (const char of haystack) {
+    if (char === needle[index]) index += 1;
+    if (index === needle.length) return true;
+  }
+  return false;
 }
 
 function buildProfileLookup(profiles: OrchestratorProfileCard[] | undefined): Map<string, OrchestratorProfileCard> {
@@ -216,6 +254,148 @@ function actorIdentityForEvent(
     };
   }
   return sourceFallbackIdentity(event);
+}
+
+function easyReadForEvent(event: OrchestratorContinuityEvent, actor: ActorIdentity): string {
+  const summary = event.summary.trim();
+  if (/^PASS:/i.test(summary)) {
+    return `${actor.emoji} ${actor.label} made progress. ${summary.replace(/^PASS:\s*/i, "")}`;
+  }
+  if (/^BLOCKER:/i.test(summary)) {
+    return `Needs help: ${actor.label} hit a blocker. ${summary.replace(/^BLOCKER:\s*/i, "")}`;
+  }
+  if (event.kind === "proof") {
+    return `${actor.emoji} ${actor.label} posted proof. ${summary}`;
+  }
+  if (event.kind === "decision" || event.tags?.includes("decision")) {
+    return `${actor.emoji} Decision from ${actor.label}: ${summary}`;
+  }
+  if (event.source_kind === "todo") {
+    return `Job update: ${summary}`;
+  }
+  if (event.source_kind === "signal") {
+    return `Signal to notice: ${summary}`;
+  }
+  if (event.role === "user") {
+    return `Chris said: ${summary.replace(/^user:\s*/i, "")}`;
+  }
+  if (event.role === "assistant") {
+    return `AI replied: ${summary.replace(/^assistant:\s*/i, "")}`;
+  }
+  return `${actor.emoji} ${actor.label}: ${summary}`;
+}
+
+function educationHintForEvent(event: OrchestratorContinuityEvent): string {
+  if (/^PASS:/i.test(event.summary)) {
+    return "Hint: PASS means something useful moved forward and there should be proof nearby.";
+  }
+  if (/^BLOCKER:/i.test(event.summary)) {
+    return "Hint: BLOCKER means a seat stopped safely instead of guessing.";
+  }
+  if (event.kind === "proof") {
+    return "Hint: proof is the receipt that tells you why a change can be trusted.";
+  }
+  if (event.kind === "decision" || event.tags?.includes("decision")) {
+    return "Hint: decision means this should guide future seats until Chris changes it.";
+  }
+  if (event.source_kind === "signal") {
+    return "Hint: signals are attention lights. They point to things worth checking.";
+  }
+  if (event.source_kind === "todo") {
+    return "Hint: jobs are the work cards seats can claim, prove, and close.";
+  }
+  if (event.source_kind === "boardroom_message") {
+    return "Hint: Boardroom is where seats leave short shared work updates.";
+  }
+  if (event.source_kind === "conversation_turn") {
+    return "Hint: chat turns are context breadcrumbs from the human or AI conversation.";
+  }
+  return "Hint: keywords like proof, blocker, decision, and signal tell Orchestrator what kind of update this is.";
+}
+
+function analogyForEvent(event: OrchestratorContinuityEvent): string {
+  if (/^PASS:/i.test(event.summary) || event.kind === "proof") {
+    return "Analogy: like a worker leaving a signed receipt after finishing a small job.";
+  }
+  if (/^BLOCKER:/i.test(event.summary) || event.source_kind === "signal") {
+    return "Analogy: like a warning light on the dashboard asking for a quick look.";
+  }
+  if (event.kind === "decision" || event.tags?.includes("decision")) {
+    return "Analogy: like putting a sticky note on the control panel so everyone steers the same way.";
+  }
+  if (event.source_kind === "todo") {
+    return "Analogy: like a card on the work board moving from waiting to doing to done.";
+  }
+  if (event.source_kind === "conversation_turn") {
+    return "Analogy: like adding a fresh line to the shared notebook everyone reads from.";
+  }
+  return "Analogy: like one more breadcrumb in the trail Orchestrator follows.";
+}
+
+function shouldShowDrip(index: number, event: OrchestratorContinuityEvent): boolean {
+  return index === 0 || event.kind === "decision" || event.kind === "proof" || /^BLOCKER:/i.test(event.summary) || index % 4 === 0;
+}
+
+function readStoredBoolean(key: string, defaultValue: boolean): boolean {
+  try {
+    const saved = localStorage.getItem(key);
+    return saved ? saved === "true" : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+function writeStoredBoolean(key: string, value: boolean) {
+  try {
+    localStorage.setItem(key, String(value));
+  } catch {
+    // Local storage can be unavailable in private browsing; the UI still works for this session.
+  }
+}
+
+function eventSearchText(
+  event: OrchestratorContinuityEvent,
+  actor: ActorIdentity,
+  absoluteDate: string,
+): string {
+  return [
+    actor.emoji,
+    actor.label,
+    actor.detail,
+    event.kind,
+    event.source_kind,
+    event.actor_agent_id,
+    event.role,
+    event.summary,
+    easyReadForEvent(event, actor),
+    educationHintForEvent(event),
+    analogyForEvent(event),
+    absoluteDate,
+    ...(event.tags ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function matchesEventSearch(
+  event: OrchestratorContinuityEvent,
+  actor: ActorIdentity,
+  query: string,
+): boolean {
+  const normalizedQuery = normalizeSearch(query);
+  if (!normalizedQuery) return true;
+
+  const text = normalizeSearch(eventSearchText(event, actor, formatAbsolute(event.created_at)));
+  const compactText = text.replace(/\s+/g, "");
+  const words = text.split(/\s+/).filter(Boolean);
+
+  return normalizedQuery.split(/\s+/).every((token) => {
+    const compactToken = compactSearch(token);
+    if (!compactToken) return true;
+    if (text.includes(token)) return true;
+    if (compactText.includes(compactToken)) return true;
+    return words.some((word) => word.startsWith(token) || word.includes(token) || isSubsequence(compactToken, word));
+  });
 }
 
 export default function AdminOrchestratorPage() {
@@ -355,11 +535,55 @@ function OrchestratorContinuityPanel({
   loading: boolean;
   chatStatusLabel: string;
 }) {
-  const events = context?.continuity_events ?? [];
+  const events = useMemo(
+    () => context?.continuity_events ?? [],
+    [context?.continuity_events],
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+  const [easyRead, setEasyRead] = useState(() => readStoredBoolean(EASY_READ_STORAGE_KEY, true));
+  const [dripfeedEducation, setDripfeedEducation] = useState(() =>
+    readStoredBoolean(DRIPFEED_EDUCATION_STORAGE_KEY, true),
+  );
+  const [analogies, setAnalogies] = useState(() => readStoredBoolean(ANALOGY_STORAGE_KEY, true));
   const profileByAgentId = useMemo(
     () => buildProfileLookup(context?.profile_cards),
     [context?.profile_cards],
   );
+  const eventViews = useMemo(
+    () =>
+      events.map((event, index) => {
+        const actor = actorIdentityForEvent(event, profileByAgentId);
+        const absoluteDate = formatAbsolute(event.created_at);
+        return {
+          event,
+          actor,
+          index,
+          absoluteDate,
+          easySummary: easyReadForEvent(event, actor),
+        };
+      }),
+    [events, profileByAgentId],
+  );
+  const filteredEventViews = useMemo(
+    () =>
+      eventViews.filter(({ event, actor }) => matchesEventSearch(event, actor, searchQuery)),
+    [eventViews, searchQuery],
+  );
+
+  function toggleEasyRead(nextValue: boolean) {
+    setEasyRead(nextValue);
+    writeStoredBoolean(EASY_READ_STORAGE_KEY, nextValue);
+  }
+
+  function toggleDripfeedEducation(nextValue: boolean) {
+    setDripfeedEducation(nextValue);
+    writeStoredBoolean(DRIPFEED_EDUCATION_STORAGE_KEY, nextValue);
+  }
+
+  function toggleAnalogies(nextValue: boolean) {
+    setAnalogies(nextValue);
+    writeStoredBoolean(ANALOGY_STORAGE_KEY, nextValue);
+  }
 
   return (
     <section className="flex min-h-[620px] flex-col rounded-2xl border border-white/[0.08] bg-[#0d0d0d]">
@@ -381,7 +605,79 @@ function OrchestratorContinuityPanel({
 
       <div className="flex items-center justify-between gap-3 border-b border-white/[0.06] px-5 py-3 text-[11px] text-white/40">
         <span>{chatStatusLabel}</span>
-        <span>{events.length} loaded event{events.length === 1 ? "" : "s"}</span>
+        <span>
+          {searchQuery.trim()
+            ? `${filteredEventViews.length} of ${events.length} events match`
+            : `${events.length} loaded event${events.length === 1 ? "" : "s"}`}
+        </span>
+      </div>
+
+      <div className="grid gap-3 border-b border-white/[0.06] px-5 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-white/30" />
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Filter Orchestrator feed"
+            className="w-full rounded-md border border-white/[0.06] bg-black/20 py-2 pl-8 pr-8 text-sm text-white/80 outline-none transition-colors placeholder:text-white/25 focus:border-[#61C1C4]/35"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery("")}
+              className="absolute right-2 top-2 rounded-[5px] p-1 text-white/35 hover:bg-white/[0.06] hover:text-white/65"
+              aria-label="Clear Orchestrator feed filter"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+
+        <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2">
+          <span>
+            <span className="block text-xs font-medium text-white/75">Easy reading for humans</span>
+            <span className="block text-[10px] text-white/35">
+              {easyRead ? "Friendly layer on" : "Natural context view"}
+            </span>
+          </span>
+          <input
+            type="checkbox"
+            aria-label="Easy reading for humans"
+            checked={easyRead}
+            onChange={(event) => toggleEasyRead(event.target.checked)}
+            className="sr-only"
+          />
+          <span className={`relative h-6 w-11 rounded-full border transition ${easyRead ? "border-[#61C1C4]/40 bg-[#61C1C4]/25" : "border-white/[0.08] bg-white/[0.08]"}`}>
+            <span className={`absolute top-1 h-4 w-4 rounded-full transition ${easyRead ? "left-6 bg-[#61C1C4]" : "left-1 bg-white/55"}`} />
+          </span>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 border-b border-white/[0.06] px-5 py-3 text-xs text-white/55">
+        <label className="inline-flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            aria-label="Dripfeed Education"
+            checked={dripfeedEducation}
+            onChange={(event) => toggleDripfeedEducation(event.target.checked)}
+            className="h-4 w-4 rounded border-white/[0.12] bg-black/30 accent-[#61C1C4]"
+          />
+          <span>Dripfeed Education</span>
+        </label>
+        <label className="inline-flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            aria-label="Analogies"
+            checked={analogies}
+            onChange={(event) => toggleAnalogies(event.target.checked)}
+            className="h-4 w-4 rounded border-white/[0.12] bg-black/30 accent-[#61C1C4]"
+          />
+          <span>Analogies</span>
+        </label>
+        <span className="text-[11px] text-white/30">
+          These only add friendly hints in Easy reading mode.
+        </span>
       </div>
 
       <div className="flex-1 space-y-3 overflow-y-auto px-5 py-4">
@@ -394,11 +690,23 @@ function OrchestratorContinuityPanel({
             or run the UnClick heartbeat so Orchestrator has something to show.
           </div>
         )}
-        {!loading && events.slice(0, 24).map((event) => (
+        {!loading && events.length > 0 && filteredEventViews.length === 0 && (
+          <div className="rounded-xl border border-white/[0.08] bg-black/20 p-5 text-sm leading-6 text-white/55">
+            No Orchestrator events match that filter.
+          </div>
+        )}
+        {!loading && filteredEventViews.slice(0, 24).map(({ event, actor, index, absoluteDate, easySummary }) => (
           <ContinuityFeedRow
             key={`${event.source_kind}:${event.source_id}`}
             event={event}
-            profileByAgentId={profileByAgentId}
+            actor={actor}
+            index={index}
+            absoluteDate={absoluteDate}
+            easySummary={easySummary}
+            easyRead={easyRead}
+            dripfeedEducation={dripfeedEducation}
+            analogies={analogies}
+            searchQuery={searchQuery}
           />
         ))}
       </div>
@@ -408,12 +716,26 @@ function OrchestratorContinuityPanel({
 
 function ContinuityFeedRow({
   event,
-  profileByAgentId,
+  actor,
+  index,
+  absoluteDate,
+  easySummary,
+  easyRead,
+  dripfeedEducation,
+  analogies,
+  searchQuery,
 }: {
   event: OrchestratorContinuityEvent;
-  profileByAgentId: Map<string, OrchestratorProfileCard>;
+  actor: ActorIdentity;
+  index: number;
+  absoluteDate: string;
+  easySummary: string;
+  easyRead: boolean;
+  dripfeedEducation: boolean;
+  analogies: boolean;
+  searchQuery: string;
 }) {
-  const actor = actorIdentityForEvent(event, profileByAgentId);
+  const showFriendlyExtras = easyRead && shouldShowDrip(index, event);
   const content = (
     <article className="rounded-xl border border-white/[0.06] bg-[#111111] px-4 py-3">
       <div className="mb-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
@@ -423,7 +745,9 @@ function ContinuityFeedRow({
           </span>
           <div className="min-w-0">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-              <span className="min-w-0 truncate text-sm font-semibold text-white/85">{actor.label}</span>
+              <span className="min-w-0 truncate text-sm font-semibold text-white/85">
+                {highlightSearchText(actor.label, searchQuery)}
+              </span>
               <span className="rounded-md border border-[#61C1C4]/20 bg-[#61C1C4]/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-[#61C1C4]">
                 {event.kind}
               </span>
@@ -438,9 +762,32 @@ function ContinuityFeedRow({
             </div>
           </div>
         </div>
-        <span className="text-[10px] text-white/30">{formatRelative(event.created_at)}</span>
+        <div className="text-left sm:text-right">
+          <span className="block text-[10px] text-white/40">{formatRelative(event.created_at)}</span>
+          <span className="block text-[10px] text-white/25">{highlightSearchText(absoluteDate, searchQuery)}</span>
+        </div>
       </div>
-      <p className="text-sm leading-6 text-white/70">{event.summary}</p>
+      {easyRead && (
+        <p className="sr-only">AI-native natural context: {event.summary}</p>
+      )}
+      <p className="text-sm leading-6 text-white/70">
+        {highlightSearchText(easyRead ? easySummary : event.summary, searchQuery)}
+      </p>
+      {easyRead && (
+        <p className="mt-2 rounded-lg border border-white/[0.05] bg-black/20 px-2 py-1.5 text-[11px] leading-4 text-white/35">
+          Natural context for AI: {highlightSearchText(event.summary, searchQuery)}
+        </p>
+      )}
+      {showFriendlyExtras && dripfeedEducation && (
+        <p className="mt-2 rounded-lg border border-[#61C1C4]/15 bg-[#61C1C4]/5 px-2 py-1.5 text-[11px] leading-4 text-[#A9EEF0]/80">
+          {highlightSearchText(educationHintForEvent(event), searchQuery)}
+        </p>
+      )}
+      {showFriendlyExtras && analogies && (
+        <p className="mt-2 rounded-lg border border-[#E2B93B]/15 bg-[#E2B93B]/5 px-2 py-1.5 text-[11px] leading-4 text-[#F1D982]/80">
+          {highlightSearchText(analogyForEvent(event), searchQuery)}
+        </p>
+      )}
       {event.tags && event.tags.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1">
           {event.tags.slice(0, 5).map((tag) => (

--- a/src/pages/admin/searchHighlight.test.tsx
+++ b/src/pages/admin/searchHighlight.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { highlightSearchText } from "./searchHighlight";
+
+describe("highlightSearchText", () => {
+  it("highlights exact keyword matches", () => {
+    render(<p>{highlightSearchText("Orchestrator proof landed", "proof")}</p>);
+
+    expect(screen.getByText("proof").tagName).toBe("MARK");
+  });
+
+  it("highlights typed letters for compact fuzzy matches", () => {
+    render(<p>{highlightSearchText("Codex Orchestrator Seat", "cos")}</p>);
+
+    const marked = Array.from(document.querySelectorAll("mark"))
+      .map((node) => node.textContent)
+      .join("");
+    expect(marked.toLowerCase()).toContain("c");
+    expect(marked.toLowerCase()).toContain("o");
+    expect(marked.toLowerCase()).toContain("s");
+  });
+});

--- a/src/pages/admin/searchHighlight.tsx
+++ b/src/pages/admin/searchHighlight.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+
+function markDirectMatches(mask: boolean[], lowerText: string, token: string) {
+  let start = lowerText.indexOf(token);
+  while (start >= 0) {
+    for (let index = start; index < start + token.length; index += 1) {
+      mask[index] = true;
+    }
+    start = lowerText.indexOf(token, start + 1);
+  }
+}
+
+function markSubsequenceMatch(mask: boolean[], lowerText: string, token: string) {
+  let tokenIndex = 0;
+  const matchedIndexes: number[] = [];
+  for (let index = 0; index < lowerText.length && tokenIndex < token.length; index += 1) {
+    const char = lowerText[index];
+    if (/\s/.test(char)) continue;
+    if (char === token[tokenIndex]) {
+      matchedIndexes.push(index);
+      tokenIndex += 1;
+    }
+  }
+  if (tokenIndex !== token.length) return;
+  for (const index of matchedIndexes) {
+    mask[index] = true;
+  }
+}
+
+export function highlightSearchText(text: string, query: string): ReactNode {
+  const trimmedQuery = query.toLowerCase().trim();
+  if (!trimmedQuery) return text;
+
+  const mask = Array.from({ length: text.length }, () => false);
+  const lowerText = text.toLowerCase();
+  const compactText = lowerText.replace(/[\s:_-]+/g, "");
+  const tokens = trimmedQuery
+    .split(/\s+/)
+    .map((token) => token.replace(/[\s:_-]+/g, ""))
+    .filter(Boolean);
+
+  for (const token of tokens) {
+    if (lowerText.includes(token)) {
+      markDirectMatches(mask, lowerText, token);
+    } else if (compactText.includes(token)) {
+      markSubsequenceMatch(mask, lowerText, token);
+    } else {
+      markSubsequenceMatch(mask, lowerText, token);
+    }
+  }
+
+  const parts: ReactNode[] = [];
+  let index = 0;
+  while (index < text.length) {
+    const highlighted = mask[index];
+    let end = index + 1;
+    while (end < text.length && mask[end] === highlighted) {
+      end += 1;
+    }
+    const value = text.slice(index, end);
+    parts.push(
+      highlighted ? (
+        <mark key={index} className="rounded-[3px] bg-[#61C1C4]/15 px-0.5 font-semibold text-[#8EF5F8]">
+          {value}
+        </mark>
+      ) : (
+        <span key={index}>{value}</span>
+      ),
+    );
+    index = end;
+  }
+
+  return parts;
+}


### PR DESCRIPTION
## Summary
- Add Orchestrator keyword filtering near the top of the continuity feed.
- Add Easy reading for humans, Dripfeed Education, and Analogies controls, all on by default.
- Keep AI-native natural context available in Easy mode and show date stamps in both Easy and Natural views.
- Add shared typed-letter keyword highlighting and wire it into Orchestrator plus Jobs rows.

## Tests
- npx eslint src\pages\admin\AdminOrchestrator.tsx src\pages\admin\AdminOrchestrator.test.tsx src\pages\admin\AdminJobs.tsx src\pages\admin\searchHighlight.tsx src\pages\admin\searchHighlight.test.tsx
- npx vitest run src\pages\admin\AdminOrchestrator.test.tsx src\pages\admin\searchHighlight.test.tsx
- npm run build
- git diff --check

UnClick todo: dbba9664-a8cf-4c65-845f-a740b3343f46