### PR TITLE
fix(reliability): gate tether builder claims

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -188,6 +188,42 @@ function ownerHintAllowsBuilderCompatibleOrchestrator(todo = {}, scopePack = {})
   return tokens.includes("builder") && tokens.includes("orchestrator");
 }
 
+function listRunnerClaimTokens(runner = {}) {
+  const raw = [
+    runner.id,
+    runner.agent_id,
+    runner.agentId,
+    runner.name,
+    runner.role,
+    runner.worker_role,
+    runner.lane,
+    runner.readiness,
+    ...(Array.isArray(runner.capabilities) ? runner.capabilities : []),
+  ];
+
+  return raw
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function autonomousRunnerAgentId(runner = {}) {
+  return String(runner.agent_id || runner.agentId || runner.id || "").trim();
+}
+
+function isWatcherOrTetherRunner(runner = {}) {
+  const tokens = new Set(listRunnerClaimTokens(runner));
+  return tokens.has("watcher") || tokens.has("tether");
+}
+
+function scopePackLooksBuilderAssigned({ roleTokens = [], hasBuilderCompatibleOwnerHint = false } = {}) {
+  return hasBuilderCompatibleOwnerHint || roleTokens.some((role) => role === "builder" || role === "plex-builder");
+}
+
 function recentTodoCommentText(todo = {}) {
   const comments = Array.isArray(todo.recent_comments)
     ? todo.recent_comments
@@ -1628,6 +1664,7 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
     allowedActionReasons = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons,
     allowedTodoRoles = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles,
     allowProtectedSurfaces = false,
+    runner = DEFAULT_AUTONOMOUS_RUNNER,
     now = new Date().toISOString(),
   } = {},
 ) {
@@ -1647,13 +1684,17 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
   }
 
   const assignedTo = String(todo.assigned_to_agent_id || "").trim();
-  if (assignedTo) {
+  const runnerAgentId = autonomousRunnerAgentId(runner);
+  const assignedToRunner = Boolean(assignedTo && runnerAgentId && assignedTo === runnerAgentId);
+  if (assignedTo && !assignedToRunner) {
     return { ok: false, reason: "boardroom_todo_already_assigned", assigned_to_agent_id: assignedTo };
   }
 
   const actionReason = normalizeToken(todo.actionability_reason || "");
   const safeActionReasons = tokenSet(allowedActionReasons, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons);
-  if (actionReason && safeActionReasons.size > 0 && !safeActionReasons.has(actionReason)) {
+  const selfAssignedActionReason =
+    assignedToRunner && (actionReason === "role_assigned_open" || actionReason === "assigned_open");
+  if (actionReason && safeActionReasons.size > 0 && !safeActionReasons.has(actionReason) && !selfAssignedActionReason) {
     return { ok: false, reason: "boardroom_todo_action_reason_not_allowed", actionability_reason: actionReason };
   }
 
@@ -1676,6 +1717,13 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
   const hasBuilderCompatibleOwnerHint = ownerHintAllowsBuilderCompatibleRunner(todo, scopePack);
   const hasBuilderCompatibleOrchestratorHint =
     roleTokens.includes("orchestrator") && ownerHintAllowsBuilderCompatibleOrchestrator(todo, scopePack);
+  if (
+    !assignedToRunner &&
+    isWatcherOrTetherRunner(runner) &&
+    scopePackLooksBuilderAssigned({ roleTokens, hasBuilderCompatibleOwnerHint })
+  ) {
+    return { ok: false, reason: "watcher_tether_builder_lane_not_assigned", role: roleTokens[0] || null };
+  }
   const hasAllowedRole =
     roleTokens.length === 0 ||
     roleTokens.some((role) => safeRoles.has(role)) ||
@@ -1751,6 +1799,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
       allowedActionReasons,
       allowedTodoRoles,
       allowProtectedSurfaces,
+      runner,
       now,
     });
     if (!eligibility.ok) {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -534,6 +534,85 @@ describe("PinballWake autonomous Runner seat", () => {
     );
   });
 
+  it("keeps watcher and tether runners off unassigned builder ScopePacks unless exactly assigned", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      const tetherRunner = createAutonomousRunner({
+        id: "pc-tether-runner",
+        agentId: "pc-tether-agent",
+        readiness: "builder_ready",
+        capabilities: ["implementation", "test_fix", "tether"],
+      });
+      const base = {
+        id: "todo-tether-builder-unassigned",
+        title: "Builder lane lift packet",
+        status: "open",
+        priority: "urgent",
+        assigned_to_agent_id: null,
+        actionability_reason: "unassigned_open",
+        scope_pack: {
+          owned_files: ["docs/tether-claim-filter.md"],
+          patch: "diff --git a/docs/tether-claim-filter.md b/docs/tether-claim-filter.md\n--- a/docs/tether-claim-filter.md\n+++ b/docs/tether-claim-filter.md\n@@ -1 +1 @@\n-old\n+new\n",
+          role: "builder",
+        },
+      };
+      const assigned = {
+        ...base,
+        id: "todo-tether-builder-assigned",
+        assigned_to_agent_id: "pc-tether-agent",
+        actionability_reason: "role_assigned_open",
+      };
+
+      assert.equal(evaluateBoardroomTodoAutoClaimEligibility(base, { runner: tetherRunner }).ok, false);
+      assert.equal(
+        evaluateBoardroomTodoAutoClaimEligibility(base, { runner: tetherRunner }).reason,
+        "watcher_tether_builder_lane_not_assigned",
+      );
+      assert.equal(evaluateBoardroomTodoAutoClaimEligibility(assigned, { runner: tetherRunner }).ok, true);
+      assert.equal(evaluateBoardroomTodoAutoClaimEligibility(base, { runner }).ok, true);
+
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+      const fetchImpl = async () => ({
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ todos: [base, assigned] }),
+                },
+              ],
+            },
+          };
+        },
+      });
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner: tetherRunner,
+        mode: "dry-run",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-16T22:55:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.queue_source.imported, 1);
+      assert.equal(result.queue_source.skipped.length, 1);
+      assert.equal(result.queue_source.skipped[0].id, "todo-tether-builder-unassigned");
+      assert.equal(result.queue_source.skipped[0].skip_reason, "watcher_tether_builder_lane_not_assigned");
+      assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-tether-builder-assigned");
+      assert.equal(result.ledger.jobs[0].worker, "pc-tether-agent");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("allows dirty-branch hygiene titles when a builder owner hint names a safe ScopePack", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");


### PR DESCRIPTION
## Summary
Adds runner-aware claim eligibility so watcher or tether seats skip unassigned builder ScopePacks unless UnClick explicitly assigns the todo to that runner agent id. Exact self-assigned todos can still pass through with assigned-open action reasons.

## Scope
Owned files: `scripts/pinballwake-autonomous-runner.mjs`, `scripts/pinballwake-autonomous-runner.test.mjs`.
Linked todo: `b637857a-8607-40d3-a983-10823297d41f` Tether/Watcher seat claim filter.

## Owner Proof Refresh
Refreshed by `unclick-fleet-action-runner` after QueuePush `queuepush:v3:pr-808:draft_green_needs_owner_lift:0350341:a5bbe9b7ea` and the original owner missed check-in.

Current status at refresh: PR is open, draft, mergeable, and clean on head `035034160ebf6e07efd634b1492cd02befbb4633`.

Live checks at refresh: Website package, MCP server package, TestPass smoke run, Vercel, and Vercel Preview Comments all passed.

Reviews at refresh: no submitted reviews and no review decision.

Draft decision: safe to mark ready for normal review and merge flow.

## Non-overlap
Did not touch production data, secrets, billing, DNS, auth flows, migrations, deploy config, or unrelated dirty worktree changes.

## Verification
`node --test scripts/pinballwake-autonomous-runner.test.mjs` passed, 46 tests.

GitHub checks passed: Website package, MCP server package, TestPass smoke run, Vercel, and Vercel Preview Comments.

## Risk
Low. The change is limited to queue claim eligibility and only tightens unassigned builder ScopePack routing for runner identities containing watcher or tether. Exact assignment remains allowed.

## Follow-up
Ready for standard review and merge flow.