### PR TITLE
fix(orchestrator): ignore heartbeat tick blocker chatter

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -329,6 +329,7 @@ export function isHeartbeatAutomationText(input: unknown): boolean {
   if (lower.startsWith("run unclick heartbeat.")) return true;
   if (lower.startsWith("load unclick seats > heartbeat")) return true;
   if (lower.startsWith("heartbeat schedule request:") || lower.includes("run embedded unclick heartbeat instructions")) return true;
+  if (lower.startsWith("heartbeat tick ") && (lower.includes("check_signals") || lower.includes("job hunt:"))) return true;
   if (lower.startsWith("unclick heartbeat pass") || lower.startsWith("unclick healthy. pass")) return true;
   if (lower.includes("heartbeat_protocol=")) return true;
   if (lower.startsWith("unclick heartbeat ") && lower.includes("check_signals=")) return true;

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -686,15 +686,30 @@ describe("orchestrator context", () => {
             "UnClick Heartbeat 2026-05-12. check_signals: 1 info. no action_needed/blocker signals.",
           created_at: "2026-05-12T12:44:56.000Z",
         },
+        {
+          id: "turn-heartbeat-tick-r1-blocker",
+          session_id: "unclick-heartbeat-seat",
+          role: "assistant",
+          content:
+            "Heartbeat tick 2026-05-14T01:36Z. PASS. check_signals: 1 info. Job hunt: active_jobs=5 in_progress. R1 BLOCKER is backlog state, not a live blocker event.",
+          created_at: "2026-05-12T12:45:56.000Z",
+        },
       ],
     });
 
+    expect(
+      isHeartbeatAutomationText(
+        "Heartbeat tick 2026-05-14T01:36Z. PASS. check_signals: 1 info. Job hunt: active_jobs=5 in_progress. R1 BLOCKER is backlog state.",
+      ),
+    ).toBe(true);
     expect(context.current_state_card.blocker_count).toBe(0);
     expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.seat_handshake.active_blocker).toBeNull();
     expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-request")?.kind).toBe("status");
     expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-protocol-pass")?.kind).toBe("proof");
     expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-pass-at")?.kind).toBe("proof");
     expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-no-slash-signals")?.kind).toBe("status");
+    expect(context.continuity_events.find((event) => event.source_id === "turn-heartbeat-tick-r1-blocker")?.kind).toBe("status");
   });
 
   it("keeps fresh-seat active_decision populated from active work when no decision event is live", () => {


### PR DESCRIPTION
## Summary
- Treat `Heartbeat tick ...` assistant status rows as heartbeat automation noise when they include `check_signals` or job-hunt state.
- Add a regression for `Heartbeat tick ... PASS ... R1 BLOCKER ...` so it stays out of live blocker counts.

## Proof
- `npm run test -- api/orchestrator-context.test.ts` passed, 24 tests.
- `git diff --check` passed.

Links todo e9e308cd-7711-4f30-8ebd-d5402fefd205.