### PR TITLE
fix(reliability): plan worker self-healing signal inserts

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -16,6 +16,7 @@ import {
   isWakepassAutoRerouteEligible,
   messageAcknowledgesDispatch,
   planWorkerSelfHealingDecision,
+  planWorkerSelfHealingTodoSignal,
   resolveWakepassRerouteTarget,
   shouldMarkDispatchStaleAfterReclaimSignalInsert,
   type DispatchRow,
@@ -553,6 +554,55 @@ describe("worker self-healing decision plan", () => {
     expect(signal?.payload).not.toHaveProperty("lease_token");
   });
 
+  it("plans an insert row for an expired lease signal without exposing the token", () => {
+    const decision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-expired-lease",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-5",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    const plan = planWorkerSelfHealingTodoSignal({
+      apiKeyHash: "hash_123",
+      decision,
+      emittedAt: "2026-05-01T01:22:01.000Z",
+    });
+
+    expect(plan).toMatchObject({
+      signal: {
+        action: "worker_self_healing_reclaimable_lease",
+        severity: "action_needed",
+      },
+      insert: {
+        api_key_hash: "hash_123",
+        tool: "fishbowl",
+        action: "worker_self_healing_reclaimable_lease",
+        severity: "action_needed",
+        summary: "Todo todo-expired-lease has an expired worker lease and can be reclaimed.",
+        deep_link: "/admin/jobs#todo-todo-expired-lease",
+        payload: {
+          todo_id: "todo-expired-lease",
+          assigned_to_agent_id: "worker-1",
+          has_lease_token: true,
+          lease_expires_at: "2026-05-01T01:10:00.000Z",
+          reclaim_count: 2,
+          next_reclaim_count: 3,
+          latest_handoff_receipt_id: "handoff-latest-5",
+          reason: "lease_expired",
+          emitted_at: "2026-05-01T01:22:01.000Z",
+        },
+      },
+    });
+    expect(plan?.insert.payload).not.toHaveProperty("lease_token");
+  });
+
   it("turns a stale worker decision into an action-needed signal with profile context", () => {
     const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
     const decision = planWorkerSelfHealingDecision({
@@ -602,5 +652,12 @@ describe("worker self-healing decision plan", () => {
     });
 
     expect(buildWorkerSelfHealingSignal(decision)).toBeNull();
+    expect(
+      planWorkerSelfHealingTodoSignal({
+        apiKeyHash: "hash_123",
+        decision,
+        emittedAt: "2026-05-01T01:22:01.000Z",
+      }),
+    ).toBeNull();
   });
 });

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -141,6 +141,21 @@ export interface WorkerSelfHealingSignal {
   payload: Record<string, unknown>;
 }
 
+export interface WorkerSelfHealingSignalInsertRow {
+  api_key_hash: string;
+  tool: "fishbowl";
+  action: WorkerSelfHealingSignalAction;
+  severity: WorkerSelfHealingSignal["severity"];
+  summary: string;
+  deep_link: string;
+  payload: Record<string, unknown>;
+}
+
+export interface WorkerSelfHealingTodoSignalPlan {
+  signal: WorkerSelfHealingSignal;
+  insert: WorkerSelfHealingSignalInsertRow;
+}
+
 export function isMissedCheckinCandidate(profile: ProfileRow, nowMs: number): boolean {
   if (!profile.next_checkin_at) return false;
   const dueMs = new Date(profile.next_checkin_at).getTime();
@@ -326,6 +341,36 @@ export function buildWorkerSelfHealingSignal(
   }
 
   return null;
+}
+
+export function planWorkerSelfHealingTodoSignal(params: {
+  apiKeyHash: string;
+  decision: WorkerSelfHealingDecision;
+  emittedAt: string;
+  deepLink?: string;
+}): WorkerSelfHealingTodoSignalPlan | null {
+  const apiKeyHash = nonEmptyString(params.apiKeyHash);
+  const emittedAt = nonEmptyString(params.emittedAt);
+  if (!apiKeyHash || !emittedAt) return null;
+
+  const signal = buildWorkerSelfHealingSignal(params.decision);
+  if (!signal) return null;
+
+  return {
+    signal,
+    insert: {
+      api_key_hash: apiKeyHash,
+      tool: "fishbowl",
+      action: signal.action,
+      severity: signal.severity,
+      summary: signal.summary,
+      deep_link: params.deepLink ?? `/admin/jobs#todo-${params.decision.todo_id}`,
+      payload: {
+        ...signal.payload,
+        emitted_at: emittedAt,
+      },
+    },
+  };
 }
 
 function dispatchToDbRow(dispatch: AgentDispatch) {


### PR DESCRIPTION
## Summary
- Add a Worker self-healing todo signal plan that converts sanitized decisions into insert-ready fishbowl rows.
- Keep quiet no-action decisions silent and keep lease tokens out of signal payloads.
- Cover the new insert plan with focused watcher tests.

## Verification
- npm run test -- api/fishbowl-watcher.test.ts api/fishbowl-todo-handoff.test.ts
- npx eslint api/fishbowl-watcher.ts api/fishbowl-watcher.test.ts
- git diff --check
- rg -n "—" api/fishbowl-watcher.ts api/fishbowl-watcher.test.ts

## Safety
- No production data changes.
- No secrets, billing, DNS, auth, or deploy changes.