### PR TITLE
fix(runner): hydrate scoped Boardroom jobs

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -15,6 +15,7 @@ import {
   runCodingRoomRunnerCycle,
 } from "./pinballwake-coding-room-runner.mjs";
 import { evaluateOrchestratorProofWakeGate } from "./lib/autopilotkit-liveness.mjs";
+import { buildScopePackHydrationReceipt } from "./pinballwake-scopepack-hydrator.mjs";
 
 export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
 
@@ -849,6 +850,8 @@ function buildRunClaimabilityScorecard({
   finalAction = lastResult.action || null,
   finalReason = lastResult.reason || null,
   scopingRequested = 0,
+  hydrationBlocked = 0,
+  hydrationSuppressed = 0,
 } = {}) {
   const base = queueSourceResult.claimability_scorecard || buildClaimabilityScorecard({
     seen: queueSourceResult.seen || 0,
@@ -865,8 +868,13 @@ function buildRunClaimabilityScorecard({
   return {
     ...base,
     imported_claimable: importedClaimable,
-    claim_attemptable_after_safety: Math.max(0, importedClaimable - protectedBlocked - scopingRequested),
+    claim_attemptable_after_safety: Math.max(
+      0,
+      importedClaimable - protectedBlocked - scopingRequested - hydrationBlocked - hydrationSuppressed,
+    ),
     scoping_requested: scopingRequested,
+    scopepack_hydration_blocked: hydrationBlocked,
+    scopepack_hydration_suppressed: hydrationSuppressed,
     protected_blocked: protectedBlocked,
     claimed: results.filter((result) => result?.action === "claimed").length,
     last_action: finalAction,
@@ -912,6 +920,30 @@ export async function syncBoardroomTodoScopingRequestToUnClick({
     };
   }
 
+  const hydration = buildScopePackHydrationReceipt(todo);
+  if (hydration.action === "suppress") {
+    return {
+      ok: true,
+      todo_id: todoId,
+      status: "open",
+      assigned_to_agent_id: null,
+      comment_ok: false,
+      comment_suppressed: true,
+      comment_detail: hydration.reason,
+      scopepack_hydration: hydration,
+    };
+  }
+
+  const commentText = hydration.receipt || compact(
+    [
+      "Autonomous Runner could not safely build this job yet because no file-level ScopePack was attached.",
+      "Reopened for scoping instead of holding a stale active claim.",
+      "Next: attach exact owned files, proof/tests, and stop conditions, or split this into a smaller job.",
+      `reason=${todo.actionability_reason || "missing_scopepack"}.`,
+    ].join(" "),
+    700,
+  );
+
   const comment = await callUnClickMcpTool({
     mcpUrl,
     apiKey,
@@ -921,15 +953,7 @@ export async function syncBoardroomTodoScopingRequestToUnClick({
       agent_id: agentId,
       target_kind: "todo",
       target_id: todoId,
-      text: compact(
-        [
-          "Autonomous Runner could not safely build this job yet because no file-level ScopePack was attached.",
-          "Reopened for scoping instead of holding a stale active claim.",
-          "Next: attach exact owned files, proof/tests, and stop conditions, or split this into a smaller job.",
-          `reason=${todo.actionability_reason || "missing_scopepack"}.`,
-        ].join(" "),
-        700,
-      ),
+      text: commentText,
     },
   });
 
@@ -941,6 +965,7 @@ export async function syncBoardroomTodoScopingRequestToUnClick({
     comment_ok: comment.ok,
     comment_id: comment.ok ? comment.data?.comment?.id || null : null,
     comment_detail: comment.ok ? null : comment.reason || comment.error || null,
+    scopepack_hydration: hydration.action === "needs_manual_scoping" ? null : hydration,
   };
 }
 
@@ -1178,6 +1203,13 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
         assigned_to_agent_id: todo.assigned_to_agent_id || null,
         actionability_reason: todo.actionability_reason || null,
         scope_pack_seen: Boolean(scopePack.hasScopePack),
+        scope_pack: todo.scope_pack ?? todo.scopePack ?? null,
+        runner_scope: todo.runner_scope ?? todo.runnerScope ?? null,
+        recent_comments: Array.isArray(todo.recent_comments) ? todo.recent_comments : undefined,
+        comments: Array.isArray(todo.comments) ? todo.comments : undefined,
+        description: todo.description || null,
+        body: todo.body || null,
+        notes: todo.notes || null,
         lane: todo.lane || scopePack.lane || null,
         owner_hint: todo.owner_hint || todo.ownerHint || scopePack.owner_hint || null,
       };
@@ -1494,9 +1526,9 @@ export async function runAutonomousRunnerFile({
   let todoClaimSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
   let todoScopingSync = { ok: true, skipped: true, reason: "sync_not_applicable" };
   const todoForScoping = selectBoardroomTodoForScoping({ queueSourceResult, lastResult: last });
-  const finalAction = todoForScoping && shouldPersist ? "scoping_requested" : last.action;
-  const finalReason = todoForScoping && shouldPersist ? "boardroom_todo_reopened_for_scoping" : last.reason;
-  const claimabilityScorecard = buildRunClaimabilityScorecard({
+  let finalAction = todoForScoping && shouldPersist ? "scoping_requested" : last.action;
+  let finalReason = todoForScoping && shouldPersist ? "boardroom_todo_reopened_for_scoping" : last.reason;
+  let claimabilityScorecard = buildRunClaimabilityScorecard({
     queueSourceResult,
     results,
     lastResult: last,
@@ -1565,6 +1597,28 @@ export async function runAutonomousRunnerFile({
         todo_scoping_sync: todoScopingSync,
       };
     }
+
+    const hydrationAction = todoScopingSync.scopepack_hydration?.action || "";
+    if (hydrationAction === "scopepack_hydrated") {
+      finalAction = "scopepack_hydrated";
+      finalReason = "boardroom_todo_scopepack_hydrated";
+    } else if (hydrationAction === "blocker") {
+      finalAction = "blocked";
+      finalReason = todoScopingSync.scopepack_hydration?.reason || "scopepack_hydration_missing_fields";
+    } else if (hydrationAction === "suppress") {
+      finalAction = "suppressed";
+      finalReason = todoScopingSync.scopepack_hydration?.reason || "duplicate_scopepack_hydration_receipt";
+    }
+    claimabilityScorecard = buildRunClaimabilityScorecard({
+      queueSourceResult,
+      results,
+      lastResult: last,
+      finalAction,
+      finalReason,
+      scopingRequested: hydrationAction ? 0 : 1,
+      hydrationBlocked: hydrationAction === "blocker" ? 1 : 0,
+      hydrationSuppressed: hydrationAction === "suppress" ? 1 : 0,
+    });
   }
 
   if (shouldPersist) {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -24,6 +24,7 @@ import {
   runAutonomousRunnerCycle,
   runAutonomousRunnerFile,
 } from "./pinballwake-autonomous-runner.mjs";
+import { buildScopePackHydrationReceipt } from "./pinballwake-scopepack-hydrator.mjs";
 
 const runner = createAutonomousRunner({
   id: "runner-plex-1",
@@ -888,7 +889,7 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
-  it("reopens scoped Boardroom todos for file-level scoping when owned files are missing", async () => {
+  it("posts a ScopePack hydration blocker when scoped Boardroom todos are missing required fields", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
     try {
@@ -993,31 +994,280 @@ describe("PinballWake autonomous Runner seat", () => {
       });
 
       assert.equal(result.ok, true);
-      assert.equal(result.action, "scoping_requested");
-      assert.equal(result.reason, "boardroom_todo_reopened_for_scoping");
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "scopepack_hydration_missing_fields");
       assert.equal(result.queue_source.imported, 1);
       assert.equal(result.skipped[0].reason, "boardroom_todo_missing_scopepack");
       assert.equal(result.claimability_scorecard.imported_claimable, 1);
       assert.equal(result.claimability_scorecard.claim_attemptable_after_safety, 0);
-      assert.equal(result.claimability_scorecard.scoping_requested, 1);
+      assert.equal(result.claimability_scorecard.scoping_requested, 0);
       assert.equal(result.claimability_scorecard.protected_blocked, 0);
-      assert.equal(result.claimability_scorecard.last_action, "scoping_requested");
-      assert.equal(result.claimability_scorecard.last_reason, "boardroom_todo_reopened_for_scoping");
-      assert.equal(result.claimability_scorecard.final_action, "scoping_requested");
-      assert.equal(result.claimability_scorecard.final_reason, "boardroom_todo_reopened_for_scoping");
+      assert.equal(result.claimability_scorecard.last_action, "blocked");
+      assert.equal(result.claimability_scorecard.last_reason, "scopepack_hydration_missing_fields");
+      assert.equal(result.claimability_scorecard.final_action, "blocked");
+      assert.equal(result.claimability_scorecard.final_reason, "scopepack_hydration_missing_fields");
       assert.equal(result.todo_scoping_sync.todo_id, "todo-orchestrator-scope");
       assert.equal(result.todo_scoping_sync.comment_ok, true);
+      assert.equal(result.todo_scoping_sync.scopepack_hydration.action, "blocker");
+      assert.deepEqual(result.todo_scoping_sync.scopepack_hydration.missing_fields, [
+        "acceptance",
+        "stop_conditions",
+        "proof_required",
+        "non_goals",
+      ]);
 
       const updateCall = calls.find((call) => call.body.params.name === "update_todo");
       assert.equal(updateCall.body.params.arguments.todo_id, "todo-orchestrator-scope");
       assert.equal(updateCall.body.params.arguments.assigned_to_agent_id, "");
 
       const commentCall = calls.find((call) => call.body.params.name === "comment_on");
-      assert.match(commentCall.body.params.arguments.text, /file-level ScopePack/);
-      assert.match(commentCall.body.params.arguments.text, /exact owned files/);
+      assert.match(commentCall.body.params.arguments.text, /BLOCKER: scopepack_hydration_missing_fields/);
+      assert.match(commentCall.body.params.arguments.text, /missing_fields=acceptance,stop_conditions,proof_required,non_goals/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("hydrates a vague Boardroom todo when the safe ScopePack fields are present", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const calls = [];
+      const fetchImpl = async (_url, init = {}) => {
+        calls.push({ body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-scope-hydrate",
+                            title: "Scope vague job into safe runner packet",
+                            status: "open",
+                            priority: "urgent",
+                            assigned_to_agent_id: null,
+                            actionability_reason: "unassigned_open",
+                            scope_pack: {
+                              lane: "orchestrator",
+                              owner_hint: "live_builder_or_orchestrator_seat",
+                              owned_modules: ["PinballWake Runner scope hydration"],
+                              acceptance: ["Hydrate vague jobs before execution"],
+                              verification: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+                              stop_conditions: ["Stop if owned files cannot be inferred safely"],
+                              proof_required: "Boardroom receipt with scopepack_hydrated or BLOCKER",
+                              out_of_scope: ["No new schedules", "No merge authority expansion"],
+                            },
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "update_todo") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todo: {
+                          id: "todo-scope-hydrate",
+                          status: "open",
+                          assigned_to_agent_id: null,
+                        },
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "comment_on") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({ comment: { id: "comment-hydrate-1" } }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-13T12:46:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "scopepack_hydrated");
+      assert.equal(result.reason, "boardroom_todo_scopepack_hydrated");
+      assert.equal(result.todo_scoping_sync.scopepack_hydration.action, "scopepack_hydrated");
+      assert.equal(result.claimability_scorecard.scoping_requested, 0);
+
+      const commentCall = calls.find((call) => call.body.params.name === "comment_on");
+      assert.match(commentCall.body.params.arguments.text, /PASS: scopepack_hydrated/);
+      assert.match(commentCall.body.params.arguments.text, /owned_modules=PinballWake Runner scope hydration/);
+      assert.match(commentCall.body.params.arguments.text, /No new schedules/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses duplicate ScopePack hydration receipts for the same job and head", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const todo = {
+        id: "todo-scope-duplicate",
+        title: "Scope vague job once",
+        status: "open",
+        priority: "urgent",
+        assigned_to_agent_id: null,
+        actionability_reason: "unassigned_open",
+        scope_pack: {
+          lane: "orchestrator",
+          owner_hint: "live_builder_or_orchestrator_seat",
+          owned_modules: ["PinballWake Runner scope hydration"],
+          acceptance: ["Hydrate vague jobs before execution"],
+          verification: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+          stop_conditions: ["Stop if owned files cannot be inferred safely"],
+          proof_required: "Boardroom receipt with scopepack_hydrated or BLOCKER",
+          out_of_scope: ["No new schedules"],
+        },
+      };
+      const key = buildScopePackHydrationReceipt(todo).scopepack_hydration_key;
+      todo.recent_comments = [
+        {
+          text: `PASS: scopepack_hydrated. scopepack_hydration_key=${key}.`,
+        },
+      ];
+
+      const calls = [];
+      const fetchImpl = async (_url, init = {}) => {
+        calls.push({ body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [{ type: "text", text: JSON.stringify({ todos: [todo] }) }],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "update_todo") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todo: {
+                          id: "todo-scope-duplicate",
+                          status: "open",
+                          assigned_to_agent_id: null,
+                        },
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-13T12:47:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "suppressed");
+      assert.equal(result.reason, "duplicate_scopepack_hydration_receipt");
+      assert.equal(result.todo_scoping_sync.comment_suppressed, true);
+      assert.equal(result.todo_scoping_sync.scopepack_hydration.action, "suppress");
+      assert.deepEqual(calls.map((call) => call.body.params.name), ["list_actionable_todos", "update_todo"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("redacts secret-shaped values from ScopePack hydration receipts", () => {
+    const result = buildScopePackHydrationReceipt({
+      id: "todo-redact-scopepack",
+      title: "Redact ScopePack receipt",
+      scope_pack: {
+        lane: "orchestrator",
+        owner_hint: "live_builder_or_orchestrator_seat",
+        owned_modules: ["PinballWake Runner scope hydration"],
+        acceptance: ["Never print ?key=plain-secret-value in receipts"],
+        verification: ["curl https://example.test/check?key=plain-secret-value&ok=1"],
+        stop_conditions: ["Stop if access_token=plain-token-value appears"],
+        proof_required: "client_secret=plain-client-secret must be redacted",
+        out_of_scope: ["No new schedules"],
+      },
+    });
+
+    assert.equal(result.action, "scopepack_hydrated");
+    assert.doesNotMatch(result.receipt, /plain-secret-value/);
+    assert.doesNotMatch(result.receipt, /plain-token-value/);
+    assert.doesNotMatch(result.receipt, /plain-client-secret/);
+    assert.match(result.receipt, /key=\[redacted\]/);
+    assert.match(result.receipt, /access_token=\[redacted\]/);
+    assert.match(result.receipt, /client_secret=\[redacted\]/);
   });
 
   it("quietly skips stale assigned UnClick todo claims before syncing ownership", async () => {

--- a/scripts/pinballwake-scopepack-hydrator.mjs
+++ b/scripts/pinballwake-scopepack-hydrator.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+
+function compact(value, max = 500) {
+  const text = redactSecretLikeText(value).replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function redactSecretLikeText(value) {
+  return String(value ?? "")
+    .replace(
+      /([?&](?:key|api_key|access_token|refresh_token|client_secret|token)=)[^&\s]+/gi,
+      "$1[redacted]",
+    )
+    .replace(
+      /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|token)\s*[:=]\s*([^\s,;]+)/gi,
+      "$1=[redacted]",
+    );
+}
+
+function normalizePath(value) {
+  return String(value ?? "").replace(/\\/g, "/").trim();
+}
+
+function safeList(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => compact(item, 240)).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n|,/)
+      .map((item) => compact(item, 240))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function parseJsonObject(value) {
+  if (!value) return null;
+  if (typeof value === "object" && !Array.isArray(value)) return value;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseLabeledJsonObjectFromText(value, labels = ["ScopePack", "scopepack", "Scope Pack", "Runner Scope"]) {
+  const text = String(value ?? "");
+  if (!text.trim()) return null;
+
+  for (const label of labels) {
+    const fencePattern = new RegExp(String.raw`${label}\s*:\s*\r?\n\s*` + "```(?:json)?\\s*\\r?\\n([\\s\\S]*?)\\r?\\n```", "i");
+    const fence = text.match(fencePattern);
+    const parsedFence = parseJsonObject(fence?.[1]);
+    if (parsedFence) return parsedFence;
+
+    const inlinePattern = new RegExp(String.raw`(?:^|\n)\s*${label}\s*:\s*(\{[^\r\n]*\})`, "i");
+    const inline = text.match(inlinePattern);
+    const parsedInline = parseJsonObject(inline?.[1]);
+    if (parsedInline) return parsedInline;
+  }
+
+  return null;
+}
+
+function firstObject(...values) {
+  for (const value of values) {
+    const parsed = parseJsonObject(value);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+function firstText(...values) {
+  for (const value of values) {
+    const text = compact(value, 600);
+    if (text) return text;
+  }
+  return "";
+}
+
+function firstList(...values) {
+  for (const value of values) {
+    const list = safeList(value);
+    if (list.length > 0) return list;
+  }
+  return [];
+}
+
+function recentTodoText(todo = {}) {
+  const comments = Array.isArray(todo.recent_comments)
+    ? todo.recent_comments
+    : Array.isArray(todo.comments)
+      ? todo.comments
+      : [];
+
+  return [
+    todo.latest_comment_text,
+    todo.last_comment_text,
+    ...comments.map((comment) => `${comment?.body || ""}\n${comment?.text || ""}`),
+  ].join("\n");
+}
+
+export function extractHydratableScopePack(todo = {}) {
+  return firstObject(
+    todo.scope_pack,
+    todo.scopePack,
+    todo.runner_scope,
+    todo.runnerScope,
+    todo.autonomous_scope,
+    todo.autonomousScope,
+    parseLabeledJsonObjectFromText(todo.description),
+    parseLabeledJsonObjectFromText(todo.body),
+    parseLabeledJsonObjectFromText(todo.notes),
+  );
+}
+
+export function scopePackHydrationKey(todo = {}, scope = {}, { headSha = "" } = {}) {
+  const sourceHead = firstText(
+    headSha,
+    todo.head_sha,
+    todo.headSha,
+    todo.source_head,
+    todo.sourceHead,
+    scope.head_sha,
+    scope.headSha,
+    "no-head",
+  );
+  const seed = [
+    todo.id || todo.todo_id || "unknown-todo",
+    todo.title || scope.chip_title || scope.title || "",
+    sourceHead,
+    JSON.stringify(scope.owned_files || scope.ownedFiles || scope.owned_modules || scope.ownedModules || []),
+  ].join("|");
+  return createHash("sha256").update(seed).digest("hex").slice(0, 16);
+}
+
+function normalizeHydrationScope(todo = {}, scope = {}, options = {}) {
+  const ownedFiles = firstList(scope.owned_files, scope.ownedFiles, scope.files, scope.paths).map(normalizePath);
+  const ownedModules = firstList(scope.owned_modules, scope.ownedModules, scope.owned_surfaces, scope.ownedSurfaces);
+  const acceptance = firstList(scope.acceptance, scope.acceptance_criteria, scope.acceptanceCriteria);
+  const verification = firstList(
+    scope.verification,
+    scope.tests,
+    scope.test_proof_plan?.allowlist_tests,
+    scope.testProofPlan?.allowlistTests,
+  );
+  const stopConditions = firstList(scope.stop_conditions, scope.stopConditions);
+  const nonGoals = firstList(scope.non_goals, scope.nonGoals, scope.out_of_scope, scope.outOfScope);
+  const proofRequired = firstText(scope.proof_required, scope.proofRequired, scope.expected_proof, scope.expectedProof);
+  const laneHint = firstText(
+    scope.owner_hint,
+    scope.ownerHint,
+    scope.lane,
+    scope.worker_lane,
+    scope.workerLane,
+    scope.worker,
+    scope.role,
+    todo.owner_hint,
+    todo.ownerHint,
+    todo.lane,
+  );
+  const duplicateSuppressionKey = firstText(
+    scope.duplicate_suppression_key,
+    scope.duplicateSuppressionKey,
+    scope.suppression_key,
+    scope.suppressionKey,
+    scopePackHydrationKey(todo, scope, options),
+  );
+
+  return {
+    owned_files: ownedFiles,
+    owned_modules: ownedModules,
+    acceptance,
+    verification,
+    stop_conditions: stopConditions,
+    proof_required: proofRequired,
+    owner_or_lane_hint: laneHint,
+    non_goals: nonGoals,
+    duplicate_suppression_key: duplicateSuppressionKey,
+  };
+}
+
+function missingHydrationFields(hydrated = {}) {
+  const missing = [];
+  if (!hydrated.owned_files?.length && !hydrated.owned_modules?.length) missing.push("owned_files_or_owned_modules");
+  if (!hydrated.acceptance?.length) missing.push("acceptance");
+  if (!hydrated.verification?.length) missing.push("verification");
+  if (!hydrated.stop_conditions?.length) missing.push("stop_conditions");
+  if (!hydrated.proof_required) missing.push("proof_required");
+  if (!hydrated.owner_or_lane_hint) missing.push("owner_or_lane_hint");
+  if (!hydrated.non_goals?.length) missing.push("non_goals");
+  if (!hydrated.duplicate_suppression_key) missing.push("duplicate_suppression_key");
+  return missing;
+}
+
+function hydrationAlreadyRecorded(todo = {}, suppressionKey = "") {
+  const text = recentTodoText(todo);
+  return Boolean(
+    suppressionKey &&
+      text.includes(`scopepack_hydration_key=${suppressionKey}`) &&
+      /scopepack_hydrated|scopepack_hydration_missing_fields|SUPPRESS/i.test(text),
+  );
+}
+
+function receiptList(label, values) {
+  return `${label}=${(values || []).map((value) => compact(value, 160)).join(" | ") || "none"}`;
+}
+
+export function buildScopePackHydrationReceipt(todo = {}, options = {}) {
+  const scope = extractHydratableScopePack(todo);
+  if (!scope) {
+    return {
+      ok: false,
+      action: "needs_manual_scoping",
+      reason: "no_hydratable_scopepack",
+      receipt: "",
+      scopepack_hydration_key: "",
+    };
+  }
+
+  const hydrated = normalizeHydrationScope(todo, scope, options);
+  if (hydrationAlreadyRecorded(todo, hydrated.duplicate_suppression_key)) {
+    return {
+      ok: true,
+      action: "suppress",
+      reason: "duplicate_scopepack_hydration_receipt",
+      receipt: "",
+      scopepack_hydration_key: hydrated.duplicate_suppression_key,
+      scopepack: hydrated,
+    };
+  }
+
+  const missing = missingHydrationFields(hydrated);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      action: "blocker",
+      reason: "scopepack_hydration_missing_fields",
+      missing_fields: missing,
+      receipt: compact(
+        [
+          "BLOCKER: scopepack_hydration_missing_fields.",
+          `scopepack_hydration_key=${hydrated.duplicate_suppression_key}.`,
+          `missing_fields=${missing.join(",")}.`,
+          "Next: attach the missing ScopePack fields before BuildBait emits an execution_packet.",
+        ].join(" "),
+        1200,
+      ),
+      scopepack_hydration_key: hydrated.duplicate_suppression_key,
+      scopepack: hydrated,
+    };
+  }
+
+  return {
+    ok: true,
+    action: "scopepack_hydrated",
+    reason: "scopepack_hydrated",
+    receipt: compact(
+      [
+        "PASS: scopepack_hydrated.",
+        `scopepack_hydration_key=${hydrated.duplicate_suppression_key}.`,
+        receiptList("owned_files", hydrated.owned_files),
+        receiptList("owned_modules", hydrated.owned_modules),
+        receiptList("acceptance", hydrated.acceptance),
+        receiptList("verification", hydrated.verification),
+        receiptList("stop_conditions", hydrated.stop_conditions),
+        `proof_required=${compact(hydrated.proof_required, 220)}.`,
+        `owner_or_lane_hint=${compact(hydrated.owner_or_lane_hint, 120)}.`,
+        receiptList("non_goals", hydrated.non_goals),
+        "Next: BuildBait may emit execution_packet only from this bounded ScopePack; Runner still needs owned_files before code claim.",
+      ].join(" "),
+      2400,
+    ),
+    scopepack_hydration_key: hydrated.duplicate_suppression_key,
+    scopepack: hydrated,
+  };
+}


### PR DESCRIPTION
Summary:
- Adds a deterministic ScopePack hydration helper for Boardroom todos that are too vague to claim directly.
- Runner now records scopepack_hydrated, scopepack_hydration_missing_fields, or duplicate suppression instead of repeating generic scoping comments when a hydratable ScopePack is present.
- Claimability scorecard now distinguishes hydration blockers/suppression from ordinary scoping requests.

Scope:
- Owned files: scripts/pinballwake-scopepack-hydrator.mjs, scripts/pinballwake-autonomous-runner.mjs, scripts/pinballwake-autonomous-runner.test.mjs
- Linked issue: #752
- Boardroom todo: 350d2f72-556f-4e97-8896-c5f17ba7a2ca

Non-overlap:
- No new schedules, no merge/approve/close authority, no Orchestrator/WakePass broad rewrite.
- Does not make Runner execute code automatically; it only improves scope hydration receipts before claim.

Verification:
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- node --test scripts/pinballwake-autopilot-triage.test.mjs scripts/pinballwake-jobs-room.test.mjs
- git diff --check

Risk:
- Low to medium automation-routing risk: changes Runner behavior for hydratable Boardroom scoping gaps.
- Missing fully safe fields now produce explicit BLOCKER receipts instead of another generic scope request.

Follow-up:
- Reviewer/Safety should confirm the receipt wording cannot be mistaken for build/merge authority.