### PR TITLE
feat(securitypass): wire memory embed spend guardrail

### DIFF
--- a/api/memory-embed-guardrail.test.ts
+++ b/api/memory-embed-guardrail.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { decideMemoryEmbedProviderCall } from "./memory/embed";
+
+describe("memory embed spend guardrail", () => {
+  it("blocks the OpenAI embedding provider path by default", () => {
+    expect(decideMemoryEmbedProviderCall(false)).toMatchObject({
+      allowed: false,
+      path_id: "memory.api.openai.embed-endpoint",
+      provider: "OpenAI",
+      model: "text-embedding-3-small",
+      cost_tier: "paid",
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "ADMIN_EMBED_SECRET",
+    });
+  });
+
+  it("allows the provider path only after the existing admin embed gate passes", () => {
+    expect(decideMemoryEmbedProviderCall(true)).toMatchObject({
+      allowed: true,
+      path_id: "memory.api.openai.embed-endpoint",
+      provider: "OpenAI",
+      model: "text-embedding-3-small",
+      cost_tier: "paid",
+      reason: "explicit_paid_allowed",
+      allow_paid_flag: "ADMIN_EMBED_SECRET",
+    });
+  });
+});

--- a/api/memory/embed.ts
+++ b/api/memory/embed.ts
@@ -15,6 +15,10 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient } from "@supabase/supabase-js";
+import {
+  decideAiProviderCall,
+  type AiProviderCallDecision,
+} from "../lib/ai-provider-inventory";
 
 const ALLOWED_TABLES = new Set([
   "mc_extracted_facts",
@@ -25,9 +29,18 @@ const ALLOWED_TABLES = new Set([
 
 const EMBEDDING_MODEL = "text-embedding-3-small";
 const MAX_INPUT_CHARS = 32_000;
+const MEMORY_EMBED_PROVIDER_PATH_ID = "memory.api.openai.embed-endpoint";
 
 interface OpenAIEmbeddingResponse {
   data: Array<{ embedding: number[] }>;
+}
+
+export function decideMemoryEmbedProviderCall(allowPaid: boolean): AiProviderCallDecision {
+  return decideAiProviderCall({
+    path_id: MEMORY_EMBED_PROVIDER_PATH_ID,
+    model: EMBEDDING_MODEL,
+    allow_paid: allowPaid,
+  });
 }
 
 function shouldSkipMemoryEmbedding(text: string): boolean {
@@ -86,6 +99,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const provided = req.headers["x-embed-secret"] ?? req.headers["authorization"]?.replace("Bearer ", "");
   if (provided !== secret) {
     return res.status(401).json({ error: "unauthorized" });
+  }
+
+  const providerDecision = decideMemoryEmbedProviderCall(provided === secret);
+  if (!providerDecision.allowed) {
+    return res.status(503).json({
+      error: "AI provider call blocked by spend guardrail",
+      provider: providerDecision.provider,
+      model: providerDecision.model,
+      cost_tier: providerDecision.cost_tier,
+      reason: providerDecision.reason,
+      allow_paid_flag: providerDecision.allow_paid_flag,
+    });
   }
 
   const openaiKey = process.env.OPENAI_API_KEY;


### PR DESCRIPTION
Summary:
Wires the /api/memory/embed runtime path through the merged AI provider inventory decision helper before it can call OpenAI embeddings.

Scope:
- Owned files: api/memory/embed.ts, api/memory-embed-guardrail.test.ts
- Linked todo: 6408ff7b-7629-471b-b745-318ebb82b7a0 AI spend guardrails

Non-overlap:
No UI, keychain, billing, DNS, production data, Supabase schema, or other AI call paths changed.

Verification:
- npm run test -- api/memory-embed-guardrail.test.ts api/ai-provider-inventory.test.ts
- git diff --cached --check before commit

Risk:
Low. The provider call remains behind the existing ADMIN_EMBED_SECRET auth gate, and the new guard exposes a fail-closed decision path for the paid OpenAI embedding surface.

Follow-up:
Wire the next model or classifier surface after this narrow runtime slice is reviewed.

Draft status:
Draft PR for CI and review.