### PR TITLE
Suppress superseded heartbeat status blockers

### DIFF
--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -368,6 +368,34 @@ describe("NudgeOnlyAPI policy", () => {
     });
   });
 
+  it("suppresses superseded heartbeat status comments instead of keeping old blockers active", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      event_text: "PASS progress from heartbeat: created focused production hotfix PR #761 to promote NudgeOnly/WakePass suppression to main. Next safe step: wait for CI.",
+      context: "Superseded by PR #761 closed and PR #762 merged to main with live Publish MCP server proof. Current live nudgeonly_receipt_bridge suppresses the ACK-only wake.",
+      source_id: "wake-issue_comment-comment-4436827196-32a36c4d4da6",
+      source_url: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/751#issuecomment-4436827196",
+      target: "issue #751 comment 4436827196",
+      ack_status: "stale",
+      proof_status: "present",
+      created_at: "2026-05-13T03:13:27.000Z",
+      now: "2026-05-13T03:31:00.000Z",
+      ttl_minutes: 60,
+    })).resolves.toMatchObject({
+      bridge_status: "suppress",
+      painpoint_detected: false,
+      painpoint_type: "none",
+      suppressed_painpoint_type: "stale_ack",
+      suppression: {
+        reason: "superseded_status_comment",
+        source_id: "wake-issue_comment-comment-4436827196-32a36c4d4da6",
+        target: "issue #751 comment 4436827196",
+      },
+      quality_gate: "superseded status suppression",
+    });
+  });
+
   it("routes unclear ownership only to Job Manager for resolution", async () => {
     await expect(nudgeonlyReceiptBridge({
       painpoint_detected: true,

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -361,6 +361,22 @@ function ackOnlyWakeProof(value: unknown): { original_wake_id: string | null; re
   return null;
 }
 
+function supersededStatusProof(value: unknown): { superseded_by: string | null; reason: string } | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+
+  const historicalStatus = /\b(blocker root-cause update|pass progress|progress from heartbeat|status update|historical status|old blocker|old pass|superseded status)\b/i.test(text);
+  if (!historicalStatus) return null;
+
+  const supersededBy = text.match(/\bsuperseded by\b.{0,180}\b((?:pr|pull request)\s*#?\d+|merged|live proof|production proof|publish mcp server proof|later proof)\b/i)?.[1] ?? null;
+  const laterProof = /\b(later production proof|current live .*proof|publish mcp server proof|live .*suppresses?)\b/i.test(text);
+  if (supersededBy || laterProof) {
+    return { superseded_by: supersededBy, reason: "superseded_status_comment" };
+  }
+
+  return null;
+}
+
 function asOptionalString(value: unknown): string | null {
   const trimmed = String(value ?? "").trim();
   return trimmed ? trimmed : null;
@@ -553,6 +569,7 @@ export async function nudgeonlyReceiptBridge(args: Record<string, unknown>): Pro
   const hasSourceEvidence = Boolean(sourceId || sourceUrl || target);
   const hasCue = hasConcreteCue(painpointType, text);
   const ackOnlyProof = ackOnlyWakeProof(args.event_text ?? args.context ?? nudge.nudge);
+  const supersededProof = supersededStatusProof(text);
   const traceInput = JSON.stringify({
     painpoint_type: painpointType,
     source_id: sourceId,
@@ -586,6 +603,32 @@ export async function nudgeonlyReceiptBridge(args: Record<string, unknown>): Pro
       quality_gate: "duplicate ACK wake suppression",
       requires_verifier: true,
       allowed_actions: ["record suppress receipt", "attach proof metadata to original wake"],
+      prohibited_actions: NUDGEONLY_POLICY.prohibited_actions,
+    };
+  }
+
+  if (supersededProof) {
+    return {
+      bridge_id: bridgeId,
+      bridge_status: "suppress",
+      worker: NUDGEONLY_POLICY.worker_name,
+      official_name: NUDGEONLY_POLICY.official_name,
+      code_name: NUDGEONLY_POLICY.code_name,
+      ecosystem: NUDGEONLY_POLICY.ecosystem,
+      authority: NUDGEONLY_POLICY.authority,
+      painpoint_detected: false,
+      painpoint_type: "none",
+      suppressed_painpoint_type: painpointType,
+      suppression: {
+        ...supersededProof,
+        source_id: sourceId,
+        source_url: sourceUrl,
+        target,
+      },
+      reason: "Historical heartbeat PASS/BLOCKER status that is superseded by later proof is proof metadata, not a fresh blocker.",
+      quality_gate: "superseded status suppression",
+      requires_verifier: true,
+      allowed_actions: ["record suppress receipt", "attach proof metadata to superseding proof"],
       prohibited_actions: NUDGEONLY_POLICY.prohibited_actions,
     };
   }


### PR DESCRIPTION
## Summary
- suppress historical heartbeat PASS/BLOCKER status comments when a later proof supersedes them
- keep these as proof metadata instead of fresh stale_ack receipt requests
- add regression coverage for the issue #751 PR #761 superseded by PR #762 shape

## TestPass
- npm --workspace @unclick/mcp-server exec vitest run src/nudgeonly-tool.test.ts
- npm --workspace @unclick/mcp-server run build