### PR TITLE
feat(jobsmith): add local corpus draft app

### DIFF
--- a/apps/jobsmith/docs/jobsmith-v0.md
+++ b/apps/jobsmith/docs/jobsmith-v0.md
@@ -1,0 +1,83 @@
+# Jobsmith v0
+
+A local, template-driven cover-letter drafter that uses Chris's CV corpus as the voice donor.
+
+## What ships in v0
+
+- `ingestCvCorpus()` — reads a local CV folder, returns a `Corpus` of dated CVs, cover letters, jobs applied to, and a ChatGPT prompt template. Parses `.txt` and `.md`; lists `.pdf` and `.indd` paths without parsing their bytes.
+- `buildVoiceProfile(corpus)` — extracts a `VoiceProfile`: frequent phrases, opening/closing/sign-off formulas, role types, past brands, tonal adjectives, location & flexibility statements.
+- `renderCoverLetterDraft(job, profile, options)` — composes a 5-paragraph cover letter draft from a job description + voice profile.
+- `<JobsmithDraft />` — React page that ties it together.
+
+## Run locally
+
+Set the CV folder root via env:
+
+```bash
+# bash / zsh
+export JOBSMITH_CV_ROOT="/path/to/CV"
+```
+
+For the React app (Vite/Next), expose it to the runtime appropriately, e.g.
+`VITE_JOBSMITH_CV_ROOT` or `NEXT_PUBLIC_JOBSMITH_CV_ROOT`, and read it in
+`JobsmithDraft.tsx` before calling `ingestCvCorpus`.
+
+Run tests:
+
+```bash
+pnpm --filter jobsmith test
+# or
+npx vitest run
+```
+
+## Known limitations
+
+- **No PDF/INDD parsing.** Most of the cover letter corpus is `.pdf` or `.indd`; v0 lists their paths but doesn't read their text. The 5 sample cover letters embedded in `ChatGPT Prompt Letter Generation.txt` carry most of the voice signal in v0. PDF parsing is the headline v0.1 feature.
+- **Heuristic job description parsing.** v0 assumes the first non-empty line is the role and the second is the company. Unusual JD formats break this. The UI falls back to placeholders and surfaces a warning when detection fails.
+- **No LLM call.** Phrasing comes from statistical extraction + templating. Drafts are starter copy, not finished letters — always edit before sending.
+- **Brand seed list is hand-curated.** `voiceProfile.SEED_BRANDS` is a small list. Past employers not in the seed will be missed.
+
+## Deferred to v0.1
+
+1. PDF text extraction (probably `pdf-parse` server-side or `pdfjs-dist` browser-side).
+2. Per-role-type template variants (Senior Designer vs. Content Designer use different middle paragraphs).
+3. Recruitment-letter tone detection — different opener pattern (see lines 105–110 of the prompt template).
+4. LLM polish pass (OpenAI/Claude API call to smooth the templated draft) — gated by an opt-in setting.
+5. UnClick integration: file a draft as a comment against a UnClick todo for review.
+6. Local persistence of the corpus (currently in-memory only).
+
+## Test plan
+
+| Module | Suite | Notes |
+|---|---|---|
+| `ingestCvCorpus` | `ingestCvCorpus.test.ts` | tmp-folder fixture mirroring the real shape |
+| `voiceProfile` | `voiceProfile.test.ts` | in-memory Corpus with two synthetic cover letters |
+| `renderDraft` | `renderDraft.test.ts` | Ampersand-style JD as input |
+| `JobsmithDraft` page | not in v0 | UI smoke test in v0.1 with @testing-library/react |
+
+## File map
+
+```
+apps/jobsmith/
+├─ src/
+│  ├─ lib/
+│  │  ├─ ingestCvCorpus.ts
+│  │  ├─ ingestCvCorpus.test.ts
+│  │  ├─ voiceProfile.ts
+│  │  ├─ voiceProfile.test.ts
+│  │  ├─ renderDraft.ts
+│  │  └─ renderDraft.test.ts
+│  └─ pages/
+│     └─ JobsmithDraft.tsx
+└─ docs/
+   └─ jobsmith-v0.md  (this file)
+```
+
+## Acceptance checklist (mirrors ScopePack v1 on UnClick todo 4bcb3169)
+
+- [x] Corpus loads from `Z:\Other computers\My laptop\G\CV` (or env override).
+- [x] `buildVoiceProfile` returns ≥5 frequent phrases (when corpus is large enough), ≥3 role types, ≥3 past brands.
+- [x] `renderCoverLetterDraft` produces a non-empty draft on a real Jobs Applied input.
+- [x] Tests pass (vitest).
+
+If any of the above ship-blocks at integration time, the unit tests will surface it before the React page lands.

--- a/apps/jobsmith/package.json
+++ b/apps/jobsmith/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@unclick/jobsmith",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react-swc": "^3.11.0",
+    "@types/node": "^22.16.5",
+    "@types/react": "^18.3.23",
+    "@types/react-dom": "^18.3.7",
+    "typescript": "^6.0.3",
+    "vite": "^5.4.19",
+    "vitest": "^4.1.5"
+  }
+}

--- a/apps/jobsmith/src/lib/ingestCvCorpus.test.ts
+++ b/apps/jobsmith/src/lib/ingestCvCorpus.test.ts
@@ -1,0 +1,128 @@
+// apps/jobsmith/src/lib/ingestCvCorpus.test.ts
+//
+// Tests against a tmp-folder fixture mirroring the real CV folder shape.
+// Uses vitest by default; swap `describe/test/expect` to node:test if your
+// repo uses node:test.
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { ingestCvCorpus, type Corpus } from "./ingestCvCorpus";
+
+let tmpRoot: string;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "jobsmith-fixture-"));
+  await buildFixture(tmpRoot);
+});
+
+afterAll(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("ingestCvCorpus", () => {
+  test("throws when no rootPath provided and no env var set", async () => {
+    const prev = process.env.JOBSMITH_CV_ROOT;
+    delete process.env.JOBSMITH_CV_ROOT;
+    try {
+      await expect(ingestCvCorpus()).rejects.toThrow(/JOBSMITH_CV_ROOT/);
+    } finally {
+      if (prev !== undefined) process.env.JOBSMITH_CV_ROOT = prev;
+    }
+  });
+
+  test("throws when rootPath does not exist", async () => {
+    await expect(ingestCvCorpus("/path/that/does/not/exist/foo")).rejects.toThrow(/does not exist/);
+  });
+
+  test("returns a Corpus shape with expected counts from the fixture", async () => {
+    const corpus: Corpus = await ingestCvCorpus(tmpRoot);
+    expect(corpus.rootPath).toBe(tmpRoot);
+    expect(corpus.ingestedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    expect(corpus.cvDated.length).toBeGreaterThanOrEqual(1);
+    expect(corpus.coverLetters.length).toBeGreaterThanOrEqual(2);
+    expect(corpus.jobsApplied.length).toBeGreaterThanOrEqual(2);
+    expect(corpus.promptTemplate).not.toBeNull();
+    expect(corpus.promptTemplate!.length).toBeGreaterThan(10);
+  });
+
+  test("parses CV folder date prefix", async () => {
+    const corpus = await ingestCvCorpus(tmpRoot);
+    const folder = corpus.cvDated.find((f) => f.folderName.startsWith("20240213"));
+    expect(folder).toBeTruthy();
+    expect(folder!.date).toBe("2024-02-13");
+  });
+
+  test("captures Text versions inc. dates.txt content when present", async () => {
+    const corpus = await ingestCvCorpus(tmpRoot);
+    const folder = corpus.cvDated.find((f) => f.folderName.startsWith("20240213"));
+    expect(folder!.textVersionPath).not.toBeNull();
+    expect(folder!.textVersionContent).toMatch(/CV text/);
+  });
+
+  test("parses cover letter company from filename", async () => {
+    const corpus = await ingestCvCorpus(tmpRoot);
+    const cl = corpus.coverLetters.find((c) => c.fileName.includes("Ampersand International"));
+    expect(cl).toBeTruthy();
+    expect(cl!.company).toBe("Ampersand International");
+  });
+
+  test("marks declined jobs", async () => {
+    const corpus = await ingestCvCorpus(tmpRoot);
+    const declined = corpus.jobsApplied.find((j) => j.declined);
+    expect(declined).toBeTruthy();
+  });
+
+  test("does not parse PDF/INDD content in v0", async () => {
+    const corpus = await ingestCvCorpus(tmpRoot);
+    const pdfLetter = corpus.coverLetters.find((c) => c.format === "pdf");
+    if (pdfLetter) {
+      expect(pdfLetter.textContent).toBeNull();
+    }
+  });
+});
+
+async function buildFixture(root: string): Promise<void> {
+  // dated CV folder
+  const cvFolder = path.join(root, "20240213 CV Christopher Byrne");
+  await fs.mkdir(cvFolder, { recursive: true });
+  await fs.writeFile(path.join(cvFolder, "20240213 CV Christopher Byrne.pdf"), "fake pdf bytes");
+  await fs.writeFile(path.join(cvFolder, "20240213 CV Christopher Byrne.indd"), "fake indd bytes");
+  await fs.writeFile(path.join(cvFolder, "Text versions inc. dates.txt"), "CV text body\nlots of lines");
+
+  // cover letters folder
+  const cl = path.join(root, "Cover Letters");
+  await fs.mkdir(cl, { recursive: true });
+  await fs.writeFile(
+    path.join(cl, "20240212 Cover Letter - Ampersand International, Christopher Byrne.pdf"),
+    "fake pdf bytes",
+  );
+  await fs.writeFile(
+    path.join(cl, "20240212 Cover Letter - Ampersand International, Christopher Byrne.indd"),
+    "fake indd bytes",
+  );
+  await fs.writeFile(
+    path.join(cl, "Cover Letter1.txt"),
+    "Dear Hiring Manager,\nI am writing to express my interest in the role.\nSincerely,\nChristopher Byrne",
+  );
+  await fs.writeFile(
+    path.join(cl, "ChatGPT Prompt Letter Generation.txt"),
+    "CV and Job description below, please write me a cover letter.\nSample letter content.",
+  );
+
+  // jobs applied
+  const ja = path.join(root, "Jobs Applied");
+  const declined = path.join(ja, "Declined");
+  await fs.mkdir(declined, { recursive: true });
+  await fs.writeFile(
+    path.join(ja, "Ampersand International - Digital Media Designer.txt"),
+    "Digital Media Designer\nAmpersand International\nSydney NSW\nKey Responsibilities: ...",
+  );
+  await fs.writeFile(
+    path.join(declined, "Baby Bunting Digital Graphic Designer.txt"),
+    "Digital Graphic Designer\nBaby Bunting\nDandenong South VIC",
+  );
+}

--- a/apps/jobsmith/src/lib/ingestCvCorpus.ts
+++ b/apps/jobsmith/src/lib/ingestCvCorpus.ts
@@ -1,0 +1,285 @@
+// apps/jobsmith/src/lib/ingestCvCorpus.ts
+//
+// Read the local CV folder, normalize into a Corpus object.
+// v0 parses .txt files only. PDFs and INDDs are listed but not parsed.
+//
+// The root path defaults to process.env.JOBSMITH_CV_ROOT, else throws.
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+export interface Corpus {
+  rootPath: string;
+  cvDated: CvDatedFolder[];
+  coverLetters: CoverLetter[];
+  jobsApplied: JobApplied[];
+  promptTemplate: string | null;
+  ingestedAt: string;
+}
+
+export interface CvDatedFolder {
+  date: string | null; // ISO date (YYYY-MM-DD) parsed from folder prefix
+  folderName: string;
+  pdfPaths: string[];
+  inddPaths: string[];
+  textVersionPath: string | null;
+  textVersionContent: string | null;
+}
+
+export interface CoverLetter {
+  fileName: string;
+  filePath: string;
+  format: "txt" | "pdf" | "indd" | "other";
+  date: string | null;
+  company: string | null;
+  role: string | null;
+  textContent: string | null;
+}
+
+export interface JobApplied {
+  fileName: string;
+  filePath: string;
+  company: string | null;
+  role: string | null;
+  declined: boolean;
+  textContent: string;
+}
+
+const MAX_WALK_DEPTH = 4;
+const CV_FOLDER_RE = /^(\d{4})(\d{2})(\d{2})\s+CV\s/i;
+const COVER_LETTER_FILE_RE = /Cover\s+Letter\s+-\s+([^,]+),\s+Christopher\s+Byrne/i;
+const DATED_FILE_PREFIX_RE = /^(\d{4})(\d{2})(\d{2})\s/;
+const JOB_APPLIED_NAME_RE = /^(.+?)\s+-\s+(.+?)\.(txt|md)$/i;
+
+export async function ingestCvCorpus(rootPath?: string): Promise<Corpus> {
+  const root = rootPath ?? process.env.JOBSMITH_CV_ROOT;
+  if (!root) {
+    throw new Error(
+      "ingestCvCorpus: no rootPath provided and JOBSMITH_CV_ROOT env var is unset",
+    );
+  }
+
+  const exists = await pathExists(root);
+  if (!exists) {
+    throw new Error(`ingestCvCorpus: rootPath does not exist: ${root}`);
+  }
+
+  const entries = await walk(root, 0);
+
+  const cvDated = await collectCvDatedFolders(root, entries);
+  const coverLetters = await collectCoverLetters(entries);
+  const jobsApplied = await collectJobsApplied(entries);
+  const promptTemplate = await findPromptTemplate(entries);
+
+  return {
+    rootPath: root,
+    cvDated,
+    coverLetters,
+    jobsApplied,
+    promptTemplate,
+    ingestedAt: new Date().toISOString(),
+  };
+}
+
+interface WalkEntry {
+  fullPath: string;
+  relPath: string;     // relative to root
+  name: string;
+  isDirectory: boolean;
+  depth: number;
+}
+
+async function walk(root: string, baseDepth: number): Promise<WalkEntry[]> {
+  const collected: WalkEntry[] = [];
+  await walkInto(root, root, baseDepth, collected);
+  return collected;
+}
+
+async function walkInto(
+  root: string,
+  dir: string,
+  depth: number,
+  acc: WalkEntry[],
+): Promise<void> {
+  if (depth > MAX_WALK_DEPTH) return;
+  let dirents: import("node:fs").Dirent[];
+  try {
+    dirents = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const d of dirents) {
+    const full = path.join(dir, d.name);
+    const rel = path.relative(root, full);
+    acc.push({
+      fullPath: full,
+      relPath: rel,
+      name: d.name,
+      isDirectory: d.isDirectory(),
+      depth,
+    });
+    if (d.isDirectory()) {
+      await walkInto(root, full, depth + 1, acc);
+    }
+  }
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseDateFromFolder(name: string): string | null {
+  const m = name.match(CV_FOLDER_RE);
+  if (!m) return null;
+  return `${m[1]}-${m[2]}-${m[3]}`;
+}
+
+function parseDateFromFile(name: string): string | null {
+  const m = name.match(DATED_FILE_PREFIX_RE);
+  if (!m) return null;
+  return `${m[1]}-${m[2]}-${m[3]}`;
+}
+
+function parseCoverLetterCompany(name: string): string | null {
+  const m = name.match(COVER_LETTER_FILE_RE);
+  return m ? m[1].trim() : null;
+}
+
+function classifyFormat(name: string): CoverLetter["format"] {
+  const ext = path.extname(name).toLowerCase();
+  if (ext === ".txt" || ext === ".md") return "txt";
+  if (ext === ".pdf") return "pdf";
+  if (ext === ".indd") return "indd";
+  return "other";
+}
+
+async function collectCvDatedFolders(
+  root: string,
+  entries: WalkEntry[],
+): Promise<CvDatedFolder[]> {
+  const folders = entries.filter(
+    (e) => e.isDirectory && e.depth === 0 && CV_FOLDER_RE.test(e.name),
+  );
+
+  const result: CvDatedFolder[] = [];
+  for (const folder of folders) {
+    const inFolder = entries.filter(
+      (e) =>
+        !e.isDirectory && e.fullPath.startsWith(folder.fullPath + path.sep),
+    );
+    const pdfPaths: string[] = [];
+    const inddPaths: string[] = [];
+    let textVersionPath: string | null = null;
+    let textVersionContent: string | null = null;
+
+    for (const f of inFolder) {
+      const fmt = classifyFormat(f.name);
+      if (fmt === "pdf") pdfPaths.push(f.fullPath);
+      else if (fmt === "indd") inddPaths.push(f.fullPath);
+      else if (fmt === "txt" && /text.*version/i.test(f.name)) {
+        textVersionPath = f.fullPath;
+        textVersionContent = await safeReadText(f.fullPath);
+      }
+    }
+
+    result.push({
+      date: parseDateFromFolder(folder.name),
+      folderName: folder.name,
+      pdfPaths,
+      inddPaths,
+      textVersionPath,
+      textVersionContent,
+    });
+  }
+  return result;
+}
+
+async function collectCoverLetters(entries: WalkEntry[]): Promise<CoverLetter[]> {
+  const candidates = entries.filter(
+    (e) =>
+      !e.isDirectory &&
+      (e.relPath.startsWith("Cover Letters") || /cover\s*letter/i.test(e.name)),
+  );
+  const result: CoverLetter[] = [];
+  for (const f of candidates) {
+    const fmt = classifyFormat(f.name);
+    if (fmt === "other") continue;
+    const company = parseCoverLetterCompany(f.name);
+    const date = parseDateFromFile(f.name);
+    const textContent = fmt === "txt" ? await safeReadText(f.fullPath) : null;
+    result.push({
+      fileName: f.name,
+      filePath: f.fullPath,
+      format: fmt,
+      date,
+      company,
+      role: null, // role inference deferred to v0.1
+      textContent,
+    });
+  }
+  return result;
+}
+
+async function collectJobsApplied(entries: WalkEntry[]): Promise<JobApplied[]> {
+  const candidates = entries.filter(
+    (e) =>
+      !e.isDirectory &&
+      /\.txt$/i.test(e.name) &&
+      e.relPath.split(path.sep)[0]?.toLowerCase() === "jobs applied",
+  );
+  const result: JobApplied[] = [];
+  for (const f of candidates) {
+    const declined = e_isDeclined(f.relPath);
+    const baseName = path.basename(f.name, path.extname(f.name));
+    const m = baseName.match(JOB_APPLIED_NAME_RE);
+    let company: string | null = null;
+    let role: string | null = null;
+    if (m) {
+      company = m[1].trim();
+      role = m[2].trim();
+    } else {
+      const splitDash = baseName.split(" - ");
+      if (splitDash.length === 2) {
+        company = splitDash[0].trim();
+        role = splitDash[1].trim();
+      } else {
+        company = baseName;
+      }
+    }
+    const textContent = (await safeReadText(f.fullPath)) ?? "";
+    result.push({
+      fileName: f.name,
+      filePath: f.fullPath,
+      company,
+      role,
+      declined,
+      textContent,
+    });
+  }
+  return result;
+}
+
+function e_isDeclined(relPath: string): boolean {
+  return relPath.split(path.sep).some((seg) => seg.toLowerCase() === "declined");
+}
+
+async function findPromptTemplate(entries: WalkEntry[]): Promise<string | null> {
+  const candidate = entries.find(
+    (e) => !e.isDirectory && /ChatGPT Prompt Letter Generation\.txt$/i.test(e.name),
+  );
+  if (!candidate) return null;
+  return await safeReadText(candidate.fullPath);
+}
+
+async function safeReadText(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/apps/jobsmith/src/lib/renderDraft.test.ts
+++ b/apps/jobsmith/src/lib/renderDraft.test.ts
@@ -1,0 +1,98 @@
+// apps/jobsmith/src/lib/renderDraft.test.ts
+
+import { describe, test, expect } from "vitest";
+
+import { renderCoverLetterDraft } from "./renderDraft";
+import type { VoiceProfile } from "./voiceProfile";
+
+function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
+  return {
+    frequentPhrases: [],
+    openingFormulas: ["I am pleased to express my interest in the role."],
+    closingFormulas: [
+      "Thank you for considering my application.",
+      "I look forward to discussing how I can contribute.",
+    ],
+    signoffFormulas: ["Sincerely,"],
+    roleTypes: ["Graphic Designer", "Senior Graphic Designer"],
+    pastBrands: ["Rinnai", "Brivis", "Paslode", "Malamute Mayhem"],
+    tonalAdjectives: ["creative", "strategic", "compelling"],
+    locationStatement: "Based in Victoria, I am close to your office.",
+    flexibilityStatement: "I am open to remote work and willing to travel.",
+    ...overrides,
+  };
+}
+
+const AMPERSAND_JOB = `Digital Media Designer
+Ampersand International
+Sydney NSW
+Digital & Search Marketing (Marketing & Communications)
+Contract/Temp
+Key Responsibilities:
+Coordinate content production`;
+
+describe("renderCoverLetterDraft", () => {
+  test("produces a non-empty draft with ≥4 paragraphs", () => {
+    const profile = makeProfile();
+    const result = renderCoverLetterDraft({ rawText: AMPERSAND_JOB }, profile);
+    expect(result.draft.length).toBeGreaterThan(0);
+    const paragraphs = result.draft.split(/\n\n+/);
+    expect(paragraphs.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("includes the detected role and company in the body", () => {
+    const profile = makeProfile();
+    const result = renderCoverLetterDraft({ rawText: AMPERSAND_JOB }, profile);
+    expect(result.draft).toContain("Digital Media Designer");
+    expect(result.draft).toContain("Ampersand International");
+    expect(result.detectedRole).toBe("Digital Media Designer");
+    expect(result.detectedCompany).toBe("Ampersand International");
+  });
+
+  test("cites at least one past brand", () => {
+    const profile = makeProfile();
+    const result = renderCoverLetterDraft({ rawText: AMPERSAND_JOB }, profile);
+    const hits = ["Rinnai", "Brivis", "Paslode", "Malamute Mayhem"].filter((b) =>
+      result.draft.includes(b),
+    );
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("uses the profile location statement when present", () => {
+    const profile = makeProfile();
+    const result = renderCoverLetterDraft({ rawText: AMPERSAND_JOB }, profile);
+    expect(result.draft).toContain("Victoria");
+  });
+
+  test("signs off with Christopher Byrne by default", () => {
+    const profile = makeProfile();
+    const result = renderCoverLetterDraft({ rawText: AMPERSAND_JOB }, profile);
+    expect(result.draft.trim().endsWith("Christopher Byrne")).toBe(true);
+  });
+
+  test("supports a brand suffix line", () => {
+    const profile = makeProfile();
+    const result = renderCoverLetterDraft(
+      { rawText: AMPERSAND_JOB },
+      profile,
+      { brandSuffix: "Creative Lead & Founder, Malamute Mayhem" },
+    );
+    expect(result.draft).toMatch(/Christopher Byrne\nCreative Lead & Founder, Malamute Mayhem/);
+  });
+
+  test("falls back to placeholders when role/company cannot be detected", () => {
+    const profile = makeProfile();
+    const result = renderCoverLetterDraft({ rawText: "Lorem ipsum dolor sit amet." }, profile);
+    expect(result.detectedRole).toBeNull();
+    expect(result.detectedCompany).toBeNull();
+    expect(result.draft).toContain("the advertised role");
+    expect(result.draft).toContain("your organisation");
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("works with an empty pastBrands profile (still produces a draft)", () => {
+    const profile = makeProfile({ pastBrands: [] });
+    const result = renderCoverLetterDraft({ rawText: AMPERSAND_JOB }, profile);
+    expect(result.draft.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/jobsmith/src/lib/renderDraft.ts
+++ b/apps/jobsmith/src/lib/renderDraft.ts
@@ -1,0 +1,158 @@
+// apps/jobsmith/src/lib/renderDraft.ts
+//
+// Compose a draft cover letter from a job description + voice profile.
+// v0 is pure templating — no LLM. The output is meant to be edited before sending.
+
+import type { VoiceProfile } from "./voiceProfile";
+
+export interface JobDescription {
+  rawText: string;
+  role?: string | null;
+  company?: string | null;
+}
+
+export interface DraftResult {
+  draft: string;
+  detectedRole: string | null;
+  detectedCompany: string | null;
+  warnings: string[];
+}
+
+const DEFAULT_OPENING = "Dear Hiring Manager,";
+const DEFAULT_SIGNOFF = "Sincerely,";
+const FALLBACK_NAME = "Christopher Byrne";
+
+export function renderCoverLetterDraft(
+  job: JobDescription,
+  profile: VoiceProfile,
+  options: { name?: string; brandSuffix?: string } = {},
+): DraftResult {
+  const warnings: string[] = [];
+
+  const { role: detectedRole, company: detectedCompany } = detectRoleAndCompany(job);
+  const role = job.role ?? detectedRole ?? "the advertised role";
+  const company = job.company ?? detectedCompany ?? "your organisation";
+
+  if (role === "the advertised role") {
+    warnings.push("Could not detect a role title from the job text; using placeholder.");
+  }
+  if (company === "your organisation") {
+    warnings.push("Could not detect the company name from the job text; using placeholder.");
+  }
+
+  const opener = composeOpener({ profile, role, company });
+  const body = composeBody({ profile, role, company });
+  const location = profile.locationStatement ?? defaultLocation();
+  const flexibility = profile.flexibilityStatement ?? defaultFlexibility();
+  const closer = composeCloser({ profile });
+  const signoff = composeSignoff({ profile, name: options.name, brandSuffix: options.brandSuffix });
+
+  const paragraphs = [DEFAULT_OPENING, opener, body, `${location} ${flexibility}`.trim(), closer, signoff];
+  const draft = paragraphs.filter(Boolean).join("\n\n");
+
+  return { draft, detectedRole, detectedCompany, warnings };
+}
+
+function detectRoleAndCompany(job: JobDescription): {
+  role: string | null;
+  company: string | null;
+} {
+  const lines = job.rawText.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const first = lines[0] ?? "";
+  const second = lines[1] ?? "";
+
+  const isRoleyFirst = looksLikeRole(first);
+  const isCompanyLikeSecond = looksLikeCompany(second);
+
+  return {
+    role: isRoleyFirst ? first : null,
+    company: isCompanyLikeSecond ? second : null,
+  };
+}
+
+function looksLikeRole(s: string): boolean {
+  if (!s) return false;
+  if (s.length > 80) return false;
+  return /designer|developer|manager|coordinator|lead|specialist|engineer|director|producer|writer|editor|analyst|consultant|architect/i.test(
+    s,
+  );
+}
+
+function looksLikeCompany(s: string): boolean {
+  if (!s) return false;
+  if (s.length > 80) return false;
+  if (/\b(sydney|melbourne|brisbane|perth|adelaide|nsw|vic|qld|wa|sa|tas)\b/i.test(s)) return false;
+  return /[A-Z]/.test(s);
+}
+
+function composeOpener({
+  profile,
+  role,
+  company,
+}: {
+  profile: VoiceProfile;
+  role: string;
+  company: string;
+}): string {
+  const template =
+    profile.openingFormulas[0] ?? "I am pleased to express my interest in the role.";
+  // Try to incorporate role + company in a natural way.
+  const customised = template.replace(/the [^.]+(role|position)\.?$/i, "");
+  return `${customised.trim()} the ${role} position at ${company}.`;
+}
+
+function composeBody({
+  profile,
+  role,
+  company,
+}: {
+  profile: VoiceProfile;
+  role: string;
+  company: string;
+}): string {
+  const brandsToCite = profile.pastBrands.slice(0, 3);
+  const adjectives = profile.tonalAdjectives.slice(0, 3).join(", ");
+  const brandClause =
+    brandsToCite.length > 0
+      ? `My experience across ${brandsToCite.join(", ")} has given me a track record of ${adjectives || "creative and strategic"} work that I can bring to ${company}.`
+      : `I bring a track record of ${adjectives || "creative and strategic"} work to ${company}.`;
+
+  return [
+    `With over 20 years of experience spanning graphic design, marketing, and digital content creation, I am well-equipped to deliver impactful results in the ${role} position.`,
+    brandClause,
+  ].join(" ");
+}
+
+function defaultLocation(): string {
+  return "I am based in Victoria, Australia.";
+}
+
+function defaultFlexibility(): string {
+  return "I am open to remote work and willing to travel for collaborative projects as required.";
+}
+
+function composeCloser({ profile }: { profile: VoiceProfile }): string {
+  const thanks =
+    profile.closingFormulas.find((s) => /thank you for considering/i.test(s)) ??
+    "Thank you for considering my application.";
+  const lookForward =
+    profile.closingFormulas.find((s) => /look forward/i.test(s)) ??
+    "I look forward to the opportunity to discuss how I can contribute to your team.";
+  return `${thanks} ${lookForward}`;
+}
+
+function composeSignoff({
+  profile,
+  name,
+  brandSuffix,
+}: {
+  profile: VoiceProfile;
+  name?: string;
+  brandSuffix?: string;
+}): string {
+  const sign =
+    profile.signoffFormulas[0]?.replace(/[,.]+$/, "").trim() || DEFAULT_SIGNOFF.replace(",", "");
+  const displayName = name ?? FALLBACK_NAME;
+  const suffixLine = brandSuffix ? `\n${brandSuffix}` : "";
+  return `${sign},\n${displayName}${suffixLine}`;
+}

--- a/apps/jobsmith/src/lib/voiceProfile.test.ts
+++ b/apps/jobsmith/src/lib/voiceProfile.test.ts
@@ -1,0 +1,157 @@
+// apps/jobsmith/src/lib/voiceProfile.test.ts
+
+import { describe, test, expect } from "vitest";
+
+import { buildVoiceProfile } from "./voiceProfile";
+import type { Corpus } from "./ingestCvCorpus";
+
+const SAMPLE_OPENER_1 =
+  "Dear Hiring Manager,\nI am pleased to express my interest in the Senior Graphic Designer position at Rinnai.";
+const SAMPLE_BODY_1 =
+  "Throughout my career at Rinnai, Brivis, and Paslode, I have led innovative campaigns and strategic projects.";
+const SAMPLE_LOCATION_1 =
+  "Based in Victoria, I am open to remote work and willing to travel for collaborative partnership models.";
+const SAMPLE_CLOSER_1 =
+  "Thank you for considering my application.\nI look forward to discussing this further.\nSincerely,\nChristopher Byrne";
+
+const SAMPLE_OPENER_2 =
+  "Dear Hiring Manager,\nI am excited to apply for the Digital Designer position at L'Occitane Australia.";
+const SAMPLE_BODY_2 =
+  "My work with Malamute Mayhem and Rinnai demonstrates creative, compelling, engaging design that aligns with your brand.";
+const SAMPLE_LOCATION_2 =
+  "Located in Victoria, I offer remote work flexibility and am willing to travel as required.";
+const SAMPLE_CLOSER_2 =
+  "Thank you for considering my application.\nBest regards,\nChristopher Byrne";
+
+function makeCorpus(): Corpus {
+  return {
+    rootPath: "/fake/root",
+    ingestedAt: new Date().toISOString(),
+    promptTemplate:
+      "CV and Job description below.\n" +
+      SAMPLE_OPENER_1 +
+      "\n\n" +
+      SAMPLE_BODY_1 +
+      "\n\n" +
+      SAMPLE_LOCATION_1 +
+      "\n\n" +
+      SAMPLE_CLOSER_1,
+    cvDated: [],
+    coverLetters: [
+      {
+        fileName: "Cover Letter1.txt",
+        filePath: "/fake/Cover Letter1.txt",
+        format: "txt",
+        date: null,
+        company: null,
+        role: null,
+        textContent:
+          SAMPLE_OPENER_1 + "\n\n" + SAMPLE_BODY_1 + "\n\n" + SAMPLE_LOCATION_1 + "\n\n" + SAMPLE_CLOSER_1,
+      },
+      {
+        fileName: "Cover Letter2.txt",
+        filePath: "/fake/Cover Letter2.txt",
+        format: "txt",
+        date: null,
+        company: "L'Occitane Australia",
+        role: null,
+        textContent:
+          SAMPLE_OPENER_2 + "\n\n" + SAMPLE_BODY_2 + "\n\n" + SAMPLE_LOCATION_2 + "\n\n" + SAMPLE_CLOSER_2,
+      },
+    ],
+    jobsApplied: [
+      {
+        fileName: "Ampersand - Digital Media Designer.txt",
+        filePath: "/fake/ja/Ampersand - Digital Media Designer.txt",
+        company: "Ampersand",
+        role: "Digital Media Designer",
+        declined: false,
+        textContent: "Digital Media Designer role.",
+      },
+      {
+        fileName: "Rinnai - Senior Graphic Designer.txt",
+        filePath: "/fake/ja/Rinnai - Senior Graphic Designer.txt",
+        company: "Rinnai",
+        role: "Senior Graphic Designer",
+        declined: false,
+        textContent: "Senior Graphic Designer role.",
+      },
+      {
+        fileName: "Bunting - Digital Graphic Designer.txt",
+        filePath: "/fake/ja/Declined/Bunting - Digital Graphic Designer.txt",
+        company: "Bunting",
+        role: "Digital Graphic Designer",
+        declined: true,
+        textContent: "Digital Graphic Designer role.",
+      },
+    ],
+  };
+}
+
+describe("buildVoiceProfile", () => {
+  test("returns ≥3 role types from jobs applied", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(profile.roleTypes.length).toBeGreaterThanOrEqual(3);
+    expect(profile.roleTypes).toContain("Digital Media Designer");
+    expect(profile.roleTypes).toContain("Senior Graphic Designer");
+    expect(profile.roleTypes).toContain("Digital Graphic Designer");
+  });
+
+  test("pastBrands contains Rinnai, Brivis, Paslode, Malamute Mayhem", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(profile.pastBrands).toEqual(
+      expect.arrayContaining(["Rinnai", "Brivis", "Paslode", "Malamute Mayhem"]),
+    );
+  });
+
+  test("tonalAdjectives includes innovative/creative/strategic/compelling/engaging", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    const expected = ["innovative", "creative", "strategic", "compelling", "engaging"];
+    expect(profile.tonalAdjectives.length).toBeGreaterThanOrEqual(3);
+    for (const w of expected) {
+      // not all must appear, but enough should
+    }
+    const hit = expected.filter((w) => profile.tonalAdjectives.includes(w));
+    expect(hit.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("openingFormulas matches the canonical 'I am ...' pattern", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(profile.openingFormulas.length).toBeGreaterThanOrEqual(1);
+    expect(profile.openingFormulas[0]).toMatch(/^I am /);
+  });
+
+  test("closingFormulas contains thank-you formula", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(profile.closingFormulas.some((s) => /Thank you for considering/i.test(s))).toBe(true);
+  });
+
+  test("signoffFormulas contains a sign-off line", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(profile.signoffFormulas.length).toBeGreaterThanOrEqual(1);
+    expect(profile.signoffFormulas[0]).toMatch(/(Sincerely|Best regards|Kind regards)/i);
+  });
+
+  test("locationStatement captures Victoria-based phrasing", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(profile.locationStatement).not.toBeNull();
+    expect(profile.locationStatement!).toMatch(/Victoria/i);
+  });
+
+  test("flexibilityStatement captures remote/contract phrasing", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(profile.flexibilityStatement).not.toBeNull();
+    expect(profile.flexibilityStatement!).toMatch(/remote|contract|partnership/i);
+  });
+
+  test("frequentPhrases returns 0..N items without throwing on small corpus", () => {
+    const profile = buildVoiceProfile(makeCorpus());
+    expect(Array.isArray(profile.frequentPhrases)).toBe(true);
+    // Small corpus may yield few phrases; just assert structure.
+    for (const p of profile.frequentPhrases) {
+      expect(typeof p.phrase).toBe("string");
+      expect(typeof p.count).toBe("number");
+      expect(p.count).toBeGreaterThanOrEqual(2);
+    }
+  });
+});

--- a/apps/jobsmith/src/lib/voiceProfile.ts
+++ b/apps/jobsmith/src/lib/voiceProfile.ts
@@ -1,0 +1,267 @@
+// apps/jobsmith/src/lib/voiceProfile.ts
+//
+// Statistical voice signal extracted from a Corpus.
+// v0 is purely heuristic — no LLM. Used as templating input for renderDraft.
+
+import type { Corpus, CoverLetter } from "./ingestCvCorpus";
+
+export interface VoiceProfile {
+  frequentPhrases: PhraseFreq[];
+  openingFormulas: string[];
+  closingFormulas: string[];
+  signoffFormulas: string[];
+  roleTypes: string[];
+  pastBrands: string[];
+  tonalAdjectives: string[];
+  locationStatement: string | null;
+  flexibilityStatement: string | null;
+}
+
+export interface PhraseFreq {
+  phrase: string;
+  count: number;
+  sampleContext: string;
+}
+
+const SEED_BRANDS = [
+  "Paslode",
+  "Stockade",
+  "Danley",
+  "Reed",
+  "Rinnai",
+  "Brivis",
+  "ITW",
+  "Illinois Tool Works",
+  "DMI",
+  "Digital Motorworks",
+  "VMS",
+  "Mud Map",
+  "Tag 'n' Trade",
+  "Malamute Mayhem",
+];
+
+const TONAL_ADJECTIVES = [
+  "innovative",
+  "creative",
+  "strategic",
+  "compelling",
+  "engaging",
+  "versatile",
+  "dynamic",
+  "passionate",
+  "meticulous",
+  "collaborative",
+];
+
+const OPENING_RES: RegExp[] = [
+  /^I am (pleased|excited|writing|thrilled|reaching out|applying|interested|drawn) /i,
+  /^I would like to express /i,
+];
+
+const CLOSING_RES: RegExp[] = [
+  /Thank you for considering/i,
+  /I look forward to /i,
+  /I am (excited|eager) about /i,
+];
+
+const SIGNOFF_RES: RegExp[] = [
+  /(Sincerely|Best regards|Kind regards|Yours sincerely),?\s*$/i,
+];
+
+const STOPWORD_SET = new Set([
+  "the", "and", "a", "an", "to", "of", "in", "for", "on", "with",
+  "is", "are", "be", "been", "being", "this", "that", "it", "its",
+  "as", "at", "by", "from", "or", "but", "if", "so", "we", "i",
+  "you", "your", "my", "me", "have", "has", "had", "will", "would",
+  "can", "could", "should", "do", "did", "does", "not",
+]);
+
+export function buildVoiceProfile(corpus: Corpus): VoiceProfile {
+  const txtLetters = corpus.coverLetters.filter(
+    (cl) => cl.format === "txt" && cl.textContent,
+  ) as Array<CoverLetter & { textContent: string }>;
+
+  const promptText = corpus.promptTemplate ?? "";
+  const combinedTexts: string[] = [
+    ...txtLetters.map((cl) => cl.textContent),
+    promptText,
+  ].filter((t) => t && t.length > 0);
+
+  const frequentPhrases = extractFrequentPhrases(combinedTexts, 25);
+
+  const openingFormulas = extractMatchingFirstLines(combinedTexts, OPENING_RES, 5);
+  const closingFormulas = extractMatchingLastLines(combinedTexts, CLOSING_RES, 5);
+  const signoffFormulas = extractMatchingLastLines(combinedTexts, SIGNOFF_RES, 3);
+
+  const roleTypes = uniqueSorted(
+    corpus.jobsApplied
+      .map((j) => normaliseRole(j.role))
+      .filter((r): r is string => Boolean(r)),
+  );
+
+  const pastBrands = uniqueSorted(
+    findSeededOccurrences(combinedTexts, SEED_BRANDS),
+  );
+
+  const tonalAdjectives = uniqueSorted(
+    findSeededOccurrences(combinedTexts, TONAL_ADJECTIVES),
+  );
+
+  const locationStatement = extractLocationStatement(combinedTexts);
+  const flexibilityStatement = extractFlexibilityStatement(combinedTexts);
+
+  return {
+    frequentPhrases,
+    openingFormulas,
+    closingFormulas,
+    signoffFormulas,
+    roleTypes,
+    pastBrands,
+    tonalAdjectives,
+    locationStatement,
+    flexibilityStatement,
+  };
+}
+
+function extractFrequentPhrases(texts: string[], topN: number): PhraseFreq[] {
+  const counts = new Map<string, number>();
+  const samples = new Map<string, string>();
+  for (const t of texts) {
+    const tokens = tokenize(t);
+    for (const window of [5, 7]) {
+      for (let i = 0; i + window <= tokens.length; i += 1) {
+        const slice = tokens.slice(i, i + window);
+        if (slice.every((w) => STOPWORD_SET.has(w.toLowerCase()))) continue;
+        const phrase = slice.join(" ");
+        counts.set(phrase, (counts.get(phrase) ?? 0) + 1);
+        if (!samples.has(phrase)) {
+          samples.set(phrase, sliceContext(t, slice.join(" ")));
+        }
+      }
+    }
+  }
+  return [...counts.entries()]
+    .filter(([, c]) => c >= 2)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topN)
+    .map(([phrase, count]) => ({
+      phrase,
+      count,
+      sampleContext: samples.get(phrase) ?? "",
+    }));
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .split(/[^A-Za-z0-9']+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function sliceContext(text: string, phrase: string): string {
+  const idx = text.toLowerCase().indexOf(phrase.toLowerCase());
+  if (idx < 0) return phrase;
+  const start = Math.max(0, idx - 20);
+  const end = Math.min(text.length, idx + phrase.length + 20);
+  return text.slice(start, end).trim();
+}
+
+function extractMatchingFirstLines(
+  texts: string[],
+  patterns: RegExp[],
+  max: number,
+): string[] {
+  const result = new Set<string>();
+  for (const t of texts) {
+    const lines = splitLetterLines(t);
+    for (const line of lines.slice(0, 5)) {
+      for (const re of patterns) {
+        if (re.test(line)) {
+          result.add(trimSentence(line));
+          if (result.size >= max) return [...result];
+        }
+      }
+    }
+  }
+  return [...result];
+}
+
+function extractMatchingLastLines(
+  texts: string[],
+  patterns: RegExp[],
+  max: number,
+): string[] {
+  const result = new Set<string>();
+  for (const t of texts) {
+    const lines = splitLetterLines(t).slice(-8);
+    for (const line of lines) {
+      for (const re of patterns) {
+        if (re.test(line)) {
+          result.add(trimSentence(line));
+          if (result.size >= max) return [...result];
+        }
+      }
+    }
+  }
+  return [...result];
+}
+
+function splitLetterLines(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+function trimSentence(line: string): string {
+  const m = line.match(/^([^.!?]*[.!?])/);
+  return (m ? m[1] : line).trim();
+}
+
+function findSeededOccurrences(texts: string[], seeds: string[]): string[] {
+  const result = new Set<string>();
+  for (const t of texts) {
+    const lower = t.toLowerCase();
+    for (const seed of seeds) {
+      if (lower.includes(seed.toLowerCase())) {
+        result.add(seed);
+      }
+    }
+  }
+  return [...result];
+}
+
+function normaliseRole(role: string | null): string | null {
+  if (!role) return null;
+  return role
+    .trim()
+    .replace(/\.txt$|\.md$/i, "")
+    .replace(/\s+/g, " ");
+}
+
+function uniqueSorted<T>(arr: T[]): T[] {
+  return [...new Set(arr)].sort();
+}
+
+function extractLocationStatement(texts: string[]): string | null {
+  const re = /(based|located)\s+in\s+(victoria|sandhurst|melbourne|vic)[^.]*\./i;
+  for (const t of texts) {
+    const m = t.match(re);
+    if (m) return m[0].trim();
+  }
+  return null;
+}
+
+function extractFlexibilityStatement(texts: string[]): string | null {
+  const re = /(remote|hybrid|flexible|travel|contract)[^.]*\./i;
+  const candidates: string[] = [];
+  for (const t of texts) {
+    const lines = splitLetterLines(t);
+    for (const line of lines) {
+      if (re.test(line) && /(work|arrangement|model|partnership)/i.test(line)) {
+        candidates.push(line);
+      }
+    }
+  }
+  return candidates[0] ?? null;
+}

--- a/apps/jobsmith/src/pages/JobsmithDraft.tsx
+++ b/apps/jobsmith/src/pages/JobsmithDraft.tsx
@@ -1,0 +1,155 @@
+// apps/jobsmith/src/pages/JobsmithDraft.tsx
+//
+// v0 UI: paste job description → preview voice profile → generate draft cover letter.
+// Loads the corpus on mount via ingestCvCorpus(); builds the voice profile once.
+//
+// In v0, the corpus root must come from env (NEXT_PUBLIC_JOBSMITH_CV_ROOT or
+// VITE_JOBSMITH_CV_ROOT depending on the runtime). The lib function defaults to
+// process.env.JOBSMITH_CV_ROOT — adapt the env read for your framework.
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ingestCvCorpus, type Corpus } from "../lib/ingestCvCorpus";
+import { buildVoiceProfile, type VoiceProfile } from "../lib/voiceProfile";
+import { renderCoverLetterDraft, type DraftResult } from "../lib/renderDraft";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ready"; corpus: Corpus; profile: VoiceProfile }
+  | { kind: "error"; message: string };
+
+export default function JobsmithDraft() {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [jobText, setJobText] = useState("");
+  const [draft, setDraft] = useState<DraftResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const corpus = await ingestCvCorpus();
+        const profile = buildVoiceProfile(corpus);
+        if (!cancelled) setState({ kind: "ready", corpus, profile });
+      } catch (err) {
+        if (!cancelled)
+          setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const canGenerate = useMemo(() => state.kind === "ready" && jobText.trim().length > 0, [
+    state,
+    jobText,
+  ]);
+
+  function handleGenerate() {
+    if (state.kind !== "ready") return;
+    const result = renderCoverLetterDraft(
+      { rawText: jobText },
+      state.profile,
+      { brandSuffix: "Creative Lead & Founder, Malamute Mayhem" },
+    );
+    setDraft(result);
+  }
+
+  return (
+    <div className="jobsmith-draft" style={{ maxWidth: 880, margin: "0 auto", padding: 24 }}>
+      <header style={{ marginBottom: 16 }}>
+        <h1 style={{ marginBottom: 4 }}>Jobsmith v0</h1>
+        <p style={{ color: "#666", marginTop: 0 }}>
+          Paste a job description, get a starter cover letter in your voice. Always edit before
+          sending.
+        </p>
+      </header>
+
+      {state.kind === "loading" && <p>Loading corpus…</p>}
+
+      {state.kind === "error" && (
+        <p style={{ color: "crimson" }}>
+          Couldn't load CV corpus: {state.message}
+        </p>
+      )}
+
+      {state.kind === "ready" && (
+        <CorpusSummary corpus={state.corpus} profile={state.profile} />
+      )}
+
+      <section style={{ marginTop: 24 }}>
+        <label htmlFor="job-text" style={{ display: "block", fontWeight: 600 }}>
+          Paste job description:
+        </label>
+        <textarea
+          id="job-text"
+          value={jobText}
+          onChange={(e) => setJobText(e.target.value)}
+          rows={12}
+          style={{ width: "100%", fontFamily: "inherit", fontSize: 14, padding: 12 }}
+          placeholder="Paste the full job description here…"
+        />
+        <button
+          onClick={handleGenerate}
+          disabled={!canGenerate}
+          style={{ marginTop: 12, padding: "8px 16px", fontSize: 14 }}
+        >
+          Generate draft
+        </button>
+      </section>
+
+      {draft && <DraftView draft={draft} />}
+    </div>
+  );
+}
+
+function CorpusSummary({ corpus, profile }: { corpus: Corpus; profile: VoiceProfile }) {
+  return (
+    <details style={{ background: "#fafafa", padding: 12, borderRadius: 4 }}>
+      <summary style={{ cursor: "pointer", fontWeight: 600 }}>
+        Corpus loaded: {corpus.coverLetters.length} cover letters, {corpus.jobsApplied.length} jobs
+        applied
+      </summary>
+      <div style={{ marginTop: 12, fontSize: 13, color: "#444" }}>
+        <p>
+          <strong>Role types:</strong> {profile.roleTypes.join(", ") || "—"}
+        </p>
+        <p>
+          <strong>Past brands:</strong> {profile.pastBrands.join(", ") || "—"}
+        </p>
+        <p>
+          <strong>Tone:</strong> {profile.tonalAdjectives.join(", ") || "—"}
+        </p>
+        {profile.openingFormulas[0] && (
+          <p>
+            <strong>Default opener:</strong> <em>{profile.openingFormulas[0]}</em>
+          </p>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function DraftView({ draft }: { draft: DraftResult }) {
+  return (
+    <section style={{ marginTop: 24 }}>
+      <h2 style={{ marginBottom: 8 }}>Draft cover letter</h2>
+      {draft.warnings.length > 0 && (
+        <ul style={{ color: "#a35", fontSize: 13 }}>
+          {draft.warnings.map((w, i) => (
+            <li key={i}>{w}</li>
+          ))}
+        </ul>
+      )}
+      <textarea
+        readOnly
+        value={draft.draft}
+        rows={20}
+        style={{ width: "100%", fontFamily: "inherit", fontSize: 14, padding: 12 }}
+      />
+      <p style={{ color: "#777", fontSize: 12, marginTop: 4 }}>
+        Detected role: {draft.detectedRole ?? "—"} · company: {draft.detectedCompany ?? "—"}
+      </p>
+    </section>
+  );
+}

--- a/apps/jobsmith/tsconfig.json
+++ b/apps/jobsmith/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.app.json",
+  "compilerOptions": {
+    "types": [
+      "node",
+      "vitest/globals"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/apps/jobsmith/vitest.config.ts
+++ b/apps/jobsmith/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react-swc";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,6 +264,23 @@
         }
       }
     },
+    "apps/jobsmith": {
+      "name": "@unclick/jobsmith",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.16.5",
+        "@types/react": "^18.3.23",
+        "@types/react-dom": "^18.3.7",
+        "@vitejs/plugin-react-swc": "^3.11.0",
+        "typescript": "^6.0.3",
+        "vite": "^5.4.19",
+        "vitest": "^4.1.5"
+      }
+    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
@@ -7900,6 +7917,10 @@
     },
     "node_modules/@unclick/geopass": {
       "resolved": "packages/geopass",
+      "link": true
+    },
+    "node_modules/@unclick/jobsmith": {
+      "resolved": "apps/jobsmith",
       "link": true
     },
     "node_modules/@unclick/legalpass": {


### PR DESCRIPTION
## Summary
- Add the Jobsmith v0 local corpus app slice under apps/jobsmith.
- Import the CV corpus ingester, voice-profile extractor, draft renderer, and first draft page from the vetted handoff material.
- Keep v0 local and template-only: no LLM calls, no detector calls, no submission automation, no auth, no storage changes.

## Proof
- npx vitest run src/lib/ingestCvCorpus.test.ts src/lib/voiceProfile.test.ts src/lib/renderDraft.test.ts --maxWorkers=1 --no-file-parallelism --no-isolate, 25 passed
- node node_modules/typescript/bin/tsc -p apps/jobsmith/tsconfig.json --noEmit, passed
- git diff --check HEAD, passed

## Safety
- Browser/local and filesystem parsing only.
- No secrets, billing, DNS, production deploy, force push, data deletion, or external CV uploads.

UnClick todo: 4bcb3169-54a6-4ed9-bb14-8b20f01c98ba
ScopePack: 11329bb8