### PR TITLE
fix(queuepush): suppress stale passed PR wakes

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -206,6 +206,27 @@ function shortSha(sha) {
   return String(sha || "").slice(0, 7);
 }
 
+function headShaTokens(sha) {
+  const normalized = normalizeText(sha);
+  if (!normalized) return [];
+  return [...new Set([normalized, normalized.slice(0, 12), normalized.slice(0, 7)].filter((token) => token.length >= 7))];
+}
+
+function mentionsHeadSha(text, sha) {
+  const tokens = headShaTokens(sha);
+  return tokens.length > 0 && tokens.some((token) => text.includes(token));
+}
+
+function isReviewerSafetyHeadPassText(text) {
+  const reviewerSafetyPair =
+    /\b(reviewer\/safety|reviewer\s+(?:and|&)\s+safety|safety\s+(?:and|&)\s+reviewer|reviewer\s*\+\s*safety|safety\s*\+\s*reviewer)\b/.test(
+      text,
+    );
+  const gateCheck = /\bgate check\b/.test(text) && /\b(reviewer|safety|safe to lift|safe to merge)\b/.test(text);
+  const safeDecision = /\bsafe to (?:lift|merge)\b/.test(text) && /\b(reviewer|safety|qc)\b/.test(text);
+  return reviewerSafetyPair || gateCheck || safeDecision;
+}
+
 function parseTime(value) {
   const time = Date.parse(String(value || ""));
   return Number.isFinite(time) ? time : null;
@@ -363,7 +384,7 @@ export function checksAreGreen(checkRuns = [], statuses = []) {
   return runsOk && statusesOk;
 }
 
-export function latestCommentSignals(comments = []) {
+export function latestCommentSignals(comments = [], { headSha = "" } = {}) {
   const sorted = [...comments].sort((a, b) =>
     String(a.created_at || "").localeCompare(String(b.created_at || "")),
   );
@@ -375,6 +396,7 @@ export function latestCommentSignals(comments = []) {
   let lastSafetyPass = -1;
   let lastBuilderPass = -1;
   let lastReviewerPass = -1;
+  let lastReviewerSafetyHeadPass = -1;
   let lastMissingFinalQcAck = -1;
   let hasChrisOnly = false;
   let hasProof = false;
@@ -412,6 +434,9 @@ export function latestCommentSignals(comments = []) {
     }
     if (lanePass && /\b(qc|reviewer|tester)\b|🔍|🧪/.test(text)) {
       lastReviewerPass = index;
+    }
+    if (lanePass && mentionsHeadSha(text, headSha) && isReviewerSafetyHeadPassText(text)) {
+      lastReviewerSafetyHeadPass = index;
     }
     const qcWaitOnlyHold = isQcWaitOnlyHold(text);
     if (
@@ -451,6 +476,7 @@ export function latestCommentSignals(comments = []) {
     hasSafetyPass: lastSafetyPass >= 0 && lastSafetyPass > lastHold,
     hasBuilderPass: lastBuilderPass >= 0 && lastBuilderPass > lastHold,
     hasReviewerPass: lastReviewerPass >= 0 && lastReviewerPass > lastHold,
+    hasReviewerSafetyHeadPass: lastReviewerSafetyHeadPass >= 0 && lastReviewerSafetyHeadPass > lastHold,
     hasMissingFinalQcAck: lastMissingFinalQcAck > lastReviewerPass,
     hasChrisOnly,
     hasProof,
@@ -552,7 +578,15 @@ function packetInstructionForJobKind(jobKind) {
 
 export function classifyPullRequest(input) {
   const { pr, files = [], comments = [], reviews = [], checkRuns = [], statuses = [] } = input;
-  const signals = latestCommentSignals([...comments, ...reviews.map((review) => ({ body: review.body, created_at: review.submitted_at }))]);
+  const prState = normalizeText(pr.state);
+  if (pr.merged || pr.merged_at || (prState && prState !== "open")) {
+    return { state: null, reason: "PR is closed or merged; no QueuePush action needed." };
+  }
+  const headSha = pr.head?.sha || pr.headRefOid || "";
+  const signals = latestCommentSignals(
+    [...comments, ...reviews.map((review) => ({ body: review.body, created_at: review.submitted_at }))],
+    { headSha },
+  );
   const green = checksAreGreen(checkRuns, statuses);
   const mergeState = String(pr.mergeable_state || pr.mergeStateStatus || "").toLowerCase();
   const clean = ["clean", "has_hooks", "unstable"].includes(mergeState) || mergeState === "";
@@ -563,6 +597,9 @@ export function classifyPullRequest(input) {
   if (signals.hasFailedProof) return { state: "failed_targeted_proof", reason: "Targeted proof was reported as failing." };
   if (signals.hasOverlap) return { state: "hold_overlap", reason: "Overlap or anti-stomp blocker is present." };
   if (signals.hasActiveHold) return { state: "blocked_chris_only", reason: "Active HOLD/blocker comment remains." };
+  if (green && clean && signals.hasReviewerSafetyHeadPass) {
+    return { state: null, reason: "Reviewer/Safety PASS already exists on this head; no duplicate QueuePush action needed." };
+  }
   if (
     pr.draft &&
     green &&

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -79,6 +79,74 @@ describe("QueuePush PR classifier", () => {
     assert.equal(result.state, "draft_green_needs_owner_lift");
   });
 
+  it("does not wake closed or merged PRs", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 724, draft: false, state: "closed", merged: true, merged_at: "2026-05-12T04:00:00Z" }),
+      files: [{ filename: "src/pages/admin/OrchestratorStory.tsx" }],
+      comments: [{ body: "PASS: Reviewer/Safety gate check on abcdef1234567890.", created_at: "2026-05-12T03:40:00Z" }],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, null);
+    assert.match(result.reason, /closed or merged/);
+  });
+
+  it("does not re-wake when Reviewer/Safety PASS already exists on the same head", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 724, draft: true, head: { sha: "e6389f6151ef6ee53e8ea10570932fe6c960c0a5" } }),
+      files: [{ filename: "src/pages/admin/OrchestratorStory.tsx" }],
+      comments: [
+        {
+          body: "PASS: Reviewer/Safety gate check on e6389f6151ef6ee53e8ea10570932fe6c960c0a5. Safe to lift and merge.",
+          created_at: "2026-05-12T03:40:00Z",
+          user: { login: "reviewer-seat" },
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, null);
+    assert.match(result.reason, /Reviewer\/Safety PASS already exists/);
+  });
+
+  it("keeps routing when Reviewer/Safety PASS is for an older head", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 724, draft: true, head: { sha: "e6389f6151ef6ee53e8ea10570932fe6c960c0a5" } }),
+      files: [{ filename: "src/pages/admin/OrchestratorStory.tsx" }],
+      comments: [
+        {
+          body: "PASS: Reviewer/Safety gate check on 1111111151ef6ee53e8ea10570932fe6c960c0a5. Safe to lift and merge.",
+          created_at: "2026-05-12T03:40:00Z",
+          user: { login: "reviewer-seat" },
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "missing_review_safety_ack");
+  });
+
+  it("does not treat bot same-head PASS text as Reviewer/Safety duplicate proof", () => {
+    const result = classifyPullRequest({
+      pr: pr({ number: 724, draft: true, head: { sha: "e6389f6151ef6ee53e8ea10570932fe6c960c0a5" } }),
+      files: [{ filename: "src/pages/admin/OrchestratorStory.tsx" }],
+      comments: [
+        {
+          body: "PASS: Reviewer/Safety gate check on e6389f6151ef6ee53e8ea10570932fe6c960c0a5. Safe to lift and merge.",
+          created_at: "2026-05-12T03:40:00Z",
+          user: { login: "github-actions" },
+        },
+      ],
+      checkRuns: greenChecks,
+      statuses: greenStatus,
+    });
+
+    assert.equal(result.state, "missing_review_safety_ack");
+  });
+
   it("routes green clean draft PRs with proof comment to review", () => {
     const result = classifyPullRequest({
       pr: pr({ number: 714, draft: true, title: "fix(runner): tolerate heartbeat log summaries" }),


### PR DESCRIPTION
## Summary
- Stops QueuePush from emitting packets for PRs that are already closed or merged.
- Adds a same-head Reviewer/Safety PASS gate so already-reviewed heads do not get duplicate wake packets.
- Keeps stale-head PASS comments and bot-authored PASS text from suppressing real review routing.

## Scope
- QueuePush PR classification in `scripts/fleet-throughput-watch.mjs`.
- Focused Fleet Throughput Watch tests in `scripts/fleet-throughput-watch.test.mjs`.

## Non-overlap
- Does not change Runner claim authority, merge authority, build authority, or PR review authority.
- Does not change NudgeOnly, IgniteOnly, PushOnly, WakePass, or Orchestrator Story behavior.

## Verification
- `node --test scripts/fleet-throughput-watch.test.mjs` passes, 59/59.
- `git diff --check` passes with Windows line-ending warnings only.

## Risk
- Low. This is a read/classification guard for QueuePush packets and only suppresses duplicate or stale PR wake paths.

## Follow-up
- Reviewer/Safety should confirm the same-head PASS matcher is narrow enough and that Coordinator merge routing remains covered by the existing gates.

Owned scope: QueuePush / Fleet Throughput Watch. Draft PR for Reviewer/Safety gate.