### PR TITLE
feat(connect): two-card Passport key onboarding with inline mint

### DIFF
--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams, Link } from "react-router-dom";
 import { CONNECTORS, type ConnectorConfig, type CredentialField } from "@/lib/connectors";
+import { useSession } from "@/lib/auth";
 import { Button }   from "@/components/ui/button";
 import { Input }    from "@/components/ui/input";
 import { Label }    from "@/components/ui/label";
@@ -153,7 +154,50 @@ export default function ConnectPage() {
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [shopifyStore, setShopifyStore] = useState("");
   const [apiKey, setApiKey]           = useState(getApiKey);
+  const [mintingKey, setMintingKey]   = useState(false);
+  const [mintError, setMintError]     = useState<string | null>(null);
+  const [showManualPaste, setShowManualPaste] = useState(false);
   const callbackFired                 = useRef(false);
+
+  const { session } = useSession();
+
+  async function handleMintKey() {
+    if (!session) return;
+    setMintingKey(true);
+    setMintError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=generate_api_key", {
+        method:  "POST",
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      const body = (await res.json()) as {
+        api_key?:           string | null;
+        already_provisioned?: boolean;
+        error?:             string;
+      };
+      if (!res.ok) {
+        setMintError(body.error ?? "Could not get your Passport key.");
+        return;
+      }
+      if (body.api_key) {
+        try { localStorage.setItem("unclick_api_key", body.api_key); } catch { /* ignore */ }
+        setApiKey(body.api_key);
+        return;
+      }
+      // No raw key returned: user already has one on file. Open the manual
+      // paste card so they can supply the existing key (or reset from the
+      // dashboard, which we surface as a link).
+      setShowManualPaste(true);
+      setMintError(
+        "You already have a Passport key. Paste it below, or reset it from your dashboard."
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Network error.";
+      setMintError(message);
+    } finally {
+      setMintingKey(false);
+    }
+  }
 
   // -- Handle OAuth callback ------------------------------------------------
   useEffect(() => {
@@ -398,24 +442,96 @@ export default function ConnectPage() {
   return (
     <ConnectShell connector={connector}>
       <div className="space-y-6">
-        {/* API key input (needed for all flows) */}
-        <div className="space-y-1.5 border border-white/10 rounded-lg p-4 bg-white/[0.02]">
-          <Label htmlFor="api_key" className="text-sm text-[#E8E8E8]">
-            Your UnClick Passport key
-          </Label>
-          <p className="text-xs text-[#E8E8E8]/50">
-            Needed once in this browser so Passport can store access securely.{" "}
-            <Link to="/" className="text-[#E2B93B] hover:underline">Get one here.</Link>
-          </p>
-          <Input
-            id="api_key"
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="uc_xxxxxxxx or agt_live_xxxxxxxx"
-            className="bg-white/5 border-white/10 text-[#E8E8E8] placeholder:text-[#E8E8E8]/30"
-          />
-        </div>
+        {/* Passport key onboarding.
+            - Logged-in user with no localStorage key: show numbered 1/2 cards.
+            - Otherwise: show the classic single paste field.
+            The Connect button below is gated on apiKey being set either way. */}
+        {session && !apiKey ? (
+          <div className="space-y-3">
+            <p className="text-xs text-[#E8E8E8]/60 leading-relaxed">
+              Your Passport key lives in your browser, not on our servers.
+              We only store a one-way fingerprint, so even we cannot read
+              your saved credentials. Only you can.
+            </p>
+
+            {/* Option 1: mint inline */}
+            <button
+              type="button"
+              onClick={() => void handleMintKey()}
+              disabled={mintingKey}
+              className="w-full flex items-center gap-3 rounded-lg border border-[#E2B93B]/30 bg-[#E2B93B]/5 px-4 py-3 text-left hover:bg-[#E2B93B]/10 transition-colors disabled:opacity-50"
+            >
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#E2B93B] text-black font-bold text-sm">
+                1
+              </span>
+              <span className="flex-1">
+                <span className="block text-sm font-semibold text-[#E8E8E8]">
+                  {mintingKey ? "Getting your key..." : "Get my Passport key"}
+                </span>
+                <span className="block text-xs text-[#E8E8E8]/50">
+                  Fresh key, saved to this browser.
+                </span>
+              </span>
+            </button>
+
+            {/* Option 2: paste an existing key */}
+            <button
+              type="button"
+              onClick={() => setShowManualPaste((v) => !v)}
+              className="w-full flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3 text-left hover:bg-white/[0.04] transition-colors"
+            >
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white/10 text-[#E8E8E8] font-bold text-sm">
+                2
+              </span>
+              <span className="flex-1">
+                <span className="block text-sm font-semibold text-[#E8E8E8]">
+                  I have one already
+                </span>
+                <span className="block text-xs text-[#E8E8E8]/50">
+                  Paste your existing uc_ or agt_live_ key.
+                </span>
+              </span>
+            </button>
+
+            {showManualPaste && (
+              <div className="space-y-1.5 border border-white/10 rounded-lg p-4 bg-white/[0.02]">
+                <Label htmlFor="api_key" className="text-sm text-[#E8E8E8]">
+                  Your UnClick Passport key
+                </Label>
+                <Input
+                  id="api_key"
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder="uc_xxxxxxxx or agt_live_xxxxxxxx"
+                  className="bg-white/5 border-white/10 text-[#E8E8E8] placeholder:text-[#E8E8E8]/30"
+                />
+              </div>
+            )}
+
+            {mintError && (
+              <p className="text-xs text-red-400/80">{mintError}</p>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-1.5 border border-white/10 rounded-lg p-4 bg-white/[0.02]">
+            <Label htmlFor="api_key" className="text-sm text-[#E8E8E8]">
+              Your UnClick Passport key
+            </Label>
+            <p className="text-xs text-[#E8E8E8]/50">
+              Needed once in this browser so Passport can store access securely.{" "}
+              <Link to="/" className="text-[#E2B93B] hover:underline">Get one here.</Link>
+            </p>
+            <Input
+              id="api_key"
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="uc_xxxxxxxx or agt_live_xxxxxxxx"
+              className="bg-white/5 border-white/10 text-[#E8E8E8] placeholder:text-[#E8E8E8]/30"
+            />
+          </div>
+        )}
 
         {/* OAuth2 flow */}
         {isOAuth2 && (


### PR DESCRIPTION
Closes UnClick todo a3802906.

## What changed

`src/pages/Connect.tsx`: when a logged-in user lands on `/connect/<platform>` without a Passport key in localStorage, they now see two numbered options instead of a bare paste field:

**1. Get my Passport key** — calls `/api/memory-admin?action=generate_api_key` with the Supabase session JWT. If the user has no key on file yet, mints a fresh one, writes it to localStorage, hydrates `apiKey` state, and the OAuth Connect button immediately enables. If the user already has a key on file, the existing endpoint returns `api_key: null, already_provisioned: true` — we open the manual paste card with a friendly note ("you already have one, paste it or reset from dashboard").

**2. I have one already** — toggles the existing paste field.

Small inline explainer above the buttons:

> Your Passport key lives in your browser, not on our servers. We only store a one-way fingerprint, so even we cannot read your saved credentials. Only you can.

Logged-out users (or anyone with a key already in localStorage) see the existing flow unchanged.

## Why

Today the Connect page asks every user to paste their Passport key into a field before the OAuth button enables, even when they're logged into the dashboard on the same browser. For a user setting up GitHub in incognito or on a fresh device, that's a wall — they have to leave for the dashboard, find the key, copy, come back. The new flow collapses that to one click for the common case.

## Security

No change to the zero-knowledge model. The Passport key is still minted server-side, hashed for storage, returned exactly once, and held only in the user's browser. Server still cannot decrypt stored credentials. AES-256-GCM with PBKDF2 derivation unchanged.

The `generate_api_key` endpoint already exists and is session-cookie gated via `resolveSessionUser`. This PR only adds a frontend caller — no new server attack surface.

## Test plan

- Logged-in user, no localStorage key, no prior api_keys row → click option 1 → key minted, button enables.
- Logged-in user, no localStorage key, prior api_keys row exists → click option 1 → manual paste opens with the "you already have one" message.
- Logged-in user with localStorage key → existing flow (paste field hidden, button enabled).
- Logged-out user → existing classic paste flow unchanged.
- Manual `Use a token instead` fallback for non-OAuth connectors → unchanged.

## Non-overlap

- No changes to `oauth-callback.ts`, `oauth-state.ts`, `credentials.ts`, or any backend endpoint.
- No Passport public-name lock work (todo f0268aad).
- No keychain/encryption refactor.