### PR TITLE
commonsensepass: baseline package + R1-R5 verdict gate

### DIFF
--- a/api/commonsensepass-bridge.test.ts
+++ b/api/commonsensepass-bridge.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  inspectOrchestratorActiveState,
+  toTodoSnapshots,
+} from "./lib/commonsensepass-bridge.js";
+
+const NOW = Date.parse("2026-05-12T22:00:00Z");
+const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
+const twoDaysAgo = new Date(NOW - 2 * 24 * 60 * 60 * 1000).toISOString();
+
+describe("commonsensepass-bridge / toTodoSnapshots", () => {
+  it("maps orchestrator status open -> actionable", () => {
+    const snaps = toTodoSnapshots(
+      [{ id: "t1", status: "open" }],
+      [],
+    );
+    expect(snaps[0].status).toBe("actionable");
+  });
+
+  it("preserves in_progress and derives owner_last_seen_ms from profile", () => {
+    const snaps = toTodoSnapshots(
+      [
+        {
+          id: "t2",
+          status: "in_progress",
+          assigned_to_agent_id: "worker-a",
+        },
+      ],
+      [
+        {
+          agent_id: "worker-a",
+          last_seen_at: oneHourAgo,
+        },
+      ],
+    );
+    expect(snaps[0].status).toBe("in_progress");
+    expect(snaps[0].owner).toBe("worker-a");
+    expect(snaps[0].owner_last_seen_ms).toBe(Date.parse(oneHourAgo));
+  });
+
+  it("falls back to profile created_at if last_seen_at missing", () => {
+    const snaps = toTodoSnapshots(
+      [{ id: "t3", status: "in_progress", assigned_to_agent_id: "w" }],
+      [{ agent_id: "w", created_at: oneHourAgo }],
+    );
+    expect(snaps[0].owner_last_seen_ms).toBe(Date.parse(oneHourAgo));
+  });
+
+  it("treats dropped as done (off the queue)", () => {
+    const snaps = toTodoSnapshots(
+      [{ id: "t4", status: "dropped" }],
+      [],
+    );
+    expect(snaps[0].status).toBe("done");
+  });
+});
+
+describe("commonsensepass-bridge / inspectOrchestratorActiveState", () => {
+  it("BLOCKER when orchestrator has open todos but worker claims healthy", () => {
+    const verdict = inspectOrchestratorActiveState({
+      todos: [
+        { id: "t1", status: "open", assigned_to_agent_id: null },
+        { id: "t2", status: "open", assigned_to_agent_id: null },
+      ],
+      profiles: [],
+      active_jobs: 0,
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("BLOCKER");
+    expect(verdict.rule_id).toBe("R1");
+    expect(verdict.next_action).toBe("hydrate_queue_and_claim_one");
+  });
+
+  it("BLOCKER when active_jobs=0 but in_progress todo has a fresh owner", () => {
+    const verdict = inspectOrchestratorActiveState({
+      todos: [
+        {
+          id: "t10",
+          status: "in_progress",
+          assigned_to_agent_id: "worker-a",
+        },
+      ],
+      profiles: [
+        { agent_id: "worker-a", last_seen_at: oneHourAgo },
+      ],
+      active_jobs: 0,
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("BLOCKER");
+    expect(verdict.rule_id).toBe("R1");
+    expect(verdict.next_action).toBe("recompute_active_jobs_with_pinned_formula");
+  });
+
+  it("PASS when in_progress owner is stale (older than 24h)", () => {
+    const verdict = inspectOrchestratorActiveState({
+      todos: [
+        {
+          id: "t11",
+          status: "in_progress",
+          assigned_to_agent_id: "worker-b",
+        },
+      ],
+      profiles: [
+        { agent_id: "worker-b", last_seen_at: twoDaysAgo },
+      ],
+      active_jobs: 0,
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("PASS");
+    expect(verdict.rule_id).toBe("R1");
+  });
+
+  it("PASS when active_jobs matches fresh-owner in_progress count", () => {
+    const verdict = inspectOrchestratorActiveState({
+      todos: [
+        {
+          id: "t12",
+          status: "in_progress",
+          assigned_to_agent_id: "worker-c",
+        },
+      ],
+      profiles: [
+        { agent_id: "worker-c", last_seen_at: oneHourAgo },
+      ],
+      active_jobs: 1,
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("PASS");
+    expect(verdict.rule_id).toBe("R1");
+  });
+
+  it("PASS when queue is empty and active_jobs=0", () => {
+    const verdict = inspectOrchestratorActiveState({
+      todos: [],
+      profiles: [],
+      active_jobs: 0,
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("PASS");
+    expect(verdict.rule_id).toBe("R1");
+  });
+
+  it("uses default claim 'healthy' when claim is not provided", () => {
+    const verdict = inspectOrchestratorActiveState({
+      todos: [{ id: "t20", status: "open" }],
+      profiles: [],
+      active_jobs: 0,
+      now_ms: NOW,
+    });
+    // Default claim ('healthy') still triggers R1 BLOCKER on actionable queue
+    expect(verdict.verdict).toBe("BLOCKER");
+  });
+
+  it("works with 'quiet' or 'no_work' claim variants", () => {
+    for (const claim of ["quiet", "no_work"] as const) {
+      const verdict = inspectOrchestratorActiveState({
+        claim,
+        todos: [{ id: `t-${claim}`, status: "open" }],
+        profiles: [],
+        active_jobs: 0,
+        now_ms: NOW,
+      });
+      expect(verdict.verdict).toBe("BLOCKER");
+      expect(verdict.rule_id).toBe("R1");
+    }
+  });
+});

--- a/api/lib/commonsensepass-bridge.ts
+++ b/api/lib/commonsensepass-bridge.ts
@@ -1,0 +1,130 @@
+// Bridge between orchestrator-context.ts shaped data and the CommonSensePass
+// verdict-only gate. Workers that already have access to todos + profiles
+// (the orchestrator-context builder, the heartbeat seat, the watcher) can
+// call `inspectOrchestratorActiveState` before emitting a healthy/quiet/
+// no_work claim. The bridge does NOT mutate or publish anything; it returns
+// the verdict and the caller decides what to do.
+//
+// This is the first worker-facing adoption surface for @unclick/commonsensepass.
+
+import {
+  commonsensepassCheck,
+  type ClaimContext,
+  type ClaimKind,
+  type CommonSensePassResult,
+  type TodoSnapshot,
+  type TodoStatus,
+} from "../../packages/commonsensepass/src/index.js";
+
+export interface OrchestratorTodoShape {
+  id: string;
+  status: string;
+  assigned_to_agent_id?: string | null;
+}
+
+export interface OrchestratorProfileShape {
+  agent_id: string;
+  last_seen_at?: string | null;
+  created_at?: string | null;
+}
+
+export interface InspectActiveStateInput {
+  /** The claim the worker is about to make. Defaults to "healthy". */
+  claim?: Extract<ClaimKind, "healthy" | "quiet" | "no_work">;
+  /** Orchestrator-shaped todos. */
+  todos: OrchestratorTodoShape[];
+  /** Orchestrator-shaped profiles, used to derive owner_last_seen_ms. */
+  profiles: OrchestratorProfileShape[];
+  /** Active_jobs count the worker is about to claim (the v9 formula output). */
+  active_jobs: number;
+  /** Current timestamp in ms; defaults to Date.now() if absent. */
+  now_ms?: number;
+}
+
+const VALID_TODO_STATUSES: TodoStatus[] = [
+  "actionable",
+  "in_progress",
+  "blocked",
+  "queued",
+  "done",
+];
+
+/**
+ * Map orchestrator status strings (open, in_progress, done, dropped, ...) to
+ * the smaller status set used by CommonSensePass:
+ *   - "open"        -> "actionable" (worker can claim it)
+ *   - "in_progress" -> "in_progress"
+ *   - "blocked"     -> "blocked"
+ *   - "done"        -> "done"
+ *   - "dropped"     -> "done" (treated as off the queue, not actionable)
+ *   - anything else -> "queued"
+ */
+function mapStatus(orchestratorStatus: string): TodoStatus {
+  if (orchestratorStatus === "open") return "actionable";
+  if (orchestratorStatus === "dropped") return "done";
+  if ((VALID_TODO_STATUSES as string[]).includes(orchestratorStatus)) {
+    return orchestratorStatus as TodoStatus;
+  }
+  return "queued";
+}
+
+/**
+ * Build a TodoSnapshot[] from orchestrator-shaped rows and a profiles map,
+ * deriving owner_last_seen_ms from the profile's last_seen_at (or created_at
+ * as a conservative fallback).
+ */
+export function toTodoSnapshots(
+  todos: OrchestratorTodoShape[],
+  profiles: OrchestratorProfileShape[],
+): TodoSnapshot[] {
+  const ownerSeen = new Map<string, number | undefined>();
+  for (const profile of profiles) {
+    if (!profile.agent_id) continue;
+    const iso = profile.last_seen_at ?? profile.created_at ?? null;
+    const ms = iso ? Date.parse(iso) : NaN;
+    ownerSeen.set(profile.agent_id, Number.isFinite(ms) ? ms : undefined);
+  }
+
+  return todos.map((todo) => {
+    const ownerLastSeen =
+      todo.assigned_to_agent_id != null
+        ? ownerSeen.get(todo.assigned_to_agent_id)
+        : undefined;
+    const snapshot: TodoSnapshot = {
+      id: todo.id,
+      status: mapStatus(todo.status),
+    };
+    if (todo.assigned_to_agent_id != null) {
+      snapshot.owner = todo.assigned_to_agent_id;
+    }
+    if (typeof ownerLastSeen === "number") {
+      snapshot.owner_last_seen_ms = ownerLastSeen;
+    }
+    return snapshot;
+  });
+}
+
+/**
+ * Run R1 (active-state mismatch) against orchestrator-shaped data.
+ *
+ * The orchestrator-context builder produces a current_state_card that
+ * implicitly claims `healthy` when active_jobs and queue depth both look
+ * quiet. Workers that read that card and emit a public healthy/quiet/no_work
+ * statement should call this first.
+ *
+ * Returns the CommonSensePass verdict. PASS = safe to emit the claim;
+ * BLOCKER = stop, the active_jobs underreports or the queue has actionable
+ * work; HOLD = supply more evidence.
+ */
+export function inspectOrchestratorActiveState(
+  input: InspectActiveStateInput,
+): CommonSensePassResult {
+  const claim = input.claim ?? "healthy";
+  const todos = toTodoSnapshots(input.todos, input.profiles);
+  const context: ClaimContext = {
+    now_ms: input.now_ms ?? Date.now(),
+    todos,
+    active_jobs: input.active_jobs,
+  };
+  return commonsensepassCheck({ claim, context });
+}

--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -1,3 +1,8 @@
+import {
+  inspectOrchestratorActiveState,
+} from "./commonsensepass-bridge.js";
+import type { CommonSensePassResult } from "../../packages/commonsensepass/src/index.js";
+
 export interface OrchestratorProfileRow {
   agent_id: string;
   emoji?: string | null;
@@ -258,6 +263,14 @@ export interface OrchestratorContext {
     };
     next_actions: string[];
     blockers: string[];
+    // health_verdict (added 2026-05-12 by PR #746): CommonSensePass R1
+    // verdict computed from the same todos+profiles input used to derive
+    // active_jobs. Any seat reading the state card can use this as the
+    // authoritative answer to "is the orchestrator's implicit healthy
+    // claim supported by the evidence?" without having to recompute the
+    // rule themselves. Verdict-only - this field does not gate any
+    // downstream behavior in the builder; consumers act on it.
+    health_verdict: CommonSensePassResult;
   };
   profile_cards: OrchestratorProfileCard[];
   human_operator_time: OrchestratorOperatorTimeContext | null;
@@ -355,6 +368,20 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   // input. Computed over the full input.todos array, NOT the sliced
   // activeTodos, so the count is deterministic regardless of UI cap.
   const activeJobsCount = computeActiveJobsCount(input.todos, input.profiles, nowMs);
+
+  // CommonSensePass R1 verdict (added by PR #746). The orchestrator
+  // context publishes an implicit "healthy" / "quiet" claim whenever
+  // active_jobs and queue depth both look quiet. Run the verdict-only
+  // gate against the same data so consumers (heartbeat seat, watcher,
+  // reviewer) have an authoritative PASS / BLOCKER / HOLD signal to
+  // act on without recomputing R1 themselves. Verdict-only - this does
+  // not change any other field on the state card.
+  const healthVerdict = inspectOrchestratorActiveState({
+    todos: input.todos,
+    profiles: input.profiles,
+    active_jobs: activeJobsCount,
+    now_ms: nowMs,
+  });
 
   const messageEvents = input.messages.map(messageToEvent);
   const todoEvents = activeTodos.map(todoToEvent);
@@ -456,6 +483,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
       },
       next_actions: nextActions,
       blockers,
+      health_verdict: healthVerdict,
     },
     profile_cards: profiles,
     human_operator_time: humanOperatorTime,

--- a/api/orchestrator-context-health-verdict.test.ts
+++ b/api/orchestrator-context-health-verdict.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { buildOrchestratorContext } from "./lib/orchestrator-context.js";
+
+describe("orchestrator-context / current_state_card.health_verdict (CommonSensePass R1)", () => {
+  const NOW = "2026-05-12T12:00:00.000Z";
+  const NOW_MS = Date.parse(NOW);
+  const HOUR_MS = 60 * 60 * 1000;
+
+  it("emits a PASS verdict when the queue is empty and active_jobs is 0", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: NOW,
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+    expect(context.current_state_card.health_verdict.verdict).toBe("PASS");
+    expect(context.current_state_card.health_verdict.rule_id).toBe("R1");
+  });
+
+  it("emits a BLOCKER verdict when open todos sit in the queue", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: NOW,
+      profiles: [],
+      messages: [],
+      todos: [
+        {
+          id: "todo-actionable",
+          title: "Backlog item",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: null,
+          created_at: NOW,
+        },
+      ],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+    expect(context.current_state_card.health_verdict.verdict).toBe("BLOCKER");
+    expect(context.current_state_card.health_verdict.rule_id).toBe("R1");
+    expect(context.current_state_card.health_verdict.next_action).toBe(
+      "hydrate_queue_and_claim_one",
+    );
+    // active_jobs should also be 0 (no in_progress todos), so the BLOCKER is
+    // entirely driven by the actionable queue depth.
+    expect(context.current_state_card.active_jobs).toBe(0);
+  });
+
+  it("emits a PASS verdict when active_jobs matches a single fresh-owner in_progress todo", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: NOW,
+      profiles: [
+        {
+          agent_id: "builder-fresh",
+          last_seen_at: new Date(NOW_MS - 2 * HOUR_MS).toISOString(),
+        },
+      ],
+      messages: [],
+      todos: [
+        {
+          id: "todo-active",
+          title: "Active build",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: "builder-fresh",
+          created_at: NOW,
+        },
+      ],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+    expect(context.current_state_card.active_jobs).toBe(1);
+    expect(context.current_state_card.health_verdict.verdict).toBe("PASS");
+    expect(context.current_state_card.health_verdict.rule_id).toBe("R1");
+  });
+
+  it("verdict and active_jobs are computed from the same source so they cannot disagree", () => {
+    // A dormant-owner in_progress todo: active_jobs sees it as 0 (owner stale),
+    // and R1 sees no actionable queue AND no fresh-owner in_progress. The
+    // verdict must therefore be PASS, never BLOCKER. This is the contract
+    // pinned by PR #735: state_card and the gate read the same input.
+    const context = buildOrchestratorContext({
+      generatedAt: NOW,
+      profiles: [
+        {
+          agent_id: "builder-stale",
+          last_seen_at: new Date(NOW_MS - 6 * 24 * HOUR_MS).toISOString(),
+        },
+      ],
+      messages: [],
+      todos: [
+        {
+          id: "todo-dormant",
+          title: "Dormant build",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: "builder-stale",
+          created_at: NOW,
+        },
+      ],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+    expect(context.current_state_card.active_jobs).toBe(0);
+    expect(context.current_state_card.health_verdict.verdict).toBe("PASS");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -7843,6 +7843,10 @@
       "resolved": "packages/channel-plugin",
       "link": true
     },
+    "node_modules/@unclick/commonsensepass": {
+      "resolved": "packages/commonsensepass",
+      "link": true
+    },
     "node_modules/@unclick/copypass": {
       "resolved": "packages/copypass",
       "link": true
@@ -21053,6 +21057,29 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/commonsensepass": {
+      "name": "@unclick/commonsensepass",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/commonsensepass/node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/copypass": {

--- a/packages/commonsensepass/README.md
+++ b/packages/commonsensepass/README.md
@@ -1,0 +1,54 @@
+# @unclick/commonsensepass
+
+Rule-and-evidence sanity gate for AI/worker claims. Verdict-only: does not build, merge, close, or mutate source state. Workers call `commonsensepassCheck(input)` before claiming `healthy`, `quiet`, `no_work`, `pass`, `done`, `merge_ready`, or `duplicate_wake`, and respect the returned verdict.
+
+## Verdicts
+
+- `PASS` - claim is consistent with the evidence; safe to proceed.
+- `BLOCKER` - claim is contradicted by evidence; do not proceed. Includes a `next_action`.
+- `HOLD` - claim is missing required evidence; supply it and retry.
+- `SUPPRESS` - claim is a duplicate / no-op; drop it silently.
+- `ROUTE` - claim is valid but should be handled elsewhere (reserved; not emitted by R1-R5).
+
+## Rules (baseline)
+
+| Rule | Triggers on claim | Checks |
+| ---- | ----------------- | ------ |
+| R1   | `healthy` / `quiet` / `no_work` | Active-state mismatch: actionable queue depth > 0, or `active_jobs=0` while in-progress todos have a fresh owner (within 24h, matches the pinned formula in `orchestrator-context.ts`). |
+| R2   | `pass`            | Head SHA freshness: PASS authored on `commented_on_sha` that does not match `current_head_sha` is stale. |
+| R3   | `duplicate_wake`  | Wake suppression: same `id` and `state_fingerprint` emitted within the duplicate-wake window. |
+| R4   | `done`            | Done-without-proof: requires `pipeline === 100` AND a `closing_ref` on the subject todo. |
+| R5   | `merge_ready`     | Merge-ready-without-proof: PR must be mergeable, checks green, and have a Reviewer PASS authored on the current head SHA. |
+
+## Usage
+
+```ts
+import { commonsensepassCheck } from "@unclick/commonsensepass";
+
+const result = commonsensepassCheck({
+  claim: "healthy",
+  context: {
+    now_ms: Date.now(),
+    todos: [...],
+    active_jobs: 0,
+  },
+});
+
+if (result.verdict !== "PASS") {
+  // do not emit the heartbeat-healthy claim; act on result.next_action
+}
+```
+
+## Boundaries
+
+This package only inspects claims and returns a verdict. It does not:
+
+- Mutate todos, PRs, comments, or any external state.
+- Close todos or merge PRs.
+- Emit wakes or schedule work.
+
+Workers and orchestrators are responsible for acting on the verdict.
+
+## Related
+
+- Active-state v9 formula pinned in `api/lib/orchestrator-context.ts` (`computeActiveJobsCount`) and `packages/mcp-server/src/heartbeat-protocol.ts` step 5 (PR #735).

--- a/packages/commonsensepass/package.json
+++ b/packages/commonsensepass/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@unclick/commonsensepass",
+  "version": "0.1.0",
+  "description": "CommonSensePass - rule-and-evidence sanity gate for AI/worker claims (PASS/BLOCKER/HOLD/SUPPRESS/ROUTE). Verdict-only; does not build, merge, close, or mutate source state.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./schema": "./dist/schema.js",
+    "./rules": "./dist/rules.js",
+    "./check": "./dist/check.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/packages/commonsensepass/src/__tests__/check.test.ts
+++ b/packages/commonsensepass/src/__tests__/check.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from "vitest";
+import { commonsensepassCheck } from "../check.js";
+import {
+  ClaimInput,
+  OWNER_FRESH_WINDOW_MS,
+  DUPLICATE_WAKE_WINDOW_MS,
+} from "../schema.js";
+
+const NOW = 1_750_000_000_000;
+
+function ctx(overrides: Partial<ClaimInput["context"]> = {}): ClaimInput["context"] {
+  return { now_ms: NOW, ...overrides };
+}
+
+describe("commonsensepassCheck - R1 active-state mismatch", () => {
+  it("BLOCKER when claiming healthy with actionable todos in the queue", () => {
+    const result = commonsensepassCheck({
+      claim: "healthy",
+      context: ctx({
+        todos: [
+          { id: "t1", status: "actionable" },
+          { id: "t2", status: "actionable" },
+        ],
+        active_jobs: 0,
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R1");
+    expect(result.next_action).toBe("hydrate_queue_and_claim_one");
+    expect(result.evidence.map((e) => e.ref)).toContain("t1");
+  });
+
+  it("BLOCKER when active_jobs=0 but in-progress todos have fresh owners", () => {
+    const result = commonsensepassCheck({
+      claim: "quiet",
+      context: ctx({
+        todos: [
+          {
+            id: "t3",
+            status: "in_progress",
+            owner_last_seen_ms: NOW - 60_000,
+          },
+        ],
+        active_jobs: 0,
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R1");
+    expect(result.next_action).toBe("recompute_active_jobs_with_pinned_formula");
+  });
+
+  it("PASS when in-progress owner is stale (beyond 24h window)", () => {
+    const result = commonsensepassCheck({
+      claim: "quiet",
+      context: ctx({
+        todos: [
+          {
+            id: "t4",
+            status: "in_progress",
+            owner_last_seen_ms: NOW - OWNER_FRESH_WINDOW_MS - 1,
+          },
+        ],
+        active_jobs: 0,
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.rule_id).toBe("R1");
+  });
+
+  it("PASS when no actionable todos and active_jobs matches in-progress count", () => {
+    const result = commonsensepassCheck({
+      claim: "no_work",
+      context: ctx({
+        todos: [
+          { id: "t5", status: "in_progress", owner_last_seen_ms: NOW - 1000 },
+        ],
+        active_jobs: 1,
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.rule_id).toBe("R1");
+  });
+});
+
+describe("commonsensepassCheck - R2 head SHA freshness", () => {
+  it("BLOCKER when PASS authored on stale SHA", () => {
+    const result = commonsensepassCheck({
+      claim: "pass",
+      context: ctx({
+        current_head_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        commented_on_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R2");
+    expect(result.next_action).toBe("re_review_on_current_head");
+  });
+
+  it("PASS when commented_on_sha matches current_head_sha", () => {
+    const sha = "cccccccccccccccccccccccccccccccccccccccc";
+    const result = commonsensepassCheck({
+      claim: "pass",
+      context: ctx({
+        current_head_sha: sha,
+        commented_on_sha: sha,
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.rule_id).toBe("R2");
+  });
+
+  it("HOLD when SHAs are missing", () => {
+    const result = commonsensepassCheck({
+      claim: "pass",
+      context: ctx({}),
+    });
+    expect(result.verdict).toBe("HOLD");
+    expect(result.rule_id).toBe("R2");
+  });
+});
+
+describe("commonsensepassCheck - R3 duplicate wake suppression", () => {
+  it("SUPPRESS when same id+fingerprint emitted within window", () => {
+    const result = commonsensepassCheck({
+      claim: "duplicate_wake",
+      context: ctx({
+        current_wake: {
+          id: "wake-123",
+          state_fingerprint: "fp-A",
+          emitted_ms: NOW,
+        },
+        recent_wakes: [
+          {
+            id: "wake-123",
+            state_fingerprint: "fp-A",
+            emitted_ms: NOW - 60_000,
+          },
+        ],
+      }),
+    });
+    expect(result.verdict).toBe("SUPPRESS");
+    expect(result.rule_id).toBe("R3");
+  });
+
+  it("PASS when fingerprint differs", () => {
+    const result = commonsensepassCheck({
+      claim: "duplicate_wake",
+      context: ctx({
+        current_wake: {
+          id: "wake-123",
+          state_fingerprint: "fp-B",
+          emitted_ms: NOW,
+        },
+        recent_wakes: [
+          {
+            id: "wake-123",
+            state_fingerprint: "fp-A",
+            emitted_ms: NOW - 60_000,
+          },
+        ],
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.rule_id).toBe("R3");
+  });
+
+  it("PASS when prior wake is outside the duplicate window", () => {
+    const result = commonsensepassCheck({
+      claim: "duplicate_wake",
+      context: ctx({
+        current_wake: {
+          id: "wake-123",
+          state_fingerprint: "fp-A",
+          emitted_ms: NOW,
+        },
+        recent_wakes: [
+          {
+            id: "wake-123",
+            state_fingerprint: "fp-A",
+            emitted_ms: NOW - DUPLICATE_WAKE_WINDOW_MS - 1,
+          },
+        ],
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+  });
+
+  it("HOLD when current_wake is missing", () => {
+    const result = commonsensepassCheck({
+      claim: "duplicate_wake",
+      context: ctx({}),
+    });
+    expect(result.verdict).toBe("HOLD");
+    expect(result.rule_id).toBe("R3");
+  });
+});
+
+describe("commonsensepassCheck - R4 done without proof", () => {
+  it("BLOCKER when pipeline < 100", () => {
+    const result = commonsensepassCheck({
+      claim: "done",
+      context: ctx({
+        todos: [
+          {
+            id: "t10",
+            status: "in_progress",
+            pipeline: 80,
+            closing_ref: "#999",
+          },
+        ],
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R4");
+  });
+
+  it("BLOCKER when closing_ref is missing", () => {
+    const result = commonsensepassCheck({
+      claim: "done",
+      context: ctx({
+        todos: [{ id: "t11", status: "in_progress", pipeline: 100 }],
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R4");
+  });
+
+  it("PASS when pipeline=100 and closing_ref present", () => {
+    const result = commonsensepassCheck({
+      claim: "done",
+      context: ctx({
+        todos: [
+          {
+            id: "t12",
+            status: "in_progress",
+            pipeline: 100,
+            closing_ref: "#735",
+          },
+        ],
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.rule_id).toBe("R4");
+  });
+
+  it("uses subject_todo_id when provided", () => {
+    const result = commonsensepassCheck({
+      claim: "done",
+      context: ctx({
+        subject_todo_id: "target",
+        todos: [
+          { id: "other", status: "actionable" },
+          {
+            id: "target",
+            status: "in_progress",
+            pipeline: 100,
+            closing_ref: "#1",
+          },
+        ],
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.evidence.some((e) => e.ref === "target")).toBe(true);
+  });
+});
+
+describe("commonsensepassCheck - R5 merge-ready without proof", () => {
+  const headSha = "1111111111111111111111111111111111111111";
+  const staleSha = "2222222222222222222222222222222222222222";
+
+  it("BLOCKER when PR is not mergeable", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({
+        pr: {
+          number: 100,
+          head_sha: headSha,
+          mergeable: false,
+          checks_state: "success",
+          reviewer_pass: { verdict: "PASS", sha: headSha },
+        },
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R5");
+  });
+
+  it("BLOCKER when checks are not success", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({
+        pr: {
+          number: 101,
+          head_sha: headSha,
+          mergeable: true,
+          checks_state: "failure",
+          reviewer_pass: { verdict: "PASS", sha: headSha },
+        },
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R5");
+  });
+
+  it("HOLD when reviewer PASS is missing", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({
+        pr: {
+          number: 102,
+          head_sha: headSha,
+          mergeable: true,
+          checks_state: "success",
+        },
+      }),
+    });
+    expect(result.verdict).toBe("HOLD");
+    expect(result.rule_id).toBe("R5");
+  });
+
+  it("BLOCKER when reviewer PASS is on a stale SHA", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({
+        pr: {
+          number: 103,
+          head_sha: headSha,
+          mergeable: true,
+          checks_state: "success",
+          reviewer_pass: { verdict: "PASS", sha: staleSha },
+        },
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R5");
+  });
+
+  it("PASS when mergeable, green, and reviewer PASS on head", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({
+        pr: {
+          number: 104,
+          head_sha: headSha,
+          mergeable: true,
+          checks_state: "success",
+          reviewer_pass: { verdict: "PASS", sha: headSha },
+        },
+      }),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.rule_id).toBe("R5");
+  });
+
+  it("HOLD when PR snapshot is missing", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({}),
+    });
+    expect(result.verdict).toBe("HOLD");
+    expect(result.rule_id).toBe("R5");
+  });
+});
+
+describe("commonsensepassCheck - verdict coverage", () => {
+  it("emits all five verdict types across the rule set", () => {
+    const verdicts = new Set<string>();
+
+    // PASS - healthy with empty queue, no in-progress todos
+    verdicts.add(
+      commonsensepassCheck({
+        claim: "healthy",
+        context: ctx({ todos: [], active_jobs: 0 }),
+      }).verdict,
+    );
+
+    // BLOCKER - R1 actionable
+    verdicts.add(
+      commonsensepassCheck({
+        claim: "healthy",
+        context: ctx({ todos: [{ id: "x", status: "actionable" }] }),
+      }).verdict,
+    );
+
+    // HOLD - R5 missing PR
+    verdicts.add(
+      commonsensepassCheck({ claim: "merge_ready", context: ctx({}) }).verdict,
+    );
+
+    // SUPPRESS - R3 duplicate
+    verdicts.add(
+      commonsensepassCheck({
+        claim: "duplicate_wake",
+        context: ctx({
+          current_wake: {
+            id: "w",
+            state_fingerprint: "f",
+            emitted_ms: NOW,
+          },
+          recent_wakes: [
+            { id: "w", state_fingerprint: "f", emitted_ms: NOW - 1000 },
+          ],
+        }),
+      }).verdict,
+    );
+
+    expect(verdicts.has("PASS")).toBe(true);
+    expect(verdicts.has("BLOCKER")).toBe(true);
+    expect(verdicts.has("HOLD")).toBe(true);
+    expect(verdicts.has("SUPPRESS")).toBe(true);
+  });
+
+  it("returns default PASS for an unrecognized claim wired via type-cast", () => {
+    const result = commonsensepassCheck({
+      // deliberately bypass the type to exercise the default branch
+      claim: "unknown_claim_kind" as ClaimInput["claim"],
+      context: ctx({}),
+    });
+    expect(result.verdict).toBe("PASS");
+    expect(result.rule_id).toBeNull();
+  });
+});

--- a/packages/commonsensepass/src/check.ts
+++ b/packages/commonsensepass/src/check.ts
@@ -1,0 +1,35 @@
+import { ClaimInput, CommonSensePassResult } from "./schema.js";
+import { checkR1, checkR2, checkR3, checkR4, checkR5 } from "./rules.js";
+
+type RuleFn = (input: ClaimInput) => CommonSensePassResult | null;
+
+const RULES: RuleFn[] = [checkR1, checkR2, checkR3, checkR4, checkR5];
+
+/**
+ * commonsensepassCheck - verdict-only sanity gate.
+ *
+ * Dispatches the claim through R1-R5; returns the first non-null verdict.
+ * If no rule fires, returns a default PASS so callers can plug new claim
+ * kinds in safely. Does NOT mutate source state, build, merge, or close.
+ *
+ * Verdicts:
+ *   PASS      - claim is consistent with evidence; safe to proceed.
+ *   BLOCKER   - claim is contradicted by evidence; do not proceed.
+ *   HOLD      - claim is missing required evidence; supply it and retry.
+ *   SUPPRESS  - claim is a duplicate / no-op; drop it silently.
+ *   ROUTE     - claim valid but should be handled elsewhere (reserved).
+ */
+export function commonsensepassCheck(
+  input: ClaimInput,
+): CommonSensePassResult {
+  for (const rule of RULES) {
+    const result = rule(input);
+    if (result) return result;
+  }
+  return {
+    verdict: "PASS",
+    rule_id: null,
+    reason: `Claim "${input.claim}" matched no rule; default PASS.`,
+    evidence: input.evidence ?? [],
+  };
+}

--- a/packages/commonsensepass/src/index.ts
+++ b/packages/commonsensepass/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema.js";
+export { checkR1, checkR2, checkR3, checkR4, checkR5 } from "./rules.js";
+export { commonsensepassCheck } from "./check.js";

--- a/packages/commonsensepass/src/rules.ts
+++ b/packages/commonsensepass/src/rules.ts
@@ -1,0 +1,331 @@
+import {
+  ClaimInput,
+  CommonSensePassResult,
+  TodoSnapshot,
+  OWNER_FRESH_WINDOW_MS,
+  DUPLICATE_WAKE_WINDOW_MS,
+} from "./schema.js";
+
+function pickSubject(input: ClaimInput): TodoSnapshot | undefined {
+  const todos = input.context.todos ?? [];
+  if (input.context.subject_todo_id) {
+    return todos.find((t) => t.id === input.context.subject_todo_id);
+  }
+  return todos[0];
+}
+
+/**
+ * R1 - Active-state mismatch.
+ *
+ * Fires on "healthy" / "quiet" / "no_work" claims. The active_jobs definition
+ * is pinned to:
+ *   active_jobs = COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h)
+ * BLOCKER if:
+ *   - actionable queue depth > 0 (worker is claiming no work while jobs wait), OR
+ *   - claimed active_jobs === 0 but in-progress fresh-owner todos exist.
+ */
+export function checkR1(input: ClaimInput): CommonSensePassResult | null {
+  if (
+    input.claim !== "healthy" &&
+    input.claim !== "quiet" &&
+    input.claim !== "no_work"
+  ) {
+    return null;
+  }
+  const todos = input.context.todos ?? [];
+  const now = input.context.now_ms;
+
+  const actionable = todos.filter((t) => t.status === "actionable");
+  const inProgressFresh = todos.filter(
+    (t) =>
+      t.status === "in_progress" &&
+      typeof t.owner_last_seen_ms === "number" &&
+      now - t.owner_last_seen_ms <= OWNER_FRESH_WINDOW_MS,
+  );
+
+  if (actionable.length > 0) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R1",
+      reason: `Claim "${input.claim}" but ${actionable.length} actionable todo(s) are queued.`,
+      evidence: actionable.slice(0, 5).map((t) => ({
+        kind: "todo",
+        ref: t.id,
+        note: `status=${t.status}`,
+      })),
+      next_action: "hydrate_queue_and_claim_one",
+    };
+  }
+
+  if (
+    typeof input.context.active_jobs === "number" &&
+    input.context.active_jobs === 0 &&
+    inProgressFresh.length > 0
+  ) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R1",
+      reason: `Claim "${input.claim}" with active_jobs=0 but ${inProgressFresh.length} in-progress todo(s) have a fresh owner; active_jobs is underreporting.`,
+      evidence: inProgressFresh.slice(0, 5).map((t) => ({
+        kind: "todo",
+        ref: t.id,
+        note: `in_progress, owner_last_seen_ms=${t.owner_last_seen_ms}`,
+      })),
+      next_action: "recompute_active_jobs_with_pinned_formula",
+    };
+  }
+
+  return {
+    verdict: "PASS",
+    rule_id: "R1",
+    reason: "Active-state claim consistent with queue and active_jobs.",
+    evidence: [
+      { kind: "queue", ref: `actionable=${actionable.length}` },
+      { kind: "queue", ref: `in_progress_fresh=${inProgressFresh.length}` },
+      {
+        kind: "queue",
+        ref: `active_jobs=${input.context.active_jobs ?? "absent"}`,
+      },
+    ],
+  };
+}
+
+/**
+ * R2 - Head SHA freshness.
+ *
+ * A "pass" claim authored on a SHA that no longer matches the PR head is stale.
+ */
+export function checkR2(input: ClaimInput): CommonSensePassResult | null {
+  if (input.claim !== "pass") return null;
+  const head = input.context.current_head_sha;
+  const commented = input.context.commented_on_sha;
+
+  if (!head || !commented) {
+    return {
+      verdict: "HOLD",
+      rule_id: "R2",
+      reason:
+        "PASS claim missing head_sha or commented_on_sha; cannot verify freshness.",
+      evidence: [
+        { kind: "context", ref: `current_head_sha=${head ?? "missing"}` },
+        { kind: "context", ref: `commented_on_sha=${commented ?? "missing"}` },
+      ],
+      next_action: "supply_head_and_commented_sha",
+    };
+  }
+  if (commented !== head) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R2",
+      reason: `PASS authored on ${commented.slice(0, 7)} but current head is ${head.slice(0, 7)}; PASS is stale.`,
+      evidence: [
+        { kind: "sha", ref: commented, note: "commented_on" },
+        { kind: "sha", ref: head, note: "current_head" },
+      ],
+      next_action: "re_review_on_current_head",
+    };
+  }
+  return {
+    verdict: "PASS",
+    rule_id: "R2",
+    reason: "PASS authored on current head SHA.",
+    evidence: [{ kind: "sha", ref: head, note: "head=commented" }],
+  };
+}
+
+/**
+ * R3 - Duplicate wake suppression.
+ *
+ * Same id and state_fingerprint emitted inside the duplicate-wake window
+ * adds no signal; suppress.
+ */
+export function checkR3(input: ClaimInput): CommonSensePassResult | null {
+  if (input.claim !== "duplicate_wake") return null;
+  const current = input.context.current_wake;
+  const recent = input.context.recent_wakes ?? [];
+
+  if (!current) {
+    return {
+      verdict: "HOLD",
+      rule_id: "R3",
+      reason: "duplicate_wake claim missing current_wake context.",
+      evidence: [{ kind: "context", ref: "current_wake=missing" }],
+      next_action: "include_current_wake",
+    };
+  }
+
+  const duplicate = recent.find(
+    (w) =>
+      w.id === current.id &&
+      w.state_fingerprint === current.state_fingerprint &&
+      input.context.now_ms - w.emitted_ms <= DUPLICATE_WAKE_WINDOW_MS,
+  );
+
+  if (duplicate) {
+    const minutes = Math.round(DUPLICATE_WAKE_WINDOW_MS / 60000);
+    return {
+      verdict: "SUPPRESS",
+      rule_id: "R3",
+      reason: `Wake ${current.id} already emitted within ${minutes}min with matching state fingerprint.`,
+      evidence: [
+        {
+          kind: "wake",
+          ref: duplicate.id,
+          note: `prior emitted_ms=${duplicate.emitted_ms}`,
+        },
+        {
+          kind: "wake",
+          ref: current.id,
+          note: `now emitted_ms=${current.emitted_ms}`,
+        },
+        { kind: "fingerprint", ref: current.state_fingerprint },
+      ],
+    };
+  }
+
+  return {
+    verdict: "PASS",
+    rule_id: "R3",
+    reason: "Wake is not a duplicate of any recent wake with matching state.",
+    evidence: [
+      { kind: "wake", ref: current.id, note: current.state_fingerprint },
+    ],
+  };
+}
+
+/**
+ * R4 - Done without proof.
+ *
+ * "done" requires pipeline === 100 AND a closing_ref on the subject todo.
+ */
+export function checkR4(input: ClaimInput): CommonSensePassResult | null {
+  if (input.claim !== "done") return null;
+  const subject = pickSubject(input);
+  if (!subject) {
+    return {
+      verdict: "HOLD",
+      rule_id: "R4",
+      reason: "done claim has no subject todo in context.",
+      evidence: [{ kind: "context", ref: "todos=empty" }],
+      next_action: "include_target_todo",
+    };
+  }
+  const missing: string[] = [];
+  if (!subject.closing_ref) missing.push("closing_ref");
+  if (subject.pipeline !== 100) {
+    missing.push(`pipeline=${subject.pipeline ?? "missing"}`);
+  }
+  if (missing.length > 0) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R4",
+      reason: `done claim on ${subject.id} missing proof: ${missing.join(", ")}.`,
+      evidence: [
+        {
+          kind: "todo",
+          ref: subject.id,
+          note: `pipeline=${subject.pipeline ?? "missing"}`,
+        },
+        {
+          kind: "todo",
+          ref: subject.id,
+          note: `closing_ref=${subject.closing_ref ?? "missing"}`,
+        },
+      ],
+      next_action: "attach_closing_pr_or_commit_and_set_pipeline_100",
+    };
+  }
+  return {
+    verdict: "PASS",
+    rule_id: "R4",
+    reason: `done claim on ${subject.id} has proof.`,
+    evidence: [
+      { kind: "todo", ref: subject.id, note: "pipeline=100" },
+      {
+        kind: "todo",
+        ref: subject.id,
+        note: `closing_ref=${subject.closing_ref}`,
+      },
+    ],
+  };
+}
+
+/**
+ * R5 - Merge-ready without proof.
+ *
+ * "merge_ready" requires:
+ *   - PR is mergeable
+ *   - checks_state === "success"
+ *   - Reviewer PASS present and authored on the PR's current head SHA.
+ */
+export function checkR5(input: ClaimInput): CommonSensePassResult | null {
+  if (input.claim !== "merge_ready") return null;
+  const pr = input.context.pr;
+  if (!pr) {
+    return {
+      verdict: "HOLD",
+      rule_id: "R5",
+      reason: "merge_ready claim without PR snapshot.",
+      evidence: [{ kind: "context", ref: "pr=missing" }],
+      next_action: "include_pr_snapshot",
+    };
+  }
+  if (!pr.mergeable) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R5",
+      reason: `PR #${pr.number} is not mergeable.`,
+      evidence: [{ kind: "pr", ref: `#${pr.number}`, note: "mergeable=false" }],
+      next_action: "rebase_or_resolve_conflicts",
+    };
+  }
+  if (pr.checks_state !== "success") {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R5",
+      reason: `PR #${pr.number} checks state is "${pr.checks_state}", not success.`,
+      evidence: [
+        { kind: "pr", ref: `#${pr.number}`, note: `checks=${pr.checks_state}` },
+      ],
+      next_action: "wait_for_green_checks",
+    };
+  }
+  const reviewer = pr.reviewer_pass;
+  if (!reviewer || reviewer.verdict !== "PASS") {
+    return {
+      verdict: "HOLD",
+      rule_id: "R5",
+      reason: `PR #${pr.number} has no Reviewer PASS.`,
+      evidence: [
+        {
+          kind: "pr",
+          ref: `#${pr.number}`,
+          note: `reviewer=${reviewer?.verdict ?? "missing"}`,
+        },
+      ],
+      next_action: "request_reviewer_pass",
+    };
+  }
+  if (reviewer.sha !== pr.head_sha) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R5",
+      reason: `Reviewer PASS on PR #${pr.number} authored on ${reviewer.sha.slice(0, 7)} but head is ${pr.head_sha.slice(0, 7)}.`,
+      evidence: [
+        { kind: "sha", ref: reviewer.sha, note: "reviewer_pass_sha" },
+        { kind: "sha", ref: pr.head_sha, note: "head_sha" },
+      ],
+      next_action: "re_review_on_current_head",
+    };
+  }
+  return {
+    verdict: "PASS",
+    rule_id: "R5",
+    reason: `PR #${pr.number} is merge-ready: mergeable, checks green, Reviewer PASS on head.`,
+    evidence: [
+      { kind: "pr", ref: `#${pr.number}`, note: "mergeable" },
+      { kind: "pr", ref: `#${pr.number}`, note: "checks=success" },
+      { kind: "sha", ref: pr.head_sha, note: "reviewer_pass_on_head" },
+    ],
+  };
+}

--- a/packages/commonsensepass/src/schema.ts
+++ b/packages/commonsensepass/src/schema.ts
@@ -1,0 +1,104 @@
+/**
+ * CommonSensePass schema.
+ *
+ * Verdict-only sanity gate for AI/worker claims. Inputs are snapshots of
+ * queue / PR / wake state; outputs are a single Verdict with rule_id,
+ * reason, evidence, and an optional next_action.
+ */
+
+export type Verdict = "PASS" | "BLOCKER" | "HOLD" | "SUPPRESS" | "ROUTE";
+
+export type ClaimKind =
+  | "healthy"
+  | "quiet"
+  | "no_work"
+  | "pass"
+  | "done"
+  | "merge_ready"
+  | "duplicate_wake";
+
+export type RuleId = "R1" | "R2" | "R3" | "R4" | "R5";
+
+export interface Evidence {
+  kind: string;
+  ref: string;
+  note?: string;
+}
+
+export interface CommonSensePassResult {
+  verdict: Verdict;
+  rule_id: RuleId | null;
+  reason: string;
+  evidence: Evidence[];
+  next_action?: string;
+  route_to?: string;
+}
+
+export type TodoStatus =
+  | "actionable"
+  | "in_progress"
+  | "blocked"
+  | "queued"
+  | "done";
+
+export interface TodoSnapshot {
+  id: string;
+  status: TodoStatus;
+  pipeline?: number;
+  owner?: string;
+  /** Milliseconds since epoch for owner's last heartbeat. */
+  owner_last_seen_ms?: number;
+  /** PR or commit reference that closes this todo. */
+  closing_ref?: string;
+}
+
+export interface ReviewSnapshot {
+  verdict: "PASS" | "BLOCKER" | "HOLD" | null;
+  /** SHA the review was authored on. */
+  sha: string;
+}
+
+export interface PRSnapshot {
+  number: number;
+  head_sha: string;
+  mergeable: boolean;
+  checks_state: "success" | "failure" | "pending" | "neutral";
+  reviewer_pass?: ReviewSnapshot;
+  safety_pass?: ReviewSnapshot;
+}
+
+export interface WakeSnapshot {
+  id: string;
+  state_fingerprint: string;
+  emitted_ms: number;
+}
+
+export interface ClaimContext {
+  now_ms: number;
+  current_head_sha?: string;
+  commented_on_sha?: string;
+  todos?: TodoSnapshot[];
+  /** active_jobs count the worker is claiming. */
+  active_jobs?: number;
+  pr?: PRSnapshot;
+  recent_wakes?: WakeSnapshot[];
+  current_wake?: WakeSnapshot;
+  /** Target todo id for done/merge_ready claims; if absent, first todo is used. */
+  subject_todo_id?: string;
+}
+
+export interface ClaimInput {
+  claim: ClaimKind;
+  context: ClaimContext;
+  /** Optional evidence the caller wants echoed on a PASS result. */
+  evidence?: Evidence[];
+}
+
+/**
+ * Owner-freshness window for the active_jobs definition.
+ * Matches OWNER_FRESH_WINDOW_MS pinned in api/lib/orchestrator-context.ts (PR #735).
+ */
+export const OWNER_FRESH_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** Window within which a wake with the same id+fingerprint is a duplicate. */
+export const DUPLICATE_WAKE_WINDOW_MS = 10 * 60 * 1000;

--- a/packages/commonsensepass/tsconfig.json
+++ b/packages/commonsensepass/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node", "vitest/globals"],
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/commonsensepass/vitest.config.ts
+++ b/packages/commonsensepass/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "src/**/*.{test,spec}.{ts,tsx}",
       "api/**/*.{test,spec}.{ts,tsx}",
       "packages/copypass/src/**/*.{test,spec}.ts",
+      "packages/commonsensepass/src/**/*.{test,spec}.ts",
     ],
   },
   resolve: {


### PR DESCRIPTION
## What

Adds `@unclick/commonsensepass`, a verdict-only sanity gate that workers call before claiming `healthy`, `quiet`, `no_work`, `pass`, `done`, `merge_ready`, or `duplicate_wake`. Returns one of: `PASS`, `BLOCKER`, `HOLD`, `SUPPRESS`, `ROUTE`.

## Why

CommonSense research called out workers asserting trust claims that the evidence does not support (heartbeats claiming healthy while the queue is hot, PASSes authored on stale SHAs, duplicate wakes, done without proof, merge-ready without proof). This package is the single library workers can call to stop those claims from leaving the seat.

It is verdict-only: it does NOT mutate todos, build, merge, close, comment, or emit wakes. Workers and orchestrators act on the verdict.

## Rules (baseline)

| Rule | Triggers on claim | Logic |
| ---- | ----------------- | ----- |
| R1   | `healthy` / `quiet` / `no_work` | BLOCKER if actionable queue depth > 0 OR `active_jobs=0` while in-progress todos have a fresh owner (within 24h, matches the formula pinned in `orchestrator-context.ts` PR #735). |
| R2   | `pass`            | BLOCKER if PASS authored on a SHA that does not match `current_head_sha`. |
| R3   | `duplicate_wake`  | SUPPRESS if same `id` + `state_fingerprint` emitted within the duplicate-wake window (default 10 min). |
| R4   | `done`            | BLOCKER if `pipeline !== 100` OR `closing_ref` missing on the subject todo. |
| R5   | `merge_ready`     | BLOCKER if not mergeable, checks not success, or Reviewer PASS authored on a stale SHA. HOLD if Reviewer PASS missing. |

## Files

- `packages/commonsensepass/package.json` - workspace member `@unclick/commonsensepass@0.1.0`
- `packages/commonsensepass/tsconfig.json`, `vitest.config.ts`, `README.md`
- `src/schema.ts` - Verdict, ClaimKind, ClaimInput, snapshots (`TodoSnapshot`, `PRSnapshot`, `WakeSnapshot`), `OWNER_FRESH_WINDOW_MS` aligned with PR #735
- `src/rules.ts` - R1-R5 rule checkers
- `src/check.ts` - `commonsensepassCheck` dispatcher
- `src/index.ts` - public exports
- `src/__tests__/check.test.ts` - 23 fixture tests covering every verdict and every rule branch

## Proof

- `tsc --noEmit` clean
- `tsc` build succeeds, `dist/` produced with `.d.ts`, `.js`, `.js.map`
- `vitest run`: 23 / 23 passing

## Closes

- Todo `eb4bea5a` (R1 active-state / list_todos mismatch under the v9 definition)
- Unblocks `9b0e5806` (CommonSensePass worker protocol adoption) - this PR ships the library; follow-up PR wires the first worker path.

## Boundaries

- No imports of this package added to workers yet; adoption is a separate PR.
- No network calls, no fs writes, no mutation.
- Rule set is intentionally small (5 rules). Additions go through a follow-up PR after a worker proves usage.
