### PR TITLE
[codex] Add native analytics intake

### DIFF
--- a/api/analytics.test.ts
+++ b/api/analytics.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import handler, { buildNativeAnalyticsRow } from "./analytics";
+
+const originalSupabaseUrl = process.env.SUPABASE_URL;
+const originalServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function createResponse() {
+  const response = {
+    headers: {} as Record<string, string>,
+    statusCode: 200,
+    body: undefined as unknown,
+    ended: false,
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
+
+  return response;
+}
+
+function restoreAnalyticsEnv() {
+  if (originalSupabaseUrl === undefined) {
+    delete process.env.SUPABASE_URL;
+  } else {
+    process.env.SUPABASE_URL = originalSupabaseUrl;
+  }
+
+  if (originalServiceRoleKey === undefined) {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  } else {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = originalServiceRoleKey;
+  }
+}
+
+describe("native analytics API", () => {
+  afterEach(() => {
+    restoreAnalyticsEnv();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("builds sanitized rows from browser analytics payloads", () => {
+    const result = buildNativeAnalyticsRow({
+      headers: { "user-agent": "vitest-agent" },
+      body: {
+        event: "signup_started",
+        path: "/signup",
+        title: "Signup",
+        referrer: "https://unclick.world/",
+        anonymousId: "anon-123",
+        properties: {
+          method: "magic_link",
+          count: 1,
+          active: true,
+          empty: null,
+          nested: { ignored: true },
+          api_key: "hidden",
+        },
+      },
+    } as never);
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 202,
+      row: {
+        event: "signup_started",
+        path: "/signup",
+        title: "Signup",
+        referrer: "https://unclick.world/",
+        anonymous_id: "anon-123",
+        user_agent: "vitest-agent",
+        source: "browser",
+        properties: {
+          method: "magic_link",
+          count: 1,
+          active: true,
+          empty: null,
+        },
+      },
+    });
+    expect(result.row?.properties).not.toHaveProperty("api_key");
+    expect(result.row?.properties).not.toHaveProperty("nested");
+  });
+
+  it("rejects invalid event names before storage work", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = createResponse();
+    await handler(
+      {
+        method: "POST",
+        headers: {},
+        body: { event: "../bad event", properties: { page: "/signup" } },
+      } as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "event is required and must use analytics-safe characters." });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid events when storage is not configured", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = createResponse();
+    await handler(
+      {
+        method: "POST",
+        headers: {},
+        body: { event: "$pageview", path: "/tools", properties: { title: "Tools" } },
+      } as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({
+      accepted: true,
+      persisted: false,
+      reason: "storage_not_configured",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("persists valid events to Supabase when storage is configured", async () => {
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-test";
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: vi.fn(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = createResponse();
+    await handler(
+      {
+        method: "POST",
+        headers: { "user-agent": "vitest-agent" },
+        body: {
+          event: "signup_started",
+          path: "/signup",
+          properties: { method: "google", token: "hidden" },
+        },
+      } as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({ accepted: true, persisted: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.supabase.co/rest/v1/native_analytics_events",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          apikey: "service-role-test",
+          Authorization: "Bearer service-role-test",
+          Prefer: "return=minimal",
+        }),
+      }),
+    );
+
+    const request = fetchMock.mock.calls[0][1] as { body: string };
+    expect(JSON.parse(request.body)).toMatchObject({
+      event: "signup_started",
+      path: "/signup",
+      source: "browser",
+      user_agent: "vitest-agent",
+      properties: { method: "google" },
+    });
+  });
+
+  it("fails soft when Supabase rejects the insert", async () => {
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-test";
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: vi.fn().mockResolvedValue("table missing"),
+      }),
+    );
+
+    const res = createResponse();
+    await handler(
+      {
+        method: "POST",
+        headers: {},
+        body: { event: "signup_started", properties: { method: "magic_link" } },
+      } as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({
+      accepted: true,
+      persisted: false,
+      reason: "storage_error",
+      status: 404,
+    });
+  });
+});

--- a/api/analytics.ts
+++ b/api/analytics.ts
@@ -1,0 +1,155 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+type Primitive = string | number | boolean | null;
+type RawProperties = Record<string, unknown>;
+
+const ANALYTICS_TABLE = "native_analytics_events";
+const MAX_EVENT_LENGTH = 80;
+const MAX_STRING_LENGTH = 500;
+const MAX_PROPERTY_COUNT = 25;
+const EVENT_NAME_PATTERN = /^[a-zA-Z0-9_$][a-zA-Z0-9_.$:/-]{0,79}$/;
+const SENSITIVE_PROPERTY_PATTERN = /(api[_-]?key|authorization|cookie|password|secret|token)/i;
+
+export interface NativeAnalyticsRow {
+  event: string;
+  path: string | null;
+  title: string | null;
+  properties: Record<string, Primitive>;
+  anonymous_id: string | null;
+  referrer: string | null;
+  user_agent: string | null;
+  source: "browser";
+}
+
+export interface NativeAnalyticsBuildResult {
+  ok: boolean;
+  status: number;
+  row?: NativeAnalyticsRow;
+  error?: string;
+}
+
+function parseBody(input: unknown): RawProperties {
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as RawProperties) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  return input && typeof input === "object" && !Array.isArray(input) ? (input as RawProperties) : {};
+}
+
+function readHeader(req: Pick<VercelRequest, "headers">, name: string): string | null {
+  const value = req.headers[name.toLowerCase()] ?? req.headers[name];
+  if (Array.isArray(value)) return value[0] ?? null;
+  return typeof value === "string" ? value : null;
+}
+
+function textField(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, MAX_STRING_LENGTH);
+}
+
+function isPrimitive(value: unknown): value is Primitive {
+  return value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function sanitizeProperties(value: unknown): Record<string, Primitive> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+
+  const clean: Record<string, Primitive> = {};
+  for (const [rawKey, rawValue] of Object.entries(value as RawProperties)) {
+    const key = rawKey.trim().slice(0, MAX_EVENT_LENGTH);
+    if (!key || SENSITIVE_PROPERTY_PATTERN.test(key)) continue;
+    if (!isPrimitive(rawValue)) continue;
+
+    clean[key] = typeof rawValue === "string" ? rawValue.slice(0, MAX_STRING_LENGTH) : rawValue;
+    if (Object.keys(clean).length >= MAX_PROPERTY_COUNT) break;
+  }
+
+  return clean;
+}
+
+export function buildNativeAnalyticsRow(req: Pick<VercelRequest, "body" | "headers">): NativeAnalyticsBuildResult {
+  const body = parseBody(req.body);
+  const event = textField(body.event);
+
+  if (!event || event.length > MAX_EVENT_LENGTH || !EVENT_NAME_PATTERN.test(event)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "event is required and must use analytics-safe characters.",
+    };
+  }
+
+  return {
+    ok: true,
+    status: 202,
+    row: {
+      event,
+      path: textField(body.path),
+      title: textField(body.title),
+      properties: sanitizeProperties(body.properties),
+      anonymous_id: textField(body.anonymous_id ?? body.anonymousId),
+      referrer: textField(body.referrer),
+      user_agent: textField(body.user_agent ?? body.userAgent) ?? textField(readHeader(req, "user-agent")),
+      source: "browser",
+    },
+  };
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "https://unclick.world");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed." });
+
+  const result = buildNativeAnalyticsRow(req);
+  if (!result.ok || !result.row) {
+    return res.status(result.status).json({ error: result.error ?? "Invalid analytics event." });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(202).json({
+      accepted: true,
+      persisted: false,
+      reason: "storage_not_configured",
+    });
+  }
+
+  const response = await fetch(`${supabaseUrl}/rest/v1/${ANALYTICS_TABLE}`, {
+    method: "POST",
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      "Content-Type": "application/json",
+      Prefer: "return=minimal",
+    },
+    body: JSON.stringify(result.row),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    console.error("native analytics insert failed", response.status, errorText);
+    return res.status(202).json({
+      accepted: true,
+      persisted: false,
+      reason: "storage_error",
+      status: response.status,
+    });
+  }
+
+  return res.status(201).json({
+    accepted: true,
+    persisted: true,
+  });
+}

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -18,22 +18,52 @@ type TestWindow = Window &
   };
 
 describe("analytics", () => {
+  const fetchMock = vi.fn();
+
   beforeEach(() => {
     posthogCapture.mockReset();
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
     document.title = "UnClick Test Page";
     window.history.replaceState({}, "", "/test-path?from=analytics#proof");
   });
 
   afterEach(() => {
     Reflect.deleteProperty(window, "umami");
+    vi.unstubAllGlobals();
   });
 
-  it("emits route page views to PostHog and the optional Umami fallback", () => {
+  function latestNativePayload() {
+    const request = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]?.[1] as RequestInit | undefined;
+    return JSON.parse(String(request?.body));
+  }
+
+  it("emits route page views to native analytics, PostHog, and the optional Umami fallback", () => {
     const umamiTrack = vi.fn();
     (window as TestWindow).umami = { track: umamiTrack };
 
     trackPageView("/test-path?from=analytics#proof");
 
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/analytics",
+      expect.objectContaining({
+        method: "POST",
+        keepalive: true,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(latestNativePayload()).toEqual({
+      event: "$pageview",
+      path: "/test-path?from=analytics#proof",
+      title: "UnClick Test Page",
+      properties: {
+        path: "/test-path?from=analytics#proof",
+        title: "UnClick Test Page",
+        $current_url: "http://localhost:3000/test-path?from=analytics#proof",
+        $pathname: "/test-path?from=analytics#proof",
+      },
+    });
     expect(posthogCapture).toHaveBeenCalledWith("$pageview", {
       path: "/test-path?from=analytics#proof",
       title: "UnClick Test Page",
@@ -54,6 +84,15 @@ describe("analytics", () => {
 
     track("signup_started", { method: "magic", page: "/signup" });
 
+    expect(latestNativePayload()).toEqual({
+      event: "signup_started",
+      path: "/test-path?from=analytics#proof",
+      title: "UnClick Test Page",
+      properties: {
+        method: "magic",
+        page: "/signup",
+      },
+    });
     expect(posthogCapture).toHaveBeenCalledWith("signup_started", {
       method: "magic",
       page: "/signup",
@@ -71,5 +110,6 @@ describe("analytics", () => {
 
     expect(() => track("signup_started", { method: "google" })).not.toThrow();
     expect(() => trackPageView("/safe-even-when-provider-fails")).not.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -15,10 +15,41 @@ interface UmamiWindow {
   };
 }
 
+function currentPath(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function sendNativeAnalytics(event: string, data?: EventData, path?: string): void {
+  if (typeof window === "undefined" || typeof fetch !== "function") return;
+  try {
+    void fetch("/api/analytics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      body: JSON.stringify({
+        event,
+        path: path ?? currentPath(),
+        title: document.title || undefined,
+        referrer: document.referrer || undefined,
+        properties: data ?? {},
+      }),
+    }).catch(() => undefined);
+  } catch {
+    // Never let analytics break the app.
+  }
+}
+
 export function track(event: string, data?: EventData): void {
   if (typeof window === "undefined") return;
+  sendNativeAnalytics(event, data);
   try {
     posthog.capture(event, data);
+  } catch {
+    // Never let analytics break the app.
+  }
+
+  try {
     const umami = (window as unknown as UmamiWindow).umami;
     if (umami && typeof umami.track === "function") {
       umami.track(event, data);
@@ -30,14 +61,21 @@ export function track(event: string, data?: EventData): void {
 
 export function trackPageView(path: string): void {
   if (typeof window === "undefined") return;
+  const properties = {
+    path,
+    title: document.title || undefined,
+    $current_url: window.location.href,
+    $pathname: path,
+  };
+  sendNativeAnalytics("$pageview", properties, path);
+
   try {
-    const properties = {
-      path,
-      title: document.title || undefined,
-      $current_url: window.location.href,
-      $pathname: path,
-    };
     posthog.capture("$pageview", properties);
+  } catch {
+    // Never let analytics break the app.
+  }
+
+  try {
     const umami = (window as unknown as UmamiWindow).umami;
     if (umami && typeof umami.track === "function") {
       umami.track("pageview", properties);


### PR DESCRIPTION
## Summary

Adds a first-party analytics intake endpoint and wires the browser analytics helper to send page views and signup events to it before optional third-party providers.

## What changed

- Added `POST /api/analytics` with event-name validation, property sanitization, sensitive-key filtering, and safe fallback when Supabase storage is not configured.
- Sends native analytics from `src/lib/analytics.ts` with `keepalive` and swallowed failures so analytics cannot break the app.
- Kept PostHog and Umami behavior intact, with provider failures isolated from the native path.
- Added focused API and browser-helper tests.

## Safety

No secrets, billing, DNS, migrations, production deploys, or production data mutations. Storage writes only happen when `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are configured, and Supabase failures return accepted but not persisted.

## Verification

- `npm run test -- api/analytics.test.ts src/lib/analytics.test.ts`
- `git diff --check`
- `git diff --cached --check`
- Touched-file em dash scan clean