### PR TITLE
fix(pinballwake): add runner claimability scorecard

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -812,6 +812,52 @@ export function selectBoardroomTodoForScoping({ queueSourceResult = {}, lastResu
   )) || null;
 }
 
+function buildClaimabilityScorecard({
+  seen = 0,
+  claimable = 0,
+  imported = 0,
+  skipped = [],
+} = {}) {
+  const skipReasons = {};
+  for (const skip of skipped || []) {
+    const reason = String(skip?.reason || skip?.skip_reason || "unknown").trim() || "unknown";
+    skipReasons[reason] = (skipReasons[reason] || 0) + 1;
+  }
+
+  const skippedCount = Array.isArray(skipped) ? skipped.length : 0;
+  const state = seen <= 0
+    ? "empty"
+    : claimable > 0
+      ? "claimable"
+      : "blocked_no_claimable";
+
+  return {
+    seen,
+    claimable,
+    imported,
+    skipped: skippedCount,
+    skip_reasons: skipReasons,
+    state,
+    healthy: state !== "blocked_no_claimable",
+  };
+}
+
+function buildRunClaimabilityScorecard({ queueSourceResult = {}, results = [], lastResult = {} } = {}) {
+  const base = queueSourceResult.claimability_scorecard || buildClaimabilityScorecard({
+    seen: queueSourceResult.seen || 0,
+    claimable: queueSourceResult.imported || 0,
+    imported: queueSourceResult.imported || 0,
+    skipped: queueSourceResult.skipped || [],
+  });
+
+  return {
+    ...base,
+    claimed: results.filter((result) => result?.action === "claimed").length,
+    last_action: lastResult.action || null,
+    last_reason: lastResult.reason || null,
+  };
+}
+
 export async function syncBoardroomTodoScopingRequestToUnClick({
   todo,
   runner = DEFAULT_AUTONOMOUS_RUNNER,
@@ -1027,6 +1073,11 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
       ledger: createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now }),
       imported: 0,
       seen: 0,
+      claimability_scorecard: {
+        ...buildClaimabilityScorecard(),
+        state: "queue_unavailable",
+        healthy: false,
+      },
     };
   }
 
@@ -1037,6 +1088,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
 
   let next = createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now });
   let imported = 0;
+  let claimable = 0;
   const skipped = [];
   for (const todo of ordered) {
     const scopePack = extractBoardroomTodoScopePack(todo);
@@ -1067,6 +1119,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
       continue;
     }
 
+    claimable += 1;
     const upserted = upsertCodingRoomJob({
       ledger: next,
       job: createCodingRoomJobFromBoardroomTodo(
@@ -1091,6 +1144,12 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
     imported,
     seen: ordered.length,
     skipped,
+    claimability_scorecard: buildClaimabilityScorecard({
+      seen: ordered.length,
+      claimable,
+      imported,
+      skipped,
+    }),
     todos: ordered.map((todo) => {
       const scopePack = extractBoardroomTodoScopePack(todo);
       return {
@@ -1387,6 +1446,7 @@ export async function runAutonomousRunnerFile({
         ledger,
         ledger_path: ledgerPath,
         queue_source: queueSourceResult,
+        claimability_scorecard: queueSourceResult.claimability_scorecard,
       };
     }
   }
@@ -1413,6 +1473,11 @@ export async function runAutonomousRunnerFile({
   const executeBlocked = safeMode === "execute" && !safePolicy.allowExecute;
   const shouldPersist = safeMode !== "dry-run" && !safePolicy.disabled && !executeBlocked;
   const last = results[results.length - 1] || { ok: true, action: "idle", reason: "no_cycle_run", ledger };
+  const claimabilityScorecard = buildRunClaimabilityScorecard({
+    queueSourceResult,
+    results,
+    lastResult: last,
+  });
   let todoClaimSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
   let todoScopingSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
 
@@ -1443,6 +1508,7 @@ export async function runAutonomousRunnerFile({
         ledger,
         ledger_path: ledgerPath,
         queue_source: queueSourceResult,
+        claimability_scorecard: claimabilityScorecard,
         todo_claim_sync: todoClaimSync,
       };
     }
@@ -1471,6 +1537,7 @@ export async function runAutonomousRunnerFile({
         ledger,
         ledger_path: ledgerPath,
         queue_source: queueSourceResult,
+        claimability_scorecard: claimabilityScorecard,
         todo_claim_sync: todoClaimSync,
         todo_scoping_sync: todoScopingSync,
       };
@@ -1493,6 +1560,7 @@ export async function runAutonomousRunnerFile({
     ledger,
     ledger_path: ledgerPath,
     queue_source: queueSourceResult,
+    claimability_scorecard: claimabilityScorecard,
     todo_claim_sync: todoClaimSync,
     todo_scoping_sync: todoScopingSync,
   };

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -326,6 +326,22 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.action, "claimed");
       assert.equal(result.queue_source.seen, 5);
       assert.equal(result.queue_source.imported, 1);
+      assert.deepEqual(result.queue_source.claimability_scorecard, {
+        seen: 5,
+        claimable: 1,
+        imported: 1,
+        skipped: 4,
+        skip_reasons: {
+          boardroom_todo_already_assigned: 1,
+          boardroom_todo_hold_or_blocker_marker: 1,
+          boardroom_todo_priority_not_allowed: 1,
+          protected_surface_auth: 1,
+        },
+        state: "claimable",
+        healthy: true,
+      });
+      assert.equal(result.claimability_scorecard.claimed, 1);
+      assert.equal(result.claimability_scorecard.last_action, "claimed");
       assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-safe");
       assert.deepEqual(
         result.queue_source.skipped.map((skip) => skip.reason).sort(),
@@ -1059,6 +1075,20 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.ok, true);
       assert.equal(result.action, "idle");
       assert.equal(result.reason, "no_claimable_jobs");
+      assert.deepEqual(result.queue_source.claimability_scorecard, {
+        seen: 1,
+        claimable: 0,
+        imported: 0,
+        skipped: 1,
+        skip_reasons: {
+          boardroom_todo_not_open: 1,
+        },
+        state: "blocked_no_claimable",
+        healthy: false,
+      });
+      assert.equal(result.claimability_scorecard.claimed, 0);
+      assert.equal(result.claimability_scorecard.last_action, "idle");
+      assert.equal(result.claimability_scorecard.last_reason, "no_claimable_jobs");
       assert.equal(result.queue_source.skipped[0].id, "todo-stale-scoped-1");
       assert.equal(result.queue_source.skipped[0].reason, "boardroom_todo_not_open");
       assert.deepEqual(calls.map((call) => call.body.params.name), ["list_actionable_todos"]);


### PR DESCRIPTION
## Summary
Adds an explicit Runner claimability scorecard so autopilot can distinguish "Runner woke" from "Runner can actually claim work".

The scorecard reports seen, claimable, imported, skipped, skip reasons, claimed count, last action, and last reason. Visible jobs with zero claimable work now report `blocked_no_claimable` rather than looking healthy.

## Scope
- `scripts/pinballwake-autonomous-runner.mjs`
- `scripts/pinballwake-autonomous-runner.test.mjs`
- Linked coordination: #715

## Non-overlap
Does not change claim authority, execute mode, merge/approve/close powers, worker routing, or QueuePush behavior.

## Verification
- `node --test scripts\pinballwake-autonomous-runner.test.mjs` passed, 33/33
- `git diff --check` passed

## Risk
Low. Observability-only output change for Runner JSON. No secrets, auth, cron, or production mutation change.

## Follow-up
Use this scorecard in the next scheduled Runner proof on fresh main to diagnose whether visible backlog is claimable, blocked, or correctly empty.