### PR TITLE
[codex] Update repo slug to unclick

### DIFF
--- a/docs/UNCLICK_ADMIN_BUILD_PLAN.md
+++ b/docs/UNCLICK_ADMIN_BUILD_PLAN.md
@@ -2,7 +2,7 @@
 
 **For execution by Claude Code**
 **Author: Chris Byrne (with Cowork strategy session, April 15, 2026)**
-**Repo: malamutemayhem/unclick-agent-native-endpoints**
+**Repo: malamutemayhem/unclick**
 
 **v2 changelog (April 15, 2026):** Corrections folded in from a prior Claude Code exploration session that caught codebase drift in v1. See "CODEBASE GROUND TRUTH" below for the specifics.
 

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -2,14 +2,14 @@
 
 **Phase 1 Ground Floor QC. Generated 2026-04-24. Read-only snapshot of `main` at commit `4f655f2`.**
 
-This document is the investor-readable reality map of the `unclick-agent-native-endpoints` repository. Every claim cites a concrete file path or migration. Nothing in this document is aspirational. For the target-state design, see [`target-state.md`](./target-state.md).
+This document is the investor-readable reality map of the `unclick` repository. Every claim cites a concrete file path or migration. Nothing in this document is aspirational. For the target-state design, see [`target-state.md`](./target-state.md).
 
 ---
 
 ## 1. Repository structure
 
 ```
-unclick-agent-native-endpoints/
+unclick/
 ├── api/                    # Vercel serverless functions (22 files, ~10.1k LOC)
 ├── apps/                   # Workspace app roots (currently only apps/api, a Hono service)
 ├── packages/               # Published / publishable npm workspace packages (6 dirs)

--- a/docs/connectors/system-credentials-health-panel.md
+++ b/docs/connectors/system-credentials-health-panel.md
@@ -115,7 +115,7 @@ type CredentialOwner = {
 Rules:
 
 - Use `confidence: "known"` only when returned by a provider API, admin metadata, or explicit operator configuration.
-- Use `confidence: "inferred"` only for safe metadata such as `GitHub Actions secret in malamutemayhem/unclick-agent-native-endpoints`.
+- Use `confidence: "inferred"` only for safe metadata such as `GitHub Actions secret in malamutemayhem/unclick`.
 - Use `confidence: "unknown"` when only the env var name is known.
 - Never derive owner from a secret value.
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -65,6 +65,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/malamutemayhem/unclick-agent-native-endpoints"
+    "url": "https://github.com/malamutemayhem/unclick"
   }
 }

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -5,7 +5,7 @@
   "description": "AI agent tool marketplace. 178+ tools for social, e-commerce, accounting, and messaging.",
   "version": "0.3.72",
   "repository": {
-    "url": "https://github.com/malamutemayhem/unclick-agent-native-endpoints.git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
     "source": "github"
   },
   "icons": [

--- a/packages/mcp-server/src/local-catalog-handlers.ts
+++ b/packages/mcp-server/src/local-catalog-handlers.ts
@@ -1062,7 +1062,7 @@ export const LOCAL_CATALOG_HANDLERS: Record<string, LocalHandler> = {
 
   "report_bug.create": (args) => {
     process.stderr.write(`[UnClick BugReport] ${JSON.stringify(args)}\n`);
-    return { submitted: true, message: "Bug report logged. To file publicly, visit https://github.com/malamutemayhem/unclick-agent-native-endpoints/issues" };
+    return { submitted: true, message: "Bug report logged. To file publicly, visit https://github.com/malamutemayhem/unclick/issues" };
   },
 
   // ── KV STORE (in-memory, per session) ─────────────────────────────────────────

--- a/packages/memory-mcp/package.json
+++ b/packages/memory-mcp/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/malamutemayhem/unclick-agent-native-endpoints"
+    "url": "https://github.com/malamutemayhem/unclick"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,7 +19,7 @@ Text processing, data utilities, media (image/QR/color), timestamps, networking,
 ## Links
 - Website: https://unclick.world
 - npm: https://www.npmjs.com/package/@unclick/mcp-server
-- GitHub: https://github.com/malamutemayhem/unclick-agent-native-endpoints
+- GitHub: https://github.com/malamutemayhem/unclick
 - Arena (AI competition): https://unclick.world/arena
 - Developer platform: https://unclick.world/developers
 

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const eventName = process.env.GITHUB_EVENT_NAME || "manual";
 const eventPath = process.env.GITHUB_EVENT_PATH || "";
-const repository = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick-agent-native-endpoints";
+const repository = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick";
 const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
 const runId = process.env.GITHUB_RUN_ID || "";
 const apiUrl = process.env.UNCLICK_API_URL || "https://unclick.world/api/memory-admin";

--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -3,7 +3,7 @@
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
-const repository = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick-agent-native-endpoints";
+const repository = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick";
 const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
 const githubToken = process.env.GITHUB_TOKEN || "";
 const apiUrl = process.env.UNCLICK_API_URL || "https://unclick.world/api/memory-admin";

--- a/scripts/tier2-auto-merge-queue-check.mjs
+++ b/scripts/tier2-auto-merge-queue-check.mjs
@@ -202,7 +202,7 @@ export async function runCommandJson(command, args, { cwd = process.cwd(), env =
 }
 
 export async function fetchOpenPullRequests({
-  repo = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick-agent-native-endpoints",
+  repo = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick",
   limit = parseBoundedInt(process.env.TIER2_AUTOMERGE_PR_LIMIT, 30, 1, 100),
   cwd = process.cwd(),
   runJson = runCommandJson,

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,7 +16,7 @@ const RESOURCES_LINKS = [
 
 const COMPANY_LINKS = [
   { label: "Contact", href: "mailto:hello@unclick.world" },
-  { label: "GitHub", href: "https://github.com/malamutemayhem/unclick-agent-native-endpoints", external: true },
+  { label: "GitHub", href: "https://github.com/malamutemayhem/unclick", external: true },
   { label: "npm", href: "https://www.npmjs.com/package/@unclick/mcp-server", external: true },
 ];
 

--- a/src/pages/admin/systemCredentialInventory.test.ts
+++ b/src/pages/admin/systemCredentialInventory.test.ts
@@ -55,7 +55,7 @@ describe("system credential inventory", () => {
     const byName = new Map(listSystemCredentialHealthRows().map((entry) => [entry.name, entry]));
 
     expect(byName.get("TESTPASS_TOKEN")).toMatchObject({
-      ownerLabel: "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints",
+      ownerLabel: "GitHub Actions - malamutemayhem/unclick",
       ownerConfidence: "inferred",
     });
     expect(byName.get("SUPABASE_SERVICE_ROLE_KEY")).toMatchObject({
@@ -98,7 +98,7 @@ describe("system credential inventory", () => {
 
     expect(testpass).toMatchObject({
       sourceLabel: "GitHub Actions secret name",
-      ownerLabel: "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints",
+      ownerLabel: "GitHub Actions - malamutemayhem/unclick",
       ownerConfidence: "inferred",
       displayStatus: "untested",
       healthEvidenceLabel: "Use latest TestPass PR check receipt.",

--- a/src/pages/admin/systemCredentialInventory.ts
+++ b/src/pages/admin/systemCredentialInventory.ts
@@ -446,7 +446,7 @@ function sanitizeMetadataCopy(
 function ownerLabelFor(entry: SystemCredentialInventoryEntry): string {
   switch (entry.source) {
     case "github_actions_secret":
-      return "GitHub Actions - malamutemayhem/unclick-agent-native-endpoints";
+      return "GitHub Actions - malamutemayhem/unclick";
     case "vercel_env":
       return "Vercel project environment";
   }


### PR DESCRIPTION
## Summary

- Updates current public GitHub links and package repository metadata to `malamutemayhem/unclick`.
- Updates automation fallback repository names used when `GITHUB_REPOSITORY` is missing.
- Updates admin credential owner labels and matching docs/tests to the new repo slug.

## Safety Notes

- No API keys, database tables, memory storage, or deployment environment variables were changed.
- Historical test fixtures and session records that intentionally point at old PR or issue URLs were left alone because GitHub now redirects the old slug.

## Validation

- Verified `https://github.com/malamutemayhem/unclick` returns 200.
- Verified `https://github.com/malamutemayhem/unclick-agent-native-endpoints` redirects to the new repo.
- Verified `https://unclick.world` and the existing Vercel project URL return 200.
- Verified `/api/mcp` OPTIONS returns 204 and GET returns 405.
- Verified protected Memory admin context read returns 401 without auth, as expected.
- Ran `npx vitest run src/pages/admin/systemCredentialInventory.test.ts`, 16 tests passed.
- Ran `npm run build`, passed.