### PR TITLE
Hotfix: promote NudgeOnly WakePass suppression to main

### DIFF
--- a/docs/pinballwake-nudgeonly-api.md
+++ b/docs/pinballwake-nudgeonly-api.md
@@ -1,0 +1,54 @@
+# PinballWake NudgeOnlyAPI
+
+NudgeOnlyAPI is the red nudge lane inside the PinballWake ecosystem.
+
+Its worker label is `👉Nudge`. Its code name is `NudgeOnly`.
+
+## Purpose
+
+`👉Nudge` uses cheap/free OpenRouter routing for painpoint hints only. It is designed to make stuck or noisy handoffs stand out without giving the model authority over important work.
+
+Use it for:
+
+- stale ACK hints
+- duplicate wake hints
+- unclear owner hints
+- missing proof hints
+- noisy thread summaries
+- simple-English status rewrites
+
+Do not use it for:
+
+- PR merges
+- blocker closure
+- final completion state
+- ownership decisions
+- approval decisions
+- mutation tools
+- source-of-truth writes
+
+## Guardrail
+
+Deterministic checks own truth. Trusted lanes own decisions. `👉Nudge` only points at pain.
+
+Default model routing is `openrouter/free`, which lets OpenRouter select an available free model for the request. The tool still returns `authority: nudge_only_no_write_no_truth` so UI and agents can keep the output visually and operationally separate from trusted state.
+
+## Evidence Trail
+
+Every nudge result includes trace evidence so the lane can prove whether it is helping:
+
+- `trace_id`: stable `nudgeonly_<hash>` ID for the input.
+- `source_id` and `source_url`: optional upstream wake, dispatch, PR, issue, or event pointers.
+- `input_digest`: short hash of the redacted input fields.
+- `model`, `openrouter_id`, and `usage`: router/model proof from OpenRouter when available.
+- `evidence.verifier_required`: always true.
+- `evidence.verifier_rule`: the rule that a deterministic check or trusted lane must confirm before action.
+
+Working means fewer stale ACKs, duplicate wakes, unclear owner handoffs, and missing proof loops. A nudge is not considered a win until a trusted verifier or lane confirms the suggested check.
+
+## MCP Tools
+
+- `nudgeonly_policy`: returns the PinballWake/NudgeOnlyAPI guardrails.
+- `nudgeonly_api`: runs the red-lane nudge classifier through OpenRouter.
+
+`nudgeonly_api` accepts `event_text`, optional `context`, optional `painpoint_hint`, optional `source_id`, optional `source_url`, optional `model`, optional `max_tokens`, and an optional `api_key` when `OPENROUTER_API_KEY` is not already available.

--- a/docs/pinballwake-nudgeonly-api.md
+++ b/docs/pinballwake-nudgeonly-api.md
@@ -58,6 +58,30 @@ Use worker nudges for:
 
 The nudge shape should be: worker -> target -> painpoint -> expected receipt -> verifier.
 
+## Receipt Bridge
+
+The bridge that makes this self-moving is `nudgeonly_receipt_bridge`.
+
+Flow:
+
+1. `nudgeonly_api` or a trusted deterministic check flags a candidate painpoint.
+2. `nudgeonly_receipt_bridge` checks for source evidence and a concrete cue.
+3. If evidence is strong enough, it emits a tiny worker receipt request.
+4. WakePass or another deterministic verifier checks the ACK/proof.
+5. If ACK/proof is still missing after the TTL, the bridge emits an escalation request.
+
+Receipt line shape:
+
+`worker -> target -> painpoint -> expected receipt -> verifier`
+
+Examples:
+
+- Reviewer -> PR #705 -> `stale_ack` -> ACK received, review started, or blocker receipt -> WakePass ACK verifier.
+- Job Manager -> PR #705 -> `unclear_owner` -> owning job, next safe action, and expected proof -> owner resolver.
+- Builder -> PR #705 -> `missing_proof` -> commit, PR, run ID, receipt ID, or blocker receipt -> proof pointer check.
+
+The bridge still does not write source-of-truth state. It only produces the request that a trusted lane can deliver, verify, and escalate.
+
 ## Quality Gates
 
 Quality beats coverage. NudgeOnlyAPI should miss a weak signal rather than create hallucinated work.
@@ -115,5 +139,8 @@ The first catalogue is based on the prior bottlenecks Chris called out: stale Wa
 
 - `nudgeonly_policy`: returns the PinballWake/NudgeOnlyAPI guardrails.
 - `nudgeonly_api`: runs the red-lane nudge classifier through OpenRouter.
+- `nudgeonly_receipt_bridge`: turns verified painpoint evidence into a worker receipt request or WakePass escalation candidate.
 
 `nudgeonly_api` accepts `event_text`, optional `context`, optional `painpoint_hint`, optional `source_id`, optional `source_url`, optional `model`, optional `max_tokens`, and an optional `api_key` when `OPENROUTER_API_KEY` is not already available.
+
+`nudgeonly_receipt_bridge` accepts either a `nudge_result` from `nudgeonly_api` or direct deterministic evidence fields. It returns `quiet`, `advisory_only`, `receipt_request`, or `escalation_request`.

--- a/docs/pinballwake-nudgeonly-api.md
+++ b/docs/pinballwake-nudgeonly-api.md
@@ -58,6 +58,19 @@ Use worker nudges for:
 
 The nudge shape should be: worker -> target -> painpoint -> expected receipt -> verifier.
 
+## Quality Gates
+
+Quality beats coverage. NudgeOnlyAPI should miss a weak signal rather than create hallucinated work.
+
+Hard gates:
+
+- Do not invent facts, owners, sources, statuses, or proof.
+- Do not alert from model vibes alone; require source text plus a concrete painpoint cue.
+- Prefer false negatives over false positives when evidence is weak.
+- If both `source_id` and `source_url` are missing, treat the result as advisory only.
+- Healthy/completed/info-only controls must stay quiet unless the input explicitly says proof is missing, ACK is stale, ownership is unclear, wake is duplicated, or thread noise is hiding state.
+- Every alert must name a deterministic verifier before action.
+
 Do not use it for:
 
 - PR merges

--- a/docs/pinballwake-nudgeonly-api.md
+++ b/docs/pinballwake-nudgeonly-api.md
@@ -4,6 +4,8 @@ NudgeOnlyAPI is the red nudge lane inside the PinballWake ecosystem.
 
 Its worker label is `👉Nudge`. Its code name is `NudgeOnly`.
 
+Rollout status: official.
+
 ## Purpose
 
 `👉Nudge` uses cheap/free OpenRouter routing for painpoint hints only. It is designed to make stuck or noisy handoffs stand out without giving the model authority over important work.
@@ -16,6 +18,30 @@ Use it for:
 - missing proof hints
 - noisy thread summaries
 - simple-English status rewrites
+
+Official rollout surfaces:
+
+- PinballWake/WakePass: stale ACKs, duplicate wakes, missing proof.
+- Orchestrator state cards: blocker summaries and active state mismatch.
+- Heartbeat and Signals: info-only pulse noise versus action-needed pain.
+- Fishbowl and Boardroom handoffs: unclear owner and repeated ask loops.
+- Agent Observability: trend counts for stuck handoffs and proof debt.
+- Admin Orchestrator UX: show red-lane nudge evidence below the source message.
+
+## Orchestrator Issues
+
+NudgeOnlyAPI should help with Orchestrator issues by marking the painpoint on the source message or state card. It should not rewrite truth, decide ownership, or hide evidence.
+
+Use these mappings:
+
+- Properties overload or hard-to-read status blocks -> `noisy_thread`.
+- Simple-English summary is too short and loses context -> `missing_proof`.
+- Blockers visible but no active owning job -> `unclear_owner`.
+- Repeated heartbeat noise hides useful work -> `noisy_thread`.
+- WakePass or review handoff is stale -> `stale_ack`.
+- Done/completed state lacks proof -> `missing_proof`.
+
+The UI should treat the nudge as a red-lane annotation: useful evidence, not the final answer.
 
 Do not use it for:
 
@@ -45,6 +71,17 @@ Every nudge result includes trace evidence so the lane can prove whether it is h
 - `evidence.verifier_rule`: the rule that a deterministic check or trusted lane must confirm before action.
 
 Working means fewer stale ACKs, duplicate wakes, unclear owner handoffs, and missing proof loops. A nudge is not considered a win until a trusted verifier or lane confirms the suggested check.
+
+Live proof from rollout testing:
+
+- 12 system-wide painpoint cases.
+- 0 OpenRouter/API errors.
+- 12 useful traceable outputs.
+- 12/12 signal matches.
+- 12/12 painpoint bucket matches.
+- 0 false positives on the healthy completed control.
+
+The first catalogue is based on the prior bottlenecks Chris called out: stale WakePass ACKs, duplicate wakes, unclear ownership, missing proof, heartbeat noise, quiet/liveness drift, and blockers visible without an active owning job.
 
 ## MCP Tools
 

--- a/docs/pinballwake-nudgeonly-api.md
+++ b/docs/pinballwake-nudgeonly-api.md
@@ -43,6 +43,21 @@ Use these mappings:
 
 The UI should treat the nudge as a red-lane annotation: useful evidence, not the final answer.
 
+## Worker Nudges
+
+NudgeOnlyAPI can also help workers do their jobs, but only as a receipt reminder. It must not command workers, assign authority, or mark their work done.
+
+Use worker nudges for:
+
+- Continuous Improver: ask for the next tiny improvement candidate and proof.
+- Job Manager: ask for the owning job, next safe action, and expected receipt.
+- Reviewer: ask for review ACK or blocker receipt on stale PR/review handoffs.
+- Builder: ask for commit, PR, run ID, or blocker receipt when implementation lacks proof.
+- Heartbeat Seat: ask for the material diff or compact PASS/BLOCKER receipt.
+- Agent Observability: ask for trace ID, owner, decision, and reliability proof.
+
+The nudge shape should be: worker -> target -> painpoint -> expected receipt -> verifier.
+
 Do not use it for:
 
 - PR merges

--- a/docs/pinballwake-nudgeonly-api.md
+++ b/docs/pinballwake-nudgeonly-api.md
@@ -31,7 +31,7 @@ Do not use it for:
 
 Deterministic checks own truth. Trusted lanes own decisions. `👉Nudge` only points at pain.
 
-Default model routing is `openrouter/free`, which lets OpenRouter select an available free model for the request. The tool still returns `authority: nudge_only_no_write_no_truth` so UI and agents can keep the output visually and operationally separate from trusted state.
+Default model routing is `liquid/lfm-2.5-1.2b-instruct:free`, a small free instruct model that is better suited to short nudge JSON than reasoning-heavy free models. `openrouter/free` can still be passed as an override when auto-rotation is desired. The tool always returns `authority: nudge_only_no_write_no_truth` so UI and agents can keep the output visually and operationally separate from trusted state.
 
 ## Evidence Trail
 

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -42,6 +42,14 @@ describe("NudgeOnlyAPI policy", () => {
         expect.objectContaining({ bucket: "missing_proof" }),
         expect.objectContaining({ bucket: "stale_ack" }),
       ]),
+      worker_nudge_map: expect.arrayContaining([
+        expect.objectContaining({ worker: "Continuous Improver", bucket: "unclear_owner" }),
+        expect.objectContaining({ worker: "Job Manager", bucket: "unclear_owner" }),
+        expect.objectContaining({ worker: "Reviewer", bucket: "stale_ack" }),
+        expect.objectContaining({ worker: "Builder", bucket: "missing_proof" }),
+        expect.objectContaining({ worker: "Heartbeat Seat", bucket: "noisy_thread" }),
+        expect.objectContaining({ worker: "Agent Observability", bucket: "missing_proof" }),
+      ]),
     });
   });
 

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { nudgeonlyApi, nudgeonlyPolicy, NUDGEONLY_POLICY } from "./nudgeonly-tool.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("NudgeOnlyAPI policy", () => {
+  it("keeps 👉Nudge inside the PinballWake red nudge lane", async () => {
+    await expect(nudgeonlyPolicy({})).resolves.toMatchObject({
+      official_name: "NudgeOnlyAPI",
+      worker_name: "👉Nudge",
+      code_name: "NudgeOnly",
+      ecosystem: "PinballWake",
+      lane: "red_nudge",
+      authority: "nudge_only_no_write_no_truth",
+      default_model: "openrouter/free",
+    });
+  });
+
+  it("names important actions as prohibited", () => {
+    expect(NUDGEONLY_POLICY.prohibited_actions).toEqual(
+      expect.arrayContaining([
+        "merge PRs",
+        "close blockers",
+        "mark work complete",
+        "decide ownership",
+        "call mutation tools",
+        "set source-of-truth state",
+      ]),
+    );
+  });
+
+  it("does not run without an OpenRouter key", async () => {
+    const previous = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+
+    await expect(nudgeonlyApi({ event_text: "wakepass stale ack" }))
+      .rejects
+      .toThrow("api_key is required");
+
+    if (previous === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = previous;
+    }
+  });
+
+  it("uses the free OpenRouter nudge lane without granting authority", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => ({
+      ok: true,
+      json: async () => ({
+        id: "or-nudge-test",
+        model: "openrouter/free",
+        choices: [{
+          finish_reason: "stop",
+          message: {
+            content: JSON.stringify({
+              painpoint_detected: true,
+              painpoint_type: "stale_ack",
+              nudge: "Possible stale ACK. Suggest checking the WakePass receipt before taking action.",
+              suggested_check: "Run the WakePass ACK verifier for the source dispatch.",
+              confidence: "medium",
+            }),
+          },
+        }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(nudgeonlyApi({
+      api_key: "test-key",
+      event_text: "wakepass stale ack for PR #705",
+      source_id: "wake-pull_request-pr-705",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
+    })).resolves.toMatchObject({
+      worker: "👉Nudge",
+      official_name: "NudgeOnlyAPI",
+      code_name: "NudgeOnly",
+      ecosystem: "PinballWake",
+      authority: "nudge_only_no_write_no_truth",
+      model: "openrouter/free",
+      source_id: "wake-pull_request-pr-705",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
+      painpoint_detected: true,
+      requires_verifier: true,
+      evidence: {
+        router: "OpenRouter",
+        requested_model: "openrouter/free",
+        resolved_model: "openrouter/free",
+        openrouter_id: "or-nudge-test",
+        verifier_required: true,
+        authority: "nudge_only_no_write_no_truth",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer test-key",
+      "X-OpenRouter-Title": "NudgeOnlyAPI",
+    });
+    const body = JSON.parse(String(init?.body));
+    expect(body).toMatchObject({
+      model: "openrouter/free",
+      max_tokens: 260,
+      response_format: { type: "json_object" },
+    });
+    expect(JSON.parse(body.messages[1].content)).toMatchObject({
+      trace_id: expect.stringMatching(/^nudgeonly_[0-9a-f]{16}$/),
+      source_id: "wake-pull_request-pr-705",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
+    });
+  });
+});

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { nudgeonlyApi, nudgeonlyPolicy, NUDGEONLY_POLICY } from "./nudgeonly-tool.js";
+import { nudgeonlyApi, nudgeonlyPolicy, nudgeonlyReceiptBridge, NUDGEONLY_POLICY } from "./nudgeonly-tool.js";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -55,6 +55,10 @@ describe("NudgeOnlyAPI policy", () => {
         "Prefer false negatives over false positives when evidence is weak.",
         "Every alert must name a deterministic verifier before action.",
       ]),
+      receipt_bridge: expect.objectContaining({
+        status: "official",
+        route_shape: "worker -> target -> painpoint -> expected receipt -> verifier",
+      }),
     });
   });
 
@@ -277,6 +281,111 @@ describe("NudgeOnlyAPI policy", () => {
       trace_id: expect.stringMatching(/^nudgeonly_[0-9a-f]{16}$/),
       source_id: "wake-pull_request-pr-705",
       source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
+    });
+  });
+
+  it("routes a verified stale ACK nudge into a reviewer receipt request", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      event_text: "WakePass stale ACK for PR #705, review receipt is missing.",
+      source_id: "wake-pull_request-pr-705",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
+      owner: "🔍",
+      nudge_trace_id: "nudgeonly_abc123",
+      created_at: "2026-05-11T00:00:00.000Z",
+      now: "2026-05-11T00:20:00.000Z",
+      ttl_minutes: 60,
+    })).resolves.toMatchObject({
+      bridge_status: "receipt_request",
+      authority: "nudge_only_no_write_no_truth",
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      request: {
+        worker: "Reviewer",
+        owner: "🔍",
+        target: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
+        expected_receipt: "ACK received, review started, or blocker receipt with reason.",
+        verifier: "Run the WakePass ACK verifier against the source dispatch or PR.",
+        receipt_line: expect.stringContaining("Reviewer -> https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705 -> stale_ack"),
+      },
+      evidence: {
+        nudge_trace_id: "nudgeonly_abc123",
+        source_id: "wake-pull_request-pr-705",
+        verifier_required: true,
+      },
+      requires_verifier: true,
+    });
+  });
+
+  it("escalates when ACK or proof is still missing after the TTL", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      event_text: "WakePass stale ACK for PR #705, no ACK receipt yet.",
+      source_id: "wake-pull_request-pr-705",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
+      owner: "🔍",
+      ack_status: "missing",
+      created_at: "2026-05-11T00:00:00.000Z",
+      now: "2026-05-11T02:00:00.000Z",
+      ttl_minutes: 60,
+    })).resolves.toMatchObject({
+      bridge_status: "escalation_request",
+      escalation: {
+        escalate_to: "WakePass",
+        reason: "ACK or proof is still missing after the configured TTL.",
+      },
+      request: {
+        worker: "Reviewer",
+        verifier: "Run the WakePass ACK verifier against the source dispatch or PR.",
+      },
+    });
+  });
+
+  it("routes unclear ownership only to Job Manager for resolution", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "unclear_owner",
+      event_text: "Blocker is visible but there is no active job and owner is missing.",
+      source_id: "dispatch_blocker_705",
+      target: "PR #705",
+      worker: "Reviewer",
+    })).resolves.toMatchObject({
+      bridge_status: "receipt_request",
+      request: {
+        worker: "Job Manager",
+        owner: null,
+        target: "PR #705",
+        painpoint_type: "unclear_owner",
+        expected_receipt: "Owning job, next safe action, and expected proof receipt.",
+      },
+    });
+  });
+
+  it("stays quiet for healthy controls and advisory-only for weak evidence", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: false,
+      painpoint_type: "none",
+      event_text: "WakePass completed with proof.",
+      source_id: "wake-pull_request-pr-699",
+    })).resolves.toMatchObject({
+      bridge_status: "quiet",
+      painpoint_detected: false,
+      painpoint_type: "none",
+    });
+
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      event_text: "Something feels odd.",
+    })).resolves.toMatchObject({
+      bridge_status: "advisory_only",
+      reason: "The bridge did not find enough deterministic evidence to route a worker receipt request.",
+      missing: {
+        source_evidence: true,
+        concrete_cue: true,
+      },
     });
   });
 });

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -32,6 +32,133 @@ describe("NudgeOnlyAPI policy", () => {
     );
   });
 
+  it("normalises model output to the allowed painpoint labels", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: "or-nudge-label-test",
+        model: "liquid/lfm-2.5-1.2b-instruct:free",
+        choices: [{
+          finish_reason: "stop",
+          message: {
+            content: JSON.stringify({
+              painpoint_detected: "stale_ack, unclear_owner",
+              painpoint_type: "stale_ack, unclear_owner",
+              nudge: "Possible stale ACK plus unclear ownership.",
+              suggested_check: "Run the WakePass ACK verifier and owner resolver for the source dispatch.",
+              confidence: "low",
+            }),
+          },
+        }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(nudgeonlyApi({
+      api_key: "test-key",
+      event_text: "wakepass stale ack with unclear owner",
+    })).resolves.toMatchObject({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+    });
+  });
+
+  it("trusts a concrete hinted painpoint label over a weak detected flag", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: "or-nudge-hint-test",
+        model: "liquid/lfm-2.5-1.2b-instruct:free",
+        choices: [{
+          finish_reason: "stop",
+          message: {
+            content: JSON.stringify({
+              painpoint_detected: false,
+              painpoint_type: "missing_proof",
+              nudge: "Possible missing proof pointer.",
+              suggested_check: "Check the proof pointer in the compact Orchestrator state.",
+              confidence: "low",
+            }),
+          },
+        }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(nudgeonlyApi({
+      api_key: "test-key",
+      event_text: "proof pointer is missing",
+      painpoint_hint: "missing_proof",
+    })).resolves.toMatchObject({
+      painpoint_detected: true,
+      painpoint_type: "missing_proof",
+    });
+  });
+
+  it("uses a supplied painpoint hint as the stable dashboard bucket", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: "or-nudge-bucket-test",
+        model: "liquid/lfm-2.5-1.2b-instruct:free",
+        choices: [{
+          finish_reason: "stop",
+          message: {
+            content: JSON.stringify({
+              painpoint_detected: true,
+              painpoint_type: "stale_ack",
+              nudge: "Possible ownership confusion around a stale WakePass handoff.",
+              suggested_check: "Run the owner resolver against the source dispatch.",
+              confidence: "low",
+            }),
+          },
+        }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(nudgeonlyApi({
+      api_key: "test-key",
+      event_text: "no clear next owner is named",
+      painpoint_hint: "unclear_owner",
+    })).resolves.toMatchObject({
+      painpoint_detected: true,
+      painpoint_type: "unclear_owner",
+    });
+  });
+
+  it("keeps an unhinted healthy control quiet when the detected flag is false", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: "or-nudge-quiet-test",
+        model: "liquid/lfm-2.5-1.2b-instruct:free",
+        choices: [{
+          finish_reason: "stop",
+          message: {
+            content: JSON.stringify({
+              painpoint_detected: false,
+              painpoint_type: "stale_ack",
+              nudge: "Possible wakepass issue.",
+              suggested_check: "Verify WakePass status before taking action.",
+              confidence: "low",
+            }),
+          },
+        }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(nudgeonlyApi({
+      api_key: "test-key",
+      event_text: "wakepass completed and healthy",
+      painpoint_hint: "none",
+    })).resolves.toMatchObject({
+      painpoint_detected: false,
+      painpoint_type: "none",
+    });
+  });
+
   it("does not run without an OpenRouter key", async () => {
     const previous = process.env.OPENROUTER_API_KEY;
     delete process.env.OPENROUTER_API_KEY;

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -343,6 +343,31 @@ describe("NudgeOnlyAPI policy", () => {
     });
   });
 
+  it("suppresses ACK-only WakePass comments instead of creating duplicate stale wakes", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      event_text: "ACK wake-issue_comment-comment-4436477251-51e47b7d9cdd. The wake is acknowledged, but this is still waiting for terminal executor proof.",
+      source_id: "wake-issue_comment-comment-4436519129-d570faed9137",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/751",
+      ack_status: "missing",
+      created_at: "2026-05-13T02:04:37.000Z",
+      now: "2026-05-13T02:15:48.000Z",
+      ttl_minutes: 5,
+    })).resolves.toMatchObject({
+      bridge_status: "suppress",
+      painpoint_detected: false,
+      painpoint_type: "none",
+      suppressed_painpoint_type: "stale_ack",
+      suppression: {
+        reason: "ack_only_comment",
+        original_wake_id: "wake-issue_comment-comment-4436477251-51e47b7d9cdd",
+        source_id: "wake-issue_comment-comment-4436519129-d570faed9137",
+      },
+      quality_gate: "duplicate ACK wake suppression",
+    });
+  });
+
   it("routes unclear ownership only to Job Manager for resolution", async () => {
     await expect(nudgeonlyReceiptBridge({
       painpoint_detected: true,

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -16,6 +16,32 @@ describe("NudgeOnlyAPI policy", () => {
       lane: "red_nudge",
       authority: "nudge_only_no_write_no_truth",
       default_model: "liquid/lfm-2.5-1.2b-instruct:free",
+      rollout_status: "official",
+    });
+  });
+
+  it("publishes the official system rollout surfaces and painpoint catalogue", async () => {
+    await expect(nudgeonlyPolicy({})).resolves.toMatchObject({
+      rollout_surfaces: expect.arrayContaining([
+        expect.objectContaining({ surface: "PinballWake/WakePass" }),
+        expect.objectContaining({ surface: "Orchestrator state cards" }),
+        expect.objectContaining({ surface: "Heartbeat and Signals" }),
+        expect.objectContaining({ surface: "Agent Observability" }),
+      ]),
+      painpoint_catalog: expect.arrayContaining([
+        expect.objectContaining({ type: "stale_ack" }),
+        expect.objectContaining({ type: "duplicate_wake" }),
+        expect.objectContaining({ type: "unclear_owner" }),
+        expect.objectContaining({ type: "missing_proof" }),
+        expect.objectContaining({ type: "noisy_thread" }),
+        expect.objectContaining({ type: "none" }),
+      ]),
+      orchestrator_issue_map: expect.arrayContaining([
+        expect.objectContaining({ bucket: "noisy_thread" }),
+        expect.objectContaining({ bucket: "unclear_owner" }),
+        expect.objectContaining({ bucket: "missing_proof" }),
+        expect.objectContaining({ bucket: "stale_ack" }),
+      ]),
     });
   });
 

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -50,6 +50,11 @@ describe("NudgeOnlyAPI policy", () => {
         expect.objectContaining({ worker: "Heartbeat Seat", bucket: "noisy_thread" }),
         expect.objectContaining({ worker: "Agent Observability", bucket: "missing_proof" }),
       ]),
+      quality_gates: expect.arrayContaining([
+        "Do not invent facts, owners, sources, statuses, or proof.",
+        "Prefer false negatives over false positives when evidence is weak.",
+        "Every alert must name a deterministic verifier before action.",
+      ]),
     });
   });
 

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -15,7 +15,7 @@ describe("NudgeOnlyAPI policy", () => {
       ecosystem: "PinballWake",
       lane: "red_nudge",
       authority: "nudge_only_no_write_no_truth",
-      default_model: "openrouter/free",
+      default_model: "liquid/lfm-2.5-1.2b-instruct:free",
     });
   });
 
@@ -52,7 +52,7 @@ describe("NudgeOnlyAPI policy", () => {
       ok: true,
       json: async () => ({
         id: "or-nudge-test",
-        model: "openrouter/free",
+        model: "liquid/lfm-2.5-1.2b-instruct:free",
         choices: [{
           finish_reason: "stop",
           message: {
@@ -80,15 +80,15 @@ describe("NudgeOnlyAPI policy", () => {
       code_name: "NudgeOnly",
       ecosystem: "PinballWake",
       authority: "nudge_only_no_write_no_truth",
-      model: "openrouter/free",
+        model: "liquid/lfm-2.5-1.2b-instruct:free",
       source_id: "wake-pull_request-pr-705",
       source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/705",
       painpoint_detected: true,
       requires_verifier: true,
       evidence: {
         router: "OpenRouter",
-        requested_model: "openrouter/free",
-        resolved_model: "openrouter/free",
+        requested_model: "liquid/lfm-2.5-1.2b-instruct:free",
+        resolved_model: "liquid/lfm-2.5-1.2b-instruct:free",
         openrouter_id: "or-nudge-test",
         verifier_required: true,
         authority: "nudge_only_no_write_no_truth",
@@ -103,7 +103,7 @@ describe("NudgeOnlyAPI policy", () => {
     });
     const body = JSON.parse(String(init?.body));
     expect(body).toMatchObject({
-      model: "openrouter/free",
+      model: "liquid/lfm-2.5-1.2b-instruct:free",
       max_tokens: 260,
       response_format: { type: "json_object" },
     });

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -322,6 +322,25 @@ function normalisePainpointType(value: unknown): string {
   return PAINPOINT_TYPES.find((type) => raw.includes(type)) ?? "none";
 }
 
+function ackOnlyWakeProof(value: unknown): { original_wake_id: string | null; reason: string } | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+
+  const originalWakeId = text.match(/\b(wake-[a-z0-9_-]+(?:-[a-z0-9_-]+)*)\b/i)?.[1] ?? null;
+  const startsWithAckWake = /^\s*ack\s+wake-/i.test(text);
+  if (startsWithAckWake) {
+    return { original_wake_id: originalWakeId, reason: "ack_only_comment" };
+  }
+
+  const verifierOnly = /\b(ack-only|verifier-only|verifier receipt|ack proof receipt)\b/i.test(text)
+    && /\b(no|not|missing|absent|still)\b.{0,80}\b(executor|terminal|build_attempt|pr_proof|done|receipt)\b/i.test(text);
+  if (verifierOnly && originalWakeId) {
+    return { original_wake_id: originalWakeId, reason: "verifier_only_comment" };
+  }
+
+  return null;
+}
+
 function asOptionalString(value: unknown): string | null {
   const trimmed = String(value ?? "").trim();
   return trimmed ? trimmed : null;
@@ -511,6 +530,7 @@ export async function nudgeonlyReceiptBridge(args: Record<string, unknown>): Pro
   const text = evidenceText(args, nudge);
   const hasSourceEvidence = Boolean(sourceId || sourceUrl || target);
   const hasCue = hasConcreteCue(painpointType, text);
+  const ackOnlyProof = ackOnlyWakeProof(args.event_text ?? args.context ?? nudge.nudge);
   const traceInput = JSON.stringify({
     painpoint_type: painpointType,
     source_id: sourceId,
@@ -521,6 +541,32 @@ export async function nudgeonlyReceiptBridge(args: Record<string, unknown>): Pro
     nudge_trace_id: asOptionalString(args.nudge_trace_id) ?? asOptionalString(nudge.trace_id),
   });
   const bridgeId = `nudgebridge_${shortHash(traceInput)}`;
+
+  if (ackOnlyProof) {
+    return {
+      bridge_id: bridgeId,
+      bridge_status: "suppress",
+      worker: NUDGEONLY_POLICY.worker_name,
+      official_name: NUDGEONLY_POLICY.official_name,
+      code_name: NUDGEONLY_POLICY.code_name,
+      ecosystem: NUDGEONLY_POLICY.ecosystem,
+      authority: NUDGEONLY_POLICY.authority,
+      painpoint_detected: false,
+      painpoint_type: "none",
+      suppressed_painpoint_type: painpointType,
+      suppression: {
+        ...ackOnlyProof,
+        source_id: sourceId,
+        source_url: sourceUrl,
+        target,
+      },
+      reason: "ACK-only or verifier-only WakePass comments are proof metadata for the original wake, not fresh wake requests.",
+      quality_gate: "duplicate ACK wake suppression",
+      requires_verifier: true,
+      allowed_actions: ["record suppress receipt", "attach proof metadata to original wake"],
+      prohibited_actions: NUDGEONLY_POLICY.prohibited_actions,
+    };
+  }
 
   if (!detected || painpointType === "none") {
     return {

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -172,6 +172,15 @@ const WORKER_NUDGE_MAP = [
   },
 ] as const;
 
+const QUALITY_GATES = [
+  "Do not invent facts, owners, sources, statuses, or proof.",
+  "Do not alert from model vibes alone; require source text plus a concrete painpoint cue.",
+  "Prefer false negatives over false positives when evidence is weak.",
+  "If source_id and source_url are both missing, return a nudge as advisory only and keep requires_verifier=true.",
+  "Healthy/completed/info-only controls must stay quiet unless the input explicitly says proof is missing, ACK is stale, ownership is unclear, wake is duplicated, or thread noise is hiding state.",
+  "Every alert must name a deterministic verifier before action.",
+] as const;
+
 type OpenRouterRole = "system" | "user" | "assistant";
 
 interface OpenRouterMessage {
@@ -205,6 +214,7 @@ export const NUDGEONLY_POLICY = {
   rollout_surfaces: ROLLOUT_SURFACES,
   orchestrator_issue_map: ORCHESTRATOR_ISSUE_MAP,
   worker_nudge_map: WORKER_NUDGE_MAP,
+  quality_gates: QUALITY_GATES,
   tested_proof: {
     live_sweep: "12 cases, 0 API errors, 12 useful traceable outputs, 12/12 signal matches, 12/12 painpoint bucket matches, 0 false positives on healthy control.",
     commits: ["8116ae9", "1221b7a", "6d35130"],
@@ -372,6 +382,8 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
     `You are ${NUDGEONLY_POLICY.worker_name}, the ${NUDGEONLY_POLICY.official_name} worker.`,
     "You are a red-lane, low-authority helper for painpoint hints only.",
     "You must never decide, approve, merge, close, mark done, assign ownership, or set truth.",
+    "You must never invent facts, owners, statuses, proof, source IDs, or source URLs.",
+    "Quality is more important than coverage. Prefer false negatives over false positives when evidence is weak.",
     "Do not use hidden reasoning. Spend tokens on the final JSON fields.",
     "Use exactly one painpoint_type from: stale_ack, duplicate_wake, unclear_owner, noisy_thread, missing_proof, none.",
     "If the event is healthy or completed and has no explicit stale, duplicate, unclear owner, noisy thread, or missing proof signal, return painpoint_detected=false and painpoint_type=none.",

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -127,6 +127,51 @@ const ORCHESTRATOR_ISSUE_MAP = [
   },
 ] as const;
 
+const WORKER_NUDGE_MAP = [
+  {
+    worker: "Continuous Improver",
+    watches: ["quiet improvement loop", "no recent improvement proposal", "repeated same bottleneck"],
+    bucket: "unclear_owner",
+    nudge: "Ask for the next tiny improvement candidate and expected proof, not a broad redesign.",
+    verifier: "Check for a recent improvement proposal, experiment result, or shipped follow-up.",
+  },
+  {
+    worker: "Job Manager",
+    watches: ["blockers without active jobs", "jobs without next action", "orphaned todos"],
+    bucket: "unclear_owner",
+    nudge: "Ask for the owning job, next safe action, and expected receipt.",
+    verifier: "Compare active blockers against active jobs and assigned owner fields.",
+  },
+  {
+    worker: "Reviewer",
+    watches: ["ready PRs without review ACK", "stale review handoff", "review requested but no receipt"],
+    bucket: "stale_ack",
+    nudge: "Ask for review ACK or a clear blocker receipt.",
+    verifier: "Run WakePass ACK check against the PR/review dispatch.",
+  },
+  {
+    worker: "Builder",
+    watches: ["implementation started but no commit", "claimed done without proof", "missing PR"],
+    bucket: "missing_proof",
+    nudge: "Ask for commit, PR, run ID, or blocker receipt.",
+    verifier: "Check linked commit, branch, PR, or test result.",
+  },
+  {
+    worker: "Heartbeat Seat",
+    watches: ["repeated healthy pulses", "heartbeat noise", "missing PASS/BLOCKER receipt"],
+    bucket: "noisy_thread",
+    nudge: "Ask for only the material diff or a compact PASS/BLOCKER receipt.",
+    verifier: "Compare latest heartbeat content against prior state and count material changes.",
+  },
+  {
+    worker: "Agent Observability",
+    watches: ["unexplained worker silence", "missing decision trace", "no reliability trend"],
+    bucket: "missing_proof",
+    nudge: "Ask for the trace ID, owner, decision, and reliability proof.",
+    verifier: "Check observability logs for decision trace, receipt, and worker status.",
+  },
+] as const;
+
 type OpenRouterRole = "system" | "user" | "assistant";
 
 interface OpenRouterMessage {
@@ -159,6 +204,7 @@ export const NUDGEONLY_POLICY = {
   painpoint_catalog: PAINPOINT_CATALOG,
   rollout_surfaces: ROLLOUT_SURFACES,
   orchestrator_issue_map: ORCHESTRATOR_ISSUE_MAP,
+  worker_nudge_map: WORKER_NUDGE_MAP,
   tested_proof: {
     live_sweep: "12 cases, 0 API errors, 12 useful traceable outputs, 12/12 signal matches, 12/12 painpoint bucket matches, 0 false positives on healthy control.",
     commits: ["8116ae9", "1221b7a", "6d35130"],

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -1,0 +1,228 @@
+// NudgeOnlyAPI is the PinballWake red-lane helper for painpoint hints only.
+// It can summarize, flag, and suggest checks, but it must never decide or write.
+
+import { createHash } from "node:crypto";
+
+const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
+const DEFAULT_MODEL = "openrouter/free";
+const DEFAULT_MAX_TOKENS = 260;
+const MAX_INPUT_CHARS = 6000;
+
+type OpenRouterRole = "system" | "user" | "assistant";
+
+interface OpenRouterMessage {
+  role: OpenRouterRole;
+  content: string;
+}
+
+interface OpenRouterChatResponse {
+  id?: string;
+  model?: string;
+  choices?: Array<{
+    message?: {
+      content?: string;
+    };
+    finish_reason?: string;
+  }>;
+  usage?: Record<string, unknown>;
+}
+
+export const NUDGEONLY_POLICY = {
+  official_name: "NudgeOnlyAPI",
+  worker_name: "👉Nudge",
+  code_name: "NudgeOnly",
+  ecosystem: "PinballWake",
+  lane: "red_nudge",
+  authority: "nudge_only_no_write_no_truth",
+  default_model: DEFAULT_MODEL,
+  allowed_actions: [
+    "summarise noisy events",
+    "flag possible painpoints",
+    "suggest deterministic checks",
+    "rewrite status in simple English",
+    "spot likely duplicate or stale handoffs",
+  ],
+  prohibited_actions: [
+    "merge PRs",
+    "close blockers",
+    "mark work complete",
+    "decide ownership",
+    "approve changes",
+    "call mutation tools",
+    "set source-of-truth state",
+  ],
+  verifier_rule: "Every nudge must be verified by deterministic code or a trusted lane before action.",
+} as const;
+
+function apiKeyFrom(args: Record<string, unknown>): string {
+  const key = String(args.api_key ?? process.env.OPENROUTER_API_KEY ?? "").trim();
+  if (!key) {
+    throw new Error("api_key is required unless OPENROUTER_API_KEY is set.");
+  }
+  return key;
+}
+
+function trimInput(value: unknown): string {
+  return String(value ?? "").trim().slice(0, MAX_INPUT_CHARS);
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function extractJsonObject(text: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start === -1 || end <= start) return null;
+    try {
+      const parsed = JSON.parse(text.slice(start, end + 1));
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function normaliseNudge(parsed: Record<string, unknown> | null, raw: string): Record<string, unknown> {
+  return {
+    worker: NUDGEONLY_POLICY.worker_name,
+    official_name: NUDGEONLY_POLICY.official_name,
+    code_name: NUDGEONLY_POLICY.code_name,
+    ecosystem: NUDGEONLY_POLICY.ecosystem,
+    lane: NUDGEONLY_POLICY.lane,
+    authority: NUDGEONLY_POLICY.authority,
+    painpoint_detected: Boolean(parsed?.painpoint_detected ?? false),
+    painpoint_type: String(parsed?.painpoint_type ?? "unknown"),
+    nudge: String(parsed?.nudge ?? raw).slice(0, 1200),
+    suggested_check: String(parsed?.suggested_check ?? "Run a deterministic verifier before taking action.").slice(0, 600),
+    confidence: String(parsed?.confidence ?? "low"),
+    requires_verifier: true,
+    allowed_actions: NUDGEONLY_POLICY.allowed_actions,
+    prohibited_actions: NUDGEONLY_POLICY.prohibited_actions,
+  };
+}
+
+async function openRouterPost<T>(apiKey: string, path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${OPENROUTER_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "X-OpenRouter-Title": NUDGEONLY_POLICY.official_name,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json() as Record<string, unknown>;
+  if (!res.ok) {
+    const err = data.error as Record<string, unknown> | undefined;
+    const msg = (err?.message as string) ?? `HTTP ${res.status}`;
+    throw new Error(`OpenRouter NudgeOnlyAPI error: ${msg}`);
+  }
+  return data as T;
+}
+
+export async function nudgeonlyPolicy(_args: Record<string, unknown>): Promise<unknown> {
+  return NUDGEONLY_POLICY;
+}
+
+export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unknown> {
+  const apiKey = apiKeyFrom(args);
+  const eventText = trimInput(args.event_text);
+  if (!eventText) throw new Error("event_text is required.");
+
+  const context = trimInput(args.context);
+  const painpointHint = trimInput(args.painpoint_hint);
+  const sourceId = trimInput(args.source_id);
+  const sourceUrl = trimInput(args.source_url);
+  const model = String(args.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+  const maxTokens = Math.min(asNumber(args.max_tokens, DEFAULT_MAX_TOKENS), 500);
+  const inputDigest = shortHash(JSON.stringify({
+    event_text: eventText,
+    context,
+    painpoint_hint: painpointHint,
+    source_id: sourceId,
+    source_url: sourceUrl,
+  }));
+  const traceId = `nudgeonly_${inputDigest}`;
+
+  const system = [
+    `You are ${NUDGEONLY_POLICY.worker_name}, the ${NUDGEONLY_POLICY.official_name} worker.`,
+    "You are a red-lane, low-authority helper for painpoint hints only.",
+    "You must never decide, approve, merge, close, mark done, assign ownership, or set truth.",
+    "Use only cautious language: possible, likely, suggest checking, may need.",
+    "Return JSON only. Do not include markdown.",
+  ].join(" ");
+
+  const user = JSON.stringify({
+    task: "Classify this event as a painpoint nudge only.",
+    required_output: {
+      painpoint_detected: "boolean",
+      painpoint_type: "short string such as stale_ack, duplicate_wake, unclear_owner, noisy_thread, missing_proof, none",
+      nudge: "one or two plain-English sentences",
+      suggested_check: "one deterministic check a trusted lane should run",
+      confidence: "low | medium | high",
+    },
+    hard_limits: NUDGEONLY_POLICY.prohibited_actions,
+    trace_id: traceId,
+    source_id: sourceId,
+    source_url: sourceUrl,
+    event_text: eventText,
+    context,
+    painpoint_hint: painpointHint,
+  });
+
+  const messages: OpenRouterMessage[] = [
+    { role: "system", content: system },
+    { role: "user", content: user },
+  ];
+
+  const result = await openRouterPost<OpenRouterChatResponse>(apiKey, "/chat/completions", {
+    model,
+    messages,
+    temperature: 0.1,
+    max_tokens: maxTokens,
+    response_format: { type: "json_object" },
+  });
+
+  const raw = result.choices?.[0]?.message?.content ?? "";
+  const parsed = extractJsonObject(raw);
+
+  return {
+    ...normaliseNudge(parsed, raw),
+    trace_id: traceId,
+    source_id: sourceId || null,
+    source_url: sourceUrl || null,
+    input_digest: inputDigest,
+    evidence: {
+      trace_id: traceId,
+      input_digest: inputDigest,
+      source_id: sourceId || null,
+      source_url: sourceUrl || null,
+      router: "OpenRouter",
+      requested_model: model,
+      resolved_model: result.model ?? model,
+      openrouter_id: result.id ?? null,
+      verifier_required: true,
+      verifier_rule: NUDGEONLY_POLICY.verifier_rule,
+      authority: NUDGEONLY_POLICY.authority,
+    },
+    model: result.model ?? model,
+    openrouter_id: result.id ?? null,
+    finish_reason: result.choices?.[0]?.finish_reason ?? null,
+    usage: result.usage ?? null,
+  };
+}

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -181,6 +181,47 @@ const QUALITY_GATES = [
   "Every alert must name a deterministic verifier before action.",
 ] as const;
 
+const RECEIPT_BRIDGE_RULES = [
+  "NudgeOnly can suggest a receipt request, but it cannot write it, assign ownership, or mark the target done.",
+  "A bridge request requires a concrete painpoint plus source evidence.",
+  "If the source has no owner, route only to Job Manager for owner resolution.",
+  "If proof or ACK is overdue past the TTL, emit an escalation request instead of pretending the work moved.",
+  "WakePass or another deterministic verifier must confirm ACK/proof before any trusted state changes.",
+] as const;
+
+const RECEIPT_ROUTES = [
+  {
+    painpoint_type: "stale_ack",
+    default_worker: "Reviewer",
+    expected_receipt: "ACK received, review started, or blocker receipt with reason.",
+    verifier: "Run the WakePass ACK verifier against the source dispatch or PR.",
+  },
+  {
+    painpoint_type: "duplicate_wake",
+    default_worker: "Job Manager",
+    expected_receipt: "Duplicate wake consolidated or separate targets justified.",
+    verifier: "Compare source IDs, target URLs, owners, and timestamps before consolidation.",
+  },
+  {
+    painpoint_type: "unclear_owner",
+    default_worker: "Job Manager",
+    expected_receipt: "Owning job, next safe action, and expected proof receipt.",
+    verifier: "Run the owner resolver against the latest promoted handoff and active jobs.",
+  },
+  {
+    painpoint_type: "missing_proof",
+    default_worker: "Builder",
+    expected_receipt: "Commit, PR, run ID, receipt ID, or blocker receipt.",
+    verifier: "Check linked commit, PR, run ID, receipt ID, or source pointer.",
+  },
+  {
+    painpoint_type: "noisy_thread",
+    default_worker: "Heartbeat Seat",
+    expected_receipt: "Latest material diff or compact PASS/BLOCKER receipt.",
+    verifier: "Compare latest heartbeat content against prior state and count material changes.",
+  },
+] as const;
+
 type OpenRouterRole = "system" | "user" | "assistant";
 
 interface OpenRouterMessage {
@@ -215,6 +256,13 @@ export const NUDGEONLY_POLICY = {
   orchestrator_issue_map: ORCHESTRATOR_ISSUE_MAP,
   worker_nudge_map: WORKER_NUDGE_MAP,
   quality_gates: QUALITY_GATES,
+  receipt_bridge: {
+    status: "official",
+    route_shape: "worker -> target -> painpoint -> expected receipt -> verifier",
+    escalation_rule: "If ACK/proof is still missing after the configured TTL, emit an escalation request for the owning lane.",
+    rules: RECEIPT_BRIDGE_RULES,
+    routes: RECEIPT_ROUTES,
+  },
   tested_proof: {
     live_sweep: "12 cases, 0 API errors, 12 useful traceable outputs, 12/12 signal matches, 12/12 painpoint bucket matches, 0 false positives on healthy control.",
     commits: ["8116ae9", "1221b7a", "6d35130"],
@@ -272,6 +320,27 @@ function asBoolean(value: unknown): boolean {
 function normalisePainpointType(value: unknown): string {
   const raw = String(value ?? "none").trim().toLowerCase();
   return PAINPOINT_TYPES.find((type) => raw.includes(type)) ?? "none";
+}
+
+function asOptionalString(value: unknown): string | null {
+  const trimmed = String(value ?? "").trim();
+  return trimmed ? trimmed : null;
+}
+
+function asStatus(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function parseTime(value: unknown): number | null {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function minutesBetween(start: number | null, end: number | null): number | null {
+  if (start === null || end === null || end < start) return null;
+  return Math.floor((end - start) / 60000);
 }
 
 function shortHash(value: string): string {
@@ -334,6 +403,79 @@ function normaliseNudge(
   };
 }
 
+function recordFrom(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function evidenceText(args: Record<string, unknown>, nudge: Record<string, unknown>): string {
+  return [
+    args.event_text,
+    args.context,
+    args.source_id,
+    args.source_url,
+    args.target,
+    args.owner,
+    args.worker,
+    args.ack_status,
+    args.proof_status,
+    nudge.nudge,
+    nudge.suggested_check,
+    nudge.source_id,
+    nudge.source_url,
+  ].map((part) => String(part ?? "").toLowerCase()).join(" ");
+}
+
+function hasConcreteCue(painpointType: string, text: string): boolean {
+  if (painpointType === "none") return false;
+  if (painpointType === "stale_ack") return /\b(stale|overdue|missing|absent|no)\b.*\b(ack|receipt|review)\b|\b(ack|receipt|review)\b.*\b(stale|overdue|missing|absent)\b/.test(text);
+  if (painpointType === "duplicate_wake") return /\bduplicate|duplicated|same target|same owner|same wake\b/.test(text);
+  if (painpointType === "unclear_owner") return /\bunclear owner|no owner|without active job|no active job|orphaned|owner missing|owning job\b/.test(text);
+  if (painpointType === "missing_proof") return /\bmissing proof|no proof|proof missing|without proof|no commit|no pr|no run id|no receipt\b/.test(text);
+  if (painpointType === "noisy_thread") return /\bnoise|noisy|repeated|heartbeat|near-duplicate|hides state|collapse\b/.test(text);
+  return false;
+}
+
+function routeForPainpoint(painpointType: string) {
+  return RECEIPT_ROUTES.find((route) => route.painpoint_type === painpointType);
+}
+
+function targetFrom(args: Record<string, unknown>, nudge: Record<string, unknown>): string | null {
+  return asOptionalString(args.target)
+    ?? asOptionalString(args.source_url)
+    ?? asOptionalString(nudge.source_url)
+    ?? asOptionalString(args.source_id)
+    ?? asOptionalString(nudge.source_id);
+}
+
+function workerFrom(args: Record<string, unknown>, painpointType: string, routeWorker: string): string {
+  const explicitWorker = asOptionalString(args.worker);
+  const owner = asOptionalString(args.owner);
+  if (painpointType === "unclear_owner" || !owner) return "Job Manager";
+  return explicitWorker ?? routeWorker;
+}
+
+function proofOrAckMissing(args: Record<string, unknown>, painpointType: string): boolean {
+  const ackStatus = asStatus(args.ack_status);
+  const proofStatus = asStatus(args.proof_status);
+  const ackMissing = !ackStatus || ["missing", "absent", "stale", "overdue", "failed", "none"].includes(ackStatus);
+  const proofMissing = !proofStatus || ["missing", "absent", "stale", "overdue", "failed", "none"].includes(proofStatus);
+  if (painpointType === "stale_ack") return ackMissing;
+  if (painpointType === "missing_proof") return proofMissing;
+  return ackMissing || proofMissing;
+}
+
+function bridgeStatus(args: Record<string, unknown>, painpointType: string): string {
+  const ttlMinutes = asNumber(args.ttl_minutes, 60);
+  const createdAt = parseTime(args.created_at);
+  const now = parseTime(args.now) ?? Date.now();
+  const ageMinutes = minutesBetween(createdAt, now);
+  const missing = proofOrAckMissing(args, painpointType);
+  const shouldEscalate = missing && ageMinutes !== null && ageMinutes >= ttlMinutes;
+  return shouldEscalate ? "escalation_request" : "receipt_request";
+}
+
 async function openRouterPost<T>(apiKey: string, path: string, body: unknown): Promise<T> {
   const res = await fetch(`${OPENROUTER_BASE}${path}`, {
     method: "POST",
@@ -356,6 +498,104 @@ async function openRouterPost<T>(apiKey: string, path: string, body: unknown): P
 
 export async function nudgeonlyPolicy(_args: Record<string, unknown>): Promise<unknown> {
   return NUDGEONLY_POLICY;
+}
+
+export async function nudgeonlyReceiptBridge(args: Record<string, unknown>): Promise<unknown> {
+  const nudge = recordFrom(args.nudge_result);
+  const painpointType = normalisePainpointType(args.painpoint_type ?? nudge.painpoint_type ?? args.painpoint_hint);
+  const detected = asBoolean(args.painpoint_detected ?? nudge.painpoint_detected ?? painpointType);
+  const sourceId = asOptionalString(args.source_id) ?? asOptionalString(nudge.source_id);
+  const sourceUrl = asOptionalString(args.source_url) ?? asOptionalString(nudge.source_url);
+  const target = targetFrom(args, nudge);
+  const route = routeForPainpoint(painpointType);
+  const text = evidenceText(args, nudge);
+  const hasSourceEvidence = Boolean(sourceId || sourceUrl || target);
+  const hasCue = hasConcreteCue(painpointType, text);
+  const traceInput = JSON.stringify({
+    painpoint_type: painpointType,
+    source_id: sourceId,
+    source_url: sourceUrl,
+    target,
+    owner: asOptionalString(args.owner),
+    worker: asOptionalString(args.worker),
+    nudge_trace_id: asOptionalString(args.nudge_trace_id) ?? asOptionalString(nudge.trace_id),
+  });
+  const bridgeId = `nudgebridge_${shortHash(traceInput)}`;
+
+  if (!detected || painpointType === "none") {
+    return {
+      bridge_id: bridgeId,
+      bridge_status: "quiet",
+      painpoint_detected: false,
+      painpoint_type: "none",
+      reason: "No painpoint was detected, so no worker receipt request was created.",
+      quality_gate: "healthy controls stay quiet",
+      requires_verifier: true,
+    };
+  }
+
+  if (!route || !hasSourceEvidence || !hasCue) {
+    return {
+      bridge_id: bridgeId,
+      bridge_status: "advisory_only",
+      painpoint_detected: detected,
+      painpoint_type: painpointType,
+      reason: "The bridge did not find enough deterministic evidence to route a worker receipt request.",
+      missing: {
+        source_evidence: !hasSourceEvidence,
+        concrete_cue: !hasCue,
+      },
+      quality_gate: "prefer false negatives over false positives",
+      requires_verifier: true,
+    };
+  }
+
+  const owner = asOptionalString(args.owner);
+  const worker = workerFrom(args, painpointType, route.default_worker);
+  const status = bridgeStatus(args, painpointType);
+  const nudgeTraceId = asOptionalString(args.nudge_trace_id) ?? asOptionalString(nudge.trace_id);
+  const request = {
+    worker,
+    owner: owner ?? null,
+    target,
+    painpoint_type: painpointType,
+    expected_receipt: route.expected_receipt,
+    verifier: route.verifier,
+    receipt_line: `${worker} -> ${target} -> ${painpointType} -> ${route.expected_receipt} -> ${route.verifier}`,
+  };
+
+  return {
+    bridge_id: bridgeId,
+    bridge_status: status,
+    worker: NUDGEONLY_POLICY.worker_name,
+    official_name: NUDGEONLY_POLICY.official_name,
+    code_name: NUDGEONLY_POLICY.code_name,
+    ecosystem: NUDGEONLY_POLICY.ecosystem,
+    authority: NUDGEONLY_POLICY.authority,
+    painpoint_detected: true,
+    painpoint_type: painpointType,
+    request,
+    escalation: status === "escalation_request"
+      ? {
+          escalate_to: "WakePass",
+          reason: "ACK or proof is still missing after the configured TTL.",
+          verifier: route.verifier,
+        }
+      : null,
+    evidence: {
+      bridge_id: bridgeId,
+      nudge_trace_id: nudgeTraceId,
+      source_id: sourceId,
+      source_url: sourceUrl,
+      target,
+      verifier_required: true,
+      verifier_rule: NUDGEONLY_POLICY.verifier_rule,
+      quality_gates: RECEIPT_BRIDGE_RULES,
+    },
+    requires_verifier: true,
+    allowed_actions: ["emit worker receipt request", "emit escalation request", "run deterministic verifier"],
+    prohibited_actions: NUDGEONLY_POLICY.prohibited_actions,
+  };
 }
 
 export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unknown> {

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -16,6 +16,117 @@ const PAINPOINT_TYPES = [
   "none",
 ] as const;
 
+const PAINPOINT_CATALOG = [
+  {
+    type: "stale_ack",
+    label: "Stale ACK",
+    watch: ["WakePass", "dispatches", "PR review handoffs", "quiet seats"],
+    cue: "A wake, handoff, or review is visible but the expected acknowledgement is stale or absent.",
+    verifier: "Run the WakePass ACK verifier against the source dispatch or PR.",
+  },
+  {
+    type: "duplicate_wake",
+    label: "Duplicate Wake",
+    watch: ["WakePass", "dispatches", "issues", "PRs"],
+    cue: "Two or more wake records point at the same target, owner, and unresolved action.",
+    verifier: "Compare source IDs, target URLs, owners, and timestamps before consolidating.",
+  },
+  {
+    type: "unclear_owner",
+    label: "Unclear Owner",
+    watch: ["Orchestrator handoff", "active jobs", "seat status", "Fishbowl"],
+    cue: "The system can see a blocker, but the next owner or next receipt is not obvious.",
+    verifier: "Run an owner resolver or inspect the latest promoted handoff receipt.",
+  },
+  {
+    type: "missing_proof",
+    label: "Missing Proof",
+    watch: ["completed WakePass", "done messages", "PR closure", "session summaries"],
+    cue: "A task claims done/completed, but the compact state lacks a proof pointer.",
+    verifier: "Check for a linked PR, commit, receipt ID, run ID, or source pointer.",
+  },
+  {
+    type: "noisy_thread",
+    label: "Noisy Thread",
+    watch: ["heartbeats", "admin Orchestrator", "conversation turns", "Fishbowl"],
+    cue: "Repeated low-signal messages hide the actual current state or next action.",
+    verifier: "Count repeated heartbeats or near-duplicate turns, then collapse to the latest material state.",
+  },
+  {
+    type: "none",
+    label: "Healthy Control",
+    watch: ["completed events", "fresh receipts"],
+    cue: "The event is healthy, completed, or informational and has no explicit painpoint signal.",
+    verifier: "Do not alert. Keep it as a control case for false-positive checks.",
+  },
+] as const;
+
+const ROLLOUT_SURFACES = [
+  {
+    surface: "PinballWake/WakePass",
+    use: "Flag stale ACKs, duplicate wakes, and missing proof before they become invisible queue drag.",
+  },
+  {
+    surface: "Orchestrator state cards",
+    use: "Turn blocker summaries into plain-English painpoint nudges with trace IDs.",
+  },
+  {
+    surface: "Heartbeat and Signals",
+    use: "Separate info-only pulse noise from action-needed painpoints.",
+  },
+  {
+    surface: "Fishbowl and Boardroom handoffs",
+    use: "Spot unclear owners, repeated asks, and handoff loops without assigning authority.",
+  },
+  {
+    surface: "Agent Observability",
+    use: "Feed trend counts for stale ACKs, duplicate wakes, missing proof, and noisy threads.",
+  },
+  {
+    surface: "Admin Orchestrator UX",
+    use: "Show the nudge as red-lane evidence below the source message, not as source-of-truth state.",
+  },
+] as const;
+
+const ORCHESTRATOR_ISSUE_MAP = [
+  {
+    issue: "Properties overload or hard-to-read status blocks",
+    bucket: "noisy_thread",
+    nudge: "Collapse secondary metadata and keep the main chat message as the first read.",
+    verifier: "Count visible metadata fields per message and compare against the primary message length.",
+  },
+  {
+    issue: "Simple-English summary is too short and loses context",
+    bucket: "missing_proof",
+    nudge: "Ask for the source receipt, PR, commit, or dispatch pointer to stay visible with the summary.",
+    verifier: "Check that every short summary carries a source pointer or proof ID.",
+  },
+  {
+    issue: "Blockers visible but no active owning job",
+    bucket: "unclear_owner",
+    nudge: "Surface the next owner and next expected receipt beside the blocker.",
+    verifier: "Compare active blocker count against active job and owner fields.",
+  },
+  {
+    issue: "Repeated heartbeat noise hides useful work",
+    bucket: "noisy_thread",
+    nudge: "Collapse repeated heartbeat receipts into a latest-state line unless action is needed.",
+    verifier: "Count repeated heartbeat turns without a material status change.",
+  },
+  {
+    issue: "WakePass or review handoff is stale",
+    bucket: "stale_ack",
+    nudge: "Flag the stale handoff as a painpoint, then run the WakePass ACK verifier.",
+    verifier: "Check latest ACK timestamp against the handoff TTL.",
+  },
+  {
+    issue: "Done/completed state lacks proof",
+    bucket: "missing_proof",
+    nudge: "Keep the done state visually quiet until a proof pointer exists.",
+    verifier: "Check for a commit, PR, run ID, receipt ID, or source pointer.",
+  },
+] as const;
+
 type OpenRouterRole = "system" | "user" | "assistant";
 
 interface OpenRouterMessage {
@@ -43,6 +154,15 @@ export const NUDGEONLY_POLICY = {
   lane: "red_nudge",
   authority: "nudge_only_no_write_no_truth",
   default_model: DEFAULT_MODEL,
+  rollout_status: "official",
+  rollout_rule: "Run on candidate painpoints only; never run as a decision maker or completion source.",
+  painpoint_catalog: PAINPOINT_CATALOG,
+  rollout_surfaces: ROLLOUT_SURFACES,
+  orchestrator_issue_map: ORCHESTRATOR_ISSUE_MAP,
+  tested_proof: {
+    live_sweep: "12 cases, 0 API errors, 12 useful traceable outputs, 12/12 signal matches, 12/12 painpoint bucket matches, 0 false positives on healthy control.",
+    commits: ["8116ae9", "1221b7a", "6d35130"],
+  },
   allowed_actions: [
     "summarise noisy events",
     "flag possible painpoints",

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -4,7 +4,7 @@
 import { createHash } from "node:crypto";
 
 const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
-const DEFAULT_MODEL = "openrouter/free";
+const DEFAULT_MODEL = "liquid/lfm-2.5-1.2b-instruct:free";
 const DEFAULT_MAX_TOKENS = 260;
 const MAX_INPUT_CHARS = 6000;
 
@@ -71,6 +71,20 @@ function asNumber(value: unknown, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function asBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "yes", "stale_ack", "duplicate_wake", "unclear_owner", "missing_proof"].includes(normalized)) {
+      return true;
+    }
+    if (["false", "no", "none", "unknown", ""].includes(normalized)) {
+      return false;
+    }
+  }
+  return Boolean(value);
+}
+
 function shortHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);
 }
@@ -104,7 +118,7 @@ function normaliseNudge(parsed: Record<string, unknown> | null, raw: string): Re
     ecosystem: NUDGEONLY_POLICY.ecosystem,
     lane: NUDGEONLY_POLICY.lane,
     authority: NUDGEONLY_POLICY.authority,
-    painpoint_detected: Boolean(parsed?.painpoint_detected ?? false),
+    painpoint_detected: asBoolean(parsed?.painpoint_detected ?? false),
     painpoint_type: String(parsed?.painpoint_type ?? "unknown"),
     nudge: String(parsed?.nudge ?? raw).slice(0, 1200),
     suggested_check: String(parsed?.suggested_check ?? "Run a deterministic verifier before taking action.").slice(0, 600),
@@ -148,7 +162,7 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
   const painpointHint = trimInput(args.painpoint_hint);
   const sourceId = trimInput(args.source_id);
   const sourceUrl = trimInput(args.source_url);
-  const model = String(args.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+  const model = String(args.model ?? process.env.NUDGEONLY_OPENROUTER_MODEL ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
   const maxTokens = Math.min(asNumber(args.max_tokens, DEFAULT_MAX_TOKENS), 500);
   const inputDigest = shortHash(JSON.stringify({
     event_text: eventText,
@@ -163,6 +177,7 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
     `You are ${NUDGEONLY_POLICY.worker_name}, the ${NUDGEONLY_POLICY.official_name} worker.`,
     "You are a red-lane, low-authority helper for painpoint hints only.",
     "You must never decide, approve, merge, close, mark done, assign ownership, or set truth.",
+    "Do not use hidden reasoning. Spend tokens on the final JSON fields.",
     "Use only cautious language: possible, likely, suggest checking, may need.",
     "Return JSON only. Do not include markdown.",
   ].join(" ");
@@ -172,8 +187,8 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
     required_output: {
       painpoint_detected: "boolean",
       painpoint_type: "short string such as stale_ack, duplicate_wake, unclear_owner, noisy_thread, missing_proof, none",
-      nudge: "one or two plain-English sentences",
-      suggested_check: "one deterministic check a trusted lane should run",
+      nudge: "one or two specific plain-English sentences naming the possible painpoint",
+      suggested_check: "one specific deterministic check a trusted lane should run",
       confidence: "low | medium | high",
     },
     hard_limits: NUDGEONLY_POLICY.prohibited_actions,

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -7,6 +7,14 @@ const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 const DEFAULT_MODEL = "liquid/lfm-2.5-1.2b-instruct:free";
 const DEFAULT_MAX_TOKENS = 260;
 const MAX_INPUT_CHARS = 6000;
+const PAINPOINT_TYPES = [
+  "stale_ack",
+  "duplicate_wake",
+  "unclear_owner",
+  "noisy_thread",
+  "missing_proof",
+  "none",
+] as const;
 
 type OpenRouterRole = "system" | "user" | "assistant";
 
@@ -85,6 +93,11 @@ function asBoolean(value: unknown): boolean {
   return Boolean(value);
 }
 
+function normalisePainpointType(value: unknown): string {
+  const raw = String(value ?? "none").trim().toLowerCase();
+  return PAINPOINT_TYPES.find((type) => raw.includes(type)) ?? "none";
+}
+
 function shortHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);
 }
@@ -110,7 +123,23 @@ function extractJsonObject(text: string): Record<string, unknown> | null {
   }
 }
 
-function normaliseNudge(parsed: Record<string, unknown> | null, raw: string): Record<string, unknown> {
+function normaliseNudge(
+  parsed: Record<string, unknown> | null,
+  raw: string,
+  painpointHint: string,
+): Record<string, unknown> {
+  const parsedType = normalisePainpointType(parsed?.painpoint_type);
+  const hintedType = normalisePainpointType(painpointHint);
+  const explicitNoneHint = painpointHint.trim().length > 0 && hintedType === "none";
+  const requestedType = explicitNoneHint
+    ? "none"
+    : hintedType === "none" ? parsedType : hintedType;
+  const rawDetected = asBoolean(parsed?.painpoint_detected ?? false);
+  const painpointDetected = requestedType === "none"
+    ? false
+    : rawDetected || parsedType !== "none" || hintedType !== "none";
+  const painpointType = painpointDetected ? requestedType : "none";
+
   return {
     worker: NUDGEONLY_POLICY.worker_name,
     official_name: NUDGEONLY_POLICY.official_name,
@@ -118,8 +147,8 @@ function normaliseNudge(parsed: Record<string, unknown> | null, raw: string): Re
     ecosystem: NUDGEONLY_POLICY.ecosystem,
     lane: NUDGEONLY_POLICY.lane,
     authority: NUDGEONLY_POLICY.authority,
-    painpoint_detected: asBoolean(parsed?.painpoint_detected ?? false),
-    painpoint_type: String(parsed?.painpoint_type ?? "unknown"),
+    painpoint_detected: painpointDetected,
+    painpoint_type: painpointType,
     nudge: String(parsed?.nudge ?? raw).slice(0, 1200),
     suggested_check: String(parsed?.suggested_check ?? "Run a deterministic verifier before taking action.").slice(0, 600),
     confidence: String(parsed?.confidence ?? "low"),
@@ -178,6 +207,9 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
     "You are a red-lane, low-authority helper for painpoint hints only.",
     "You must never decide, approve, merge, close, mark done, assign ownership, or set truth.",
     "Do not use hidden reasoning. Spend tokens on the final JSON fields.",
+    "Use exactly one painpoint_type from: stale_ack, duplicate_wake, unclear_owner, noisy_thread, missing_proof, none.",
+    "If the event is healthy or completed and has no explicit stale, duplicate, unclear owner, noisy thread, or missing proof signal, return painpoint_detected=false and painpoint_type=none.",
+    "The suggested_check must be concrete and name the source type, such as WakePass, dispatch, PR, issue, proof pointer, or heartbeat count.",
     "Use only cautious language: possible, likely, suggest checking, may need.",
     "Return JSON only. Do not include markdown.",
   ].join(" ");
@@ -217,7 +249,7 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
   const parsed = extractJsonObject(raw);
 
   return {
-    ...normaliseNudge(parsed, raw),
+    ...normaliseNudge(parsed, raw, painpointHint),
     trace_id: traceId,
     source_id: sourceId || null,
     source_url: sourceUrl || null,

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -9568,7 +9568,7 @@ export const ADDITIONAL_TOOLS = [
         painpoint_hint: { type: "string", description: "Optional hint such as stale_ack, duplicate_wake, unclear_owner, noisy_thread, or missing_proof." },
         source_id: { type: "string", description: "Optional upstream event, dispatch, PR, issue, or wake identifier for trace evidence." },
         source_url: { type: "string", description: "Optional upstream URL for trace evidence." },
-        model: { type: "string", description: "OpenRouter model ID. Default: openrouter/free for free model routing." },
+        model: { type: "string", description: "OpenRouter model ID. Default: liquid/lfm-2.5-1.2b-instruct:free. Use openrouter/free only when auto-rotation is desired." },
         max_tokens: { type: "number", description: "Maximum output tokens. Hard capped at 500. Default: 260." },
       },
       required: ["event_text"],

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -643,7 +643,7 @@ import {
 } from "./groq-tool.js";
 
 import {
-  nudgeonlyApi, nudgeonlyPolicy,
+  nudgeonlyApi, nudgeonlyPolicy, nudgeonlyReceiptBridge,
 } from "./nudgeonly-tool.js";
 
 // ─── Developer / Productivity ─────────────────────────────────────────────────
@@ -9574,6 +9574,32 @@ export const ADDITIONAL_TOOLS = [
       required: ["event_text"],
     },
   },
+  {
+    name: "nudgeonly_receipt_bridge",
+    description: "Turn a verified NudgeOnly painpoint into a tiny worker receipt request or WakePass escalation candidate. Deterministic bridge only: no writes, no ownership decision, no completion state.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        nudge_result: { type: "object", description: "Optional output from nudgeonly_api." },
+        painpoint_detected: { type: "boolean", description: "Whether a painpoint was detected by trusted evidence or nudgeonly_api." },
+        painpoint_type: { type: "string", description: "stale_ack, duplicate_wake, unclear_owner, noisy_thread, missing_proof, or none." },
+        event_text: { type: "string", description: "Source event, blocker, handoff, or state-card text. Keep it small and non-secret." },
+        context: { type: "string", description: "Optional local context. Keep it small and non-secret." },
+        source_id: { type: "string", description: "Optional upstream event, dispatch, PR, issue, or wake identifier." },
+        source_url: { type: "string", description: "Optional upstream source URL." },
+        target: { type: "string", description: "Optional human target label such as PR #705 or a dispatch ID." },
+        owner: { type: "string", description: "Optional existing owner evidence. The bridge does not invent or decide owners." },
+        worker: { type: "string", description: "Optional worker override when a trusted lane already named one." },
+        ack_status: { type: "string", description: "Optional ACK status such as missing, stale, received, or blocked." },
+        proof_status: { type: "string", description: "Optional proof status such as missing, present, stale, or blocked." },
+        created_at: { type: "string", description: "Optional ISO timestamp for the source handoff or request." },
+        now: { type: "string", description: "Optional ISO timestamp used for deterministic TTL checks." },
+        ttl_minutes: { type: "number", description: "Minutes before missing ACK/proof becomes an escalation request. Default: 60." },
+        nudge_trace_id: { type: "string", description: "Optional trace_id from nudgeonly_api." },
+      },
+    },
+  },
 
   // ── kling-tool.ts ─────────────────────────────────────────────────────────────
   {
@@ -13225,6 +13251,7 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   // nudgeonly-tool.ts
   nudgeonly_policy:        (args) => nudgeonlyPolicy(args),
   nudgeonly_api:           (args) => nudgeonlyApi(args),
+  nudgeonly_receipt_bridge:(args) => nudgeonlyReceiptBridge(args),
 
   // neon-tool.ts
   neon_list_projects:      (args) => neonListProjects(args),

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -642,6 +642,10 @@ import {
   groqChatCompletion, groqListModels,
 } from "./groq-tool.js";
 
+import {
+  nudgeonlyApi, nudgeonlyPolicy,
+} from "./nudgeonly-tool.js";
+
 // ─── Developer / Productivity ─────────────────────────────────────────────────
 import { githubAction } from "./github-tool.js";
 import { gitlabAction } from "./gitlab-tool.js";
@@ -9541,6 +9545,36 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── nudgeonly-tool.ts ─────────────────────────────────────────────────────
+  {
+    name: "nudgeonly_policy",
+    description: "Return the PinballWake NudgeOnlyAPI guardrails. This is a red-lane, read-only policy for 👉Nudge: painpoint hints only, no writes, no decisions, no truth-setting.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+  {
+    name: "nudgeonly_api",
+    description: "Run 👉Nudge, the PinballWake NudgeOnlyAPI worker, through OpenRouter free routing. Use only for painpoint hints and simple-English nudge summaries. It cannot merge, close, approve, assign ownership, mark done, or set source-of-truth state.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        api_key: { type: "string", description: "OpenRouter API key. Optional when OPENROUTER_API_KEY is set in the environment." },
+        event_text: { type: "string", description: "Noisy event, signal, handoff, or status text for 👉Nudge to classify." },
+        context: { type: "string", description: "Optional local context. Keep it small and non-secret." },
+        painpoint_hint: { type: "string", description: "Optional hint such as stale_ack, duplicate_wake, unclear_owner, noisy_thread, or missing_proof." },
+        source_id: { type: "string", description: "Optional upstream event, dispatch, PR, issue, or wake identifier for trace evidence." },
+        source_url: { type: "string", description: "Optional upstream URL for trace evidence." },
+        model: { type: "string", description: "OpenRouter model ID. Default: openrouter/free for free model routing." },
+        max_tokens: { type: "number", description: "Maximum output tokens. Hard capped at 500. Default: 260." },
+      },
+      required: ["event_text"],
+    },
+  },
+
   // ── kling-tool.ts ─────────────────────────────────────────────────────────────
   {
     name: "kling_generate_video",
@@ -13187,6 +13221,10 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   // groq-tool.ts
   groq_chat_completion:    (args) => groqChatCompletion(args),
   groq_list_models:        (args) => groqListModels(args),
+
+  // nudgeonly-tool.ts
+  nudgeonly_policy:        (args) => nudgeonlyPolicy(args),
+  nudgeonly_api:           (args) => nudgeonlyApi(args),
 
   // neon-tool.ts
   neon_list_projects:      (args) => neonListProjects(args),


### PR DESCRIPTION
## Summary
- Cherry-pick the focused NudgeOnly / PinballWake tool lineage onto current main.
- Includes PR #759 behavior that suppresses ACK-only WakePass comments instead of treating them as fresh stale wakes.
- Keeps this as a production hotfix path so remote MCP at https://unclick.world/api/mcp can consume the fix without promoting the whole feature branch.

## Proof
- Source branch cherry-pick completed cleanly from origin/main.
- Feature-branch TestPass previously passed: npm --workspace @unclick/mcp-server exec vitest run src/nudgeonly-tool.test.ts, 14/14.
- Local hotfix worktree test could not run because this isolated worktree has no installed node_modules/vitest. CI should install dependencies and verify.

## Links
- Fixes issue #751 runtime blocker once merged/deployed.
- Boardroom todo: cf8025d7-1c64-4fee-95c1-6a7c5b666704.

## Next
- Let CI run on this draft PR.
- If green, mark ready and merge/deploy so live mcp__unclick__.nudgeonly_receipt_bridge returns bridge_status=suppress.