### PR TITLE
fix(orchestrator): suppress superseded wake blockers

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -676,6 +676,7 @@ function isActiveBlockerEvent(
 ): boolean {
   if (event.kind !== "blocker") return false;
   if (isWakeIssueCommentStale(event, activeTodos)) return false;
+  if (isSuppressedWakePassStatusDispatch(event)) return false;
   if (!isHistoricalWakeOrFishbowlStale(event, activeTodos, nowMs)) return true;
   return false;
 }
@@ -694,6 +695,29 @@ function isWakeIssueCommentStale(
   if (!isWakePass || !isStale) return false;
 
   return /\bwake-issue_comment-comment-\d+/.test(summary) || /\bissue_comment\b/.test(summary);
+}
+
+function isSuppressedWakePassStatusDispatch(event: OrchestratorContinuityEvent): boolean {
+  if (event.source_kind !== "dispatch") return false;
+
+  const tags = (event.tags ?? []).map((tag) => tag.toLowerCase());
+  const summary = event.summary.toLowerCase();
+  const text = `${summary} ${tags.join(" ")}`;
+  const isWakePass =
+    tags.some((tag) => tag.includes("wakepass")) ||
+    /\b(wakepass|wake router|wake-issue_comment|manual wake)\b/.test(summary);
+  if (!isWakePass) return false;
+
+  const hasSuppressReceipt =
+    tags.includes("superseded_status_comment") ||
+    tags.includes("bridge_status:suppress") ||
+    text.includes("superseded_status_comment") ||
+    (text.includes("bridge_status") && text.includes("suppress"));
+  const isDuplicateAck =
+    tags.includes("duplicate_ack") ||
+    (text.includes("duplicate") && (text.includes("ack") || text.includes("wake")));
+
+  return hasSuppressReceipt || isDuplicateAck;
 }
 
 function isHistoricalWakeOrFishbowlStale(
@@ -877,6 +901,7 @@ function commentToEvent(comment: OrchestratorCommentRow): OrchestratorContinuity
 }
 
 function dispatchToEvent(dispatch: OrchestratorDispatchRow): OrchestratorContinuityEvent {
+  const payloadTags = dispatchPayloadEvidenceTags(dispatch.payload);
   const detail = [
     dispatch.source,
     dispatch.status,
@@ -893,8 +918,19 @@ function dispatchToEvent(dispatch: OrchestratorDispatchRow): OrchestratorContinu
     kind: dispatch.status === "leased" ? "handoff" : dispatch.status === "failed" || dispatch.status === "stale" ? "blocker" : "status",
     actor_agent_id: dispatch.lease_owner ?? dispatch.target_agent_id,
     summary: compactText(detail, 240),
-    tags: ["dispatch", dispatch.source, dispatch.status],
+    tags: ["dispatch", dispatch.source, dispatch.status, ...payloadTags],
   };
+}
+
+function dispatchPayloadEvidenceTags(payload: OrchestratorDispatchRow["payload"]): string[] {
+  const text = compactText(payload, 800).toLowerCase();
+  const tags: string[] = [];
+
+  if (text.includes("superseded_status_comment")) tags.push("superseded_status_comment");
+  if (text.includes("bridge_status") && text.includes("suppress")) tags.push("bridge_status:suppress");
+  if (text.includes("duplicate") && (text.includes("ack") || text.includes("wake"))) tags.push("duplicate_ack");
+
+  return Array.from(new Set(tags));
 }
 
 function signalToEvent(signal: OrchestratorSignalRow): OrchestratorContinuityEvent {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -387,6 +387,78 @@ describe("orchestrator context", () => {
     expect(context.seat_handshake.active_blocker).toBeNull();
   });
 
+  it("keeps superseded WakePass stale dispatches in history without counting active blockers", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-13T03:48:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [
+        {
+          id: "todo-current-backlog",
+          title: "Current backlog item",
+          description: "Keep active work visible while stale proof is cleaned up.",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "codex",
+          created_at: "2026-05-13T02:50:00.000Z",
+          updated_at: "2026-05-13T03:40:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-superseded-wakepass",
+          source: "wakepass",
+          target_agent_id: "master",
+          task_ref: null,
+          status: "stale",
+          payload: {
+            reason: "superseded_status_comment",
+            bridge_status: "suppress",
+            painpoint_detected: false,
+            painpoint_type: "none",
+            title: "Old heartbeat BLOCKER superseded by later PASS proof",
+            source_url:
+              "https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/751#issuecomment-4436810525",
+          },
+          created_at: "2026-05-13T03:20:00.000Z",
+          updated_at: "2026-05-13T03:30:00.000Z",
+        },
+        {
+          dispatch_id: "dispatch-real-wakepass",
+          source: "wakepass",
+          target_agent_id: "master",
+          task_ref: null,
+          status: "stale",
+          payload: {
+            title: "WakePass current blocker still needs review",
+            source_url:
+              "https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues/800#issuecomment-4437000000",
+          },
+          created_at: "2026-05-13T03:25:00.000Z",
+          updated_at: "2026-05-13T03:31:00.000Z",
+        },
+      ],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    const blockerEvents = context.continuity_events.filter((event) => event.kind === "blocker");
+    const activeBlockerIds = context.rolling_snapshot.active_blockers.map((event) => event.source_id);
+
+    expect(blockerEvents.map((event) => event.source_id)).toEqual(
+      expect.arrayContaining(["dispatch-superseded-wakepass", "dispatch-real-wakepass"]),
+    );
+    expect(context.current_state_card.active_todo_count).toBe(1);
+    expect(context.current_state_card.blocker_count).toBe(1);
+    expect(activeBlockerIds).toEqual(["dispatch-real-wakepass"]);
+    expect(JSON.stringify(context.current_state_card.blockers)).toContain("current blocker");
+    expect(JSON.stringify(context.current_state_card.blockers)).not.toContain("superseded_status_comment");
+  });
+
   it("keeps heartbeat prompt bodies out of continuity summaries", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-09T23:45:00.000Z",


### PR DESCRIPTION
Summary:
- Stops superseded WakePass stale dispatch receipts from counting as active Orchestrator blockers.
- Keeps the raw dispatch continuity event visible in history while excluding bridge_status=suppress / superseded_status_comment / duplicate ACK receipts from current-state blockers.
- Adds a regression test proving a real WakePass stale blocker still remains active beside a suppressed one.
- Rebased onto current main and kept the existing fresh WakePass issue-comment stale-row cleanup from main.

Scope:
- Owned files: api/lib/orchestrator-context.ts, api/orchestrator-context.test.ts
- Lane: Orchestrator current-state stale-proof cleanup
- Linked todo: 2f3d6780-d32a-43d0-9645-0d4f8d426afc

Non-overlap:
- Does not mutate dispatch rows, todos, comments, WakePass, NudgeOnly, IgniteOnly, PushOnly, Runner, or worker authority.
- Does not delete audit history or hide non-suppressed stale blockers.

Verification:
- Focused Orchestrator context suite: 24/24 passed using Vitest from the existing local install against this clean checkout.
- git diff --check passed; Windows LF/CRLF warnings only.

Risk:
- Low. Filtering is limited to dispatch-origin WakePass receipts that already carry suppress/superseded/duplicate ACK evidence.
- Audit history remains in continuity_events; only active blocker/current-state promotion changes.

Follow-up:
- After merge, run/read Orchestrator current_state proof to confirm issue #751 stale dispatch rows stop reporting as active blockers.