### PR TITLE
fix(pinballwake): request file-level scoping for unclaimable todos

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -649,6 +649,7 @@ export function extractBoardroomTodoIdFromCodingRoomJob(job = {}) {
 }
 
 const BOARDROOM_SCOPING_ACTION_REASONS = new Set([
+  "unassigned_open",
   "stale_in_progress",
   "stale_assigned_open",
   "role_assigned_open",
@@ -794,16 +795,19 @@ export function selectBoardroomTodoForScoping({ queueSourceResult = {}, lastResu
     return null;
   }
 
-  const missingScopepackIds = new Set(
+  const needsScopingIds = new Set(
     (lastResult.skipped || [])
-      .filter((skip) => skip?.reason === "boardroom_todo_missing_scopepack")
+      .filter((skip) => (
+        skip?.reason === "boardroom_todo_missing_scopepack" ||
+        skip?.reason === "missing_owned_files"
+      ))
       .map((skip) => String(skip.job_id || "").replace(/^boardroom-todo:/, "").trim())
       .filter(Boolean),
   );
-  if (missingScopepackIds.size === 0) return null;
+  if (needsScopingIds.size === 0) return null;
 
   return (queueSourceResult.todos || []).find((todo) => (
-    missingScopepackIds.has(String(todo.id || "").trim()) &&
+    needsScopingIds.has(String(todo.id || "").trim()) &&
     BOARDROOM_SCOPING_ACTION_REASONS.has(String(todo.actionability_reason || "").trim())
   )) || null;
 }
@@ -855,7 +859,7 @@ export async function syncBoardroomTodoScopingRequestToUnClick({
       target_id: todoId,
       text: compact(
         [
-          "Autonomous Runner could not safely build this job yet because no ScopePack was attached.",
+          "Autonomous Runner could not safely build this job yet because no file-level ScopePack was attached.",
           "Reopened for scoping instead of holding a stale active claim.",
           "Next: attach exact owned files, proof/tests, and stop conditions, or split this into a smaller job.",
           `reason=${todo.actionability_reason || "missing_scopepack"}.`,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -872,6 +872,130 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("reopens scoped Boardroom todos for file-level scoping when owned files are missing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const calls = [];
+      const fetchImpl = async (url, init = {}) => {
+        calls.push({ url, init, body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-orchestrator-scope",
+                            title: "Orchestrator continuity wiring",
+                            status: "open",
+                            priority: "urgent",
+                            assigned_to_agent_id: null,
+                            actionability_reason: "unassigned_open",
+                            scope_pack: {
+                              lane: "orchestrator",
+                              owner_hint: "live_builder_or_orchestrator_seat",
+                              owned_surfaces: [
+                                "Orchestrator pointer-index hooks",
+                                "read_orchestrator_context filtering",
+                              ],
+                              tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+                            },
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "update_todo") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todo: {
+                          id: "todo-orchestrator-scope",
+                          status: "open",
+                          assigned_to_agent_id: null,
+                        },
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "comment_on") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({ comment: { id: "comment-scope-1" } }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-12T00:40:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "scoping_requested");
+      assert.equal(result.reason, "boardroom_todo_reopened_for_scoping");
+      assert.equal(result.queue_source.imported, 1);
+      assert.equal(result.skipped[0].reason, "boardroom_todo_missing_scopepack");
+      assert.equal(result.todo_scoping_sync.todo_id, "todo-orchestrator-scope");
+      assert.equal(result.todo_scoping_sync.comment_ok, true);
+
+      const updateCall = calls.find((call) => call.body.params.name === "update_todo");
+      assert.equal(updateCall.body.params.arguments.todo_id, "todo-orchestrator-scope");
+      assert.equal(updateCall.body.params.arguments.assigned_to_agent_id, "");
+
+      const commentCall = calls.find((call) => call.body.params.name === "comment_on");
+      assert.match(commentCall.body.params.arguments.text, /file-level ScopePack/);
+      assert.match(commentCall.body.params.arguments.text, /exact owned files/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("quietly skips stale assigned UnClick todo claims before syncing ownership", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");


### PR DESCRIPTION
Summary:
- Changes the autonomous Runner idle path so unassigned Boardroom todos that have a broad ScopePack but no concrete owned files get reopened for file-level scoping instead of silently idling as no_claimable_jobs.
- Adds `unassigned_open` to the scoping request reasons and keeps the existing safety gate that refuses code claims without exact owned files.
- Updates the scoping comment to ask for exact owned files, proof/tests, and stop conditions.

Scope:
- `scripts/pinballwake-autonomous-runner.mjs`
- `scripts/pinballwake-autonomous-runner.test.mjs`
- Automation closure lane, related to issue #715 and the e9e308cd claimability bottleneck.

Non-overlap:
- Does not make broad `owned_surfaces` claimable.
- Does not assign ownership, merge, close, approve, or execute code.
- Does not change QueuePush/WakePass duplicate packet reconciliation.
- Does not touch Passport, analytics, seat UI, auth, billing, DNS, or migrations.

Verification:
- `node --test scripts\\pinballwake-autonomous-runner.test.mjs` passes, 32/32.
- `git diff --check` passes.

Risk:
- Low. The runner remains conservative and still refuses missing-file jobs. The change only turns that idle state into a proofed scoping request so the queue can move.

Follow-up:
- Patch QueuePush PASS-aware duplicate filtering.
- Sweep remaining dormant-master todos once this claimability path is proven.