### PR TITLE
[codex] add Jobsmith phase 0 spec

### DIFF
--- a/docs/jobsmith-guardrails.md
+++ b/docs/jobsmith-guardrails.md
@@ -1,0 +1,199 @@
+# Jobsmith Guardrails
+
+Jobsmith exists to help people apply for real jobs honestly. These guardrails are product rules, not marketing notes.
+
+## Naming
+
+- Use **Jobsmith** in all product, repo, Jobs room, GitHub, UI, and docs surfaces.
+- Treat older names in research files as source context only.
+- Do not create dual branding or transition copy unless Chris asks for it.
+
+## Truth First
+
+Jobsmith must never invent:
+
+- Employers.
+- Titles.
+- Dates.
+- Degrees.
+- Certifications.
+- Referrals.
+- Salary history.
+- Metrics.
+- Portfolio evidence.
+- Tool experience.
+- Team size.
+- Business outcomes.
+
+Every generated claim must map to `source_cv_facts`, portfolio evidence, or a user-approved note. Unsupported claims are blocked until the user supplies evidence.
+
+## Interview-Defensible Standard
+
+Before a claim appears in a CV, cover letter, email, or portal answer, ask:
+
+Could the applicant defend this clearly in an interview?
+
+If the answer is no, Jobsmith should revise, weaken, cite the missing evidence, or block the claim. Specific language is good. Inflated language is not.
+
+## No ATS Abuse
+
+Allowed:
+
+- Clear standard headings.
+- Single-column layout.
+- Plain date formats.
+- Role-relevant keywords used in context.
+- Text-based DOCX, PDF, and plain text exports.
+- Parse self-tests and vendor-specific lint.
+
+Blocked:
+
+- Hidden text.
+- White-on-white text.
+- Keyword stuffing.
+- Repeated skill spam.
+- Image-only CVs.
+- Misleading headings.
+- Fake role matching.
+- Claims designed only for a scanner and not for a human reader.
+
+ATS risk is a review signal, not a promise that an application will rank or pass.
+
+## No Detector Evasion
+
+Jobsmith must not include:
+
+- Humaniser mode.
+- AI detector bypass mode.
+- Fake typos.
+- Random awkwardness.
+- Prompted imperfection.
+- Rewriting whose goal is to beat a detector score.
+
+Detector checks, if included, are optional false-positive risk awareness only. They must be clearly labeled as weak, noisy, and potentially biased signals.
+
+## Redaction Before External Checks
+
+Never submit a real CV, cover letter, email, or profile containing personal or sensitive details to a public detector or external checker.
+
+Before any optional external check:
+
+- Remove name, email, phone, address, and account handles.
+- Remove employer names if they identify the applicant too strongly.
+- Remove project codenames, client names, and private portfolio details.
+- Remove references, recruiter details, and application IDs.
+- Show the user exactly what would leave the system.
+- Block the call if redaction is incomplete.
+
+Record a redaction receipt with what was removed, where the redacted copy went, when, and which rule version allowed it.
+
+## Privacy And Retention
+
+Default posture:
+
+- No secrets in logs.
+- No training on user data without a separate explicit opt-in.
+- User-controlled deletion and export.
+- Minimal third-party sharing.
+- Generated assets retained only as long as useful.
+- Source facts retained only with user control and clear explanation.
+
+Recommended defaults:
+
+- Generated assets: 90 days.
+- Source facts: 365 days.
+- Audit and rule receipts: retained as proof unless user deletion requires removal.
+
+## Age And Over-Seniority Lens
+
+Jobsmith may reduce unnecessary age or over-seniority signals by:
+
+- Removing graduation dates when not needed.
+- Compressing older early-career detail.
+- Highlighting recent, relevant proof first.
+- Matching seniority tone to the actual role.
+- Avoiding founder-heavy or overqualified framing where it hurts fit.
+
+Jobsmith must not lie about dates, omit legally relevant facts, invent junior experience, or disguise the applicant's real background. The lens is about relevance and emphasis.
+
+## Voice Preservation
+
+Voice preservation means grounded, natural writing based on the applicant's own samples.
+
+Allowed:
+
+- Prefer plain English.
+- Preserve sentence rhythm where useful.
+- Replace generic AI phrases with specific evidence.
+- Use domain-appropriate tone.
+- Flag language the applicant would not naturally say.
+
+Blocked:
+
+- Fake personal quirks.
+- Artificial mistakes.
+- Over-casual language that misrepresents the applicant.
+- Style transfer that erases the user's professional identity.
+
+## Rule Updates
+
+Hiring tools, ATS parsers, AI detector claims, and employment AI rules change often. Jobsmith rules must be versioned.
+
+Each rule update needs:
+
+- Source.
+- Date checked.
+- Jurisdiction or vendor if relevant.
+- What changed.
+- Why it changed.
+- Approval level.
+- Rollback note.
+
+Human review is required for any rule that changes redaction behaviour, ethical policy, export format, or user-facing risk wording.
+
+## Build Boundaries
+
+Do not build in v0 without a narrower ScopePack:
+
+- Mass auto-apply.
+- Recruiter CRM.
+- Job board.
+- LinkedIn automation.
+- Interview-prep suite.
+- Public billing.
+- External detector integrations that handle unredacted text.
+- Training pipeline over user documents.
+- Production data migrations.
+
+Do not touch:
+
+- Secrets.
+- Billing.
+- DNS.
+- Production deploys.
+- Data deletion.
+- Force pushes.
+- New schedules outside the existing UnClick heartbeat policy.
+
+## Open Source Use
+
+Open-source projects can inform export or parsing plumbing only after a license and fit check.
+
+Rules:
+
+- No copied competitor UI.
+- No copied templates without license proof.
+- No dependencies with unclear data handling.
+- No license that conflicts with UnClick's distribution model.
+- Record borrowed code, license, source URL, and reason in the implementation PR.
+
+## Release Gate
+
+Before any user can rely on Jobsmith output:
+
+- Generated claims must have a source trace.
+- Unsupported claims must be blocked or clearly marked.
+- Redaction receipt must show zero unredacted external detector calls.
+- Export parse self-test must pass the target portal profile.
+- User must approve final materials before send.
+- Outcome tracking must be available for dogfood learning.

--- a/docs/jobsmith-v0-spec.md
+++ b/docs/jobsmith-v0-spec.md
@@ -1,0 +1,177 @@
+# Jobsmith v0 Spec
+
+Jobsmith is the UnClick application workshop for real job applications. It helps a person turn verified career facts into role-specific CVs, cover letters, short emails, and portal copy without fake claims, hidden text, keyword stuffing, or detector evasion.
+
+Source context:
+
+- `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\CV_research_2_2.md`
+- `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\CV_research_1_2.md`
+- Jobs todo `4bcb3169-54a6-4ed9-bb14-8b20f01c98ba`
+- GitHub issue `#779`
+
+The research files use an older working name. The product, docs, Jobs room, GitHub surfaces, UI, and user-facing copy must use **Jobsmith**.
+
+## Positioning
+
+Jobsmith is not an ATS-hacking tool and not a generic AI resume writer. It is a truthful application workshop built around four promises:
+
+- Every generated claim traces back to an applicant source fact.
+- Every draft is written so the applicant can defend it in an interview.
+- Every external check is privacy-aware and redacted first.
+- Every sent application becomes learning evidence for the next one.
+
+The market gap is the space between template resume builders, ATS score tools, mass auto-apply products, and generic AI rewriters. Jobsmith should win by combining grounded tailoring, applicant voice, privacy receipts, and outcome learning.
+
+## First User
+
+Chris is the first user and dogfood loop. v0 should support one applicant well before it tries to support every applicant.
+
+First-user needs:
+
+- Capture a job in under 60 seconds from a URL, pasted description, or recruiter note.
+- Reuse a trusted master CV, skills list, timeline, portfolio links, LinkedIn export, and voice samples.
+- Generate application materials that are specific, plain, and interview-defensible.
+- Reduce avoidable age and over-seniority signals while preserving honest history.
+- Export material that survives Workday, Greenhouse, Lever, and manual portal copy-paste.
+- Record outcome signals after silence, rejection, interview, offer, or user revision.
+
+## Product Slices
+
+### Phase 0: Spec and Guardrails
+
+Ship this spec and `docs/jobsmith-guardrails.md`. The docs define naming, scope, risks, feature slices, data shape, and stop conditions before app code starts.
+
+### Phase 1: Admin Job Capture and Manual Wizard
+
+Build an internal admin-first flow for Chris:
+
+- Add job by URL, pasted description, or manual notes.
+- Capture company, role, salary, location, closing date, level, recruiter, source, and likely ATS vendor.
+- Attach source materials: master CV, portfolio links, writing samples, role history, skills, and notes.
+- Produce a manual tailoring plan before generation.
+
+### Phase 2: Source Facts and Truth Ledger
+
+Create a structured source record before any generated content:
+
+- `source_cv_facts`: atomic role, employer, date, achievement, skill, project, portfolio, education, and credential facts.
+- `claim_ledger`: every generated bullet, paragraph, or email claim maps to one or more source facts.
+- `unsupported_claims`: blocked claims that need user evidence before use.
+- `interview_defensible`: a boolean and note for claims that can survive a recruiter or hiring-manager question.
+
+### Phase 3: Tailoring and Voice
+
+Generate:
+
+- ATS-safe CV draft.
+- Cover letter.
+- Short application email.
+- Portal copy chunks for Workday, Greenhouse, Lever, and manual fields.
+- Portfolio proof pack mapping claims to case studies, projects, or examples.
+
+Voice preservation should use real writing samples to avoid generic AI tone. It must improve specificity and natural rhythm without adding fake imperfections or detector-evasion tricks.
+
+### Phase 4: Risk Dashboard
+
+Show practical risks before send:
+
+- Truthfulness risk: unsupported, inflated, vague, or interview-fragile claims.
+- ATS and formatting risk: columns, headings, date formats, tables, images, file type, and parse self-test output.
+- Tone risk: generic AI phrases, corporate fluff, over-polish, or weak opening evidence.
+- Age and over-seniority risk: unnecessary graduation dates, excessive early-career detail, or role-level mismatch.
+- Detector false-positive risk: optional and redacted-only, framed as weak signal awareness.
+- Privacy risk: what would leave the machine and why.
+
+### Phase 5: Exports
+
+v0 export targets:
+
+- DOCX as the safest default for ATS portals.
+- Text-based PDF for non-portal use.
+- Plain text for paste fields and parse self-tests.
+- Portal copy kit with summary, achievements, skills, short motivation, and email body.
+
+Avoid design-heavy layouts, image PDFs, hidden text, and unusual headings.
+
+### Phase 6: Outcome Learning
+
+After each application, capture:
+
+- Sent date.
+- Materials used.
+- Recruiter or portal notes.
+- Silence, rejection, interview, offer, or withdrawal.
+- User edits before send.
+- Lessons for rules, voice, claims, or formatting.
+
+Outcome learning should improve recommendations, not silently rewrite policy. Rule changes need source, date, reason, and approval level.
+
+## Minimal Data Outline
+
+- `applicant_profile`
+- `source_cv_facts`
+- `job_description`
+- `company_profile`
+- `tailoring_notes`
+- `generated_assets`
+- `claim_ledger`
+- `risk_reports`
+- `redacted_detector_copy`
+- `source_links`
+- `rule_versions`
+- `application_status`
+
+Generated assets should be reproducible from source facts, job description, rule version, and user-approved style settings.
+
+## Build Vs Borrow Audit
+
+Phase 0 should record a build-vs-borrow check before implementation. Open-source resume/CV projects can be inspected for parsing ideas, export plumbing, and schema inspiration only if license, quality, maintenance, and product fit are clean.
+
+Rules:
+
+- No copied competitor branding, UI, templates, or flows.
+- No dependency that forces user CV data through unknown external services.
+- Browser-local or permissively licensed parsing ideas may be useful, but Jobsmith remains UnClick-native unless a specific dependency passes review.
+- Any borrowed code needs license proof and a narrow integration note.
+
+## Acceptance
+
+Phase 0 is accepted when:
+
+- This spec and `docs/jobsmith-guardrails.md` exist in the repo.
+- The docs cite the two research files as source context.
+- Public naming is locked to Jobsmith.
+- The first app-code PR can choose exact app and package paths from these docs without rereading the research.
+- Guardrails clearly block fake claims, hidden text, keyword stuffing, detector evasion, unredacted detector calls, mass auto-apply, and user-data training without opt-in.
+
+Future product acceptance:
+
+- Chris can capture a job in under 60 seconds.
+- Generated CV, cover letter, and email drafts contain zero unsupported claims.
+- DOCX, text-based PDF, and plain-text exports pass Workday, Greenhouse, and Lever parse self-tests.
+- Redaction audit shows zero unredacted external detector calls.
+- Five real Chris applications run end to end and outcomes are captured.
+
+## Non Goals
+
+v0 does not include:
+
+- Mass auto-apply.
+- Recruiter CRM.
+- Full job board.
+- Interview prep suite.
+- LinkedIn auto-posting.
+- Multi-language output.
+- Mobile-native app.
+- Detector evasion or humaniser features.
+- Billing or public growth loops before dogfood proof.
+
+## Next Implementation Slice
+
+The next PR after Phase 0 should inspect the current repo and choose the smallest admin-first path. A likely slice is:
+
+- One Jobsmith admin route or panel.
+- Job capture form.
+- Source material placeholders.
+- Manual tailoring plan model.
+- No generation engine yet unless the spec receives a narrower ScopePack.


### PR DESCRIPTION
## Summary
- Adds the Phase 0 Jobsmith product spec from the attached deep research and Jobs ScopePack.
- Adds Jobsmith guardrails covering truth ledger, redaction, no ATS abuse, no detector evasion, age/over-seniority handling, and release gates.
- Locks public naming to Jobsmith and keeps the older research name as source context only.

## Checks
- git diff --check --cached
- docs-only change, no app code touched