### PR TITLE
fix(runner): allow job hunt after empty handoff

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -462,14 +462,12 @@ export function evaluateOrchestratorSeatHandshakeProof(context = {}) {
     };
   }
 
-  const handoffText = JSON.stringify(handshake);
+  const { next_prompt: _nextPrompt, ...handoffEnvelope } = handshake;
+  const handoffText = JSON.stringify(handoffEnvelope);
   const noisy = /<heartbeat\b|current_time_iso|unclick-heartbeat|run unclick heartbeat|dont_notify/i.test(handoffText);
   const sourcePointers = Array.isArray(handshake.source_pointers) ? handshake.source_pointers : [];
   const seatFreshness = Array.isArray(handshake.seat_freshness) ? handshake.seat_freshness : [];
   const missing = [];
-  if (!String(handshake.active_decision || "").trim()) missing.push("active_decision");
-  if (!String(handshake.active_job || "").trim()) missing.push("active_job");
-  if (!String(handshake.recent_proof || "").trim()) missing.push("recent_proof");
   if (sourcePointers.length === 0) missing.push("source_pointers");
   if (seatFreshness.length === 0) missing.push("seat_freshness");
   if (noisy) missing.push("noise_free_handoff");

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -562,19 +562,19 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.wake_gate.scheduler_watchdog.action, "tap_orchestrator_with_trusted_unclick_fallback");
   });
 
-  it("blocks empty or noisy Orchestrator seat_handshake proof packets", async () => {
+  it("accepts empty active work but blocks noisy Orchestrator seat_handshake proof packets", async () => {
     const direct = evaluateOrchestratorSeatHandshakeProof({
       seat_handshake: {
-        active_decision: "Chris greenlit Orchestrator V1.",
+        active_decision: null,
         active_job: "",
-        recent_proof: "PASS: proof exists.",
+        recent_proof: null,
         seat_freshness: ["PinballWake: Live"],
         source_pointers: [{ source_id: "todo-1" }],
       },
     });
 
-    assert.equal(direct.ok, false);
-    assert(direct.missing.includes("active_job"));
+    assert.equal(direct.ok, true);
+    assert.equal(direct.reason, "seat_handshake_ready");
 
     const fetched = await fetchUnClickOrchestratorContext({
       apiKey: "uc_test",
@@ -591,6 +591,7 @@ describe("PinballWake autonomous Runner seat", () => {
                 seat_freshness: ["PinballWake: Live"],
                 source_pointers: [{ source_id: "todo-1" }],
                 next_prompt: "Run UnClick Heartbeat. Use the Seats > Heartbeat policy.",
+                raw_wake: "<heartbeat><current_time_iso>2026-05-11T09:00:00Z</current_time_iso></heartbeat>",
               },
             },
           };
@@ -602,6 +603,23 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(noisy.ok, false);
     assert(noisy.missing.includes("noise_free_handoff"));
     assert.match(noisy.proof_line, /^BLOCKER:/);
+  });
+
+  it("allows safe heartbeat wording inside seat_handshake next_prompt", () => {
+    const proof = evaluateOrchestratorSeatHandshakeProof({
+      seat_handshake: {
+        mode: "fresh-seat-pickup",
+        active_decision: null,
+        active_job: null,
+        recent_proof: null,
+        seat_freshness: ["QueuePush: Live"],
+        source_pointers: [{ source_id: "dispatch-1" }],
+        next_prompt: "Run UnClick Heartbeat. Use the Seats > Heartbeat policy.",
+      },
+    });
+
+    assert.equal(proof.ok, true);
+    assert.equal(proof.reason, "seat_handshake_ready");
   });
 
   it("extracts Boardroom todo ids only from imported UnClick jobs", () => {


### PR DESCRIPTION
## Summary
- allow Orchestrator seat handoff proof to pass when there is no active job yet
- ignore safe heartbeat wording inside seat_handshake.next_prompt when checking for noisy raw heartbeat envelopes
- keep blocking raw heartbeat envelope fields outside next_prompt

## Why
Runner was firing but failing before job hunt, so Orchestrator could report 0 active jobs even when QueuePush and UnClick todos showed backlog.

## Tests
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check

## Safety
- no execute mode changes
- no merge/close/assignment behavior changes
- only unblocks the existing job hunt after a readable handoff