### PR TITLE
fix(orchestrator): ignore prompt template blocker labels

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -1052,6 +1052,7 @@ function classify(tags: string[], text: string): OrchestratorContinuityEvent["ki
   if (lower.startsWith("blocker: heartbeat")) return "status";
   if (tagSet.has("info")) return "status";
   if ((tagSet.has("done") || tagSet.has("fyi")) && !lower.startsWith("blocker:")) return "status";
+  if (isPromptTemplateInstructionText(lower)) return "status";
   if (tagSet.has("proof") || lower.startsWith("pass:") || lower.includes("proof:") || lower.includes(" pr #")) return "proof";
   if (isZeroBlockerMetricStatus(lower)) return "status";
   if (tagSet.has("blocker") || lower.startsWith("blocker:") || /\bblocked\b/.test(lower) || /\bblocker\b/.test(lower)) return "blocker";
@@ -1068,6 +1069,27 @@ function classifyHeartbeatAutomationText(lower: string): OrchestratorContinuityE
   if (lower.startsWith("pass:")) return "proof";
   if (lower.startsWith("unclick heartbeat pass") || lower.startsWith("unclick healthy. pass")) return "proof";
   return "status";
+}
+
+function isPromptTemplateInstructionText(lower: string): boolean {
+  const hasOutputLabels =
+    lower.includes("pass/blocker") ||
+    lower.includes("pass, blocker") ||
+    lower.includes("pass / blocker") ||
+    lower.includes("pass/blocker/hold") ||
+    (lower.includes("pass:") && lower.includes("blocker:"));
+  if (!hasOutputLabels) return false;
+
+  return (
+    lower.includes("master broadcast prompt") ||
+    lower.includes("broadcast prompt") ||
+    lower.includes("prompt-template") ||
+    lower.includes("finish with exactly one") ||
+    lower.includes("finish with one") ||
+    lower.includes("finish with pass") ||
+    lower.includes("tells seats to") ||
+    lower.includes("use this prompt")
+  );
 }
 
 function isZeroBlockerMetricStatus(lower: string): boolean {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -604,6 +604,45 @@ describe("orchestrator context", () => {
     expect(context.continuity_events.find((event) => event.source_id === "signal-message-posted")?.kind).toBe("status");
   });
 
+  it("does not promote prompt templates that mention PASS/BLOCKER/HOLD as live blockers", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-14T02:10:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [
+        {
+          id: "turn-master-prompt-summary",
+          session_id: "codex-2026-05-14-master-broadcast-prompt",
+          role: "assistant",
+          content:
+            "Created a master broadcast prompt for all seats. It tells seats to read Memory/Orchestrator first, claim before working, choose the highest-priority job, do one bounded useful step, verify it, post proof, and finish with PASS/BLOCKER/HOLD.",
+          created_at: "2026-05-14T02:03:29.000Z",
+        },
+        {
+          id: "turn-master-prompt-body",
+          session_id: "codex-2026-05-14-master-broadcast-prompt",
+          role: "assistant",
+          content:
+            "Use this prompt. Finish with exactly one: PASS: <what moved>; proof: <link/id>; next: <best next step>. BLOCKER: <what stopped you>; checked: <what you verified>; need: <smallest decision>.",
+          created_at: "2026-05-14T02:03:28.000Z",
+        },
+      ],
+    });
+
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.seat_handshake.active_blocker).toBeNull();
+    expect(context.continuity_events.find((event) => event.source_id === "turn-master-prompt-summary")?.kind).toBe("status");
+    expect(context.continuity_events.find((event) => event.source_id === "turn-master-prompt-body")?.kind).toBe("status");
+  });
+
   it("does not promote zero blocker metric chatter as a live blocker", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-12T12:35:00.000Z",


### PR DESCRIPTION
## Summary
- Keep instructional prompt-template text from becoming a live Orchestrator blocker just because it mentions PASS/BLOCKER/HOLD labels.
- Add regression coverage for the master broadcast prompt summary and body shapes.

## Proof
- `npm run test -- api/orchestrator-context.test.ts` passed, 25 tests.
- `git diff --check` passed.

Links todo e9e308cd-7711-4f30-8ebd-d5402fefd205.