### PR TITLE
Prove Orchestrator AI chat turn ingest

### DIFF
--- a/src/components/admin/AIChatPanel.test.tsx
+++ b/src/components/admin/AIChatPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AIChatPanel from "./AIChatPanel";
 
@@ -44,5 +44,55 @@ describe("AIChatPanel auth", () => {
     render(<AIChatPanel />);
 
     expect(screen.getByText("Sign in to use the Orchestrator chat.")).toBeInTheDocument();
+  });
+
+  it("mirrors fallback AI assistant turns into Orchestrator continuity", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          channel_active: false,
+          last_seen: null,
+          client_info: null,
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ turn_id: "user-turn" }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode('data: {"delta":"saved assistant reply"}\n\n'),
+            );
+            controller.close();
+          },
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ turn_id: "assistant-turn" }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AIChatPanel authToken="session-jwt-token" />);
+
+    const input = await screen.findByPlaceholderText("Message the AI assistant...");
+    fireEvent.change(input, { target: { value: "save this harmless turn" } });
+    fireEvent.click(screen.getAllByRole("button").at(-1)!);
+
+    expect(await screen.findByText("saved assistant reply")).toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+
+    const ingestCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("admin_conversation_turn_ingest"),
+    );
+    expect(ingestCalls).toHaveLength(2);
+    expect(JSON.parse(String(ingestCalls[0][1]?.body))).toMatchObject({
+      role: "user",
+      content: "save this harmless turn",
+      source_app: "orchestrator-admin-ai-chat",
+    });
+    expect(JSON.parse(String(ingestCalls[1][1]?.body))).toMatchObject({
+      role: "assistant",
+      content: "saved assistant reply",
+      source_app: "orchestrator-admin-ai-chat",
+    });
   });
 });

--- a/src/components/admin/AIChatPanel.tsx
+++ b/src/components/admin/AIChatPanel.tsx
@@ -209,7 +209,7 @@ export default function AIChatPanel({ authToken = "" }: AIChatPanelProps) {
         }
         setMessages((prev) => [...prev, reply]);
       } else {
-        void saveTurn("user", text);
+        await saveTurn("user", text);
         // admin_ai_chat expects UIMessage[] (AI SDK v6). Build the full
         // conversation as `parts`-shaped messages and stream the response.
         const history = [...messages, userMsg].filter(
@@ -308,7 +308,7 @@ export default function AIChatPanel({ authToken = "" }: AIChatPanelProps) {
             ),
           );
         } else {
-          void saveTurn("assistant", acc);
+          await saveTurn("assistant", acc);
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- awaits fallback Orchestrator AI assistant turn-ingest calls so the save completes before moving on
- adds a focused test that sends a message through AIChatPanel fallback mode and proves both user and assistant turns hit dmin_conversation_turn_ingest

## Test
- npx vitest run src/components/admin/AIChatPanel.test.tsx
- npm run build

Note: this proves the in-app Orchestrator AI Assistant path. External Codex/Claude subscription chats still need their own client-side save hook or MCP tool call to appear in Orchestrator search.

Refs #676