### PR TITLE
feat(architecture): add engineering steward lane seed

### DIFF
--- a/api/lib/route-packet-consumer.test.ts
+++ b/api/lib/route-packet-consumer.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { runRoutePacketConsumerDryRun, type RoutePacket } from "./route-packet-consumer";
+import {
+  normalizeRoutePacketLane,
+  runRoutePacketConsumerDryRun,
+  type RoutePacket,
+} from "./route-packet-consumer";
 
 const basePacket: RoutePacket = {
   experiment: true,
@@ -72,6 +76,43 @@ describe("route packet consumer dry run", () => {
       target_agent_id: "jobs-manager-live",
       reason: "live_worker_available",
     });
+  });
+
+  it("routes architecture health packets to Engineering Steward", () => {
+    const result = runRoutePacketConsumerDryRun({
+      packet: {
+        ...basePacket,
+        lane: "Engineering Steward",
+        item: {
+          id: "todo-engineering-steward",
+          title: "Architecture health review",
+        },
+        needed_action: "Check repo boundaries and automation reliability.",
+      },
+      visibleWorkers: [
+        { agent_id: "builder-live", lane: "Builder", status: "active" },
+        { agent_id: "engineering-steward-live", lane: "Engineering Steward", status: "active" },
+      ],
+      now: new Date("2026-05-09T00:05:00.000Z"),
+    });
+
+    expect(result.decision).toMatchObject({
+      status: "assigned",
+      target_agent_id: "engineering-steward-live",
+      reason: "live_worker_available",
+    });
+  });
+
+  it("normalizes Engineering Steward route aliases", () => {
+    expect(normalizeRoutePacketLane("Principal Engineer")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("architecture health")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("infrastructure-health")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("repo boundaries")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("data model health")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("automation reliability")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("onboarding clarity")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("cost traps")).toBe("Engineering Steward");
+    expect(normalizeRoutePacketLane("build velocity")).toBe("Engineering Steward");
   });
 
   it("holds expired packets instead of assigning stale work", () => {

--- a/api/lib/route-packet-consumer.ts
+++ b/api/lib/route-packet-consumer.ts
@@ -5,7 +5,8 @@ export type RoutePacketLane =
   | "Safety"
   | "Coordinator"
   | "Jobs Manager"
-  | "Watcher";
+  | "Watcher"
+  | "Engineering Steward";
 
 export interface RoutePacket {
   experiment: boolean;
@@ -100,6 +101,29 @@ export function normalizeRoutePacketLane(input: unknown): RoutePacketLane {
     case "duplicate jobs":
     case "duplicate-jobs":
       return "Jobs Manager";
+    case "engineering steward":
+    case "engineering-steward":
+    case "principal engineer":
+    case "principal-engineer":
+    case "architecture health":
+    case "architecture-health":
+    case "infrastructure health":
+    case "infrastructure-health":
+    case "scaling health":
+    case "scaling-health":
+    case "repo boundaries":
+    case "repo-boundaries":
+    case "data model health":
+    case "data-model-health":
+    case "automation reliability":
+    case "automation-reliability":
+    case "onboarding clarity":
+    case "onboarding-clarity":
+    case "cost traps":
+    case "cost-traps":
+    case "build velocity":
+    case "build-velocity":
+      return "Engineering Steward";
     case "watcher":
     case "relay":
       return "Watcher";

--- a/api/lib/unclick-connect-worker-discovery.test.ts
+++ b/api/lib/unclick-connect-worker-discovery.test.ts
@@ -79,6 +79,29 @@ describe("UnClick Connect worker discovery", () => {
     ]);
   });
 
+  it("maps Engineering Steward profiles into the Engineering Steward lane", () => {
+    const workers = fishbowlProfilesToVisibleWorkers(
+      [
+        {
+          agent_id: "engineering-steward-seat",
+          display_name: "Principal Engineer",
+          current_status: "Watching architecture health, repo boundaries, cost traps, and automation reliability",
+          last_seen_at: "2026-05-09T00:10:00.000Z",
+        },
+      ],
+      new Date("2026-05-09T00:30:00.000Z"),
+    );
+
+    expect(workers).toEqual([
+      {
+        agent_id: "engineering-steward-seat",
+        lane: "Engineering Steward",
+        status: "active",
+        live: true,
+      },
+    ]);
+  });
+
   it("does not treat unknown, stale, or blocked profiles as production workers", () => {
     const workers = fishbowlProfilesToVisibleWorkers(
       [

--- a/api/lib/unclick-connect-worker-discovery.ts
+++ b/api/lib/unclick-connect-worker-discovery.ts
@@ -98,6 +98,21 @@ function inferLaneFromText(text: string): RoutePacketLane | null {
   ) {
     return "Jobs Manager";
   }
+  if (
+    value.includes("engineering steward") ||
+    value.includes("principal engineer") ||
+    value.includes("architecture health") ||
+    value.includes("infrastructure health") ||
+    value.includes("scaling health") ||
+    value.includes("repo boundaries") ||
+    value.includes("data model health") ||
+    value.includes("automation reliability") ||
+    value.includes("onboarding clarity") ||
+    value.includes("cost traps") ||
+    value.includes("build velocity")
+  ) {
+    return "Engineering Steward";
+  }
   if (value.includes("watcher") || value.includes("relay")) {
     return "Watcher";
   }

--- a/src/pages/admin/AdminEcosystemPages.test.tsx
+++ b/src/pages/admin/AdminEcosystemPages.test.tsx
@@ -12,4 +12,12 @@ describe("AdminWorkers", () => {
     expect(screen.getByText(/coordinator escalation/i)).toBeInTheDocument();
     expect(screen.getByText(/proof-to-done reconciliation/i)).toBeInTheDocument();
   });
+
+  it("shows Engineering Steward as an architecture health worker role", () => {
+    render(React.createElement(AdminWorkers));
+
+    expect(screen.getByText("🧱 Engineering Steward")).toBeInTheDocument();
+    expect(screen.getByText(/architecture health/i)).toBeInTheDocument();
+    expect(screen.getByText(/scaling risks/i)).toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -174,6 +174,7 @@ export function AdminWorkers() {
           { title: "📋 Planner", body: "Creates the exact work packet and ownership boundaries.", icon: FileText },
           { title: "📣 Messenger", body: "Sends worker packets and chases missing ACKs.", icon: MessagesSquare },
           { title: "👁️ Watcher", body: "Tracks status, proof, stale jobs, and visible changes.", icon: Eye },
+          { title: "🧱 Engineering Steward", body: "Checks architecture health, repo boundaries, data model shape, scaling risks, automation reliability, onboarding clarity, cost traps, and build velocity.", icon: Code2 },
           { title: "🚀 Publisher", body: "Confirms deployment and public release proof.", icon: Rocket },
           { title: "🩹 Repairer", body: "Fixes exact failed proof or broken workflow steps.", icon: Wrench },
           { title: "♻️ Improver", body: "Finds recurring friction and creates improvement jobs.", icon: RefreshCw },


### PR DESCRIPTION
## Summary
- Adds an Engineering Steward worker card to the AutoPilot Workers page.
- Adds Engineering Steward and Principal Engineer route aliases for architecture health, infrastructure health, repo boundaries, data model health, automation reliability, onboarding clarity, cost traps, and build velocity.
- Maps matching live worker profiles into the Engineering Steward lane.

## Scope
- Owned files from UnClick todo 28f42305.
- Admin Workers UI, route packet lane normalization, and UnClick Connect worker discovery.

## Non-overlap
- Does not implement recurring architecture review cadence, scoring, permissions, merges, cleanup automation, or production settings.
- Does not touch auth, billing, DNS, migrations, secrets, or customer data.

## Verification
- npm run test -- src/pages/admin/AdminEcosystemPages.test.tsx
- npm run test -- api/lib/route-packet-consumer.test.ts api/lib/unclick-connect-worker-discovery.test.ts
- git diff --check
- GitHub CI run 25641053640: Website root package and MCP server package passed.
- TestPass PR Check run 25641053638 passed.
- Vercel preview oDoNCXD3xfQ7BcJ8hkrojifFAqcT passed.

## Risk
- Low. This is a visible lane seed plus deterministic routing aliases and focused tests. No migrations, credentials, cron, or production mutation.

## Follow-up
- A later chip can add recurring architecture review cadence after the lane seed is merged.

## Owner Decision
- Owner: chatgpt-codex-worker2.
- Linked todo: 28f42305-ce62-400d-bd86-936bf227e823.
- Status: ready for review after refreshed green checks at 2026-05-10T22:29Z.