### PR TITLE
build worker movement proof API

### DIFF
--- a/api/worker-movement-pilot.test.ts
+++ b/api/worker-movement-pilot.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  runWorkerMovementPilotDryRun,
+  type WorkerMovementPilotStore,
+  type WorkerMovementPilotTodoRow,
+} from "./worker-movement-pilot.js";
+
+const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
+
+function buildStore(params: {
+  candidate: WorkerMovementPilotTodoRow | null;
+  recentProof?: boolean;
+  fetchError?: string | null;
+  dedupeError?: string | null;
+  insertError?: string | null;
+}) {
+  const inserted: unknown[] = [];
+  const dedupeChecks: unknown[] = [];
+  const fetches: string[] = [];
+  const store: WorkerMovementPilotStore = {
+    async fetchCandidate(nowIso) {
+      fetches.push(nowIso);
+      return {
+        data: params.candidate,
+        error: params.fetchError ?? null,
+      };
+    },
+    async hasRecentProof(check) {
+      dedupeChecks.push(check);
+      return {
+        data: params.recentProof ?? false,
+        error: params.dedupeError ?? null,
+      };
+    },
+    async insertProof(row) {
+      inserted.push(row);
+      return { error: params.insertError ?? null };
+    },
+  };
+  return { store, inserted, dedupeChecks, fetches };
+}
+
+function expiredLeaseCandidate(overrides: Partial<WorkerMovementPilotTodoRow> = {}) {
+  return {
+    id: "todo-expired-lease",
+    api_key_hash: "hash_123",
+    title: "Worker self-healing: heartbeat timeout, reclaim, and resume-safe queue behavior",
+    status: "in_progress",
+    assigned_to_agent_id: "worker-1",
+    lease_token: "lease-secret",
+    lease_expires_at: "2026-05-01T01:10:00.000Z",
+    reclaim_count: 2,
+    ...overrides,
+  };
+}
+
+describe("worker movement pilot API dry-run", () => {
+  it("skips cleanly when no expired todo lease candidate exists", async () => {
+    const { store, inserted, dedupeChecks, fetches } = buildStore({ candidate: null });
+
+    const result = await runWorkerMovementPilotDryRun({ store, nowMs });
+
+    expect(result).toMatchObject({
+      ok: true,
+      mode: "dry_run",
+      status: "skip_no_candidate",
+      candidate_id: null,
+      action: "skip_no_candidate",
+      proof_inserted: false,
+      proof_deduped: false,
+      next_safe_step: "skip workflow start and keep cron watcher as fallback",
+    });
+    expect(fetches).toEqual(["2026-05-01T01:22:00.000Z"]);
+    expect(dedupeChecks).toEqual([]);
+    expect(inserted).toEqual([]);
+  });
+
+  it("inserts PASS proof for one safe expired lease candidate", async () => {
+    const { store, inserted, dedupeChecks } = buildStore({
+      candidate: expiredLeaseCandidate(),
+    });
+
+    const result = await runWorkerMovementPilotDryRun({ store, nowMs });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "proof_inserted",
+      candidate_id: "todo-expired-lease",
+      action: "start_dry_run",
+      proof_signal_action: "worker_movement_workflow_pilot_pass",
+      proof_status: "PASS",
+      proof_inserted: true,
+      proof_deduped: false,
+      next_safe_step: "start Vercel Workflow in dry-run mode and post proof only",
+    });
+    expect(dedupeChecks).toMatchObject([
+      {
+        apiKeyHash: "hash_123",
+        action: "worker_movement_workflow_pilot_pass",
+        candidateId: "todo-expired-lease",
+        sinceIso: "2026-05-01T00:52:00.000Z",
+      },
+    ]);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      api_key_hash: "hash_123",
+      tool: "fishbowl",
+      action: "worker_movement_workflow_pilot_pass",
+      severity: "info",
+      deep_link: "/admin/jobs#todo-todo-expired-lease",
+      payload: {
+        proof_status: "PASS",
+        candidate_id: "todo-expired-lease",
+        has_lease_token: true,
+        action: "start_dry_run",
+      },
+    });
+    expect(JSON.stringify(inserted[0])).not.toContain("lease-secret");
+  });
+
+  it("inserts BLOCKER proof for an owner or security gated candidate", async () => {
+    const { store, inserted } = buildStore({
+      candidate: expiredLeaseCandidate({
+        id: "todo-security",
+        title: "SECURITY: deactivate legacy plaintext api_keys_legacy rows after owner auth",
+      }),
+    });
+
+    const result = await runWorkerMovementPilotDryRun({ store, nowMs });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "proof_inserted",
+      candidate_id: "todo-security",
+      action: "post_refusal_proof",
+      proof_signal_action: "worker_movement_workflow_pilot_blocker",
+      proof_status: "BLOCKER",
+      next_safe_step:
+        "post refusal proof and leave the job with its owner (owner_or_security_gated_job)",
+    });
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      action: "worker_movement_workflow_pilot_blocker",
+      severity: "action_needed",
+      payload: {
+        proof_status: "BLOCKER",
+        candidate_id: "todo-security",
+        safety_reason: "owner_or_security_gated_job",
+      },
+    });
+    expect(JSON.stringify(inserted[0])).not.toContain("lease-secret");
+  });
+
+  it("dedupes proof when the same candidate was recently emitted", async () => {
+    const { store, inserted } = buildStore({
+      candidate: expiredLeaseCandidate(),
+      recentProof: true,
+    });
+
+    const result = await runWorkerMovementPilotDryRun({ store, nowMs });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "proof_recently_emitted",
+      candidate_id: "todo-expired-lease",
+      proof_inserted: false,
+      proof_deduped: true,
+    });
+    expect(inserted).toEqual([]);
+  });
+
+  it("reports proof insert failure without mutating the candidate", async () => {
+    const { store } = buildStore({
+      candidate: expiredLeaseCandidate(),
+      insertError: "temporary insert failure",
+    });
+
+    const result = await runWorkerMovementPilotDryRun({ store, nowMs });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "proof_insert_failed",
+      candidate_id: "todo-expired-lease",
+      action: "start_dry_run",
+      proof_signal_action: "worker_movement_workflow_pilot_pass",
+      proof_status: "PASS",
+      proof_inserted: false,
+      proof_deduped: false,
+      error: "temporary insert failure",
+    });
+  });
+});

--- a/api/worker-movement-pilot.ts
+++ b/api/worker-movement-pilot.ts
@@ -1,0 +1,277 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+import {
+  planWorkerMovementWorkflowPilot,
+  planWorkerMovementWorkflowPilotProofSignal,
+  type WorkerMovementWorkflowPilotAction,
+  type WorkerMovementWorkflowPilotProofAction,
+  type WorkerMovementWorkflowPilotProofSignalInsertRow,
+  type WorkerSelfHealingTodoState,
+} from "./fishbowl-watcher.js";
+
+const WORKER_MOVEMENT_PILOT_DEDUP_WINDOW_MS = 30 * 60 * 1000;
+
+export interface WorkerMovementPilotTodoRow extends WorkerSelfHealingTodoState {
+  api_key_hash: string;
+  title?: string | null;
+}
+
+export interface WorkerMovementPilotStore {
+  fetchCandidate(nowIso: string): Promise<{
+    data: WorkerMovementPilotTodoRow | null;
+    error: string | null;
+  }>;
+  hasRecentProof(params: {
+    apiKeyHash: string;
+    action: WorkerMovementWorkflowPilotProofAction;
+    candidateId: string;
+    sinceIso: string;
+  }): Promise<{
+    data: boolean;
+    error: string | null;
+  }>;
+  insertProof(row: WorkerMovementWorkflowPilotProofSignalInsertRow): Promise<{
+    error: string | null;
+  }>;
+}
+
+export type WorkerMovementPilotRunStatus =
+  | "skip_no_candidate"
+  | "proof_inserted"
+  | "proof_recently_emitted"
+  | "candidate_fetch_failed"
+  | "proof_planning_failed"
+  | "proof_dedupe_failed"
+  | "proof_insert_failed";
+
+export interface WorkerMovementPilotRunResult {
+  ok: boolean;
+  mode: "dry_run";
+  status: WorkerMovementPilotRunStatus;
+  candidate_id: string | null;
+  action: WorkerMovementWorkflowPilotAction | "skip_no_candidate" | null;
+  proof_signal_action: WorkerMovementWorkflowPilotProofAction | null;
+  proof_status: "PASS" | "BLOCKER" | null;
+  proof_inserted: boolean;
+  proof_deduped: boolean;
+  summary: string;
+  next_safe_step: string;
+  error?: string;
+}
+
+export function createWorkerMovementPilotStore(
+  supabase: ReturnType<typeof createClient>,
+): WorkerMovementPilotStore {
+  return {
+    async fetchCandidate(nowIso) {
+      const { data, error } = await supabase
+        .from("mc_fishbowl_todos")
+        .select("id, api_key_hash, title, status, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count")
+        .in("status", ["open", "in_progress"])
+        .not("lease_expires_at", "is", null)
+        .lt("lease_expires_at", nowIso)
+        .order("lease_expires_at", { ascending: true })
+        .limit(1);
+      return {
+        data: ((data ?? []) as WorkerMovementPilotTodoRow[])[0] ?? null,
+        error: error?.message ?? null,
+      };
+    },
+    async hasRecentProof(params) {
+      const { data, error } = await supabase
+        .from("mc_signals")
+        .select("action, payload, created_at")
+        .eq("api_key_hash", params.apiKeyHash)
+        .eq("tool", "fishbowl")
+        .eq("action", params.action)
+        .gt("created_at", params.sinceIso);
+
+      if (error) {
+        return { data: false, error: error.message };
+      }
+
+      const alreadyEmitted = ((data ?? []) as Array<{
+        payload: Record<string, unknown> | null;
+      }>).some((signal) => signal.payload?.candidate_id === params.candidateId);
+      return { data: alreadyEmitted, error: null };
+    },
+    async insertProof(row) {
+      const { error } = await supabase.from("mc_signals").insert(row);
+      return { error: error?.message ?? null };
+    },
+  };
+}
+
+export async function runWorkerMovementPilotDryRun(params: {
+  store: WorkerMovementPilotStore;
+  nowMs?: number;
+}): Promise<WorkerMovementPilotRunResult> {
+  const nowMs = params.nowMs ?? Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const candidateResult = await params.store.fetchCandidate(nowIso);
+
+  if (candidateResult.error) {
+    return failureResult({
+      status: "candidate_fetch_failed",
+      summary: "Worker movement pilot could not fetch a candidate.",
+      nextSafeStep: "fix candidate query or database access, then rerun dry-run",
+      error: candidateResult.error,
+    });
+  }
+
+  const candidate = candidateResult.data;
+  if (!candidate) {
+    return {
+      ok: true,
+      mode: "dry_run",
+      status: "skip_no_candidate",
+      candidate_id: null,
+      action: "skip_no_candidate",
+      proof_signal_action: null,
+      proof_status: null,
+      proof_inserted: false,
+      proof_deduped: false,
+      summary: "Worker movement pilot found no expired todo lease candidate.",
+      next_safe_step: "skip workflow start and keep cron watcher as fallback",
+    };
+  }
+
+  const plan = planWorkerMovementWorkflowPilot({
+    todo: candidate,
+    title: candidate.title,
+    profile: null,
+    latestHandoffReceiptId: null,
+    nowMs,
+  });
+  const proof = planWorkerMovementWorkflowPilotProofSignal({
+    apiKeyHash: candidate.api_key_hash,
+    plan,
+    emittedAt: nowIso,
+  });
+
+  if (!proof) {
+    return failureResult({
+      status: "proof_planning_failed",
+      candidateId: plan.candidate_id,
+      action: plan.action,
+      summary: "Worker movement pilot could not build proof signal.",
+      nextSafeStep: "check tenant hash and emitted time before rerun",
+    });
+  }
+
+  const proofStatus = proof.signal.action === "worker_movement_workflow_pilot_blocker"
+    ? "BLOCKER"
+    : "PASS";
+  const dedupeResult = await params.store.hasRecentProof({
+    apiKeyHash: candidate.api_key_hash,
+    action: proof.insert.action,
+    candidateId: plan.candidate_id,
+    sinceIso: new Date(nowMs - WORKER_MOVEMENT_PILOT_DEDUP_WINDOW_MS).toISOString(),
+  });
+
+  if (dedupeResult.error) {
+    return failureResult({
+      status: "proof_dedupe_failed",
+      candidateId: plan.candidate_id,
+      action: plan.action,
+      proofSignalAction: proof.signal.action,
+      proofStatus,
+      summary: "Worker movement pilot could not check recent proof.",
+      nextSafeStep: "fix proof dedupe query or database access, then rerun dry-run",
+      error: dedupeResult.error,
+    });
+  }
+
+  if (dedupeResult.data) {
+    return {
+      ok: true,
+      mode: "dry_run",
+      status: "proof_recently_emitted",
+      candidate_id: plan.candidate_id,
+      action: plan.action,
+      proof_signal_action: proof.signal.action,
+      proof_status: proofStatus,
+      proof_inserted: false,
+      proof_deduped: true,
+      summary: proof.signal.summary,
+      next_safe_step: plan.proof.next_safe_step,
+    };
+  }
+
+  const insertResult = await params.store.insertProof(proof.insert);
+  if (insertResult.error) {
+    return failureResult({
+      status: "proof_insert_failed",
+      candidateId: plan.candidate_id,
+      action: plan.action,
+      proofSignalAction: proof.signal.action,
+      proofStatus,
+      summary: "Worker movement pilot could not insert proof signal.",
+      nextSafeStep: "fix proof insert or database access, then rerun dry-run",
+      error: insertResult.error,
+    });
+  }
+
+  return {
+    ok: true,
+    mode: "dry_run",
+    status: "proof_inserted",
+    candidate_id: plan.candidate_id,
+    action: plan.action,
+    proof_signal_action: proof.signal.action,
+    proof_status: proofStatus,
+    proof_inserted: true,
+    proof_deduped: false,
+    summary: proof.signal.summary,
+    next_safe_step: plan.proof.next_safe_step,
+  };
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const authHeader = req.headers.authorization ?? "";
+  const expected = `Bearer ${process.env.CRON_SECRET ?? ""}`;
+  if (!process.env.CRON_SECRET || authHeader !== expected) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    return res.status(500).json({ error: "Database service unavailable" });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const result = await runWorkerMovementPilotDryRun({
+    store: createWorkerMovementPilotStore(supabase),
+  });
+  return res.status(result.ok ? 200 : 500).json(result);
+}
+
+function failureResult(params: {
+  status: Exclude<
+    WorkerMovementPilotRunStatus,
+    "skip_no_candidate" | "proof_inserted" | "proof_recently_emitted"
+  >;
+  candidateId?: string | null;
+  action?: WorkerMovementWorkflowPilotAction | null;
+  proofSignalAction?: WorkerMovementWorkflowPilotProofAction | null;
+  proofStatus?: "PASS" | "BLOCKER" | null;
+  summary: string;
+  nextSafeStep: string;
+  error?: string;
+}): WorkerMovementPilotRunResult {
+  return {
+    ok: false,
+    mode: "dry_run",
+    status: params.status,
+    candidate_id: params.candidateId ?? null,
+    action: params.action ?? null,
+    proof_signal_action: params.proofSignalAction ?? null,
+    proof_status: params.proofStatus ?? null,
+    proof_inserted: false,
+    proof_deduped: false,
+    summary: params.summary,
+    next_safe_step: params.nextSafeStep,
+    ...(params.error ? { error: params.error } : {}),
+  };
+}

--- a/docs/vercel-workflow-worker-movement-pilot.md
+++ b/docs/vercel-workflow-worker-movement-pilot.md
@@ -107,6 +107,18 @@ The next proof-only slice adds `planWorkerMovementWorkflowPilotProofSignal`, whi
 - Lease tokens remain redacted, only `has_lease_token` is exposed.
 - The helper returns null if tenant hash or emitted time is missing.
 
+## API Entrypoint Slice
+
+The next slice adds `/api/worker-movement-pilot` as a protected dry-run entrypoint:
+
+- Auth uses the same `Bearer ${CRON_SECRET}` pattern as the existing watcher jobs.
+- Each run fetches at most one expired Boardroom todo lease candidate.
+- The route reuses `planWorkerMovementWorkflowPilot` and `planWorkerMovementWorkflowPilotProofSignal`.
+- It inserts PASS or BLOCKER proof into `mc_signals` only.
+- It dedupes proof for the same candidate and signal action for 30 minutes.
+- It does not reclaim, release, reassign, complete, or mutate the todo lease.
+- A later Workflow wrapper can call this route once the proof-only behavior is stable.
+
 ## Proof Trail
 
 - Greenlight receipt: `876f228a-38fa-45a3-8373-d24a319a0670`


### PR DESCRIPTION
## Summary
- Adds `/api/worker-movement-pilot` as a `CRON_SECRET` protected dry-run endpoint.
- Fetches at most one expired Boardroom todo lease, plans with existing worker movement helpers, and inserts PASS or BLOCKER proof into `mc_signals`.
- Adds 30 minute proof dedupe plus no-candidate and insert-failure handling.
- Updates the worker movement pilot doc with the API entrypoint slice.

## Safety
- Proof-only: no todo reclaim, release, reassignment, completion, or lease mutation.
- Lease tokens stay redacted, only `has_lease_token` is exposed.
- Unsafe owner or security gated candidates produce BLOCKER proof instead of movement.

## Checks
- `npx vitest run api/fishbowl-watcher.test.ts api/worker-movement-pilot.test.ts`
- `npm run build`
- `npx eslint api/worker-movement-pilot.ts api/worker-movement-pilot.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`