### PR TITLE
[codex] Add worker self-healing decision plan

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -14,6 +14,7 @@ import {
   isReclaimableDispatchCandidate,
   isWakepassAutoRerouteEligible,
   messageAcknowledgesDispatch,
+  planWorkerSelfHealingDecision,
   resolveWakepassRerouteTarget,
   shouldMarkDispatchStaleAfterReclaimSignalInsert,
   type DispatchRow,
@@ -396,6 +397,123 @@ describe("fishbowl watcher PinballWake ACK coverage", () => {
       recipient: "🧭",
       role: "coordinator",
       reason: "default_coordinator",
+    });
+  });
+});
+
+describe("worker self-healing decision plan", () => {
+  it("preserves an active todo lease even when the worker missed check-in", () => {
+    const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
+
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-active-lease",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-fresh",
+        lease_expires_at: "2026-05-01T01:25:00.000Z",
+        reclaim_count: 1,
+      },
+      profile: baseProfile,
+      latestHandoffReceiptId: "handoff-latest-1",
+      nowMs,
+    });
+
+    expect(decision).toMatchObject({
+      action: "active_lease_preserved",
+      todo_id: "todo-active-lease",
+      assigned_to_agent_id: "worker-1",
+      lease_token: "lease-fresh",
+      lease_expires_at: "2026-05-01T01:25:00.000Z",
+      reclaim_count: 1,
+      next_reclaim_count: 1,
+      latest_handoff_receipt_id: "handoff-latest-1",
+      reason: "active_lease_not_expired",
+    });
+  });
+
+  it("marks an expired todo lease reclaimable with the next reclaim count", () => {
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-expired-lease",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-old",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-2",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(decision).toMatchObject({
+      action: "expired_lease_reclaimable",
+      todo_id: "todo-expired-lease",
+      assigned_to_agent_id: "worker-1",
+      lease_token: "lease-old",
+      reclaim_count: 2,
+      next_reclaim_count: 3,
+      latest_handoff_receipt_id: "handoff-latest-2",
+      reason: "lease_expired",
+    });
+  });
+
+  it("flags a stale worker for action when no active todo lease exists", () => {
+    const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
+
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-stale-worker",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: null,
+        lease_expires_at: null,
+        reclaim_count: 0,
+      },
+      profile: baseProfile,
+      latestHandoffReceiptId: "handoff-latest-3",
+      nowMs,
+    });
+
+    expect(decision).toMatchObject({
+      action: "stale_worker_action_needed",
+      todo_id: "todo-stale-worker",
+      assigned_to_agent_id: "worker-1",
+      profile_agent_id: "worker-1",
+      next_checkin_at: "2026-05-01T01:10:00.000Z",
+      last_seen_at: "2026-05-01T00:30:00.000Z",
+      latest_handoff_receipt_id: "handoff-latest-3",
+      reason: "missed_next_checkin_without_active_lease",
+    });
+  });
+
+  it("carries the latest handoff receipt through resume-safe no-action decisions", () => {
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-current-worker",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: null,
+        lease_expires_at: null,
+        reclaim_count: null,
+      },
+      profile: {
+        ...baseProfile,
+        last_seen_at: "2026-05-01T01:21:00.000Z",
+        next_checkin_at: "2026-05-01T01:30:00.000Z",
+      },
+      latestHandoffReceiptId: "handoff-latest-4",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(decision).toMatchObject({
+      action: "no_action",
+      todo_id: "todo-current-worker",
+      reclaim_count: 0,
+      next_reclaim_count: 0,
+      latest_handoff_receipt_id: "handoff-latest-4",
+      reason: "no_stale_worker_or_reclaimable_lease",
     });
   });
 });

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -99,6 +99,36 @@ export interface WakepassReroutePlan {
   };
 }
 
+export interface WorkerSelfHealingTodoState {
+  id: string;
+  status: string;
+  assigned_to_agent_id?: string | null;
+  lease_token?: string | null;
+  lease_expires_at?: string | null;
+  reclaim_count?: number | null;
+}
+
+export type WorkerSelfHealingAction =
+  | "active_lease_preserved"
+  | "expired_lease_reclaimable"
+  | "stale_worker_action_needed"
+  | "no_action";
+
+export interface WorkerSelfHealingDecision {
+  action: WorkerSelfHealingAction;
+  todo_id: string;
+  assigned_to_agent_id: string | null;
+  lease_token: string | null;
+  lease_expires_at: string | null;
+  reclaim_count: number;
+  next_reclaim_count: number;
+  latest_handoff_receipt_id: string | null;
+  reason: string;
+  profile_agent_id?: string | null;
+  next_checkin_at?: string | null;
+  last_seen_at?: string | null;
+}
+
 export function isMissedCheckinCandidate(profile: ProfileRow, nowMs: number): boolean {
   if (!profile.next_checkin_at) return false;
   const dueMs = new Date(profile.next_checkin_at).getTime();
@@ -150,6 +180,77 @@ export function buildMissedCheckinDispatch(
     status: "leased",
     leaseOwner: profile.agent_id,
     leaseExpiresAt: new Date(nowMs + CHECKIN_ACK_LEASE_SECONDS * 1000).toISOString(),
+  };
+}
+
+export function planWorkerSelfHealingDecision(params: {
+  todo: WorkerSelfHealingTodoState;
+  profile?: ProfileRow | null;
+  latestHandoffReceiptId?: string | null;
+  nowMs: number;
+}): WorkerSelfHealingDecision {
+  const todo = params.todo;
+  const assignedToAgentId = nonEmptyString(todo.assigned_to_agent_id);
+  const leaseToken = nonEmptyString(todo.lease_token);
+  const leaseExpiresAt = nonEmptyString(todo.lease_expires_at);
+  const reclaimCountValue = Number(todo.reclaim_count ?? 0);
+  const reclaimCount = Number.isFinite(reclaimCountValue)
+    ? Math.max(0, reclaimCountValue)
+    : 0;
+  const latestHandoffReceiptId = nonEmptyString(params.latestHandoffReceiptId);
+  const base = {
+    todo_id: todo.id,
+    assigned_to_agent_id: assignedToAgentId,
+    lease_token: leaseToken,
+    lease_expires_at: leaseExpiresAt,
+    reclaim_count: reclaimCount,
+    latest_handoff_receipt_id: latestHandoffReceiptId,
+  };
+
+  if (leaseToken && leaseExpiresAt) {
+    const staleDecision = decideStaleLease(
+      {
+        status: "leased",
+        leaseExpiresAt,
+        lastRealActionAt: null,
+      },
+      new Date(params.nowMs),
+    );
+
+    if (!staleDecision.isStale) {
+      return {
+        ...base,
+        action: "active_lease_preserved",
+        next_reclaim_count: reclaimCount,
+        reason: "active_lease_not_expired",
+      };
+    }
+
+    return {
+      ...base,
+      action: "expired_lease_reclaimable",
+      next_reclaim_count: reclaimCount + 1,
+      reason: "lease_expired",
+    };
+  }
+
+  if (params.profile && isMissedCheckinCandidate(params.profile, params.nowMs)) {
+    return {
+      ...base,
+      action: "stale_worker_action_needed",
+      next_reclaim_count: reclaimCount,
+      profile_agent_id: params.profile.agent_id,
+      next_checkin_at: params.profile.next_checkin_at,
+      last_seen_at: params.profile.last_seen_at,
+      reason: "missed_next_checkin_without_active_lease",
+    };
+  }
+
+  return {
+    ...base,
+    action: "no_action",
+    next_reclaim_count: reclaimCount,
+    reason: "no_stale_worker_or_reclaimable_lease",
   };
 }
 


### PR DESCRIPTION
## Scope
- Adds a read-only worker self-healing decision helper for stale worker and todo lease states.
- Preserves active leases, marks expired leases reclaimable, flags missed check-ins only when no active lease exists, and carries latest handoff receipt ids for resume-safe routing.
- Touches only api/fishbowl-watcher.ts and api/fishbowl-watcher.test.ts.

## Safety
- No live lease mutation.
- No production data, secrets, billing, DNS, deploy, migration, or auth changes.
- Non-destructive reliability helper plus focused tests only.

## Owner Proof Refresh
- Head: 90e99a694a43e1d72cce82aee50c3482cf7c30af.
- Mergeability: CLEAN / MERGEABLE at proof refresh.
- Changed files: api/fishbowl-watcher.ts and api/fishbowl-watcher.test.ts.
- Local proof passed: npm run test -- api/fishbowl-watcher.test.ts.
- Local proof passed: npm run test -- api/fishbowl-watcher.test.ts api/fishbowl-todo-handoff.test.ts.
- Local proof passed: git diff --check.
- Remote checks passed: Website (root package), MCP server package, TestPass smoke run, Vercel, Vercel Preview Comments.

## Job
Refs UnClick todo 2889ee70-9e9c-4568-b172-81769e0baa39.