### PR TITLE
[codex] Harden MCP publish retry

### DIFF
--- a/.github/workflows/publish-mcp-package.yml
+++ b/.github/workflows/publish-mcp-package.yml
@@ -139,7 +139,15 @@ jobs:
 
       - name: Push version bump
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        run: git push
+        run: |
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "Version bump push failed, rebasing on latest main before retry ${attempt}."
+            git pull --rebase origin main
+          done
+          git push
 
       - name: Publish to npm
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -62,6 +62,8 @@ Scheduled AI Seats can call `heartbeat_protocol` with no arguments to fetch the 
 
 Tethered AI Seats should also treat `save_conversation_turn` as the receipt-first path for Orchestrator continuity: save the accepted turn, keep the returned receipt id, and fail loud with `UNTETHERED` plus any partial receipts when the save path is missing.
 
+After saving an accepted external turn, tethered seats should call `read_orchestrator_context` before deciding what the user meant. The safe order is Log -> Read -> Decide -> Reply -> Log reply, so a test cue or proof phrase is not mistaken for a real operator request.
+
 ## Configuration
 
 | Environment Variable | Default | Description |


### PR DESCRIPTION
## What changed
- Added retry + rebase around the MCP package version-bump push.
- Added a small MCP README note about the Orchestrator Log -> Read -> Decide gate, which also gives the MCP publish workflow a fresh package-scoped change to release.

## Why
PR #689 merged cleanly, but the MCP publish job failed because the Channel package publisher pushed a version-bump commit to `main` first. This keeps future publish jobs from failing on that race and gives the current MCP package another clean publish attempt.

## Validation
- `git diff --check`