### PR TITLE
fix(orchestrator): stop stale wake rows looking active

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -352,7 +352,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     .slice(0, 36);
 
   const blockers = continuityEvents
-    .filter((event) => event.kind === "blocker")
+    .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs))
     .map((event) => event.summary)
     .slice(0, 5);
 
@@ -383,6 +383,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   const newestCheckinAt = newestIso(input.profiles.map((row) => row.last_seen_at));
   const rollingSnapshot = buildRollingSnapshot({
     generatedAt: input.generatedAt,
+    nowMs,
     newestActivityAt,
     activeTodos,
     continuityEvents,
@@ -544,12 +545,14 @@ function buildOperatorTimeContext(
 
 function buildRollingSnapshot({
   generatedAt,
+  nowMs,
   newestActivityAt,
   activeTodos,
   continuityEvents,
   blockers,
 }: {
   generatedAt: string;
+  nowMs: number;
   newestActivityAt: string | null;
   activeTodos: OrchestratorTodoRow[];
   continuityEvents: OrchestratorContinuityEvent[];
@@ -561,7 +564,7 @@ function buildRollingSnapshot({
     .slice(0, 5)
     .map((event) => eventToSnapshotItem(event, "decision"));
   const activeBlockers = snapshotEvents
-    .filter((event) => event.kind === "blocker")
+    .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs))
     .slice(0, 5)
     .map((event) => eventToSnapshotItem(event, "blocker"));
   const activeJobs = activeTodos.slice(0, 6).map((todo) => ({
@@ -609,6 +612,38 @@ function buildRollingSnapshot({
     recent_continuity: recentContinuity,
     source_pointers: sourcePointers,
   };
+}
+
+function isActiveBlockerEvent(
+  event: OrchestratorContinuityEvent,
+  activeTodos: OrchestratorTodoRow[],
+  nowMs: number,
+): boolean {
+  if (event.kind !== "blocker") return false;
+  if (!isHistoricalWakeOrFishbowlStale(event, activeTodos, nowMs)) return true;
+  return false;
+}
+
+function isHistoricalWakeOrFishbowlStale(
+  event: OrchestratorContinuityEvent,
+  activeTodos: OrchestratorTodoRow[],
+  nowMs: number,
+): boolean {
+  if (event.source_kind !== "dispatch") return false;
+  if (activeTodos.length > 0) return false;
+
+  const tags = (event.tags ?? []).map((tag) => tag.toLowerCase());
+  const summary = event.summary.toLowerCase();
+  const isWakeOrFishbowl =
+    tags.includes("wakepass") ||
+    tags.includes("fishbowl") ||
+    /\b(wakepass|fishbowl)\b/.test(summary);
+  const isStale = tags.includes("stale") || /\bstale\b/.test(summary);
+  if (!isWakeOrFishbowl || !isStale) return false;
+
+  const createdMs = event.created_at ? Date.parse(event.created_at) : NaN;
+  if (!Number.isFinite(createdMs) || !Number.isFinite(nowMs)) return false;
+  return nowMs - createdMs >= 60 * 60 * 1000;
 }
 
 function eventToSnapshotItem(

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -295,6 +295,56 @@ describe("orchestrator context", () => {
     expect(context.rolling_snapshot.persistence_plan.raw_transcript_policy).toContain("Do not persist raw transcripts");
   });
 
+  it("does not count old WakePass or Fishbowl stale rows as active blockers when no jobs remain", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-11T06:30:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-stale-wakepass",
+          source: "wakepass",
+          target_agent_id: "master",
+          task_ref: null,
+          status: "stale",
+          payload: {
+            title: "LaunchOnly worker renamed to IgniteOnly and PR merged",
+            source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/706",
+          },
+          created_at: "2026-05-11T04:00:00.000Z",
+          updated_at: "2026-05-11T04:10:00.000Z",
+        },
+        {
+          dispatch_id: "dispatch-stale-fishbowl",
+          source: "fishbowl",
+          target_agent_id: "master",
+          task_ref: null,
+          status: "stale",
+          payload: {
+            title: "Old todo assignment that no longer has an active todo",
+          },
+          created_at: "2026-05-11T04:05:00.000Z",
+          updated_at: "2026-05-11T04:15:00.000Z",
+        },
+      ],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.continuity_events.filter((event) => event.kind === "blocker")).toHaveLength(2);
+    expect(context.current_state_card.active_todo_count).toBe(0);
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.current_state_card.blockers).toHaveLength(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.rolling_snapshot.summary).toContain("0 blocker signals");
+    expect(context.seat_handshake.active_blocker).toBeNull();
+  });
+
   it("keeps heartbeat prompt bodies out of continuity summaries", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-09T23:45:00.000Z",


### PR DESCRIPTION
## Summary
- Downgrade old WakePass/Fishbowl stale dispatch rows when no active jobs remain
- Keep the stale rows visible in continuity history, but stop them inflating active blocker count and fresh-seat handoff
- Add focused Orchestrator context test for the exact no-active-job stale-row case

## Proof
- npm test -- api/orchestrator-context.test.ts -- --runInBand

## Notes
This does not change IgniteOnly authority. It addresses the confusing post-Ignite state where completed work still looked blocked because historical stale rows were counted as active blockers.