### PR TITLE
fix(orchestrator): ignore heartbeat blocker self-noise

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -309,11 +309,13 @@ export function isHeartbeatAutomationText(input: unknown): boolean {
   const text = redactSensitive(input).replace(/\s+/g, " ").trim();
   const lower = text.toLowerCase();
   if (!lower) return false;
+  if (lower.startsWith("heartbeat proof")) return true;
   if (/<heartbeat\b|<\/heartbeat>/.test(lower)) return true;
   if (lower.includes("automation_id") && lower.includes("unclick-heartbeat")) return true;
   if (lower.includes("current_time_iso") && lower.includes("instructions") && lower.includes("heartbeat")) return true;
   if (lower.startsWith("run unclick heartbeat.")) return true;
   if (lower.startsWith("load unclick seats > heartbeat")) return true;
+  if (/^(pass|blocker):\s*heartbeat\b/i.test(text)) return true;
   if (/^pass:\s*.+;\s*proof:\s*.+;\s*cleanup:\s*/i.test(text)) return true;
   if (/^blocker:\s*.+;\s*next:\s*/i.test(text)) return true;
   if (lower.startsWith("dont_notify:") || lower.startsWith("notify:")) return true;
@@ -958,6 +960,9 @@ function sessionToSnapshot(row: OrchestratorSessionRow): OrchestratorLibrarySnap
 function classify(tags: string[], text: string): OrchestratorContinuityEvent["kind"] {
   const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
   const lower = text.toLowerCase();
+  if (lower.startsWith("heartbeat proof")) return "proof";
+  if (lower.startsWith("pass: heartbeat")) return "proof";
+  if (lower.startsWith("blocker: heartbeat")) return "status";
   if (tagSet.has("blocker") || lower.startsWith("blocker:") || lower.includes(" blocked") || lower.includes(" blocker")) return "blocker";
   if (tagSet.has("proof") || lower.startsWith("pass:") || lower.includes("proof:") || lower.includes(" pr #")) return "proof";
   if (tagSet.has("handoff") || lower.includes("handoff") || lower.includes("assigned to")) return "handoff";

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -401,6 +401,52 @@ describe("orchestrator context", () => {
     expect(context.rolling_snapshot.source_pointers.some((pointer) => pointer.source_id === "turn-heartbeat")).toBe(false);
   });
 
+  it("does not promote heartbeat status summaries that mention blockers", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-12T11:45:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [
+        {
+          id: "comment-heartbeat-proof",
+          target_kind: "todo",
+          target_id: "todo-active-state",
+          author_agent_id: "chatgpt-codex-heartbeat-seat",
+          text: "Heartbeat proof 2026-05-12T11:43Z: active_jobs=6. Remaining blocker noise is stale history, not the active_jobs formula.",
+          created_at: "2026-05-12T11:43:00.000Z",
+        },
+      ],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [
+        {
+          id: "turn-heartbeat-pass",
+          session_id: "unclick-heartbeat",
+          role: "assistant",
+          content: "PASS: Heartbeat completed one safe useful step. Remaining blocker noise is stale history.",
+          created_at: "2026-05-12T11:44:00.000Z",
+        },
+        {
+          id: "turn-heartbeat-blocker",
+          session_id: "unclick-heartbeat",
+          role: "assistant",
+          content: "BLOCKER: Heartbeat verified unchanged state, progress checked, next native cleanup.",
+          created_at: "2026-05-12T11:42:00.000Z",
+        },
+      ],
+    });
+
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.continuity_events.find((event) => event.source_id === "comment-heartbeat-proof")?.kind).toBe("proof");
+    expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-pass")?.kind).toBe("proof");
+    expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-blocker")?.kind).toBe("status");
+  });
+
   it("keeps fresh-seat active_decision populated from active work when no decision event is live", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-10T04:16:00.000Z",


### PR DESCRIPTION
## Summary
- classify heartbeat proof/status summaries before generic blocker keyword matching
- prevent heartbeat PASS/BLOCKER/proof records that mention blocker counts from becoming live blockers
- add regression coverage for heartbeat status summaries that mention blockers

## Tests
- npx vitest run api/orchestrator-context.test.ts

## Notes
- no new schedules created; this keeps the single unclick-heartbeat tether model