### PR TITLE
fix(securitypass): tighten Supabase Data API grants

### DIFF
--- a/api/supabase-data-api-grants.test.ts
+++ b/api/supabase-data-api-grants.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readRepoFile(repoPath: string): string {
+  return readFileSync(join(process.cwd(), repoPath), "utf8");
+}
+
+describe("Supabase Data API grants audit guardrails", () => {
+  it("keeps public demo rate-limit writes on the server-only Supabase key", () => {
+    const source = readRepoFile("api/tools/demo.ts");
+
+    expect(source).toContain("process.env.SUPABASE_SERVICE_ROLE_KEY");
+    expect(source).not.toContain("process.env.VITE_SUPABASE_ANON_KEY");
+  });
+
+  it("does not fall back to anon for tenant settings reads", () => {
+    const source = readRepoFile("packages/mcp-server/src/memory/tenant-settings.ts");
+
+    expect(source).toContain("process.env.SUPABASE_SERVICE_ROLE_KEY");
+    expect(source).not.toContain("process.env.SUPABASE_ANON_KEY");
+  });
+
+  it("adds explicit service-only grants for audited server-controlled tables", () => {
+    const migration = readRepoFile("supabase/migrations/20260514000000_data_api_service_only_grants.sql");
+    const tables = [
+      "build_tasks",
+      "build_workers",
+      "build_dispatch_events",
+      "memory_load_events",
+      "conflict_detections",
+      "tool_detections",
+      "tenant_settings",
+      "demo_rate_limits",
+    ];
+
+    for (const table of tables) {
+      expect(migration).toContain(`'${table}'`);
+    }
+    expect(migration).toContain("ENABLE ROW LEVEL SECURITY");
+    expect(migration).toContain("REVOKE ALL ON TABLE public.%I FROM anon, authenticated");
+    expect(migration).toContain("GRANT ALL ON TABLE public.%I TO service_role");
+  });
+});

--- a/api/tools/demo.ts
+++ b/api/tools/demo.ts
@@ -191,8 +191,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const ipHash = hashIp(rawIp);
   const callDate = todayDate();
 
-  const supabaseUrl = process.env.VITE_SUPABASE_URL;
-  const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   let currentCount = 0;
 
@@ -227,7 +227,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (error) console.error("Rate limit upsert error:", error.message);
       });
   } else {
-    console.warn("Supabase env vars missing - demo rate limiting disabled");
+    console.warn("Supabase service env vars missing - demo rate limiting disabled");
   }
 
   const remaining = Math.max(0, DEMO_LIMIT - (currentCount + 1));

--- a/packages/mcp-server/src/memory/tenant-settings.ts
+++ b/packages/mcp-server/src/memory/tenant-settings.ts
@@ -53,8 +53,7 @@ export async function getTenantSettings(): Promise<TenantSettings> {
 
   const apiKey = process.env.UNCLICK_API_KEY;
   const supabaseUrl = process.env.SUPABASE_URL;
-  const serviceKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   // Local mode or missing key: just use defaults.
   if (!apiKey || !supabaseUrl || !serviceKey) {

--- a/supabase/migrations/20260514000000_data_api_service_only_grants.sql
+++ b/supabase/migrations/20260514000000_data_api_service_only_grants.sql
@@ -1,0 +1,27 @@
+-- Supabase Data API explicit service-only grants before the May 30 rollout.
+--
+-- These tables are used by server-controlled endpoints or MCP server internals.
+-- Keep anon/authenticated denied at the table-grant layer; browser-safe access
+-- should be added later with table-specific RLS policies and a separate review.
+
+DO $$
+DECLARE
+  service_only_table text;
+BEGIN
+  FOREACH service_only_table IN ARRAY ARRAY[
+    'build_tasks',
+    'build_workers',
+    'build_dispatch_events',
+    'memory_load_events',
+    'conflict_detections',
+    'tool_detections',
+    'tenant_settings',
+    'demo_rate_limits'
+  ] LOOP
+    IF to_regclass(format('public.%I', service_only_table)) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', service_only_table);
+      EXECUTE format('REVOKE ALL ON TABLE public.%I FROM anon, authenticated', service_only_table);
+      EXECUTE format('GRANT ALL ON TABLE public.%I TO service_role', service_only_table);
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
Summary:
- Moves the public demo rate-limit table off anon-key writes by requiring the server-only Supabase service role key.
- Stops tenant settings reads from falling back to anon when service role is missing.
- Adds an idempotent service-only Data API grants migration for the audited server-controlled tables.
- Adds a focused guardrail test for the grant/key posture.

Scope:
- SecurityPass / Supabase Data API grants audit for todo d119a032.
- Touched `api/tools/demo.ts`, `packages/mcp-server/src/memory/tenant-settings.ts`, `api/supabase-data-api-grants.test.ts`, and `supabase/migrations/20260514000000_data_api_service_only_grants.sql`.

Non-overlap:
- Does not change developer dashboard auth or payout/profile access.
- Does not grant anon/authenticated access to audited service-only tables.
- Does not touch production data, secrets, billing, DNS, or deployment settings.

Verification:
- `npm run test -- api/supabase-data-api-grants.test.ts`, 3/3 passed.
- `git diff --check`, passed.

Risk:
- Low to medium. Demo rate limiting now requires `SUPABASE_SERVICE_ROLE_KEY`; if missing, rate limiting is disabled as a safe fallback rather than requiring anon write grants.
- The migration explicitly revokes anon/authenticated table grants for the audited service-only tables, so review should confirm no intentional browser/client path depends on those tables.

Follow-up:
- Developer dashboard remains a separate auth-model decision because switching it to service role without auth could expose developer profile/payout data by `developer_id`.