### PR TITLE
feat(orchestrator): active-state v9 definition pinned across state_card + heartbeat

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -236,6 +236,12 @@ export interface OrchestratorContext {
     newest_activity_at: string | null;
     newest_checkin_at: string | null;
     active_todo_count: number;
+    // active_jobs is the strict v9 definition used by Heartbeat step 5:
+    // COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h).
+    // active_todo_count is the broader open+in_progress count kept for
+    // back-compat with the rolling snapshot list. PASS/BLOCKER reasoning
+    // should use active_jobs.
+    active_jobs: number;
     blocker_count: number;
     active_seat_count: number;
     live_sources: {
@@ -262,6 +268,12 @@ export interface OrchestratorContext {
 }
 
 const ACTIVE_WINDOW_MS = 30 * 60 * 1000;
+// active_jobs (v9 definition pinned 2026-05-12 by todo a4cd5229): an
+// in_progress todo is "active" only when its assigned owner has been seen
+// in the last 24 hours. A todo assigned to a dormant or never-seen owner
+// is NOT active, even if its status is in_progress. This is the same
+// window used by Heartbeat step 5 so PASS/BLOCKER does not oscillate.
+const OWNER_FRESH_WINDOW_MS = 24 * 60 * 60 * 1000;
 const PRIORITY_RANK: Record<string, number> = {
   urgent: 4,
   high: 3,
@@ -331,6 +343,12 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     .filter((todo) => todo.status === "open" || todo.status === "in_progress")
     .sort(compareTodoPriorityThenUpdated)
     .slice(0, 8);
+  // active_jobs (v9 definition pinned by todo a4cd5229): strict
+  // in_progress + owner_last_seen <= 24h. Heartbeat step 5 uses the same
+  // formula so state_card and PASS/BLOCKER never disagree on identical
+  // input. Computed over the full input.todos array, NOT the sliced
+  // activeTodos, so the count is deterministic regardless of UI cap.
+  const activeJobsCount = computeActiveJobsCount(input.todos, input.profiles, nowMs);
 
   const messageEvents = input.messages.map(messageToEvent);
   const todoEvents = activeTodos.map(todoToEvent);
@@ -409,12 +427,13 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     },
     current_state_card: {
       summary: compactText(
-        `${activeTodos.length} active job${activeTodos.length === 1 ? "" : "s"}, ${activeSeatCount} active seat${activeSeatCount === 1 ? "" : "s"}, ${blockers.length} blocker signal${blockers.length === 1 ? "" : "s"}.${humanOperatorTime ? ` Operator time: ${humanOperatorTime.summary}.` : ""}`,
+        `${activeJobsCount} active job${activeJobsCount === 1 ? "" : "s"}, ${activeSeatCount} active seat${activeSeatCount === 1 ? "" : "s"}, ${blockers.length} blocker signal${blockers.length === 1 ? "" : "s"}.${humanOperatorTime ? ` Operator time: ${humanOperatorTime.summary}.` : ""}`,
         180,
       ),
       newest_activity_at: newestActivityAt,
       newest_checkin_at: newestCheckinAt,
       active_todo_count: activeTodos.length,
+      active_jobs: activeJobsCount,
       blocker_count: blockers.length,
       active_seat_count: activeSeatCount,
       live_sources: {
@@ -977,6 +996,35 @@ function isFresh(iso: string | null | undefined, nowMs: number): boolean {
   if (!iso) return false;
   const seenMs = Date.parse(iso);
   return Number.isFinite(seenMs) && Number.isFinite(nowMs) && nowMs - seenMs <= ACTIVE_WINDOW_MS;
+}
+
+// Owner-freshness gate for current_state_card.active_jobs. Mirrors the
+// Heartbeat step 5 definition: active_jobs = COUNT(todos WHERE
+// status='in_progress' AND owner_last_seen <= 24h). Keeps state_card and
+// heartbeat aligned so identical input always produces identical PASS/BLOCKER.
+function isOwnerFresh(iso: string | null | undefined, nowMs: number): boolean {
+  if (!iso) return false;
+  const seenMs = Date.parse(iso);
+  return Number.isFinite(seenMs) && Number.isFinite(nowMs) && nowMs - seenMs <= OWNER_FRESH_WINDOW_MS;
+}
+
+export function computeActiveJobsCount(
+  todos: OrchestratorTodoRow[],
+  profiles: OrchestratorProfileRow[],
+  nowMs: number,
+): number {
+  const ownerLastSeen = new Map<string, string | null>();
+  for (const profile of profiles) {
+    if (profile.agent_id) {
+      ownerLastSeen.set(profile.agent_id, profile.last_seen_at ?? profile.created_at ?? null);
+    }
+  }
+  return todos.filter((todo) => {
+    if (todo.status !== "in_progress") return false;
+    const owner = todo.assigned_to_agent_id;
+    if (!owner) return false;
+    return isOwnerFresh(ownerLastSeen.get(owner), nowMs);
+  }).length;
 }
 
 function prettifyAgentId(agentId: string): string {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildOrchestratorContext,
   compactText,
+  computeActiveJobsCount,
   isHeartbeatAutomationText,
   redactSensitive,
 } from "./lib/orchestrator-context";
@@ -138,6 +139,11 @@ describe("orchestrator context", () => {
 
     expect(context.version).toBe("orchestrator-context-v1");
     expect(context.current_state_card.active_todo_count).toBe(1);
+    // active_jobs is the v9-pinned strict count: in_progress + owner_last_seen <= 24h.
+    // The codex-seat owner here was last seen 5 minutes before generatedAt, so the
+    // single in_progress todo counts as active. Stays in lock-step with heartbeat
+    // step 5 so PASS/BLOCKER never oscillates on identical state (todo a4cd5229).
+    expect(context.current_state_card.active_jobs).toBe(1);
     expect(context.current_state_card.active_seat_count).toBe(1);
     expect(context.current_state_card.blocker_count).toBe(1);
     expect(context.current_state_card.next_actions[0]).toContain("Orchestrator context layer");
@@ -603,5 +609,222 @@ describe("orchestrator context", () => {
     expect(context.seat_handshake.source_pointers.map((pointer) => pointer.source_id)).toEqual(
       expect.arrayContaining(["session-orchestrator-fallback", "todo-active", "msg-proof"]),
     );
+  });
+});
+
+// active_jobs v9 definition pinned by todo a4cd5229 + Heartbeat step 5:
+//   active_jobs = COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h)
+// These tests lock that contract so the Heartbeat and the Orchestrator
+// state_card never disagree on identical input.
+describe("computeActiveJobsCount (v9 definition)", () => {
+  const NOW_MS = Date.parse("2026-05-12T00:00:00.000Z");
+  const HOUR_MS = 60 * 60 * 1000;
+
+  it("counts an in_progress todo whose owner was seen in the last 24h", () => {
+    const count = computeActiveJobsCount(
+      [
+        {
+          id: "todo-active",
+          title: "Active build",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: "builder-fresh",
+          created_at: "2026-05-11T00:00:00.000Z",
+        },
+      ],
+      [
+        {
+          agent_id: "builder-fresh",
+          last_seen_at: new Date(NOW_MS - 2 * HOUR_MS).toISOString(),
+        },
+      ],
+      NOW_MS,
+    );
+    expect(count).toBe(1);
+  });
+
+  it("excludes an in_progress todo whose owner has been dormant more than 24h", () => {
+    const count = computeActiveJobsCount(
+      [
+        {
+          id: "todo-dormant",
+          title: "Dormant owner",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: "builder-stale",
+          created_at: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+      [
+        {
+          agent_id: "builder-stale",
+          // 6 days ago. The exact case Chris hit earlier today (todo e9e308cd
+          // assigned to "master" who hadn't been seen in 6 days but was
+          // still counted as an active job).
+          last_seen_at: new Date(NOW_MS - 6 * 24 * HOUR_MS).toISOString(),
+        },
+      ],
+      NOW_MS,
+    );
+    expect(count).toBe(0);
+  });
+
+  it("does not count open todos even when the owner is fresh", () => {
+    const count = computeActiveJobsCount(
+      [
+        {
+          id: "todo-open",
+          title: "Open todo",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: "builder-fresh",
+          created_at: "2026-05-11T00:00:00.000Z",
+        },
+      ],
+      [
+        {
+          agent_id: "builder-fresh",
+          last_seen_at: new Date(NOW_MS - 10 * 60 * 1000).toISOString(),
+        },
+      ],
+      NOW_MS,
+    );
+    expect(count).toBe(0);
+  });
+
+  it("does not count an in_progress todo with no assigned owner", () => {
+    const count = computeActiveJobsCount(
+      [
+        {
+          id: "todo-unowned",
+          title: "Unowned in_progress",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: null,
+          created_at: "2026-05-11T00:00:00.000Z",
+        },
+      ],
+      [],
+      NOW_MS,
+    );
+    expect(count).toBe(0);
+  });
+
+  it("does not count an in_progress todo whose owner has no profile row", () => {
+    // Owner string exists on the todo, but the profile is missing entirely.
+    // This protects against a "ghost owner" where reclaim_count or a
+    // historical lease left the assigned_to_agent_id non-empty but the
+    // worker has never been seen at all.
+    const count = computeActiveJobsCount(
+      [
+        {
+          id: "todo-ghost",
+          title: "Ghost owner",
+          status: "in_progress",
+          priority: "high",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: "builder-ghost",
+          created_at: "2026-05-11T00:00:00.000Z",
+        },
+      ],
+      [],
+      NOW_MS,
+    );
+    expect(count).toBe(0);
+  });
+
+  it("returns the identical count on identical input (no oscillation)", () => {
+    // Acceptance criterion: heartbeat PASS/BLOCKER stops oscillating on
+    // identical state. Same input must always produce the same count.
+    const todos = [
+      {
+        id: "todo-a",
+        title: "A",
+        status: "in_progress",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: "builder-1",
+        created_at: "2026-05-11T00:00:00.000Z",
+      },
+      {
+        id: "todo-b",
+        title: "B",
+        status: "in_progress",
+        priority: "high",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: "builder-2",
+        created_at: "2026-05-11T00:00:00.000Z",
+      },
+    ];
+    const profiles = [
+      { agent_id: "builder-1", last_seen_at: new Date(NOW_MS - HOUR_MS).toISOString() },
+      { agent_id: "builder-2", last_seen_at: new Date(NOW_MS - 3 * 24 * HOUR_MS).toISOString() },
+    ];
+    const first = computeActiveJobsCount(todos, profiles, NOW_MS);
+    const second = computeActiveJobsCount(todos, profiles, NOW_MS);
+    const third = computeActiveJobsCount(todos, profiles, NOW_MS);
+    expect(first).toBe(1);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it("current_state_card.active_jobs matches computeActiveJobsCount for the same inputs", () => {
+    // Acceptance criterion: orchestrator state_card matches list_todos query.
+    // The state_card builder MUST delegate to the same computeActiveJobsCount
+    // function used by Heartbeat step 5, so an external caller asking
+    // list_todos.filter(status=in_progress, fresh_owner) gets the same N.
+    const todos = [
+      {
+        id: "todo-fresh",
+        title: "Fresh",
+        status: "in_progress",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: "builder-fresh",
+        created_at: "2026-05-11T00:00:00.000Z",
+      },
+      {
+        id: "todo-stale",
+        title: "Stale",
+        status: "in_progress",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: "builder-stale",
+        created_at: "2026-05-08T00:00:00.000Z",
+      },
+      {
+        id: "todo-open",
+        title: "Open",
+        status: "open",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: null,
+        created_at: "2026-05-11T00:00:00.000Z",
+      },
+    ];
+    const profiles = [
+      { agent_id: "builder-fresh", last_seen_at: new Date(NOW_MS - 30 * 60 * 1000).toISOString() },
+      { agent_id: "builder-stale", last_seen_at: new Date(NOW_MS - 5 * 24 * HOUR_MS).toISOString() },
+    ];
+    const directCount = computeActiveJobsCount(todos, profiles, NOW_MS);
+    const context = buildOrchestratorContext({
+      generatedAt: new Date(NOW_MS).toISOString(),
+      profiles,
+      messages: [],
+      todos,
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+    expect(directCount).toBe(1);
+    expect(context.current_state_card.active_jobs).toBe(directCount);
   });
 });

--- a/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
@@ -40,6 +40,12 @@ describe("heartbeat_protocol payload", () => {
     expect(protocol.procedure[3]).toContain("job hunt");
     expect(protocol.procedure[4]).toContain("0 active jobs");
     expect(protocol.procedure[4]).toContain("queue hydration failure");
+    // active_jobs definition is pinned in step 5 (procedure[4]) so the
+    // Heartbeat and Orchestrator state_card use the identical query.
+    // Stops PASS/BLOCKER from oscillating on identical state (todo a4cd5229).
+    expect(protocol.procedure[4]).toContain("status='in_progress'");
+    expect(protocol.procedure[4]).toContain("owner_last_seen <= 24h");
+    expect(protocol.procedure[4]).toContain("current_state_card.active_jobs");
     expect(protocol.procedure[5]).toContain("PinballWake JobHunt Mirror");
     expect(protocol.procedure[5]).toContain("Job Worker");
     expect(protocol.procedure[5]).toContain("free API classifiers may only classify or nudge");
@@ -76,9 +82,9 @@ describe("heartbeat_protocol payload", () => {
       procedure: [...protocol.procedure, "new instruction"],
     };
 
-    expect(formatHeartbeatProtocolVersion(9)).toBe("2026-05-07.v9");
-    expect(protocol.version).toBe("2026-05-07.v9");
-    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("2fffabe70d5b31e2");
+    expect(formatHeartbeatProtocolVersion(10)).toBe("2026-05-12.v10");
+    expect(protocol.version).toBe("2026-05-12.v10");
+    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("a589b15dfc093012");
     expect(heartbeatProtocolContentFingerprint(changed)).not.toBe(
       heartbeatProtocolContentFingerprint(protocol),
     );

--- a/packages/mcp-server/src/heartbeat-protocol.ts
+++ b/packages/mcp-server/src/heartbeat-protocol.ts
@@ -22,8 +22,8 @@ export type HeartbeatProtocol = {
   watch_state_key: string;
 };
 
-export const HEARTBEAT_PROTOCOL_DATE = "2026-05-07";
-export const HEARTBEAT_PROTOCOL_REVISION = 9;
+export const HEARTBEAT_PROTOCOL_DATE = "2026-05-12";
+export const HEARTBEAT_PROTOCOL_REVISION = 10;
 
 export function formatHeartbeatProtocolVersion(revision: number): string {
   return `${HEARTBEAT_PROTOCOL_DATE}.v${revision}`;
@@ -36,7 +36,7 @@ const HEARTBEAT_PROTOCOL: HeartbeatProtocol = {
     "This heartbeat is explicitly authorized to write Orchestrator continuity receipts for the wake and the final PASS/BLOCKER result.",
     "Use stable session_id='unclick-heartbeat-seat' for every scheduled heartbeat run so Orchestrator can thread receipts across isolated scheduler sessions.",
     "Call UnClick check_signals first, then always do a compact job hunt before declaring health: read_orchestrator_context if available, list_actionable_todos, list_todos for open or in_progress work, recent dispatches, and recent Boardroom messages. Cap to the most recent items UnClick returns.",
-    "Treat '0 active jobs' as PASS only when the job hunt also finds 0 actionable todos, 0 open or in_progress todos, and 0 unhandled dispatch or Boardroom work. If any backlog exists while active jobs are 0, this is BLOCKER: queue hydration failure.",
+    "Pinned v9 definition: active_jobs = COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h). Orchestrator current_state_card.active_jobs uses the same query, so PASS/BLOCKER does not oscillate on identical state. Treat '0 active jobs' as PASS only when actionable_todos is also 0 (or every backlog item is explicitly held with a stated reason in the last 24h). If active_jobs is 0 while unheld actionable backlog exists, this is BLOCKER: queue hydration failure.",
     "Use PinballWake JobHunt Mirror as the fallback path for that failure: mirror compact backlog counts and source pointers into NudgeOnly first, then IgniteOnly only after verifier-backed receipt_bridge output requests a worker wake, then PushOnly only after IgniteOnly emits a verified public wake packet. Target the existing Job Worker as executor when it is registered; free API classifiers may only classify or nudge. The mirror may request a wake and PushOnly may emit a worker push envelope, but both must not create duplicate jobs, assign ownership, mark done, merge, close, or edit source state.",
     "After check_signals, call save_conversation_turn with session_id='unclick-heartbeat-seat', role='assistant', and content containing the safe alert lines plus a brief progress summary and proof id if available.",
     "When UnClick returns action_needed, blocker, stale ACK, missing proof, duplicate wake, unclear owner, or queue hydration failure items, call nudgeonly_receipt_bridge if available using compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, and ttl_minutes.",


### PR DESCRIPTION
Closes UnClick todo a4cd5229 (closure stack item 4 / "stop heartbeat from lying").

## Pinned definition

```
active_jobs = COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h)
```

The same query is now used in two places that must agree:

1. **`api/lib/orchestrator-context.ts`** — new exported `computeActiveJobsCount(todos, profiles, nowMs)` helper, called from `buildOrchestratorContext`. The result is exposed as `current_state_card.active_jobs`. The state_card summary line is now derived from the strict count, not the broader `activeTodos.length` (open + in_progress, sliced to 8) it used before.

2. **`packages/mcp-server/src/heartbeat-protocol.ts`** — Step 5 (`procedure[4]`) replaced with a precise statement of the same formula. Heartbeat must use this count when deciding PASS vs BLOCKER. Bumped `HEARTBEAT_PROTOCOL_DATE` to `2026-05-12` and `HEARTBEAT_PROTOCOL_REVISION` to `10`; new fingerprint `a589b15dfc093012`.

Because both surfaces now answer the same question with the same arithmetic, PASS/BLOCKER cannot oscillate on identical state.

## What this fixes

The bug that fooled the heartbeat earlier today:
- todo `e9e308cd` was assigned to `master`, whose `owner_last_seen_at` was 6 days ago
- Old `active_todo_count` counted this as 1 active job
- Heartbeat saw "1 active job" + "0 actionable_todos" and reported PASS, even though the work was actually stalled
- After this PR: `active_jobs` correctly reads 0 because master's owner-freshness is stale, and the heartbeat correctly reports BLOCKER pointing at the dormant ownership

## Window choice (24h vs 30min)

Two distinct freshness windows now live in the file:
- `ACTIVE_WINDOW_MS = 30 * 60 * 1000` — for "Live" seat label in the profile cards (UI freshness)
- `OWNER_FRESH_WINDOW_MS = 24 * 60 * 60 * 1000` — for the v9 active_jobs gate (work-ownership freshness)

A seat that checked in 2 hours ago will still own an active job, even though the UI shows "Recent" rather than "Live." That matches operator intent: ownership lasts longer than the UI's heartbeat indicator.

## Test plan

### orchestrator-context.test.ts (11 tests pass locally)

- Original 5 tests untouched.
- 1 new assertion in the existing "builds read-first cross-seat state" test: `active_jobs === 1`.
- New `describe("computeActiveJobsCount (v9 definition)")` block with 7 focused tests covering every branch (fresh owner counted, dormant owner excluded, open todos excluded, unowned todos excluded, ghost-owner excluded, idempotency, state_card === helper agreement).

Run:
```
npx vitest run api/orchestrator-context.test.ts
```

Result: `Test Files 1 passed (1), Tests 11 passed (11)`.

### heartbeat-protocol.test.ts (4 tests pass locally)

- Pinned `procedure[4]` now asserts the three new key phrases (`status='in_progress'`, `owner_last_seen <= 24h`, `current_state_card.active_jobs`).
- Version assertion updated to `2026-05-12.v10`.
- Fingerprint assertion updated to `a589b15dfc093012`.

Run:
```
npx vitest run packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
```

Result: `Test Files 1 passed (1), Tests 4 passed (4)`.

## Non-overlap

- No mutation surface added. `computeActiveJobsCount` is pure: same input always yields same output.
- `active_todo_count` is preserved exactly so the rolling snapshot's active_jobs list (different concept, used by the UI) keeps working unchanged.
- No NudgeOnly / IgniteOnly / PushOnly authority touched.
- No schema change.
- No production state changes; this is read-side accounting.

## Source

GROUP BROADCAST cycle 5 closure stack + ASSIGN cycle to cowork-bailey-builder. Closes #715 item 4.