### PR TITLE
Hotfix: suppress ACK-only WakePass loops

### DIFF
--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -343,6 +343,31 @@ describe("NudgeOnlyAPI policy", () => {
     });
   });
 
+  it("suppresses ACK-only WakePass comments instead of creating duplicate stale wakes", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      event_text: "ACK wake-issue_comment-comment-4436477251-51e47b7d9cdd. The wake is acknowledged, but this is still waiting for terminal executor proof.",
+      source_id: "wake-issue_comment-comment-4436519129-d570faed9137",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/751",
+      ack_status: "missing",
+      created_at: "2026-05-13T02:04:37.000Z",
+      now: "2026-05-13T02:15:48.000Z",
+      ttl_minutes: 5,
+    })).resolves.toMatchObject({
+      bridge_status: "suppress",
+      painpoint_detected: false,
+      painpoint_type: "none",
+      suppressed_painpoint_type: "stale_ack",
+      suppression: {
+        reason: "ack_only_comment",
+        original_wake_id: "wake-issue_comment-comment-4436477251-51e47b7d9cdd",
+        source_id: "wake-issue_comment-comment-4436519129-d570faed9137",
+      },
+      quality_gate: "duplicate ACK wake suppression",
+    });
+  });
+
   it("routes unclear ownership only to Job Manager for resolution", async () => {
     await expect(nudgeonlyReceiptBridge({
       painpoint_detected: true,

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -342,6 +342,25 @@ function normalisePainpointType(value: unknown): string {
   return PAINPOINT_TYPES.find((type) => raw.includes(type)) ?? "none";
 }
 
+function ackOnlyWakeProof(value: unknown): { original_wake_id: string | null; reason: string } | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+
+  const originalWakeId = text.match(/\b(wake-[a-z0-9_-]+(?:-[a-z0-9_-]+)*)\b/i)?.[1] ?? null;
+  const startsWithAckWake = /^\s*ack\s+wake-/i.test(text);
+  if (startsWithAckWake) {
+    return { original_wake_id: originalWakeId, reason: "ack_only_comment" };
+  }
+
+  const verifierOnly = /\b(ack-only|verifier-only|verifier receipt|ack proof receipt)\b/i.test(text)
+    && /\b(no|not|missing|absent|still)\b.{0,80}\b(executor|terminal|build_attempt|pr_proof|done|receipt)\b/i.test(text);
+  if (verifierOnly && originalWakeId) {
+    return { original_wake_id: originalWakeId, reason: "verifier_only_comment" };
+  }
+
+  return null;
+}
+
 function asOptionalString(value: unknown): string | null {
   const trimmed = String(value ?? "").trim();
   return trimmed ? trimmed : null;
@@ -533,6 +552,7 @@ export async function nudgeonlyReceiptBridge(args: Record<string, unknown>): Pro
   const text = evidenceText(args, nudge);
   const hasSourceEvidence = Boolean(sourceId || sourceUrl || target);
   const hasCue = hasConcreteCue(painpointType, text);
+  const ackOnlyProof = ackOnlyWakeProof(args.event_text ?? args.context ?? nudge.nudge);
   const traceInput = JSON.stringify({
     painpoint_type: painpointType,
     source_id: sourceId,
@@ -543,6 +563,32 @@ export async function nudgeonlyReceiptBridge(args: Record<string, unknown>): Pro
     nudge_trace_id: asOptionalString(args.nudge_trace_id) ?? asOptionalString(nudge.trace_id),
   });
   const bridgeId = `nudgebridge_${shortHash(traceInput)}`;
+
+  if (ackOnlyProof) {
+    return {
+      bridge_id: bridgeId,
+      bridge_status: "suppress",
+      worker: NUDGEONLY_POLICY.worker_name,
+      official_name: NUDGEONLY_POLICY.official_name,
+      code_name: NUDGEONLY_POLICY.code_name,
+      ecosystem: NUDGEONLY_POLICY.ecosystem,
+      authority: NUDGEONLY_POLICY.authority,
+      painpoint_detected: false,
+      painpoint_type: "none",
+      suppressed_painpoint_type: painpointType,
+      suppression: {
+        ...ackOnlyProof,
+        source_id: sourceId,
+        source_url: sourceUrl,
+        target,
+      },
+      reason: "ACK-only or verifier-only WakePass comments are proof metadata for the original wake, not fresh wake requests.",
+      quality_gate: "duplicate ACK wake suppression",
+      requires_verifier: true,
+      allowed_actions: ["record suppress receipt", "attach proof metadata to original wake"],
+      prohibited_actions: NUDGEONLY_POLICY.prohibited_actions,
+    };
+  }
 
   if (!detected || painpointType === "none") {
     return {


### PR DESCRIPTION
## Summary
- Add the focused ACK-only WakePass suppression on top of current main.
- Keeps NudgeOnly from treating ACK/verifier proof comments as fresh stale wakes.
- This is the production path for remote MCP at https://unclick.world/api/mcp to clear issue #751 blockers after merge/deploy.

## Proof
- PASS: npm --workspace @unclick/mcp-server exec vitest run src/nudgeonly-tool.test.ts, 15 tests.
- PASS: npm --workspace @unclick/mcp-server run build.

## Links
- Fixes #751.
- Supersedes draft PR #761, which was too broad and conflicted after main already gained the NudgeOnly baseline.
- Boardroom todo: cf8025d7-1c64-4fee-95c1-6a7c5b666704.

## Expected live result
After merge and deploy, live mcp__unclick__.nudgeonly_receipt_bridge should return bridge_status=suppress for ACK-only issue #751 comments 4436477251 and 4436519129.