### PR TITLE
Default off Memory MCP OpenAI embeddings

### DIFF
--- a/packages/memory-mcp/src/__tests__/search-memory-fallback.test.ts
+++ b/packages/memory-mcp/src/__tests__/search-memory-fallback.test.ts
@@ -289,6 +289,23 @@ describe("acceptance: keyword fallback restores search when hybrid returns []", 
 // ─── Embeddings helper ────────────────────────────────────────────────────
 
 describe("embedText", () => {
+  it("returns null unless OpenAI embeddings are explicitly enabled", async () => {
+    const savedKey = process.env.OPENAI_API_KEY;
+    const savedFlag = process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+    process.env.OPENAI_API_KEY = "sk-test-no-fetch";
+    delete process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+    try {
+      const { embedText } = await import("../embeddings.js");
+      const result = await embedText("a searchable memory query that is long enough");
+      expect(result).toBeNull();
+    } finally {
+      if (savedKey !== undefined) process.env.OPENAI_API_KEY = savedKey;
+      else delete process.env.OPENAI_API_KEY;
+      if (savedFlag !== undefined) process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED = savedFlag;
+      else delete process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED;
+    }
+  });
+
   it("returns null when OPENAI_API_KEY is not set", async () => {
     const saved = process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_API_KEY;

--- a/packages/memory-mcp/src/embeddings.ts
+++ b/packages/memory-mcp/src/embeddings.ts
@@ -37,8 +37,13 @@ function shouldSkipEmbedding(text: string): boolean {
   ].some((needle) => lower.includes(needle));
 }
 
+export function isOpenAIEmbeddingsEnabled(): boolean {
+  const raw = process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED ?? "";
+  return raw === "1" || raw.toLowerCase() === "true";
+}
+
 export async function embedText(text: string): Promise<number[] | null> {
-  if (process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED === "false") return null;
+  if (!isOpenAIEmbeddingsEnabled()) return null;
   if (shouldSkipEmbedding(text)) return null;
 
   const apiKey = process.env.OPENAI_API_KEY;


### PR DESCRIPTION
## Summary
- Tightens the standalone Memory MCP OpenAI embedding helper so it only calls OpenAI when `MEMORY_OPENAI_EMBEDDINGS_ENABLED` is explicitly `1` or `true`.
- Aligns `packages/memory-mcp` with the newer default-off gate already used by `packages/mcp-server`.
- Adds a focused regression test for the default-off paid-call guardrail.

## Changes
- `packages/memory-mcp/src/embeddings.ts`: adds `isOpenAIEmbeddingsEnabled()` and gates `embedText()` behind an explicit true-like env flag.
- `packages/memory-mcp/src/__tests__/search-memory-fallback.test.ts`: adds coverage proving an `OPENAI_API_KEY` alone is not enough to call embeddings.

## Owner and lift status
- Owner: `unclick-fleet-action-runner` for UnClick todo `6408ff7b-7629-471b-b745-318ebb82b7a0`.
- Non-overlap: scoped to Memory MCP embedding guardrails only. No secrets, billing settings, provider calls, production data, runner files, or UI changes.
- Status: draft, ready for review/lift after CI.

## Deletions
None

## Archaeology
N/A - not a restore/reorg PR

## Testing
- PASS: `npm --workspace @unclick/memory-mcp test -- src/__tests__/search-memory-fallback.test.ts` 
- PASS: `git diff --check`

## UnClick Memory linkage
- Boardroom todo: `6408ff7b-7629-471b-b745-318ebb82b7a0`
- Claim comment: `e3fd8786-3b7c-423d-9c56-a99898b126fc`