### PR TITLE
Add Orchestrator subscription turn ingest

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -58,6 +58,9 @@
  *                              Bumps the channel_status.last_seen timestamp.
  *   - admin_ai_chat: POST with Bearer <api_key>, body { session_id, content }
  *                    Gemini fallback used when no Channel plugin is active.
+ *   - admin_conversation_turn_ingest: POST with Bearer <api_key>,
+ *                    body { session_id, role, content, source_app?, client_session_id? }
+ *                    Saves a safe subscription/tether turn for Orchestrator continuity.
  *
  * Admin spotlight + bug visibility:
  *   - admin_search: GET with Bearer <api_key>, ?query=&limit=
@@ -103,6 +106,7 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import {
   buildOrchestratorContext,
+  redactSensitive,
   type OrchestratorBusinessContextRow,
   type OrchestratorCommentRow,
   type OrchestratorConversationTurnRow,
@@ -6036,6 +6040,60 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const { data, error } = await q;
         if (error) throw error;
         return res.status(200).json({ data: data ?? [] });
+      }
+
+      case "admin_conversation_turn_ingest": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+
+        const body = (req.body ?? {}) as {
+          session_id?: string;
+          role?: string;
+          content?: string;
+          source_app?: string;
+          client_session_id?: string;
+        };
+        const sessionId = String(body.session_id ?? "").trim();
+        const role = String(body.role ?? "").trim();
+        const content = String(body.content ?? "");
+        const sourceApp = String(body.source_app ?? "subscription-tether").trim().slice(0, 80);
+        const clientSessionId = String(body.client_session_id ?? "").trim().slice(0, 200);
+
+        if (!sessionId) return res.status(400).json({ error: "session_id required" });
+        if (!["user", "assistant", "system"].includes(role)) {
+          return res.status(400).json({ error: "role must be user, assistant, or system" });
+        }
+        if (!content.trim()) return res.status(400).json({ error: "content required" });
+        if (content.length > 12_000) return res.status(413).json({ error: "content must be 12000 characters or less" });
+
+        const safeContent = redactSensitive(content);
+        const { data, error } = await supabase
+          .from("chat_messages")
+          .insert({
+            api_key_hash: apiKeyHash,
+            session_id: sessionId,
+            role,
+            content: safeContent,
+            status: "completed",
+            metadata: {
+              source_app: sourceApp || "subscription-tether",
+              client_session_id: clientSessionId || null,
+              ingest_source: "subscription_turn",
+              ingested_at: new Date().toISOString(),
+            },
+          })
+          .select("id, session_id, role, created_at")
+          .single();
+        if (error) throw error;
+
+        return res.status(200).json({
+          turn_id: data.id,
+          session_id: data.session_id,
+          role: data.role,
+          created_at: data.created_at,
+          redacted: safeContent !== content,
+        });
       }
 
       case "admin_channel_status": {

--- a/scripts/orchestrator-turn-ingest.test.mjs
+++ b/scripts/orchestrator-turn-ingest.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+const apiSource = await readFile("api/memory-admin.ts", "utf8");
+
+describe("orchestrator subscription turn ingest", () => {
+  it("exposes a safe endpoint that writes direct turns to chat_messages", () => {
+    assert.match(apiSource, /case "admin_conversation_turn_ingest"/);
+    assert.match(apiSource, /from\("chat_messages"\)[\s\S]*insert\(\{/);
+    assert.match(apiSource, /status:\s*"completed"/);
+    assert.match(apiSource, /ingest_source:\s*"subscription_turn"/);
+  });
+
+  it("validates role, length, and redacts content before storage", () => {
+    assert.match(apiSource, /role must be user, assistant, or system/);
+    assert.match(apiSource, /content\.length > 12_000/);
+    assert.match(apiSource, /const safeContent = redactSensitive\(content\)/);
+    assert.match(apiSource, /redacted:\s*safeContent !== content/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `admin_conversation_turn_ingest` so subscription seats can save a single user/assistant/system turn into the live Orchestrator feed source.
- Store turns in `chat_messages` with completed status and source metadata so PR #673 can surface them in continuity.
- Redact obvious secrets before storage and return whether redaction happened.

## Tests
- `node --test scripts\orchestrator-turn-ingest.test.mjs scripts\orchestrator-chat-continuity.test.mjs`
- `npx vitest run api\orchestrator-context.test.ts src\pages\admin\AdminOrchestrator.test.tsx`
- `npm run build`

Refs #670
