### PR TITLE
Require public channel package publish proof

### DIFF
--- a/.github/workflows/publish-channel-package.yml
+++ b/.github/workflows/publish-channel-package.yml
@@ -146,18 +146,27 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Force public npm access
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        run: npm access public @unclick/channel
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Verify published version
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
         working-directory: packages/channel-plugin
         run: |
           local_ver=$(node -p "require('./package.json').version")
           echo "Published @unclick/channel@${local_ver}"
+          public_npmrc="$(mktemp)"
+          printf 'registry=https://registry.npmjs.org/\n' > "$public_npmrc"
           for i in 1 2 3 4 5; do
-            remote_ver=$(npm view @unclick/channel version 2>/dev/null || echo "")
+            remote_ver=$(NPM_CONFIG_USERCONFIG="$public_npmrc" NODE_AUTH_TOKEN= npm view @unclick/channel version --registry=https://registry.npmjs.org/ 2>/dev/null || echo "")
             if [ "$remote_ver" = "$local_ver" ]; then
-              echo "Confirmed on registry."
+              echo "Confirmed on public registry."
               exit 0
             fi
             sleep 4
           done
-          echo "Warning: registry still shows ${remote_ver}, expected ${local_ver}"
+          echo "Public registry still shows ${remote_ver:-<missing>}, expected ${local_ver}"
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -21043,7 +21043,7 @@
     },
     "packages/channel-plugin": {
       "name": "@unclick/channel",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.103.0"

--- a/packages/channel-plugin/package.json
+++ b/packages/channel-plugin/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@unclick/channel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "UnClick Channel plugin for Claude Code - routes admin chat through your Claude Code session so no separate AI key is needed.",
   "license": "MIT",
   "type": "module",
   "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "unclick-channel": "./index.js"
   },


### PR DESCRIPTION
## Summary
- bump @unclick/channel to 0.1.1 and add publishConfig access=public
- force public npm access after publish
- make the publish workflow fail unless an unauthenticated public npm lookup sees the just-published version

## Tests
- `node --test packages/channel-plugin/*.test.js`
- `npm test`
- `npm pack --dry-run --workspace @unclick/channel`
- workflow YAML parse check

Follow-up to #684. The first publish job succeeded but only warned when public npm lookup still returned missing; this makes that proof hard-gated.