### PR TITLE
fix(orchestrator): ignore zero blocker metric chatter

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -965,13 +965,18 @@ function classify(tags: string[], text: string): OrchestratorContinuityEvent["ki
   if (lower.startsWith("blocker: heartbeat")) return "status";
   if (tagSet.has("info")) return "status";
   if ((tagSet.has("done") || tagSet.has("fyi")) && !lower.startsWith("blocker:")) return "status";
-  if (tagSet.has("blocker") || lower.startsWith("blocker:") || lower.includes(" blocked") || lower.includes(" blocker")) return "blocker";
   if (tagSet.has("proof") || lower.startsWith("pass:") || lower.includes("proof:") || lower.includes(" pr #")) return "proof";
+  if (isZeroBlockerMetricStatus(lower)) return "status";
+  if (tagSet.has("blocker") || lower.startsWith("blocker:") || /\bblocked\b/.test(lower) || /\bblocker\b/.test(lower)) return "blocker";
   if (tagSet.has("handoff") || lower.includes("handoff") || lower.includes("assigned to")) return "handoff";
   if (tagSet.has("ack") || lower.startsWith("ack ") || lower.includes(" ack ")) return "ack";
   if (lower.includes("claimed") || lower.includes("claiming") || lower.includes("in_progress")) return "claim";
   if (tagSet.has("decision") || lower.includes("decided") || lower.includes("greenlit")) return "decision";
   return "status";
+}
+
+function isZeroBlockerMetricStatus(lower: string): boolean {
+  return /\bblocker_count\s*[=:]\s*0\b/.test(lower) || /\b0\s+blocker signals?\b/.test(lower);
 }
 
 function normalizeTags(tags?: string[] | null): string[] {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -496,6 +496,43 @@ describe("orchestrator context", () => {
     expect(context.continuity_events.find((event) => event.source_id === "signal-message-posted")?.kind).toBe("status");
   });
 
+  it("does not promote zero blocker metric chatter as a live blocker", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-12T12:35:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [
+        {
+          id: "turn-zero-metric-pass",
+          session_id: "unclick-heartbeat",
+          role: "assistant",
+          content:
+            "PASS: Verified Orchestrator after PR #737. Current state card now reports active_jobs=0, active_todo_count=0, blocker_count=0.",
+          created_at: "2026-05-12T12:21:46.000Z",
+        },
+        {
+          id: "turn-zero-metric-summary",
+          session_id: "unclick-heartbeat",
+          role: "assistant",
+          content: "Current state card summary: 0 active jobs, 1 active seat, 0 blocker signals.",
+          created_at: "2026-05-12T12:22:46.000Z",
+        },
+      ],
+    });
+
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.continuity_events.find((event) => event.source_id === "turn-zero-metric-pass")?.kind).toBe("proof");
+    expect(context.continuity_events.find((event) => event.source_id === "turn-zero-metric-summary")?.kind).toBe("status");
+  });
+
   it("keeps fresh-seat active_decision populated from active work when no decision event is live", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-10T04:16:00.000Z",


### PR DESCRIPTION
## Summary
- keep PASS lines with blocker_count=0 classified as proof before blocker keyword matching
- classify zero blocker metric summaries as status, not active alerts
- add a regression for heartbeat zero-metric chatter

## Tests
- npx vitest run api/orchestrator-context.test.ts

No new schedules created.