### PR TITLE
build Vercel worker movement pilot planner

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -8,6 +8,7 @@ import {
   WAKEPASS_REROUTE_LEASE_SECONDS,
   buildDispatchReclaimSignal,
   buildMissedCheckinDispatch,
+  buildWorkerMovementWorkflowPilotProofText,
   buildWakepassAutoReroutePlan,
   buildWorkerSelfHealingSignal,
   hasRecentWorkerSelfHealingTodoSignal,
@@ -16,6 +17,7 @@ import {
   isReclaimableDispatchCandidate,
   isWakepassAutoRerouteEligible,
   messageAcknowledgesDispatch,
+  planWorkerMovementWorkflowPilot,
   planWorkerSelfHealingDecision,
   planWorkerSelfHealingTodoSignal,
   resolveWakepassRerouteTarget,
@@ -715,5 +717,128 @@ describe("worker self-healing decision plan", () => {
         emittedAt: "2026-05-01T01:22:01.000Z",
       }),
     ).toBeNull();
+  });
+});
+
+describe("Vercel worker movement workflow pilot plan", () => {
+  it("builds a dry-run start plan for one safe expired lease candidate", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "Worker self-healing: heartbeat timeout, reclaim, and resume-safe queue behavior",
+      todo: {
+        id: "todo-expired-lease",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-8",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(plan).toMatchObject({
+      mode: "dry_run",
+      action: "start_dry_run",
+      candidate_id: "todo-expired-lease",
+      safety: {
+        allowed: true,
+        reason: "safe_proof_only_candidate",
+      },
+      owner_age_minutes: 12,
+      decision: {
+        action: "expired_lease_reclaimable",
+        latest_handoff_receipt_id: "handoff-latest-8",
+      },
+      signal: {
+        action: "worker_self_healing_reclaimable_lease",
+      },
+      proof: {
+        next_safe_step: "start Vercel Workflow in dry-run mode and post proof only",
+        payload: {
+          proof_mode: "dry_run",
+          action: "start_dry_run",
+          has_lease_token: true,
+          planned_signal_action: "worker_self_healing_reclaimable_lease",
+        },
+      },
+    });
+    expect(plan.workflow_key).toContain("todo-expired-lease");
+    expect(JSON.stringify(plan.proof.payload)).not.toContain("lease-secret");
+    expect(buildWorkerMovementWorkflowPilotProofText(plan)).toContain(
+      "Vercel worker movement pilot start_dry_run",
+    );
+  });
+
+  it("refuses security-gated candidates even when the stale lease is detectable", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "SECURITY: deactivate legacy plaintext api_keys_legacy rows after owner auth",
+      todo: {
+        id: "todo-security",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 0,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-9",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(plan).toMatchObject({
+      mode: "dry_run",
+      action: "post_refusal_proof",
+      candidate_id: "todo-security",
+      safety: {
+        allowed: false,
+        reason: "owner_or_security_gated_job",
+      },
+      signal: null,
+      proof: {
+        next_safe_step:
+          "post refusal proof and leave the job with its owner (owner_or_security_gated_job)",
+        payload: {
+          action: "post_refusal_proof",
+          planned_signal_action: "worker_self_healing_reclaimable_lease",
+        },
+      },
+    });
+    expect(JSON.stringify(plan)).not.toContain("lease-secret");
+  });
+
+  it("skips workflow start when existing planner finds no movement needed", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "Worker self-healing: heartbeat timeout, reclaim, and resume-safe queue behavior",
+      todo: {
+        id: "todo-current-worker",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: null,
+        lease_expires_at: null,
+        reclaim_count: 0,
+      },
+      profile: {
+        ...baseProfile,
+        last_seen_at: "2026-05-01T01:21:00.000Z",
+        next_checkin_at: "2026-05-01T01:30:00.000Z",
+      },
+      latestHandoffReceiptId: "handoff-latest-10",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(plan).toMatchObject({
+      mode: "dry_run",
+      action: "skip_no_action",
+      safety: {
+        allowed: false,
+        reason: "no_stale_worker_or_reclaimable_lease",
+      },
+      signal: null,
+      owner_age_minutes: 0,
+      proof: {
+        next_safe_step: "skip workflow start and keep cron watcher as fallback",
+      },
+    });
   });
 });

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -165,6 +165,35 @@ export interface WorkerSelfHealingTodoSignalPlan {
   insert: WorkerSelfHealingSignalInsertRow;
 }
 
+export type WorkerMovementWorkflowPilotAction =
+  | "start_dry_run"
+  | "post_refusal_proof"
+  | "skip_no_action";
+
+export type WorkerMovementWorkflowPilotDecision =
+  Omit<WorkerSelfHealingDecision, "lease_token"> & {
+    has_lease_token: boolean;
+  };
+
+export interface WorkerMovementWorkflowPilotPlan {
+  mode: "dry_run";
+  action: WorkerMovementWorkflowPilotAction;
+  candidate_id: string;
+  workflow_key: string;
+  decision: WorkerMovementWorkflowPilotDecision;
+  signal: WorkerSelfHealingSignal | null;
+  safety: {
+    allowed: boolean;
+    reason: string;
+  };
+  owner_age_minutes: number | null;
+  proof: {
+    summary: string;
+    next_safe_step: string;
+    payload: Record<string, unknown>;
+  };
+}
+
 export function isMissedCheckinCandidate(profile: ProfileRow, nowMs: number): boolean {
   if (!profile.next_checkin_at) return false;
   const dueMs = new Date(profile.next_checkin_at).getTime();
@@ -393,6 +422,106 @@ export function hasRecentWorkerSelfHealingTodoSignal(
   ));
 }
 
+export function planWorkerMovementWorkflowPilot(params: {
+  todo: WorkerSelfHealingTodoState;
+  title?: string | null;
+  profile?: ProfileRow | null;
+  latestHandoffReceiptId?: string | null;
+  nowMs: number;
+}): WorkerMovementWorkflowPilotPlan {
+  const rawDecision = planWorkerSelfHealingDecision({
+    todo: params.todo,
+    profile: params.profile,
+    latestHandoffReceiptId: params.latestHandoffReceiptId,
+    nowMs: params.nowMs,
+  });
+  const decision = sanitizeWorkerMovementDecision(rawDecision);
+  const plannedSignal = buildWorkerSelfHealingSignal(rawDecision);
+  const blockedReason = workerMovementBlockedReason(params.title);
+  const hasActionableSignal = plannedSignal?.severity === "action_needed";
+  const action: WorkerMovementWorkflowPilotAction = blockedReason
+    ? "post_refusal_proof"
+    : hasActionableSignal
+      ? "start_dry_run"
+      : "skip_no_action";
+  const safety = action === "start_dry_run"
+    ? { allowed: true, reason: "safe_proof_only_candidate" }
+    : { allowed: false, reason: blockedReason ?? decision.reason };
+  const ownerAgeMinutes = workerMovementOwnerAgeMinutes(
+    decision,
+    params.nowMs,
+    params.profile,
+  );
+  const nextSafeStep = workerMovementNextSafeStep(action, safety.reason);
+  const workflowKey = [
+    "worker-movement",
+    decision.todo_id,
+    decision.action,
+    decision.lease_expires_at ?? decision.next_checkin_at ?? "no-due",
+  ].join(":");
+  const signal = blockedReason ? null : plannedSignal;
+  const proofPayload: Record<string, unknown> = {
+    proof_mode: "dry_run",
+    candidate_id: decision.todo_id,
+    workflow_key: workflowKey,
+    action,
+    safety_reason: safety.reason,
+    owner_age_minutes: ownerAgeMinutes,
+    decision_action: decision.action,
+    assigned_to_agent_id: decision.assigned_to_agent_id,
+    has_lease_token: decision.has_lease_token,
+    lease_expires_at: decision.lease_expires_at,
+    reclaim_count: decision.reclaim_count,
+    next_reclaim_count: decision.next_reclaim_count,
+    latest_handoff_receipt_id: decision.latest_handoff_receipt_id,
+    next_checkin_at: decision.next_checkin_at ?? null,
+    last_seen_at: decision.last_seen_at ?? null,
+    planned_signal_action: plannedSignal?.action ?? null,
+  };
+
+  return {
+    mode: "dry_run",
+    action,
+    candidate_id: decision.todo_id,
+    workflow_key: workflowKey,
+    decision,
+    signal,
+    safety,
+    owner_age_minutes: ownerAgeMinutes,
+    proof: {
+      summary: `Vercel worker movement pilot ${action} for todo ${decision.todo_id}.`,
+      next_safe_step: nextSafeStep,
+      payload: proofPayload,
+    },
+  };
+}
+
+export function buildWorkerMovementWorkflowPilotProofText(
+  plan: WorkerMovementWorkflowPilotPlan,
+): string {
+  const ownerAge = plan.owner_age_minutes === null
+    ? "unknown"
+    : `${plan.owner_age_minutes}m`;
+  return [
+    `Vercel worker movement pilot ${plan.action}`,
+    `candidate ${plan.candidate_id}`,
+    `owner age ${ownerAge}`,
+    `decision ${plan.decision.action}`,
+    `reason ${plan.safety.reason}`,
+    `next ${plan.proof.next_safe_step}`,
+  ].join("; ");
+}
+
+function sanitizeWorkerMovementDecision(
+  decision: WorkerSelfHealingDecision,
+): WorkerMovementWorkflowPilotDecision {
+  const { lease_token: leaseToken, ...safeDecision } = decision;
+  return {
+    ...safeDecision,
+    has_lease_token: Boolean(leaseToken),
+  };
+}
+
 function dispatchToDbRow(dispatch: AgentDispatch) {
   return {
     api_key_hash: dispatch.apiKeyHash,
@@ -423,6 +552,47 @@ function nonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
+}
+
+function workerMovementBlockedReason(title: unknown): string | null {
+  const text = String(title ?? "").toLowerCase();
+  if (!text) return null;
+  if (/\bsecurity\b|owner auth|owner-auth/.test(text)) {
+    return "owner_or_security_gated_job";
+  }
+  if (/\bbilling\b|\bdns\b|\bsecret(s)?\b|production deploy|data deletion|human decision/.test(text)) {
+    return "high_risk_job_requires_human_or_owner";
+  }
+  return null;
+}
+
+function workerMovementOwnerAgeMinutes(
+  decision: WorkerMovementWorkflowPilotDecision,
+  nowMs: number,
+  profile?: ProfileRow | null,
+): number | null {
+  const timestamp = decision.lease_expires_at
+    ?? decision.next_checkin_at
+    ?? decision.last_seen_at
+    ?? profile?.next_checkin_at
+    ?? profile?.last_seen_at;
+  if (!timestamp) return null;
+  const eventMs = new Date(timestamp).getTime();
+  if (Number.isNaN(eventMs)) return null;
+  return Math.max(0, Math.round((nowMs - eventMs) / 60_000));
+}
+
+function workerMovementNextSafeStep(
+  action: WorkerMovementWorkflowPilotAction,
+  reason: string,
+): string {
+  if (action === "start_dry_run") {
+    return "start Vercel Workflow in dry-run mode and post proof only";
+  }
+  if (action === "post_refusal_proof") {
+    return `post refusal proof and leave the job with its owner (${reason})`;
+  }
+  return "skip workflow start and keep cron watcher as fallback";
 }
 
 function ackTokenForDispatch(row: DispatchRow): string | null {

--- a/docs/vercel-workflow-worker-movement-pilot.md
+++ b/docs/vercel-workflow-worker-movement-pilot.md
@@ -1,0 +1,94 @@
+# Vercel Workflow Worker Movement Pilot
+
+## Decision
+
+Chris greenlit the worker-movement infrastructure split on 2026-05-16:
+
+- Use Vercel Workflow or Vercel Queues first for short reliable background tasks.
+- Use Railway only if UnClick needs a true always-running watcher or reclaimer and Vercel cannot keep that loop reliable.
+
+This pilot should prove the Vercel path before adding a separate Railway worker.
+
+## Job
+
+Boardroom job: `ae075a74-86a6-450a-8986-c14fca8cecd5`
+
+Title: Vercel Workflow pilot: worker movement proof-first job
+
+Owner hint: `unclick-fleet-action-runner`
+
+## Goal
+
+Add a proof-first Vercel Workflow pilot that can run the worker-movement decision loop safely:
+
+1. Find at most one stale or expired claim candidate.
+2. Reuse the existing worker self-healing planner logic.
+3. Decide whether the candidate is safe to act on.
+4. Post Boardroom proof with the candidate id, owner age, decision, and next safe step.
+5. Keep the current cron watcher as fallback until the pilot proves durable behavior.
+
+## Existing Anchors
+
+Reuse these files before creating new concepts:
+
+- `api/fishbowl-watcher.ts`
+  - Missed check-in handling.
+  - Stale dispatch reclaim and reroute handling.
+  - Worker self-healing todo lease signal sweep.
+  - Planner-style helpers such as `planWorkerSelfHealingDecision`, `buildWorkerSelfHealingSignal`, and `planWorkerSelfHealingTodoSignal`.
+- `api/lib/fishbowl-todo-handoff.ts`
+  - Todo claim, refresh, release, lease expiry, and `reclaim_count` helpers.
+- `api/signals-dispatch.ts`
+  - Delivery path for `mc_signals` after signal creation.
+
+## Vercel Split
+
+Use Vercel Workflow when the pilot needs step-based durable execution, retry, pause or resume behavior, and dashboard visibility.
+
+Use raw Vercel Queues only if the implementation needs explicit topics, consumer groups, delayed delivery, fanout, or polling outside Vercel.
+
+Keep Railway out of this PR unless the Vercel pilot cannot provide reliable movement after proof.
+
+## Safety Rules
+
+The first implementation must be proof-first and non-destructive.
+
+Do not reclaim or mutate:
+
+- Security-gated jobs.
+- Owner-auth jobs.
+- Billing, DNS, secret, production deploy, or data deletion jobs.
+- Jobs with a pending human decision.
+- Active leases that have not expired.
+
+Do not print lease tokens, API keys, auth values, or private credentials.
+
+## Acceptance
+
+- The workflow run is idempotent by todo id, lease id, or other stable candidate id.
+- The default mode is dry-run or proof-only.
+- Each run evaluates at most one candidate.
+- Unsafe candidates produce a refusal proof instead of action.
+- Stale detection and refusal paths have a small focused test.
+- Boardroom proof includes candidate id, owner age, decision, and next safe step.
+- The existing cron watcher remains in place as fallback.
+
+## Suggested First Slice
+
+Add a thin workflow route or workflow module that wraps existing planner logic and posts proof only.
+
+Do not add a new job table. Do not add a new scheduler family. Do not introduce Railway.
+
+The useful first PR can be as small as:
+
+- Workflow entrypoint.
+- Shared candidate decision wrapper that calls existing helpers.
+- Test fixtures for one stale safe candidate and one unsafe refused candidate.
+- Boardroom proof text builder.
+
+## Proof Trail
+
+- Greenlight receipt: `876f228a-38fa-45a3-8373-d24a319a0670`
+- Job request receipt: `4a35502c-4c36-44a4-a860-0eb74a1f8b4c`
+- Prior Worker self-healing todo: `2889ee70-9e9c-4568-b172-81769e0baa39`
+- Prior scoping comments: `546cf029-eae9-4ee6-a92f-3550a7d5f2fe`, `7281ff3e-a29c-4b50-97a1-bfa6c753d1bc`, `b4a4b5ad-664d-43d5-bdd4-0e687e7e9f06`, `0c75d639-cb14-435d-a5cb-6b41ac0bab51`, `0d037a4c-c768-4e34-80a5-076af452b19d`

--- a/docs/vercel-workflow-worker-movement-pilot.md
+++ b/docs/vercel-workflow-worker-movement-pilot.md
@@ -86,6 +86,17 @@ The useful first PR can be as small as:
 - Test fixtures for one stale safe candidate and one unsafe refused candidate.
 - Boardroom proof text builder.
 
+## Current PR Slice
+
+PR #816 now adds the workflow-ready planner shape before adding a live Workflow DevKit dependency:
+
+- `planWorkerMovementWorkflowPilot` wraps the existing worker self-healing decision logic.
+- Default mode is `dry_run`.
+- The plan evaluates one candidate and emits either `start_dry_run`, `post_refusal_proof`, or `skip_no_action`.
+- Security, owner-auth, billing, DNS, secrets, production deploy, data deletion, and pending human decision titles are refused before a workflow run is started.
+- `buildWorkerMovementWorkflowPilotProofText` formats the Boardroom proof line.
+- Tests cover a safe stale candidate, a security-gated refusal, and a no-action skip.
+
 ## Proof Trail
 
 - Greenlight receipt: `876f228a-38fa-45a3-8373-d24a319a0670`


### PR DESCRIPTION
## Summary
- Adds a proof-first Vercel Workflow worker-movement pilot brief.
- Adds `planWorkerMovementWorkflowPilot`, a dry-run planner that wraps the existing worker self-healing decision logic.
- Adds refusal and proof text helpers so a future workflow can evaluate one candidate, start only in dry-run mode, or leave refusal proof for high-risk work.
- Links the Boardroom job `ae075a74-86a6-450a-8986-c14fca8cecd5` and records the Vercel-first, Railway-later split.

## Safety
- Default mode is `dry_run`.
- No live reclaim, lease mutation, secrets, billing, DNS, auth, production data, or deploy behavior changes.
- Security, owner-auth, billing, DNS, secrets, production deploy, data deletion, and pending human decision titles refuse before workflow start.
- Keeps the existing cron watcher as fallback.

## Verification
- `npx vitest run api/fishbowl-watcher.test.ts`
- `git diff --check`
- `npm run build`

Proof receipts: `876f228a-38fa-45a3-8373-d24a319a0670`, `4a35502c-4c36-44a4-a860-0eb74a1f8b4c`.