### PR TITLE
fix(wakepass): add quiet-window proof ladder guard

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1109,6 +1109,234 @@ function claimabilityEvidence(scorecard = {}) {
   ];
 }
 
+const QUIET_WINDOW_AUTONOMY_RUNGS = [
+  {
+    id: "tick",
+    aliases: ["tick", "heartbeat_tick", "scheduled_tick", "scheduled_heartbeat_tick"],
+  },
+  {
+    id: "buildbait_crumb",
+    aliases: ["buildbait", "buildbait_crumb", "crumb", "job_crumb"],
+  },
+  {
+    id: "claim_or_lease",
+    aliases: ["claim", "claimed", "lease", "lease_claimed", "claim_or_lease"],
+  },
+  {
+    id: "execution_packet",
+    aliases: ["execution", "execution_packet", "execute_packet"],
+  },
+  {
+    id: "build_attempt_or_commonsense_blocker",
+    aliases: [
+      "build_attempt_or_commonsense_blocker",
+      "build_attempt",
+      "build_result",
+      "commonsensepass_blocker",
+      "explicit_commonsensepass_blocker",
+      "commonsense_blocker",
+    ],
+  },
+  {
+    id: "proof_packet",
+    aliases: ["proof", "proof_packet", "proof_submitted"],
+  },
+  {
+    id: "terminal_receipt",
+    aliases: ["terminal", "terminal_receipt", "terminal_state", "done", "blocked", "hold"],
+  },
+];
+
+const QUIET_WINDOW_BLOCKER_RUNGS = new Set([
+  "build_attempt_or_commonsense_blocker",
+  "proof_packet",
+  "terminal_receipt",
+]);
+
+const NOT_CLEAN_AUTONOMY_SOURCES = new Set([
+  "manual",
+  "manual_chat",
+  "operator_chat",
+  "user_chat",
+  "human_chat",
+  "chat",
+  "workflow_dispatch",
+]);
+
+function normalizeQuietWindowToken(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function quietWindowEventTokens(event = {}) {
+  const values = typeof event === "string"
+    ? [event]
+    : [
+        event.rung,
+        event.kind,
+        event.type,
+        event.name,
+        event.event,
+        event.action,
+        event.status,
+        event.result,
+        event.reason,
+        event.receipt_kind,
+        event.source,
+        event.source_type,
+        event.trigger_source,
+      ];
+
+  return new Set(values.map(normalizeQuietWindowToken).filter(Boolean));
+}
+
+function quietWindowEventTimeMs(event = {}) {
+  if (typeof event === "string") return null;
+  const raw = event.at || event.time || event.timestamp || event.created_at || event.createdAt;
+  const ms = Date.parse(String(raw || ""));
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function eventFallsInsideWindow(event, windowStartMs, windowEndMs) {
+  const eventMs = quietWindowEventTimeMs(event);
+  if (!Number.isFinite(eventMs)) return true;
+  if (Number.isFinite(windowStartMs) && eventMs < windowStartMs) return false;
+  if (Number.isFinite(windowEndMs) && eventMs > windowEndMs) return false;
+  return true;
+}
+
+function hasNotCleanAutonomyToken(tokens) {
+  return [...tokens].some((token) =>
+    NOT_CLEAN_AUTONOMY_SOURCES.has(token) ||
+    token.includes("manual") ||
+    token.includes("operator_chat") ||
+    token.includes("human_chat") ||
+    token.includes("user_chat")
+  );
+}
+
+function hasQuietWindowRung(events, aliases) {
+  const normalizedAliases = new Set(aliases.map(normalizeQuietWindowToken));
+  return events.some((event) => {
+    const tokens = quietWindowEventTokens(event);
+    return [...normalizedAliases].some((alias) => tokens.has(alias));
+  });
+}
+
+function buildQuietWindowAutonomyResult({
+  verdict,
+  reason,
+  reasonCode,
+  firstMissingRung = null,
+  evidence,
+  nextAction,
+}) {
+  return {
+    ok: verdict === "PASS",
+    verdict,
+    reason,
+    reason_code: reasonCode,
+    first_missing_rung: firstMissingRung,
+    evidence,
+    next_action: nextAction,
+  };
+}
+
+export function evaluateQuietWindowAutonomyProofLadder(input = {}) {
+  const events = Array.isArray(input.events) ? input.events : [];
+  const windowStart = input.window_start || input.windowStart || input.window?.start || input.window?.window_start || "";
+  const windowEnd = input.window_end || input.windowEnd || input.window?.end || input.window?.window_end || "";
+  const windowStartMs = Date.parse(String(windowStart || ""));
+  const windowEndMs = Date.parse(String(windowEnd || ""));
+  const triggerSource = normalizeQuietWindowToken(
+    input.trigger_source || input.triggerSource || input.source || input.event_source || "",
+  );
+  const observedRungs = QUIET_WINDOW_AUTONOMY_RUNGS
+    .filter((rung) => hasQuietWindowRung(events, rung.aliases))
+    .map((rung) => rung.id);
+  const evidence = {
+    window_start: windowStart || null,
+    window_end: windowEnd || null,
+    trigger_source: triggerSource || null,
+    job_id: input.job_id || input.jobId || null,
+    claim_id: input.claim_id || input.claimId || null,
+    run_id: input.run_id || input.runId || null,
+    observed_rungs: observedRungs,
+  };
+
+  if (!windowStart || !Number.isFinite(windowStartMs)) {
+    return buildQuietWindowAutonomyResult({
+      verdict: "HOLD",
+      reason: "quiet_window_missing_start",
+      reasonCode: "quiet_window_missing_start",
+      firstMissingRung: "window_start",
+      evidence,
+      nextAction: "record_window_start",
+    });
+  }
+
+  if (!windowEnd || !Number.isFinite(windowEndMs)) {
+    return buildQuietWindowAutonomyResult({
+      verdict: "HOLD",
+      reason: "quiet_window_missing_end",
+      reasonCode: "quiet_window_missing_end",
+      firstMissingRung: "window_end",
+      evidence,
+      nextAction: "record_window_end",
+    });
+  }
+
+  if (hasNotCleanAutonomyToken(new Set([triggerSource]))) {
+    return buildQuietWindowAutonomyResult({
+      verdict: "HOLD",
+      reason: "not_clean_autonomy_proof",
+      reasonCode: "not_clean_autonomy_proof",
+      firstMissingRung: "scheduled_trigger",
+      evidence,
+      nextAction: "wait_for_scheduled_unclick_heartbeat_window",
+    });
+  }
+
+  const notCleanEvent = events.find((event) =>
+    eventFallsInsideWindow(event, windowStartMs, windowEndMs) &&
+    hasNotCleanAutonomyToken(quietWindowEventTokens(event))
+  );
+  if (notCleanEvent) {
+    return buildQuietWindowAutonomyResult({
+      verdict: "HOLD",
+      reason: "not_clean_autonomy_proof",
+      reasonCode: "not_clean_autonomy_proof",
+      firstMissingRung: "no_human_operator_chat_trigger",
+      evidence,
+      nextAction: "restart_window_after_human_or_operator_activity",
+    });
+  }
+
+  for (const rung of QUIET_WINDOW_AUTONOMY_RUNGS) {
+    if (observedRungs.includes(rung.id)) continue;
+    const verdict = QUIET_WINDOW_BLOCKER_RUNGS.has(rung.id) ? "BLOCKER" : "HOLD";
+    return buildQuietWindowAutonomyResult({
+      verdict,
+      reason: `quiet_window_missing_${rung.id}`,
+      reasonCode: `quiet_window_missing_${rung.id}`,
+      firstMissingRung: rung.id,
+      evidence,
+      nextAction: `record_${rung.id}`,
+    });
+  }
+
+  return buildQuietWindowAutonomyResult({
+    verdict: "PASS",
+    reason: "quiet_window_autonomy_proof_complete",
+    reasonCode: "quiet_window_autonomy_proof_complete",
+    evidence,
+    nextAction: "submit_terminal_proof_receipt",
+  });
+}
+
 export function evaluateAutonomousRunnerCommonSensePass({
   queueSourceResult = {},
   claimabilityScorecard = {},

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -16,6 +16,7 @@ import {
   evaluateAutonomousRunnerCommonSensePass,
   evaluateBoardroomTodoAutoClaimEligibility,
   evaluateOrchestratorSeatHandshakeProof,
+  evaluateQuietWindowAutonomyProofLadder,
   extractBoardroomTodoIdFromCodingRoomJob,
   fetchUnClickActionableTodos,
   fetchUnClickOrchestratorContext,
@@ -1538,6 +1539,95 @@ describe("PinballWake autonomous Runner seat", () => {
     });
     assert.equal(blocked.verdict, "BLOCKER");
     assert.equal(blocked.reason_code, "commonsensepass_no_work_blocked_by_visible_queue");
+  });
+
+  it("classifies quiet-window autonomy proof without treating manual triggers as clean proof", () => {
+    const clean = evaluateQuietWindowAutonomyProofLadder({
+      windowStart: "2026-05-14T12:00:00.000Z",
+      windowEnd: "2026-05-14T12:07:00.000Z",
+      triggerSource: "scheduled_heartbeat",
+      jobId: "0068a201",
+      claimId: "lease-1",
+      runId: "run-1",
+      events: [
+        { rung: "heartbeat_tick", at: "2026-05-14T12:00:00.000Z" },
+        { rung: "buildbait_crumb", at: "2026-05-14T12:00:20.000Z" },
+        { rung: "lease_claimed", at: "2026-05-14T12:00:30.000Z" },
+        { rung: "execution_packet", at: "2026-05-14T12:01:00.000Z" },
+        { rung: "build_attempt", at: "2026-05-14T12:02:00.000Z" },
+        { rung: "proof_packet", at: "2026-05-14T12:03:00.000Z" },
+        { rung: "terminal_receipt", at: "2026-05-14T12:04:00.000Z" },
+      ],
+    });
+
+    assert.equal(clean.verdict, "PASS");
+    assert.equal(clean.ok, true);
+    assert.equal(clean.evidence.job_id, "0068a201");
+    assert.equal(clean.evidence.claim_id, "lease-1");
+    assert.equal(clean.evidence.run_id, "run-1");
+
+    const manualDispatch = evaluateQuietWindowAutonomyProofLadder({
+      windowStart: "2026-05-14T12:00:00.000Z",
+      windowEnd: "2026-05-14T12:07:00.000Z",
+      triggerSource: "workflow_dispatch",
+      events: clean.evidence.observed_rungs,
+    });
+
+    assert.equal(manualDispatch.verdict, "HOLD");
+    assert.equal(manualDispatch.reason_code, "not_clean_autonomy_proof");
+    assert.equal(manualDispatch.first_missing_rung, "scheduled_trigger");
+
+    const humanChatInsideWindow = evaluateQuietWindowAutonomyProofLadder({
+      windowStart: "2026-05-14T12:00:00.000Z",
+      windowEnd: "2026-05-14T12:07:00.000Z",
+      triggerSource: "scheduled_heartbeat",
+      events: [
+        ...clean.evidence.observed_rungs,
+        { kind: "operator_chat", at: "2026-05-14T12:03:30.000Z" },
+      ],
+    });
+
+    assert.equal(humanChatInsideWindow.verdict, "HOLD");
+    assert.equal(humanChatInsideWindow.reason_code, "not_clean_autonomy_proof");
+    assert.equal(humanChatInsideWindow.first_missing_rung, "no_human_operator_chat_trigger");
+  });
+
+  it("fails quiet-window proof closed with first_missing_rung for claim-only and incomplete proof ladders", () => {
+    const base = {
+      windowStart: "2026-05-14T12:00:00.000Z",
+      windowEnd: "2026-05-14T12:07:00.000Z",
+      triggerSource: "scheduled_heartbeat",
+    };
+
+    const claimOnly = evaluateQuietWindowAutonomyProofLadder({
+      ...base,
+      events: ["heartbeat_tick", "buildbait_crumb", "lease_claimed"],
+    });
+
+    assert.equal(claimOnly.verdict, "HOLD");
+    assert.equal(claimOnly.first_missing_rung, "execution_packet");
+
+    const missingBuildAttempt = evaluateQuietWindowAutonomyProofLadder({
+      ...base,
+      events: ["heartbeat_tick", "buildbait_crumb", "lease_claimed", "execution_packet"],
+    });
+
+    assert.equal(missingBuildAttempt.verdict, "BLOCKER");
+    assert.equal(missingBuildAttempt.first_missing_rung, "build_attempt_or_commonsense_blocker");
+
+    const missingProofPacket = evaluateQuietWindowAutonomyProofLadder({
+      ...base,
+      events: [
+        "heartbeat_tick",
+        "buildbait_crumb",
+        "lease_claimed",
+        "execution_packet",
+        "commonsensepass_blocker",
+      ],
+    });
+
+    assert.equal(missingProofPacket.verdict, "BLOCKER");
+    assert.equal(missingProofPacket.first_missing_rung, "proof_packet");
   });
 
   it("blocks stale UnClick todo lease tokens before syncing ownership", async () => {


### PR DESCRIPTION
Summary:
Adds a deterministic quiet-window autonomy proof ladder evaluator so scheduled autonomy proof can PASS only when the window includes the full tick to terminal receipt chain and no human/operator trigger.

Scope:
Owned files for Jobs todo 0068a201 slice:
- scripts/pinballwake-autonomous-runner.mjs
- scripts/pinballwake-autonomous-runner.test.mjs

Non-overlap:
No workflow edits, no schedule changes, no execute-mode enablement, no BuildBait room or quiet-window-proof helper file creation, and no build-executor behavior changes.

Verification:
- node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-build-executor.test.mjs, 51/51 passed
- git diff --check passed with line-ending warnings only

Risk:
Low runtime risk. This adds an exported evaluator and tests. It does not mutate production state, auth, secrets, billing, DNS, deploys, or live schedules.

Follow-up:
Wire this evaluator into the next proof recorder or runner receipt path so real scheduled windows emit PASS/HOLD/BLOCKER using first_missing_rung.

UnClick:
Linked Jobs todo 0068a201. PR is draft until runner owner decides where to call the evaluator in the full autonomy proof loop.