### PR TITLE
fix(pinballwake): suppress resolved QueuePush packets

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -654,6 +654,8 @@ export function buildQueuePacket(input) {
   if (!STATES.has(state)) throw new Error(`Unknown QueuePush state: ${state}`);
   const worker = routeWorkerForPr(pr, files, state);
   const packetId = queuepushPacketId(pr, state);
+  const headSha = pr.head?.sha || pr.headRefOid || "";
+  const head = shortSha(headSha || "unknown");
   const jobKind = jobKindForState(state);
   const chip = `PR #${pr.number} ${state}`;
   const filePreview = files
@@ -675,6 +677,7 @@ export function buildQueuePacket(input) {
     `job kind: ${jobKind}`,
     `requires code: ${stateRequiresCode(state) ? "yes" : "no"}`,
     `chip: ${chip}`,
+    `head: ${head}`,
     `context: ${context}`,
     `allowed files: ${allowedFilesText(files)}`,
     `do: ${directAction}`,
@@ -693,6 +696,8 @@ export function buildQueuePacket(input) {
     recipient: agentMap[worker] || worker,
     state,
     pr: pr.number,
+    head,
+    headSha,
     text,
     sourceUrl: sourceUrl(pr),
   };
@@ -710,6 +715,34 @@ function messageCreatedAt(message) {
   return Number.isFinite(time) ? time : null;
 }
 
+function queuePushResolutionSignal(packet, message) {
+  const text = normalizeText(message?.text || message?.body || "");
+  if (!text) return false;
+  const prMention = new RegExp(`(?:pr|pull request|#)\\s*#?${packet.pr}\\b`, "i");
+  if (!prMention.test(text)) return false;
+
+  const head = normalizeText(packet.head || "");
+  const hasSameHead = !head || head === "unknown" || text.includes(head) || text.includes(packet.packetId);
+  const passLike = /\b(pass|merge-ok|qc pass|safe to merge|safe next action)\b/.test(text);
+  const mergedLike = /\b(merged|closed|auto-closed|ready for review|draft lifted|lifted draft)\b/.test(text);
+
+  if (mergedLike) return true;
+  if (!hasSameHead || !passLike) return false;
+
+  if (packet.state === "missing_review_safety_ack") {
+    return /\b(reviewer\/safety|reviewer and safety|reviewer|qc)\b/.test(text) &&
+      /\b(safety|gatekeeper|release safety)\b/.test(text);
+  }
+  if (packet.state === "missing_final_qc_ack" || packet.state === "ready_for_qc") {
+    return /\b(reviewer|qc|tester|second-read)\b/.test(text);
+  }
+  if (packet.state === "draft_green_needs_owner_lift") {
+    return /\b(coordinator|owner|ready for review|draft lifted|lifted draft|merged)\b/.test(text);
+  }
+
+  return false;
+}
+
 export function filterDuplicatePackets(
   packets,
   fishbowlMessages = [],
@@ -717,6 +750,9 @@ export function filterDuplicatePackets(
 ) {
   const retryMs = retryAfterMinutes * 60 * 1000;
   return packets.filter((packet) => {
+    if (fishbowlMessages.some((message) => queuePushResolutionSignal(packet, message))) {
+      return false;
+    }
     const matches = fishbowlMessages.filter((message) => String(message.text || "").includes(packet.packetId));
     if (matches.length === 0) return true;
     const newest = Math.max(...matches.map((message) => messageCreatedAt(message) ?? now));

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -679,6 +679,84 @@ describe("QueuePush routing and packets", () => {
     assert.deepEqual(remaining, []);
   });
 
+  it("suppresses review packets after same-head Reviewer/Safety PASS appears", () => {
+    const packet = buildQueuePacket({
+      pr: pr({
+        number: 714,
+        title: "fix(runner): tolerate heartbeat log summaries",
+        head: { sha: "abcdef1234567890" },
+      }),
+      state: "missing_review_safety_ack",
+      reason: "Draft PR is green and clean with proof; Reviewer/Safety PASS is missing.",
+      files: [{ filename: "scripts/pinballwake-autonomous-runner.mjs" }],
+    });
+    const messages = [
+      {
+        text: "PASS: Reviewer/Safety gate check on PR #714 head abcdef1. Safe to merge.",
+        created_at: "2026-05-05T06:00:00Z",
+      },
+    ];
+
+    const remaining = filterDuplicatePackets([packet], messages, {
+      now: Date.parse("2026-05-05T06:30:00Z"),
+      retryAfterMinutes: 180,
+    });
+    assert.deepEqual(remaining, []);
+  });
+
+  it("does not suppress review packets for PASS on a different head", () => {
+    const packet = buildQueuePacket({
+      pr: pr({
+        number: 714,
+        title: "fix(runner): tolerate heartbeat log summaries",
+        head: { sha: "abcdef1234567890" },
+      }),
+      state: "missing_review_safety_ack",
+      reason: "Draft PR is green and clean with proof; Reviewer/Safety PASS is missing.",
+      files: [{ filename: "scripts/pinballwake-autonomous-runner.mjs" }],
+    });
+    const messages = [
+      {
+        text: "PASS: Reviewer/Safety gate check on PR #714 head fedcba9. Safe to merge.",
+        created_at: "2026-05-05T06:00:00Z",
+      },
+    ];
+
+    const remaining = filterDuplicatePackets([packet], messages, {
+      now: Date.parse("2026-05-05T06:30:00Z"),
+      retryAfterMinutes: 180,
+    });
+    assert.deepEqual(
+      remaining.map((candidate) => candidate.packetId),
+      [packet.packetId],
+    );
+  });
+
+  it("suppresses owner-lift packets after Boardroom reports the PR merged", () => {
+    const packet = buildQueuePacket({
+      pr: pr({
+        number: 724,
+        title: "feat(orchestrator): add story view",
+        head: { sha: "e6389f6156c2538f7c8044a7e0cf95704fbaea2a" },
+      }),
+      state: "draft_green_needs_owner_lift",
+      reason: "Draft PR is green and clean.",
+      files: [{ filename: "src/pages/admin/AdminOrchestrator.tsx" }],
+    });
+    const messages = [
+      {
+        text: "PASS: PR #724 merged cleanly and #723 closed.",
+        created_at: "2026-05-12T04:15:00Z",
+      },
+    ];
+
+    const remaining = filterDuplicatePackets([packet], messages, {
+      now: Date.parse("2026-05-12T04:20:00Z"),
+      retryAfterMinutes: 180,
+    });
+    assert.deepEqual(remaining, []);
+  });
+
   it("prioritizes missing final QC before routine owner lift", async () => {
     const packets = await buildPacketsFromInputs([
       {


### PR DESCRIPTION
## Summary
Stops QueuePush from re-posting packets when Boardroom already contains a resolving PASS for the same PR head, or when Boardroom already reports the PR merged or closed.

Part of #715.

## Scope
- `scripts/fleet-throughput-watch.mjs`
- `scripts/fleet-throughput-watch.test.mjs`

## Non-overlap
- Does not change Runner claim authority.
- Does not merge, lift drafts, approve, or close PRs.
- Does not weaken NudgeOnly, IgniteOnly, or PushOnly boundaries.

## Verification
- `node --test scripts/fleet-throughput-watch.test.mjs`
- `npm run brainmap:check`
- `git diff --check`

## Risk
Low. This only suppresses duplicate QueuePush packets when the same PR is explicitly resolved by a same-head PASS signal or a merged/closed signal. Different-head PASS notes still do not suppress current packets.

## Follow-up
Next #715 chips are the healthy autopilot definition and Flight Recorder cycle receipt.