### PR TITLE
[codex] Add Orchestrator log-read-decide gate

### DIFF
--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -25,6 +25,13 @@ It saves one external chat turn through
 the turn. If neither save path is available, the seat should say `UNTETHERED`
 with any partial receipt it captured instead of silently continuing.
 
+The plugin also exposes `unclick_orchestrator_context_read`. Call it
+immediately after saving the accepted turn and before deciding what the user
+meant. The required order is: Log -> Read -> Decide -> Reply -> Log reply.
+This stops a seat from treating a test cue, proof marker, or check phrase as a
+real operator request without reading nearby Orchestrator context first. If the
+read fails, say `CONTEXT_UNREAD` or `UNTETHERED` instead of guessing.
+
 The plugin also exposes `unclick_orchestrator_tether_check`. Call it on startup
 or heartbeat to save a harmless synthetic self-check turn and confirm
 `/admin/orchestrator` search can find it. The backup order is:
@@ -33,9 +40,10 @@ or heartbeat to save a harmless synthetic self-check turn and confirm
 2. use the UnClick MCP `save_conversation_turn` tool;
 3. use this channel plugin's `unclick_save_conversation_turn` tool;
 4. use the `admin_conversation_turn_ingest` API directly;
-5. run `unclick_orchestrator_tether_check`;
-6. save any safe partial status/proof still available;
-7. say `UNTETHERED` with the missing path and any captured receipt ids.
+5. read Orchestrator context before deciding what the saved turn means;
+6. run `unclick_orchestrator_tether_check`;
+7. save any safe partial status/proof still available;
+8. say `UNTETHERED` with the missing path and any captured receipt ids.
 
 Every 30 seconds the plugin POSTs a heartbeat to `admin_channel_heartbeat`
 so the admin UI knows the channel is online.

--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -37,6 +37,8 @@ import { createHeartbeatGate } from "./heartbeat-gate.js";
 import { readTimingConfig } from "./config.js";
 import {
   getReceiptFirstTetherLadder,
+  orchestratorContextReadTool,
+  readOrchestratorContext,
   runTetherSelfCheck,
   saveConversationTurn,
   saveConversationTurnTool,
@@ -147,6 +149,7 @@ async function handleRpcLine(line) {
             },
           },
           saveConversationTurnTool,
+          orchestratorContextReadTool,
           tetherSelfCheckTool,
         ],
       },
@@ -209,6 +212,50 @@ async function handleRpcLine(line) {
               {
                 type: "text",
                 text: `UNTETHERED: could not save Orchestrator turn: ${message}`,
+              },
+            ],
+          },
+        });
+      }
+      return;
+    }
+    if (name === "unclick_orchestrator_context_read") {
+      try {
+        const result = await readOrchestratorContext(apiFetch, args);
+        writeRpc({
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeRpc({
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    ok: false,
+                    status: "CONTEXT_UNREAD",
+                    missing: message,
+                    guidance:
+                      "The turn may be saved, but do not interpret or act until Orchestrator context is readable. Treat test/proof/check wording as context until confirmed.",
+                    ladder: getReceiptFirstTetherLadder(),
+                  },
+                  null,
+                  2
+                ),
               },
             ],
           },

--- a/packages/channel-plugin/orchestrator-turns.js
+++ b/packages/channel-plugin/orchestrator-turns.js
@@ -8,9 +8,10 @@ export const RECEIPT_FIRST_TETHER_LADDER = [
   "2. MCP path: call save_conversation_turn when the UnClick MCP tool is available.",
   "3. Channel path: call unclick_save_conversation_turn when running through @unclick/channel.",
   "4. API path: call admin_conversation_turn_ingest with the UnClick API key in Authorization.",
-  "5. Self-check path: save a harmless synthetic turn and verify Orchestrator search can find it.",
-  "6. Partial capture path: save whatever safe status/proof you still can before declaring the missing link.",
-  "7. Fail-loud path: reply UNTETHERED with captured receipt ids plus the missing tool/path instead of silently continuing.",
+  "5. Context-read path: read Orchestrator context before deciding what the saved turn means.",
+  "6. Self-check path: save a harmless synthetic turn and verify Orchestrator search can find it.",
+  "7. Partial capture path: save whatever safe status/proof you still can before declaring the missing link.",
+  "8. Fail-loud path: reply UNTETHERED with captured receipt ids plus the missing tool/path instead of silently continuing.",
 ];
 
 export const saveConversationTurnTool = {
@@ -18,7 +19,8 @@ export const saveConversationTurnTool = {
   description:
     "Save an external or subscription chat turn into UnClick Orchestrator continuity. " +
     "Receipt-first rule: call this immediately after an accepted human wake/message when the normal UnClick MCP save_conversation_turn tool is unavailable, then keep the returned turn_id as proof. " +
-    "Use the backup ladder: MCP save tool, channel save tool, API ingest, tether self-check, partial safe capture, then UNTETHERED with captured receipts if any link is still missing. " +
+    "Then read Orchestrator context before deciding what the saved turn means. " +
+    "Use the backup ladder: MCP save tool, channel save tool, API ingest, context read, tether self-check, partial safe capture, then UNTETHERED with captured receipts if any link is still missing. " +
     "Do not store secrets, API keys, passwords, one-time codes, or private credentials. " +
     "If this tool is unavailable or fails, say UNTETHERED instead of silently continuing.",
   inputSchema: {
@@ -48,6 +50,32 @@ export const saveConversationTurnTool = {
       },
     },
     required: ["session_id", "role", "content"],
+  },
+};
+
+export const orchestratorContextReadTool = {
+  name: "unclick_orchestrator_context_read",
+  description:
+    "Read UnClick Orchestrator continuity after saving an accepted human turn and before interpreting or acting. " +
+    "This is the mandatory Log -> Read -> Decide gate: save the turn, read nearby context, then decide whether the text is a test cue, real request, blocker, proof, or status. " +
+    "Use q to narrow around words from the saved turn, or omit q for recent context. " +
+    "If context cannot be read, say CONTEXT_UNREAD or UNTETHERED instead of guessing what the user meant.",
+  inputSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      q: {
+        type: "string",
+        description: "Optional search text from the saved turn. Do not use secrets.",
+      },
+      limit: {
+        type: "number",
+        minimum: 20,
+        maximum: 200,
+        default: 80,
+        description: "Maximum events to read.",
+      },
+    },
   },
 };
 
@@ -112,6 +140,23 @@ export async function saveConversationTurn(apiFetch, args) {
   });
 }
 
+export function buildOrchestratorContextReadQuery(args = {}) {
+  const q = String(args?.q ?? "").replace(/\s+/g, " ").trim().slice(0, 100);
+  const requestedLimit = Number(args?.limit ?? 80);
+  const maxLimit = q ? 200 : 120;
+  const limit = Math.min(Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 80, 20), maxLimit);
+  const query = { limit };
+  if (q) query.q = q;
+  return query;
+}
+
+export async function readOrchestratorContext(apiFetch, args = {}) {
+  return apiFetch("orchestrator_context_read", {
+    method: "GET",
+    query: buildOrchestratorContextReadQuery(args),
+  });
+}
+
 function defaultMarker() {
   const randomPart = Math.random().toString(36).slice(2, 10);
   return `unclick-tether-self-check-${Date.now().toString(36)}-${randomPart}`;
@@ -151,12 +196,9 @@ export async function runTetherSelfCheck(apiFetch, args = {}) {
     throw new Error("admin_conversation_turn_ingest returned no receipt turn_id");
   }
 
-  const contextRead = await apiFetch("orchestrator_context_read", {
-    method: "GET",
-    query: {
-      q: payload.marker,
-      limit: 20,
-    },
+  const contextRead = await readOrchestratorContext(apiFetch, {
+    q: payload.marker,
+    limit: 20,
   });
 
   if (!orchestratorContextContainsReceipt(contextRead, { marker: payload.marker, turnId })) {

--- a/packages/channel-plugin/orchestrator-turns.test.js
+++ b/packages/channel-plugin/orchestrator-turns.test.js
@@ -1,9 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildOrchestratorContextReadQuery,
   buildTetherSelfCheckPayload,
   getReceiptFirstTetherLadder,
   orchestratorContextContainsReceipt,
+  orchestratorContextReadTool,
+  readOrchestratorContext,
   runTetherSelfCheck,
   buildConversationTurnPayload,
   saveConversationTurn,
@@ -16,6 +19,12 @@ test("saveConversationTurnTool advertises the explicit Orchestrator tether hook"
   assert.match(saveConversationTurnTool.description, /Orchestrator continuity/);
   assert.match(saveConversationTurnTool.description, /Receipt-first/);
   assert.match(saveConversationTurnTool.description, /UNTETHERED/);
+});
+
+test("orchestratorContextReadTool advertises the Log Read Decide gate", () => {
+  assert.equal(orchestratorContextReadTool.name, "unclick_orchestrator_context_read");
+  assert.match(orchestratorContextReadTool.description, /Log -> Read -> Decide/);
+  assert.match(orchestratorContextReadTool.description, /CONTEXT_UNREAD/);
 });
 
 test("tetherSelfCheckTool advertises startup and heartbeat proof", () => {
@@ -31,9 +40,10 @@ test("getReceiptFirstTetherLadder keeps reliable paths ordered with partial capt
   assert.match(ladder[1], /MCP path/);
   assert.match(ladder[2], /Channel path/);
   assert.match(ladder[3], /API path/);
-  assert.match(ladder[4], /Self-check path/);
-  assert.match(ladder[5], /Partial capture path/);
-  assert.match(ladder[6], /UNTETHERED/);
+  assert.match(ladder[4], /Context-read path/);
+  assert.match(ladder[5], /Self-check path/);
+  assert.match(ladder[6], /Partial capture path/);
+  assert.match(ladder[7], /UNTETHERED/);
 });
 
 test("buildConversationTurnPayload validates and defaults a safe API body", () => {
@@ -105,6 +115,39 @@ test("saveConversationTurn calls the existing admin ingest endpoint", async () =
           content: "saved",
           source_app: "test-client",
           client_session_id: "thread-1",
+        },
+      },
+    },
+  ]);
+});
+
+test("buildOrchestratorContextReadQuery normalizes search and clamps limits", () => {
+  assert.deepEqual(
+    buildOrchestratorContextReadQuery({ q: "  proof   check  ", limit: 500 }),
+    { limit: 200, q: "proof check" }
+  );
+  assert.deepEqual(buildOrchestratorContextReadQuery({ limit: 1 }), { limit: 20 });
+});
+
+test("readOrchestratorContext calls the read-only context endpoint", async () => {
+  const calls = [];
+  const result = await readOrchestratorContext(async (action, options) => {
+    calls.push({ action, options });
+    return { context: { continuity_events: [] } };
+  }, {
+    q: "status",
+    limit: 40,
+  });
+
+  assert.deepEqual(result, { context: { continuity_events: [] } });
+  assert.deepEqual(calls, [
+    {
+      action: "orchestrator_context_read",
+      options: {
+        method: "GET",
+        query: {
+          limit: 40,
+          q: "status",
         },
       },
     },

--- a/packages/mcp-server/src/__tests__/orchestrator-tether-contract.test.ts
+++ b/packages/mcp-server/src/__tests__/orchestrator-tether-contract.test.ts
@@ -9,10 +9,13 @@ describe("Orchestrator tether contract", () => {
     expect(MCP_SERVER_INSTRUCTIONS).toContain("save_conversation_turn");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("unclick_save_conversation_turn");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("admin_conversation_turn_ingest");
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("read_orchestrator_context");
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("Log -> Read -> Decide");
+    expect(MCP_SERVER_INSTRUCTIONS).toContain("CONTEXT_UNREAD:");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("Partial capture path");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("UNTETHERED:");
     expect(MCP_SERVER_INSTRUCTIONS).toContain("First real Orchestrator receipt wins");
-    expect(MCP_SERVER_INSTRUCTIONS.length).toBeLessThan(3300);
+    expect(MCP_SERVER_INSTRUCTIONS.length).toBeLessThan(3800);
   });
 
   it("advertises the primary save tool to seats", () => {
@@ -20,5 +23,12 @@ describe("Orchestrator tether contract", () => {
 
     expect(saveTurnTool?.description).toContain("primary receipt path");
     expect(saveTurnTool?.description).toContain("UNTETHERED");
+  });
+
+  it("advertises the read-before-decide tool to seats", () => {
+    const readContextTool = VISIBLE_TOOLS.find((tool) => tool.name === "read_orchestrator_context");
+
+    expect(readContextTool?.description).toContain("Log -> Read -> Decide");
+    expect(readContextTool?.description).toContain("CONTEXT_UNREAD");
   });
 });

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -16,6 +16,7 @@ describe("runtime tool schema validation", () => {
       },
     },
     { name: "check_signals", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
+    { name: "read_orchestrator_context", args: { q: "strict schema probe", bogus_field: "should reject" } },
     { name: "heartbeat_protocol", args: { bogus_field: "should reject" } },
     {
       name: "ack_handoff",
@@ -77,6 +78,10 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("unclick_generate_uuid", { count: 1 })).toBeNull();
     expect(validateToolArgumentsForRuntime("check_signals", {
       agent_id: "strict-probe",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("read_orchestrator_context", {
+      q: "strict schema probe",
+      limit: 40,
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("heartbeat_protocol", {})).toBeNull();
     expect(validateToolArgumentsForRuntime("ack_handoff", {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -92,11 +92,16 @@ export const MCP_SERVER_INSTRUCTIONS = [
   "  3. Channel path: call `unclick_save_conversation_turn` if exposed.",
   "  4. API path: call `admin_conversation_turn_ingest` with the UnClick API",
   "     key in Authorization only. Never print or log secrets.",
-  "  5. Self-check path: save a harmless synthetic turn and verify",
+  "  5. Context-read path: call `read_orchestrator_context` or",
+  "     `unclick_orchestrator_context_read` before deciding what the saved",
+  "     turn means. Required order: Log -> Read -> Decide -> Reply -> Log reply.",
+  "  6. Self-check path: save a harmless synthetic turn and verify",
   "     Orchestrator search can find it.",
-  "  6. Partial capture path: save any safe status/proof you still can.",
-  "  7. Fail-loud path: say `UNTETHERED:` with captured receipt ids plus",
+  "  7. Partial capture path: save any safe status/proof you still can.",
+  "  8. Fail-loud path: say `UNTETHERED:` or `CONTEXT_UNREAD:` with captured receipt ids plus",
   "     the missing capability instead of silently continuing.",
+  "If the saved turn looks like a test, proof, check, or keyword cue, do not",
+  "treat the phrase as real operator state until the context read confirms it.",
   "First real Orchestrator receipt wins. Extra successful paths are duplicate",
   "proof to consolidate, not blockers.",
   "Skip or redact secrets, API keys, passwords, one-time codes, and private",
@@ -468,6 +473,31 @@ export const VISIBLE_TOOLS = [
         },
       },
       required: ["session_id", "role", "content"],
+    },
+  },
+  {
+    name: "read_orchestrator_context",
+    title: "Read Orchestrator context",
+    description:
+      "Reads current UnClick Orchestrator continuity so a seat can interpret a freshly saved turn before acting. " +
+      "Use immediately after save_conversation_turn in the required Log -> Read -> Decide -> Reply -> Log reply gate. " +
+      "If this read fails, say CONTEXT_UNREAD or UNTETHERED instead of guessing whether a phrase is a test cue, real request, blocker, proof, or status.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        q: {
+          type: "string",
+          description: "Optional search text from the saved turn. Do not include secrets.",
+        },
+        limit: {
+          type: "number",
+          minimum: 20,
+          maximum: 200,
+          default: 80,
+          description: "Maximum events to read.",
+        },
+      },
     },
   },
   {
@@ -1552,6 +1582,57 @@ export function createServer(): Server {
       if (name === "heartbeat_protocol") {
         return {
           content: [{ type: "text", text: JSON.stringify(getHeartbeatProtocol(), null, 2) }],
+        };
+      }
+
+      // ── Orchestrator context: mandatory read step after turn capture ──
+      if (name === "read_orchestrator_context") {
+        const apiKey = process.env.UNCLICK_API_KEY;
+        const base =
+          process.env.UNCLICK_MEMORY_BASE_URL ||
+          process.env.UNCLICK_SITE_URL ||
+          "https://unclick.world";
+        if (!apiKey) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  ok: false,
+                  status: "CONTEXT_UNREAD",
+                  missing: "UNCLICK_API_KEY not configured",
+                  guidance:
+                    "The turn may be saved locally, but do not interpret or act until Orchestrator context is readable.",
+                }, null, 2),
+              },
+            ],
+            isError: true,
+          };
+        }
+        const q =
+          typeof args.q === "string"
+            ? args.q.replace(/\s+/g, " ").trim().slice(0, 100)
+            : "";
+        const requestedLimit = Number(args.limit ?? 80);
+        const limit = Math.min(
+          Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 80, 20),
+          q ? 200 : 120
+        );
+        const url = new URL(`${base.replace(/\/$/, "")}/api/memory-admin`);
+        url.searchParams.set("action", "orchestrator_context_read");
+        url.searchParams.set("limit", String(limit));
+        if (q) url.searchParams.set("q", q);
+        const resp = await fetch(url, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+        });
+        const body = await resp.json().catch(() => ({}));
+        return {
+          content: [{ type: "text", text: JSON.stringify(body, null, 2) }],
+          isError: !resp.ok,
         };
       }
 


### PR DESCRIPTION
## What changed
- Added a read-only Orchestrator context tool to the MCP server: `read_orchestrator_context`.
- Added the matching channel-plugin tool: `unclick_orchestrator_context_read`.
- Updated the tether contract to require `Log -> Read -> Decide -> Reply -> Log reply`.
- Tightened the failure mode so seats say `CONTEXT_UNREAD` or `UNTETHERED` instead of guessing when context cannot be read.

## Why
The latest live proof showed that external-seat turns can be captured, but a seat can still misread a test cue as a real operator request when it acts before reading nearby Orchestrator context.

## Validation
- `node --test packages/channel-plugin/orchestrator-turns.test.js`
- `npx vitest run --config vitest.config.ts src/__tests__/orchestrator-tether-contract.test.ts src/__tests__/tool-schema-validation.test.ts` from `packages/mcp-server`
- `npm run build --workspace=@unclick/mcp-server`
- `node --check packages/channel-plugin/index.js`
- `node --check packages/channel-plugin/orchestrator-turns.js`