### PR TITLE
Add channel Orchestrator turn save hook

### DIFF
--- a/.github/workflows/publish-channel-package.yml
+++ b/.github/workflows/publish-channel-package.yml
@@ -1,0 +1,163 @@
+name: Publish Channel package
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish-channel-package.yml'
+      - 'packages/channel-plugin/**'
+      - 'package-lock.json'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Auto-publishes @unclick/channel to npm whenever files under
+# packages/channel-plugin/ change on main. If the package already exists on
+# npm, the workflow bumps the patch version before publishing.
+
+concurrency:
+  group: publish-channel-package
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect publish scope
+        id: scope
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "PR package check only; skipping publish."
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null || git show --name-only --format="" "${{ github.sha }}")
+          if echo "$changed_files" | grep -Eq '^(\.github/workflows/publish-channel-package\.yml|packages/channel-plugin/)'; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "No channel package changes detected; skipping publish."
+          fi
+
+      - name: Set up Node
+        if: steps.scope.outputs.should_publish == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Skip if last commit was a bot version bump
+        if: steps.scope.outputs.should_publish == 'true'
+        id: skip_check
+        run: |
+          last_msg=$(git log -1 --pretty=%B)
+          if echo "$last_msg" | grep -q "\[skip ci\]"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        run: npm ci --no-audit --no-fund
+
+      - name: Test package
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        run: node --test packages/channel-plugin/*.test.js
+
+      - name: Verify package contents
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        working-directory: packages/channel-plugin
+        run: npm pack --dry-run
+
+      - name: Configure git identity
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        run: |
+          git config user.email "bot@unclick.world"
+          git config user.name "UnClick Bot"
+
+      - name: Publish version plan
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        id: version_plan
+        working-directory: packages/channel-plugin
+        run: |
+          remote_ver=$(npm view @unclick/channel version 2>/dev/null || echo "")
+          new_ver=$(node - "$remote_ver" <<'NODE'
+          const fs = require("fs");
+          const remote = process.argv[2] || "";
+          const pkgPath = "package.json";
+          const lockPath = "../../package-lock.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          const parts = (version) => String(version).split(".").map((part) => Number(part) || 0);
+          const compare = (a, b) => {
+            const aa = parts(a);
+            const bb = parts(b);
+            for (let i = 0; i < 3; i += 1) {
+              if (aa[i] !== bb[i]) return aa[i] - bb[i];
+            }
+            return 0;
+          };
+          if (remote && compare(remote, pkg.version) >= 0) {
+            const next = parts(remote);
+            next[2] += 1;
+            pkg.version = next.join(".");
+            fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+            const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+            if (lock.packages?.["packages/channel-plugin"]) {
+              lock.packages["packages/channel-plugin"].version = pkg.version;
+            }
+            fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+          }
+          console.log(pkg.version);
+          NODE
+          )
+          echo "version=${new_ver}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version bump
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        run: |
+          if git diff --quiet -- packages/channel-plugin/package.json package-lock.json; then
+            echo "No version bump needed."
+          else
+            git add packages/channel-plugin/package.json package-lock.json
+            git commit -m "chore: bump channel package to v${{ steps.version_plan.outputs.version }} [skip ci]"
+            git push
+          fi
+
+      - name: Publish to npm
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        working-directory: packages/channel-plugin
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify published version
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        working-directory: packages/channel-plugin
+        run: |
+          local_ver=$(node -p "require('./package.json').version")
+          echo "Published @unclick/channel@${local_ver}"
+          for i in 1 2 3 4 5; do
+            remote_ver=$(npm view @unclick/channel version 2>/dev/null || echo "")
+            if [ "$remote_ver" = "$local_ver" ]; then
+              echo "Confirmed on registry."
+              exit 0
+            fi
+            sleep 4
+          done
+          echo "Warning: registry still shows ${remote_ver}, expected ${local_ver}"

--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -15,6 +15,14 @@ your local Claude Code session so you do not need a separate AI API key.
    calls back via the `unclick_channel_respond` tool.
 5. The reply is written back to Supabase and streamed to the admin UI.
 
+The plugin also exposes `unclick_save_conversation_turn`, a small fallback
+tool for Orchestrator continuity. Use it when a seat is running through this
+channel but the normal UnClick MCP `save_conversation_turn` tool is not
+available. It saves one external chat turn through
+`admin_conversation_turn_ingest`, so `/admin/orchestrator` can show and search
+the turn. If neither save path is available, the seat should say `UNTETHERED`
+instead of silently continuing.
+
 Every 30 seconds the plugin POSTs a heartbeat to `admin_channel_heartbeat`
 so the admin UI knows the channel is online.
 

--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -35,6 +35,7 @@ import readline from "node:readline";
 import { apiFetchJson } from "./http.js";
 import { createHeartbeatGate } from "./heartbeat-gate.js";
 import { readTimingConfig } from "./config.js";
+import { saveConversationTurn, saveConversationTurnTool } from "./orchestrator-turns.js";
 
 const API_BASE       = process.env.UNCLICK_API_BASE     || "https://unclick.world";
 const API_KEY        = process.env.UNCLICK_API_KEY      || "";
@@ -78,7 +79,7 @@ function waitForResponse(messageId) {
   });
 }
 
-function handleRpcLine(line) {
+async function handleRpcLine(line) {
   let msg;
   try {
     msg = JSON.parse(line);
@@ -139,6 +140,7 @@ function handleRpcLine(line) {
               required: ["message_id", "content"],
             },
           },
+          saveConversationTurnTool,
         ],
       },
     });
@@ -162,6 +164,49 @@ function handleRpcLine(line) {
           content: [{ type: "text", text: "ok" }],
         },
       });
+      return;
+    }
+    if (name === "unclick_save_conversation_turn") {
+      try {
+        const result = await saveConversationTurn(apiFetch, args);
+        writeRpc({
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    ok: true,
+                    turn_id: result?.turn_id ?? null,
+                    session_id: result?.session_id ?? null,
+                    role: result?.role ?? null,
+                    redacted: Boolean(result?.redacted),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeRpc({
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: `UNTETHERED: could not save Orchestrator turn: ${message}`,
+              },
+            ],
+          },
+        });
+      }
       return;
     }
     writeRpc({

--- a/packages/channel-plugin/orchestrator-turns.js
+++ b/packages/channel-plugin/orchestrator-turns.js
@@ -1,0 +1,72 @@
+const ALLOWED_ROLES = new Set(["user", "assistant", "system"]);
+const DEFAULT_SOURCE_APP = "claude-code-channel";
+const MAX_CONTENT_LENGTH = 12_000;
+
+export const saveConversationTurnTool = {
+  name: "unclick_save_conversation_turn",
+  description:
+    "Save an external or subscription chat turn into UnClick Orchestrator continuity. " +
+    "Use this after accepted human turns and useful assistant replies when the normal UnClick MCP save_conversation_turn tool is unavailable. " +
+    "Do not store secrets, API keys, passwords, one-time codes, or private credentials. " +
+    "If this tool is unavailable or fails, say UNTETHERED instead of silently continuing.",
+  inputSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      session_id: {
+        type: "string",
+        description: "Stable external chat or seat session identifier.",
+      },
+      role: {
+        type: "string",
+        enum: ["user", "assistant", "system"],
+        description: "Who produced this turn.",
+      },
+      content: {
+        type: "string",
+        description: "Turn text to save, with secrets removed.",
+      },
+      source_app: {
+        type: "string",
+        description: "Short source label such as claude-code-channel or chatgpt-subscription.",
+      },
+      client_session_id: {
+        type: "string",
+        description: "Optional client-native thread id. Defaults to session_id.",
+      },
+    },
+    required: ["session_id", "role", "content"],
+  },
+};
+
+export function buildConversationTurnPayload(args, options = {}) {
+  const defaultSourceApp = String(options.defaultSourceApp ?? DEFAULT_SOURCE_APP).trim() || DEFAULT_SOURCE_APP;
+  const sessionId = String(args?.session_id ?? "").trim();
+  const role = String(args?.role ?? "").trim();
+  const content = String(args?.content ?? "");
+  const sourceApp = String(args?.source_app ?? defaultSourceApp).trim().slice(0, 80) || defaultSourceApp;
+  const clientSessionId = String(args?.client_session_id ?? sessionId).trim().slice(0, 200);
+
+  if (!sessionId) throw new Error("session_id required");
+  if (!ALLOWED_ROLES.has(role)) throw new Error("role must be user, assistant, or system");
+  if (!content.trim()) throw new Error("content required");
+  if (content.length > MAX_CONTENT_LENGTH) {
+    throw new Error(`content must be ${MAX_CONTENT_LENGTH} characters or less`);
+  }
+
+  return {
+    session_id: sessionId,
+    role,
+    content,
+    source_app: sourceApp,
+    client_session_id: clientSessionId || sessionId,
+  };
+}
+
+export async function saveConversationTurn(apiFetch, args) {
+  const payload = buildConversationTurnPayload(args);
+  return apiFetch("admin_conversation_turn_ingest", {
+    method: "POST",
+    body: payload,
+  });
+}

--- a/packages/channel-plugin/orchestrator-turns.test.js
+++ b/packages/channel-plugin/orchestrator-turns.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildConversationTurnPayload,
+  saveConversationTurn,
+  saveConversationTurnTool,
+} from "./orchestrator-turns.js";
+
+test("saveConversationTurnTool advertises the explicit Orchestrator tether hook", () => {
+  assert.equal(saveConversationTurnTool.name, "unclick_save_conversation_turn");
+  assert.match(saveConversationTurnTool.description, /Orchestrator continuity/);
+  assert.match(saveConversationTurnTool.description, /UNTETHERED/);
+});
+
+test("buildConversationTurnPayload validates and defaults a safe API body", () => {
+  const payload = buildConversationTurnPayload({
+    session_id: " external-thread ",
+    role: "user",
+    content: "hello",
+  });
+
+  assert.deepEqual(payload, {
+    session_id: "external-thread",
+    role: "user",
+    content: "hello",
+    source_app: "claude-code-channel",
+    client_session_id: "external-thread",
+  });
+});
+
+test("buildConversationTurnPayload rejects invalid role and empty content", () => {
+  assert.throws(
+    () => buildConversationTurnPayload({ session_id: "s", role: "tool", content: "x" }),
+    /role must be user, assistant, or system/
+  );
+  assert.throws(
+    () => buildConversationTurnPayload({ session_id: "s", role: "user", content: " " }),
+    /content required/
+  );
+});
+
+test("buildConversationTurnPayload ignores credential-shaped extra fields", () => {
+  const payload = buildConversationTurnPayload({
+    session_id: "thread-1",
+    role: "user",
+    content: "safe message",
+    api_key: "uc_should_not_be_forwarded",
+    authorization: "Bearer secret",
+  });
+
+  assert.equal(Object.hasOwn(payload, "api_key"), false);
+  assert.equal(Object.hasOwn(payload, "authorization"), false);
+});
+
+test("saveConversationTurn calls the existing admin ingest endpoint", async () => {
+  const calls = [];
+  const result = await saveConversationTurn(async (action, options) => {
+    calls.push({ action, options });
+    return {
+      turn_id: "turn-1",
+      session_id: options.body.session_id,
+      role: options.body.role,
+      redacted: false,
+    };
+  }, {
+    session_id: "thread-1",
+    role: "assistant",
+    content: "saved",
+    source_app: "test-client",
+  });
+
+  assert.equal(result.turn_id, "turn-1");
+  assert.deepEqual(calls, [
+    {
+      action: "admin_conversation_turn_ingest",
+      options: {
+        method: "POST",
+        body: {
+          session_id: "thread-1",
+          role: "assistant",
+          content: "saved",
+          source_app: "test-client",
+          client_session_id: "thread-1",
+        },
+      },
+    },
+  ]);
+});

--- a/packages/channel-plugin/package.json
+++ b/packages/channel-plugin/package.json
@@ -13,6 +13,7 @@
     "heartbeat-gate.js",
     "http.js",
     "index.js",
+    "orchestrator-turns.js",
     "README.md"
   ],
   "engines": {


### PR DESCRIPTION
## Summary
- add `unclick_save_conversation_turn` to the Claude Code channel plugin so tethered seats can save external chat turns into Orchestrator when the normal MCP save tool is unavailable
- route the tool through the existing `admin_conversation_turn_ingest` endpoint with validation and no credential-shaped fields forwarded
- add a GitHub Actions publish rail for `@unclick/channel`, including package tests and dry-run packaging before npm publish

## Tests
- `node --test packages/channel-plugin/*.test.js`
- `npm test`
- `npm run build`
- `npm pack --dry-run --workspace @unclick/channel`
- workflow YAML parse check

Closes #683
Refs #676