### PR TITLE
fix(pinballwake): add runner schedule mirror

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -6,6 +6,7 @@ on:
   workflow_run:
     workflows:
       - Fleet Throughput Watch
+      - TestPass Scheduled Smoke
     types: [completed]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Summary:
- Adds TestPass Scheduled Smoke as a second workflow_run trigger for PinballWake Autonomous Runner.
- This gives Runner another scheduled proof path when Fleet Throughput Watch cron stalls.

Scope:
- .github/workflows/autonomous-runner.yml only.

Non-overlap:
- Does not change Runner code, claim logic, job ownership, merge authority, or execution authority.

Verification:
- git diff --check passed.
- Confirmed TestPass Scheduled Smoke is firing on fresh main e12ef89, while Runner/Fleet scheduled proof is stale.

Risk:
- Low. This may increase Runner wake frequency because TestPass Scheduled Smoke runs every 5 minutes. Runner remains claim-only with execute disabled and protected surfaces disabled.

Follow-up:
- Watch the next TestPass scheduled run on main. It should trigger PinballWake Autonomous Runner through workflow_run and produce scheduled fresh-main proof.