### PR TITLE
fix(orchestrator): keep status chatter out of blockers

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -309,7 +309,7 @@ export function isHeartbeatAutomationText(input: unknown): boolean {
   const text = redactSensitive(input).replace(/\s+/g, " ").trim();
   const lower = text.toLowerCase();
   if (!lower) return false;
-  if (lower.startsWith("heartbeat proof")) return true;
+  if (/^heartbeat\b.*\bproof\b/.test(lower)) return true;
   if (/<heartbeat\b|<\/heartbeat>/.test(lower)) return true;
   if (lower.includes("automation_id") && lower.includes("unclick-heartbeat")) return true;
   if (lower.includes("current_time_iso") && lower.includes("instructions") && lower.includes("heartbeat")) return true;
@@ -854,7 +854,7 @@ function signalToEvent(signal: OrchestratorSignalRow): OrchestratorContinuityEve
     source_id: signal.id,
     deep_link: signal.deep_link ?? null,
     created_at: signal.created_at,
-    kind: signal.severity === "critical" || signal.severity === "action_needed" ? "blocker" : classify([signal.action], signal.summary),
+    kind: signal.severity === "critical" || signal.severity === "action_needed" ? "blocker" : classify([signal.action, signal.severity], signal.summary),
     summary: compactText(`${signal.tool} ${signal.action}: ${signal.summary}`, 240),
     tags: ["signal", signal.tool, signal.action, signal.severity],
   };
@@ -960,9 +960,11 @@ function sessionToSnapshot(row: OrchestratorSessionRow): OrchestratorLibrarySnap
 function classify(tags: string[], text: string): OrchestratorContinuityEvent["kind"] {
   const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
   const lower = text.toLowerCase();
-  if (lower.startsWith("heartbeat proof")) return "proof";
+  if (/^heartbeat\b.*\bproof\b/.test(lower)) return "proof";
   if (lower.startsWith("pass: heartbeat")) return "proof";
   if (lower.startsWith("blocker: heartbeat")) return "status";
+  if (tagSet.has("info")) return "status";
+  if ((tagSet.has("done") || tagSet.has("fyi")) && !lower.startsWith("blocker:")) return "status";
   if (tagSet.has("blocker") || lower.startsWith("blocker:") || lower.includes(" blocked") || lower.includes(" blocker")) return "blocker";
   if (tagSet.has("proof") || lower.startsWith("pass:") || lower.includes("proof:") || lower.includes(" pr #")) return "proof";
   if (tagSet.has("handoff") || lower.includes("handoff") || lower.includes("assigned to")) return "handoff";

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -447,6 +447,55 @@ describe("orchestrator context", () => {
     expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-blocker")?.kind).toBe("status");
   });
 
+  it("does not promote done/fyi and info status chatter that mentions blocker cleanup", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-12T12:10:00.000Z",
+      profiles: [],
+      messages: [
+        {
+          id: "msg-pr-merged",
+          author_agent_id: "chatgpt-codex-heartbeat-seat",
+          text: "PR #736 is merged. It fixes Orchestrator heartbeat self-noise so heartbeat PASS/BLOCKER/proof text should stop inflating live blocker counts.",
+          tags: ["done", "fyi"],
+          created_at: "2026-05-12T12:02:00.000Z",
+        },
+      ],
+      todos: [],
+      comments: [
+        {
+          id: "comment-heartbeat-post-merge-proof",
+          target_kind: "todo",
+          target_id: "todo-dead-seat",
+          author_agent_id: "chatgpt-codex-heartbeat-seat",
+          text: "Heartbeat post-merge proof 2026-05-12T12:06Z: PR #736 is merged. Live Orchestrator still reports blocker_count=5.",
+          created_at: "2026-05-12T12:06:00.000Z",
+        },
+      ],
+      dispatches: [],
+      signals: [
+        {
+          id: "signal-message-posted",
+          tool: "fishbowl",
+          action: "message_posted",
+          severity: "info",
+          summary: "PR #736 opened for the Orchestrator heartbeat blocker self-noise fix.",
+          deep_link: "/admin/boardroom#msg-736",
+          created_at: "2026-05-12T11:56:00.000Z",
+        },
+      ],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.continuity_events.find((event) => event.source_id === "msg-pr-merged")?.kind).toBe("status");
+    expect(context.continuity_events.find((event) => event.source_id === "comment-heartbeat-post-merge-proof")?.kind).toBe("proof");
+    expect(context.continuity_events.find((event) => event.source_id === "signal-message-posted")?.kind).toBe("status");
+  });
+
   it("keeps fresh-seat active_decision populated from active work when no decision event is live", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-10T04:16:00.000Z",


### PR DESCRIPTION
## Summary
- treat heartbeat post-merge proof as proof instead of a live blocker
- keep done/fyi Boardroom status messages out of active blockers unless they explicitly start with BLOCKER
- include info signal severity in classification so message_posted info signals stay status

## Tests
- npx vitest run api/orchestrator-context.test.ts

## Notes
- follows up PR #736 after live context showed PR status chatter still mentioning blocker wording
- no new schedules created