### PR TITLE
[codex] Fix Orchestrator Story load more scroll

### DIFF
--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -19,6 +19,59 @@ function renderOrchestrator(route = "/admin/orchestrator") {
   );
 }
 
+function jsonResponse(value: unknown): Response {
+  return {
+    ok: true,
+    json: async () => value,
+  } as Response;
+}
+
+function contextWithEvents(events: Array<Record<string, unknown>>) {
+  return {
+    context: {
+      version: "orchestrator-context-v1",
+      generated_at: "2026-05-10T06:00:00.000Z",
+      current_state_card: {
+        summary: "1 active job, 1 active seat, 0 blocker signals.",
+        newest_activity_at: "2026-05-10T05:55:00.000Z",
+        newest_checkin_at: "2026-05-10T05:55:00.000Z",
+        active_todo_count: 1,
+        blocker_count: 0,
+        active_seat_count: 1,
+        next_actions: [],
+        blockers: [],
+        live_sources: {
+          profiles: 1,
+          boardroom_messages: 0,
+          todos: 0,
+          comments: 0,
+          dispatches: 0,
+          signals: 0,
+          sessions: 0,
+          library: 0,
+          business_context: 0,
+          conversation_turns: events.length,
+        },
+      },
+      profile_cards: [
+        {
+          agent_id: "codex-orchestrator-seat",
+          label: "Codex Orchestrator Seat",
+          role: "ai-seat",
+          emoji: "🤖",
+          source_app_label: "Codex",
+          connection_label: "Connected",
+          last_seen_at: "2026-05-10T05:55:00.000Z",
+          freshness_label: "Live",
+        },
+      ],
+      human_operator_time: null,
+      continuity_events: events,
+      library_snapshots: [],
+    },
+  };
+}
+
 describe("AdminOrchestratorPage", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -256,6 +309,91 @@ describe("AdminOrchestratorPage", () => {
     expect(screen.queryByText(/Archive event 24/i)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText("Message the AI assistant...")).not.toBeInTheDocument();
     expect(screen.queryByText("Using AI Assistant")).not.toBeInTheDocument();
+  });
+
+  it("loads a larger Story context window by default", async () => {
+    renderOrchestrator();
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("orchestrator_context_read&limit=120"),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer session-token" }),
+        }),
+      ),
+    );
+  });
+
+  it("keeps Story content visible while deeper history loads", async () => {
+    let resolveDeepHistory: (response: Response) => void = () => undefined;
+    const deepHistoryPromise = new Promise<Response>((resolve) => {
+      resolveDeepHistory = resolve;
+    });
+    const initialEvents = [
+      {
+        source_kind: "conversation_turn",
+        source_id: "story-scroll-ask",
+        created_at: "2026-05-10T06:15:00.000Z",
+        kind: "context",
+        role: "user",
+        summary: "user: Can Story hold more conversation by default?",
+        tags: ["conversation", "user"],
+      },
+      ...Array.from({ length: 119 }, (_, index) => ({
+        source_kind: "conversation_turn",
+        source_id: `archive-${index}`,
+        created_at: `2026-05-10T04:${String(59 - (index % 50)).padStart(2, "0")}:00.000Z`,
+        kind: "context",
+        role: "assistant",
+        summary: `Archive event ${index}: older detail.`,
+        tags: ["archive"],
+      })),
+    ];
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      const textUrl = String(url);
+      if (textUrl.includes("orchestrator_context_read") && textUrl.includes("limit=200")) {
+        return deepHistoryPromise;
+      }
+      if (textUrl.includes("orchestrator_context_read")) {
+        return jsonResponse(contextWithEvents(initialEvents));
+      }
+      if (textUrl.includes("tenant_settings")) {
+        return jsonResponse({
+          env_enabled: true,
+          settings: {
+            ai_chat_enabled: true,
+            ai_chat_provider: "google",
+            ai_chat_model: "gemini-2.5-flash-lite",
+            ai_chat_system_prompt: null,
+            ai_chat_max_turns: 20,
+            has_api_key: true,
+          },
+        });
+      }
+      if (textUrl.includes("admin_channel_status")) {
+        return jsonResponse({ channel_active: false, last_seen: null, client_info: null });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderOrchestrator();
+
+    expect((await screen.findAllByText(/Chris pulled the thread back to the real question/i)).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByText("Read more"));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("orchestrator_context_read&limit=200"),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer session-token" }),
+        }),
+      ),
+    );
+    expect(screen.queryByText("Writing the latest story...")).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Chris pulled the thread back to the real question/i).length).toBeGreaterThan(0);
+
+    resolveDeepHistory(jsonResponse(contextWithEvents(initialEvents)));
   });
 
   it("shows read-only continuity on the Timeline subpage", async () => {

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -145,10 +145,10 @@ const DRIPFEED_EDUCATION_STORAGE_KEY = "unclick_orchestrator_dripfeed_education_
 const ANALOGY_STORAGE_KEY = "unclick_orchestrator_analogy_v1";
 const EVENT_PREVIEW_CHARS = 520;
 const NATURAL_CONTEXT_PREVIEW_CHARS = 360;
-const INITIAL_CONTEXT_LIMIT = 80;
+const INITIAL_CONTEXT_LIMIT = 120;
 const MAX_CONTEXT_LIMIT = 200;
 const CONTINUITY_VISIBLE_STEP = 24;
-const STORY_CHAPTER_VISIBLE_STEP = 8;
+const STORY_CHAPTER_VISIBLE_STEP = 10;
 const STORY_CHAPTER_SPLIT_MS = 45 * 60_000;
 const STORY_CHAPTER_MAX_TOTAL = 14;
 const STORY_CHAPTER_MAX_PER_BEAT = 2;
@@ -862,17 +862,21 @@ export default function AdminOrchestratorPage() {
   const [orchestratorContext, setOrchestratorContext] = useState<OrchestratorContext | null>(null);
   const [contextLimit, setContextLimit] = useState(INITIAL_CONTEXT_LIMIT);
   const [loading, setLoading] = useState(true);
+  const hasLoadedOrchestratorContextRef = useRef(false);
 
   const envEnabled = aiChatEnvEnabled();
 
   useEffect(() => {
     if (sessionLoading) return;
     if (!authToken) {
+      hasLoadedOrchestratorContextRef.current = false;
       queueMicrotask(() => setLoading(false));
       return;
     }
     let cancelled = false;
-    setLoading(true);
+    if (!hasLoadedOrchestratorContextRef.current) {
+      setLoading(true);
+    }
     (async () => {
       try {
         const [channelRes, statusRes, connRes, contextRes, tenantRes] = await Promise.all([
@@ -900,6 +904,7 @@ export default function AdminOrchestratorPage() {
         if (contextRes.ok) {
           const body = (await contextRes.json()) as { context?: OrchestratorContext };
           setOrchestratorContext(body.context ?? null);
+          hasLoadedOrchestratorContextRef.current = true;
         }
         if (tenantRes?.env_enabled) setTenant(tenantRes.settings);
       } finally {


### PR DESCRIPTION
## Summary
- Increases the initial Orchestrator Story context window from 80 to 120 events.
- Shows 10 Story chapters by default instead of 8.
- Keeps the existing Story content rendered while deeper history refreshes, so clicking Read more does not collapse the panel or bounce the reader back up the page.
- Adds regression coverage for the larger default window and quiet deeper-history loading.

## Root cause
Story reused the main blocking loading state every time the context limit changed. On deeper loads, the panel briefly replaced the current story with the loading view, which could collapse the content under the reader and make the page feel like it jumped.

## Validation
- npm test -- src/pages/admin/AdminOrchestrator.test.tsx
- npm run brainmap:check
