### PR TITLE
feat(wakepass): add quiet-window helper modules

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -21,6 +21,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/brainmap-auto-update.yml | 7e8b08eb16aa | 1137 |
 | package.json | 37074f6e60a5 | 4175 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
+| scripts/pinballwake-buildbait-room.mjs | 400dccb101ba | 5214 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |
 | scripts/pinballwake-coding-room.mjs | 9fa5689c555e | 25310 |
 | scripts/pinballwake-continuous-improvement-room.mjs | c80556b2d930 | 12439 |
@@ -393,6 +394,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Room | Meaning | Source |
 | --- | --- | --- |
 | ack ledger | PinballWake room logic generated from scripts/pinballwake-ack-ledger-room.mjs. | scripts/pinballwake-ack-ledger-room.mjs |
+| buildbait | PinballWake room logic generated from scripts/pinballwake-buildbait-room.mjs. | scripts/pinballwake-buildbait-room.mjs |
 | close supersede | PinballWake room logic generated from scripts/pinballwake-close-supersede-room.mjs. | scripts/pinballwake-close-supersede-room.mjs |
 | coding | PinballWake room logic generated from scripts/pinballwake-coding-room.mjs. | scripts/pinballwake-coding-room.mjs |
 | continuous improvement | PinballWake room logic generated from scripts/pinballwake-continuous-improvement-room.mjs. | scripts/pinballwake-continuous-improvement-room.mjs |

--- a/scripts/pinballwake-buildbait-room.mjs
+++ b/scripts/pinballwake-buildbait-room.mjs
@@ -1,0 +1,173 @@
+const PARSER_TAG_PREFIX = "BUILDBAIT/STEP=";
+const MIN_STEP = 1;
+const MAX_STEP = 12;
+const OPEN_LANE_MAX = 8;
+
+const STEP_LABELS = {
+  1: "Observe",
+  2: "Acknowledge",
+  3: "Classify",
+  4: "Summarize",
+  5: "Question",
+  6: "Recommend",
+  7: "ScopePack",
+  8: "Pseudo-code",
+  9: "Trivial patch",
+  10: "Test scaffold",
+  11: "Small helper",
+  12: "Real change",
+};
+
+function assertStep(step, name = "step") {
+  if (!Number.isInteger(step) || step < MIN_STEP || step > MAX_STEP) {
+    throw new RangeError(`${name} must be ${MIN_STEP}..${MAX_STEP}`);
+  }
+}
+
+function commentBody(record = {}) {
+  return String(record.body ?? record.text ?? record.message ?? "");
+}
+
+function getCommentId(record = {}) {
+  return record.id ?? record.commentId ?? record.comment_id ?? record.comment?.id ?? null;
+}
+
+function getAuthorId(record = {}) {
+  return record.authorId ?? record.author_id ?? record.agentId ?? record.agent_id ?? record.author_agent_id ?? null;
+}
+
+function getCreatedAt(record = {}) {
+  return record.createdAt ?? record.created_at ?? record.timestamp ?? null;
+}
+
+function getResultCommentId(result = {}) {
+  return result.commentId ?? result.comment_id ?? result.id ?? result.comment?.id ?? null;
+}
+
+function resolveClientMethod(client, camelName, snakeName) {
+  const method = client?.[camelName] ?? client?.[snakeName];
+  return typeof method === "function" ? method.bind(client) : null;
+}
+
+export function stepLabel(step) {
+  return STEP_LABELS[step] ?? null;
+}
+
+export function isOpenLaneStep(step) {
+  return Number.isInteger(step) && step >= MIN_STEP && step <= OPEN_LANE_MAX;
+}
+
+export function isExecutorLaneStep(step) {
+  return Number.isInteger(step) && step > OPEN_LANE_MAX && step <= MAX_STEP;
+}
+
+export function parserTagFor(step) {
+  assertStep(step, "BuildBait step");
+  return `${PARSER_TAG_PREFIX}${step}`;
+}
+
+export function parseStepFromBody(body) {
+  const match = String(body ?? "").match(/BUILDBAIT\/STEP=(\d{1,2})/);
+  if (!match) return null;
+  const step = Number.parseInt(match[1], 10);
+  return Number.isInteger(step) && step >= MIN_STEP && step <= MAX_STEP ? step : null;
+}
+
+export function normalizeBuildbaitCrumb(record = {}) {
+  const body = commentBody(record);
+  const step = parseStepFromBody(body);
+  if (step === null) return null;
+  return {
+    commentId: getCommentId(record),
+    todoId: record.todoId ?? record.todo_id ?? record.target_id ?? null,
+    step,
+    label: stepLabel(step),
+    parserTag: parserTagFor(step),
+    authorId: getAuthorId(record),
+    createdAt: getCreatedAt(record),
+    body,
+  };
+}
+
+export function createBuildbaitRoom({ unclickClient, logger = console } = {}) {
+  const commentOn = resolveClientMethod(unclickClient, "commentOn", "comment_on");
+  const listComments = resolveClientMethod(unclickClient, "listComments", "list_comments");
+
+  if (!commentOn || !listComments) {
+    throw new TypeError("createBuildbaitRoom requires commentOn/comment_on and listComments/list_comments");
+  }
+
+  async function postCrumb({
+    todoId,
+    step,
+    body,
+    seatId = "buildbait-room",
+    parserTag = parserTagFor(step),
+  } = {}) {
+    if (!todoId) throw new TypeError("postCrumb requires todoId");
+    assertStep(step, "postCrumb step");
+    const label = stepLabel(step);
+    const text = `[${parserTag}] Step ${step} ${label}: ${String(body ?? "").trim()}`;
+    const result = await commentOn({
+      agent_id: seatId,
+      agentId: seatId,
+      target_kind: "todo",
+      target_id: todoId,
+      todoId,
+      body: text,
+      text,
+    });
+    const commentId = getResultCommentId(result);
+    logger.info?.(`buildbait-room posted ${parserTag} on ${todoId}`);
+    return { commentId, todoId, step, label, parserTag, body: text };
+  }
+
+  async function listCrumbs({ todoId, limit = 100 } = {}) {
+    if (!todoId) throw new TypeError("listCrumbs requires todoId");
+    const result = await listComments({
+      target_kind: "todo",
+      target_id: todoId,
+      todoId,
+      limit,
+    });
+    const comments = Array.isArray(result) ? result : result?.comments ?? result?.items ?? [];
+    return comments
+      .map((record) => normalizeBuildbaitCrumb({ ...record, todoId: record.todoId ?? record.todo_id ?? todoId }))
+      .filter(Boolean);
+  }
+
+  async function latestStep({ todoId } = {}) {
+    const crumbs = await listCrumbs({ todoId });
+    if (crumbs.length === 0) return null;
+    return Math.max(...crumbs.map((crumb) => crumb.step));
+  }
+
+  async function nextStep({ todoId } = {}) {
+    const latest = await latestStep({ todoId });
+    if (latest === null) return MIN_STEP;
+    if (latest >= MAX_STEP) return null;
+    return latest + 1;
+  }
+
+  async function stageState({ todoId } = {}) {
+    const crumbs = await listCrumbs({ todoId });
+    const latest = crumbs.length === 0 ? null : Math.max(...crumbs.map((crumb) => crumb.step));
+    return {
+      todoId,
+      crumbs,
+      latestStep: latest,
+      nextStep: latest === null ? MIN_STEP : latest >= MAX_STEP ? null : latest + 1,
+      complete: latest >= MAX_STEP,
+    };
+  }
+
+  return { postCrumb, listCrumbs, latestStep, nextStep, stageState };
+}
+
+export const __testing__ = {
+  MAX_STEP,
+  MIN_STEP,
+  OPEN_LANE_MAX,
+  PARSER_TAG_PREFIX,
+  STEP_LABELS,
+};

--- a/scripts/pinballwake-buildbait-room.test.mjs
+++ b/scripts/pinballwake-buildbait-room.test.mjs
@@ -1,0 +1,119 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createBuildbaitRoom,
+  isExecutorLaneStep,
+  isOpenLaneStep,
+  normalizeBuildbaitCrumb,
+  parseStepFromBody,
+  parserTagFor,
+  stepLabel,
+} from "./pinballwake-buildbait-room.mjs";
+
+function createClient(seed = []) {
+  const comments = [...seed];
+  let nextId = 1;
+  return {
+    comments,
+    async comment_on({ target_id, text, body, agent_id }) {
+      const record = {
+        id: `comment-${nextId++}`,
+        target_id,
+        text: text ?? body,
+        author_agent_id: agent_id,
+        created_at: "2026-05-15T02:00:00.000Z",
+      };
+      comments.push(record);
+      return { comment: { id: record.id } };
+    },
+    async list_comments({ target_id }) {
+      return { comments: comments.filter((comment) => (comment.target_id ?? comment.todoId) === target_id) };
+    },
+  };
+}
+
+const silentLogger = { info() {} };
+
+describe("BuildBait room helpers", () => {
+  test("labels and lane helpers match the 12-step ladder", () => {
+    assert.equal(stepLabel(1), "Observe");
+    assert.equal(stepLabel(8), "Pseudo-code");
+    assert.equal(stepLabel(12), "Real change");
+    assert.equal(stepLabel(13), null);
+    assert.equal(isOpenLaneStep(8), true);
+    assert.equal(isOpenLaneStep(9), false);
+    assert.equal(isExecutorLaneStep(9), true);
+    assert.equal(isExecutorLaneStep(8), false);
+  });
+
+  test("parser tags round-trip from comment bodies", () => {
+    assert.equal(parserTagFor(7), "BUILDBAIT/STEP=7");
+    assert.equal(parseStepFromBody("[BUILDBAIT/STEP=11] Step 11 Small helper"), 11);
+    assert.equal(parseStepFromBody("no crumb"), null);
+    assert.equal(parseStepFromBody("BUILDBAIT/STEP=99"), null);
+    assert.throws(() => parserTagFor(0), RangeError);
+  });
+
+  test("normalizes UnClick comment shapes into crumbs", () => {
+    const crumb = normalizeBuildbaitCrumb({
+      id: "abc",
+      target_id: "todo-1",
+      text: "[BUILDBAIT/STEP=3] Step 3 Classify: route this",
+      author_agent_id: "pinballwake-job-runner",
+      created_at: "2026-05-15T02:00:00.000Z",
+    });
+    assert.equal(crumb.commentId, "abc");
+    assert.equal(crumb.todoId, "todo-1");
+    assert.equal(crumb.step, 3);
+    assert.equal(crumb.authorId, "pinballwake-job-runner");
+    assert.equal(normalizeBuildbaitCrumb({ text: "ordinary proof comment" }), null);
+  });
+
+  test("postCrumb writes a parser-readable todo comment", async () => {
+    const client = createClient();
+    const room = createBuildbaitRoom({ unclickClient: client, logger: silentLogger });
+    const result = await room.postCrumb({
+      todoId: "11957893",
+      step: 1,
+      body: "observed ready ScopePack",
+      seatId: "chatgpt-codex-desktop",
+    });
+    assert.equal(result.commentId, "comment-1");
+    assert.match(client.comments[0].text, /^\[BUILDBAIT\/STEP=1\] Step 1 Observe:/);
+    assert.equal(client.comments[0].author_agent_id, "chatgpt-codex-desktop");
+  });
+
+  test("stageState is idempotent and advances to the first missing step", async () => {
+    const client = createClient([
+      { id: "a", target_id: "11957893", text: "[BUILDBAIT/STEP=1] Step 1 Observe: x" },
+      { id: "b", target_id: "11957893", text: "[BUILDBAIT/STEP=4] Step 4 Summarize: x" },
+      { id: "noise", target_id: "11957893", text: "not a crumb" },
+    ]);
+    const room = createBuildbaitRoom({ unclickClient: client, logger: silentLogger });
+    const first = await room.stageState({ todoId: "11957893" });
+    const second = await room.stageState({ todoId: "11957893" });
+    assert.deepEqual(second, first);
+    assert.equal(first.latestStep, 4);
+    assert.equal(first.nextStep, 5);
+    assert.equal(first.complete, false);
+  });
+
+  test("nextStep returns null once step 12 exists", async () => {
+    const client = createClient([
+      { id: "z", target_id: "11957893", text: "[BUILDBAIT/STEP=12] Step 12 Real change: merged" },
+    ]);
+    const room = createBuildbaitRoom({ unclickClient: client, logger: silentLogger });
+    assert.equal(await room.latestStep({ todoId: "11957893" }), 12);
+    assert.equal(await room.nextStep({ todoId: "11957893" }), null);
+    assert.equal((await room.stageState({ todoId: "11957893" })).complete, true);
+  });
+
+  test("rejects missing client methods and invalid writes", async () => {
+    assert.throws(() => createBuildbaitRoom(), TypeError);
+    assert.throws(() => createBuildbaitRoom({ unclickClient: { comment_on() {} } }), TypeError);
+    const room = createBuildbaitRoom({ unclickClient: createClient(), logger: silentLogger });
+    await assert.rejects(() => room.postCrumb({ todoId: "x", step: 0, body: "bad" }), RangeError);
+    await assert.rejects(() => room.postCrumb({ step: 1, body: "missing todo" }), TypeError);
+  });
+});

--- a/scripts/pinballwake-quiet-window-proof.mjs
+++ b/scripts/pinballwake-quiet-window-proof.mjs
@@ -1,0 +1,314 @@
+const DEFAULT_QUIET_WINDOW = { startHourUtc: 22, endHourUtc: 7 };
+
+const RECEIPT_TYPE_PASS = "quiet_window_proof_pass";
+const RECEIPT_TYPE_HOLD = "quiet_window_proof_hold";
+const RECEIPT_TYPE_BLOCKER = "quiet_window_proof_blocker";
+
+const NOT_CLEAN_TOKENS = new Set([
+  "manual",
+  "manual_chat",
+  "operator_chat",
+  "user_chat",
+  "human_chat",
+  "workflow_dispatch",
+]);
+
+const REQUIRED_RUNGS = [
+  {
+    id: "heartbeat_tick",
+    aliases: ["heartbeat_tick", "scheduled_tick", "scheduled_heartbeat_tick", "tick"],
+  },
+  {
+    id: "buildbait_crumb",
+    aliases: ["buildbait_crumb", "buildbait", "crumb", "job_crumb"],
+  },
+  {
+    id: "claim_or_lease",
+    aliases: ["claim_or_lease", "claim", "claimed", "lease", "lease_claimed"],
+  },
+  {
+    id: "execution_packet",
+    aliases: ["execution_packet", "execution", "execute_packet"],
+  },
+  {
+    id: "build_attempt_or_commonsensepass_blocker",
+    aliases: [
+      "build_attempt_or_commonsensepass_blocker",
+      "build_attempt_or_commonsense_blocker",
+      "build_attempt",
+      "build_result",
+      "commonsensepass_blocker",
+      "explicit_commonsensepass_blocker",
+      "commonsense_blocker",
+    ],
+  },
+  {
+    id: "proof_packet",
+    aliases: ["proof_packet", "proof", "proof_submitted"],
+  },
+  {
+    id: "terminal_receipt",
+    aliases: ["terminal_receipt", "terminal", "terminal_state", "done", "blocked", "hold"],
+  },
+];
+
+const BLOCKER_RUNGS = new Set([
+  "build_attempt_or_commonsensepass_blocker",
+  "proof_packet",
+  "terminal_receipt",
+]);
+
+function token(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function eventTokens(event = {}) {
+  const values = typeof event === "string"
+    ? [event]
+    : [
+        event.rung,
+        event.kind,
+        event.type,
+        event.name,
+        event.event,
+        event.action,
+        event.status,
+        event.result,
+        event.reason,
+        event.receipt_kind,
+        event.source,
+        event.source_type,
+        event.trigger_source,
+        event.authorId,
+        event.author_id,
+        event.author_agent_id,
+      ];
+  return new Set(values.map(token).filter(Boolean));
+}
+
+function eventTimeMs(event = {}) {
+  if (typeof event === "string") return null;
+  const raw = event.at ?? event.time ?? event.timestamp ?? event.created_at ?? event.createdAt;
+  const ms = Date.parse(String(raw ?? ""));
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function isInsideWindow(event, startMs, endMs) {
+  const ms = eventTimeMs(event);
+  if (!Number.isFinite(ms)) return true;
+  if (Number.isFinite(startMs) && ms < startMs) return false;
+  if (Number.isFinite(endMs) && ms > endMs) return false;
+  return true;
+}
+
+function hasNotCleanToken(tokens) {
+  return [...tokens].some((value) =>
+    NOT_CLEAN_TOKENS.has(value) ||
+    value.startsWith("human_") ||
+    value.startsWith("human_chris") ||
+    value.includes("manual") ||
+    value.includes("operator_chat") ||
+    value.includes("human_chat") ||
+    value.includes("user_chat")
+  );
+}
+
+function hasRung(events, aliases) {
+  const wanted = new Set(aliases.map(token));
+  return events.some((event) => {
+    const tokens = eventTokens(event);
+    return [...wanted].some((alias) => tokens.has(alias));
+  });
+}
+
+function result({ verdict, reasonCode, reason = reasonCode, firstMissingRung = null, evidence, nextAction }) {
+  return {
+    ok: verdict === "PASS",
+    verdict,
+    receipt_type: verdict === "PASS"
+      ? RECEIPT_TYPE_PASS
+      : verdict === "BLOCKER"
+        ? RECEIPT_TYPE_BLOCKER
+        : RECEIPT_TYPE_HOLD,
+    reason,
+    reason_code: reasonCode,
+    hold_reason: verdict === "HOLD" ? reasonCode : undefined,
+    blocker_reason: verdict === "BLOCKER" ? reasonCode : undefined,
+    first_missing_rung: firstMissingRung,
+    evidence,
+    next_action: nextAction,
+    proof_required: REQUIRED_RUNGS.map((rung) => rung.id),
+  };
+}
+
+export function isInQuietWindow(date, window = DEFAULT_QUIET_WINDOW) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new TypeError("isInQuietWindow requires a valid Date");
+  }
+  const hour = date.getUTCHours();
+  const start = Number(window.startHourUtc);
+  const end = Number(window.endHourUtc);
+  if (start === end) return true;
+  if (start < end) return hour >= start && hour < end;
+  return hour >= start || hour < end;
+}
+
+export function evaluateQuietWindowProof(input = {}) {
+  const events = Array.isArray(input.events) ? input.events : [];
+  const windowStart = input.window_start ?? input.windowStart ?? input.window?.start ?? input.window?.window_start ?? "";
+  const windowEnd = input.window_end ?? input.windowEnd ?? input.window?.end ?? input.window?.window_end ?? "";
+  const windowStartMs = Date.parse(String(windowStart));
+  const windowEndMs = Date.parse(String(windowEnd));
+  const triggerSource = token(input.trigger_source ?? input.triggerSource ?? input.source ?? "");
+  const observedRungs = REQUIRED_RUNGS
+    .filter((rung) => hasRung(events, rung.aliases))
+    .map((rung) => rung.id);
+  const evidence = {
+    window_start: windowStart || null,
+    window_end: windowEnd || null,
+    trigger_source: triggerSource || null,
+    job_id: input.job_id ?? input.jobId ?? null,
+    claim_id: input.claim_id ?? input.claimId ?? null,
+    run_id: input.run_id ?? input.runId ?? input.heartbeatRunId ?? null,
+    observed_rungs: observedRungs,
+  };
+
+  if (!windowStart || !Number.isFinite(windowStartMs)) {
+    return result({
+      verdict: "HOLD",
+      reasonCode: "quiet_window_missing_start",
+      firstMissingRung: "window_start",
+      evidence,
+      nextAction: "record_window_start",
+    });
+  }
+
+  if (!windowEnd || !Number.isFinite(windowEndMs)) {
+    return result({
+      verdict: "HOLD",
+      reasonCode: "quiet_window_missing_end",
+      firstMissingRung: "window_end",
+      evidence,
+      nextAction: "record_window_end",
+    });
+  }
+
+  if (hasNotCleanToken(new Set([triggerSource]))) {
+    return result({
+      verdict: "HOLD",
+      reasonCode: "not_clean_autonomy_proof",
+      firstMissingRung: "scheduled_trigger",
+      evidence,
+      nextAction: "wait_for_scheduled_unclick_heartbeat_window",
+    });
+  }
+
+  const notCleanEvent = events.find((event) =>
+    isInsideWindow(event, windowStartMs, windowEndMs) && hasNotCleanToken(eventTokens(event))
+  );
+  if (notCleanEvent) {
+    return result({
+      verdict: "HOLD",
+      reasonCode: "not_clean_autonomy_proof",
+      firstMissingRung: "no_human_operator_chat_trigger",
+      evidence,
+      nextAction: "restart_window_after_human_or_operator_activity",
+    });
+  }
+
+  for (const rung of REQUIRED_RUNGS) {
+    if (observedRungs.includes(rung.id)) continue;
+    const verdict = BLOCKER_RUNGS.has(rung.id) ? "BLOCKER" : "HOLD";
+    return result({
+      verdict,
+      reasonCode: `quiet_window_missing_${rung.id}`,
+      firstMissingRung: rung.id,
+      evidence,
+      nextAction: `record_${rung.id}`,
+    });
+  }
+
+  return result({
+    verdict: "PASS",
+    reasonCode: "quiet_window_autonomy_proof_complete",
+    evidence,
+    nextAction: "submit_terminal_proof_receipt",
+  });
+}
+
+export async function proveQuietWindow({
+  heartbeatRunId,
+  runTime,
+  targetTodoId,
+  room,
+  window = DEFAULT_QUIET_WINDOW,
+  since,
+  triggerSource = "schedule",
+  events = [],
+} = {}) {
+  if (!heartbeatRunId) throw new TypeError("proveQuietWindow requires heartbeatRunId");
+  if (!(runTime instanceof Date) || Number.isNaN(runTime.getTime())) {
+    throw new TypeError("proveQuietWindow requires runTime: Date");
+  }
+  if (!targetTodoId) throw new TypeError("proveQuietWindow requires targetTodoId");
+  if (!room || typeof room.listCrumbs !== "function") {
+    throw new TypeError("proveQuietWindow requires a buildbait room with listCrumbs");
+  }
+
+  const quiet = isInQuietWindow(runTime, window);
+  const windowStart = since instanceof Date ? since : runTime;
+  const baseEvents = [
+    { rung: "heartbeat_tick", at: runTime.toISOString(), trigger_source: triggerSource },
+    ...events,
+  ];
+
+  if (!quiet) {
+    return result({
+      verdict: "HOLD",
+      reasonCode: "outside_quiet_window",
+      firstMissingRung: "quiet_window",
+      evidence: {
+        window_start: windowStart.toISOString(),
+        window_end: runTime.toISOString(),
+        trigger_source: token(triggerSource),
+        job_id: targetTodoId,
+        claim_id: null,
+        run_id: heartbeatRunId,
+        observed_rungs: ["heartbeat_tick"],
+      },
+      nextAction: "rerun_during_quiet_window",
+    });
+  }
+
+  const crumbs = await room.listCrumbs({ todoId: targetTodoId });
+  const crumbEvents = (crumbs ?? []).map((crumb) => ({
+    rung: "buildbait_crumb",
+    at: crumb.createdAt,
+    authorId: crumb.authorId,
+    comment_id: crumb.commentId,
+    step: crumb.step,
+  }));
+
+  return evaluateQuietWindowProof({
+    window_start: windowStart.toISOString(),
+    window_end: runTime.toISOString(),
+    trigger_source: triggerSource,
+    job_id: targetTodoId,
+    run_id: heartbeatRunId,
+    events: [...baseEvents, ...crumbEvents],
+  });
+}
+
+export const __testing__ = {
+  BLOCKER_RUNGS,
+  DEFAULT_QUIET_WINDOW,
+  NOT_CLEAN_TOKENS,
+  RECEIPT_TYPE_BLOCKER,
+  RECEIPT_TYPE_HOLD,
+  RECEIPT_TYPE_PASS,
+  REQUIRED_RUNGS,
+};

--- a/scripts/pinballwake-quiet-window-proof.test.mjs
+++ b/scripts/pinballwake-quiet-window-proof.test.mjs
@@ -1,0 +1,192 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  __testing__,
+  evaluateQuietWindowProof,
+  isInQuietWindow,
+  proveQuietWindow,
+} from "./pinballwake-quiet-window-proof.mjs";
+
+const WINDOW_START = "2026-05-15T00:00:00.000Z";
+const WINDOW_END = "2026-05-15T02:00:00.000Z";
+
+function fullEvents() {
+  return [
+    { rung: "heartbeat_tick", at: "2026-05-15T00:00:05.000Z" },
+    { rung: "buildbait_crumb", at: "2026-05-15T00:00:10.000Z" },
+    { rung: "lease_claimed", at: "2026-05-15T00:00:20.000Z" },
+    { rung: "execution_packet", at: "2026-05-15T00:00:30.000Z" },
+    { rung: "build_attempt", at: "2026-05-15T00:00:40.000Z" },
+    { rung: "proof_packet", at: "2026-05-15T00:00:50.000Z" },
+    { rung: "terminal_receipt", at: "2026-05-15T00:01:00.000Z" },
+  ];
+}
+
+function roomWith(crumbs) {
+  return {
+    async listCrumbs() {
+      return crumbs;
+    },
+  };
+}
+
+describe("quiet-window clock helper", () => {
+  test("default quiet window wraps midnight UTC", () => {
+    assert.equal(isInQuietWindow(new Date("2026-05-15T00:30:00.000Z")), true);
+    assert.equal(isInQuietWindow(new Date("2026-05-15T06:59:00.000Z")), true);
+    assert.equal(isInQuietWindow(new Date("2026-05-15T07:00:00.000Z")), false);
+    assert.equal(isInQuietWindow(new Date("2026-05-15T21:59:00.000Z")), false);
+    assert.equal(isInQuietWindow(new Date("2026-05-15T22:00:00.000Z")), true);
+  });
+
+  test("rejects invalid dates", () => {
+    assert.throws(() => isInQuietWindow(new Date("not a date")), TypeError);
+    assert.throws(() => isInQuietWindow("2026-05-15T00:00:00Z"), TypeError);
+  });
+});
+
+describe("evaluateQuietWindowProof", () => {
+  test("PASS requires the full scheduled tick-to-terminal ladder", () => {
+    const proof = evaluateQuietWindowProof({
+      window_start: WINDOW_START,
+      window_end: WINDOW_END,
+      trigger_source: "schedule",
+      job_id: "0068a201",
+      claim_id: "claim-1",
+      run_id: "run-1",
+      events: fullEvents(),
+    });
+    assert.equal(proof.verdict, "PASS");
+    assert.equal(proof.receipt_type, __testing__.RECEIPT_TYPE_PASS);
+    assert.equal(proof.first_missing_rung, null);
+    assert.deepEqual(proof.evidence.observed_rungs, __testing__.REQUIRED_RUNGS.map((rung) => rung.id));
+  });
+
+  test("workflow_dispatch trigger is not clean autonomy proof", () => {
+    const proof = evaluateQuietWindowProof({
+      window_start: WINDOW_START,
+      window_end: WINDOW_END,
+      trigger_source: "workflow_dispatch",
+      events: fullEvents(),
+    });
+    assert.equal(proof.verdict, "HOLD");
+    assert.equal(proof.reason_code, "not_clean_autonomy_proof");
+    assert.equal(proof.first_missing_rung, "scheduled_trigger");
+  });
+
+  test("manual chat inside the window is not clean autonomy proof", () => {
+    const proof = evaluateQuietWindowProof({
+      window_start: WINDOW_START,
+      window_end: WINDOW_END,
+      trigger_source: "schedule",
+      events: [
+        ...fullEvents(),
+        { kind: "manual_chat", at: "2026-05-15T00:30:00.000Z", author_agent_id: "human-chris" },
+      ],
+    });
+    assert.equal(proof.verdict, "HOLD");
+    assert.equal(proof.reason_code, "not_clean_autonomy_proof");
+    assert.equal(proof.first_missing_rung, "no_human_operator_chat_trigger");
+  });
+
+  test("claim-only proof holds at the first missing execution packet", () => {
+    const proof = evaluateQuietWindowProof({
+      window_start: WINDOW_START,
+      window_end: WINDOW_END,
+      trigger_source: "schedule",
+      events: [
+        { rung: "heartbeat_tick", at: "2026-05-15T00:00:05.000Z" },
+        { rung: "buildbait_crumb", at: "2026-05-15T00:00:10.000Z" },
+        { rung: "lease_claimed", at: "2026-05-15T00:00:20.000Z" },
+      ],
+    });
+    assert.equal(proof.verdict, "HOLD");
+    assert.equal(proof.first_missing_rung, "execution_packet");
+    assert.equal(proof.next_action, "record_execution_packet");
+  });
+
+  test("missing build attempt or CommonSensePass blocker is a BLOCKER", () => {
+    const proof = evaluateQuietWindowProof({
+      window_start: WINDOW_START,
+      window_end: WINDOW_END,
+      trigger_source: "schedule",
+      events: [
+        { rung: "heartbeat_tick" },
+        { rung: "buildbait_crumb" },
+        { rung: "lease_claimed" },
+        { rung: "execution_packet" },
+      ],
+    });
+    assert.equal(proof.verdict, "BLOCKER");
+    assert.equal(proof.receipt_type, __testing__.RECEIPT_TYPE_BLOCKER);
+    assert.equal(proof.first_missing_rung, "build_attempt_or_commonsensepass_blocker");
+  });
+
+  test("explicit CommonSensePass blocker satisfies the build-attempt rung", () => {
+    const proof = evaluateQuietWindowProof({
+      window_start: WINDOW_START,
+      window_end: WINDOW_END,
+      trigger_source: "schedule",
+      events: [
+        { rung: "heartbeat_tick" },
+        { rung: "buildbait_crumb" },
+        { rung: "lease_claimed" },
+        { rung: "execution_packet" },
+        { rung: "commonsensepass_blocker" },
+        { rung: "proof_packet" },
+        { rung: "terminal_receipt" },
+      ],
+    });
+    assert.equal(proof.verdict, "PASS");
+  });
+
+  test("missing timestamps hold with parser-readable first_missing_rung", () => {
+    const proof = evaluateQuietWindowProof({ window_start: WINDOW_START, trigger_source: "schedule" });
+    assert.equal(proof.verdict, "HOLD");
+    assert.equal(proof.first_missing_rung, "window_end");
+  });
+});
+
+describe("proveQuietWindow", () => {
+  test("outside quiet window returns a hold receipt", async () => {
+    const proof = await proveQuietWindow({
+      heartbeatRunId: "run-1",
+      runTime: new Date("2026-05-15T12:00:00.000Z"),
+      targetTodoId: "11957893",
+      room: roomWith([]),
+      since: new Date("2026-05-15T11:59:00.000Z"),
+      triggerSource: "schedule",
+    });
+    assert.equal(proof.verdict, "HOLD");
+    assert.equal(proof.reason_code, "outside_quiet_window");
+  });
+
+  test("room crumbs can satisfy the BuildBait rung but not the whole ladder alone", async () => {
+    const proof = await proveQuietWindow({
+      heartbeatRunId: "run-2",
+      runTime: new Date("2026-05-15T02:00:00.000Z"),
+      targetTodoId: "11957893",
+      room: roomWith([
+        {
+          commentId: "crumb-1",
+          createdAt: "2026-05-15T01:00:00.000Z",
+          authorId: "pinballwake-job-runner",
+          step: 1,
+        },
+      ]),
+      since: new Date("2026-05-15T00:00:00.000Z"),
+      triggerSource: "schedule",
+    });
+    assert.equal(proof.verdict, "HOLD");
+    assert.equal(proof.first_missing_rung, "claim_or_lease");
+    assert.deepEqual(proof.evidence.observed_rungs, ["heartbeat_tick", "buildbait_crumb"]);
+  });
+
+  test("validates required arguments", async () => {
+    await assert.rejects(() => proveQuietWindow({ runTime: new Date(), targetTodoId: "x", room: roomWith([]) }), TypeError);
+    await assert.rejects(() => proveQuietWindow({ heartbeatRunId: "run", targetTodoId: "x", room: roomWith([]) }), TypeError);
+    await assert.rejects(() => proveQuietWindow({ heartbeatRunId: "run", runTime: new Date(), room: roomWith([]) }), TypeError);
+    await assert.rejects(() => proveQuietWindow({ heartbeatRunId: "run", runTime: new Date(), targetTodoId: "x", room: {} }), TypeError);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the BuildBait room helper for parser-readable crumb comments, stage state, and next-step detection.
- Adds the quiet-window proof helper for scheduled tick-to-terminal evidence, manual trigger rejection, missing-rung HOLD/BLOCKER receipts, and proof receipt shape.
- Adds focused node:test coverage for both helper pairs.

## Scope
- Todo: 0068a201-b218-4cb3-a8be-8f0533dd156b
- ScopePack: 40b4807d-cc7c-4f5b-8db1-ebd5c70f0dc1
- This draft covers the helper/test creation slice. Runner and executor wiring can land as the next small slice.

## Verification
- node --test scripts/pinballwake-buildbait-room.test.mjs scripts/pinballwake-quiet-window-proof.test.mjs scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-build-executor.test.mjs
- git diff --check

## Safety
- No workflow edits, schedules, execute-mode enablement, deploys, secrets, billing, DNS, data deletion, force push, merge authority changes, or production writes.