### PR TITLE
test(brainmap): normalize generated doc line endings

### DIFF
--- a/scripts/UnClick-brainmap.test.mjs
+++ b/scripts/UnClick-brainmap.test.mjs
@@ -8,7 +8,7 @@ import { GENERATED_PATH, generateBrainmap } from "./UnClick-brainmap.mjs";
 describe("UnClick ecosystem Brainmap", () => {
   it("keeps the generated artifact fresh", async () => {
     const generated = await generateBrainmap({ root: process.cwd() });
-    const saved = await readFile(GENERATED_PATH, "utf8");
+    const saved = (await readFile(GENERATED_PATH, "utf8")).replace(/\r\n/g, "\n");
     assert.equal(saved, generated);
   });
 


### PR DESCRIPTION
Summary:
Normalize the generated Brainmap fixture read before strict comparison so Windows CRLF checkouts do not fail `npm run test:brainmap` while the generated content is otherwise fresh.

Scope:
`scripts/UnClick-brainmap.test.mjs` only. UnClick job: `ac8abd1b-2ddb-46c4-b1ef-c87ddb066345`.

Non-overlap:
No generated Brainmap content changes, no admin UI changes, no route or nav changes, no production data, auth, billing, DNS, secrets, deploy, or merge behavior.

Verification:
`npm run brainmap:check`
`npm run test:brainmap`
`npm run test -- src/pages/admin/AdminBrainmap.test.tsx`
`git diff --check`

Risk:
Low. Test-only normalization mirrors the generator check path, which already normalizes CRLF through `readText`.

Follow-up:
Jobs card can be closed after PR is reviewed or merged, because origin/main already has the generated artifact, admin page, route, nav, workflow, and generator.