### PR TITLE
build worker movement proof signal planner

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -18,6 +18,7 @@ import {
   isWakepassAutoRerouteEligible,
   messageAcknowledgesDispatch,
   planWorkerMovementWorkflowPilot,
+  planWorkerMovementWorkflowPilotProofSignal,
   planWorkerSelfHealingDecision,
   planWorkerSelfHealingTodoSignal,
   resolveWakepassRerouteTarget,
@@ -840,5 +841,130 @@ describe("Vercel worker movement workflow pilot plan", () => {
         next_safe_step: "skip workflow start and keep cron watcher as fallback",
       },
     });
+  });
+
+  it("turns a safe dry-run plan into a PASS proof signal insert", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "Worker self-healing: heartbeat timeout, reclaim, and resume-safe queue behavior",
+      todo: {
+        id: "todo-expired-lease",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-11",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    const proof = planWorkerMovementWorkflowPilotProofSignal({
+      apiKeyHash: "hash_123",
+      plan,
+      emittedAt: "2026-05-01T01:22:01.000Z",
+    });
+
+    expect(proof).toMatchObject({
+      signal: {
+        action: "worker_movement_workflow_pilot_pass",
+        severity: "info",
+        summary:
+          "PASS: Vercel worker movement pilot start_dry_run; candidate todo-expired-lease; owner age 12m; decision expired_lease_reclaimable; reason safe_proof_only_candidate; next start Vercel Workflow in dry-run mode and post proof only",
+        payload: {
+          proof_status: "PASS",
+          candidate_id: "todo-expired-lease",
+          action: "start_dry_run",
+          next_safe_step: "start Vercel Workflow in dry-run mode and post proof only",
+          emitted_at: "2026-05-01T01:22:01.000Z",
+        },
+      },
+      insert: {
+        api_key_hash: "hash_123",
+        tool: "fishbowl",
+        action: "worker_movement_workflow_pilot_pass",
+        severity: "info",
+        deep_link: "/admin/jobs#todo-todo-expired-lease",
+      },
+    });
+    expect(JSON.stringify(proof)).not.toContain("lease-secret");
+  });
+
+  it("turns a refused candidate into a BLOCKER proof signal insert", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "SECURITY: deactivate legacy plaintext api_keys_legacy rows after owner auth",
+      todo: {
+        id: "todo-security",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 0,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-12",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    const proof = planWorkerMovementWorkflowPilotProofSignal({
+      apiKeyHash: "hash_123",
+      plan,
+      emittedAt: "2026-05-01T01:22:01.000Z",
+      deepLink: "/admin/jobs#todo-security",
+    });
+
+    expect(proof).toMatchObject({
+      signal: {
+        action: "worker_movement_workflow_pilot_blocker",
+        severity: "action_needed",
+        payload: {
+          proof_status: "BLOCKER",
+          candidate_id: "todo-security",
+          action: "post_refusal_proof",
+          safety_reason: "owner_or_security_gated_job",
+        },
+      },
+      insert: {
+        api_key_hash: "hash_123",
+        tool: "fishbowl",
+        action: "worker_movement_workflow_pilot_blocker",
+        severity: "action_needed",
+        deep_link: "/admin/jobs#todo-security",
+      },
+    });
+    expect(proof?.signal.summary).toContain("BLOCKER:");
+    expect(JSON.stringify(proof)).not.toContain("lease-secret");
+  });
+
+  it("does not plan a proof signal without a tenant hash or emitted time", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "Worker self-healing: heartbeat timeout, reclaim, and resume-safe queue behavior",
+      todo: {
+        id: "todo-expired-lease",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-13",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(
+      planWorkerMovementWorkflowPilotProofSignal({
+        apiKeyHash: "",
+        plan,
+        emittedAt: "2026-05-01T01:22:01.000Z",
+      }),
+    ).toBeNull();
+    expect(
+      planWorkerMovementWorkflowPilotProofSignal({
+        apiKeyHash: "hash_123",
+        plan,
+        emittedAt: "",
+      }),
+    ).toBeNull();
   });
 });

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -165,6 +165,10 @@ export interface WorkerSelfHealingTodoSignalPlan {
   insert: WorkerSelfHealingSignalInsertRow;
 }
 
+export type WorkerMovementWorkflowPilotProofAction =
+  | "worker_movement_workflow_pilot_pass"
+  | "worker_movement_workflow_pilot_blocker";
+
 export type WorkerMovementWorkflowPilotAction =
   | "start_dry_run"
   | "post_refusal_proof"
@@ -192,6 +196,28 @@ export interface WorkerMovementWorkflowPilotPlan {
     next_safe_step: string;
     payload: Record<string, unknown>;
   };
+}
+
+export interface WorkerMovementWorkflowPilotProofSignal {
+  action: WorkerMovementWorkflowPilotProofAction;
+  severity: "info" | "action_needed";
+  summary: string;
+  payload: Record<string, unknown>;
+}
+
+export interface WorkerMovementWorkflowPilotProofSignalInsertRow {
+  api_key_hash: string;
+  tool: "fishbowl";
+  action: WorkerMovementWorkflowPilotProofAction;
+  severity: WorkerMovementWorkflowPilotProofSignal["severity"];
+  summary: string;
+  deep_link: string;
+  payload: Record<string, unknown>;
+}
+
+export interface WorkerMovementWorkflowPilotProofSignalPlan {
+  signal: WorkerMovementWorkflowPilotProofSignal;
+  insert: WorkerMovementWorkflowPilotProofSignalInsertRow;
 }
 
 export function isMissedCheckinCandidate(profile: ProfileRow, nowMs: number): boolean {
@@ -510,6 +536,52 @@ export function buildWorkerMovementWorkflowPilotProofText(
     `reason ${plan.safety.reason}`,
     `next ${plan.proof.next_safe_step}`,
   ].join("; ");
+}
+
+export function planWorkerMovementWorkflowPilotProofSignal(params: {
+  apiKeyHash: string;
+  plan: WorkerMovementWorkflowPilotPlan;
+  emittedAt: string;
+  deepLink?: string;
+}): WorkerMovementWorkflowPilotProofSignalPlan | null {
+  const apiKeyHash = nonEmptyString(params.apiKeyHash);
+  const emittedAt = nonEmptyString(params.emittedAt);
+  if (!apiKeyHash || !emittedAt) return null;
+
+  const action: WorkerMovementWorkflowPilotProofAction =
+    params.plan.action === "post_refusal_proof"
+      ? "worker_movement_workflow_pilot_blocker"
+      : "worker_movement_workflow_pilot_pass";
+  const severity: WorkerMovementWorkflowPilotProofSignal["severity"] =
+    action === "worker_movement_workflow_pilot_blocker" ? "action_needed" : "info";
+  const status = action === "worker_movement_workflow_pilot_blocker"
+    ? "BLOCKER"
+    : "PASS";
+  const summary = `${status}: ${buildWorkerMovementWorkflowPilotProofText(params.plan)}`;
+  const payload = {
+    ...params.plan.proof.payload,
+    proof_status: status,
+    emitted_at: emittedAt,
+    next_safe_step: params.plan.proof.next_safe_step,
+  };
+
+  return {
+    signal: {
+      action,
+      severity,
+      summary,
+      payload,
+    },
+    insert: {
+      api_key_hash: apiKeyHash,
+      tool: "fishbowl",
+      action,
+      severity,
+      summary,
+      deep_link: params.deepLink ?? `/admin/jobs#todo-${params.plan.candidate_id}`,
+      payload,
+    },
+  };
 }
 
 function sanitizeWorkerMovementDecision(

--- a/docs/vercel-workflow-worker-movement-pilot.md
+++ b/docs/vercel-workflow-worker-movement-pilot.md
@@ -97,6 +97,16 @@ PR #816 now adds the workflow-ready planner shape before adding a live Workflow 
 - `buildWorkerMovementWorkflowPilotProofText` formats the Boardroom proof line.
 - Tests cover a safe stale candidate, a security-gated refusal, and a no-action skip.
 
+## Follow-Up Slice
+
+The next proof-only slice adds `planWorkerMovementWorkflowPilotProofSignal`, which turns a dry-run planner result into a safe `mc_signals` insert row:
+
+- Safe candidates produce `worker_movement_workflow_pilot_pass` with `severity: "info"`.
+- Refused candidates produce `worker_movement_workflow_pilot_blocker` with `severity: "action_needed"`.
+- Payloads carry candidate id, owner age, decision, next safe step, proof status, and emitted time.
+- Lease tokens remain redacted, only `has_lease_token` is exposed.
+- The helper returns null if tenant hash or emitted time is missing.
+
 ## Proof Trail
 
 - Greenlight receipt: `876f228a-38fa-45a3-8373-d24a319a0670`


### PR DESCRIPTION
## Summary
- Adds `planWorkerMovementWorkflowPilotProofSignal` for the Vercel worker movement pilot.
- Converts dry-run planner results into safe PASS or BLOCKER `mc_signals` insert rows.
- Keeps lease tokens redacted and only exposes `has_lease_token`.
- Updates the pilot doc with this proof-only follow-up slice.

## Safety
- Proof-only helper, no live reclaim, no lease mutation, no database writes by itself.
- No secrets, billing, DNS, auth, production data, or deploy behavior changes.
- BLOCKER proof is used for refused candidates instead of movement.

## Verification
- `npx vitest run api/fishbowl-watcher.test.ts`
- `git diff --check`
- `npm run build`

Boardroom claim: `5dcae33a-8efb-4de5-8984-14bdc0450627`.