### PR TITLE
fix(reliability): add worker self-healing signals

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -9,6 +9,7 @@ import {
   buildDispatchReclaimSignal,
   buildMissedCheckinDispatch,
   buildWakepassAutoReroutePlan,
+  buildWorkerSelfHealingSignal,
   isMissedCheckinDispatch,
   isMissedCheckinCandidate,
   isReclaimableDispatchCandidate,
@@ -515,5 +516,91 @@ describe("worker self-healing decision plan", () => {
       latest_handoff_receipt_id: "handoff-latest-4",
       reason: "no_stale_worker_or_reclaimable_lease",
     });
+  });
+
+  it("turns an expired lease decision into a reclaim signal without exposing the token", () => {
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-expired-lease",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-5",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    const signal = buildWorkerSelfHealingSignal(decision);
+
+    expect(signal).toMatchObject({
+      action: "worker_self_healing_reclaimable_lease",
+      severity: "action_needed",
+      summary: "Todo todo-expired-lease has an expired worker lease and can be reclaimed.",
+      payload: {
+        todo_id: "todo-expired-lease",
+        assigned_to_agent_id: "worker-1",
+        has_lease_token: true,
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+        next_reclaim_count: 3,
+        latest_handoff_receipt_id: "handoff-latest-5",
+        reason: "lease_expired",
+      },
+    });
+    expect(signal?.payload).not.toHaveProperty("lease_token");
+  });
+
+  it("turns a stale worker decision into an action-needed signal with profile context", () => {
+    const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-stale-worker",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: null,
+        lease_expires_at: null,
+        reclaim_count: 0,
+      },
+      profile: baseProfile,
+      latestHandoffReceiptId: "handoff-latest-6",
+      nowMs,
+    });
+
+    expect(buildWorkerSelfHealingSignal(decision)).toMatchObject({
+      action: "worker_self_healing_stale_worker",
+      severity: "action_needed",
+      payload: {
+        todo_id: "todo-stale-worker",
+        profile_agent_id: "worker-1",
+        next_checkin_at: "2026-05-01T01:10:00.000Z",
+        last_seen_at: "2026-05-01T00:30:00.000Z",
+        reason: "missed_next_checkin_without_active_lease",
+      },
+    });
+  });
+
+  it("keeps no-action decisions quiet", () => {
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-current-worker",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: null,
+        lease_expires_at: null,
+        reclaim_count: 0,
+      },
+      profile: {
+        ...baseProfile,
+        last_seen_at: "2026-05-01T01:21:00.000Z",
+        next_checkin_at: "2026-05-01T01:30:00.000Z",
+      },
+      latestHandoffReceiptId: "handoff-latest-7",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(buildWorkerSelfHealingSignal(decision)).toBeNull();
   });
 });

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -129,6 +129,18 @@ export interface WorkerSelfHealingDecision {
   last_seen_at?: string | null;
 }
 
+export type WorkerSelfHealingSignalAction =
+  | "worker_self_healing_active_lease"
+  | "worker_self_healing_reclaimable_lease"
+  | "worker_self_healing_stale_worker";
+
+export interface WorkerSelfHealingSignal {
+  action: WorkerSelfHealingSignalAction;
+  severity: "info" | "action_needed";
+  summary: string;
+  payload: Record<string, unknown>;
+}
+
 export function isMissedCheckinCandidate(profile: ProfileRow, nowMs: number): boolean {
   if (!profile.next_checkin_at) return false;
   const dueMs = new Date(profile.next_checkin_at).getTime();
@@ -252,6 +264,68 @@ export function planWorkerSelfHealingDecision(params: {
     next_reclaim_count: reclaimCount,
     reason: "no_stale_worker_or_reclaimable_lease",
   };
+}
+
+function workerSelfHealingSignalPayload(decision: WorkerSelfHealingDecision) {
+  const payload: Record<string, unknown> = {
+    todo_id: decision.todo_id,
+    assigned_to_agent_id: decision.assigned_to_agent_id,
+    has_lease_token: Boolean(decision.lease_token),
+    lease_expires_at: decision.lease_expires_at,
+    reclaim_count: decision.reclaim_count,
+    next_reclaim_count: decision.next_reclaim_count,
+    latest_handoff_receipt_id: decision.latest_handoff_receipt_id,
+    reason: decision.reason,
+  };
+
+  if (decision.profile_agent_id) {
+    payload.profile_agent_id = decision.profile_agent_id;
+  }
+  if (decision.next_checkin_at) {
+    payload.next_checkin_at = decision.next_checkin_at;
+  }
+  if (decision.last_seen_at) {
+    payload.last_seen_at = decision.last_seen_at;
+  }
+
+  return payload;
+}
+
+export function buildWorkerSelfHealingSignal(
+  decision: WorkerSelfHealingDecision,
+): WorkerSelfHealingSignal | null {
+  if (decision.action === "active_lease_preserved") {
+    return {
+      action: "worker_self_healing_active_lease",
+      severity: "info",
+      summary: `Todo ${decision.todo_id} has an active worker lease through ${
+        decision.lease_expires_at ?? "unknown"
+      }.`,
+      payload: workerSelfHealingSignalPayload(decision),
+    };
+  }
+
+  if (decision.action === "expired_lease_reclaimable") {
+    return {
+      action: "worker_self_healing_reclaimable_lease",
+      severity: "action_needed",
+      summary: `Todo ${decision.todo_id} has an expired worker lease and can be reclaimed.`,
+      payload: workerSelfHealingSignalPayload(decision),
+    };
+  }
+
+  if (decision.action === "stale_worker_action_needed") {
+    return {
+      action: "worker_self_healing_stale_worker",
+      severity: "action_needed",
+      summary: `Worker ${
+        decision.profile_agent_id ?? decision.assigned_to_agent_id ?? "unknown"
+      } missed the next check-in for todo ${decision.todo_id} without an active lease.`,
+      payload: workerSelfHealingSignalPayload(decision),
+    };
+  }
+
+  return null;
 }
 
 function dispatchToDbRow(dispatch: AgentDispatch) {


### PR DESCRIPTION
## Summary
- add a read-only signal builder for Worker self-healing decisions
- expose actionable expired-lease and stale-worker signal shapes for the next executor slice
- keep no-action decisions quiet and avoid exposing raw lease tokens in signal payloads

## Tests
- npm run test -- api/fishbowl-watcher.test.ts api/fishbowl-todo-handoff.test.ts
- npx eslint api/fishbowl-watcher.ts api/fishbowl-watcher.test.ts
- git diff --check