### PR TITLE
Correct channel package public access command

### DIFF
--- a/.github/workflows/publish-channel-package.yml
+++ b/.github/workflows/publish-channel-package.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Force public npm access
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        run: npm access public @unclick/channel
+        run: npm access set status=public @unclick/channel
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- correct the npm access syntax to `npm access set status=public @unclick/channel`
- keep the unauthenticated public registry proof as the hard gate

## Proof
- public npm lookup now returns @unclick/channel 0.1.1
- workflow YAML parses locally

Follow-up to #685 after the stricter main publish run correctly failed on the bad npm access command.