### PR TITLE
fix(memory): default search to local retrieval

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
@@ -90,6 +90,23 @@ describe("RRF scoring math", () => {
 // ─── 2. embedText returns null when key absent ────────────────────────────────
 
 describe("embedText", () => {
+  test("returns null unless OpenAI embeddings are explicitly enabled", async () => {
+    const savedKey = process.env.OPENAI_API_KEY;
+    const savedFlag = process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+    process.env.OPENAI_API_KEY = "sk-test-no-fetch";
+    delete process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+    try {
+      const { embedText } = await import("../embeddings.js");
+      const result = await embedText("a searchable memory query that is long enough");
+      assert.equal(result, null);
+    } finally {
+      if (savedKey === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = savedKey;
+      if (savedFlag === undefined) delete process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+      else process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED = savedFlag;
+    }
+  });
+
   test("returns null when OPENAI_API_KEY is not set", async () => {
     // Ensure the env var is absent for this test
     const saved = process.env.OPENAI_API_KEY;
@@ -102,6 +119,58 @@ describe("embedText", () => {
     } finally {
       if (saved !== undefined) process.env.OPENAI_API_KEY = saved;
     }
+  });
+});
+
+describe("local memory scoring", () => {
+  test("tokenizes proper nouns and identifiers without duplicates", async () => {
+    const { tokenizeLocalMemoryQuery } = await import("../supabase.js");
+    assert.deepEqual(
+      tokenizeLocalMemoryQuery("UnClick API, UnClick semantic-search v1"),
+      ["unclick", "api", "semantic-search", "v1"]
+    );
+  });
+
+  test("exact phrase scores above the same tokens split apart", async () => {
+    const { tokenizeLocalMemoryQuery, scoreLocalMemoryContent } = await import("../supabase.js");
+    const query = "semantic memory";
+    const tokens = tokenizeLocalMemoryQuery(query);
+    const phrase = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: "Chris wants semantic memory search to work locally",
+      confidence: 1,
+      source: "fact",
+    });
+    const split = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: "Chris wants semantic retrieval so memory works locally",
+      confidence: 1,
+      source: "fact",
+    });
+    assert.ok(phrase.finalScore > split.finalScore);
+  });
+
+  test("partial token overlap scores above unrelated text", async () => {
+    const { tokenizeLocalMemoryQuery, scoreLocalMemoryContent } = await import("../supabase.js");
+    const query = "open source memory search";
+    const tokens = tokenizeLocalMemoryQuery(query);
+    const partial = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: "The memory system should use local search when providers are unavailable",
+      confidence: 1,
+      source: "fact",
+    });
+    const unrelated = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: "Billing exports should stay separate from worker lane routing",
+      confidence: 1,
+      source: "fact",
+    });
+    assert.ok(partial.finalScore > unrelated.finalScore);
   });
 });
 
@@ -139,6 +208,31 @@ class FakeClient {
 
   from(table: string) {
     const query = new FakeQuery(table);
+    this.queries.push(query);
+    return query;
+  }
+}
+
+class FakeDataQuery extends FakeQuery {
+  constructor(table: string, private rows: unknown[]) {
+    super(table);
+  }
+
+  then<TResult1 = { data: unknown[] }, TResult2 = never>(
+    onfulfilled?: ((value: { data: unknown[] }) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve({ data: this.rows }).then(onfulfilled, onrejected);
+  }
+}
+
+class FakeDataClient {
+  queries: FakeDataQuery[] = [];
+
+  constructor(private rowsByTable: Record<string, unknown[]>) {}
+
+  from(table: string) {
+    const query = new FakeDataQuery(table, this.rowsByTable[table] ?? []);
     this.queries.push(query);
     return query;
   }
@@ -183,6 +277,50 @@ describe("keyword fallback asOf cutoff", () => {
       sessionQuery.calls.some((c) => c.method === "lte" && c.args[0] === "created_at" && c.args[1] === asOf),
       "session fallback should not return summaries created after asOf"
     );
+  });
+});
+
+describe("searchMemory local-first behavior", () => {
+  test("returns local keyword results before optional OpenAI hybrid", async () => {
+    const { SupabaseBackend } = await import("../supabase.js");
+    const client = new FakeDataClient({
+      extracted_facts: [
+        {
+          id: "fact-local-default",
+          fact: "Chris wants open source semantic search as the memory default",
+          category: "decision",
+          confidence: 0.95,
+          created_at: "2026-05-10T00:00:00Z",
+        },
+      ],
+      session_summaries: [],
+    });
+    const backend = Object.create(SupabaseBackend.prototype) as {
+      client: FakeDataClient;
+      tenancy: { mode: "byod" };
+      tables: { extracted_facts: string; session_summaries: string };
+      searchMemory: (query: string, maxResults: number, asOf?: string) => Promise<unknown[]>;
+    };
+    backend.client = client;
+    backend.tenancy = { mode: "byod" };
+    backend.tables = {
+      extracted_facts: "extracted_facts",
+      session_summaries: "session_summaries",
+    };
+
+    const savedKey = process.env.OPENAI_API_KEY;
+    const savedFlag = process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+    process.env.OPENAI_API_KEY = "sk-test-no-fetch";
+    process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED = "true";
+    try {
+      const results = await backend.searchMemory("open source semantic search", 5);
+      assert.equal((results[0] as { id: string }).id, "fact-local-default");
+    } finally {
+      if (savedKey === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = savedKey;
+      if (savedFlag === undefined) delete process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+      else process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED = savedFlag;
+    }
   });
 });
 
@@ -366,6 +504,8 @@ describe("acceptance: hybrid search finds semantically similar fact", () => {
       return;
     }
 
+    const savedFlag = process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+    process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED = "true";
     const { createClient } = await import("@supabase/supabase-js");
     const { embedText, EMBEDDING_MODEL } = await import("../embeddings.js");
 
@@ -425,6 +565,8 @@ describe("acceptance: hybrid search finds semantically similar fact", () => {
       );
       console.log(`    [passed] fact found at position ${ids.indexOf(factId) + 1} of ${ids.length}`);
     } finally {
+      if (savedFlag === undefined) delete process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+      else process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED = savedFlag;
       // Clean up
       await supabase.from("extracted_facts").delete().eq("id", factId);
     }

--- a/packages/mcp-server/src/memory/embeddings.ts
+++ b/packages/mcp-server/src/memory/embeddings.ts
@@ -37,8 +37,13 @@ function shouldSkipEmbedding(text: string): boolean {
   ].some((needle) => lower.includes(needle));
 }
 
+export function isOpenAIEmbeddingsEnabled(): boolean {
+  const raw = process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED ?? "";
+  return raw === "1" || raw.toLowerCase() === "true";
+}
+
 export async function embedText(text: string): Promise<number[] | null> {
-  if (process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED === "false") return null;
+  if (!isOpenAIEmbeddingsEnabled()) return null;
   if (shouldSkipEmbedding(text)) return null;
 
   const apiKey = process.env.OPENAI_API_KEY;

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -108,6 +108,68 @@ interface TableNames {
   code_dumps: string;
 }
 
+const LOCAL_SEARCH_STOP_WORDS = new Set([
+  "and",
+  "are",
+  "for",
+  "from",
+  "how",
+  "the",
+  "this",
+  "that",
+  "with",
+]);
+
+export function tokenizeLocalMemoryQuery(query: string): string[] {
+  const seen = new Set<string>();
+  const tokens = query
+    .toLowerCase()
+    .match(/[a-z0-9][a-z0-9_-]*/g) ?? [];
+  return tokens.filter((token) => {
+    if (token.length < 2) return false;
+    if (LOCAL_SEARCH_STOP_WORDS.has(token)) return false;
+    if (seen.has(token)) return false;
+    seen.add(token);
+    return true;
+  });
+}
+
+function normalizeLocalMemoryText(text: string): string {
+  return (text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? []).join(" ");
+}
+
+export function scoreLocalMemoryContent(input: {
+  query: string;
+  tokens: string[];
+  text: string;
+  confidence?: number | null;
+  source?: "fact" | "session";
+}): { finalScore: number; matchedTokenCount: number; exactPhrase: boolean } {
+  const { query, tokens, text } = input;
+  if (tokens.length === 0) {
+    return { finalScore: 0, matchedTokenCount: 0, exactPhrase: false };
+  }
+
+  const normalizedText = normalizeLocalMemoryText(text);
+  const normalizedQuery = normalizeLocalMemoryText(query);
+  const matchedTokenCount = tokens.reduce(
+    (count, token) => count + (normalizedText.includes(token) ? 1 : 0),
+    0
+  );
+  const exactPhrase =
+    normalizedQuery.length >= 4 &&
+    normalizedText.includes(normalizedQuery);
+  const phraseBonus = exactPhrase ? Math.max(1, tokens.length) : 0;
+  const coverage = (matchedTokenCount + phraseBonus) / (tokens.length * 2);
+  const confidence = Math.max(0, Math.min(1, input.confidence ?? 1));
+  const sourceWeight = input.source === "session" ? 0.5 : 1;
+  return {
+    finalScore: coverage * confidence * sourceWeight,
+    matchedTokenCount,
+    exactPhrase,
+  };
+}
+
 const BYOD_TABLES: TableNames = {
   business_context: "business_context",
   knowledge_library: "knowledge_library",
@@ -285,21 +347,11 @@ export class SupabaseBackend implements MemoryBackend {
   }
 
   async searchMemory(query: string, maxResults: number, asOf?: string): Promise<unknown> {
-    // Hybrid lane: BM25 + pgvector RRF over mc_extracted_facts and
-    // mc_session_summaries. Two well-known failure modes turn this into a
-    // black hole and force a fallback:
-    //
-    //   1. Per-row embeddings are NULL (legacy facts, BYOD installs without
-    //      backfill, or facts written before embedding wiring) so the vector
-    //      lane drops them.
-    //   2. plainto_tsquery('english', ...) tokenizes proper nouns and short
-    //      identifiers ("Chris", "Bailey", "UnClick") in ways that don't
-    //      align with the matching to_tsvector lexemes, so the keyword lane
-    //      misses too. Both branches fail, hybrid returns [].
-    //
-    // To stop returning [] when matching content exists, we run a robust
-    // ILIKE keyword fallback over the same tables whenever the hybrid call
-    // throws OR returns an empty result.
+    const localResults = await this.keywordFallback(query, maxResults, asOf);
+    if (localResults.length > 0) return localResults;
+
+    // Optional high-accuracy lane: BM25 + pgvector RRF over facts and
+    // sessions. This only runs when MEMORY_OPENAI_EMBEDDINGS_ENABLED is set.
     try {
       const { embedText } = await import("./embeddings.js");
       const embedding = await embedText(query);
@@ -313,9 +365,9 @@ export class SupabaseBackend implements MemoryBackend {
         if (Array.isArray(results) && results.length > 0) return results;
       }
     } catch (err) {
-      console.error("[search_memory] hybrid search failed, falling back to keyword:", err);
+      console.error("[search_memory] optional hybrid search failed:", err);
     }
-    return this.keywordFallback(query, maxResults, asOf);
+    return [];
   }
 
   /**
@@ -331,18 +383,9 @@ export class SupabaseBackend implements MemoryBackend {
    * many tokens they contain so partial matches at least surface something.
    */
   private async keywordFallback(query: string, maxResults: number, asOf?: string): Promise<unknown[]> {
-    const tokens = query
-      .toLowerCase()
-      .split(/\s+/)
-      .filter((t) => t.length >= 2 && !/[,():]/.test(t));
+    const tokens = tokenizeLocalMemoryQuery(query);
     if (tokens.length === 0) return [];
     const patterns = tokens.map((t) => `%${t.replace(/[\\%_]/g, (c) => `\\${c}`)}%`);
-    const score = (text: string): number => {
-      const lower = text.toLowerCase();
-      let n = 0;
-      for (const t of tokens) if (lower.includes(t)) n++;
-      return n;
-    };
 
     const runScan = async (mode: "and" | "or"): Promise<unknown[]> => {
       let factQ = this.client
@@ -384,7 +427,13 @@ export class SupabaseBackend implements MemoryBackend {
       type FactRow = { id: string; fact: string; category: string; confidence: number; created_at: string };
       type SessRow = { id: string; summary: string; created_at: string };
       const facts = ((factsRes.data ?? []) as FactRow[]).map((r) => {
-        const s = score(r.fact);
+        const s = scoreLocalMemoryContent({
+          query,
+          tokens,
+          text: r.fact,
+          confidence: r.confidence,
+          source: "fact",
+        });
         return {
           id: r.id,
           source: "fact",
@@ -392,14 +441,20 @@ export class SupabaseBackend implements MemoryBackend {
           category: r.category,
           confidence: r.confidence,
           created_at: r.created_at,
-          final_score: (s / tokens.length) * (r.confidence ?? 0),
+          final_score: s.finalScore,
           rrf_score: 0,
-          kw_score: s,
+          kw_score: s.matchedTokenCount,
           cosine_score: 0,
         };
       });
       const sessions = ((sessRes.data ?? []) as SessRow[]).map((r) => {
-        const s = score(r.summary);
+        const s = scoreLocalMemoryContent({
+          query,
+          tokens,
+          text: r.summary,
+          confidence: 1,
+          source: "session",
+        });
         return {
           id: r.id,
           source: "session",
@@ -407,9 +462,9 @@ export class SupabaseBackend implements MemoryBackend {
           category: "session",
           confidence: 1,
           created_at: r.created_at,
-          final_score: (s / tokens.length) * 0.5,
+          final_score: s.finalScore,
           rrf_score: 0,
-          kw_score: s,
+          kw_score: s.matchedTokenCount,
           cosine_score: 0,
         };
       });


### PR DESCRIPTION
Summary:
- Makes search_memory use local token and phrase retrieval as the default path before optional OpenAI hybrid search.
- Makes OpenAI embeddings opt-in behind MEMORY_OPENAI_EMBEDDINGS_ENABLED.
- Adds focused tests for opt-in embeddings, local scoring, and local-first behavior.

Scope:
- Lane: memory.
- Owned files: packages/mcp-server/src/memory/embeddings.ts, packages/mcp-server/src/memory/supabase.ts, packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts.
- Linked todo: 745031d8.

Non-overlap:
- No env, secret, billing, schema, migration, UI, or production data changes.
- No live backfill or credential handling.

Verification:
- npm run test --workspace=@unclick/mcp-server
- npm run build --workspace=@unclick/mcp-server
- git diff --check

Risk:
- Search now prefers local matches when present. Optional vector search still runs when local returns nothing and MEMORY_OPENAI_EMBEDDINGS_ENABLED is explicitly enabled.

Follow-up:
- Add a richer open-source semantic lane only after dependency and bundle-size review.

Draft PR: yes.