### PR TITLE
Add receipt-first Orchestrator tether checks

### DIFF
--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -18,10 +18,24 @@ your local Claude Code session so you do not need a separate AI API key.
 The plugin also exposes `unclick_save_conversation_turn`, a small fallback
 tool for Orchestrator continuity. Use it when a seat is running through this
 channel but the normal UnClick MCP `save_conversation_turn` tool is not
-available. It saves one external chat turn through
+available. The receipt-first rule is: when a real chat message wakes the seat,
+save that accepted turn first and keep the returned `turn_id` as the receipt.
+It saves one external chat turn through
 `admin_conversation_turn_ingest`, so `/admin/orchestrator` can show and search
 the turn. If neither save path is available, the seat should say `UNTETHERED`
-instead of silently continuing.
+with any partial receipt it captured instead of silently continuing.
+
+The plugin also exposes `unclick_orchestrator_tether_check`. Call it on startup
+or heartbeat to save a harmless synthetic self-check turn and confirm
+`/admin/orchestrator` search can find it. The backup order is:
+
+1. save the live chat wake/message first;
+2. use the UnClick MCP `save_conversation_turn` tool;
+3. use this channel plugin's `unclick_save_conversation_turn` tool;
+4. use the `admin_conversation_turn_ingest` API directly;
+5. run `unclick_orchestrator_tether_check`;
+6. save any safe partial status/proof still available;
+7. say `UNTETHERED` with the missing path and any captured receipt ids.
 
 Every 30 seconds the plugin POSTs a heartbeat to `admin_channel_heartbeat`
 so the admin UI knows the channel is online.

--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -35,7 +35,13 @@ import readline from "node:readline";
 import { apiFetchJson } from "./http.js";
 import { createHeartbeatGate } from "./heartbeat-gate.js";
 import { readTimingConfig } from "./config.js";
-import { saveConversationTurn, saveConversationTurnTool } from "./orchestrator-turns.js";
+import {
+  getReceiptFirstTetherLadder,
+  runTetherSelfCheck,
+  saveConversationTurn,
+  saveConversationTurnTool,
+  tetherSelfCheckTool,
+} from "./orchestrator-turns.js";
 
 const API_BASE       = process.env.UNCLICK_API_BASE     || "https://unclick.world";
 const API_KEY        = process.env.UNCLICK_API_KEY      || "";
@@ -141,6 +147,7 @@ async function handleRpcLine(line) {
             },
           },
           saveConversationTurnTool,
+          tetherSelfCheckTool,
         ],
       },
     });
@@ -202,6 +209,50 @@ async function handleRpcLine(line) {
               {
                 type: "text",
                 text: `UNTETHERED: could not save Orchestrator turn: ${message}`,
+              },
+            ],
+          },
+        });
+      }
+      return;
+    }
+    if (name === "unclick_orchestrator_tether_check") {
+      try {
+        const result = await runTetherSelfCheck(apiFetch, args);
+        writeRpc({
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeRpc({
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    ok: false,
+                    status: "UNTETHERED",
+                    missing: message,
+                    guidance:
+                      "Partial capture still counts: save any safe status/proof you can, then reconnect or update the missing bridge.",
+                    ladder: getReceiptFirstTetherLadder(),
+                  },
+                  null,
+                  2
+                ),
               },
             ],
           },

--- a/packages/channel-plugin/orchestrator-turns.js
+++ b/packages/channel-plugin/orchestrator-turns.js
@@ -1,12 +1,24 @@
 const ALLOWED_ROLES = new Set(["user", "assistant", "system"]);
 const DEFAULT_SOURCE_APP = "claude-code-channel";
 const MAX_CONTENT_LENGTH = 12_000;
+const DEFAULT_SELF_CHECK_SESSION = "orchestrator-tether-self-check";
+
+export const RECEIPT_FIRST_TETHER_LADDER = [
+  "1. Live chat wake: save the accepted human turn immediately and keep the receipt id.",
+  "2. MCP path: call save_conversation_turn when the UnClick MCP tool is available.",
+  "3. Channel path: call unclick_save_conversation_turn when running through @unclick/channel.",
+  "4. API path: call admin_conversation_turn_ingest with the UnClick API key in Authorization.",
+  "5. Self-check path: save a harmless synthetic turn and verify Orchestrator search can find it.",
+  "6. Partial capture path: save whatever safe status/proof you still can before declaring the missing link.",
+  "7. Fail-loud path: reply UNTETHERED with captured receipt ids plus the missing tool/path instead of silently continuing.",
+];
 
 export const saveConversationTurnTool = {
   name: "unclick_save_conversation_turn",
   description:
     "Save an external or subscription chat turn into UnClick Orchestrator continuity. " +
-    "Use this after accepted human turns and useful assistant replies when the normal UnClick MCP save_conversation_turn tool is unavailable. " +
+    "Receipt-first rule: call this immediately after an accepted human wake/message when the normal UnClick MCP save_conversation_turn tool is unavailable, then keep the returned turn_id as proof. " +
+    "Use the backup ladder: MCP save tool, channel save tool, API ingest, tether self-check, partial safe capture, then UNTETHERED with captured receipts if any link is still missing. " +
     "Do not store secrets, API keys, passwords, one-time codes, or private credentials. " +
     "If this tool is unavailable or fails, say UNTETHERED instead of silently continuing.",
   inputSchema: {
@@ -39,6 +51,35 @@ export const saveConversationTurnTool = {
   },
 };
 
+export const tetherSelfCheckTool = {
+  name: "unclick_orchestrator_tether_check",
+  description:
+    "Run a receipt-first Orchestrator tether self-check. Saves one harmless synthetic turn through admin_conversation_turn_ingest, then checks Orchestrator search can find it. " +
+    "Call this on startup or heartbeat when you need to prove the external seat is really tethered. If it fails, say UNTETHERED with the missing path.",
+  inputSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      session_id: {
+        type: "string",
+        description: "Optional stable self-check session id.",
+      },
+      source_app: {
+        type: "string",
+        description: "Optional source label for this client.",
+      },
+      marker: {
+        type: "string",
+        description: "Optional harmless marker for tests. Do not use live operator test terms.",
+      },
+    },
+  },
+};
+
+export function getReceiptFirstTetherLadder() {
+  return [...RECEIPT_FIRST_TETHER_LADDER];
+}
+
 export function buildConversationTurnPayload(args, options = {}) {
   const defaultSourceApp = String(options.defaultSourceApp ?? DEFAULT_SOURCE_APP).trim() || DEFAULT_SOURCE_APP;
   const sessionId = String(args?.session_id ?? "").trim();
@@ -69,4 +110,64 @@ export async function saveConversationTurn(apiFetch, args) {
     method: "POST",
     body: payload,
   });
+}
+
+function defaultMarker() {
+  const randomPart = Math.random().toString(36).slice(2, 10);
+  return `unclick-tether-self-check-${Date.now().toString(36)}-${randomPart}`;
+}
+
+export function buildTetherSelfCheckPayload(args = {}) {
+  const marker = String(args?.marker ?? defaultMarker()).trim();
+  if (!marker) throw new Error("marker required");
+  const sessionId = String(args?.session_id ?? DEFAULT_SELF_CHECK_SESSION).trim() || DEFAULT_SELF_CHECK_SESSION;
+  const sourceApp = String(args?.source_app ?? DEFAULT_SOURCE_APP).trim() || DEFAULT_SOURCE_APP;
+
+  return {
+    marker,
+    turn: buildConversationTurnPayload({
+      session_id: sessionId,
+      role: "system",
+      content: `Orchestrator tether self-check receipt marker: ${marker}`,
+      source_app: sourceApp,
+      client_session_id: sessionId,
+    }),
+  };
+}
+
+export function orchestratorContextContainsReceipt(contextReadResult, { marker, turnId } = {}) {
+  const serialized = JSON.stringify(contextReadResult ?? {});
+  return Boolean(
+    (marker && serialized.includes(String(marker))) ||
+      (turnId && serialized.includes(String(turnId)))
+  );
+}
+
+export async function runTetherSelfCheck(apiFetch, args = {}) {
+  const payload = buildTetherSelfCheckPayload(args);
+  const receipt = await saveConversationTurn(apiFetch, payload.turn);
+  const turnId = receipt?.turn_id ? String(receipt.turn_id) : "";
+  if (!turnId) {
+    throw new Error("admin_conversation_turn_ingest returned no receipt turn_id");
+  }
+
+  const contextRead = await apiFetch("orchestrator_context_read", {
+    method: "GET",
+    query: {
+      q: payload.marker,
+      limit: 20,
+    },
+  });
+
+  if (!orchestratorContextContainsReceipt(contextRead, { marker: payload.marker, turnId })) {
+    throw new Error("saved self-check turn was not found by Orchestrator search");
+  }
+
+  return {
+    ok: true,
+    turn_id: turnId,
+    session_id: receipt?.session_id ?? payload.turn.session_id,
+    marker: payload.marker,
+    ladder: getReceiptFirstTetherLadder(),
+  };
 }

--- a/packages/channel-plugin/orchestrator-turns.test.js
+++ b/packages/channel-plugin/orchestrator-turns.test.js
@@ -1,15 +1,39 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildTetherSelfCheckPayload,
+  getReceiptFirstTetherLadder,
+  orchestratorContextContainsReceipt,
+  runTetherSelfCheck,
   buildConversationTurnPayload,
   saveConversationTurn,
   saveConversationTurnTool,
+  tetherSelfCheckTool,
 } from "./orchestrator-turns.js";
 
 test("saveConversationTurnTool advertises the explicit Orchestrator tether hook", () => {
   assert.equal(saveConversationTurnTool.name, "unclick_save_conversation_turn");
   assert.match(saveConversationTurnTool.description, /Orchestrator continuity/);
+  assert.match(saveConversationTurnTool.description, /Receipt-first/);
   assert.match(saveConversationTurnTool.description, /UNTETHERED/);
+});
+
+test("tetherSelfCheckTool advertises startup and heartbeat proof", () => {
+  assert.equal(tetherSelfCheckTool.name, "unclick_orchestrator_tether_check");
+  assert.match(tetherSelfCheckTool.description, /startup or heartbeat/);
+  assert.match(tetherSelfCheckTool.description, /UNTETHERED/);
+});
+
+test("getReceiptFirstTetherLadder keeps reliable paths ordered with partial capture", () => {
+  const ladder = getReceiptFirstTetherLadder();
+
+  assert.match(ladder[0], /Live chat wake/);
+  assert.match(ladder[1], /MCP path/);
+  assert.match(ladder[2], /Channel path/);
+  assert.match(ladder[3], /API path/);
+  assert.match(ladder[4], /Self-check path/);
+  assert.match(ladder[5], /Partial capture path/);
+  assert.match(ladder[6], /UNTETHERED/);
 });
 
 test("buildConversationTurnPayload validates and defaults a safe API body", () => {
@@ -85,4 +109,88 @@ test("saveConversationTurn calls the existing admin ingest endpoint", async () =
       },
     },
   ]);
+});
+
+test("buildTetherSelfCheckPayload creates a harmless synthetic turn", () => {
+  const payload = buildTetherSelfCheckPayload({
+    session_id: "seat-check",
+    source_app: "test-seat",
+    marker: "safe-marker-123",
+  });
+
+  assert.equal(payload.marker, "safe-marker-123");
+  assert.deepEqual(payload.turn, {
+    session_id: "seat-check",
+    role: "system",
+    content: "Orchestrator tether self-check receipt marker: safe-marker-123",
+    source_app: "test-seat",
+    client_session_id: "seat-check",
+  });
+});
+
+test("orchestratorContextContainsReceipt accepts marker or receipt id", () => {
+  assert.equal(
+    orchestratorContextContainsReceipt({ context: { continuity_events: [{ summary: "found marker abc" }] } }, { marker: "marker abc" }),
+    true
+  );
+  assert.equal(
+    orchestratorContextContainsReceipt({ context: { continuity_events: [{ source_id: "turn-9" }] } }, { turnId: "turn-9" }),
+    true
+  );
+  assert.equal(
+    orchestratorContextContainsReceipt({ context: { continuity_events: [] } }, { marker: "missing" }),
+    false
+  );
+});
+
+test("runTetherSelfCheck saves a synthetic turn and verifies Orchestrator search", async () => {
+  const calls = [];
+  const result = await runTetherSelfCheck(async (action, options) => {
+    calls.push({ action, options });
+    if (action === "admin_conversation_turn_ingest") {
+      return {
+        turn_id: "turn-1",
+        session_id: options.body.session_id,
+        role: options.body.role,
+        redacted: false,
+      };
+    }
+    if (action === "orchestrator_context_read") {
+      return { context: { continuity_events: [{ summary: `found ${options.query.q}` }] } };
+    }
+    throw new Error(`unexpected action ${action}`);
+  }, {
+    session_id: "seat-check",
+    source_app: "test-seat",
+    marker: "self-check-proof",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.turn_id, "turn-1");
+  assert.equal(result.marker, "self-check-proof");
+  assert.deepEqual(calls.map((call) => call.action), [
+    "admin_conversation_turn_ingest",
+    "orchestrator_context_read",
+  ]);
+  assert.equal(calls[1].options.query.q, "self-check-proof");
+});
+
+test("runTetherSelfCheck fails loud when Orchestrator search cannot find the receipt", async () => {
+  await assert.rejects(
+    () => runTetherSelfCheck(async (action, options) => {
+      if (action === "admin_conversation_turn_ingest") {
+        return {
+          turn_id: "turn-1",
+          session_id: options.body.session_id,
+          role: options.body.role,
+          redacted: false,
+        };
+      }
+      if (action === "orchestrator_context_read") return { context: { continuity_events: [] } };
+      throw new Error(`unexpected action ${action}`);
+    }, {
+      marker: "missing-marker",
+    }),
+    /not found by Orchestrator search/
+  );
 });

--- a/packages/mcp-server/src/__tests__/orchestrator-tether-contract.test.ts
+++ b/packages/mcp-server/src/__tests__/orchestrator-tether-contract.test.ts
@@ -5,17 +5,20 @@ import { MCP_SERVER_INSTRUCTIONS, VISIBLE_TOOLS } from "../server.js";
 describe("Orchestrator tether contract", () => {
   it("keeps the continuity instructions compact, forceful, and multi-path", () => {
     expect(MCP_SERVER_INSTRUCTIONS).toContain("ORCHESTRATOR TETHER CONTRACT");
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("Receipt-first rule");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("save_conversation_turn");
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("unclick_save_conversation_turn");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("admin_conversation_turn_ingest");
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("Partial capture path");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("UNTETHERED:");
-    expect(MCP_SERVER_INSTRUCTIONS).toContain("First real Orchestrator proof wins");
-    expect(MCP_SERVER_INSTRUCTIONS.length).toBeLessThan(3100);
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("First real Orchestrator receipt wins");
+    expect(MCP_SERVER_INSTRUCTIONS.length).toBeLessThan(3300);
   });
 
   it("advertises the primary save tool to seats", () => {
     const saveTurnTool = VISIBLE_TOOLS.find((tool) => tool.name === "save_conversation_turn");
 
-    expect(saveTurnTool?.description).toContain("primary proof path");
+    expect(saveTurnTool?.description).toContain("primary receipt path");
     expect(saveTurnTool?.description).toContain("UNTETHERED");
   });
 });

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -375,13 +375,13 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
 
   async log_conversation(args) {
     const db = await getBackend();
-    await db.logConversation({
+    const receipt = await db.logConversation({
       session_id: str(args.session_id),
       role: str(args.role),
       content: str(args.content),
       has_code: bool(args.has_code),
     });
-    return { logged: true };
+    return receipt;
   },
 
   async get_conversation_detail(args) {

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -330,10 +330,11 @@ export class LocalBackend implements MemoryBackend {
     return newId;
   }
 
-  async logConversation(data: ConversationInput): Promise<void> {
+  async logConversation(data: ConversationInput) {
     const rows = readTable<ConversationRow>("conversation_log");
+    const id = uuid();
     rows.push({
-      id: uuid(),
+      id,
       session_id: data.session_id,
       role: data.role,
       content: data.content,
@@ -341,6 +342,12 @@ export class LocalBackend implements MemoryBackend {
       created_at: now(),
     });
     writeTable("conversation_log", rows);
+    return {
+      logged: true as const,
+      session_id: data.session_id,
+      role: data.role,
+      receipt_id: id,
+    };
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -686,9 +686,9 @@ export class SupabaseBackend implements MemoryBackend {
     return String(data);
   }
 
-  async logConversation(data: ConversationInput): Promise<void> {
+  async logConversation(data: ConversationInput) {
     await this.enforceCaps("general");
-    const { error } = await this.client
+    const { data: row, error } = await this.client
       .from(this.tables.conversation_log)
       .insert(
         this.withTenancy({
@@ -697,8 +697,16 @@ export class SupabaseBackend implements MemoryBackend {
           content: truncate(data.content),
           has_code: data.has_code,
         })
-      );
+      )
+      .select("id, session_id, role")
+      .single();
     if (error) throw pgError("logConversation insert", error);
+    return {
+      logged: true as const,
+      session_id: String(row.session_id),
+      role: String(row.role),
+      receipt_id: String(row.id),
+    };
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -44,6 +44,13 @@ export interface ConversationInput {
   has_code: boolean;
 }
 
+export interface ConversationReceipt {
+  logged: true;
+  session_id: string;
+  role: string;
+  receipt_id: string;
+}
+
 export interface CodeInput {
   session_id: string;
   language: string;
@@ -89,7 +96,7 @@ export interface MemoryBackend {
   supersedeFact(oldId: string, newText: string, category?: string, confidence?: number): Promise<string>;
 
   /** Log a conversation message. */
-  logConversation(data: ConversationInput): Promise<void>;
+  logConversation(data: ConversationInput): Promise<ConversationReceipt>;
 
   /** Get full conversation log for a session. */
   getConversationDetail(sessionId: string): Promise<unknown>;

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -84,18 +84,20 @@ export const MCP_SERVER_INSTRUCTIONS = [
   "Never ask the user to 'catch you up' -- load first, then act.",
   "",
   "ORCHESTRATOR TETHER CONTRACT:",
-  "If you are a subscription or tethered AI seat, you must make each real",
-  "human/assistant turn land in Orchestrator continuity. Try the shortest",
-  "safe path that works, in this order:",
-  "  1. MCP tool path: call `save_conversation_turn` after accepted human",
-  "     turns and after assistant replies the client exposes.",
-  "  2. API path: call `admin_conversation_turn_ingest` with the UnClick API",
+  "Receipt-first rule: when a live chat message or heartbeat wakes you,",
+  "first save that accepted turn into Orchestrator continuity and keep the",
+  "returned receipt id. Work from most reliable to least:",
+  "  1. Live chat wake: save the accepted human turn immediately.",
+  "  2. MCP path: call `save_conversation_turn`.",
+  "  3. Channel path: call `unclick_save_conversation_turn` if exposed.",
+  "  4. API path: call `admin_conversation_turn_ingest` with the UnClick API",
   "     key in Authorization only. Never print or log secrets.",
-  "  3. Health path: if neither save path is available, say `UNTETHERED:`",
-  "     and name the missing capability instead of silently continuing.",
-  "  4. Builder path: if you can build, create the smallest safe turn-save",
-  "     hook for the client and prove it with Orchestrator search.",
-  "First real Orchestrator proof wins. Extra successful paths are duplicate",
+  "  5. Self-check path: save a harmless synthetic turn and verify",
+  "     Orchestrator search can find it.",
+  "  6. Partial capture path: save any safe status/proof you still can.",
+  "  7. Fail-loud path: say `UNTETHERED:` with captured receipt ids plus",
+  "     the missing capability instead of silently continuing.",
+  "First real Orchestrator receipt wins. Extra successful paths are duplicate",
   "proof to consolidate, not blockers.",
   "Skip or redact secrets, API keys, passwords, one-time codes, and private",
   "credentials before saving any turn.",
@@ -442,7 +444,7 @@ export const VISIBLE_TOOLS = [
     title: "Save conversation turn",
     description:
       "Saves one human, assistant, system, or tool turn into UnClick conversation history so Orchestrator continuity can show and search it. " +
-      "Tethered seats should treat this as the primary proof path after each accepted subscription chat human turn and after each assistant reply when the client can call tools. " +
+      "Tethered seats should treat this as the primary receipt path after each accepted subscription chat human turn and after each assistant reply when the client can call tools. " +
       "If this tool is unavailable, fail loud with UNTETHERED or use the documented API fallback instead of silently continuing. " +
       "Use a stable session_id for the thread. Do not store secrets, API keys, passwords, one-time codes, or private credentials.",
     inputSchema: {


### PR DESCRIPTION
## Summary
- add a receipt-first Orchestrator tether ladder for external/channel seats
- expose `unclick_orchestrator_tether_check` in @unclick/channel so startup/heartbeat can save a harmless synthetic turn and verify Orchestrator search finds it
- return receipt ids from MCP `save_conversation_turn`, so seats can prove the first save instead of relying on vibes
- make `UNTETHERED` a fail-loud status with partial-capture guidance, not a reason to drop all proof

## Proof
- `node --test packages/channel-plugin/*.test.js`
- `npx vitest run src/__tests__/orchestrator-tether-contract.test.ts src/__tests__/tool-schema-validation.test.ts` from `packages/mcp-server`
- `npm run test --workspace=packages/mcp-server`
- `npm run build --workspace=packages/mcp-server`
- `npm run build`

Refs #687
UnClick todos: 4d4935a2-1ad1-43db-b948-3b095cb1c317, 5fd4478a-b165-4661-a65c-6a76cbaff46d