### PR TITLE
fix(runner): claim legacy ScopePacks without patches

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,7 +22,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | package.json | 37074f6e60a5 | 4175 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |
-| scripts/pinballwake-coding-room.mjs | 4a48ded33a31 | 25453 |
+| scripts/pinballwake-coding-room.mjs | 9fa5689c555e | 25310 |
 | scripts/pinballwake-continuous-improvement-room.mjs | 4cbb389faf56 | 8822 |
 | scripts/pinballwake-dogfood-room.mjs | d161028d1382 | 2782 |
 | scripts/pinballwake-event-ledger-room.mjs | e8f8f9f84123 | 16104 |

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -999,7 +999,7 @@ export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date
     },
     worker: assignee || "builder",
     chip: title,
-    context: `${contextParts.join("; ")}. Imported for autonomous claim/routing; claim only when a ScopePack names owned files and an executable patch.`,
+    context: `${contextParts.join("; ")}. Imported for autonomous claim/routing; claim only when a ScopePack names owned files, verification, and stop conditions.`,
     jobType: scopePack.jobType,
     files: scopePack.files,
     expectedProof: {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -236,6 +236,66 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("claims scoped Boardroom todos that do not include a prebuilt patch", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const fetchImpl = async () => ({
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    todos: [
+                      {
+                        id: "todo-legacy-scopepack",
+                        title: "Legacy ScopePack without patch",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: null,
+                        actionability_reason: "unassigned_open",
+                        scope_pack: {
+                          role: "builder",
+                          owned_files: ["api/lib/orchestrator-context.ts"],
+                          tests: ["node --test api/orchestrator-context.test.ts"],
+                        },
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          };
+        },
+      });
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-14T08:40:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.queue_source.imported, 1);
+      assert.deepEqual(result.ledger.jobs[0].owned_files, ["api/lib/orchestrator-context.ts"]);
+      assert.equal(result.ledger.jobs[0].build.patch, "");
+      assert.equal(result.claimability_scorecard.claimed, 1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("quietly skips scoped UnClick todos that are not safe to auto-claim", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
@@ -1012,8 +1072,6 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.deepEqual(result.todo_scoping_sync.scopepack_hydration.missing_fields, [
         "acceptance",
         "stop_conditions",
-        "proof_required",
-        "non_goals",
       ]);
 
       const updateCall = calls.find((call) => call.body.params.name === "update_todo");
@@ -1022,7 +1080,7 @@ describe("PinballWake autonomous Runner seat", () => {
 
       const commentCall = calls.find((call) => call.body.params.name === "comment_on");
       assert.match(commentCall.body.params.arguments.text, /BLOCKER: scopepack_hydration_missing_fields/);
-      assert.match(commentCall.body.params.arguments.text, /missing_fields=acceptance,stop_conditions,proof_required,non_goals/);
+      assert.match(commentCall.body.params.arguments.text, /missing_fields=acceptance,stop_conditions/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/scripts/pinballwake-coding-room.mjs
+++ b/scripts/pinballwake-coding-room.mjs
@@ -72,15 +72,11 @@ function normalizeWorkerToken(value) {
   return String(value ?? "").trim().toLowerCase();
 }
 
-function hasExecutableBuildPatch(job = {}) {
-  return String(job?.build?.patch ?? "").trim().length > 0;
-}
-
 function isUnscopedBoardroomTodoJob(job = {}) {
   return (
     String(job?.source || "").trim() === "unclick-boardroom-actionable-todo" &&
     job?.job_type !== "review" &&
-    ((job?.owned_files || []).length === 0 || !hasExecutableBuildPatch(job))
+    (job?.owned_files || []).length === 0
   );
 }
 

--- a/scripts/pinballwake-coding-room.test.mjs
+++ b/scripts/pinballwake-coding-room.test.mjs
@@ -125,6 +125,22 @@ describe("PinballWake Coding Room skeleton", () => {
     assert.equal(result.job.lease_expires_at, "2026-05-04T00:01:00.000Z");
   });
 
+  it("lets builders claim Boardroom jobs that have owned files before a patch exists", () => {
+    const job = createCodingRoomJob({
+      source: "unclick-boardroom-actionable-todo",
+      worker: "forge",
+      chip: "fix active-state mismatch",
+      files: ["api/lib/orchestrator-context.ts"],
+      expectedProof: { tests: ["node --test api/orchestrator-context.test.ts"] },
+    });
+
+    const decision = runnerCanClaimCodingRoomJob({ runner: forgeRunner, job });
+
+    assert.equal(decision.ok, true);
+    assert.equal(decision.reason, "claimable");
+    assert.equal(job.build.patch, "");
+  });
+
   it("upserts jobs into a ledger without duplicating the same job id", () => {
     const first = createCodingRoomJob({
       jobId: "coding-room:test:one",

--- a/scripts/pinballwake-scopepack-hydrator.mjs
+++ b/scripts/pinballwake-scopepack-hydrator.mjs
@@ -93,6 +93,13 @@ function firstList(...values) {
   return [];
 }
 
+const DEFAULT_PROOF_REQUIRED =
+  "Boardroom receipt with PASS/BLOCKER, verification results, changed files or exact no-code blocker, and next action.";
+
+const DEFAULT_NON_GOALS = [
+  "No secrets, billing, DNS, destructive data changes, force pushes, production writes, or extra schedules unless explicitly scoped.",
+];
+
 function recentTodoText(todo = {}) {
   const comments = Array.isArray(todo.recent_comments)
     ? todo.recent_comments
@@ -152,8 +159,11 @@ function normalizeHydrationScope(todo = {}, scope = {}, options = {}) {
     scope.testProofPlan?.allowlistTests,
   );
   const stopConditions = firstList(scope.stop_conditions, scope.stopConditions);
-  const nonGoals = firstList(scope.non_goals, scope.nonGoals, scope.out_of_scope, scope.outOfScope);
-  const proofRequired = firstText(scope.proof_required, scope.proofRequired, scope.expected_proof, scope.expectedProof);
+  const explicitNonGoals = firstList(scope.non_goals, scope.nonGoals, scope.out_of_scope, scope.outOfScope);
+  const nonGoals = explicitNonGoals.length > 0 ? explicitNonGoals : DEFAULT_NON_GOALS;
+  const proofRequired =
+    firstText(scope.proof_required, scope.proofRequired, scope.expected_proof, scope.expectedProof) ||
+    DEFAULT_PROOF_REQUIRED;
   const laneHint = firstText(
     scope.owner_hint,
     scope.ownerHint,


### PR DESCRIPTION
## Summary
- let Jobs room Boardroom todo ScopePacks claim when they name owned files, even if the builder has not created a patch yet
- default missing proof_required and non_goals during ScopePack hydration so older cards do not block the whole queue
- update runner context wording and focused tests

## Verification
- node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-coding-room.test.mjs
- git diff --check

## Safety
- claim-path only
- does not enable execute mode
- no production, secret, billing, DNS, or destructive changes