### PR TITLE
fix(autopilot): add stale review wake advisory

### DIFF
--- a/scripts/autopilotkit-liveness.test.mjs
+++ b/scripts/autopilotkit-liveness.test.mjs
@@ -6,6 +6,7 @@ import {
   evaluateAutoPilotKitLiveness,
   evaluateOrchestratorProofWakeGate,
   extractMissedAckSignals,
+  extractStaleReviewWakeSignals,
   normalizeSeatLiveness,
   parseMs,
 } from "./lib/autopilotkit-liveness.mjs";
@@ -74,6 +75,43 @@ describe("AutoPilotKit liveness helpers", () => {
 
     assert.equal(signals.length, 1);
     assert.equal(signals[0].excerpt, "[redacted-sensitive-text]");
+  });
+
+  it("turns a stale Reviewer wake without ACK into a read-only fallback advisory", () => {
+    const messages = [
+      {
+        id: "wake-pull_request-pr-689-abc123",
+        tags: ["needs-doing", "wake"],
+        recipients: ["🔍"],
+        created_at: "2026-05-10T13:33:49.000Z",
+        text: [
+          "Wake event id: wake-pull_request-pr-689-abc123",
+          "Wake event: PR #689 is ready for review",
+          "Source: https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/689",
+          "Route: 🔍",
+          "ACK requested: reply ACK wake-pull_request-pr-689-abc123 and your next action.",
+        ].join("\n"),
+      },
+    ];
+
+    const signals = extractStaleReviewWakeSignals(messages, {
+      nowMs: parseMs("2026-05-10T14:10:00.000Z"),
+      staleMs: 30 * 60 * 1000,
+    });
+    const result = evaluateAutoPilotKitLiveness({
+      now: "2026-05-10T14:10:00.000Z",
+      reviewWakeStaleMinutes: 30,
+      messages,
+    });
+
+    assert.equal(signals.length, 1);
+    assert.equal(signals[0].wake_id, "wake-pull_request-pr-689-abc123");
+    assert.equal(signals[0].pr_number, 689);
+    assert.equal(result.adapter_examples.review_coordinator.execute, false);
+    assert(result.adapter_examples.review_coordinator.reason_codes.includes("review_wake_ack_stale"));
+    assert.equal(result.actions[0].action, "reroute_stale_review_wake_to_live_reviewer");
+    assert.equal(result.actions[0].pr_number, 689);
+    assert.equal(result.safe_mode.no_merge_or_claim, true);
   });
 
   it("turns stale scheduler evidence plus a fresh UnClick heartbeat into a safe fallback tap", () => {

--- a/scripts/lib/autopilotkit-liveness.mjs
+++ b/scripts/lib/autopilotkit-liveness.mjs
@@ -5,6 +5,7 @@ const DEFAULT_COORDINATOR_FALLBACK_MS = 2 * 60 * 60 * 1000;
 const DEFAULT_SCHEDULER_GRACE_MS = 15 * 60 * 1000;
 const DEFAULT_SCHEDULER_INTERVAL_MS = 15 * 60 * 1000;
 const DEFAULT_TRUSTED_FALLBACK_FRESH_MS = 10 * 60 * 1000;
+const DEFAULT_REVIEW_WAKE_STALE_MS = 30 * 60 * 1000;
 
 const SENSITIVE_KEY_RE = /(api[_-]?key|secret|token|password|credential|authorization|cookie)/i;
 const SENSITIVE_TEXT_RE =
@@ -43,6 +44,10 @@ function normalize(value) {
 
 function normalizeToken(value) {
   return normalize(value).replace(/[\s-]+/g, "_");
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function sanitizeAdvisoryText(value, max = 500) {
@@ -176,7 +181,86 @@ export function extractMissedAckSignals(messages = []) {
     }));
 }
 
-export function buildAdvisoryRerouteActions({ workers = [], missedAckReroutes = [] } = {}) {
+function messageBody(message = {}) {
+  return [
+    message.text,
+    message.body,
+    message.message,
+    message.summary,
+    message.comment,
+    safeList(message.tags).join(" "),
+  ].filter(Boolean).join("\n");
+}
+
+function extractWakeId(message = {}, text = "") {
+  const explicit = String(message.wake_id || message.wakeId || "").trim();
+  if (explicit) return explicit;
+  const match = String(text).match(/Wake event id:\s*([^\s]+)/i);
+  if (match) return match[1];
+  const id = String(message.id || message.message_id || message.messageId || "").trim();
+  return /^wake[-_]/i.test(id) ? id : "";
+}
+
+function extractPrNumber(text = "") {
+  const match = String(text).match(/(?:pull_request-pr-|pr[-\s#]*|#)(\d{1,8})/i);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function hasAckForWake(messages = [], wakeId = "", prNumber = null) {
+  if (!wakeId && !prNumber) return false;
+  const wakePattern = wakeId ? new RegExp(`\\b${escapeRegExp(wakeId)}\\b`, "i") : null;
+  const prPattern = prNumber ? new RegExp(`(?:PR\\s*#?|#)${prNumber}\\b`, "i") : null;
+  return safeList(messages).some((message) => {
+    const text = messageBody(message);
+    if (/ACK requested/i.test(text)) return false;
+    if (wakePattern?.test(text) && /\b(ack|done|pass|blocker|blocked|merged|reviewed)\b/i.test(text)) {
+      return true;
+    }
+    if (prPattern?.test(text) && /\b(ack done|review pass|reviewed|merged)\b/i.test(text)) {
+      return true;
+    }
+    return false;
+  });
+}
+
+export function extractStaleReviewWakeSignals(messages = [], { nowMs, staleMs = DEFAULT_REVIEW_WAKE_STALE_MS } = {}) {
+  if (!Number.isFinite(nowMs)) return [];
+
+  return safeList(messages)
+    .map((message) => {
+      const text = messageBody(message);
+      const createdAt = message.created_at || message.createdAt || message.timestamp || "";
+      const createdMs = parseMs(createdAt);
+      const wakeId = extractWakeId(message, text);
+      const prNumber = extractPrNumber(text);
+      const age = createdMs === null ? null : Math.max(0, nowMs - createdMs);
+      const isReviewWake =
+        /ready for review/i.test(text) ||
+        (/ACK requested/i.test(text) && /\b(route:\s*🔍|review|reviewer)\b/i.test(text));
+
+      if (!isReviewWake || age === null || age < staleMs) return null;
+      if (hasAckForWake(messages, wakeId, prNumber)) return null;
+
+      return {
+        message_id: safeString("message_id", message.id || message.message_id || message.messageId || "", 160),
+        wake_id: safeString("wake_id", wakeId, 180),
+        pr_number: prNumber,
+        created_at: new Date(createdMs).toISOString(),
+        age_minutes: minutes(age),
+        stale_after: isoFromMs(createdMs + staleMs),
+        recipients: safeList(message.recipients).map((recipient) => safeString("recipient", recipient, 80)),
+        source_url: sanitizeAdvisoryText(message.source || message.url || message.html_url || "", 240) || null,
+        excerpt: sanitizeAdvisoryText(text, 400),
+      };
+    })
+    .filter(Boolean);
+}
+
+export function buildAdvisoryRerouteActions({
+  workers = [],
+  missedAckReroutes = [],
+  staleReviewWakeReroutes = [],
+} = {}) {
   const actions = [];
   const coordinatorDormant = workers.some(
     (worker) => worker.lane === "coordinator" && worker.reasons.includes("coordinator_fallback_needed"),
@@ -196,6 +280,17 @@ export function buildAdvisoryRerouteActions({ workers = [], missedAckReroutes = 
       action: "reroute_missed_ack_to_live_worker",
       reason: "missed_ack_reroute_detected",
       proof_message_id: reroute.message_id,
+      target_lane: "reviewer",
+      advisory: true,
+    });
+  }
+  for (const reroute of staleReviewWakeReroutes) {
+    actions.push({
+      action: "reroute_stale_review_wake_to_live_reviewer",
+      reason: "review_wake_ack_stale",
+      proof_message_id: reroute.message_id,
+      wake_id: reroute.wake_id,
+      pr_number: reroute.pr_number,
       target_lane: "reviewer",
       advisory: true,
     });
@@ -252,13 +347,19 @@ export function evaluateAutoPilotKitLiveness(input = {}) {
   }
 
   const thresholds = normalizeLivenessThresholds(input);
+  const reviewWakeStaleMs = Number.isFinite(input.reviewWakeStaleMs)
+    ? input.reviewWakeStaleMs
+    : Number.isFinite(input.reviewWakeStaleMinutes)
+      ? input.reviewWakeStaleMinutes * 60 * 1000
+      : DEFAULT_REVIEW_WAKE_STALE_MS;
   const workers = safeList(input.profiles).map((profile) => normalizeSeatLiveness(profile, { nowMs, thresholds }));
   const counts = workers.reduce((acc, worker) => {
     acc[worker.freshness] = (acc[worker.freshness] ?? 0) + 1;
     return acc;
   }, { active: 0, warm: 0, stale: 0, dormant: 0, unknown: 0 });
   const missedAckReroutes = extractMissedAckSignals(input.messages);
-  const actions = buildAdvisoryRerouteActions({ workers, missedAckReroutes });
+  const staleReviewWakeReroutes = extractStaleReviewWakeSignals(input.messages, { nowMs, staleMs: reviewWakeStaleMs });
+  const actions = buildAdvisoryRerouteActions({ workers, missedAckReroutes, staleReviewWakeReroutes });
 
   const result = {
     generated_at: now,
@@ -267,10 +368,12 @@ export function evaluateAutoPilotKitLiveness(input = {}) {
       warm: minutes(thresholds.warmMs),
       dormant: minutes(thresholds.dormantMs),
       coordinator_fallback: minutes(thresholds.coordinatorFallbackMs),
+      review_wake_stale: minutes(reviewWakeStaleMs),
     },
     counts,
     workers,
     missed_ack_reroutes: missedAckReroutes,
+    stale_review_wake_reroutes: staleReviewWakeReroutes,
     actions,
     safe_mode: {
       read_only: true,

--- a/scripts/pinballwake-ack-ledger-room.test.mjs
+++ b/scripts/pinballwake-ack-ledger-room.test.mjs
@@ -295,6 +295,46 @@ describe("PinballWake ACK ledger room", () => {
     assert.equal(result.autopilotkit_review_advice.safe_mode.no_merge_or_claim, true);
   });
 
+  it("adds a stale Reviewer wake fallback advisory without executing reroute", () => {
+    const result = evaluateAckLedgerRoom({
+      pr: pr({ number: 689 }),
+      comments: [
+        comment("Gatekeeper PASS on #689.", "2026-05-10T13:20:00.000Z", "gatekeeper"),
+        comment("Forge PASS on #689.", "2026-05-10T13:20:00.000Z", "forge"),
+      ],
+      now: "2026-05-10T14:10:00.000Z",
+      liveness: {
+        now: "2026-05-10T14:10:00.000Z",
+        reviewWakeStaleMinutes: 30,
+        messages: [
+          {
+            id: "wake-pull_request-pr-689-abc123",
+            tags: ["needs-doing", "wake"],
+            recipients: ["🔍"],
+            created_at: "2026-05-10T13:33:49.000Z",
+            text: [
+              "Wake event id: wake-pull_request-pr-689-abc123",
+              "Wake event: PR #689 is ready for review",
+              "Source: https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/689",
+              "Route: 🔍",
+              "ACK requested: reply ACK wake-pull_request-pr-689-abc123 and your next action.",
+            ].join("\n"),
+          },
+        ],
+      },
+    });
+
+    assert.equal(result.result, "missing_ack");
+    assert.equal(result.autopilotkit_review_advice.execute, false);
+    assert(result.autopilotkit_review_advice.reason_codes.includes("review_wake_ack_stale"));
+    assert.equal(
+      result.autopilotkit_review_advice.recommendations[0].action,
+      "reroute_stale_review_wake_to_live_reviewer",
+    );
+    assert.equal(result.autopilotkit_review_advice.recommendations[0].wake_id, "wake-pull_request-pr-689-abc123");
+    assert.equal(result.autopilotkit_review_advice.recommendations[0].pr_number, 689);
+  });
+
   it("accepts explicitly trusted structured lane ACK records", () => {
     const result = evaluateAckLedgerRoom({
       pr: pr(),


### PR DESCRIPTION
Summary:
- Adds a read-only stale Reviewer wake fallback advisory for delivered review wakes that age past the configured stale window without ACK evidence.
- Preserves wake id, PR number, source message, stale time, and target reviewer lane in the advisory receipt.
- Wires the advisory into ACK Ledger liveness output with execute=false.

Scope:
- Owned files: scripts/lib/autopilotkit-liveness.mjs, scripts/autopilotkit-liveness.test.mjs, scripts/pinballwake-ack-ledger-room.test.mjs.
- Linked todo: d70cce3c-f4c2-42e2-bcbd-6d812b86349e.

Non-overlap:
- Does not auto-approve, auto-merge, or execute reroutes.
- Does not change wake routing, production Boardroom writes, secrets, auth, billing, DNS, migrations, or protected config.

Verification:
- node --test scripts/autopilotkit-liveness.test.mjs
- node --test scripts/pinballwake-ack-ledger-room.test.mjs
- git diff --check

Risk:
- Low, advisory-only and read-only. The output is additive and keeps no_merge_or_claim safety.

Follow-up:
- Actual reroute execution, if desired, should be a separate chip after this advisory is reviewed.

Status:
- Draft PR for review.