### PR TITLE
Fix Orchestrator keyword search depth

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7918,9 +7918,76 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           });
         }
 
-        const body = (req.body ?? {}) as { limit?: number };
-        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 80) || 80, 20), 120);
-        const smallerLimit = Math.min(limit, 40);
+        const body = (req.body ?? {}) as { limit?: number; q?: string };
+        const rawSearch =
+          typeof body.q === "string"
+            ? body.q
+            : typeof req.query.q === "string"
+              ? req.query.q
+              : "";
+        const searchQuery = rawSearch.replace(/\s+/g, " ").trim().slice(0, 100);
+        const searchPattern = searchQuery ? `%${searchQuery.replace(/[%_]/g, "\\$&")}%` : "";
+        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 80) || 80, 20), searchQuery ? 200 : 120);
+        const smallerLimit = searchQuery ? limit : Math.min(limit, 40);
+
+        let messagesQuery = supabase
+          .from("mc_fishbowl_messages")
+          .select("id, author_emoji, author_name, author_agent_id, recipients, text, tags, thread_id, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+        if (searchPattern) messagesQuery = messagesQuery.ilike("text", searchPattern);
+
+        let todosQuery = supabase
+          .from("mc_fishbowl_todos")
+          .select("id, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, source_idea_id, created_at, updated_at, completed_at")
+          .eq("api_key_hash", apiKeyHash)
+          .neq("status", "dropped")
+          .order("updated_at", { ascending: false })
+          .limit(smallerLimit);
+        if (searchPattern) {
+          todosQuery = todosQuery.or(`title.ilike.${searchPattern},description.ilike.${searchPattern}`);
+        }
+
+        let commentsQuery = supabase
+          .from("mc_fishbowl_comments")
+          .select("id, target_kind, target_id, author_agent_id, text, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(smallerLimit);
+        if (searchPattern) commentsQuery = commentsQuery.ilike("text", searchPattern);
+
+        let signalsQuery = supabase
+          .from("mc_signals")
+          .select("id, tool, action, severity, summary, deep_link, payload, created_at, read_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(smallerLimit);
+        if (searchPattern) signalsQuery = signalsQuery.ilike("summary", searchPattern);
+
+        let sessionsQuery = supabase
+          .from("mc_session_summaries")
+          .select("id, session_id, platform, summary, decisions, open_loops, topics, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(searchQuery ? 40 : 12);
+        if (searchPattern) sessionsQuery = sessionsQuery.ilike("summary", searchPattern);
+
+        let conversationTurnsQuery = supabase
+          .from("mc_conversation_log")
+          .select("id, session_id, role, content, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(smallerLimit);
+        if (searchPattern) conversationTurnsQuery = conversationTurnsQuery.ilike("content", searchPattern);
+
+        let chatMessagesQuery = supabase
+          .from("chat_messages")
+          .select("id, session_id, role, content, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(smallerLimit);
+        if (searchPattern) chatMessagesQuery = chatMessagesQuery.ilike("content", searchPattern);
 
         const [
           profilesResult,
@@ -7941,43 +8008,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .eq("api_key_hash", apiKeyHash)
             .order("last_seen_at", { ascending: false, nullsFirst: false })
             .limit(smallerLimit),
-          supabase
-            .from("mc_fishbowl_messages")
-            .select("id, author_emoji, author_name, author_agent_id, recipients, text, tags, thread_id, created_at")
-            .eq("api_key_hash", apiKeyHash)
-            .order("created_at", { ascending: false })
-            .limit(limit),
-          supabase
-            .from("mc_fishbowl_todos")
-            .select("id, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, source_idea_id, created_at, updated_at, completed_at")
-            .eq("api_key_hash", apiKeyHash)
-            .neq("status", "dropped")
-            .order("updated_at", { ascending: false })
-            .limit(smallerLimit),
-          supabase
-            .from("mc_fishbowl_comments")
-            .select("id, target_kind, target_id, author_agent_id, text, created_at")
-            .eq("api_key_hash", apiKeyHash)
-            .order("created_at", { ascending: false })
-            .limit(smallerLimit),
+          messagesQuery,
+          todosQuery,
+          commentsQuery,
           supabase
             .from("mc_agent_dispatches")
             .select("dispatch_id, source, target_agent_id, task_ref, status, lease_owner, lease_expires_at, last_real_action_at, payload, created_at, updated_at")
             .eq("api_key_hash", apiKeyHash)
             .order("updated_at", { ascending: false })
             .limit(smallerLimit),
-          supabase
-            .from("mc_signals")
-            .select("id, tool, action, severity, summary, deep_link, payload, created_at, read_at")
-            .eq("api_key_hash", apiKeyHash)
-            .order("created_at", { ascending: false })
-            .limit(smallerLimit),
-          supabase
-            .from("mc_session_summaries")
-            .select("id, session_id, platform, summary, decisions, open_loops, topics, created_at")
-            .eq("api_key_hash", apiKeyHash)
-            .order("created_at", { ascending: false })
-            .limit(12),
+          signalsQuery,
+          sessionsQuery,
           supabase
             .from("mc_knowledge_library")
             .select("slug, title, category, tags, version, updated_at, created_at")
@@ -7990,18 +8031,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .eq("api_key_hash", apiKeyHash)
             .order("priority", { ascending: false })
             .limit(16),
-          supabase
-            .from("mc_conversation_log")
-            .select("id, session_id, role, content, created_at")
-            .eq("api_key_hash", apiKeyHash)
-            .order("created_at", { ascending: false })
-            .limit(smallerLimit),
-          supabase
-            .from("chat_messages")
-            .select("id, session_id, role, content, created_at")
-            .eq("api_key_hash", apiKeyHash)
-            .order("created_at", { ascending: false })
-            .limit(smallerLimit),
+          conversationTurnsQuery,
+          chatMessagesQuery,
         ]);
 
         const errors = [

--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AdminOrchestratorPage from "./AdminOrchestrator";
@@ -19,6 +19,66 @@ describe("AdminOrchestratorPage", () => {
       "fetch",
       vi.fn(async (url: RequestInfo | URL) => {
         const textUrl = String(url);
+        if (textUrl.includes("orchestrator_context_read") && textUrl.includes("q=dog20")) {
+          return {
+            ok: true,
+            json: async () => ({
+              context: {
+                version: "orchestrator-context-v1",
+                generated_at: "2026-05-10T06:05:00.000Z",
+                current_state_card: {
+                  summary: "1 matching continuity event.",
+                  newest_activity_at: "2026-05-10T06:04:00.000Z",
+                  newest_checkin_at: "2026-05-10T05:55:00.000Z",
+                  active_todo_count: 0,
+                  blocker_count: 0,
+                  active_seat_count: 1,
+                  next_actions: [],
+                  blockers: [],
+                  live_sources: {
+                    profiles: 1,
+                    boardroom_messages: 0,
+                    todos: 0,
+                    comments: 1,
+                    dispatches: 0,
+                    signals: 0,
+                    sessions: 0,
+                    library: 0,
+                    business_context: 0,
+                    conversation_turns: 0,
+                  },
+                },
+                profile_cards: [
+                  {
+                    agent_id: "codex-orchestrator-seat",
+                    label: "Codex Orchestrator Seat",
+                    role: "ai-seat",
+                    emoji: "🤖",
+                    source_app_label: "Codex",
+                    connection_label: "Connected",
+                    last_seen_at: "2026-05-10T05:55:00.000Z",
+                    freshness_label: "Live",
+                  },
+                ],
+                human_operator_time: null,
+                continuity_events: [
+                  {
+                    source_kind: "todo_comment",
+                    source_id: "comment-dog20",
+                    created_at: "2026-05-10T06:04:00.000Z",
+                    kind: "context",
+                    actor_agent_id: "codex-orchestrator-seat",
+                    summary: "Manual Orchestrator note from this Codex chat: dog20 reached UnClick.",
+                    tags: ["todo", "comment"],
+                    deep_link: "/admin/jobs#todo-1",
+                  },
+                ],
+                library_snapshots: [],
+              },
+            }),
+          } as Response;
+        }
+
         if (textUrl.includes("orchestrator_context_read")) {
           return {
             ok: true,
@@ -154,9 +214,30 @@ describe("AdminOrchestratorPage", () => {
     const filter = await screen.findByPlaceholderText("Filter Orchestrator feed");
     fireEvent.change(filter, { target: { value: "proof" } });
 
-    expect(screen.getByText("1 of 2 events match")).toBeInTheDocument();
+    expect(await screen.findByText("1 of 2 events match")).toBeInTheDocument();
     expect(screen.getAllByText(/Orchestrator continuity proof landed/i).length).toBeGreaterThan(0);
     expect(document.querySelector("mark")?.textContent?.toLowerCase()).toContain("proof");
+  });
+
+  it("asks the server for deeper Orchestrator keyword matches", async () => {
+    render(
+      <MemoryRouter>
+        <AdminOrchestratorPage />
+      </MemoryRouter>,
+    );
+
+    const filter = await screen.findByPlaceholderText("Filter Orchestrator feed");
+    fireEvent.change(filter, { target: { value: "dog20" } });
+
+    expect(await screen.findByText(/dog20 reached UnClick/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("q=dog20"),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer session-token" }),
+        }),
+      ),
+    );
   });
 
   it("uses explicit controls for long continuity rows", async () => {

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -525,6 +525,7 @@ export default function AdminOrchestratorPage() {
             context={orchestratorContext}
             loading={loading || sessionLoading}
             chatStatusLabel={chatDisabledReason ? "Chat disabled" : tier === "channel" ? "Claude Code bridge available" : "AI chat available"}
+            authToken={authToken}
           />
         </div>
 
@@ -553,24 +554,65 @@ function OrchestratorContinuityPanel({
   context,
   loading,
   chatStatusLabel,
+  authToken,
 }: {
   context: OrchestratorContext | null;
   loading: boolean;
   chatStatusLabel: string;
+  authToken: string;
 }) {
-  const events = useMemo(
-    () => context?.continuity_events ?? [],
-    [context?.continuity_events],
-  );
   const [searchQuery, setSearchQuery] = useState("");
+  const [serverSearchContext, setServerSearchContext] = useState<OrchestratorContext | null>(null);
+  const [serverSearchLoading, setServerSearchLoading] = useState(false);
+  const trimmedSearchQuery = searchQuery.trim();
+  useEffect(() => {
+    if (!authToken || trimmedSearchQuery.length === 0) {
+      setServerSearchContext(null);
+      setServerSearchLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setServerSearchLoading(true);
+    const timeout = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const res = await fetch(
+            `/api/memory-admin?action=orchestrator_context_read&limit=120&q=${encodeURIComponent(trimmedSearchQuery)}`,
+            { headers: { Authorization: `Bearer ${authToken}` } },
+          );
+          if (cancelled) return;
+          if (res.ok) {
+            const body = (await res.json()) as { context?: OrchestratorContext };
+            setServerSearchContext(body.context ?? null);
+          } else {
+            setServerSearchContext(null);
+          }
+        } finally {
+          if (!cancelled) setServerSearchLoading(false);
+        }
+      })();
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
+  }, [authToken, trimmedSearchQuery]);
+
+  const feedContext = trimmedSearchQuery && serverSearchContext ? serverSearchContext : context;
+  const events = useMemo(
+    () => feedContext?.continuity_events ?? [],
+    [feedContext?.continuity_events],
+  );
   const [easyRead, setEasyRead] = useState(() => readStoredBoolean(EASY_READ_STORAGE_KEY, true));
   const [dripfeedEducation, setDripfeedEducation] = useState(() =>
     readStoredBoolean(DRIPFEED_EDUCATION_STORAGE_KEY, true),
   );
   const [analogies, setAnalogies] = useState(() => readStoredBoolean(ANALOGY_STORAGE_KEY, true));
   const profileByAgentId = useMemo(
-    () => buildProfileLookup(context?.profile_cards),
-    [context?.profile_cards],
+    () => buildProfileLookup(feedContext?.profile_cards),
+    [feedContext?.profile_cards],
   );
   const eventViews = useMemo(
     () =>
@@ -629,7 +671,9 @@ function OrchestratorContinuityPanel({
       <div className="flex items-center justify-between gap-3 border-b border-white/[0.06] px-5 py-3 text-[11px] text-white/40">
         <span>{chatStatusLabel}</span>
         <span>
-          {searchQuery.trim()
+          {serverSearchLoading
+            ? "Searching all continuity..."
+            : searchQuery.trim()
             ? `${filteredEventViews.length} of ${events.length} events match`
             : `${events.length} loaded event${events.length === 1 ? "" : "s"}`}
         </span>


### PR DESCRIPTION
## Summary
- make Orchestrator feed search ask the backend for keyword matches instead of only filtering the 36 events already loaded on screen
- add backend q support for continuity sources including Boardroom messages, Jobs, comments, signals, saved sessions, conversation turns, and chat messages
- add UI proof for a dog20-style keyword that is not present in the initial feed

## Tests
- npm test -- --run src/pages/admin/AdminOrchestrator.test.tsx
- npm test -- --run api/orchestrator-context.test.ts
- npm run build

Closes part of #676 by fixing the Orchestrator search visibility gap; external-seat auto-save proof remains separate.