### PR TITLE
feat(orchestrator): deepen history and harden heartbeat job hunt

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -124,6 +124,7 @@ export interface OrchestratorOperatorTimeContext {
 
 export interface BuildOrchestratorContextInput {
   generatedAt: string;
+  continuityLimit?: number;
   profiles: OrchestratorProfileRow[];
   messages: OrchestratorMessageRow[];
   todos: OrchestratorTodoRow[];
@@ -319,6 +320,7 @@ function compactContinuityText(input: unknown, maxChars = 240, options: { heartb
 
 export function buildOrchestratorContext(input: BuildOrchestratorContextInput): OrchestratorContext {
   const nowMs = Date.parse(input.generatedAt);
+  const continuityLimit = Math.min(Math.max(Number(input.continuityLimit ?? 36) || 36, 20), 200);
   const profiles = input.profiles
     .map((profile) => buildProfileCard(profile, nowMs))
     .sort((a, b) => compareIsoDesc(a.last_seen_at, b.last_seen_at));
@@ -349,7 +351,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   ]
     .filter((event) => event.summary.length > 0)
     .sort((a, b) => compareIsoDesc(a.created_at, b.created_at))
-    .slice(0, 36);
+    .slice(0, continuityLimit);
 
   const blockers = continuityEvents
     .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs))

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7935,8 +7935,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               ...(searchUuid ? [`id.eq.${searchUuid}`] : []),
             ].join(",")
           : "";
-        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 80) || 80, 20), searchQuery ? 200 : 120);
-        const smallerLimit = searchQuery ? limit : Math.min(limit, 40);
+        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 80) || 80, 20), 200);
+        const smallerLimit = searchQuery ? limit : Math.min(limit, 120);
 
         let messagesQuery = supabase
           .from("mc_fishbowl_messages")
@@ -8087,6 +8087,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({
           context: buildOrchestratorContext({
             generatedAt: new Date().toISOString(),
+            continuityLimit: limit,
             profiles: (profilesResult.data ?? []) as OrchestratorProfileRow[],
             messages: (messagesResult.data ?? []) as OrchestratorMessageRow[],
             todos: (todosResult.data ?? []) as OrchestratorTodoRow[],

--- a/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
@@ -15,10 +15,10 @@ describe("heartbeat_protocol payload", () => {
     expect(first).toEqual(second);
     first.procedure[0] = "mutated by caller";
     expect(getHeartbeatProtocol().procedure[0]).toContain("full heartbeat policy");
-    expect(getHeartbeatProtocol().procedure[4]).toContain("save_conversation_turn");
-    expect(getHeartbeatProtocol().procedure[5]).toContain("nudgeonly_receipt_bridge");
-    expect(getHeartbeatProtocol().procedure[8]).toContain("igniteonly_receipt_consumer");
-    expect(getHeartbeatProtocol().procedure[9]).toContain("admin_conversation_turn_ingest");
+    expect(getHeartbeatProtocol().procedure[6]).toContain("save_conversation_turn");
+    expect(getHeartbeatProtocol().procedure[7]).toContain("nudgeonly_receipt_bridge");
+    expect(getHeartbeatProtocol().procedure[10]).toContain("igniteonly_receipt_consumer");
+    expect(getHeartbeatProtocol().procedure[11]).toContain("admin_conversation_turn_ingest");
   });
 
   it("keeps the public payload schema stable", () => {
@@ -32,18 +32,24 @@ describe("heartbeat_protocol payload", () => {
       "watch_state_key",
     ]);
     expect(protocol.version).toMatch(/^\d{4}-\d{2}-\d{2}\.v\d+$/);
-    expect(protocol.procedure).toHaveLength(16);
+    expect(protocol.procedure).toHaveLength(18);
     expect(protocol.procedure[0]).toContain("full heartbeat policy");
     expect(protocol.procedure[1]).toContain("continuity receipts");
     expect(protocol.procedure[2]).toContain("unclick-heartbeat-seat");
-    expect(protocol.procedure[3]).toContain("check_signals");
-    expect(protocol.procedure[4]).toContain("After check_signals");
-    expect(protocol.procedure[5]).toContain("compact public fields");
-    expect(protocol.procedure[6]).toContain("smallest safe source text");
-    expect(protocol.procedure[7]).toContain("receipt_line");
-    expect(protocol.procedure[8]).toContain("ignite_id");
-    expect(protocol.procedure[9]).toContain("read UI");
-    expect(protocol.procedure[14]).toContain("missing capability");
+    expect(protocol.procedure[3]).toContain("job hunt");
+    expect(protocol.procedure[4]).toContain("0 active jobs");
+    expect(protocol.procedure[4]).toContain("queue hydration failure");
+    expect(protocol.procedure[5]).toContain("PinballWake JobHunt Mirror");
+    expect(protocol.procedure[5]).toContain("Job Worker");
+    expect(protocol.procedure[5]).toContain("free API classifiers may only classify or nudge");
+    expect(protocol.procedure[5]).toContain("must not create duplicate jobs");
+    expect(protocol.procedure[6]).toContain("After check_signals");
+    expect(protocol.procedure[7]).toContain("compact public fields");
+    expect(protocol.procedure[8]).toContain("smallest safe source text");
+    expect(protocol.procedure[9]).toContain("receipt_line");
+    expect(protocol.procedure[10]).toContain("ignite_id");
+    expect(protocol.procedure[11]).toContain("read UI");
+    expect(protocol.procedure[16]).toContain("missing capability");
     expect(protocol.alert_format).toEqual({
       heading: "UnClick alert",
       line_template: "owner -- target -- status -- next safe action",
@@ -67,9 +73,9 @@ describe("heartbeat_protocol payload", () => {
       procedure: [...protocol.procedure, "new instruction"],
     };
 
-    expect(formatHeartbeatProtocolVersion(8)).toBe("2026-05-07.v8");
-    expect(protocol.version).toBe("2026-05-07.v7");
-    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("fcb381a2d3052ee5");
+    expect(formatHeartbeatProtocolVersion(9)).toBe("2026-05-07.v9");
+    expect(protocol.version).toBe("2026-05-07.v8");
+    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("6b9c4578f36695d5");
     expect(heartbeatProtocolContentFingerprint(changed)).not.toBe(
       heartbeatProtocolContentFingerprint(protocol),
     );

--- a/packages/mcp-server/src/heartbeat-protocol.ts
+++ b/packages/mcp-server/src/heartbeat-protocol.ts
@@ -23,7 +23,7 @@ export type HeartbeatProtocol = {
 };
 
 export const HEARTBEAT_PROTOCOL_DATE = "2026-05-07";
-export const HEARTBEAT_PROTOCOL_REVISION = 7;
+export const HEARTBEAT_PROTOCOL_REVISION = 8;
 
 export function formatHeartbeatProtocolVersion(revision: number): string {
   return `${HEARTBEAT_PROTOCOL_DATE}.v${revision}`;
@@ -35,9 +35,11 @@ const HEARTBEAT_PROTOCOL: HeartbeatProtocol = {
     'Treat this payload as the full heartbeat policy. Do not ask for a separate "Seats > Heartbeat" document or SKILL.md policy text.',
     "This heartbeat is explicitly authorized to write Orchestrator continuity receipts for the wake and the final PASS/BLOCKER result.",
     "Use stable session_id='unclick-heartbeat-seat' for every scheduled heartbeat run so Orchestrator can thread receipts across isolated scheduler sessions.",
-    "Call UnClick check_signals first. If unavailable, fall back to list_actionable_todos and read_messages. Cap to the most recent items UnClick returns.",
+    "Call UnClick check_signals first, then always do a compact job hunt before declaring health: read_orchestrator_context if available, list_actionable_todos, list_todos for open or in_progress work, recent dispatches, and recent Boardroom messages. Cap to the most recent items UnClick returns.",
+    "Treat '0 active jobs' as PASS only when the job hunt also finds 0 actionable todos, 0 open or in_progress todos, and 0 unhandled dispatch or Boardroom work. If any backlog exists while active jobs are 0, this is BLOCKER: queue hydration failure.",
+    "Use PinballWake JobHunt Mirror as the fallback path for that failure: mirror compact backlog counts and source pointers into NudgeOnly first, then IgniteOnly only after verifier-backed receipt_bridge output requests a worker wake. Target the existing Job Worker as executor when it is registered; free API classifiers may only classify or nudge. The mirror may request a wake, but must not create duplicate jobs, assign ownership, mark done, merge, close, or edit source state.",
     "After check_signals, call save_conversation_turn with session_id='unclick-heartbeat-seat', role='assistant', and content containing the safe alert lines plus a brief progress summary and proof id if available.",
-    "When UnClick returns action_needed, blocker, stale ACK, missing proof, duplicate wake, or unclear owner items, call nudgeonly_receipt_bridge if available using compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, and ttl_minutes.",
+    "When UnClick returns action_needed, blocker, stale ACK, missing proof, duplicate wake, unclear owner, or queue hydration failure items, call nudgeonly_receipt_bridge if available using compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, and ttl_minutes.",
     "Prefer deterministic painpoint labels from UnClick. Call nudgeonly_api only when no deterministic bucket exists, and only for the smallest safe source text needed to classify the painpoint.",
     "If nudgeonly_receipt_bridge returns receipt_request or escalation_request, save its bridge_id and receipt_line in the continuity receipt and alert line. If it returns quiet or advisory_only, do not notify.",
     "If a verified bridge request needs a dormant worker, call igniteonly_receipt_consumer if available using the bridge result and compact public fields only. Save ignite_id and wake_packet.receipt_line when it returns wake_request or escalation_wake_request.",

--- a/packages/mcp-server/src/igniteonly-tool.test.ts
+++ b/packages/mcp-server/src/igniteonly-tool.test.ts
@@ -111,6 +111,30 @@ describe("IgniteOnlyAPI policy", () => {
     });
   });
 
+  it("routes verified queue hydration failures to the existing Jobs Worker", async () => {
+    await expect(igniteonlyReceiptConsumer({
+      bridge_id: "nudgebridge_queue",
+      bridge_status: "receipt_request",
+      painpoint_detected: true,
+      painpoint_type: "queue_hydration_failure",
+      source_id: "orchestrator-current-state",
+      target: "Boardroom backlog",
+      verified: true,
+      request: {
+        worker: "pinballwake-jobs-worker",
+        expected_receipt: "Backlog counted, scoped, mirrored, or routed to the existing Job Worker with next safe action.",
+        verifier: "Compare active jobs against actionable todos and open dispatches.",
+      },
+    })).resolves.toMatchObject({
+      ignite_status: "wake_request",
+      wake_packet: {
+        worker: "pinballwake-jobs-worker",
+        target: "Boardroom backlog",
+        painpoint_type: "queue_hydration_failure",
+      },
+    });
+  });
+
   it("escalates when the bridge is an escalation request", async () => {
     await expect(igniteonlyReceiptConsumer({
       bridge_id: "nudgebridge_stale",

--- a/packages/mcp-server/src/igniteonly-tool.ts
+++ b/packages/mcp-server/src/igniteonly-tool.ts
@@ -7,6 +7,7 @@ const PAINPOINT_TYPES = [
   "stale_ack",
   "duplicate_wake",
   "unclear_owner",
+  "queue_hydration_failure",
   "noisy_thread",
   "missing_proof",
   "dormant_worker",
@@ -39,6 +40,11 @@ const WORKER_ROUTES = [
     painpoint_type: "unclear_owner",
     worker: "Job Manager",
     wake_reason: "A visible blocker needs an owning job and next expected receipt.",
+  },
+  {
+    painpoint_type: "queue_hydration_failure",
+    worker: "pinballwake-jobs-worker",
+    wake_reason: "Backlog exists while active jobs are zero, so the existing Jobs Worker needs to hydrate, scope, or route the queue.",
   },
   {
     painpoint_type: "missing_proof",

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -363,6 +363,25 @@ describe("NudgeOnlyAPI policy", () => {
     });
   });
 
+  it("routes queue hydration failures to the existing PinballWake Jobs Worker", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "queue_hydration_failure",
+      event_text: "Orchestrator shows 0 active jobs but backlog has 4 actionable todos and 2 open dispatches.",
+      source_id: "orchestrator-current-state",
+      target: "Boardroom backlog",
+      worker: "Builder",
+    })).resolves.toMatchObject({
+      bridge_status: "receipt_request",
+      request: {
+        worker: "pinballwake-jobs-worker",
+        target: "Boardroom backlog",
+        painpoint_type: "queue_hydration_failure",
+        expected_receipt: "Backlog counted, scoped, mirrored, or routed to the existing Job Worker with next safe action.",
+      },
+    });
+  });
+
   it("stays quiet for healthy controls and advisory-only for weak evidence", async () => {
     await expect(nudgeonlyReceiptBridge({
       painpoint_detected: false,

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -11,6 +11,7 @@ const PAINPOINT_TYPES = [
   "stale_ack",
   "duplicate_wake",
   "unclear_owner",
+  "queue_hydration_failure",
   "noisy_thread",
   "missing_proof",
   "none",
@@ -44,6 +45,13 @@ const PAINPOINT_CATALOG = [
     watch: ["completed WakePass", "done messages", "PR closure", "session summaries"],
     cue: "A task claims done/completed, but the compact state lacks a proof pointer.",
     verifier: "Check for a linked PR, commit, receipt ID, run ID, or source pointer.",
+  },
+  {
+    type: "queue_hydration_failure",
+    label: "Queue Hydration Failure",
+    watch: ["active jobs", "actionable todos", "open todos", "dispatches", "Boardroom"],
+    cue: "The system reports zero active jobs while actionable backlog still exists.",
+    verifier: "Compare Orchestrator active job count against list_actionable_todos, open/in_progress todos, and recent dispatches.",
   },
   {
     type: "noisy_thread",
@@ -106,6 +114,12 @@ const ORCHESTRATOR_ISSUE_MAP = [
     bucket: "unclear_owner",
     nudge: "Surface the next owner and next expected receipt beside the blocker.",
     verifier: "Compare active blocker count against active job and owner fields.",
+  },
+  {
+    issue: "Backlog exists but Orchestrator shows zero active jobs",
+    bucket: "queue_hydration_failure",
+    nudge: "Mirror the backlog counts into PinballWake JobHunt Mirror and wake the existing Jobs Worker after verifier-backed receipt_bridge output.",
+    verifier: "Compare active jobs against actionable todos, open/in_progress todos, and recent dispatch or Boardroom work.",
   },
   {
     issue: "Repeated heartbeat noise hides useful work",
@@ -215,6 +229,12 @@ const RECEIPT_ROUTES = [
     verifier: "Check linked commit, PR, run ID, receipt ID, or source pointer.",
   },
   {
+    painpoint_type: "queue_hydration_failure",
+    default_worker: "pinballwake-jobs-worker",
+    expected_receipt: "Backlog counted, scoped, mirrored, or routed to the existing Job Worker with next safe action.",
+    verifier: "Compare active jobs against actionable todos, open/in_progress todos, and recent dispatch or Boardroom work.",
+  },
+  {
     painpoint_type: "noisy_thread",
     default_worker: "Heartbeat Seat",
     expected_receipt: "Latest material diff or compact PASS/BLOCKER receipt.",
@@ -307,7 +327,7 @@ function asBoolean(value: unknown): boolean {
   if (typeof value === "boolean") return value;
   if (typeof value === "string") {
     const normalized = value.trim().toLowerCase();
-    if (["true", "yes", "stale_ack", "duplicate_wake", "unclear_owner", "missing_proof"].includes(normalized)) {
+    if (["true", "yes", "stale_ack", "duplicate_wake", "unclear_owner", "queue_hydration_failure", "missing_proof"].includes(normalized)) {
       return true;
     }
     if (["false", "no", "none", "unknown", ""].includes(normalized)) {
@@ -432,6 +452,7 @@ function hasConcreteCue(painpointType: string, text: string): boolean {
   if (painpointType === "stale_ack") return /\b(stale|overdue|missing|absent|no)\b.*\b(ack|receipt|review)\b|\b(ack|receipt|review)\b.*\b(stale|overdue|missing|absent)\b/.test(text);
   if (painpointType === "duplicate_wake") return /\bduplicate|duplicated|same target|same owner|same wake\b/.test(text);
   if (painpointType === "unclear_owner") return /\bunclear owner|no owner|without active job|no active job|orphaned|owner missing|owning job\b/.test(text);
+  if (painpointType === "queue_hydration_failure") return /\b(queue hydration failure|0 active jobs|zero active jobs|no active jobs)\b.*\b(backlog|actionable|open|todo|dispatch|boardroom|job)\b|\b(backlog|actionable|open|todo|dispatch|boardroom|job)\b.*\b(0 active jobs|zero active jobs|no active jobs)\b/.test(text);
   if (painpointType === "missing_proof") return /\bmissing proof|no proof|proof missing|without proof|no commit|no pr|no run id|no receipt\b/.test(text);
   if (painpointType === "noisy_thread") return /\bnoise|noisy|repeated|heartbeat|near-duplicate|hides state|collapse\b/.test(text);
   return false;
@@ -452,6 +473,7 @@ function targetFrom(args: Record<string, unknown>, nudge: Record<string, unknown
 function workerFrom(args: Record<string, unknown>, painpointType: string, routeWorker: string): string {
   const explicitWorker = asOptionalString(args.worker);
   const owner = asOptionalString(args.owner);
+  if (painpointType === "queue_hydration_failure") return "pinballwake-jobs-worker";
   if (painpointType === "unclear_owner" || !owner) return "Job Manager";
   return explicitWorker ?? routeWorker;
 }
@@ -625,8 +647,8 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
     "You must never invent facts, owners, statuses, proof, source IDs, or source URLs.",
     "Quality is more important than coverage. Prefer false negatives over false positives when evidence is weak.",
     "Do not use hidden reasoning. Spend tokens on the final JSON fields.",
-    "Use exactly one painpoint_type from: stale_ack, duplicate_wake, unclear_owner, noisy_thread, missing_proof, none.",
-    "If the event is healthy or completed and has no explicit stale, duplicate, unclear owner, noisy thread, or missing proof signal, return painpoint_detected=false and painpoint_type=none.",
+    "Use exactly one painpoint_type from: stale_ack, duplicate_wake, unclear_owner, queue_hydration_failure, noisy_thread, missing_proof, none.",
+    "If the event is healthy or completed and has no explicit stale, duplicate, unclear owner, queue hydration failure, noisy thread, or missing proof signal, return painpoint_detected=false and painpoint_type=none.",
     "The suggested_check must be concrete and name the source type, such as WakePass, dispatch, PR, issue, proof pointer, or heartbeat count.",
     "Use only cautious language: possible, likely, suggest checking, may need.",
     "Return JSON only. Do not include markdown.",
@@ -636,7 +658,7 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
     task: "Classify this event as a painpoint nudge only.",
     required_output: {
       painpoint_detected: "boolean",
-      painpoint_type: "short string such as stale_ack, duplicate_wake, unclear_owner, noisy_thread, missing_proof, none",
+      painpoint_type: "short string such as stale_ack, duplicate_wake, unclear_owner, queue_hydration_failure, noisy_thread, missing_proof, none",
       nudge: "one or two specific plain-English sentences naming the possible painpoint",
       suggested_check: "one specific deterministic check a trusted lane should run",
       confidence: "low | medium | high",

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -209,6 +209,10 @@ function displayCopyFor(todo: JobTodo): JobDisplayCopy {
   };
 }
 
+function hasHiddenJobCopy(copy: JobDisplayCopy): boolean {
+  return copy.title.endsWith("...") || copy.summary.endsWith("...");
+}
+
 function relativeTime(iso: string | null | undefined): string {
   if (!iso) return "never";
   const then = new Date(iso).getTime();
@@ -615,6 +619,7 @@ function JobRow({
   const alert = attention ? attentionCopy(todo) : null;
   const emoji = ownerEmoji(todo);
   const displayCopy = displayCopyFor(todo);
+  const hiddenCopy = hasHiddenJobCopy(displayCopy);
   const syncSignal = buildJobGithubSyncSignal(todo);
 
   return (
@@ -684,6 +689,11 @@ function JobRow({
           <p className="truncate text-[10px] leading-4 text-white/35">
             {highlightSearchText(displayCopy.summary, searchQuery)}
           </p>
+          {hiddenCopy && !expanded && (
+            <span className="mt-0.5 inline-flex text-[10px] font-medium text-[#61C1C4]/80">
+              View more
+            </span>
+          )}
         </div>
 
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 md:contents">
@@ -783,7 +793,7 @@ function JobRow({
                 onClick={() => setShowDetails((value) => !value)}
                 className="text-[11px] text-[#61C1C4]/80 hover:text-[#61C1C4]"
               >
-                {showDetails ? "Hide original" : "Show original"}
+                {showDetails ? "Hide original" : "View full original"}
               </button>
             </div>
             <div className="mt-2 space-y-1.5">
@@ -923,7 +933,7 @@ function JobSection({
         </button>
         <span className="rounded-[4px] border border-white/[0.08] bg-black/20 px-2 py-0.5 text-[11px] font-semibold text-white/50">
           {showLoading
-            ? "..."
+            ? "Loading"
             : open
               ? `${visibleJobs.length}/${sectionKey === "done" ? Math.min(jobs.length, COMPLETED_MAX_VISIBLE) : jobs.length}`
               : jobs.length}

--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -142,6 +142,15 @@ describe("AdminOrchestratorPage", () => {
                     tags: ["done"],
                     deep_link: "/admin/jobs#todo-1",
                   },
+                  ...Array.from({ length: 28 }, (_, index) => ({
+                    source_kind: "conversation_turn",
+                    source_id: `turn-archive-${index + 1}`,
+                    created_at: `2026-05-10T05:${String(40 - index).padStart(2, "0")}:00.000Z`,
+                    kind: "context",
+                    role: "assistant",
+                    summary: `Archive event ${index + 1}: older Orchestrator conversation detail.`,
+                    tags: ["conversation", "archive"],
+                  })),
                 ],
                 library_snapshots: [],
               },
@@ -214,9 +223,24 @@ describe("AdminOrchestratorPage", () => {
     const filter = await screen.findByPlaceholderText("Filter Orchestrator feed");
     fireEvent.change(filter, { target: { value: "proof" } });
 
-    expect(await screen.findByText("1 of 2 events match")).toBeInTheDocument();
+    expect(await screen.findByText("1 of 1 matching events shown")).toBeInTheDocument();
     expect(screen.getAllByText(/Orchestrator continuity proof landed/i).length).toBeGreaterThan(0);
     expect(document.querySelector("mark")?.textContent?.toLowerCase()).toContain("proof");
+  });
+
+  it("lets humans view more loaded Orchestrator history", async () => {
+    render(
+      <MemoryRouter>
+        <AdminOrchestratorPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("View more history")).toBeInTheDocument();
+    expect(screen.queryByText(/Archive event 24/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View more history"));
+
+    expect((await screen.findAllByText(/Archive event 24/i)).length).toBeGreaterThan(0);
   });
 
   it("asks the server for deeper Orchestrator keyword matches", async () => {

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -144,6 +144,9 @@ const DRIPFEED_EDUCATION_STORAGE_KEY = "unclick_orchestrator_dripfeed_education_
 const ANALOGY_STORAGE_KEY = "unclick_orchestrator_analogy_v1";
 const EVENT_PREVIEW_CHARS = 520;
 const NATURAL_CONTEXT_PREVIEW_CHARS = 360;
+const INITIAL_CONTEXT_LIMIT = 80;
+const MAX_CONTEXT_LIMIT = 200;
+const CONTINUITY_VISIBLE_STEP = 24;
 
 function formatRelative(iso: string | null | undefined): string {
   if (!iso) return "never";
@@ -436,6 +439,7 @@ export default function AdminOrchestratorPage() {
   const [connection, setConnection] = useState<ConnectionCheck | null>(null);
   const [tenant, setTenant] = useState<AiChatTenantSettings | null>(null);
   const [orchestratorContext, setOrchestratorContext] = useState<OrchestratorContext | null>(null);
+  const [contextLimit, setContextLimit] = useState(INITIAL_CONTEXT_LIMIT);
   const [loading, setLoading] = useState(true);
 
   const envEnabled = aiChatEnvEnabled();
@@ -447,6 +451,7 @@ export default function AdminOrchestratorPage() {
       return;
     }
     let cancelled = false;
+    setLoading(true);
     (async () => {
       try {
         const [channelRes, statusRes, connRes, contextRes, tenantRes] = await Promise.all([
@@ -459,7 +464,7 @@ export default function AdminOrchestratorPage() {
           fetch(
             `/api/memory-admin?action=admin_check_connection&api_key=${encodeURIComponent(storedApiKey)}`,
           ),
-          fetch("/api/memory-admin?action=orchestrator_context_read&limit=80", {
+          fetch(`/api/memory-admin?action=orchestrator_context_read&limit=${contextLimit}`, {
             headers: { Authorization: `Bearer ${authToken}` },
           }),
           fetchAiChatTenantSettings(authToken),
@@ -483,7 +488,7 @@ export default function AdminOrchestratorPage() {
     return () => {
       cancelled = true;
     };
-  }, [authToken, sessionLoading, storedApiKey]);
+  }, [authToken, contextLimit, sessionLoading, storedApiKey]);
 
   const tier: ConnectionTier = useMemo(() => {
     if (channel?.channel_active) return "channel";
@@ -526,6 +531,9 @@ export default function AdminOrchestratorPage() {
             loading={loading || sessionLoading}
             chatStatusLabel={chatDisabledReason ? "Chat disabled" : tier === "channel" ? "Claude Code bridge available" : "AI chat available"}
             authToken={authToken}
+            contextLimit={contextLimit}
+            maxContextLimit={MAX_CONTEXT_LIMIT}
+            onLoadDeeperHistory={() => setContextLimit((value) => Math.min(MAX_CONTEXT_LIMIT, value + INITIAL_CONTEXT_LIMIT))}
           />
         </div>
 
@@ -555,15 +563,22 @@ function OrchestratorContinuityPanel({
   loading,
   chatStatusLabel,
   authToken,
+  contextLimit,
+  maxContextLimit,
+  onLoadDeeperHistory,
 }: {
   context: OrchestratorContext | null;
   loading: boolean;
   chatStatusLabel: string;
   authToken: string;
+  contextLimit: number;
+  maxContextLimit: number;
+  onLoadDeeperHistory: () => void;
 }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [serverSearchContext, setServerSearchContext] = useState<OrchestratorContext | null>(null);
   const [serverSearchLoading, setServerSearchLoading] = useState(false);
+  const [visibleEventCount, setVisibleEventCount] = useState(CONTINUITY_VISIBLE_STEP);
   const trimmedSearchQuery = searchQuery.trim();
   useEffect(() => {
     if (!authToken || trimmedSearchQuery.length === 0) {
@@ -634,6 +649,18 @@ function OrchestratorContinuityPanel({
       eventViews.filter(({ event, actor }) => matchesEventSearch(event, actor, searchQuery)),
     [eventViews, searchQuery],
   );
+  const visibleEventViews = filteredEventViews.slice(0, visibleEventCount);
+  const canRevealLoadedHistory = filteredEventViews.length > visibleEventCount;
+  const canLoadDeeperHistory =
+    !trimmedSearchQuery &&
+    !loading &&
+    !serverSearchLoading &&
+    contextLimit < maxContextLimit &&
+    events.length >= contextLimit;
+
+  useEffect(() => {
+    setVisibleEventCount(CONTINUITY_VISIBLE_STEP);
+  }, [events.length, trimmedSearchQuery]);
 
   function toggleEasyRead(nextValue: boolean) {
     setEasyRead(nextValue);
@@ -674,8 +701,8 @@ function OrchestratorContinuityPanel({
           {serverSearchLoading
             ? "Searching all continuity..."
             : searchQuery.trim()
-            ? `${filteredEventViews.length} of ${events.length} events match`
-            : `${events.length} loaded event${events.length === 1 ? "" : "s"}`}
+            ? `${Math.min(visibleEventCount, filteredEventViews.length)} of ${filteredEventViews.length} matching events shown`
+            : `${Math.min(visibleEventCount, filteredEventViews.length)} of ${events.length} loaded events shown`}
         </span>
       </div>
 
@@ -762,7 +789,7 @@ function OrchestratorContinuityPanel({
             No Orchestrator events match that filter.
           </div>
         )}
-        {!loading && filteredEventViews.slice(0, 24).map(({ event, actor, index, absoluteDate, easySummary }) => (
+        {!loading && visibleEventViews.map(({ event, actor, index, absoluteDate, easySummary }) => (
           <ContinuityFeedRow
             key={`${event.source_kind}:${event.source_id}`}
             event={event}
@@ -776,6 +803,34 @@ function OrchestratorContinuityPanel({
             searchQuery={searchQuery}
           />
         ))}
+        {!loading && filteredEventViews.length > 0 && (
+          <div className="flex flex-col items-center gap-2 border-t border-white/[0.06] pt-4">
+            {(canRevealLoadedHistory || canLoadDeeperHistory) ? (
+              <button
+                type="button"
+                onClick={() => {
+                  if (canRevealLoadedHistory) {
+                    setVisibleEventCount((value) => value + CONTINUITY_VISIBLE_STEP);
+                    return;
+                  }
+                  onLoadDeeperHistory();
+                }}
+                className="rounded-md border border-[#61C1C4]/25 bg-[#61C1C4]/10 px-3 py-2 text-xs font-semibold text-[#A9EEF0] hover:border-[#61C1C4]/40 hover:bg-[#61C1C4]/15"
+              >
+                {canRevealLoadedHistory ? "View more history" : "Load deeper history"}
+              </button>
+            ) : (
+              <span className="text-[11px] text-white/30">
+                End of loaded Orchestrator history.
+              </span>
+            )}
+            {!trimmedSearchQuery && (
+              <span className="text-[10px] text-white/25">
+                Loaded depth: {events.length} events from a {contextLimit}-row source window.
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -17,9 +17,14 @@ describe("AdminSeatHeartbeatPage", () => {
     expect(HEARTBEAT_CONNECTION_PROMPT).toContain("unclick-heartbeat-seat");
     expect(HEARTBEAT_CONNECTION_PROMPT).toContain("nudgeonly_receipt_bridge");
     expect(HEARTBEAT_CONNECTION_PROMPT).toContain("compact public fields");
+    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("0 active jobs is PASS only if backlog is also 0");
+    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("Target existing Job Worker first");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("public policy must stay self-contained");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("master heartbeat");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("token-light");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("queue hydration failure");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("PinballWake JobHunt Mirror");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("Target the existing Job Worker");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("nudgeonly_receipt_bridge");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("bridge_id and receipt_line");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("Do not POST to /admin/orchestrator");

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -7,11 +7,15 @@ This /admin/agents/heartbeat copy area is the master heartbeat policy. When UnCl
 
 This public policy must stay self-contained when copied into scheduled tasks. Keep every step token-light, source-backed, and safe to show in an admin UI.
 
-Use UnClick as the source of truth first. Load memory and search active jobs when those tools are available.
+Use UnClick as the source of truth first. Load memory, check_signals, read Orchestrator context, and hunt for jobs when those tools are available. Always check list_actionable_todos, open/in_progress todos, recent dispatches, and recent Boardroom messages before declaring the system healthy.
+
+"0 active jobs" is not healthy by itself. It is PASS only when the job hunt also finds no actionable todos, no open/in_progress todos, and no unhandled dispatch or Boardroom work. If any backlog exists while active jobs are 0, treat it as BLOCKER: queue hydration failure. Include the safe counts checked and the next fix.
+
+Use PinballWake JobHunt Mirror as the fallback path for that failure. Mirror compact backlog counts and source pointers into NudgeOnly first. Call IgniteOnly only after verifier-backed receipt_bridge output requests a worker wake. Target the existing Job Worker as executor when it is registered; free API classifiers may only classify or nudge. The mirror may request a wake, but must not create duplicate jobs, assign ownership, mark done, merge, close, or edit source state.
 
 This heartbeat is explicitly authorized to write one Orchestrator continuity receipt on every run. Use stable session_id="unclick-heartbeat-seat" across scheduler sessions. After check_signals, call save_conversation_turn with role="assistant" and content containing safe alert lines, progress, and proof id if available. If that is unavailable, use channel unclick_save_conversation_turn. If no connector exists but an UnClick API key is already available, POST to https://unclick.world/api/memory-admin?action=admin_conversation_turn_ingest with Authorization: Bearer <redacted>. Never print keys. Do not POST to /admin/orchestrator; it is the read UI.
 
-When UnClick shows action_needed, blocker, stale ACK, missing proof, duplicate wake, or unclear owner, call nudgeonly_receipt_bridge if available. Pass compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, ttl_minutes. Prefer deterministic UnClick labels. Call nudgeonly_api only if no bucket exists, and only with the smallest non-secret source text needed.
+When UnClick shows action_needed, blocker, stale ACK, missing proof, duplicate wake, unclear owner, or queue hydration failure, call nudgeonly_receipt_bridge if available. Pass compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, ttl_minutes. Prefer deterministic UnClick labels. Call nudgeonly_api only if no bucket exists, and only with the smallest non-secret source text needed.
 
 If the bridge returns receipt_request or escalation_request, save bridge_id and receipt_line in the receipt and alert. If it returns quiet or advisory_only, do not notify. NudgeOnly never assigns ownership, marks done, merges, closes, or mutates source-of-truth state.
 
@@ -23,7 +27,7 @@ BLOCKER: <safe reason>; progress: <what was checked>; next: <fix>.
 If no safe task is available: BLOCKER: no clear safe task available; progress: checked live queue; next: add a scoped job.`;
 
 export const HEARTBEAT_CONNECTION_PROMPT =
-  "Run UnClick Heartbeat. Use heartbeat_protocol, then check_signals. Save one receipt to session_id='unclick-heartbeat-seat'. For blockers/stale ACK/missing proof/unclear owner, call nudgeonly_receipt_bridge with compact public fields only and include bridge_id/receipt_line when it requests action. Never print secrets. Reply PASS/BLOCKER with brief progress.";
+  "Run UnClick Heartbeat. Use heartbeat_protocol, then check_signals and hunt jobs with list_actionable_todos/open todos/recent dispatches. 0 active jobs is PASS only if backlog is also 0. For queue hydration failure, call nudgeonly_receipt_bridge with compact public fields, then IgniteOnly only after verified wake request. Target existing Job Worker first; free API only classifies/nudges. Save one receipt to session_id='unclick-heartbeat-seat'. Never print secrets. Reply PASS/BLOCKER with brief progress.";
 
 export default function AdminSeatHeartbeatPage() {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
## Summary
- lets Orchestrator API return the requested continuity depth instead of always clipping to 36 events
- adds "View more history" / "Load deeper history" plus Jobs row "View more" affordances so hidden text is explicit
- updates the master heartbeat policy so "0 active jobs" is not treated as healthy until backlog sources are checked
- adds PinballWake JobHunt Mirror fallback: NudgeOnly classifies queue_hydration_failure, IgniteOnly can wake the existing pinballwake-jobs-worker after verified bridge output

## Why
The Orchestrator page could look like the conversation ended early even when more continuity existed underneath. Separately, the heartbeat silence test exposed a real autopilot bug: active jobs can read as zero while backlog still exists. This patch makes the UI easier to read and makes the heartbeat hunt the real queue before declaring PASS.

## Safety
- free API remains classifier/nudge only
- existing Job Worker remains the executor for queue hydration failure
- JobHunt Mirror may request a wake, but cannot create duplicate jobs, assign ownership, mark done, merge, close, or edit source state

## Tests
- npm test -- AdminOrchestrator.test.tsx -- --runInBand
- npm test -- api/orchestrator-context.test.ts -- --runInBand
- npm test -- AdminSeatHeartbeat.test.tsx -- --runInBand
- npx vitest run src/nudgeonly-tool.test.ts src/igniteonly-tool.test.ts src/__tests__/heartbeat-protocol.test.ts (from packages/mcp-server)
- npm run build --workspace=@unclick/mcp-server
- npm run build