### PR TITLE
fix(pinballwake): allow builder-compatible orchestrator claims

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -152,12 +152,28 @@ function listTodoRoleTokens(todo = {}, scopePack = {}) {
     scopePack.worker,
     scopePack.worker_role,
     scopePack.role,
+    scopePack.lane,
   ];
 
   return raw
     .flatMap((value) => parseList(value, []))
     .map(normalizeToken)
     .filter(Boolean);
+}
+
+function ownerHintAllowsBuilderCompatibleOrchestrator(todo = {}, scopePack = {}) {
+  const hint = [
+    todo.owner_hint,
+    todo.ownerHint,
+    scopePack.owner_hint,
+    scopePack.ownerHint,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ");
+
+  return hint.includes("builder") && hint.includes("orchestrator");
 }
 
 function recentTodoCommentText(todo = {}) {
@@ -311,6 +327,8 @@ function extractBoardroomTodoScopePack(todo = {}) {
     worker: String(scope.worker || "").trim(),
     worker_role: String(scope.worker_role || scope.workerRole || "").trim(),
     role: String(scope.role || "").trim(),
+    lane: String(scope.lane || scope.worker_lane || scope.workerLane || "").trim(),
+    owner_hint: String(scope.owner_hint || scope.ownerHint || "").trim(),
   };
 }
 
@@ -954,7 +972,12 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
 
   const safeRoles = tokenSet(allowedTodoRoles, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles);
   const roleTokens = listTodoRoleTokens(todo, scopePack);
-  const hasAllowedRole = roleTokens.length === 0 || roleTokens.some((role) => safeRoles.has(role));
+  const hasBuilderCompatibleOrchestratorHint =
+    roleTokens.includes("orchestrator") && ownerHintAllowsBuilderCompatibleOrchestrator(todo, scopePack);
+  const hasAllowedRole =
+    roleTokens.length === 0 ||
+    roleTokens.some((role) => safeRoles.has(role)) ||
+    hasBuilderCompatibleOrchestratorHint;
   if (!hasAllowedRole) {
     return { ok: false, reason: "boardroom_todo_role_not_allowed", role: roleTokens[0] || null };
   }
@@ -1029,6 +1052,11 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
         status: todo.status || null,
         assigned_to_agent_id: todo.assigned_to_agent_id || null,
         actionability_reason: todo.actionability_reason || null,
+        scope_pack_seen: Boolean(scopePack.hasScopePack),
+        lane: todo.lane || scopePack.lane || null,
+        owner_hint: todo.owner_hint || todo.ownerHint || scopePack.owner_hint || null,
+        claim_allowed: false,
+        skip_reason: eligibility.reason,
         reason: eligibility.reason,
         file: eligibility.file || null,
       });
@@ -1059,14 +1087,20 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
     imported,
     seen: ordered.length,
     skipped,
-    todos: ordered.map((todo) => ({
-      id: todo.id,
-      title: compact(todo.title, 140),
-      priority: todo.priority || null,
-      status: todo.status || null,
-      assigned_to_agent_id: todo.assigned_to_agent_id || null,
-      actionability_reason: todo.actionability_reason || null,
-    })),
+    todos: ordered.map((todo) => {
+      const scopePack = extractBoardroomTodoScopePack(todo);
+      return {
+        id: todo.id,
+        title: compact(todo.title, 140),
+        priority: todo.priority || null,
+        status: todo.status || null,
+        assigned_to_agent_id: todo.assigned_to_agent_id || null,
+        actionability_reason: todo.actionability_reason || null,
+        scope_pack_seen: Boolean(scopePack.hasScopePack),
+        lane: todo.lane || scopePack.lane || null,
+        owner_hint: todo.owner_hint || todo.ownerHint || scopePack.owner_hint || null,
+      };
+    }),
   };
 }
 

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -369,6 +369,83 @@ describe("PinballWake autonomous Runner seat", () => {
     );
   });
 
+  it("allows unassigned orchestrator ScopePacks with builder-compatible owner hints", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      const todo = {
+        id: "e9e308cd-7711-4f30-8ebd-d5402fefd205",
+        title: "Orchestrator continuity wiring: plug missing source-kinds into Orchestrator",
+        status: "open",
+        priority: "urgent",
+        assigned_to_agent_id: null,
+        actionability_reason: "unassigned_open",
+        created_at: "2026-05-11T01:38:48.701Z",
+        scope_pack: {
+          lane: "orchestrator",
+          owner_hint: "live_builder_or_orchestrator_seat",
+          owned_files: ["api/lib/orchestrator-context.ts"],
+          patch:
+            "diff --git a/api/lib/orchestrator-context.ts b/api/lib/orchestrator-context.ts\n--- a/api/lib/orchestrator-context.ts\n+++ b/api/lib/orchestrator-context.ts\n@@ -1 +1 @@\n-old\n+new\n",
+          tests: ["node --test api/orchestrator-context.test.ts"],
+        },
+      };
+
+      assert.equal(evaluateBoardroomTodoAutoClaimEligibility(todo).ok, true);
+      assert.equal(
+        evaluateBoardroomTodoAutoClaimEligibility({
+          ...todo,
+          scope_pack: {
+            ...todo.scope_pack,
+            owner_hint: "",
+          },
+        }).reason,
+        "boardroom_todo_role_not_allowed",
+      );
+
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+      const fetchImpl = async () => ({
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ todos: [todo] }),
+                },
+              ],
+            },
+          };
+        },
+      });
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-12T01:00:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.queue_source.imported, 1);
+      assert.equal(result.queue_source.skipped.length, 0);
+      assert.equal(result.queue_source.todos[0].scope_pack_seen, true);
+      assert.equal(result.queue_source.todos[0].lane, "orchestrator");
+      assert.equal(result.queue_source.todos[0].owner_hint, "live_builder_or_orchestrator_seat");
+      assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:e9e308cd-7711-4f30-8ebd-d5402fefd205");
+      assert.equal(result.ledger.jobs[0].worker, "builder");
+      assert.deepEqual(result.ledger.jobs[0].owned_files, ["api/lib/orchestrator-context.ts"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not pretend the queue is empty when UnClick queue auth is missing", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");


### PR DESCRIPTION
Summary
- Allows an unassigned urgent orchestrator ScopePack to be claimed when it carries the explicit owner_hint live_builder_or_orchestrator_seat.
- Adds claimability fields to queue-source receipts so skipped todos expose scope_pack_seen, lane, owner_hint, claim_allowed, and skip_reason.
- Adds focused coverage for todo e9e308cd shape.

Scope
- Owned files: scripts/pinballwake-autonomous-runner.mjs, scripts/pinballwake-autonomous-runner.test.mjs
- Linked todo: e9e308cd, Orchestrator continuity wiring claimability

Non-overlap
- Does not broaden all orchestrator-lane jobs.
- Does not change execute authority, merge authority, protected-surface gates, QueuePush, WakePass, NudgeOnly, IgniteOnly, or PushOnly.
- Does not implement the Orchestrator source-kind chip itself, only makes the ready ScopePack claimable.

Verification
- node --test scripts\pinballwake-autonomous-runner.test.mjs, 32/32 passing
- git diff --check

Risk
- Low. The bypass only applies when role tokens include orchestrator and the owner hint includes both builder and orchestrator.
- Plain orchestrator-lane work without that explicit hint remains blocked by boardroom_todo_role_not_allowed.

Follow-up
- After merge, the next Runner cycle should report e9e308cd as claimable or claimed instead of no_claimable_jobs.