### PR TITLE
Sync MCP server manifest version

### DIFF
--- a/.github/workflows/publish-mcp-package.yml
+++ b/.github/workflows/publish-mcp-package.yml
@@ -103,6 +103,7 @@ jobs:
           const fs = require("fs");
           const remote = process.argv[2] || "";
           const pkgPath = "package.json";
+          const manifestPath = "server.json";
           const lockPath = "../../package-lock.json";
           const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
           const parts = (version) => version.split(".").map((part) => Number(part));
@@ -119,6 +120,12 @@ jobs:
           next[2] = (next[2] || 0) + 1;
           pkg.version = next.join(".");
           fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+          manifest.version = pkg.version;
+          for (const entry of manifest.packages || []) {
+            if (entry.identifier === pkg.name) entry.version = pkg.version;
+          }
+          fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
           const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
           if (lock.packages?.["packages/mcp-server"]) {
             lock.packages["packages/mcp-server"].version = pkg.version;
@@ -127,7 +134,7 @@ jobs:
           console.log(pkg.version);
           NODE
           )
-          git add package.json ../../package-lock.json
+          git add package.json server.json ../../package-lock.json
           git commit -m "chore: bump mcp-server to v${new_ver} [skip ci]"
 
       - name: Push version bump

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.malamutemayhem/unclick-mcp-server",
   "title": "UnClick",
   "description": "AI agent tool marketplace. 178+ tools for social, e-commerce, accounting, and messaging.",
-  "version": "0.2.4",
+  "version": "0.3.56",
   "repository": {
     "url": "https://github.com/malamutemayhem/unclick-agent-native-endpoints.git",
     "source": "github"
@@ -19,7 +19,7 @@
     {
       "registryType": "npm",
       "identifier": "@unclick/mcp-server",
-      "version": "0.2.3",
+      "version": "0.3.56",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp-server/src/__tests__/server-manifest.test.ts
+++ b/packages/mcp-server/src/__tests__/server-manifest.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const packageJson = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as {
+  name: string;
+  version: string;
+};
+
+const serverJson = JSON.parse(readFileSync(resolve("server.json"), "utf8")) as {
+  version: string;
+  packages?: Array<{ identifier?: string; version?: string }>;
+};
+
+describe("MCP server manifest", () => {
+  it("stays in sync with the published package version", () => {
+    const manifestPackage = serverJson.packages?.find(
+      (entry) => entry.identifier === packageJson.name,
+    );
+
+    expect(serverJson.version).toBe(packageJson.version);
+    expect(manifestPackage?.version).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary
- updates packages/mcp-server/server.json from stale 0.2.x metadata to the current package version
- keeps server.json synced during the Publish MCP version bump
- adds a focused manifest test so stale MCP registry metadata is caught before ship

## Test
- npm run test --workspace=@unclick/mcp-server -- --run src/__tests__/server-manifest.test.ts src/__tests__/tool-schema-validation.test.ts

Why this matters: stale manifest metadata is a likely reason external seats still did not see newly published tools such as save_conversation_turn after the MCP server package changed.

Refs #676