### PR TITLE
fix(seats): use fungible cycle-share labels

### DIFF
--- a/src/pages/admin/AdminAgents.test.ts
+++ b/src/pages/admin/AdminAgents.test.ts
@@ -23,7 +23,7 @@ function seat(patch: Partial<AISeat>): AISeat {
     provider: "Codex Desktop",
     device: "Chris laptop",
     status: "Ready",
-    state: "Manual slot",
+    state: "Cycle-share capacity",
     load: 25,
     assigned: "General capacity",
     issue: "",
@@ -52,8 +52,12 @@ describe("AdminAgents seat check-ins", () => {
 
     expect(screen.getByRole("heading", { name: "Seats" })).toBeInTheDocument();
     expect(screen.getByText("AI Seats")).toBeInTheDocument();
+    expect(screen.getByText("Cycle share")).toBeInTheDocument();
+    expect(screen.getByText("Fungible mode")).toBeInTheDocument();
     expect(screen.queryByText("UnClick Workers")).not.toBeInTheDocument();
     expect(screen.queryByText("New Worker")).not.toBeInTheDocument();
+    expect(screen.queryByText("Manual mode")).not.toBeInTheDocument();
+    expect(screen.queryByText("Manual load")).not.toBeInTheDocument();
   });
 
   it("matches a live profile to a named physical seat", () => {

--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -113,7 +113,7 @@ const AI_SEATS: AISeat[] = [
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
-    state: "Manual slot",
+    state: "Cycle-share capacity",
     load: 25,
     assigned: "General capacity",
     issue: "",
@@ -125,7 +125,7 @@ const AI_SEATS: AISeat[] = [
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
-    state: "Manual slot",
+    state: "Cycle-share capacity",
     load: 25,
     assigned: "General capacity",
     issue: "",
@@ -137,7 +137,7 @@ const AI_SEATS: AISeat[] = [
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
-    state: "Manual slot",
+    state: "Cycle-share capacity",
     load: 25,
     assigned: "General capacity",
     issue: "",
@@ -149,7 +149,7 @@ const AI_SEATS: AISeat[] = [
     provider: "Unknown AI",
     device: "Unknown device",
     status: "Ready",
-    state: "Manual slot",
+    state: "Cycle-share capacity",
     load: 25,
     assigned: "General capacity",
     issue: "",
@@ -353,7 +353,7 @@ function AISeatsPanel() {
           <div>
             <h2 className="text-sm font-semibold text-heading">AI Seats</h2>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Connected AI capacity with the newest live check-in shown in each row. Manual load is a planning guide.
+              Connected AI capacity with the newest live check-in shown in each row. Cycle-share is a planning guide.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -377,7 +377,7 @@ function AISeatsPanel() {
               {profilesLoading ? "Checking..." : "Refresh"}
             </button>
             <span className="inline-flex w-fit items-center rounded-md border border-border/40 bg-card/40 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Manual mode
+              Fungible mode
             </span>
           </div>
         </div>
@@ -385,7 +385,7 @@ function AISeatsPanel() {
           <span>Seat</span>
           <span>Status</span>
           <span className="flex items-center justify-between gap-2">
-            <span>Manual load</span>
+            <span>Cycle share</span>
             <button
               type="button"
               onClick={spreadEvenly}


### PR DESCRIPTION
Summary:
- Updates the Seats page copy from manual-slot language to fungible cycle-share language.
- Adds a focused AdminAgents test assertion so the old manual mode and manual load labels do not return.

Scope:
- Owned files from todo 77429b4a ScopePack: src/pages/admin/AdminAgents.tsx and src/pages/admin/AdminAgents.test.ts.
- Product lane: Seats capacity copy.

Non-overlap:
- Does not change Worker Registry, routing, leases, check-in matching, storage, or database schema.
- Does not touch AutoPilot workers or Performance Monitor scoring.
- Leaves load override storage and routing policy to follow-up chip d0aae03c.

Verification:
- npm test -- --run src/pages/admin/AdminAgents.test.ts
- GitHub CI green: Website (root package), MCP server package, TestPass smoke run, Vercel, Vercel Preview Comments.

Risk:
- Low. User-facing copy and test-only change. Existing local load override behavior is unchanged.

Follow-up:
- Continue broader routing and Performance Monitor work in child chip d0aae03c.

Linked todo:
- 77429b4a, fungible seat migration ScopePack.

Owner status:
- Owner proof refreshed by chatgpt-codex-worker2 at 2026-05-10T16:39Z.
- Ready for review.