### PR TITLE
Expose conversation turn save tool for Orchestrator

### DIFF
--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -6,6 +6,15 @@ describe("runtime tool schema validation", () => {
   const probes: Array<{ name: string; args: Record<string, unknown> }> = [
     { name: "load_memory", args: { num_sessions: 1, bogus_field: "should reject" } },
     { name: "search_memory", args: { query: "strict schema probe", bogus_field: "should reject" } },
+    {
+      name: "save_conversation_turn",
+      args: {
+        session_id: "strict-probe-session",
+        role: "user",
+        content: "strict schema probe",
+        bogus_field: "should reject",
+      },
+    },
     { name: "check_signals", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
     { name: "heartbeat_protocol", args: { bogus_field: "should reject" } },
     {
@@ -59,6 +68,11 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("save_fact", {
       fact: "Issue: Claude tool-result submission fails in Brave. Solution: disable Brave Shields for claude.ai.",
       category: "troubleshooting",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("save_conversation_turn", {
+      session_id: "strict-probe-session",
+      role: "user",
+      content: "strict schema probe",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_generate_uuid", { count: 1 })).toBeNull();
     expect(validateToolArgumentsForRuntime("check_signals", {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -396,6 +396,36 @@ const VISIBLE_TOOLS = [
     },
   },
   {
+    name: "save_conversation_turn",
+    title: "Save conversation turn",
+    description:
+      "Saves one human, assistant, system, or tool turn into UnClick conversation history so Orchestrator continuity can show and search it. " +
+      "Use after each accepted subscription chat human turn and after each assistant reply when the client can call tools. " +
+      "Use a stable session_id for the thread. Do not store secrets, API keys, passwords, one-time codes, or private credentials.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_id: {
+          type: "string",
+          description: "Stable thread or chat session identifier",
+        },
+        role: {
+          type: "string",
+          enum: ["user", "assistant", "system", "tool"],
+          description: "Who produced this turn",
+        },
+        content: { type: "string", description: "Turn text to save, with secrets removed" },
+        has_code: {
+          type: "boolean",
+          default: false,
+          description: "True when the turn contains code worth preserving for later context",
+        },
+      },
+      required: ["session_id", "role", "content"],
+    },
+  },
+  {
     name: "invalidate_fact",
     title: "Invalidate a fact",
     description:
@@ -885,6 +915,7 @@ const MEMORY_TOOL_ALIASES: Record<string, string> = {
   save_fact: "add_fact",
   save_session: "write_session_summary",
   save_identity: "set_business_context",
+  save_conversation_turn: "log_conversation",
   // search_memory and invalidate_fact keep their names
 };
 
@@ -1464,6 +1495,13 @@ export function createServer(): Server {
         "               resume without re-asking.",
         "",
         "Never ask the user to 'catch you up' -- load first, then act.",
+        "",
+        "ORCHESTRATOR CONTINUITY:",
+        "When acting as a subscription or tethered AI seat and tools are available,",
+        "call `save_conversation_turn` after each accepted human turn and after",
+        "each assistant reply the client exposes. Use a stable session id so",
+        "Orchestrator can show the whole thread. Skip or redact secrets, API keys,",
+        "passwords, one-time codes, and private credentials.",
       ].join("\n"),
     }
   );


### PR DESCRIPTION
## Summary
- adds a visible save_conversation_turn MCP tool backed by the existing conversation log handler
- tells tethered subscription seats to save accepted human and assistant turns for Orchestrator continuity
- keeps strict argument validation coverage for the new tool

## Test
- npm run test --workspace=@unclick/mcp-server -- --run src/__tests__/tool-schema-validation.test.ts src/__tests__/memory-load-hint.test.ts

Refs #676