### PR TITLE
feat(improver): emit native receipt fields

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -23,7 +23,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |
 | scripts/pinballwake-coding-room.mjs | 9fa5689c555e | 25310 |
-| scripts/pinballwake-continuous-improvement-room.mjs | 4cbb389faf56 | 8822 |
+| scripts/pinballwake-continuous-improvement-room.mjs | c80556b2d930 | 12439 |
 | scripts/pinballwake-dogfood-room.mjs | d161028d1382 | 2782 |
 | scripts/pinballwake-event-ledger-room.mjs | e8f8f9f84123 | 16104 |
 | scripts/pinballwake-jobs-room.mjs | c77c394081c2 | 14217 |

--- a/scripts/pinballwake-continuous-improvement-room.mjs
+++ b/scripts/pinballwake-continuous-improvement-room.mjs
@@ -23,6 +23,82 @@ function compactText(value, max = 700) {
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
 }
 
+function signalCoverage(signal = {}) {
+  const candidates = [
+    ["open_todo", signal.coveredByOpenTodo ?? signal.covered_by_open_todo],
+    ["recent_proof", signal.coveredByRecentProof ?? signal.covered_by_recent_proof],
+    ["active_claim", signal.coveredByActiveClaim ?? signal.covered_by_active_claim],
+    ["covered", signal.coveredBy ?? signal.covered_by],
+  ];
+  for (const [kind, value] of candidates) {
+    const ref = compactText(value, 180);
+    if (ref) return { kind, ref };
+  }
+  return null;
+}
+
+function coverageReasonKey(coverage) {
+  if (coverage?.kind === "open_todo") return "covered_by_open_todo";
+  if (coverage?.kind === "recent_proof") return "covered_by_recent_proof";
+  if (coverage?.kind === "active_claim") return "covered_by_active_claim";
+  return "duplicate_covered";
+}
+
+function xpassAdvisoryFor(kind) {
+  const advisory = ["CommonSensePass"];
+  if (kind === "protected_surface_safeguard") advisory.push("SecurityPass");
+  else if (kind === "proof_flow") advisory.push("ProofPass");
+  else if (kind === "launchpad_routing") advisory.push("FlowPass");
+  else if (kind === "merge_flow") advisory.push("MergePass");
+  else advisory.push("QualityPass");
+  return advisory;
+}
+
+function evidenceFor(top) {
+  const signal = top.signal || {};
+  const evidence = [`kind=${top.kind}`, `score=${top.score}`];
+  const title = compactText(signal.title || signal.name, 180);
+  const source = compactText(signal.source || signal.room || signal.channel, 120);
+  const detail = compactText(signal.detail || signal.summary || signal.reason || signal.blocker || signal.text, 260);
+  if (title) evidence.push(`title=${title}`);
+  if (source) evidence.push(`source=${source}`);
+  if (detail) evidence.push(`detail=${detail}`);
+  return evidence;
+}
+
+function proofRequiredFor(tests = []) {
+  const testText = tests.length ? tests.join("; ") : "the smallest focused check for the touched files";
+  return `Patch, non-overlap note, Boardroom proof, and tests: ${testText}`;
+}
+
+function nativeImproverReceipt({ top, job, tests, now, source }) {
+  return {
+    receipt_type: "native_improver_opportunity",
+    emitted_at: now,
+    source,
+    improvement_kind: top.kind,
+    score: top.score,
+    evidence: evidenceFor(top),
+    next_action: `Build ${job.chip}: patch ${job.owned_files.join(", ")}`,
+    proof_required: proofRequiredFor(tests),
+    xpass_advisory: xpassAdvisoryFor(top.kind),
+  };
+}
+
+function nativeImproverHoldReceipt({ top, now, source }) {
+  return {
+    receipt_type: "native_improver_hold",
+    emitted_at: now,
+    source,
+    improvement_kind: top.kind,
+    score: top.score,
+    evidence: evidenceFor(top),
+    next_action: "Do not create a duplicate build job; update the covered todo, proof, or active claim instead.",
+    proof_required: "Boardroom proof of the covered item, or the exact missing receipt if coverage is stale.",
+    xpass_advisory: xpassAdvisoryFor(top.kind),
+  };
+}
+
 function signalText(signal = {}) {
   return [
     signal.type,
@@ -208,6 +284,21 @@ export function evaluateContinuousImprovementRoom({
     };
   }
 
+  const duplicateCoverage = signalCoverage(top.signal);
+  if (duplicateCoverage) {
+    return {
+      ok: true,
+      action: "continuous_improvement_room",
+      result: "hold",
+      reason: coverageReasonKey(duplicateCoverage),
+      highest_score: top.score,
+      improvement_kind: top.kind,
+      signal: top.signal,
+      duplicate_coverage: duplicateCoverage,
+      receipt: nativeImproverHoldReceipt({ top, now, source }),
+    };
+  }
+
   const files = ownedFilesFor(top.kind);
   const tests = expectedTestsFor(files);
   const signalSummary = compactText(signalText(top.signal), 500);
@@ -226,6 +317,7 @@ export function evaluateContinuousImprovementRoom({
     },
     createdAt: now,
   });
+  const receipt = nativeImproverReceipt({ top, job, tests, now, source });
 
   return {
     ok: true,
@@ -238,11 +330,16 @@ export function evaluateContinuousImprovementRoom({
     signal: top.signal,
     recommended_insertion: "prepend_to_coding_room_ledger",
     job,
+    receipt,
     packet: {
       worker,
       chip: job.chip,
       context: job.context,
       owned_files: job.owned_files,
+      evidence: receipt.evidence,
+      next_action: receipt.next_action,
+      proof_required: receipt.proof_required,
+      xpass_advisory: receipt.xpass_advisory,
       expected_proof: tests.length
         ? `Patch the smallest safe improvement and run: ${tests.join("; ")}`
         : "Patch the smallest safe improvement and run focused proof.",

--- a/scripts/pinballwake-continuous-improvement-room.test.mjs
+++ b/scripts/pinballwake-continuous-improvement-room.test.mjs
@@ -34,6 +34,43 @@ describe("PinballWake Continuous Improvement Room", () => {
     assert.equal(result.job.status, "queued");
     assert(result.job.owned_files.includes("scripts/pinballwake-merge-room.mjs"));
     assert(result.packet.expected_proof.includes("pinballwake-merge-room.test.mjs"));
+    assert.equal(result.receipt.receipt_type, "native_improver_opportunity");
+    assert.equal(result.receipt.emitted_at, "2026-05-05T01:00:00.000Z");
+    assert.equal(result.receipt.improvement_kind, "ack_handoff");
+    assert(result.receipt.evidence.some((item) => item.includes("missing ACK mirror handoff")));
+    assert.match(result.receipt.next_action, /Improve ACK handoff/);
+    assert.match(result.receipt.proof_required, /pinballwake-merge-room.test.mjs/);
+    assert(result.receipt.xpass_advisory.includes("CommonSensePass"));
+    assert.deepEqual(result.packet.evidence, result.receipt.evidence);
+    assert.equal(result.packet.next_action, result.receipt.next_action);
+    assert.equal(result.packet.proof_required, result.receipt.proof_required);
+    assert.deepEqual(result.packet.xpass_advisory, result.receipt.xpass_advisory);
+  });
+
+  it("holds duplicate-covered opportunities instead of creating another build job", () => {
+    const result = evaluateContinuousImprovementRoom({
+      now: "2026-05-05T01:00:00.000Z",
+      source: "heartbeat",
+      signals: [
+        {
+          type: "stuck",
+          title: "Queue idle for hours while jobs are waiting",
+          detail: "runner dormant and repeated manual nudges required",
+          severity: "high",
+          count: 2,
+          coveredByOpenTodo: "todo-123",
+        },
+      ],
+    });
+
+    assert.equal(result.result, "hold");
+    assert.equal(result.reason, "covered_by_open_todo");
+    assert.equal(result.improvement_kind, "queue_flow");
+    assert.equal(result.duplicate_coverage.ref, "todo-123");
+    assert.equal(result.job, undefined);
+    assert.equal(result.receipt.receipt_type, "native_improver_hold");
+    assert.equal(result.receipt.source, "heartbeat");
+    assert.match(result.receipt.next_action, /duplicate build job/);
   });
 
   it("routes stale queue resistance to the queue and jobs surfaces", () => {


### PR DESCRIPTION
## Summary
- add machine-readable native Improver opportunity receipts to front-of-line build promotions
- add HOLD receipts for duplicate-covered signals so the loop can update existing proof instead of creating another job
- forward receipt evidence, next_action, proof_required, and xpass_advisory through the worker packet

## Tests
- node --test scripts/pinballwake-continuous-improvement-room.test.mjs scripts/pinballwake-autopilot-master-loop.test.mjs
- git diff --check

Job: e0c216b1-9456-4c4d-8248-2aa8b246da71