### PR TITLE
fix(runner): tolerate heartbeat log summaries

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -463,8 +463,7 @@ export function evaluateOrchestratorSeatHandshakeProof(context = {}) {
   }
 
   const { next_prompt: _nextPrompt, ...handoffEnvelope } = handshake;
-  const handoffText = JSON.stringify(handoffEnvelope);
-  const noisy = /<heartbeat\b|current_time_iso|unclick-heartbeat|run unclick heartbeat|dont_notify/i.test(handoffText);
+  const noisy = containsRawHeartbeatPayload(handoffEnvelope);
   const sourcePointers = Array.isArray(handshake.source_pointers) ? handshake.source_pointers : [];
   const seatFreshness = Array.isArray(handshake.seat_freshness) ? handshake.seat_freshness : [];
   const missing = [];
@@ -496,6 +495,27 @@ export function evaluateOrchestratorSeatHandshakeProof(context = {}) {
     seat_freshness_count: seatFreshness.length,
     proof_line: `PASS: Orchestrator seat_handshake readable; proof: ${proofIds || "source_pointers"}; cleanup: done.`,
   };
+}
+
+function containsRawHeartbeatPayload(value, key = "") {
+  if (value == null) return false;
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (/<heartbeat\b|<\/heartbeat>|<current_time_iso\b|<automation_id\b/i.test(text)) {
+      return true;
+    }
+    if (/^raw_/i.test(key) && /current_time_iso|unclick-heartbeat|run unclick heartbeat|dont_notify/i.test(text)) {
+      return true;
+    }
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => containsRawHeartbeatPayload(item, key));
+  }
+  if (typeof value === "object") {
+    return Object.entries(value).some(([childKey, childValue]) => containsRawHeartbeatPayload(childValue, childKey));
+  }
+  return false;
 }
 
 export async function runOrchestratorSeatHandshakeProof({

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -622,6 +622,38 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(proof.reason, "seat_handshake_ready");
   });
 
+  it("allows compact Orchestrator log summaries that mention heartbeat", () => {
+    const proof = evaluateOrchestratorSeatHandshakeProof({
+      seat_handshake: {
+        mode: "fresh-seat-pickup",
+        active_decision: "Continue from latest heartbeat proof.",
+        active_job: null,
+        recent_proof: "UnClick heartbeat result: PASS, job hunt checked.",
+        active_blocker: "Runner has no fresh run after unclick-heartbeat.",
+        seat_freshness: ["QueuePush: Live"],
+        source_pointers: [{ source_kind: "conversation_turn", source_id: "receipt-1" }],
+      },
+    });
+
+    assert.equal(proof.ok, true);
+    assert.equal(proof.reason, "seat_handshake_ready");
+  });
+
+  it("blocks raw heartbeat payload text without blocking compact summaries", () => {
+    const proof = evaluateOrchestratorSeatHandshakeProof({
+      seat_handshake: {
+        mode: "fresh-seat-pickup",
+        recent_proof: "UnClick heartbeat result: PASS, compact summary only.",
+        raw_turn: "Run UnClick Heartbeat. Use the Seats > Heartbeat policy.",
+        seat_freshness: ["QueuePush: Live"],
+        source_pointers: [{ source_kind: "conversation_turn", source_id: "receipt-1" }],
+      },
+    });
+
+    assert.equal(proof.ok, false);
+    assert(proof.missing.includes("noise_free_handoff"));
+  });
+
   it("extracts Boardroom todo ids only from imported UnClick jobs", () => {
     const job = createCodingRoomJobFromBoardroomTodo({
       id: "todo-claim-1",


### PR DESCRIPTION
Summary:
- Narrows the Runner handoff noise gate so Orchestrator can remain an agent-seat log.
- Allows compact handoff summaries that mention heartbeat.
- Still blocks raw heartbeat payload fields before Runner trusts the handoff.

Scope:
- scripts/pinballwake-autonomous-runner.mjs
- scripts/pinballwake-autonomous-runner.test.mjs

Non-overlap:
- Does not change Orchestrator storage, Boardroom/job chat behavior, NudgeOnly, IgniteOnly, workflow schedules, or Connect/Passport work.
- Does not grant Runner execute authority.

Verification:
- node --test scripts\pinballwake-autonomous-runner.test.mjs
- git diff --check

Risk:
- Low. The change only adjusts the proof filter before Runner claim mode. Raw heartbeat envelopes and raw_* heartbeat payloads still block.

Follow-up:
- Once merged, the next scheduled PinballWake Autonomous Runner cycle should prove whether the Orchestrator handoff now passes and job hunting resumes.