### PR TITLE
feat(orchestrator): add story view

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -15,8 +15,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | de6d70d0d55a | 3662 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | 5a1598baa2a8 | 12717 |
-| src/pages/admin/AdminShell.tsx | 9cb148b69bc1 | 17456 |
+| src/App.tsx | 9860164eafa6 | 12908 |
+| src/pages/admin/AdminShell.tsx | 09f113d1ff4c | 19020 |
 | .github/workflows/ci.yml | 79e43dd8e26c | 1608 |
 | .github/workflows/brainmap-auto-update.yml | 7e8b08eb16aa | 1137 |
 | package.json | 9b0180a6b2f9 | 4175 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,8 @@ const App = () => (
             <Route path="crews/settings"      element={<CrewsSettings />} />
             {/* End-user visible read-only continuity surface */}
             <Route path="orchestrator"   element={<AdminOrchestratorPage />} />
+            <Route path="orchestrator/story" element={<Navigate to="/admin/orchestrator" replace />} />
+            <Route path="orchestrator/timeline" element={<AdminOrchestratorPage />} />
             {/* Admin-only surfaces (wrapped in RequireAdmin; also hidden from non-admin sidebar) */}
             <Route path="analytics"      element={<RequireAdmin><AdminAnalytics /></RequireAdmin>} />
             <Route path="codebase"       element={<RequireAdmin><AdminCodebase /></RequireAdmin>} />

--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -11,6 +11,14 @@ vi.mock("@/lib/auth", () => ({
   }),
 }));
 
+function renderOrchestrator(route = "/admin/orchestrator") {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AdminOrchestratorPage />
+    </MemoryRouter>,
+  );
+}
+
 describe("AdminOrchestratorPage", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -190,12 +198,21 @@ describe("AdminOrchestratorPage", () => {
     );
   });
 
-  it("shows read-only continuity instead of a new assistant input", async () => {
-    render(
-      <MemoryRouter>
-        <AdminOrchestratorPage />
-      </MemoryRouter>,
-    );
+  it("shows Story as the friendly default Orchestrator view", async () => {
+    renderOrchestrator();
+
+    expect(await screen.findByRole("heading", { name: "Story" })).toBeInTheDocument();
+    expect(screen.getByText("Timeline")).toBeInTheDocument();
+    expect(screen.getByLabelText("Native notes")).not.toBeChecked();
+    expect(screen.getByText(/Good news/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Orchestrator continuity proof landed/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Latest first/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Message the AI assistant...")).not.toBeInTheDocument();
+    expect(screen.queryByText("Using AI Assistant")).not.toBeInTheDocument();
+  });
+
+  it("shows read-only continuity on the Timeline subpage", async () => {
+    renderOrchestrator("/admin/orchestrator/timeline");
 
     expect(await screen.findByText("Continuity Feed")).toBeInTheDocument();
     expect(screen.getByLabelText("Easy reading for humans")).toBeChecked();
@@ -214,11 +231,7 @@ describe("AdminOrchestratorPage", () => {
   });
 
   it("filters the Orchestrator feed as the user types", async () => {
-    render(
-      <MemoryRouter>
-        <AdminOrchestratorPage />
-      </MemoryRouter>,
-    );
+    renderOrchestrator("/admin/orchestrator/timeline");
 
     const filter = await screen.findByPlaceholderText("Filter Orchestrator feed");
     fireEvent.change(filter, { target: { value: "proof" } });
@@ -229,11 +242,7 @@ describe("AdminOrchestratorPage", () => {
   });
 
   it("lets humans view more loaded Orchestrator history", async () => {
-    render(
-      <MemoryRouter>
-        <AdminOrchestratorPage />
-      </MemoryRouter>,
-    );
+    renderOrchestrator("/admin/orchestrator/timeline");
 
     expect(await screen.findByText("View more history")).toBeInTheDocument();
     expect(screen.queryByText(/Archive event 24/i)).not.toBeInTheDocument();
@@ -244,11 +253,7 @@ describe("AdminOrchestratorPage", () => {
   });
 
   it("asks the server for deeper Orchestrator keyword matches", async () => {
-    render(
-      <MemoryRouter>
-        <AdminOrchestratorPage />
-      </MemoryRouter>,
-    );
+    renderOrchestrator("/admin/orchestrator/timeline");
 
     const filter = await screen.findByPlaceholderText("Filter Orchestrator feed");
     fireEvent.change(filter, { target: { value: "dog20" } });
@@ -265,11 +270,7 @@ describe("AdminOrchestratorPage", () => {
   });
 
   it("uses explicit controls for long continuity rows", async () => {
-    render(
-      <MemoryRouter>
-        <AdminOrchestratorPage />
-      </MemoryRouter>,
-    );
+    renderOrchestrator("/admin/orchestrator/timeline");
 
     expect(await screen.findByText("Show more")).toBeInTheDocument();
     expect(screen.getByText("Open source")).toBeInTheDocument();

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -7,10 +7,11 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import {
   Sparkles,
   Terminal,
+  BookOpen,
   Plug,
   Hammer,
   Settings as SettingsIcon,
@@ -147,6 +148,10 @@ const NATURAL_CONTEXT_PREVIEW_CHARS = 360;
 const INITIAL_CONTEXT_LIMIT = 80;
 const MAX_CONTEXT_LIMIT = 200;
 const CONTINUITY_VISIBLE_STEP = 24;
+const STORY_VISIBLE_STEP = 8;
+const STORY_PREVIEW_CHARS = 880;
+const STORY_NATIVE_PREVIEW_CHARS = 560;
+const STORY_NATIVE_STORAGE_KEY = "unclick_orchestrator_story_native_v1";
 
 function formatRelative(iso: string | null | undefined): string {
   if (!iso) return "never";
@@ -424,7 +429,26 @@ function truncateText(value: string, maxChars: number): { text: string; truncate
   };
 }
 
+function storyTextForEvent(event: OrchestratorContinuityEvent, actor: ActorIdentity): string {
+  const easy = easyReadForEvent(event, actor);
+  if (/^PASS:/i.test(event.summary)) return `Good news. ${easy}`;
+  if (/^BLOCKER:/i.test(event.summary)) return easy;
+  if (event.kind === "proof") return `${easy} The receipt is kept close so another seat can trust it later.`;
+  if (event.kind === "decision" || event.tags?.includes("decision")) {
+    return `${easy} This becomes part of the shared story until Chris changes direction.`;
+  }
+  return easy;
+}
+
+function nativeNoteForEvent(event: OrchestratorContinuityEvent, actor: ActorIdentity): string {
+  const source = `${sourceLabel(event.source_kind)}${event.source_id ? ` ${event.source_id}` : ""}`;
+  const who = actor.label;
+  const summary = event.summary.trim();
+  return `${who} from ${source}: ${summary}`;
+}
+
 export default function AdminOrchestratorPage() {
+  const location = useLocation();
   const [storedApiKey] = useState<string>(() => {
     try {
       return localStorage.getItem("unclick_api_key") ?? "";
@@ -509,32 +533,73 @@ export default function AdminOrchestratorPage() {
     return null;
   }, [envEnabled, authToken, tenant]);
 
+  const timelineActive = location.pathname.endsWith("/timeline");
+  const storyActive = !timelineActive;
+
   return (
     <>
-      <div className="mb-6 flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#61C1C4]/10 text-[#61C1C4]">
-          <Sparkles className="h-5 w-5" />
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#61C1C4]/10 text-[#61C1C4]">
+            <Sparkles className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-white">Orchestrator</h1>
+            <p className="text-sm text-white/50">
+              {storyActive
+                ? "The running story of UnClick, told in friendly plain English."
+                : "The detailed timeline for seats, receipts, proof, and source links."}
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-white">Orchestrator</h1>
-          <p className="text-sm text-white/50">
-            Your AI command center. Chat, sync context, connect seats, and hand off work.
-          </p>
+        <div className="inline-flex w-full rounded-xl border border-white/[0.08] bg-black/20 p-1 md:w-auto">
+          <Link
+            to="/admin/orchestrator"
+            className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors md:flex-none ${
+              storyActive
+                ? "bg-[#61C1C4]/15 text-[#61C1C4]"
+                : "text-white/45 hover:bg-white/[0.04] hover:text-white/75"
+            }`}
+          >
+            <BookOpen className="h-4 w-4" />
+            Story
+          </Link>
+          <Link
+            to="/admin/orchestrator/timeline"
+            className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors md:flex-none ${
+              timelineActive
+                ? "bg-[#61C1C4]/15 text-[#61C1C4]"
+                : "text-white/45 hover:bg-white/[0.04] hover:text-white/75"
+            }`}
+          >
+            <Clock className="h-4 w-4" />
+            Timeline
+          </Link>
         </div>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,7fr)_minmax(0,3fr)]">
         {/* Main continuity pane */}
         <div className="flex min-h-[620px] flex-col">
-          <OrchestratorContinuityPanel
-            context={orchestratorContext}
-            loading={loading || sessionLoading}
-            chatStatusLabel={chatDisabledReason ? "Chat disabled" : tier === "channel" ? "Claude Code bridge available" : "AI chat available"}
-            authToken={authToken}
-            contextLimit={contextLimit}
-            maxContextLimit={MAX_CONTEXT_LIMIT}
-            onLoadDeeperHistory={() => setContextLimit((value) => Math.min(MAX_CONTEXT_LIMIT, value + INITIAL_CONTEXT_LIMIT))}
-          />
+          {storyActive ? (
+            <OrchestratorStoryPanel
+              context={orchestratorContext}
+              loading={loading || sessionLoading}
+              contextLimit={contextLimit}
+              maxContextLimit={MAX_CONTEXT_LIMIT}
+              onLoadDeeperHistory={() => setContextLimit((value) => Math.min(MAX_CONTEXT_LIMIT, value + INITIAL_CONTEXT_LIMIT))}
+            />
+          ) : (
+            <OrchestratorContinuityPanel
+              context={orchestratorContext}
+              loading={loading || sessionLoading}
+              chatStatusLabel={chatDisabledReason ? "Chat disabled" : tier === "channel" ? "Claude Code bridge available" : "AI chat available"}
+              authToken={authToken}
+              contextLimit={contextLimit}
+              maxContextLimit={MAX_CONTEXT_LIMIT}
+              onLoadDeeperHistory={() => setContextLimit((value) => Math.min(MAX_CONTEXT_LIMIT, value + INITIAL_CONTEXT_LIMIT))}
+            />
+          )}
         </div>
 
         {/* Right rail */}
@@ -555,6 +620,163 @@ export default function AdminOrchestratorPage() {
         </aside>
       </div>
     </>
+  );
+}
+
+function OrchestratorStoryPanel({
+  context,
+  loading,
+  contextLimit,
+  maxContextLimit,
+  onLoadDeeperHistory,
+}: {
+  context: OrchestratorContext | null;
+  loading: boolean;
+  contextLimit: number;
+  maxContextLimit: number;
+  onLoadDeeperHistory: () => void;
+}) {
+  const [visibleEventCount, setVisibleEventCount] = useState(STORY_VISIBLE_STEP);
+  const [nativeNotes, setNativeNotes] = useState(() => readStoredBoolean(STORY_NATIVE_STORAGE_KEY, false));
+  const [expandedEvents, setExpandedEvents] = useState<Set<string>>(() => new Set());
+  const profileByAgentId = useMemo(
+    () => buildProfileLookup(context?.profile_cards),
+    [context?.profile_cards],
+  );
+  const events = useMemo(
+    () =>
+      [...(context?.continuity_events ?? [])].sort((a, b) => {
+        const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
+        const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
+        return bTime - aTime;
+      }),
+    [context?.continuity_events],
+  );
+  const visibleEvents = events.slice(0, visibleEventCount);
+  const hasMoreLoaded = visibleEventCount < events.length;
+  const canLoadFromServer = contextLimit < maxContextLimit;
+
+  const toggleNativeNotes = (value: boolean) => {
+    setNativeNotes(value);
+    writeStoredBoolean(STORY_NATIVE_STORAGE_KEY, value);
+  };
+
+  const toggleEvent = (eventKey: string) => {
+    setExpandedEvents((current) => {
+      const next = new Set(current);
+      if (next.has(eventKey)) next.delete(eventKey);
+      else next.add(eventKey);
+      return next;
+    });
+  };
+
+  return (
+    <section className="flex min-h-[620px] flex-col rounded-2xl border border-white/[0.08] bg-[#101010] shadow-2xl shadow-black/30">
+      <div className="border-b border-white/[0.06] px-5 py-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-[#61C1C4]">
+              <BookOpen className="h-4 w-4" />
+              <h2 className="text-lg font-semibold text-white">Story</h2>
+            </div>
+            <p className="mt-1 text-sm text-white/45">
+              Latest first, written like the calm running story of what UnClick is doing.
+            </p>
+          </div>
+          <label className="flex items-center gap-2 rounded-full border border-white/[0.08] bg-black/20 px-3 py-2 text-xs text-white/55">
+            <input
+              type="checkbox"
+              checked={nativeNotes}
+              onChange={(event) => toggleNativeNotes(event.target.checked)}
+              className="h-3.5 w-3.5 accent-[#61C1C4]"
+            />
+            Native notes
+          </label>
+        </div>
+      </div>
+
+      <div className="flex-1 px-5 py-5">
+        {loading ? (
+          <div className="flex h-full min-h-[420px] items-center justify-center text-sm text-white/45">
+            Writing the latest story...
+          </div>
+        ) : events.length === 0 ? (
+          <div className="flex h-full min-h-[420px] items-center justify-center text-center text-sm text-white/45">
+            No story lines yet. When seats leave receipts, they will appear here as a simple read.
+          </div>
+        ) : (
+          <article className="mx-auto max-w-3xl space-y-7">
+            {visibleEvents.map((event, index) => {
+              const actor = actorIdentityForEvent(event, profileByAgentId);
+              const eventKey = `${event.source_kind}:${event.source_id}:${event.created_at ?? index}`;
+              const expanded = expandedEvents.has(eventKey);
+              const story = storyTextForEvent(event, actor);
+              const storyPreview = truncateText(story, STORY_PREVIEW_CHARS);
+              const nativeNote = nativeNoteForEvent(event, actor);
+              const nativePreview = truncateText(nativeNote, STORY_NATIVE_PREVIEW_CHARS);
+              const showFullStory = expanded || !storyPreview.truncated;
+              const shownStory = showFullStory ? story : storyPreview.text;
+              const shownNative = showFullStory ? nativeNote : nativePreview.text;
+
+              return (
+                <div key={eventKey} className="group">
+                  <time
+                    dateTime={event.created_at ?? undefined}
+                    className="mb-2 block text-[10px] font-medium uppercase tracking-[0.18em] text-white/30"
+                  >
+                    {formatRelative(event.created_at)} · {formatAbsolute(event.created_at)}
+                  </time>
+                  <p className="text-base leading-8 text-white/82 sm:text-[17px]">
+                    {shownStory}
+                  </p>
+                  {nativeNotes && (
+                    <p className="mt-3 rounded-xl border border-white/[0.06] bg-black/20 px-4 py-3 text-xs leading-6 text-white/42">
+                      Native note: {shownNative}
+                    </p>
+                  )}
+                  {(storyPreview.truncated || (nativeNotes && nativePreview.truncated)) && (
+                    <button
+                      type="button"
+                      onClick={() => toggleEvent(eventKey)}
+                      className="mt-2 text-xs font-medium text-[#61C1C4] transition-colors hover:text-[#8ee3e6]"
+                    >
+                      {expanded ? "Read less" : "Read more"}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </article>
+        )}
+      </div>
+
+      {!loading && events.length > 0 && (
+        <div className="border-t border-white/[0.06] px-5 py-4">
+          <div className="mx-auto flex max-w-3xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-white/35">
+              Showing {Math.min(visibleEventCount, events.length)} of {events.length} loaded story lines.
+            </p>
+            {(hasMoreLoaded || canLoadFromServer) && (
+              <button
+                type="button"
+                onClick={() => {
+                  if (hasMoreLoaded) {
+                    setVisibleEventCount((value) => Math.min(events.length, value + STORY_VISIBLE_STEP));
+                  } else {
+                    onLoadDeeperHistory();
+                    setVisibleEventCount((value) => value + STORY_VISIBLE_STEP);
+                  }
+                }}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#61C1C4]/25 bg-[#61C1C4]/10 px-3 py-2 text-sm font-medium text-[#61C1C4] transition-colors hover:bg-[#61C1C4]/15"
+              >
+                Read more
+                <ArrowRight className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -290,6 +290,49 @@ function SeatsNavItem({ onClick }: { onClick?: () => void }) {
   );
 }
 
+function OrchestratorNavItem({ onClick }: { onClick?: () => void }) {
+  const location = useLocation();
+  const isOrchestrator = location.pathname === "/admin/orchestrator" ||
+    location.pathname.startsWith("/admin/orchestrator/");
+  const storyActive = location.pathname === "/admin/orchestrator" ||
+    location.pathname === "/admin/orchestrator/story";
+  const timelineActive = location.pathname === "/admin/orchestrator/timeline";
+
+  return (
+    <div>
+      <SurfaceLink path="/admin/orchestrator" label="Orchestrator" icon={Terminal} onClick={onClick} />
+      {isOrchestrator && (
+        <div className="ml-7 mt-0.5 flex flex-col gap-0.5">
+          <Link
+            to="/admin/orchestrator"
+            onClick={onClick}
+            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              storyActive
+                ? "bg-[#61C1C4]/10 text-[#61C1C4]"
+                : "text-[#666] hover:bg-white/[0.04] hover:text-[#aaa]"
+            }`}
+          >
+            <BookOpen className="h-3 w-3 shrink-0" />
+            Story
+          </Link>
+          <Link
+            to="/admin/orchestrator/timeline"
+            onClick={onClick}
+            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              timelineActive
+                ? "bg-[#61C1C4]/10 text-[#61C1C4]"
+                : "text-[#666] hover:bg-white/[0.04] hover:text-[#aaa]"
+            }`}
+          >
+            <Clock className="h-3 w-3 shrink-0" />
+            Timeline
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function SidebarNav({
   isAdmin,
   signalsUnread,
@@ -304,7 +347,7 @@ function SidebarNav({
       <SurfaceLink path="/admin/dashboard" label="Dashboard"               icon={LayoutDashboard} onClick={onLinkClick} />
       <SurfaceLink path="/admin/you"      label="You"                      icon={User}    onClick={onLinkClick} />
       <MemoryNavItem onClick={onLinkClick} />
-      <SurfaceLink path="/admin/orchestrator" label="Orchestrator"          icon={Terminal} onClick={onLinkClick} />
+      <OrchestratorNavItem onClick={onLinkClick} />
       <SurfaceLink path="/admin/tools"    label="Apps"                     icon={AppWindow} onClick={onLinkClick} />
       <SurfaceLink path="/admin/keychain" label="Passport"                 icon={KeyRound} onClick={onLinkClick} />
       <SeatsNavItem onClick={onLinkClick} />


### PR DESCRIPTION
## Summary
Adds a friendly Orchestrator Story view and makes it the default Orchestrator landing page. The existing detailed continuity feed stays available as Timeline.

Closes #723.

## Scope
- `src/pages/admin/AdminOrchestrator.tsx`: Story mode, Timeline mode, latest-first story rendering, discreet timestamps, Read more, and optional Native notes.
- `src/pages/admin/AdminShell.tsx`: Orchestrator submenu with Story and Timeline.
- `src/App.tsx`: Timeline route and Story redirect.
- `src/pages/admin/AdminOrchestrator.test.tsx`: coverage for Story default and Timeline behavior.

## Non-overlap
- Does not change Orchestrator data ingestion or the memory-admin API.
- Does not change Boardroom semantics.
- Does not add AI generation or paid/free model calls. Story is deterministic from existing context.

## Verification
- `npm test -- --run src/pages/admin/AdminOrchestrator.test.tsx`
- `npm run build`
- `git diff --check`
- Local route smoke: `/admin/orchestrator` 200 and `/admin/orchestrator/timeline` 200 on Vite dev server.

## Risk
Low. User-facing admin UI change only. The Story view reuses existing Orchestrator context and keeps Timeline available for the full operational feed.

## Follow-up
If the deterministic Story proves useful, a later chip can add an API-backed summarizer for longer multi-day chapters. This PR intentionally avoids that cost and complexity.