### PR TITLE
feat(reliability): add specialist bench registry slice

### DIFF
--- a/scripts/pinballwake-worker-registry-room.mjs
+++ b/scripts/pinballwake-worker-registry-room.mjs
@@ -25,6 +25,7 @@ const VALID_LANES = new Set([
 
 const VALID_ACK_VERDICTS = new Set(["PASS", "BLOCKER", "HOLD", "COMMENT"]);
 const TRUSTED_SIGNING_AUTHORITIES = new Set(["lane", "coordinator", "system"]);
+const VALID_ACTIVATION_MODES = new Set(["active", "bench", "fallback"]);
 const LEGACY_LANE_ALIASES = new Map([
   ["master", "coordinator"],
   ["🐺", "coordinator"],
@@ -97,9 +98,27 @@ function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }
 
+function normalizeActivationMode(input = {}) {
+  const rawMode = normalize(input.activation_mode || input.activationMode || "");
+  if (VALID_ACTIVATION_MODES.has(rawMode)) return rawMode;
+  if (input.bench === true || normalize(input.status) === "bench") return "bench";
+  if (normalize(input.status) === "fallback") return "fallback";
+  return "active";
+}
+
+function normalizePromotionSignals(input = {}) {
+  return {
+    success_count: Number(input.success_count ?? input.successCount ?? 0),
+    failure_count: Number(input.failure_count ?? input.failureCount ?? 0),
+    last_promoted_at: input.last_promoted_at || input.lastPromotedAt || null,
+    promotion_threshold: Number(input.promotion_threshold ?? input.promotionThreshold ?? 3),
+  };
+}
+
 function normalizeWorker(input = {}) {
   const lane = normalizeLane(input.lane || input.role || input.worker);
   const workerId = compactText(input.worker_id || input.workerId || input.id || lane, 120);
+  const activationMode = normalizeActivationMode(input);
   return {
     worker_id: workerId,
     lane,
@@ -107,12 +126,29 @@ function normalizeWorker(input = {}) {
     provider: compactText(input.provider || "", 80),
     machine: compactText(input.machine || "", 80),
     status: normalize(input.status || "available"),
+    activation_mode: activationMode,
+    profile_slug: compactText(input.profile_slug || input.profileSlug || "", 120),
+    activation_reason: compactText(input.activation_reason || input.activationReason || "", 300),
     capabilities: uniq(safeList(input.capabilities || input.skills).map(normalize)),
+    promotion_signals: normalizePromotionSignals(input.promotion_signals || input.promotionSignals || input),
     signing_key_id: compactText(input.signing_key_id || input.signingKeyId || workerId, 160),
     signing_secret: compactText(input.signing_secret || input.signingSecret || "", 500),
     revoked_at: input.revoked_at || input.revokedAt || null,
     last_seen_at: input.last_seen_at || input.lastSeenAt || null,
   };
+}
+
+function isCallableWorker(worker = {}) {
+  return !worker.revoked_at && worker.activation_mode !== "bench";
+}
+
+function isBenchWorker(worker = {}) {
+  return !worker.revoked_at && worker.activation_mode === "bench";
+}
+
+function workerMatchesCapability(worker = {}, capability = "") {
+  const wanted = normalize(capability);
+  return !wanted || safeList(worker.capabilities).includes(wanted);
 }
 
 export function createWorkerRegistry(input = {}) {
@@ -131,6 +167,56 @@ export function findRegistryWorker(registry = {}, { workerId = "", lane = "" } =
     (wantedId && worker.worker_id === wantedId) ||
     (wantedLane && worker.lane === wantedLane)
   ) || null;
+}
+
+export function findSpecialistBenchWorkers(registry = {}, { capability = "", lane = "" } = {}) {
+  const wantedLane = normalizeLane(lane);
+  return safeList(registry.workers).filter((worker) =>
+    isBenchWorker(worker) &&
+    (!wantedLane || worker.lane === wantedLane) &&
+    workerMatchesCapability(worker, capability)
+  );
+}
+
+export function selectWorkerForCapability(registry = {}, { capability = "", lane = "" } = {}) {
+  const wantedLane = normalizeLane(lane);
+  const activeWorker = safeList(registry.workers).find((worker) =>
+    isCallableWorker(worker) &&
+    (!wantedLane || worker.lane === wantedLane) &&
+    workerMatchesCapability(worker, capability)
+  );
+
+  if (activeWorker) {
+    return {
+      ok: true,
+      worker: activeWorker,
+      activation: "active",
+      confidence: "high",
+      reason: "active_worker_match",
+      fallback_reason: "",
+    };
+  }
+
+  const benchWorker = findSpecialistBenchWorkers(registry, { capability, lane })[0] || null;
+  if (benchWorker) {
+    return {
+      ok: true,
+      worker: benchWorker,
+      activation: "bench",
+      confidence: "medium",
+      reason: "bench_specialist_match",
+      fallback_reason: "no_active_worker_match",
+    };
+  }
+
+  return {
+    ok: false,
+    worker: null,
+    activation: "none",
+    confidence: "low",
+    reason: "no_worker_match",
+    fallback_reason: "use_fungible_capacity",
+  };
 }
 
 function ackSigningPayload(input = {}) {
@@ -372,7 +458,11 @@ export function evaluateWorkerRegistryRoom({
     action: "worker_registry_room",
     result: verification ? verification.reason : "registry_ready",
     worker_count: safeList(safeRegistry.workers).length,
-    active_worker_count: safeList(safeRegistry.workers).filter((worker) => !worker.revoked_at).length,
+    active_worker_count: safeList(safeRegistry.workers).filter(isCallableWorker).length,
+    bench_worker_count: safeList(safeRegistry.workers).filter(isBenchWorker).length,
+    selection: expected.capability
+      ? selectWorkerForCapability(safeRegistry, { capability: expected.capability, lane: expected.lane })
+      : null,
     verification,
     event: verification && ack ? createAckDecisionEvent({ ack, verification }) : null,
   };

--- a/scripts/pinballwake-worker-registry-room.test.mjs
+++ b/scripts/pinballwake-worker-registry-room.test.mjs
@@ -6,6 +6,8 @@ import {
   createSignedAckRecord,
   createWorkerRegistry,
   evaluateWorkerRegistryRoom,
+  findSpecialistBenchWorkers,
+  selectWorkerForCapability,
   verifySignedAckRecord,
 } from "./pinballwake-worker-registry-room.mjs";
 
@@ -39,6 +41,18 @@ function registryFixture(overrides = {}) {
         signing_secret: "builder-secret",
         ...overrides.builder,
       },
+      {
+        worker_id: "seo-specialist-bench-1",
+        lane: "researcher",
+        status: "bench",
+        activation_mode: "bench",
+        profile_slug: "seo-specialist",
+        capabilities: ["seo", "search"],
+        activation_reason: "Wake only for search and GEO jobs.",
+        success_count: 4,
+        promotion_threshold: 5,
+        ...overrides.seoBench,
+      },
     ],
   });
 }
@@ -63,9 +77,46 @@ describe("PinballWake Worker Registry Room", () => {
     const registry = registryFixture();
 
     assert.equal(registry.version, 1);
-    assert.equal(registry.workers.length, 2);
+    assert.equal(registry.workers.length, 3);
     assert.equal(registry.workers[0].lane, "safety-checker");
     assert.equal(registry.workers[0].seat_id, "lenovo-chatgpt-safety-checker");
+    assert.equal(registry.workers[2].activation_mode, "bench");
+    assert.equal(registry.workers[2].profile_slug, "seo-specialist");
+    assert.equal(registry.workers[2].promotion_signals.success_count, 4);
+  });
+
+  it("keeps bench specialists discoverable without counting them as active workers", () => {
+    const registry = registryFixture();
+    const bench = findSpecialistBenchWorkers(registry, { capability: "seo" });
+
+    assert.equal(bench.length, 1);
+    assert.equal(bench[0].worker_id, "seo-specialist-bench-1");
+
+    const result = evaluateWorkerRegistryRoom({
+      registry,
+      expected: { capability: "seo" },
+      now: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.worker_count, 3);
+    assert.equal(result.active_worker_count, 2);
+    assert.equal(result.bench_worker_count, 1);
+    assert.equal(result.selection.reason, "bench_specialist_match");
+    assert.equal(result.selection.fallback_reason, "no_active_worker_match");
+  });
+
+  it("prefers an active worker over a bench specialist for the same capability", () => {
+    const registry = registryFixture({
+      builder: { capabilities: ["implementation", "seo"] },
+    });
+
+    const selection = selectWorkerForCapability(registry, { capability: "seo" });
+
+    assert.equal(selection.ok, true);
+    assert.equal(selection.activation, "active");
+    assert.equal(selection.worker.worker_id, "builder-1");
+    assert.equal(selection.reason, "active_worker_match");
   });
 
   it("creates and verifies a signed lane ACK", () => {
@@ -298,7 +349,7 @@ describe("PinballWake Worker Registry Room", () => {
 
     assert.equal(result.ok, true);
     assert.equal(result.result, "trusted_signed_ack");
-    assert.equal(result.worker_count, 2);
+    assert.equal(result.worker_count, 3);
     assert.equal(result.event.authority, "lane");
   });
 });

--- a/src/data/mockAgents.ts
+++ b/src/data/mockAgents.ts
@@ -205,3 +205,19 @@ export const AGENT_CATEGORIES: { key: string; label: string; colour: string }[] 
   { key: "lifestyle", label: "Lifestyle",  colour: "crew-life"     },
   { key: "meta",      label: "Meta",       colour: "crew-meta"     },
 ];
+
+export const SPECIALIST_BENCH_AGENT_SLUGS = [
+  "seo-specialist",
+  "security-engineer",
+  "librarian",
+  "dba",
+  "devops",
+  "integration-engineer",
+  "copywriter",
+  "ui-designer",
+  "researcher",
+  "qa-engineer",
+  "observability-engineer",
+  "technical-writer",
+  "api-designer",
+] as const;


### PR DESCRIPTION
Summary:
- Adds dormant specialist-bench metadata to the Worker Registry model.
- Adds explainable selection helpers that prefer active workers and fall back to bench specialists without activating them by default.
- Adds a first specialist-bench slug catalog from existing mock agent profiles.

Scope:
- Owned files from todo 3ecde631 ScopePack: scripts/pinballwake-worker-registry-room.mjs, scripts/pinballwake-worker-registry-room.test.mjs, src/data/mockAgents.ts.
- Product lane: Worker Registry specialist bench.

Non-overlap:
- No routing, lease, Coordinator, credential, signing-secret, billing, or production mutation changes.
- No activation of always-on worker armies.
- No persistent schema or database changes.

Verification:
- node --test scripts/pinballwake-worker-registry-room.test.mjs
- git diff --check
- GitHub CI green: Website (root package), MCP server package, TestPass smoke run, Vercel, Vercel Preview Comments.

Risk:
- Low. Adds metadata and pure selection helpers with focused tests. Existing signed ACK verification remains unchanged.

Linked todo:
- 3ecde631, Worker Registry specialist bench.

Owner status:
- Owner proof refreshed by chatgpt-codex-worker2 at 2026-05-10T17:11Z.
- Ready for review.