### PR TITLE
Add Todo proof reconciler classifier

### DIFF
--- a/packages/mcp-server/src/todo-proof-reconciler-tool.test.ts
+++ b/packages/mcp-server/src/todo-proof-reconciler-tool.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTodoReconcileReport,
+  classifyTodoForReconciliation,
+} from "./todo-proof-reconciler-tool.js";
+
+describe("Todo proof reconciler", () => {
+  it("marks a linked merged PR with green checks as a close candidate", () => {
+    const result = classifyTodoForReconciliation({
+      id: "todo-true-close",
+      title: "Small shipped fix",
+      status: "open",
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["build", "ship"],
+      comments: ["Ship receipt: PR merged and TestPass passed."],
+      linked_pull_requests: [{
+        url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/759",
+        state: "MERGED",
+        checks_conclusion: "SUCCESS",
+      }],
+    });
+
+    expect(result).toMatchObject({
+      decision: "close_candidate",
+      should_close: true,
+      should_comment: true,
+      missing: [],
+    });
+    expect(result.proof_refs).toContain("https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/759");
+  });
+
+  it("does not close a ScopePack or execution packet false positive", () => {
+    const result = classifyTodoForReconciliation({
+      id: "todo-scopepack",
+      title: "ScopePack auto-hydration",
+      status: "open",
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["ship"],
+      comments: ["Worker execution packet and ScopePack only, no PR proof yet."],
+    });
+
+    expect(result).toMatchObject({
+      decision: "needs_proof",
+      should_close: false,
+      missing: ["authoritative completion proof"],
+    });
+  });
+
+  it("does not close a Git sync comment without completion proof", () => {
+    const result = classifyTodoForReconciliation({
+      id: "todo-git-sync",
+      title: "Boardroom-to-Git sync",
+      status: "open",
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["ship"],
+      comments: ["Git sync proof: created GitHub issue #748 for tracking."],
+    });
+
+    expect(result).toMatchObject({
+      decision: "needs_proof",
+      should_close: false,
+      missing: ["authoritative completion proof"],
+    });
+  });
+
+  it("holds a proofed todo when an active blocker still references it", () => {
+    const result = classifyTodoForReconciliation({
+      id: "cf8025d7-1c64-4fee-95c1-6a7c5b666704",
+      title: "WakePass ACK verifier proof",
+      status: "open",
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["build", "proof", "ship"],
+      proof_refs: ["https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/751"],
+      comments: ["Ship receipt with PR proof exists."],
+    }, {
+      active_blockers: [
+        "wakepass stale https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/751",
+      ],
+    });
+
+    expect(result).toMatchObject({
+      decision: "hold",
+      should_close: false,
+      should_comment: true,
+    });
+    expect(result.blockers).toHaveLength(1);
+  });
+
+  it("keeps already-done todos idempotent and quiet", () => {
+    const result = classifyTodoForReconciliation({
+      id: "todo-already-done",
+      title: "Already done",
+      status: "done",
+      completed_at: "2026-05-13T00:00:00.000Z",
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+    });
+
+    expect(result).toMatchObject({
+      decision: "already_done",
+      should_close: false,
+      should_comment: false,
+    });
+  });
+
+  it("produces closed, blocked, skipped, and needs-human-review counts", () => {
+    const results = [
+      classifyTodoForReconciliation({
+        id: "close",
+        title: "Close me",
+        status: "open",
+        pipeline_progress: 100,
+        pipeline_source: "receipt: ship",
+        comments: ["merged PR and TestPass passed"],
+        linked_pull_requests: [{ url: "https://github.com/example/repo/pull/1", state: "MERGED" }],
+      }),
+      classifyTodoForReconciliation({
+        id: "blocked",
+        title: "Blocked",
+        status: "open",
+        pipeline_progress: 100,
+        pipeline_source: "receipt: ship",
+        proof_refs: ["https://github.com/example/repo/issues/2"],
+        comments: ["ship receipt exists"],
+      }, { active_blockers: ["https://github.com/example/repo/issues/2"] }),
+      classifyTodoForReconciliation({ id: "skip", status: "done" }),
+      classifyTodoForReconciliation({
+        id: "review",
+        status: "open",
+        pipeline_progress: 100,
+        pipeline_source: "receipt: ship",
+        comments: ["Git sync proof only."],
+      }),
+    ];
+
+    expect(buildTodoReconcileReport(results).counts).toEqual({
+      closed: 1,
+      blocked: 1,
+      skipped: 1,
+      needs_human_review: 1,
+    });
+  });
+});

--- a/packages/mcp-server/src/todo-proof-reconciler-tool.ts
+++ b/packages/mcp-server/src/todo-proof-reconciler-tool.ts
@@ -1,0 +1,273 @@
+type TodoStatus = "open" | "in_progress" | "done" | "dropped" | string;
+
+export type TodoReconcileDecision =
+  | "close_candidate"
+  | "needs_proof"
+  | "hold"
+  | "conflict"
+  | "already_done"
+  | "ignore";
+
+export interface TodoReconcileInput {
+  id?: string;
+  title?: string;
+  status?: TodoStatus;
+  completed_at?: string | null;
+  pipeline_progress?: number | null;
+  pipeline_source?: string | null;
+  pipeline_evidence?: string[] | null;
+  proof_refs?: string[] | null;
+  comments?: Array<string | { text?: string | null }> | null;
+  linked_pull_requests?: Array<{
+    url?: string | null;
+    state?: string | null;
+    merged_at?: string | null;
+    checks_conclusion?: string | null;
+  }> | null;
+  linked_issues?: Array<{
+    url?: string | null;
+    state?: string | null;
+    completion_label?: string | null;
+  }> | null;
+}
+
+export interface TodoReconcileContext {
+  active_blockers?: string[] | null;
+}
+
+export interface TodoReconcileResult {
+  todo_id: string | null;
+  title: string | null;
+  decision: TodoReconcileDecision;
+  should_close: boolean;
+  should_comment: boolean;
+  receipt: string;
+  proof_refs: string[];
+  missing: string[];
+  blockers: string[];
+  reasons: string[];
+}
+
+export interface TodoReconcileReport {
+  closed: TodoReconcileResult[];
+  blocked: TodoReconcileResult[];
+  skipped: TodoReconcileResult[];
+  needs_human_review: TodoReconcileResult[];
+  counts: {
+    closed: number;
+    blocked: number;
+    skipped: number;
+    needs_human_review: number;
+  };
+}
+
+const FINAL_PROOF_WORDS = [
+  "merged",
+  "merge commit",
+  "testpass",
+  "passed",
+  "ship",
+  "shipped",
+  "closed",
+  "done",
+  "complete",
+  "completed",
+  "receipt",
+];
+
+const FALSE_POSITIVE_WORDS = [
+  "scopepack",
+  "execution packet",
+  "git sync proof",
+  "issue sync",
+  "research brief",
+  "planning",
+  "worker execution packet",
+];
+
+function normalized(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function commentText(todo: TodoReconcileInput): string[] {
+  return (todo.comments ?? []).map((comment) => {
+    if (typeof comment === "string") return comment;
+    return String(comment?.text ?? "");
+  }).filter(Boolean);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function extractUrls(values: string[]): string[] {
+  return unique(values.flatMap((value) => value.match(/https?:\/\/\S+/g) ?? []));
+}
+
+function hasCompletionLanguage(values: string[]): boolean {
+  const text = normalized(values.join("\n"));
+  return FINAL_PROOF_WORDS.some((word) => text.includes(word));
+}
+
+function hasFalsePositiveLanguage(values: string[]): boolean {
+  const text = normalized(values.join("\n"));
+  return FALSE_POSITIVE_WORDS.some((word) => text.includes(word));
+}
+
+function hasMergedPullRequest(todo: TodoReconcileInput): boolean {
+  return (todo.linked_pull_requests ?? []).some((pr) => {
+    const state = normalized(pr.state);
+    const checks = normalized(pr.checks_conclusion);
+    return Boolean(pr.url) && (state === "merged" || Boolean(pr.merged_at)) && (!checks || checks === "success");
+  });
+}
+
+function hasClosedCompletionIssue(todo: TodoReconcileInput): boolean {
+  return (todo.linked_issues ?? []).some((issue) => {
+    const state = normalized(issue.state);
+    const label = normalized(issue.completion_label);
+    return Boolean(issue.url) && state === "closed" && ["complete", "completed", "done", "shipped"].includes(label);
+  });
+}
+
+function evidenceHasShipReceipt(todo: TodoReconcileInput): boolean {
+  const source = normalized(todo.pipeline_source);
+  const evidence = (todo.pipeline_evidence ?? []).map(normalized);
+  return source === "receipt: ship" || source.includes("receipt: ship") || evidence.includes("ship");
+}
+
+function blockerMatches(todo: TodoReconcileInput, context: TodoReconcileContext): string[] {
+  const id = normalized(todo.id);
+  const title = normalized(todo.title);
+  const proofRefs = (todo.proof_refs ?? []).map(normalized);
+  const candidates = [id, ...proofRefs, ...(title ? [title.slice(0, 80)] : [])].filter((candidate) => candidate.length > 8);
+
+  return (context.active_blockers ?? []).filter((blocker) => {
+    const text = normalized(blocker);
+    return candidates.some((candidate) => text.includes(candidate));
+  });
+}
+
+export function classifyTodoForReconciliation(
+  todo: TodoReconcileInput,
+  context: TodoReconcileContext = {},
+): TodoReconcileResult {
+  const todoId = todo.id ?? null;
+  const title = todo.title ?? null;
+  const status = normalized(todo.status);
+  const comments = commentText(todo);
+  const textEvidence = [
+    title ?? "",
+    todo.pipeline_source ?? "",
+    ...(todo.pipeline_evidence ?? []),
+    ...(todo.proof_refs ?? []),
+    ...comments,
+  ];
+  const proofRefs = unique([
+    ...(todo.proof_refs ?? []),
+    ...extractUrls(textEvidence),
+    ...((todo.linked_pull_requests ?? []).map((pr) => pr.url ?? "")),
+    ...((todo.linked_issues ?? []).map((issue) => issue.url ?? "")),
+  ]);
+  const blockers = blockerMatches({ ...todo, proof_refs: proofRefs }, context);
+  const missing: string[] = [];
+  const reasons: string[] = [];
+
+  if (status === "done") {
+    return makeResult(todoId, title, "already_done", proofRefs, missing, blockers, ["Todo is already done."]);
+  }
+
+  if (status === "dropped") {
+    return makeResult(todoId, title, "ignore", proofRefs, missing, blockers, ["Dropped todos are ignored."]);
+  }
+
+  if (todo.completed_at) reasons.push("completed_at present");
+  if (hasMergedPullRequest(todo)) reasons.push("merged PR proof");
+  if (hasClosedCompletionIssue(todo)) reasons.push("closed completion issue");
+  if (evidenceHasShipReceipt(todo)) reasons.push("ship receipt evidence");
+
+  const hasAuthoritativeProof = Boolean(todo.completed_at) || hasMergedPullRequest(todo) || hasClosedCompletionIssue(todo);
+  const hasReceiptAndPointer = evidenceHasShipReceipt(todo) && proofRefs.length > 0 && hasCompletionLanguage(textEvidence);
+  const pipelineComplete = Number(todo.pipeline_progress ?? 0) >= 100;
+
+  if (blockers.length > 0 && (hasAuthoritativeProof || hasReceiptAndPointer || pipelineComplete)) {
+    return makeResult(todoId, title, "hold", proofRefs, missing, blockers, [
+      ...reasons,
+      "Active blocker references this todo or proof source.",
+    ]);
+  }
+
+  if (pipelineComplete && hasFalsePositiveLanguage(textEvidence) && !hasAuthoritativeProof) {
+    missing.push("authoritative completion proof");
+    return makeResult(todoId, title, "needs_proof", proofRefs, missing, blockers, [
+      "Pipeline looks complete, but evidence is planning, sync, research, or execution-packet text.",
+    ]);
+  }
+
+  if (!pipelineComplete && hasAuthoritativeProof && status !== "open" && status !== "in_progress") {
+    return makeResult(todoId, title, "conflict", proofRefs, missing, blockers, [
+      "Authoritative proof exists, but todo status is not an open active state.",
+    ]);
+  }
+
+  if ((status === "open" || status === "in_progress") && (hasAuthoritativeProof || (pipelineComplete && hasReceiptAndPointer))) {
+    return makeResult(todoId, title, "close_candidate", proofRefs, missing, blockers, reasons);
+  }
+
+  if (pipelineComplete || hasCompletionLanguage(textEvidence)) {
+    if (!pipelineComplete) missing.push("pipeline_progress=100");
+    if (!evidenceHasShipReceipt(todo)) missing.push("receipt: ship");
+    if (proofRefs.length === 0) missing.push("proof pointer");
+    if (!hasCompletionLanguage(textEvidence)) missing.push("final proof language");
+    return makeResult(todoId, title, "needs_proof", proofRefs, missing, blockers, [
+      "Completion-like evidence is not enough to close safely.",
+    ]);
+  }
+
+  return makeResult(todoId, title, "ignore", proofRefs, missing, blockers, ["No completion signal."]);
+}
+
+function makeResult(
+  todoId: string | null,
+  title: string | null,
+  decision: TodoReconcileDecision,
+  proofRefs: string[],
+  missing: string[],
+  blockers: string[],
+  reasons: string[],
+): TodoReconcileResult {
+  const shouldClose = decision === "close_candidate";
+  const shouldComment = ["close_candidate", "needs_proof", "hold", "conflict"].includes(decision);
+  return {
+    todo_id: todoId,
+    title,
+    decision,
+    should_close: shouldClose,
+    should_comment: shouldComment,
+    receipt: `TodoProofReconciler ${decision}: ${shouldClose ? "safe close candidate" : reasons[0] ?? "no mutation"}`,
+    proof_refs: proofRefs,
+    missing,
+    blockers,
+    reasons,
+  };
+}
+
+export function buildTodoReconcileReport(results: TodoReconcileResult[]): TodoReconcileReport {
+  const closed = results.filter((result) => result.decision === "close_candidate");
+  const blocked = results.filter((result) => result.decision === "hold" || result.decision === "conflict");
+  const needsHumanReview = results.filter((result) => result.decision === "needs_proof");
+  const skipped = results.filter((result) => result.decision === "already_done" || result.decision === "ignore");
+
+  return {
+    closed,
+    blocked,
+    skipped,
+    needs_human_review: needsHumanReview,
+    counts: {
+      closed: closed.length,
+      blocked: blocked.length,
+      skipped: skipped.length,
+      needs_human_review: needsHumanReview.length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- adds a deterministic Todo proof reconciler classifier
- separates `close_candidate`, `needs_proof`, `hold`, `conflict`, `already_done`, and `ignore`
- adds report counts for closed, blocked, skipped, and needs-human-review
- includes fixtures for true close, ScopePack false positive, Git sync false positive, WakePass active-blocker HOLD, already-done no-op, and report counts

## TestPass
- PASS: `npm --workspace @unclick/mcp-server exec vitest run src/todo-proof-reconciler-tool.test.ts`
- PASS: `npm --workspace @unclick/mcp-server run build`

## Links
- Issue #748
- Boardroom todo e1e181c0-d95a-451e-95d2-410df25e04e4
- Live fixture comment: https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/748#issuecomment-4436674251