### PR TITLE
fix(wakepass): emit quiet-window proof receipts

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1245,6 +1245,73 @@ function buildQuietWindowAutonomyResult({
   };
 }
 
+function numberOption(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function createQuietWindowAutonomyProofReceipt({
+  now = new Date().toISOString(),
+  wakeSource = "unknown",
+  queueSourceResult = {},
+  results = [],
+  finalAction = "",
+  finalReason = "",
+  commonsensepass = {},
+} = {}) {
+  const triggerSource = normalizeQuietWindowToken(wakeSource || "unknown");
+  const imported = numberOption(queueSourceResult.imported, 0);
+  const claimedResult = results.find((result) => result?.action === "claimed" && result.job);
+  const blockedResult = results.find((result) => Array.isArray(result?.safety_blocked) && result.safety_blocked.length > 0);
+  const events = [];
+
+  if (triggerSource) {
+    events.push({
+      rung: "heartbeat_tick",
+      at: now,
+      trigger_source: triggerSource,
+      source: triggerSource,
+    });
+  }
+
+  if (imported > 0) {
+    events.push({
+      rung: "job_crumb",
+      at: now,
+      source: queueSourceResult.source || "queue",
+      result: `imported=${imported}`,
+    });
+  }
+
+  if (claimedResult) {
+    events.push({
+      rung: "lease_claimed",
+      at: now,
+      job_id: claimedResult.job.job_id || null,
+      claim_id: claimedResult.job.lease_token || claimedResult.job.claimed_by || null,
+    });
+  }
+
+  if (blockedResult || commonsensepass.verdict !== "PASS") {
+    events.push({
+      rung: "commonsensepass_blocker",
+      at: now,
+      reason: blockedResult?.reason || commonsensepass.reason_code || finalReason || "runner_blocked",
+    });
+  }
+
+  return evaluateQuietWindowAutonomyProofLadder({
+    window_start: now,
+    window_end: now,
+    trigger_source: triggerSource || "unknown",
+    job_id: claimedResult?.job?.job_id || null,
+    claim_id: claimedResult?.job?.lease_token || claimedResult?.job?.claimed_by || null,
+    run_id: `autonomous-runner:${now}`,
+    events,
+    final_action: finalAction || null,
+    final_reason: finalReason || null,
+  });
+}
+
 export function evaluateQuietWindowAutonomyProofLadder(input = {}) {
   const events = Array.isArray(input.events) ? input.events : [];
   const windowStart = input.window_start || input.windowStart || input.window?.start || input.window?.window_start || "";
@@ -2183,6 +2250,22 @@ export async function runAutonomousRunnerFile({
     };
   }
 
+  const quietWindowAutonomyProof = createQuietWindowAutonomyProofReceipt({
+    now,
+    wakeSource,
+    queueSourceResult,
+    results,
+    finalAction,
+    finalReason,
+    commonsensepass,
+  });
+  claimabilityScorecard = {
+    ...claimabilityScorecard,
+    quiet_window_autonomy_verdict: quietWindowAutonomyProof.verdict,
+    quiet_window_first_missing_rung: quietWindowAutonomyProof.first_missing_rung,
+    quiet_window_reason_code: quietWindowAutonomyProof.reason_code,
+  };
+
   if (shouldPersist) {
     await writeCodingRoomJobLedger(ledgerPath, ledger);
   }
@@ -2201,6 +2284,7 @@ export async function runAutonomousRunnerFile({
     queue_source: queueSourceResult,
     claimability_scorecard: claimabilityScorecard,
     commonsensepass,
+    quiet_window_autonomy_proof: quietWindowAutonomyProof,
     todo_claim_sync: todoClaimSync,
     todo_scoping_sync: todoScopingSync,
     main_freshness_canary: mainFreshnessCanary,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1028,10 +1028,43 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.match(calls[2].body.params.arguments.text, /wake_source=queuepush/);
       assert.equal(result.todo_claim_sync.ok, true);
       assert.equal(result.todo_claim_sync.todo_id, "todo-claim-1");
+      assert.equal(result.quiet_window_autonomy_proof.verdict, "HOLD");
+      assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "execution_packet");
+      assert.deepEqual(result.quiet_window_autonomy_proof.evidence.observed_rungs, [
+        "tick",
+        "buildbait_crumb",
+        "claim_or_lease",
+      ]);
+      assert.equal(result.claimability_scorecard.quiet_window_autonomy_verdict, "HOLD");
+      assert.equal(result.claimability_scorecard.quiet_window_first_missing_rung, "execution_packet");
 
       const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
       assert.equal(persisted.jobs[0].status, "claimed");
       assert.equal(persisted.jobs[0].claimed_by, "runner-plex-1");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a quiet-window proof receipt that rejects manual runner triggers", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        now: "2026-05-14T12:00:00.000Z",
+        wakeSource: "workflow_dispatch",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.quiet_window_autonomy_proof.verdict, "HOLD");
+      assert.equal(result.quiet_window_autonomy_proof.reason_code, "not_clean_autonomy_proof");
+      assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "scheduled_trigger");
+      assert.equal(result.claimability_scorecard.quiet_window_reason_code, "not_clean_autonomy_proof");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Wires the quiet-window proof ladder evaluator into normal autonomous-runner output as `quiet_window_autonomy_proof`.
- Mirrors verdict, reason, and first missing rung into the runner claimability scorecard.
- Adds focused coverage for claim-only HOLD proof and manual trigger rejection.

## Verification
- node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-build-executor.test.mjs
- git diff --check

## Safety
- No workflow edits, schedules, execute-mode enablement, deploys, secrets, billing, DNS, data deletion, force push, branch deletion, or production writes.