### PR TITLE
fix(reliability): keep runner claimable for hygiene jobs

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -37,7 +37,8 @@ export const DEFAULT_AUTONOMOUS_RUNNER_POLICY = {
 
 export const DEFAULT_UNCLICK_MCP_URL = "https://unclick.world/api/mcp";
 
-const HOLD_TITLE_PATTERN = /\b(hold|blocker|blocked|dirty)\b/i;
+const HOLD_TITLE_PATTERN = /\b(hold|blocker|blocked)\b/i;
+const HOLD_TITLE_MARKER_PATTERN = /^\s*(hold|blocker|blocked|dirty)\s*:/i;
 const HOLD_BODY_MARKER_PATTERN = /(?:^|\n)\s*(hold|blocker|blocked|dirty)\s*:/i;
 
 const PROTECTED_SURFACE_PATTERNS = [
@@ -162,8 +163,8 @@ function listTodoRoleTokens(todo = {}, scopePack = {}) {
     .filter(Boolean);
 }
 
-function ownerHintAllowsBuilderCompatibleOrchestrator(todo = {}, scopePack = {}) {
-  const hint = [
+function listOwnerHintTokens(todo = {}, scopePack = {}) {
+  return [
     todo.owner_hint,
     todo.ownerHint,
     scopePack.owner_hint,
@@ -172,9 +173,19 @@ function ownerHintAllowsBuilderCompatibleOrchestrator(todo = {}, scopePack = {})
     .filter(Boolean)
     .join(" ")
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ");
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
 
-  return hint.includes("builder") && hint.includes("orchestrator");
+function ownerHintAllowsBuilderCompatibleRunner(todo = {}, scopePack = {}) {
+  return listOwnerHintTokens(todo, scopePack).includes("builder");
+}
+
+function ownerHintAllowsBuilderCompatibleOrchestrator(todo = {}, scopePack = {}) {
+  const tokens = listOwnerHintTokens(todo, scopePack);
+  return tokens.includes("builder") && tokens.includes("orchestrator");
 }
 
 function recentTodoCommentText(todo = {}) {
@@ -1260,6 +1271,10 @@ function createQuietWindowAutonomyProofReceipt({
 } = {}) {
   const triggerSource = normalizeQuietWindowToken(wakeSource || "unknown");
   const imported = numberOption(queueSourceResult.imported, 0);
+  const seen = numberOption(
+    queueSourceResult.seen,
+    numberOption(queueSourceResult.claimability_scorecard?.seen, 0),
+  );
   const claimedResult = results.find((result) => result?.action === "claimed" && result.job);
   const blockedResult = results.find((result) => Array.isArray(result?.safety_blocked) && result.safety_blocked.length > 0);
   const events = [];
@@ -1273,12 +1288,12 @@ function createQuietWindowAutonomyProofReceipt({
     });
   }
 
-  if (imported > 0) {
+  if (imported > 0 || seen > 0) {
     events.push({
       rung: "job_crumb",
       at: now,
       source: queueSourceResult.source || "queue",
-      result: `imported=${imported}`,
+      result: imported > 0 ? `imported=${imported}` : `visible=${seen}`,
     });
   }
 
@@ -1644,7 +1659,11 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
 
   const title = String(todo.title || "");
   const description = String(todo.description || todo.body || todo.notes || "");
-  if (HOLD_TITLE_PATTERN.test(title) || HOLD_BODY_MARKER_PATTERN.test(description)) {
+  if (
+    HOLD_TITLE_PATTERN.test(title) ||
+    HOLD_TITLE_MARKER_PATTERN.test(title) ||
+    HOLD_BODY_MARKER_PATTERN.test(description)
+  ) {
     return { ok: false, reason: "boardroom_todo_hold_or_blocker_marker" };
   }
 
@@ -1654,11 +1673,13 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
 
   const safeRoles = tokenSet(allowedTodoRoles, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles);
   const roleTokens = listTodoRoleTokens(todo, scopePack);
+  const hasBuilderCompatibleOwnerHint = ownerHintAllowsBuilderCompatibleRunner(todo, scopePack);
   const hasBuilderCompatibleOrchestratorHint =
     roleTokens.includes("orchestrator") && ownerHintAllowsBuilderCompatibleOrchestrator(todo, scopePack);
   const hasAllowedRole =
     roleTokens.length === 0 ||
     roleTokens.some((role) => safeRoles.has(role)) ||
+    hasBuilderCompatibleOwnerHint ||
     hasBuilderCompatibleOrchestratorHint;
   if (!hasAllowedRole) {
     return { ok: false, reason: "boardroom_todo_role_not_allowed", role: roleTokens[0] || null };

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -534,6 +534,81 @@ describe("PinballWake autonomous Runner seat", () => {
     );
   });
 
+  it("allows dirty-branch hygiene titles when a builder owner hint names a safe ScopePack", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const todo = {
+        id: "todo-dirty-hygiene",
+        title: "Chip-firer dirty-branch hygiene: prevent unrelated PR drift",
+        status: "open",
+        priority: "high",
+        assigned_to_agent_id: null,
+        actionability_reason: "unassigned_open",
+        created_at: "2026-05-15T22:00:00.000Z",
+        scope_pack: {
+          lane: "reliability",
+          owner_hint: "builder",
+          owned_files: [
+            "packages/testpass/src/checks/anti-stomp.ts",
+            "scripts/pinballwake-autonomous-runner.mjs",
+          ],
+          tests: [
+            "npm run test -- packages/testpass/src/checks/anti-stomp.test.ts scripts/pinballwake-autonomous-runner.test.mjs",
+          ],
+        },
+      };
+
+      assert.equal(evaluateBoardroomTodoAutoClaimEligibility(todo).ok, true);
+      assert.equal(
+        evaluateBoardroomTodoAutoClaimEligibility({
+          ...todo,
+          title: "DIRTY: unrelated worktree drift needs owner routing",
+        }).reason,
+        "boardroom_todo_hold_or_blocker_marker",
+      );
+
+      const fetchImpl = async () => ({
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ todos: [todo] }),
+                },
+              ],
+            },
+          };
+        },
+      });
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-15T22:05:00.000Z",
+        wakeSource: "schedule",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.queue_source.imported, 1);
+      assert.equal(result.queue_source.skipped.length, 0);
+      assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-dirty-hygiene");
+      assert.equal(result.ledger.jobs[0].worker, "builder");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("allows unassigned orchestrator ScopePacks with builder-compatible owner hints", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
@@ -1530,6 +1605,12 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.claimability_scorecard.last_reason, "no_claimable_jobs");
       assert.equal(result.claimability_scorecard.final_action, "blocked");
       assert.equal(result.claimability_scorecard.final_reason, "commonsensepass_no_work_blocked_by_visible_queue");
+      assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "claim_or_lease");
+      assert.deepEqual(result.quiet_window_autonomy_proof.evidence.observed_rungs, [
+        "tick",
+        "buildbait_crumb",
+        "build_attempt_or_commonsense_blocker",
+      ]);
       assert.equal(result.queue_source.skipped[0].id, "todo-stale-scoped-1");
       assert.equal(result.queue_source.skipped[0].reason, "boardroom_todo_not_open");
       assert.deepEqual(calls.map((call) => call.body.params.name), ["list_actionable_todos"]);


### PR DESCRIPTION
Summary:
- Keeps legitimate dirty-branch hygiene jobs claimable by treating only explicit DIRTY: markers as holds.
- Lets builder owner hints unlock safe scoped work even when the ScopePack lane is reliability or another non-role label.
- Records a BuildBait crumb when UnClick jobs are visible but skipped, so no-work blocker proof no longer starts with a missing crumb.

Scope:
- scripts/pinballwake-autonomous-runner.mjs
- scripts/pinballwake-autonomous-runner.test.mjs

Owned files and linked work:
- Owned by codex-fleet-action-runner for scheduled Runner blocker https://github.com/malamutemayhem/unclick/actions/runs/25941759467
- Draft PR for review before merge.

Non-overlap:
- No workflow schedule changes.
- No secrets, auth, billing, DNS, migrations, production data, or execute-mode changes.
- No changes to unrelated Jobs room cards or live assignments.

Verification:
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check
- git diff --cached --check
- npm run test -- scripts/pinballwake-autonomous-runner.test.mjs was not applicable because the Vitest include list does not cover script-level .mjs tests.

Risk:
- Low. This changes claim eligibility for safe scoped jobs with builder owner hints and preserves explicit HOLD/BLOCKER/DIRTY markers.

Follow-up:
- After merge, rerun or observe the next scheduled PinballWake Autonomous Runner run and confirm it claims the hygiene ScopePack or records complete visible-queue proof.