### PR TITLE
add worker movement cron safety gate

### DIFF
--- a/api/worker-movement-pilot.test.ts
+++ b/api/worker-movement-pilot.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
+  isWorkerMovementPilotEnabled,
   runWorkerMovementPilotDryRun,
   type WorkerMovementPilotStore,
   type WorkerMovementPilotTodoRow,
@@ -55,6 +57,40 @@ function expiredLeaseCandidate(overrides: Partial<WorkerMovementPilotTodoRow> = 
 }
 
 describe("worker movement pilot API dry-run", () => {
+  it("requires an explicit opt-in before polling candidates", async () => {
+    const { store, inserted, dedupeChecks, fetches } = buildStore({
+      candidate: expiredLeaseCandidate(),
+    });
+
+    const result = await runWorkerMovementPilotDryRun({
+      store,
+      nowMs,
+      enabled: false,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      mode: "dry_run",
+      status: "skip_disabled",
+      candidate_id: null,
+      proof_inserted: false,
+      next_safe_step: "set WORKER_MOVEMENT_PILOT_ENABLED=true after safety review",
+    });
+    expect(fetches).toEqual([]);
+    expect(dedupeChecks).toEqual([]);
+    expect(inserted).toEqual([]);
+  });
+
+  it("accepts only explicit enabled values for the scheduler gate", () => {
+    expect(isWorkerMovementPilotEnabled(undefined)).toBe(false);
+    expect(isWorkerMovementPilotEnabled("")).toBe(false);
+    expect(isWorkerMovementPilotEnabled("0")).toBe(false);
+    expect(isWorkerMovementPilotEnabled("false")).toBe(false);
+    expect(isWorkerMovementPilotEnabled("1")).toBe(true);
+    expect(isWorkerMovementPilotEnabled("true")).toBe(true);
+    expect(isWorkerMovementPilotEnabled("enabled")).toBe(true);
+  });
+
   it("skips cleanly when no expired todo lease candidate exists", async () => {
     const { store, inserted, dedupeChecks, fetches } = buildStore({ candidate: null });
 
@@ -187,6 +223,17 @@ describe("worker movement pilot API dry-run", () => {
       proof_inserted: false,
       proof_deduped: false,
       error: "temporary insert failure",
+    });
+  });
+
+  it("keeps the Vercel cron pointed at the protected proof endpoint", () => {
+    const config = JSON.parse(
+      readFileSync("vercel.json", "utf8"),
+    ) as { crons?: Array<{ path: string; schedule: string }> };
+
+    expect(config.crons).toContainEqual({
+      path: "/api/worker-movement-pilot",
+      schedule: "*/15 * * * *",
     });
   });
 });

--- a/api/worker-movement-pilot.ts
+++ b/api/worker-movement-pilot.ts
@@ -36,6 +36,7 @@ export interface WorkerMovementPilotStore {
 }
 
 export type WorkerMovementPilotRunStatus =
+  | "skip_disabled"
   | "skip_no_candidate"
   | "proof_inserted"
   | "proof_recently_emitted"
@@ -102,10 +103,36 @@ export function createWorkerMovementPilotStore(
   };
 }
 
+export function isWorkerMovementPilotEnabled(value: string | undefined): boolean {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "enabled";
+}
+
+export function buildWorkerMovementPilotDisabledResult(): WorkerMovementPilotRunResult {
+  return {
+    ok: true,
+    mode: "dry_run",
+    status: "skip_disabled",
+    candidate_id: null,
+    action: null,
+    proof_signal_action: null,
+    proof_status: null,
+    proof_inserted: false,
+    proof_deduped: false,
+    summary: "Worker movement pilot is disabled by WORKER_MOVEMENT_PILOT_ENABLED.",
+    next_safe_step: "set WORKER_MOVEMENT_PILOT_ENABLED=true after safety review",
+  };
+}
+
 export async function runWorkerMovementPilotDryRun(params: {
   store: WorkerMovementPilotStore;
   nowMs?: number;
+  enabled?: boolean;
 }): Promise<WorkerMovementPilotRunResult> {
+  if (params.enabled === false) {
+    return buildWorkerMovementPilotDisabledResult();
+  }
+
   const nowMs = params.nowMs ?? Date.now();
   const nowIso = new Date(nowMs).toISOString();
   const candidateResult = await params.store.fetchCandidate(nowIso);
@@ -234,6 +261,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(401).json({ error: "Unauthorized" });
   }
 
+  const enabled = isWorkerMovementPilotEnabled(
+    process.env.WORKER_MOVEMENT_PILOT_ENABLED,
+  );
+  if (!enabled) {
+    return res.status(200).json(buildWorkerMovementPilotDisabledResult());
+  }
+
   const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!supabaseUrl || !supabaseKey) {
@@ -243,6 +277,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const supabase = createClient(supabaseUrl, supabaseKey);
   const result = await runWorkerMovementPilotDryRun({
     store: createWorkerMovementPilotStore(supabase),
+    enabled,
   });
   return res.status(result.ok ? 200 : 500).json(result);
 }
@@ -250,7 +285,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 function failureResult(params: {
   status: Exclude<
     WorkerMovementPilotRunStatus,
-    "skip_no_candidate" | "proof_inserted" | "proof_recently_emitted"
+    "skip_disabled" | "skip_no_candidate" | "proof_inserted" | "proof_recently_emitted"
   >;
   candidateId?: string | null;
   action?: WorkerMovementWorkflowPilotAction | null;

--- a/docs/vercel-workflow-worker-movement-pilot.md
+++ b/docs/vercel-workflow-worker-movement-pilot.md
@@ -119,6 +119,15 @@ The next slice adds `/api/worker-movement-pilot` as a protected dry-run entrypoi
 - It does not reclaim, release, reassign, complete, or mutate the todo lease.
 - A later Workflow wrapper can call this route once the proof-only behavior is stable.
 
+## Scheduler Gate Slice
+
+The scheduler-ready slice adds a quiet Vercel cron call to `/api/worker-movement-pilot` every 15 minutes.
+
+- The endpoint still requires `Bearer ${CRON_SECRET}`.
+- The endpoint now also requires `WORKER_MOVEMENT_PILOT_ENABLED` to be `1`, `true`, or `enabled`.
+- With the env unset, the cron call returns `skip_disabled` without querying todos or inserting proof.
+- This lets production exercise the protected route safely before Chris or an operator enables proof inserts.
+
 ## Proof Trail
 
 - Greenlight receipt: `876f228a-38fa-45a3-8373-d24a319a0670`

--- a/vercel.json
+++ b/vercel.json
@@ -50,6 +50,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/worker-movement-pilot",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/testpass-run?pack_id=testpass-core&profile=smoke&server_url=https%3A%2F%2Funclick.world%2Fapi%2Fmcp&source=scheduled",
       "schedule": "*/5 * * * *"
     },


### PR DESCRIPTION
## Summary
- Adds an explicit `WORKER_MOVEMENT_PILOT_ENABLED` opt-in gate for `/api/worker-movement-pilot`.
- Adds a Vercel cron call for `/api/worker-movement-pilot` every 15 minutes.
- Keeps the scheduled route quiet by default: when the env is unset, it returns `skip_disabled` before database setup, todo polling, or proof inserts.
- Adds tests for the opt-in parser, disabled path, and Vercel cron config.

## Safety
- Cron path still requires `Bearer ${CRON_SECRET}`.
- The default production behavior is quiet until an operator sets `WORKER_MOVEMENT_PILOT_ENABLED=true`.
- Disabled mode does not query todos, insert `mc_signals`, reclaim, release, reassign, complete, or mutate leases.

## Checks
- `npx vitest run api/worker-movement-pilot.test.ts api/fishbowl-watcher.test.ts`
- `npx eslint api/worker-movement-pilot.ts api/worker-movement-pilot.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check`