### PR TITLE
fix(orchestrator): ignore heartbeat protocol chatter

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -315,6 +315,10 @@ export function isHeartbeatAutomationText(input: unknown): boolean {
   if (lower.includes("current_time_iso") && lower.includes("instructions") && lower.includes("heartbeat")) return true;
   if (lower.startsWith("run unclick heartbeat.")) return true;
   if (lower.startsWith("load unclick seats > heartbeat")) return true;
+  if (lower.startsWith("heartbeat schedule request:") || lower.includes("run embedded unclick heartbeat instructions")) return true;
+  if (lower.startsWith("unclick heartbeat pass") || lower.startsWith("unclick healthy. pass")) return true;
+  if (lower.includes("heartbeat_protocol=")) return true;
+  if (lower.startsWith("unclick heartbeat ") && lower.includes("check_signals=")) return true;
   if (/^(pass|blocker):\s*heartbeat\b/i.test(text)) return true;
   if (/^pass:\s*.+;\s*proof:\s*.+;\s*cleanup:\s*/i.test(text)) return true;
   if (/^blocker:\s*.+;\s*next:\s*/i.test(text)) return true;
@@ -960,6 +964,7 @@ function sessionToSnapshot(row: OrchestratorSessionRow): OrchestratorLibrarySnap
 function classify(tags: string[], text: string): OrchestratorContinuityEvent["kind"] {
   const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
   const lower = text.toLowerCase();
+  if (isHeartbeatAutomationText(text)) return classifyHeartbeatAutomationText(lower);
   if (/^heartbeat\b.*\bproof\b/.test(lower)) return "proof";
   if (lower.startsWith("pass: heartbeat")) return "proof";
   if (lower.startsWith("blocker: heartbeat")) return "status";
@@ -972,6 +977,14 @@ function classify(tags: string[], text: string): OrchestratorContinuityEvent["ki
   if (tagSet.has("ack") || lower.startsWith("ack ") || lower.includes(" ack ")) return "ack";
   if (lower.includes("claimed") || lower.includes("claiming") || lower.includes("in_progress")) return "claim";
   if (tagSet.has("decision") || lower.includes("decided") || lower.includes("greenlit")) return "decision";
+  return "status";
+}
+
+function classifyHeartbeatAutomationText(lower: string): OrchestratorContinuityEvent["kind"] {
+  if (/^heartbeat\b.*\bproof\b/.test(lower)) return "proof";
+  if (lower.startsWith("pass: heartbeat")) return "proof";
+  if (lower.startsWith("pass:")) return "proof";
+  if (lower.startsWith("unclick heartbeat pass") || lower.startsWith("unclick healthy. pass")) return "proof";
   return "status";
 }
 

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -533,6 +533,53 @@ describe("orchestrator context", () => {
     expect(context.continuity_events.find((event) => event.source_id === "turn-zero-metric-summary")?.kind).toBe("status");
   });
 
+  it("does not promote heartbeat schedule and protocol chatter as live blockers", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-12T12:45:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [
+        {
+          id: "turn-heartbeat-request",
+          session_id: "unclick-heartbeat",
+          role: "user",
+          content:
+            '<heartbeat><automation_id>unclick-heartbeat</automation_id><instructions>Run UnClick Heartbeat and reply with PASS/BLOCKER plus progress.</instructions></heartbeat>',
+          created_at: "2026-05-12T12:41:56.000Z",
+        },
+        {
+          id: "turn-heartbeat-protocol-pass",
+          session_id: "unclick-heartbeat-seat",
+          role: "assistant",
+          content:
+            "UnClick healthy. PASS. heartbeat_protocol=v10. check_signals=2 info-only; no action_needed/blocker signals.",
+          created_at: "2026-05-12T12:42:56.000Z",
+        },
+        {
+          id: "turn-heartbeat-pass-at",
+          session_id: "unclick-heartbeat-seat",
+          role: "assistant",
+          content:
+            "UnClick Heartbeat PASS @ 2026-05-12T12:31Z. check_signals=1 info-only; list_todos in_progress=9 unchanged.",
+          created_at: "2026-05-12T12:43:56.000Z",
+        },
+      ],
+    });
+
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-request")?.kind).toBe("status");
+    expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-protocol-pass")?.kind).toBe("proof");
+    expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-pass-at")?.kind).toBe("proof");
+  });
+
   it("keeps fresh-seat active_decision populated from active work when no decision event is live", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-10T04:16:00.000Z",


### PR DESCRIPTION
## Summary
- classify heartbeat schedule request text as status instead of live alert noise
- recognize heartbeat protocol PASS chatter as proof/status before keyword matching
- add regression coverage for heartbeat schedule and protocol text containing PASS/BLOCKER language

## Tests
- npx vitest run api/orchestrator-context.test.ts

No new schedules created.