### PR TITLE
test(runner): claim-eligibility regression for orchestrator-lane ScopePack (e9e308cd shape)

### DIFF
--- a/scripts/pinballwake-runner-claim-regression.test.mjs
+++ b/scripts/pinballwake-runner-claim-regression.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  createCodingRoomJobFromBoardroomTodo,
+  evaluateBoardroomTodoAutoClaimEligibility,
+  inspectAutonomousRunnerJobSafety,
+} from "./pinballwake-autonomous-runner.mjs";
+
+// Regression for the live e9e308cd shape that GROUP BROADCAST cycle 4
+// flagged as "Runner sees work but does not think it is allowed to claim it."
+//
+// The ScopePack only carries lane + owner_hint (no worker/role tokens),
+// and the todo has no top-level lane field. The current eligibility logic
+// bypasses role gating when no role tokens are found, so this shape MUST
+// be claimable today. If a future change reintroduces a role gate that
+// also blocks empty-role todos (or tightens protected-surface detection
+// to read description bodies), this test fails and surfaces the regression.
+
+describe("PinballWake autonomous Runner — orchestrator-lane claim regression", () => {
+  const e9e308cdShape = {
+    id: "e9e308cd-7711-4f30-8ebd-d5402fefd205",
+    title:
+      "Orchestrator continuity wiring: plug missing source-kinds into Orchestrator + add per-channel visibility toggles",
+    status: "open",
+    priority: "urgent",
+    assigned_to_agent_id: null,
+    actionability_reason: "unassigned_open",
+    scope_pack: {
+      todo_id: "e9e308cd-7711-4f30-8ebd-d5402fefd205",
+      lane: "orchestrator",
+      owner_hint: "live_builder_or_orchestrator_seat",
+      status: "ready_for_focused_pr",
+      build_goal:
+        "Plug missing Orchestrator source-kind ingestion gaps and add per-channel visibility toggles.",
+      owned_surfaces: [
+        "Orchestrator pointer-index hooks for missing source kinds",
+        "source_kind normalization",
+      ],
+      smallest_safe_step:
+        "Find the existing Orchestrator continuity hook pattern used by conversation_turn.",
+      constraints: [
+        "Pointer-only design: do not copy raw Boardroom, todo, comment, signal, session, or library rows into Orchestrator.",
+      ],
+      acceptance: [
+        "At least one previously missing source kind is indexed into Orchestrator as a pointer event.",
+      ],
+      verification: ["Run focused Orchestrator/channel tests touched by the PR."],
+      non_overlap: ["No Passport rename work."],
+    },
+  };
+
+  it("evaluateBoardroomTodoAutoClaimEligibility returns ok for e9e308cd shape", () => {
+    const eligibility = evaluateBoardroomTodoAutoClaimEligibility(e9e308cdShape);
+    assert.equal(
+      eligibility.ok,
+      true,
+      `expected eligibility.ok=true, got ${JSON.stringify(eligibility)}`,
+    );
+    assert.equal(eligibility.reason, "boardroom_todo_claim_eligible");
+  });
+
+  it("inspectAutonomousRunnerJobSafety returns ok for the constructed job", () => {
+    // createCodingRoomJobFromBoardroomTodo deliberately does NOT include the
+    // todo.description body in chip/context/files, so the auth/secrets/session
+    // keywords that appear in the description ("No secrets, auth, billing,
+    // DNS, migrations of source tables.") do not leak into the safety search.
+    const job = createCodingRoomJobFromBoardroomTodo(e9e308cdShape);
+    const safety = inspectAutonomousRunnerJobSafety(job);
+    assert.equal(
+      safety.ok,
+      true,
+      `expected safety.ok=true, got ${JSON.stringify(safety)}`,
+    );
+    assert.equal(safety.reason, "safe_for_autonomous_runner");
+  });
+});


### PR DESCRIPTION
Per GROUP BROADCAST cycle 4, builder lane question:

> Why does list_actionable_todos rank e9e308cd #1, but Runner may still return no_claimable_jobs?

## What this PR proves

Builds a standalone fixture matching the live shape of todo e9e308cd:
- urgent, status=open, assigned_to_agent_id=null
- actionability_reason="unassigned_open"
- scope_pack with `lane: "orchestrator"`, `owner_hint: "live_builder_or_orchestrator_seat"`
- no `worker` / `worker_role` / `role` tokens on either todo or scope_pack

Then asserts:
1. `evaluateBoardroomTodoAutoClaimEligibility(e9e308cdShape)` → `ok=true`, `reason="boardroom_todo_claim_eligible"`
2. `inspectAutonomousRunnerJobSafety(createCodingRoomJobFromBoardroomTodo(e9e308cdShape))` → `ok=true`, `reason="safe_for_autonomous_runner"`

**Verified locally: 2/2 pass on current main.**

## What this tells the team

Claim eligibility is GREEN for the e9e308cd shape in the current runner code. So if the Runner still skips this todo, the bottleneck is downstream of these two gates. Likely candidates:

- Hydration timing: list_actionable_todos call from the workflow might predate my unassign and still see `actionability_reason="role_assigned_open"` rather than `"unassigned_open"`.
- Ledger refresh: previous workflow run cached the todo in `boardroom-todo:e9e308cd-...` ledger with stale state.
- Claim sync: `validateBoardroomClaimSourceState` checks `lease_token` against `job.claim_id` — if a previous claim attempt left a stale lease that hasn't expired, the next attempt is rejected with `boardroom_todo_lease_token_mismatch`.
- Workflow scheduling: cron lag.

This PR doesn't fix any of those — it removes "eligibility logic" from the suspect list so the next investigation can narrow.

## Why a standalone test file

`scripts/pinballwake-autonomous-runner.test.mjs` is 50KB and already exhaustive. A standalone `scripts/pinballwake-runner-claim-regression.test.mjs` keeps this regression discoverable and grep-able by its own filename. Node's `--test` runner picks it up automatically.

## Non-overlap

- Does not modify `scripts/pinballwake-autonomous-runner.mjs` (the runner itself).
- Does not modify `scripts/pinballwake-autonomous-runner.test.mjs` (the existing test file).
- Does not touch workflows, env vars, or production state.

## Test plan

```
node --test scripts/pinballwake-runner-claim-regression.test.mjs
```

Expected: 2 pass, 0 fail.