### PR TITLE
fix(queuepush): add runner freshness watchdog

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -227,6 +227,14 @@ function latestRun(runs = []) {
   return [...runs].sort((a, b) => (parseTime(runCreatedAt(b)) || 0) - (parseTime(runCreatedAt(a)) || 0))[0] || null;
 }
 
+function isAutomaticRunnerRun(run) {
+  return run?.event === "schedule" || run?.event === "workflow_run";
+}
+
+function isSuccessfulRun(run) {
+  return run?.conclusion === "success" && run?.status === "completed";
+}
+
 function formatRun(run) {
   if (!run) return "none";
   const id = runDatabaseId(run) || "unknown";
@@ -271,24 +279,24 @@ export function evaluateRunnerFreshnessWatchdog(input = {}) {
   const graceMinutes = parseBoundedInt(input.graceMinutes, runnerFreshnessGraceMinutes, 5, 180);
   const graceMs = graceMinutes * 60 * 1000;
   const runs = Array.isArray(input.runs) ? input.runs : [];
-  const scheduledRuns = runs.filter((run) => run?.event === "schedule");
+  const automaticRuns = runs.filter(isAutomaticRunnerRun);
   const manualRuns = runs.filter((run) => run?.event === "workflow_dispatch");
-  const latestScheduledRun = latestRun(scheduledRuns);
+  const latestAutomaticRun = latestRun(automaticRuns);
   const latestManualRun = latestRun(manualRuns);
-  const freshScheduledRun = scheduledRuns.find((run) => runHeadSha(run) === mainSha);
+  const freshSuccessfulAutomaticRun = automaticRuns.find((run) => runHeadSha(run) === mainSha && isSuccessfulRun(run));
 
-  if (!mainSha || !mainTime || freshScheduledRun || now - mainTime < graceMs) {
+  if (!mainSha || !mainTime || freshSuccessfulAutomaticRun || now - mainTime < graceMs) {
     return null;
   }
 
-  const packetId = runnerFreshnessPacketId(mainSha, latestScheduledRun);
+  const packetId = runnerFreshnessPacketId(mainSha, latestAutomaticRun);
   const source = `${serverUrl}/${repository}/actions/workflows/${runnerWorkflowPath}`;
   const context = compactText(
     [
       `main_sha=${shortSha(mainSha)}`,
       `main_committed_at=${mainCommittedAt}`,
       `grace_minutes=${graceMinutes}`,
-      `latest_scheduled=${formatRun(latestScheduledRun)}`,
+      `latest_automatic=${formatRun(latestAutomaticRun)}`,
       `latest_manual=${formatRun(latestManualRun)}`,
     ].join("; "),
     420,
@@ -320,7 +328,7 @@ export function evaluateRunnerFreshnessWatchdog(input = {}) {
     text,
     sourceUrl: source,
     mainSha,
-    latestScheduledRun: compactRunSummary(latestScheduledRun),
+    latestAutomaticRun: compactRunSummary(latestAutomaticRun),
     latestManualRun: compactRunSummary(latestManualRun),
   };
 }

--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -12,6 +12,18 @@ const dryRun = parseBooleanFlag(process.env.QUEUEPUSH_DRY_RUN) || process.argv.i
 const maxPackets = parseBoundedInt(process.env.QUEUEPUSH_MAX_PACKETS, 10, 1, 12);
 const recentFishbowlLimit = parseBoundedInt(process.env.QUEUEPUSH_FISHBOWL_LIMIT, 100, 20, 100);
 const packetRetryMinutes = parseBoundedInt(process.env.QUEUEPUSH_PACKET_RETRY_MINUTES, 180, 15, 1440);
+const defaultBranch = process.env.QUEUEPUSH_DEFAULT_BRANCH || "main";
+const runnerWorkflowPath = process.env.QUEUEPUSH_RUNNER_WORKFLOW_PATH || "autonomous-runner.yml";
+const runnerFreshnessWatchdogDisabled = parseBooleanFlag(
+  process.env.QUEUEPUSH_RUNNER_FRESHNESS_WATCHDOG_DISABLED,
+);
+const runnerFreshnessGraceMinutes = parseBoundedInt(
+  process.env.QUEUEPUSH_RUNNER_FRESHNESS_GRACE_MINUTES,
+  30,
+  5,
+  180,
+);
+const runnerFreshnessRunLimit = parseBoundedInt(process.env.QUEUEPUSH_RUNNER_RUN_LIMIT, 20, 5, 100);
 const agentId = "github-action-queuepush";
 const agentEmoji = "📬";
 const agentDisplayName = "QueuePush";
@@ -192,6 +204,125 @@ function sourceUrl(pr) {
 
 function shortSha(sha) {
   return String(sha || "").slice(0, 7);
+}
+
+function parseTime(value) {
+  const time = Date.parse(String(value || ""));
+  return Number.isFinite(time) ? time : null;
+}
+
+function runHeadSha(run) {
+  return String(run?.head_sha || run?.headSha || "").trim();
+}
+
+function runCreatedAt(run) {
+  return run?.created_at || run?.createdAt || "";
+}
+
+function runDatabaseId(run) {
+  return run?.id || run?.databaseId || run?.database_id || "";
+}
+
+function latestRun(runs = []) {
+  return [...runs].sort((a, b) => (parseTime(runCreatedAt(b)) || 0) - (parseTime(runCreatedAt(a)) || 0))[0] || null;
+}
+
+function formatRun(run) {
+  if (!run) return "none";
+  const id = runDatabaseId(run) || "unknown";
+  const sha = shortSha(runHeadSha(run)) || "unknown";
+  const event = run.event || "unknown";
+  const created = runCreatedAt(run) || "unknown";
+  const conclusion = run.conclusion || run.status || "unknown";
+  return `${id} ${event} ${sha} ${conclusion} ${created}`;
+}
+
+function compactRunSummary(run) {
+  if (!run) return null;
+  return {
+    id: runDatabaseId(run) || null,
+    event: run.event || null,
+    head_sha: runHeadSha(run) || null,
+    conclusion: run.conclusion || null,
+    status: run.status || null,
+    created_at: runCreatedAt(run) || null,
+    url: run.html_url || run.url || null,
+  };
+}
+
+function runnerFreshnessPacketId(mainSha, latestScheduledRun) {
+  const digest = createHash("sha256")
+    .update(`${repository}|runner-freshness|${mainSha}|${runDatabaseId(latestScheduledRun) || "none"}`)
+    .digest("hex")
+    .slice(0, 10);
+  return `queuepush:v1:runner-freshness:${shortSha(mainSha)}:${digest}`;
+}
+
+export function evaluateRunnerFreshnessWatchdog(input = {}) {
+  const mainSha = String(input.mainSha || input.mainRef?.sha || input.mainRef?.commit?.sha || "").trim();
+  const mainCommittedAt =
+    input.mainCommittedAt ||
+    input.mainRef?.committedAt ||
+    input.mainRef?.commit?.commit?.committer?.date ||
+    input.mainRef?.commit?.commit?.author?.date ||
+    "";
+  const mainTime = parseTime(mainCommittedAt);
+  const now = typeof input.now === "number" ? input.now : parseTime(input.now) ?? Date.now();
+  const graceMinutes = parseBoundedInt(input.graceMinutes, runnerFreshnessGraceMinutes, 5, 180);
+  const graceMs = graceMinutes * 60 * 1000;
+  const runs = Array.isArray(input.runs) ? input.runs : [];
+  const scheduledRuns = runs.filter((run) => run?.event === "schedule");
+  const manualRuns = runs.filter((run) => run?.event === "workflow_dispatch");
+  const latestScheduledRun = latestRun(scheduledRuns);
+  const latestManualRun = latestRun(manualRuns);
+  const freshScheduledRun = scheduledRuns.find((run) => runHeadSha(run) === mainSha);
+
+  if (!mainSha || !mainTime || freshScheduledRun || now - mainTime < graceMs) {
+    return null;
+  }
+
+  const packetId = runnerFreshnessPacketId(mainSha, latestScheduledRun);
+  const source = `${serverUrl}/${repository}/actions/workflows/${runnerWorkflowPath}`;
+  const context = compactText(
+    [
+      `main_sha=${shortSha(mainSha)}`,
+      `main_committed_at=${mainCommittedAt}`,
+      `grace_minutes=${graceMinutes}`,
+      `latest_scheduled=${formatRun(latestScheduledRun)}`,
+      `latest_manual=${formatRun(latestManualRun)}`,
+    ].join("; "),
+    420,
+  );
+  const text = [
+    `QueuePush ID: ${packetId}`,
+    "RUNNER FRESHNESS WATCHDOG",
+    "worker: 🧭",
+    "job kind: status_relay",
+    "requires code: no",
+    "chip: scheduled Runner proof gap",
+    `context: ${context}`,
+    "do: verify GitHub schedule delivery or add a read-only Runner freshness canary.",
+    "expected proof: event=schedule Runner run on current main SHA, with run id and claimability result.",
+    "deadline: next Fleet pulse",
+    "fallback: do not mark automation healthy from workflow_dispatch only.",
+    "ack: pass/blocker",
+    `source: ${source}`,
+  ].join("\n");
+
+  return {
+    packetId,
+    worker: "🧭",
+    jobKind: "status_relay",
+    requiresCode: false,
+    recipient: agentMap["🧭"] || "🧭",
+    state: "runner_scheduled_proof_overdue",
+    pr: "runner",
+    text,
+    sourceUrl: source,
+    mainSha,
+    latestScheduledRun: compactRunSummary(latestScheduledRun),
+    latestManualRun: compactRunSummary(latestManualRun),
+  };
 }
 
 export function queuepushPacketId(pr, state) {
@@ -624,6 +755,39 @@ async function fetchOpenPrInputs() {
   return inputs;
 }
 
+async function fetchDefaultBranchRef() {
+  const branch = await githubJson(`/repos/${repository}/branches/${encodeURIComponent(defaultBranch)}`);
+  return {
+    sha: branch?.commit?.sha || "",
+    committedAt: branch?.commit?.commit?.committer?.date || branch?.commit?.commit?.author?.date || "",
+  };
+}
+
+async function fetchRunnerWorkflowRuns() {
+  const workflow = encodeURIComponent(runnerWorkflowPath);
+  const branch = encodeURIComponent(defaultBranch);
+  const result = await githubJson(
+    `/repos/${repository}/actions/workflows/${workflow}/runs?branch=${branch}&per_page=${runnerFreshnessRunLimit}`,
+  );
+  return result?.workflow_runs || [];
+}
+
+async function buildRunnerFreshnessPackets() {
+  if (runnerFreshnessWatchdogDisabled) return [];
+  try {
+    const [mainRef, runs] = await Promise.all([fetchDefaultBranchRef(), fetchRunnerWorkflowRuns()]);
+    const packet = evaluateRunnerFreshnessWatchdog({
+      mainRef,
+      runs,
+      graceMinutes: runnerFreshnessGraceMinutes,
+    });
+    return packet ? [packet] : [];
+  } catch (error) {
+    console.log(`Runner freshness watchdog skipped: ${error instanceof Error ? error.message : String(error)}`);
+    return [];
+  }
+}
+
 async function postMemoryAdmin(action, body) {
   if (!unclickApiKey) {
     throw new Error("FISHBOWL_WAKE_TOKEN or FISHBOWL_AUTOCLOSE_TOKEN is required.");
@@ -699,6 +863,7 @@ export async function buildPacketsFromInputs(inputs) {
 
 function prioritizePackets(packets) {
   const priority = {
+    runner_scheduled_proof_overdue: 0,
     dirty_branch: 0,
     hold_overlap: 1,
     failed_targeted_proof: 2,
@@ -716,8 +881,9 @@ function prioritizePackets(packets) {
 }
 
 export async function main() {
-  const inputs = await fetchOpenPrInputs();
-  const rawPackets = await buildPacketsFromInputs(inputs);
+  const [inputs, runnerFreshnessPackets] = await Promise.all([fetchOpenPrInputs(), buildRunnerFreshnessPackets()]);
+  const prPackets = await buildPacketsFromInputs(inputs);
+  const rawPackets = prioritizePackets([...runnerFreshnessPackets, ...prPackets]);
   const boundedPackets = rawPackets.slice(0, maxPackets);
 
   if (dryRun) {

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -786,6 +786,44 @@ describe("Runner freshness watchdog", () => {
     assert.equal(packet, null);
   });
 
+  it("stays quiet when a scheduled-chain workflow_run proof exists on current main", () => {
+    const packet = evaluateRunnerFreshnessWatchdog({
+      mainRef: currentMainRef,
+      runs: [
+        runnerRun(),
+        runnerRun({
+          id: 25709000000,
+          event: "workflow_run",
+          head_sha: currentMainRef.sha,
+          created_at: "2026-05-12T02:33:00Z",
+        }),
+      ],
+      now: Date.parse("2026-05-12T02:44:00Z"),
+      graceMinutes: 30,
+    });
+
+    assert.equal(packet, null);
+  });
+
+  it("does not treat a failed automatic Runner run as fresh proof", () => {
+    const packet = evaluateRunnerFreshnessWatchdog({
+      mainRef: currentMainRef,
+      runs: [
+        runnerRun({
+          id: 25709000001,
+          head_sha: currentMainRef.sha,
+          conclusion: "failure",
+          created_at: "2026-05-12T02:33:00Z",
+        }),
+      ],
+      now: Date.parse("2026-05-12T02:44:00Z"),
+      graceMinutes: 30,
+    });
+
+    assert.equal(packet?.state, "runner_scheduled_proof_overdue");
+    assert.match(packet?.text || "", /latest_automatic=25709000001 schedule e12ef89 failure/);
+  });
+
   it("stays quiet while current main is still inside the grace window", () => {
     const packet = evaluateRunnerFreshnessWatchdog({
       mainRef: currentMainRef,
@@ -819,7 +857,7 @@ describe("Runner freshness watchdog", () => {
     assert.match(packet?.packetId || "", /^queuepush:v1:runner-freshness:e12ef89:[a-f0-9]{10}$/);
     assert.match(packet?.text || "", /RUNNER FRESHNESS WATCHDOG/);
     assert.match(packet?.text || "", /main_sha=e12ef89/);
-    assert.match(packet?.text || "", /latest_scheduled=25705095770 schedule eec0aa2 success/);
+    assert.match(packet?.text || "", /latest_automatic=25705095770 schedule eec0aa2 success/);
     assert.match(packet?.text || "", /latest_manual=25707410505 workflow_dispatch e12ef89 success/);
     assert.match(packet?.text || "", /do not mark automation healthy from workflow_dispatch only/);
   });

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -6,6 +6,7 @@ import {
   buildPacketsFromInputs,
   checksAreGreen,
   chooseQueuePushRunner,
+  evaluateRunnerFreshnessWatchdog,
   classifyPullRequest,
   filterDuplicatePackets,
   jobKindForState,
@@ -35,6 +36,23 @@ const greenChecks = [
 ];
 
 const greenStatus = [{ state: "success" }];
+
+function runnerRun(overrides = {}) {
+  return {
+    id: 25705095770,
+    event: "schedule",
+    head_sha: "eec0aa24c5dd024cca858746a24f4444be405493",
+    conclusion: "success",
+    status: "completed",
+    created_at: "2026-05-12T00:14:56Z",
+    ...overrides,
+  };
+}
+
+const currentMainRef = {
+  sha: "e12ef89c1560e0ddc842e225ce646c929844b2e5",
+  committedAt: "2026-05-12T01:07:03Z",
+};
 
 describe("QueuePush PR classifier", () => {
   it("keeps green clean draft PRs with only Safety PASS as owner-lift packets", () => {
@@ -747,5 +765,62 @@ describe("QueuePush signal helpers", () => {
 
     assert.equal(signals.hasDirtyBranch, true);
     assert.equal(signals.hasOverlap, true);
+  });
+});
+
+describe("Runner freshness watchdog", () => {
+  it("stays quiet when a scheduled Runner proof exists on current main", () => {
+    const packet = evaluateRunnerFreshnessWatchdog({
+      mainRef: currentMainRef,
+      runs: [
+        runnerRun({
+          id: 25708000000,
+          head_sha: currentMainRef.sha,
+          created_at: "2026-05-12T01:33:00Z",
+        }),
+      ],
+      now: Date.parse("2026-05-12T02:14:00Z"),
+      graceMinutes: 30,
+    });
+
+    assert.equal(packet, null);
+  });
+
+  it("stays quiet while current main is still inside the grace window", () => {
+    const packet = evaluateRunnerFreshnessWatchdog({
+      mainRef: currentMainRef,
+      runs: [runnerRun()],
+      now: Date.parse("2026-05-12T01:20:00Z"),
+      graceMinutes: 30,
+    });
+
+    assert.equal(packet, null);
+  });
+
+  it("emits one compact status packet when current main has only manual Runner proof", () => {
+    const packet = evaluateRunnerFreshnessWatchdog({
+      mainRef: currentMainRef,
+      runs: [
+        runnerRun(),
+        runnerRun({
+          id: 25707410505,
+          event: "workflow_dispatch",
+          head_sha: currentMainRef.sha,
+          created_at: "2026-05-12T01:22:37Z",
+        }),
+      ],
+      now: Date.parse("2026-05-12T02:14:00Z"),
+      graceMinutes: 30,
+    });
+
+    assert.equal(packet?.state, "runner_scheduled_proof_overdue");
+    assert.equal(packet?.recipient, "🧭");
+    assert.equal(packet?.requiresCode, false);
+    assert.match(packet?.packetId || "", /^queuepush:v1:runner-freshness:e12ef89:[a-f0-9]{10}$/);
+    assert.match(packet?.text || "", /RUNNER FRESHNESS WATCHDOG/);
+    assert.match(packet?.text || "", /main_sha=e12ef89/);
+    assert.match(packet?.text || "", /latest_scheduled=25705095770 schedule eec0aa2 success/);
+    assert.match(packet?.text || "", /latest_manual=25707410505 workflow_dispatch e12ef89 success/);
+    assert.match(packet?.text || "", /do not mark automation healthy from workflow_dispatch only/);
   });
 });


### PR DESCRIPTION
## Summary
Adds a read-only Runner freshness watchdog to Fleet Throughput Watch. It compares current `main` with recent PinballWake Autonomous Runner workflow runs and emits one compact QueuePush status packet when current main has aged past the grace window without an `event=schedule` Runner proof.

## Scope
- `scripts/fleet-throughput-watch.mjs`
- `scripts/fleet-throughput-watch.test.mjs`
- Lane: QueuePush / scheduled-autopilot proof visibility

## Non-overlap
- Does not change Runner claim, build, merge, approve, close, mark-done, or job mutation authority.
- Does not create duplicate jobs.
- Does not count `workflow_dispatch` as scheduled proof.

## Verification
- `node --test scripts\fleet-throughput-watch.test.mjs`
- `git diff --check`
- Dry-run proved one packet for the live gap: `queuepush:v1:runner-freshness:e12ef89:9990a89d19`

## Risk
Low. The change is read-only against GitHub state and only posts a Boardroom status packet through existing QueuePush posting when scheduled proof is overdue.

## Follow-up
Reviewer/Safety should confirm the packet stays status-only and that current scheduled Runner proof remains missing until an `event=schedule` run appears on `e12ef89` or newer.