### PR TITLE
fix(pinballwake): report runner final actions accurately

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -842,19 +842,37 @@ function buildClaimabilityScorecard({
   };
 }
 
-function buildRunClaimabilityScorecard({ queueSourceResult = {}, results = [], lastResult = {} } = {}) {
+function buildRunClaimabilityScorecard({
+  queueSourceResult = {},
+  results = [],
+  lastResult = {},
+  finalAction = lastResult.action || null,
+  finalReason = lastResult.reason || null,
+  scopingRequested = 0,
+} = {}) {
   const base = queueSourceResult.claimability_scorecard || buildClaimabilityScorecard({
     seen: queueSourceResult.seen || 0,
     claimable: queueSourceResult.imported || 0,
     imported: queueSourceResult.imported || 0,
     skipped: queueSourceResult.skipped || [],
   });
+  const protectedBlocked = results.reduce(
+    (sum, result) => sum + (Array.isArray(result?.safety_blocked) ? result.safety_blocked.length : 0),
+    0,
+  );
+  const importedClaimable = Number.isFinite(base.claimable) ? base.claimable : queueSourceResult.imported || 0;
 
   return {
     ...base,
+    imported_claimable: importedClaimable,
+    claim_attemptable_after_safety: Math.max(0, importedClaimable - protectedBlocked - scopingRequested),
+    scoping_requested: scopingRequested,
+    protected_blocked: protectedBlocked,
     claimed: results.filter((result) => result?.action === "claimed").length,
-    last_action: lastResult.action || null,
-    last_reason: lastResult.reason || null,
+    last_action: finalAction,
+    last_reason: finalReason,
+    final_action: finalAction,
+    final_reason: finalReason,
   };
 }
 
@@ -1473,13 +1491,19 @@ export async function runAutonomousRunnerFile({
   const executeBlocked = safeMode === "execute" && !safePolicy.allowExecute;
   const shouldPersist = safeMode !== "dry-run" && !safePolicy.disabled && !executeBlocked;
   const last = results[results.length - 1] || { ok: true, action: "idle", reason: "no_cycle_run", ledger };
+  let todoClaimSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
+  let todoScopingSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
+  const todoForScoping = selectBoardroomTodoForScoping({ queueSourceResult, lastResult: last });
+  const finalAction = todoForScoping && shouldPersist ? "scoping_requested" : last.action;
+  const finalReason = todoForScoping && shouldPersist ? "boardroom_todo_reopened_for_scoping" : last.reason;
   const claimabilityScorecard = buildRunClaimabilityScorecard({
     queueSourceResult,
     results,
     lastResult: last,
+    finalAction,
+    finalReason,
+    scopingRequested: todoForScoping && shouldPersist ? 1 : 0,
   });
-  let todoClaimSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
-  let todoScopingSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
 
   if (
     shouldPersist &&
@@ -1514,7 +1538,6 @@ export async function runAutonomousRunnerFile({
     }
   }
 
-  const todoForScoping = selectBoardroomTodoForScoping({ queueSourceResult, lastResult: last });
   if (shouldPersist && todoForScoping) {
     todoScopingSync = await syncBoardroomTodoScopingRequestToUnClick({
       todo: todoForScoping,
@@ -1551,8 +1574,8 @@ export async function runAutonomousRunnerFile({
   return {
     ...last,
     ok: results.every((result) => result.ok) && todoClaimSync.ok && todoScopingSync.ok,
-    action: todoForScoping && shouldPersist ? "scoping_requested" : last.action,
-    reason: todoForScoping && shouldPersist ? "boardroom_todo_reopened_for_scoping" : last.reason,
+    action: finalAction,
+    reason: finalReason,
     mode: safeMode,
     dry_run: safeMode === "dry-run",
     persisted: shouldPersist,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -997,6 +997,14 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.reason, "boardroom_todo_reopened_for_scoping");
       assert.equal(result.queue_source.imported, 1);
       assert.equal(result.skipped[0].reason, "boardroom_todo_missing_scopepack");
+      assert.equal(result.claimability_scorecard.imported_claimable, 1);
+      assert.equal(result.claimability_scorecard.claim_attemptable_after_safety, 0);
+      assert.equal(result.claimability_scorecard.scoping_requested, 1);
+      assert.equal(result.claimability_scorecard.protected_blocked, 0);
+      assert.equal(result.claimability_scorecard.last_action, "scoping_requested");
+      assert.equal(result.claimability_scorecard.last_reason, "boardroom_todo_reopened_for_scoping");
+      assert.equal(result.claimability_scorecard.final_action, "scoping_requested");
+      assert.equal(result.claimability_scorecard.final_reason, "boardroom_todo_reopened_for_scoping");
       assert.equal(result.todo_scoping_sync.todo_id, "todo-orchestrator-scope");
       assert.equal(result.todo_scoping_sync.comment_ok, true);
 


### PR DESCRIPTION
## Summary
Fixes the misleading PinballWake Autonomous Runner scorecard after #722.

When Runner imported claimable jobs but converted them into a scoping request or protected-surface block, the top-level action could be useful while the scorecard still said `last_action=idle` and `last_reason=no_claimable_jobs`. This made automation look more broken than it was.

This PR makes the scorecard report the final action and adds explicit closure fields:
- `imported_claimable`
- `claim_attemptable_after_safety`
- `scoping_requested`
- `protected_blocked`
- `final_action`
- `final_reason`

Refs #715.

## Scope
- `scripts/pinballwake-autonomous-runner.mjs`
- `scripts/pinballwake-autonomous-runner.test.mjs`

## Non-overlap
- Does not add new Runner authority.
- Does not change claim, execute, merge, approve, or close behaviour.
- Does not change NudgeOnly, IgniteOnly, PushOnly, or QueuePush.

## Verification
- `node --test scripts/pinballwake-autonomous-runner.test.mjs`
- `npm run brainmap:check`
- `git diff --check`

## Risk
Low. Reporting/observability only. It changes how the Runner explains final state, not what the Runner is allowed to do.

## Follow-up
After merge, watch the next scheduled PinballWake Runner run and confirm the scorecard says `final_action=scoping_requested` instead of hiding it behind `idle/no_claimable_jobs`.