### PR TITLE
feat(memory): add library taxonomy shelves

### DIFF
--- a/src/lib/memoryTaxonomy.test.ts
+++ b/src/lib/memoryTaxonomy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { getMemoryTaxonomyShelfLabel, groupMemoryTaxonomyShelves } from "./memoryTaxonomy";
+
+describe("memory taxonomy shelves", () => {
+  it("groups documents by category before tags", () => {
+    const shelves = groupMemoryTaxonomyShelves([
+      {
+        id: "doc-1",
+        title: "Project state",
+        category: "07 Projects & Products",
+        tags: ["research"],
+        updated_at: "2026-05-14T01:00:00.000Z",
+      },
+      {
+        id: "doc-2",
+        title: "Memory shelf",
+        category: "15 Data & Memory",
+        tags: ["source:fact"],
+        updated_at: "2026-05-14T02:00:00.000Z",
+      },
+      {
+        id: "doc-3",
+        title: "Product follow-up",
+        category: "07 Projects & Products",
+        tags: ["source:session"],
+        updated_at: "2026-05-14T03:00:00.000Z",
+      },
+    ]);
+
+    expect(shelves.map((shelf) => [shelf.label, shelf.count])).toEqual([
+      ["07 Projects & Products", 2],
+      ["15 Data & Memory", 1],
+    ]);
+    expect(shelves[0].docs.map((doc) => doc.id)).toEqual(["doc-3", "doc-1"]);
+  });
+
+  it("falls back to the first non-metadata tag then uncategorized", () => {
+    expect(
+      getMemoryTaxonomyShelfLabel({
+        id: "doc-tag",
+        tags: ["source:fact", "10 Troubleshooting & Incidents"],
+      }),
+    ).toEqual({ label: "10 Troubleshooting & Incidents", source: "tag" });
+
+    expect(
+      getMemoryTaxonomyShelfLabel({
+        id: "doc-empty",
+        tags: ["source:fact", "kind:session"],
+      }),
+    ).toEqual({ label: "Uncategorized", source: "fallback" });
+  });
+});

--- a/src/lib/memoryTaxonomy.ts
+++ b/src/lib/memoryTaxonomy.ts
@@ -1,0 +1,100 @@
+export interface MemoryTaxonomyDoc {
+  id: string;
+  slug?: string;
+  title?: string;
+  category?: string | null;
+  tags?: string[] | null;
+  updated_at?: string | null;
+}
+
+export interface MemoryTaxonomyShelf<TDoc extends MemoryTaxonomyDoc = MemoryTaxonomyDoc> {
+  id: string;
+  label: string;
+  count: number;
+  docs: TDoc[];
+  source: "category" | "tag" | "fallback";
+  newestUpdatedAt: string | null;
+}
+
+const FALLBACK_SHELF = "Uncategorized";
+const METADATA_TAG_PREFIXES = ["source:", "source_", "kind:", "kind_", "id:", "fact:"];
+
+function cleanLabel(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function shelfId(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "uncategorized";
+}
+
+function isMetadataTag(tag: string): boolean {
+  const lower = tag.toLowerCase();
+  return METADATA_TAG_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+function labelFromTags(tags: string[] | null | undefined): string | null {
+  const tag = (tags ?? [])
+    .map(cleanLabel)
+    .find((candidate) => candidate.length > 0 && !isMetadataTag(candidate));
+  return tag ?? null;
+}
+
+function compareDocs(a: MemoryTaxonomyDoc, b: MemoryTaxonomyDoc): number {
+  const dateCompare = cleanLabel(b.updated_at).localeCompare(cleanLabel(a.updated_at));
+  if (dateCompare !== 0) return dateCompare;
+  return cleanLabel(a.title || a.slug || a.id).localeCompare(cleanLabel(b.title || b.slug || b.id));
+}
+
+export function getMemoryTaxonomyShelfLabel(doc: MemoryTaxonomyDoc): {
+  label: string;
+  source: MemoryTaxonomyShelf["source"];
+} {
+  const category = cleanLabel(doc.category);
+  if (category) return { label: category, source: "category" };
+
+  const tag = labelFromTags(doc.tags);
+  if (tag) return { label: tag, source: "tag" };
+
+  return { label: FALLBACK_SHELF, source: "fallback" };
+}
+
+export function groupMemoryTaxonomyShelves<TDoc extends MemoryTaxonomyDoc>(
+  docs: TDoc[],
+): Array<MemoryTaxonomyShelf<TDoc>> {
+  const shelves = new Map<string, MemoryTaxonomyShelf<TDoc>>();
+
+  for (const doc of docs) {
+    const { label, source } = getMemoryTaxonomyShelfLabel(doc);
+    const id = shelfId(label);
+    const shelf = shelves.get(id) ?? {
+      id,
+      label,
+      source,
+      count: 0,
+      docs: [],
+      newestUpdatedAt: null,
+    };
+
+    shelf.docs.push(doc);
+    shelf.count += 1;
+    if (!shelf.newestUpdatedAt || cleanLabel(doc.updated_at).localeCompare(shelf.newestUpdatedAt) > 0) {
+      shelf.newestUpdatedAt = cleanLabel(doc.updated_at) || shelf.newestUpdatedAt;
+    }
+    shelves.set(id, shelf);
+  }
+
+  return Array.from(shelves.values())
+    .map((shelf) => ({
+      ...shelf,
+      docs: [...shelf.docs].sort(compareDocs),
+    }))
+    .sort((a, b) => {
+      if (a.label === FALLBACK_SHELF && b.label !== FALLBACK_SHELF) return 1;
+      if (b.label === FALLBACK_SHELF && a.label !== FALLBACK_SHELF) return -1;
+      return a.label.localeCompare(b.label, undefined, { numeric: true, sensitivity: "base" });
+    });
+}

--- a/src/pages/admin/memory/LibraryTab.test.tsx
+++ b/src/pages/admin/memory/LibraryTab.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LibraryTab from "./LibraryTab";
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+const docs = [
+  {
+    id: "doc-product",
+    slug: "memory-taxonomy-07-projects-and-products",
+    title: "Projects memory snapshot",
+    category: "07 Projects & Products",
+    tags: ["source:fact", "roadmap"],
+    version: 2,
+    updated_at: "2026-05-14T03:00:00.000Z",
+    decay_tier: "warm",
+  },
+  {
+    id: "doc-memory",
+    slug: "memory-taxonomy-15-data-and-memory",
+    title: "Data memory snapshot",
+    category: "15 Data & Memory",
+    tags: ["source:session"],
+    version: 1,
+    updated_at: "2026-05-14T02:00:00.000Z",
+    decay_tier: "hot",
+  },
+  {
+    id: "doc-product-older",
+    slug: "project-follow-up",
+    title: "Project follow-up",
+    category: "07 Projects & Products",
+    tags: ["source:session"],
+    version: 1,
+    updated_at: "2026-05-14T01:00:00.000Z",
+    decay_tier: "cold",
+  },
+];
+
+describe("LibraryTab", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("method=list")) return jsonResponse({ data: docs });
+        if (url.includes("method=view")) return jsonResponse({ data: { content: "Sources: fact:doc-memory" } });
+        if (url.includes("method=history")) return jsonResponse({ data: [] });
+        return jsonResponse({});
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders existing library docs under deterministic taxonomy shelves", async () => {
+    render(React.createElement(LibraryTab, { apiKey: "test-key" }));
+
+    await screen.findByText("07 Projects & Products");
+
+    expect(screen.getByText("15 Data & Memory")).toBeInTheDocument();
+    expect(screen.getByText("Projects memory snapshot")).toBeInTheDocument();
+    expect(screen.getByText("Project follow-up")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /07 Projects & Products/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Projects memory snapshot")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Data memory snapshot")).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/memory/LibraryTab.tsx
+++ b/src/pages/admin/memory/LibraryTab.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { ChevronDown, ChevronRight, BookOpen, History } from "lucide-react";
+import { groupMemoryTaxonomyShelves } from "@/lib/memoryTaxonomy";
 import EmptyState from "./EmptyState";
 
 interface LibraryDoc {
@@ -42,6 +43,8 @@ export default function LibraryTab({ apiKey }: { apiKey: string }) {
   const [historySlug, setHistorySlug] = useState<string | null>(null);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
+  const [collapsedShelfIds, setCollapsedShelfIds] = useState<Set<string>>(() => new Set());
+  const shelves = useMemo(() => groupMemoryTaxonomyShelves(docs), [docs]);
 
   const load = useCallback(async () => {
     try {
@@ -102,6 +105,15 @@ export default function LibraryTab({ apiKey }: { apiKey: string }) {
     }
   };
 
+  const toggleShelf = (shelfId: string) => {
+    setCollapsedShelfIds((current) => {
+      const next = new Set(current);
+      if (next.has(shelfId)) next.delete(shelfId);
+      else next.add(shelfId);
+      return next;
+    });
+  };
+
   if (loading) {
     return <div className="space-y-3">{[1,2,3].map(i => <div key={i} className="h-20 animate-pulse rounded-lg bg-white/[0.03] border border-white/[0.06]" />)}</div>;
   }
@@ -122,88 +134,107 @@ export default function LibraryTab({ apiKey }: { apiKey: string }) {
   }
 
   return (
-    <div className="space-y-3">
-      {docs.map((doc) => {
-        const isExpanded = expandedId === doc.id;
-        const showingHistory = historySlug === doc.slug;
-
+    <div className="space-y-5">
+      {shelves.map((shelf) => {
+        const isCollapsed = collapsedShelfIds.has(shelf.id);
         return (
-          <div key={doc.id} className="rounded-lg border border-white/[0.06] bg-white/[0.03] overflow-hidden">
+          <section key={shelf.id} className="space-y-2">
             <button
-              onClick={() => viewDoc(doc)}
-              className="flex w-full items-start gap-3 p-4 text-left hover:bg-white/[0.02] transition-colors"
+              onClick={() => toggleShelf(shelf.id)}
+              className="flex w-full items-center gap-2 border-b border-white/[0.06] pb-2 text-left text-xs text-white/50 hover:text-white transition-colors"
             >
-              {isExpanded
-                ? <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-white/30" />
-                : <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-white/30" />
+              {isCollapsed
+                ? <ChevronRight className="h-3.5 w-3.5 shrink-0 text-white/30" />
+                : <ChevronDown className="h-3.5 w-3.5 shrink-0 text-white/30" />
               }
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="font-semibold text-sm text-white">{doc.title}</span>
-                  {doc.decay_tier && (
-                    <span className="flex items-center gap-1 text-[10px] text-white/30">
-                      <span className={`inline-block h-1.5 w-1.5 rounded-full ${DECAY_COLORS[doc.decay_tier] ?? "bg-gray-500"}`} />
-                      {doc.decay_tier}
-                    </span>
-                  )}
-                </div>
-                <div className="mt-1 flex items-center gap-2 text-[10px] text-white/30">
-                  <code className="font-mono text-white/40">{doc.slug}</code>
-                  <span>v{doc.version}</span>
-                  <span>updated {formatDate(doc.updated_at)}</span>
-                </div>
-                {(doc.tags ?? []).length > 0 && (
-                  <div className="mt-1.5 flex flex-wrap gap-1">
-                    {doc.tags!.map((t) => (
-                      <span key={t} className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] text-white/40">{t}</span>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <span className="font-semibold text-white/70">{shelf.label}</span>
+              <span className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] text-white/35">{shelf.count}</span>
             </button>
 
-            {isExpanded && (
-              <div className="border-t border-white/[0.06] p-4 space-y-3">
-                {docLoading ? (
-                  <p className="text-xs text-white/30">Loading snapshot...</p>
-                ) : docContent ? (
-                  <pre className="max-h-96 overflow-auto rounded-lg bg-white/[0.02] p-4 text-xs text-white/60 whitespace-pre-wrap font-mono">
-                    {docContent}
-                  </pre>
-                ) : (
-                  <p className="text-xs text-white/30">No content available.</p>
-                )}
+            {!isCollapsed && shelf.docs.map((doc) => {
+              const isExpanded = expandedId === doc.id;
+              const showingHistory = historySlug === doc.slug;
 
-                <button
-                  onClick={() => viewHistory(doc.slug)}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.06] px-3 py-1.5 text-xs text-white/50 hover:bg-white/[0.04] hover:text-white transition-colors"
-                >
-                  <History className="h-3 w-3" />
-                  {showingHistory ? "Hide History" : "Snapshot History"}
-                </button>
-
-                {showingHistory && (
-                  <div className="space-y-2">
-                    {historyLoading ? (
-                      <p className="text-xs text-white/30">Loading history...</p>
-                    ) : history.length === 0 ? (
-                      <p className="text-xs text-white/30">No version history found.</p>
-                    ) : (
-                      history.map((h) => (
-                        <div key={h.id} className="rounded border border-white/[0.04] bg-white/[0.01] p-3">
-                          <div className="flex items-center gap-2 text-[10px] text-white/30">
-                            <span className="font-semibold text-white/50">v{h.version}</span>
-                            <span>{formatDate(h.created_at)}</span>
-                          </div>
-                          <p className="mt-1 text-xs text-white/40 line-clamp-3">{h.content}</p>
+              return (
+                <div key={doc.id} className="rounded-lg border border-white/[0.06] bg-white/[0.03] overflow-hidden">
+                  <button
+                    onClick={() => viewDoc(doc)}
+                    className="flex w-full items-start gap-3 p-4 text-left hover:bg-white/[0.02] transition-colors"
+                  >
+                    {isExpanded
+                      ? <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-white/30" />
+                      : <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-white/30" />
+                    }
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-semibold text-sm text-white">{doc.title}</span>
+                        {doc.decay_tier && (
+                          <span className="flex items-center gap-1 text-[10px] text-white/30">
+                            <span className={`inline-block h-1.5 w-1.5 rounded-full ${DECAY_COLORS[doc.decay_tier] ?? "bg-gray-500"}`} />
+                            {doc.decay_tier}
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 flex items-center gap-2 text-[10px] text-white/30">
+                        <code className="font-mono text-white/40">{doc.slug}</code>
+                        <span>v{doc.version}</span>
+                        <span>updated {formatDate(doc.updated_at)}</span>
+                      </div>
+                      {(doc.tags ?? []).length > 0 && (
+                        <div className="mt-1.5 flex flex-wrap gap-1">
+                          {doc.tags!.map((t) => (
+                            <span key={t} className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] text-white/40">{t}</span>
+                          ))}
                         </div>
-                      ))
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+                      )}
+                    </div>
+                  </button>
+
+                  {isExpanded && (
+                    <div className="border-t border-white/[0.06] p-4 space-y-3">
+                      {docLoading ? (
+                        <p className="text-xs text-white/30">Loading snapshot...</p>
+                      ) : docContent ? (
+                        <pre className="max-h-96 overflow-auto rounded-lg bg-white/[0.02] p-4 text-xs text-white/60 whitespace-pre-wrap font-mono">
+                          {docContent}
+                        </pre>
+                      ) : (
+                        <p className="text-xs text-white/30">No content available.</p>
+                      )}
+
+                      <button
+                        onClick={() => viewHistory(doc.slug)}
+                        className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.06] px-3 py-1.5 text-xs text-white/50 hover:bg-white/[0.04] hover:text-white transition-colors"
+                      >
+                        <History className="h-3 w-3" />
+                        {showingHistory ? "Hide History" : "Snapshot History"}
+                      </button>
+
+                      {showingHistory && (
+                        <div className="space-y-2">
+                          {historyLoading ? (
+                            <p className="text-xs text-white/30">Loading history...</p>
+                          ) : history.length === 0 ? (
+                            <p className="text-xs text-white/30">No version history found.</p>
+                          ) : (
+                            history.map((h) => (
+                              <div key={h.id} className="rounded border border-white/[0.04] bg-white/[0.01] p-3">
+                                <div className="flex items-center gap-2 text-[10px] text-white/30">
+                                  <span className="font-semibold text-white/50">v{h.version}</span>
+                                  <span>{formatDate(h.created_at)}</span>
+                                </div>
+                                <p className="mt-1 text-xs text-white/40 line-clamp-3">{h.content}</p>
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </section>
         );
       })}
     </div>


### PR DESCRIPTION
Summary:
- Groups Memory Library docs into taxonomy shelves using `category` metadata, with tag and uncategorized fallbacks.
- Adds collapsible shelf sections in the admin Library tab while preserving existing view/history behavior.

Scope:
- Owned files for todo f565ad1d: `src/lib/memoryTaxonomy.ts`, `src/lib/memoryTaxonomy.test.ts`, `src/pages/admin/memory/LibraryTab.tsx`, `src/pages/admin/memory/LibraryTab.test.tsx`.

Non-overlap:
- No API, Supabase, schema, RLS, RPC, storage writes, billing, DNS, or production deploy changes.
- Leaves unrelated dirty `packages/channel-plugin/index.js` untouched.

Verification:
- `npm run test -- src/lib/memoryTaxonomy.test.ts src/pages/admin/memory/LibraryTab.test.tsx`
- `git diff --cached --check`

Risk:
- Display-only admin UI change. Low runtime risk; no persistence or auth path changed.

Follow-up:
- Validate the shelf copy against canonical Library Snapshot taxonomy once the next worker has broader product context.

UnClick:
- Todo: f565ad1d, Memory Library Snapshots v1: taxonomy shelves.
- Status: draft PR, focused builder slice.