### PR TITLE
fix(runner): block false no-work claims

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -884,6 +884,86 @@ function buildRunClaimabilityScorecard({
   };
 }
 
+function claimabilityEvidence(scorecard = {}) {
+  return [
+    { kind: "queue", ref: `seen=${scorecard.seen ?? 0}` },
+    { kind: "queue", ref: `claimable=${scorecard.claimable ?? 0}` },
+    { kind: "queue", ref: `imported=${scorecard.imported ?? 0}` },
+    { kind: "queue", ref: `state=${scorecard.state || "unknown"}` },
+    { kind: "runner", ref: `final_action=${scorecard.final_action || "unknown"}` },
+    { kind: "runner", ref: `final_reason=${scorecard.final_reason || "unknown"}` },
+  ];
+}
+
+export function evaluateAutonomousRunnerCommonSensePass({
+  queueSourceResult = {},
+  claimabilityScorecard = {},
+  finalAction = claimabilityScorecard.final_action || null,
+  finalReason = claimabilityScorecard.final_reason || null,
+} = {}) {
+  if (queueSourceResult.source !== "unclick") {
+    return {
+      verdict: "PASS",
+      rule_id: null,
+      reason: "CommonSensePass guard skipped for non-UnClick queue source.",
+      evidence: claimabilityEvidence(claimabilityScorecard),
+    };
+  }
+
+  const trustedNoWorkClaim = finalAction === "idle" && finalReason === "no_claimable_jobs";
+  if (!trustedNoWorkClaim) {
+    return {
+      verdict: "PASS",
+      rule_id: "R1",
+      reason: "Runner did not emit a trusted no-work claim.",
+      evidence: claimabilityEvidence(claimabilityScorecard),
+    };
+  }
+
+  if (claimabilityScorecard.state === "queue_unavailable") {
+    return {
+      verdict: "HOLD",
+      rule_id: "R1",
+      reason: "CommonSensePass HOLD: UnClick queue evidence is unavailable, so no-work cannot be trusted.",
+      reason_code: "commonsensepass_queue_unavailable",
+      evidence: claimabilityEvidence(claimabilityScorecard),
+      next_action: "restore_queue_source_or_read_jobs_room",
+    };
+  }
+
+  const seen = Number.isFinite(claimabilityScorecard.seen) ? claimabilityScorecard.seen : 0;
+  const claimed = Number.isFinite(claimabilityScorecard.claimed) ? claimabilityScorecard.claimed : 0;
+  const attemptable = Number.isFinite(claimabilityScorecard.claim_attemptable_after_safety)
+    ? claimabilityScorecard.claim_attemptable_after_safety
+    : Number.POSITIVE_INFINITY;
+
+  if (
+    seen > 0 &&
+    claimed === 0 &&
+    (
+      claimabilityScorecard.healthy === false ||
+      claimabilityScorecard.state === "blocked_no_claimable" ||
+      attemptable === 0
+    )
+  ) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R1",
+      reason: `CommonSensePass BLOCKER: ${seen} UnClick job(s) were visible but none were claimable, so no-work cannot be trusted.`,
+      reason_code: "commonsensepass_no_work_blocked_by_visible_queue",
+      evidence: claimabilityEvidence(claimabilityScorecard),
+      next_action: "hydrate_scopepack_or_route_exact_blocker",
+    };
+  }
+
+  return {
+    verdict: "PASS",
+    rule_id: "R1",
+    reason: "No-work claim consistent with UnClick queue evidence.",
+    evidence: claimabilityEvidence(claimabilityScorecard),
+  };
+}
+
 export async function syncBoardroomTodoScopingRequestToUnClick({
   todo,
   runner = DEFAULT_AUTONOMOUS_RUNNER,
@@ -1621,13 +1701,31 @@ export async function runAutonomousRunnerFile({
     });
   }
 
+  const commonsensepass = evaluateAutonomousRunnerCommonSensePass({
+    queueSourceResult,
+    claimabilityScorecard,
+    finalAction,
+    finalReason,
+  });
+  if (commonsensepass.verdict !== "PASS") {
+    finalAction = "blocked";
+    finalReason = commonsensepass.reason_code || "commonsensepass_blocked";
+    claimabilityScorecard = {
+      ...claimabilityScorecard,
+      final_action: finalAction,
+      final_reason: finalReason,
+      commonsensepass_verdict: commonsensepass.verdict,
+      commonsensepass_rule_id: commonsensepass.rule_id,
+    };
+  }
+
   if (shouldPersist) {
     await writeCodingRoomJobLedger(ledgerPath, ledger);
   }
 
   return {
     ...last,
-    ok: results.every((result) => result.ok) && todoClaimSync.ok && todoScopingSync.ok,
+    ok: commonsensepass.verdict === "PASS" && results.every((result) => result.ok) && todoClaimSync.ok && todoScopingSync.ok,
     action: finalAction,
     reason: finalReason,
     mode: safeMode,
@@ -1638,6 +1736,7 @@ export async function runAutonomousRunnerFile({
     ledger_path: ledgerPath,
     queue_source: queueSourceResult,
     claimability_scorecard: claimabilityScorecard,
+    commonsensepass,
     todo_claim_sync: todoClaimSync,
     todo_scoping_sync: todoScopingSync,
   };

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
+  evaluateAutonomousRunnerCommonSensePass,
   evaluateBoardroomTodoAutoClaimEligibility,
   evaluateOrchestratorSeatHandshakeProof,
   extractBoardroomTodoIdFromCodingRoomJob,
@@ -1388,9 +1389,9 @@ describe("PinballWake autonomous Runner seat", () => {
         now: "2026-05-09T12:35:00.000Z",
       });
 
-      assert.equal(result.ok, true);
-      assert.equal(result.action, "idle");
-      assert.equal(result.reason, "no_claimable_jobs");
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "commonsensepass_no_work_blocked_by_visible_queue");
       assert.deepEqual(result.queue_source.claimability_scorecard, {
         seen: 1,
         claimable: 0,
@@ -1402,9 +1403,13 @@ describe("PinballWake autonomous Runner seat", () => {
         state: "blocked_no_claimable",
         healthy: false,
       });
+      assert.equal(result.commonsensepass.verdict, "BLOCKER");
+      assert.equal(result.commonsensepass.rule_id, "R1");
       assert.equal(result.claimability_scorecard.claimed, 0);
       assert.equal(result.claimability_scorecard.last_action, "idle");
       assert.equal(result.claimability_scorecard.last_reason, "no_claimable_jobs");
+      assert.equal(result.claimability_scorecard.final_action, "blocked");
+      assert.equal(result.claimability_scorecard.final_reason, "commonsensepass_no_work_blocked_by_visible_queue");
       assert.equal(result.queue_source.skipped[0].id, "todo-stale-scoped-1");
       assert.equal(result.queue_source.skipped[0].reason, "boardroom_todo_not_open");
       assert.deepEqual(calls.map((call) => call.body.params.name), ["list_actionable_todos"]);
@@ -1414,6 +1419,39 @@ describe("PinballWake autonomous Runner seat", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("CommonSensePass guard passes ordinary runner actions and blocks visible no-work", () => {
+    const claimed = evaluateAutonomousRunnerCommonSensePass({
+      queueSourceResult: { source: "unclick" },
+      claimabilityScorecard: {
+        seen: 1,
+        claimable: 1,
+        imported: 1,
+        state: "claimable",
+        healthy: true,
+        final_action: "claimed",
+        final_reason: null,
+      },
+    });
+    assert.equal(claimed.verdict, "PASS");
+
+    const blocked = evaluateAutonomousRunnerCommonSensePass({
+      queueSourceResult: { source: "unclick" },
+      claimabilityScorecard: {
+        seen: 2,
+        claimable: 0,
+        imported: 0,
+        claimed: 0,
+        claim_attemptable_after_safety: 0,
+        state: "blocked_no_claimable",
+        healthy: false,
+        final_action: "idle",
+        final_reason: "no_claimable_jobs",
+      },
+    });
+    assert.equal(blocked.verdict, "BLOCKER");
+    assert.equal(blocked.reason_code, "commonsensepass_no_work_blocked_by_visible_queue");
   });
 
   it("blocks stale UnClick todo lease tokens before syncing ownership", async () => {


### PR DESCRIPTION
## Summary
- add a runner-side CommonSensePass guard for UnClick queue results
- convert visible-queue/no-claimable idle outcomes into BLOCKER instead of trusted no-work
- keep normal claimed and non-UnClick queue paths passing

## Proof
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run test -- packages/commonsensepass/src/__tests__/check.test.ts
- git diff --check

Job: 9b0e5806-fbef-400f-823e-64e09203f897