### PR TITLE
fix(orchestrator): keep active todos hydrated

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -41,6 +41,21 @@ export interface OrchestratorTodoRow {
   completed_at?: string | null;
 }
 
+export function mergeOrchestratorTodoRows(
+  ...sources: Array<OrchestratorTodoRow[] | null | undefined>
+): OrchestratorTodoRow[] {
+  const byId = new Map<string, OrchestratorTodoRow>();
+
+  for (const source of sources) {
+    for (const todo of source ?? []) {
+      if (!todo?.id) continue;
+      byId.set(todo.id, todo);
+    }
+  }
+
+  return Array.from(byId.values());
+}
+
 export interface OrchestratorCommentRow {
   id: string;
   target_kind: "todo" | "idea" | string;

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -106,6 +106,7 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import {
   buildOrchestratorContext,
+  mergeOrchestratorTodoRows,
   redactSensitive,
   type OrchestratorBusinessContextRow,
   type OrchestratorCommentRow,
@@ -7937,6 +7938,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           : "";
         const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 80) || 80, 20), 500);
         const smallerLimit = searchQuery ? limit : Math.min(limit, 300);
+        const todoSelect =
+          "id, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, source_idea_id, created_at, updated_at, completed_at";
 
         let messagesQuery = supabase
           .from("mc_fishbowl_messages")
@@ -7948,7 +7951,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         let todosQuery = supabase
           .from("mc_fishbowl_todos")
-          .select("id, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, source_idea_id, created_at, updated_at, completed_at")
+          .select(todoSelect)
           .eq("api_key_hash", apiKeyHash)
           .neq("status", "dropped")
           .order("updated_at", { ascending: false })
@@ -7956,6 +7959,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (searchPattern) {
           todosQuery = todosQuery.or(`title.ilike.${searchPattern},description.ilike.${searchPattern}`);
         }
+        const inProgressTodosQuery = supabase
+          .from("mc_fishbowl_todos")
+          .select(todoSelect)
+          .eq("api_key_hash", apiKeyHash)
+          .eq("status", "in_progress")
+          .order("updated_at", { ascending: false })
+          .limit(100);
 
         let commentsQuery = supabase
           .from("mc_fishbowl_comments")
@@ -8001,6 +8011,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           profilesResult,
           messagesResult,
           todosResult,
+          inProgressTodosResult,
           commentsResult,
           dispatchesResult,
           signalsResult,
@@ -8018,6 +8029,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .limit(smallerLimit),
           messagesQuery,
           todosQuery,
+          inProgressTodosQuery,
           commentsQuery,
           supabase
             .from("mc_agent_dispatches")
@@ -8047,6 +8059,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           profilesResult.error,
           messagesResult.error,
           todosResult.error,
+          inProgressTodosResult.error,
           commentsResult.error,
           dispatchesResult.error,
           signalsResult.error,
@@ -8083,6 +8096,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         ]
           .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
           .slice(0, smallerLimit);
+        const todos = mergeOrchestratorTodoRows(
+          (todosResult.data ?? []) as OrchestratorTodoRow[],
+          (inProgressTodosResult.data ?? []) as OrchestratorTodoRow[],
+        );
 
         return res.status(200).json({
           context: buildOrchestratorContext({
@@ -8090,7 +8107,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             continuityLimit: limit,
             profiles: (profilesResult.data ?? []) as OrchestratorProfileRow[],
             messages: (messagesResult.data ?? []) as OrchestratorMessageRow[],
-            todos: (todosResult.data ?? []) as OrchestratorTodoRow[],
+            todos,
             comments: (commentsResult.data ?? []) as OrchestratorCommentRow[],
             dispatches: (dispatchesResult.data ?? []) as OrchestratorDispatchRow[],
             signals: (signalsResult.data ?? []) as OrchestratorSignalRow[],

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -4,6 +4,7 @@ import {
   compactText,
   computeActiveJobsCount,
   isHeartbeatAutomationText,
+  mergeOrchestratorTodoRows,
   redactSensitive,
 } from "./lib/orchestrator-context";
 
@@ -1176,5 +1177,63 @@ describe("computeActiveJobsCount (v9 definition)", () => {
     });
     expect(directCount).toBe(1);
     expect(context.current_state_card.active_jobs).toBe(directCount);
+  });
+
+  it("merges in_progress todos back into a recency or search limited Orchestrator slice", () => {
+    const recentSlice = [
+      {
+        id: "todo-open-recent",
+        title: "Recent open todo",
+        status: "open",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: null,
+        created_at: "2026-05-14T00:00:00.000Z",
+        updated_at: "2026-05-14T00:00:00.000Z",
+      },
+      {
+        id: "todo-active",
+        title: "Active job from recent slice",
+        status: "in_progress",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: "builder-1",
+        created_at: "2026-05-11T00:00:00.000Z",
+        updated_at: "2026-05-14T00:00:00.000Z",
+      },
+    ];
+    const activeStateSlice = [
+      {
+        id: "todo-active",
+        title: "Active job from canonical in_progress slice",
+        status: "in_progress",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: "builder-1",
+        created_at: "2026-05-11T00:00:00.000Z",
+        updated_at: "2026-05-14T00:01:00.000Z",
+      },
+      {
+        id: "todo-active-old",
+        title: "Old active job outside recent slice",
+        status: "in_progress",
+        priority: "urgent",
+        created_by_agent_id: "watcher",
+        assigned_to_agent_id: "builder-2",
+        created_at: "2026-05-08T00:00:00.000Z",
+        updated_at: "2026-05-08T00:00:00.000Z",
+      },
+    ];
+
+    const merged = mergeOrchestratorTodoRows(recentSlice, activeStateSlice);
+
+    expect(merged.map((todo) => todo.id)).toEqual([
+      "todo-open-recent",
+      "todo-active",
+      "todo-active-old",
+    ]);
+    expect(merged.find((todo) => todo.id === "todo-active")?.title).toBe(
+      "Active job from canonical in_progress slice",
+    );
   });
 });


### PR DESCRIPTION
Summary:
- Keeps Orchestrator current-state hydration from dropping active Jobs-room work when the normal todo slice is recency or search limited.
- Adds an in_progress todo fetch for orchestrator_context_read and merges it by id before buildOrchestratorContext computes active_jobs and R1 health.
- Adds a focused regression test for merging in_progress todos back into a limited Orchestrator slice.

Scope:
- Owned todo: bbbbe51b, with R1 carrier eb4bea5a.
- Files: api/memory-admin.ts, api/lib/orchestrator-context.ts, api/orchestrator-context.test.ts.

Non-overlap:
- Does not touch PR #776, runner authority, schedules, merges, QueuePush, WakePass, data schemas, auth, billing, DNS, or production writes.
- Does not change active_jobs formula, only the rows hydrated before the existing formula runs.

Verification:
- npm run test -- api/orchestrator-context.test.ts api/orchestrator-context-health-verdict.test.ts packages/commonsensepass/src/__tests__/check.test.ts, 53/53 passed.
- git diff --check passed.

Risk:
- Low. Adds one read-only Supabase query in orchestrator_context_read for in_progress todos and dedupes rows before context construction.
- No migrations or source-state mutations.

Follow-up:
- After merge, the next heartbeat should prove q-scoped Orchestrator reads no longer report false quiet while Jobs room has in_progress work.