### PR TITLE
feat(orchestrator): filter timeline by source kind

### DIFF
--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -426,6 +426,24 @@ describe("AdminOrchestratorPage", () => {
     expect(document.querySelector("mark")?.textContent?.toLowerCase()).toContain("proof");
   });
 
+  it("filters Timeline continuity by source kind without removing source links", async () => {
+    renderOrchestrator("/admin/orchestrator/timeline");
+
+    expect(await screen.findByText("Continuity Feed")).toBeInTheDocument();
+    expect((await screen.findAllByText(/Signal to notice: something needs attention/i)).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Work sources" }));
+
+    expect(screen.getAllByText(/Orchestrator continuity proof landed/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Signal to notice: something needs attention/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Open source")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Chat sources" }));
+
+    expect(screen.getAllByText(/Orchestrator context should show subscription messages/i).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/Orchestrator continuity proof landed/i)).toHaveLength(0);
+  });
+
   it("lets humans view more loaded Orchestrator history", async () => {
     renderOrchestrator("/admin/orchestrator/timeline");
 

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -118,6 +118,7 @@ type SeatFreshnessLabel = "Live" | "Recent" | "Missed check-in" | "Quiet";
 type OrchestratorProfileCard = OrchestratorContext["profile_cards"][number];
 type OrchestratorContinuityEvent = OrchestratorContext["continuity_events"][number];
 type ActorTone = "human" | "seat" | "system" | "work";
+type SourceVisibilityFilter = "all" | "work" | "chat" | "signals" | "memory";
 
 interface ActorIdentity {
   emoji: string;
@@ -143,6 +144,7 @@ const ACTOR_TONE_STYLES: Record<ActorTone, string> = {
 const EASY_READ_STORAGE_KEY = "unclick_orchestrator_easy_read_v1";
 const DRIPFEED_EDUCATION_STORAGE_KEY = "unclick_orchestrator_dripfeed_education_v1";
 const ANALOGY_STORAGE_KEY = "unclick_orchestrator_analogy_v1";
+const SOURCE_VISIBILITY_STORAGE_KEY = "unclick_orchestrator_source_visibility_v1";
 const EVENT_PREVIEW_CHARS = 520;
 const NATURAL_CONTEXT_PREVIEW_CHARS = 360;
 const INITIAL_CONTEXT_LIMIT = 240;
@@ -155,6 +157,13 @@ const STORY_CHAPTER_MAX_EVENTS = 4;
 const STORY_CHAPTER_PREVIEW_CHARS = 1_450;
 const STORY_NATIVE_PREVIEW_COUNT = 5;
 const STORY_NATIVE_STORAGE_KEY = "unclick_orchestrator_story_native_v1";
+const SOURCE_VISIBILITY_FILTERS: Array<{ value: SourceVisibilityFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "work", label: "Work" },
+  { value: "chat", label: "Chat" },
+  { value: "signals", label: "Signals" },
+  { value: "memory", label: "Memory" },
+];
 
 type StoryTheme = "question" | "orchestrator" | "autopilot" | "blocker" | "shipping" | "signals" | "general";
 type StoryBeat =
@@ -398,6 +407,42 @@ function writeStoredBoolean(key: string, value: boolean) {
   } catch {
     // Local storage can be unavailable in private browsing; the UI still works for this session.
   }
+}
+
+function readStoredSourceVisibility(): SourceVisibilityFilter {
+  try {
+    const saved = localStorage.getItem(SOURCE_VISIBILITY_STORAGE_KEY);
+    if (SOURCE_VISIBILITY_FILTERS.some((filter) => filter.value === saved)) {
+      return saved as SourceVisibilityFilter;
+    }
+  } catch {
+    // Local storage can be unavailable in private browsing; the UI still works for this session.
+  }
+  return "all";
+}
+
+function writeStoredSourceVisibility(value: SourceVisibilityFilter) {
+  try {
+    localStorage.setItem(SOURCE_VISIBILITY_STORAGE_KEY, value);
+  } catch {
+    // Local storage can be unavailable in private browsing; the UI still works for this session.
+  }
+}
+
+function sourceVisibilityForEvent(event: OrchestratorContinuityEvent): SourceVisibilityFilter {
+  if (event.source_kind === "todo" || event.source_kind === "todo_comment" || event.source_kind === "boardroom_message") {
+    return "work";
+  }
+  if (event.source_kind === "conversation_turn") return "chat";
+  if (event.source_kind === "signal" || event.source_kind === "dispatch") return "signals";
+  if (event.source_kind === "session_summary" || event.source_kind === "library" || event.source_kind === "business_context") {
+    return "memory";
+  }
+  return "memory";
+}
+
+function matchesSourceVisibility(event: OrchestratorContinuityEvent, filter: SourceVisibilityFilter): boolean {
+  return filter === "all" || sourceVisibilityForEvent(event) === filter;
 }
 
 function eventSearchText(
@@ -1457,6 +1502,7 @@ function OrchestratorContinuityPanel({
     readStoredBoolean(DRIPFEED_EDUCATION_STORAGE_KEY, true),
   );
   const [analogies, setAnalogies] = useState(() => readStoredBoolean(ANALOGY_STORAGE_KEY, true));
+  const [sourceVisibility, setSourceVisibility] = useState<SourceVisibilityFilter>(readStoredSourceVisibility);
   const profileByAgentId = useMemo(
     () => buildProfileLookup(feedContext?.profile_cards),
     [feedContext?.profile_cards],
@@ -1476,10 +1522,15 @@ function OrchestratorContinuityPanel({
       }),
     [events, profileByAgentId],
   );
+  const sourceFilteredEventViews = useMemo(
+    () => eventViews.filter(({ event }) => matchesSourceVisibility(event, sourceVisibility)),
+    [eventViews, sourceVisibility],
+  );
+  const sourceVisibleCount = sourceFilteredEventViews.length;
   const filteredEventViews = useMemo(
     () =>
-      eventViews.filter(({ event, actor }) => matchesEventSearch(event, actor, searchQuery)),
-    [eventViews, searchQuery],
+      sourceFilteredEventViews.filter(({ event, actor }) => matchesEventSearch(event, actor, searchQuery)),
+    [sourceFilteredEventViews, searchQuery],
   );
   const visibleEventViews = filteredEventViews.slice(0, visibleEventCount);
   const canRevealLoadedHistory = filteredEventViews.length > visibleEventCount;
@@ -1508,6 +1559,11 @@ function OrchestratorContinuityPanel({
   function toggleAnalogies(nextValue: boolean) {
     setAnalogies(nextValue);
     writeStoredBoolean(ANALOGY_STORAGE_KEY, nextValue);
+  }
+
+  function updateSourceVisibility(value: SourceVisibilityFilter) {
+    setSourceVisibility(value);
+    writeStoredSourceVisibility(value);
   }
 
   return (
@@ -1579,6 +1635,34 @@ function OrchestratorContinuityPanel({
             <span className={`absolute top-1 h-4 w-4 rounded-full transition ${easyRead ? "left-6 bg-[#61C1C4]" : "left-1 bg-white/55"}`} />
           </span>
         </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 border-b border-white/[0.06] px-5 py-3 text-xs text-white/55">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-white/35">Sources</span>
+        {SOURCE_VISIBILITY_FILTERS.map((filter) => {
+          const selected = filter.value === sourceVisibility;
+          return (
+            <button
+              key={filter.value}
+              type="button"
+              aria-label={`${filter.label} sources`}
+              aria-pressed={selected}
+              onClick={() => updateSourceVisibility(filter.value)}
+              className={`rounded-md border px-2.5 py-1.5 text-[11px] font-medium transition ${
+                selected
+                  ? "border-[#61C1C4]/35 bg-[#61C1C4]/15 text-[#A9EEF0]"
+                  : "border-white/[0.06] bg-black/20 text-white/45 hover:border-white/[0.12] hover:text-white/70"
+              }`}
+            >
+              {filter.label}
+            </button>
+          );
+        })}
+        {sourceVisibility !== "all" && (
+          <span className="text-[11px] text-white/30">
+            {sourceVisibleCount} loaded event{sourceVisibleCount === 1 ? "" : "s"} in this source view.
+          </span>
+        )}
       </div>
 
       <div className="flex flex-wrap items-center gap-3 border-b border-white/[0.06] px-5 py-3 text-xs text-white/55">


### PR DESCRIPTION
Summary:
Adds a read-only source-kind filter to the Orchestrator Timeline so humans can switch between All, Work, Chat, Signals, and Memory views without mutating source data or losing proof links.

Scope:
- src/pages/admin/AdminOrchestrator.tsx
- src/pages/admin/AdminOrchestrator.test.tsx
- Linked todo: e9e308cd
- Owned scope: Orchestrator admin visibility behavior only

Non-overlap:
- Does not change Orchestrator data model, pointer ingestion, Boardroom meaning, Runner/BuildBait/Reviewer/Safety/Coordinator authority, schedules, auth, billing, DNS, or source row writes.
- Does not close the parent Orchestrator continuity todo.
- Does not touch PR #773 Supabase grants work.

Verification:
- npm run test -- src/pages/admin/AdminOrchestrator.test.tsx, 9 passed
- git diff --check, passed
- npm ci --ignore-scripts was used to install local test dependencies in this isolated worktree

Risk:
Low. Admin-only UI filtering over already-loaded read-only continuity events. The filter stores only a local UI preference in localStorage.

Follow-up:
Reviewer/Safety should confirm this is a visibility-only change and that source links remain available in filtered views.