### PR TITLE
fix(pinballwake): route proofed drafts to review

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -60,6 +60,7 @@ const queuepushRunnerRoster = resolveQueuePushRunnerRoster(process.env.QUEUEPUSH
 
 const STATES = new Set([
   "draft_green_needs_owner_lift",
+  "missing_review_safety_ack",
   "missing_final_qc_ack",
   "hold_overlap",
   "dirty_branch",
@@ -254,7 +255,13 @@ export function latestCommentSignals(comments = []) {
       (/^(?:\W+\s*)?(pass|merge-ok|qc pass)\b/.test(text) ||
         /\b(safe next action|safe to merge)\b/.test(text)) &&
       !/\b(please keep draft|stay draft|do not merge|do not lift)\b/.test(text);
-    if (clearPass) {
+    const proofComment =
+      !["github-actions", "vercel"].includes(authorLogin) &&
+      /\bproof\b/.test(text) &&
+      /\bverification\b/.test(text) &&
+      /\bpass\b/.test(text) &&
+      !/\b(hold|blocker|blocked|fail|failed|failing|red)\b/.test(text);
+    if (clearPass || proofComment) {
       lastPass = index;
       hasProof = true;
     }
@@ -336,6 +343,7 @@ export function jobKindForState(state) {
       return "implementation";
     case "missing_final_qc_ack":
     case "ready_for_qc":
+    case "missing_review_safety_ack":
       return "qc_review";
     case "blocked_chris_only":
     case "draft_green_needs_owner_lift":
@@ -429,6 +437,12 @@ export function classifyPullRequest(input) {
       reason: "Safety and builder PASS are visible; final QC ACK is missing.",
     };
   }
+  if (pr.draft && green && clean && signals.hasProof && (!signals.hasSafetyPass || !signals.hasReviewerPass)) {
+    return {
+      state: "missing_review_safety_ack",
+      reason: "Draft PR is green and clean with proof; Reviewer/Safety PASS is missing.",
+    };
+  }
   if (pr.draft && green && clean) {
     return {
       state: "draft_green_needs_owner_lift",
@@ -445,6 +459,8 @@ export function expectedProofForState(state, pr) {
   switch (state) {
     case "draft_green_needs_owner_lift":
       return "Update PR body with owner/non-overlap/status/tests, then lift draft or state exact HOLD.";
+    case "missing_review_safety_ack":
+      return "Reviewer/Safety latest head only; reply PASS/BLOCKER with exact boundary evidence, then hand back for draft lift.";
     case "missing_final_qc_ack":
       return "QC latest head only; reply PASS/BLOCKER, then hand back to Master for lift/merge.";
     case "hold_overlap":
@@ -466,6 +482,8 @@ export function directActionForState(state) {
   switch (state) {
     case "draft_green_needs_owner_lift":
       return "Claim it, refresh proof, then lift draft or reply with the exact HOLD.";
+    case "missing_review_safety_ack":
+      return "Claim review, check latest head for safety and authority boundaries, then PASS/BLOCKER with evidence.";
     case "missing_final_qc_ack":
       return "Claim final QC, second-read latest head, then PASS/BLOCKER with exact evidence.";
     case "hold_overlap":
@@ -685,9 +703,10 @@ function prioritizePackets(packets) {
     hold_overlap: 1,
     failed_targeted_proof: 2,
     blocked_chris_only: 3,
-    missing_final_qc_ack: 4,
-    ready_for_qc: 5,
-    draft_green_needs_owner_lift: 6,
+    missing_review_safety_ack: 4,
+    missing_final_qc_ack: 5,
+    ready_for_qc: 6,
+    draft_green_needs_owner_lift: 7,
   };
   return [...packets].sort((a, b) => {
     const stateDiff = (priority[a.state] ?? 99) - (priority[b.state] ?? 99);

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -37,7 +37,7 @@ const greenChecks = [
 const greenStatus = [{ state: "success" }];
 
 describe("QueuePush PR classifier", () => {
-  it("classifies green clean draft PRs as owner-lift packets", () => {
+  it("keeps green clean draft PRs with only Safety PASS as owner-lift packets", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 506, draft: true }),
       files: [{ filename: "docs/connectors/system-credentials-health-panel.md" }],
@@ -47,6 +47,41 @@ describe("QueuePush PR classifier", () => {
     });
 
     assert.equal(result.state, "draft_green_needs_owner_lift");
+  });
+
+  it("keeps green clean draft PRs without proof as owner-lift packets", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 506, draft: true }),
+      files: [{ filename: "docs/connectors/system-credentials-health-panel.md" }],
+      comments: [{ body: "Owner refreshed context. Waiting on proof.", created_at: "2026-05-03T01:00:00Z" }],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "draft_green_needs_owner_lift");
+  });
+
+  it("routes green clean draft PRs with proof comment to review", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 714, draft: true, title: "fix(runner): tolerate heartbeat log summaries" }),
+      files: [{ filename: "scripts/pinballwake-autonomous-runner.mjs" }],
+      comments: [
+        {
+          body: [
+            "Runner handoff filter proof from Codex:",
+            "",
+            "Verification:",
+            "- `node --test scripts\\pinballwake-autonomous-runner.test.mjs` PASS, 31/31",
+            "- `git diff --check` PASS",
+          ].join("\n"),
+          created_at: "2026-05-11T23:05:29Z",
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "missing_review_safety_ack");
   });
 
   it("routes draft PRs with Safety and Builder PASS but missing QC to final QC", () => {
@@ -480,12 +515,31 @@ describe("QueuePush routing and packets", () => {
 
   it("maps process states to job kinds and code requirements", () => {
     assert.equal(jobKindForState("draft_green_needs_owner_lift"), "owner_decision");
+    assert.equal(jobKindForState("missing_review_safety_ack"), "qc_review");
     assert.equal(jobKindForState("missing_final_qc_ack"), "qc_review");
     assert.equal(jobKindForState("ready_for_qc"), "qc_review");
     assert.equal(jobKindForState("failed_targeted_proof"), "implementation");
     assert.equal(stateRequiresCode("failed_targeted_proof"), true);
     assert.equal(stateRequiresCode("missing_final_qc_ack"), false);
+    assert.equal(stateRequiresCode("missing_review_safety_ack"), false);
     assert.equal(stateRequiresCode("draft_green_needs_owner_lift"), false);
+  });
+
+  it("builds compact review packets for green draft PRs missing review and safety PASS", () => {
+    const packet = buildQueuePacket({
+      pr: pr({ number: 714, title: "fix(runner): tolerate heartbeat log summaries" }),
+      state: "missing_review_safety_ack",
+      reason: "Draft PR is green and clean with proof; Reviewer/Safety PASS is missing.",
+      files: [{ filename: "scripts/pinballwake-autonomous-runner.mjs" }],
+    });
+
+    assert.equal(packet.worker, "🔍");
+    assert.equal(packet.jobKind, "qc_review");
+    assert.equal(packet.requiresCode, false);
+    assert.match(packet.packetId, /^queuepush:v3:pr-714:missing_review_safety_ack:abcdef1:[a-f0-9]{10}$/);
+    assert.match(packet.text, /DIRECT QC PACKET/);
+    assert.match(packet.text, /Reviewer\/Safety latest head only/);
+    assert.match(packet.text, /requires code: no/);
   });
 
   it("builds compact final QC packets with deterministic id", () => {


### PR DESCRIPTION
## Summary
- Adds a QueuePush state for green draft PRs that already have a proof-style verification comment but are still missing Reviewer/Safety PASS.
- Routes those packets to QC review instead of repeating a generic owner-lift decision packet.
- Recognizes compact human proof comments with `proof`, `verification`, and `PASS` while still ignoring bot comments and active HOLD/BLOCKER text.

## Scope
- Owned files: `scripts/fleet-throughput-watch.mjs`, `scripts/fleet-throughput-watch.test.mjs`.
- Linked issue: #715 autopilot closure stack.

## Non-overlap
- Does not lift drafts, merge PRs, approve reviews, mark work done, or expand QueuePush authority.
- Does not change NudgeOnly, IgniteOnly, PushOnly, or Jobs Worker execution boundaries.

## Verification
- `node --test scripts/fleet-throughput-watch.test.mjs` PASS, 50/50.
- `git diff --check` PASS.

## Risk
- Low automation-routing risk. The change only alters packet classification/recipient for proofed green draft PRs.
- It may increase Reviewer/Safety packets for drafts that already have owner proof, which is intended for the #715 closer loop.

## Follow-up
- If Reviewer/Safety passes, a later chip can decide whether safe, non-protected draft lift is allowed under the merge room policy.