### PR TITLE
feat(securitypass): guard wake router OpenRouter spend

### DIFF
--- a/api/lib/ai-provider-inventory.ts
+++ b/api/lib/ai-provider-inventory.ts
@@ -56,8 +56,8 @@ export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
     model: "OPENROUTER_WAKE_MODEL",
     cost_tier: "paid_or_unknown",
     default_allowed: false,
-    allow_paid_flag: "OPENROUTER_WAKE_MODEL plus explicit runner approval",
-    notes: "Wake classifier model is environment-selected and must fail closed unless a runner opts into the selected paid or unknown route.",
+    allow_paid_flag: "OPENROUTER_WAKE_ALLOW_PAID",
+    notes: "Wake classifier model is environment-selected. Models explicitly ending in :free may run by default; paid or unknown routes must require the wake allow-paid flag.",
   },
   {
     id: "memory.mcp.openai.embeddings",

--- a/scripts/event-wake-router.mjs
+++ b/scripts/event-wake-router.mjs
@@ -25,6 +25,8 @@ const receivedAt = new Date().toISOString();
 const ledgerDir = process.env.WAKE_LEDGER_DIR || ".wake-ledger";
 const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY || "";
 const DEFAULT_WAKE_OWNER = "🧭";
+const WAKE_OPENROUTER_PROVIDER_PATH_ID = "event-wake-router.openrouter.classifier";
+const WAKE_OPENROUTER_ALLOW_PAID_FLAG = "OPENROUTER_WAKE_ALLOW_PAID";
 const CURRENT_WAKE_OWNERS = new Set(["🧭", "🛠️", "🧪", "🔍", "🛡️", "📣", "👁️", "🩹", "🚀", "all"]);
 const LEGACY_WAKE_OWNER_ALIASES = new Map([
   ["🤖", "🧭"],
@@ -142,6 +144,30 @@ function safeWakeOwner(owner, fallback = DEFAULT_WAKE_OWNER) {
   if (CURRENT_WAKE_OWNERS.has(normalized)) return normalized;
   const normalizedFallback = normalizeDispatchOwner(fallback);
   return CURRENT_WAKE_OWNERS.has(normalizedFallback) ? normalizedFallback : DEFAULT_WAKE_OWNER;
+}
+
+export function isWakeOpenRouterPaidEnabled(value = process.env.OPENROUTER_WAKE_ALLOW_PAID) {
+  return parseBooleanFlag(value);
+}
+
+export function isFreeOpenRouterModel(model) {
+  const normalized = String(model ?? "").trim().toLowerCase();
+  return normalized === "openrouter/free" || normalized.endsWith(":free");
+}
+
+export function decideWakeOpenRouterProviderCall(model, allowPaid = isWakeOpenRouterPaidEnabled()) {
+  const selectedModel = String(model ?? "").trim();
+  const freeModel = isFreeOpenRouterModel(selectedModel);
+  return {
+    allowed: freeModel || allowPaid === true,
+    path_id: WAKE_OPENROUTER_PROVIDER_PATH_ID,
+    provider: "OpenRouter",
+    model: selectedModel || "OPENROUTER_WAKE_MODEL",
+    cost_tier: freeModel ? "free" : "paid_or_unknown",
+    default_allowed: freeModel,
+    reason: freeModel ? "free_default_allowed" : allowPaid === true ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
+    allow_paid_flag: WAKE_OPENROUTER_ALLOW_PAID_FLAG,
+  };
 }
 
 export function normalizeHandoffMessageId(messageId) {
@@ -283,11 +309,20 @@ function eventBrief(event, decision) {
   };
 }
 
-async function cheapTriage(brief, decision) {
+export async function cheapTriage(brief, decision) {
   const apiKey = process.env.OPENROUTER_API_KEY || "";
   const model = process.env.OPENROUTER_WAKE_MODEL || "";
   if (!apiKey || !model || !decision.wake) return { used: false, decision };
   if (decision.needsTriage === false) return { used: false, decision };
+  const providerDecision = decideWakeOpenRouterProviderCall(model);
+  if (!providerDecision.allowed) {
+    return {
+      used: false,
+      skipped: "spend_guardrail",
+      provider_decision: providerDecision,
+      decision,
+    };
+  }
 
   const prompt = [
     "Return only compact JSON.",
@@ -329,12 +364,13 @@ async function cheapTriage(brief, decision) {
     return {
       used: true,
       model,
-        usage: json?.usage ?? null,
-        decision: {
-          wake: Boolean(parsed.wake),
-          owner: safeWakeOwner(parsed.owner, decision.owner),
-          urgency: ["low", "normal", "high", "urgent"].includes(parsed.urgency) ? parsed.urgency : decision.urgency,
-          reason: compactText(parsed.reason || decision.reason, 240),
+      provider_decision: providerDecision,
+      usage: json?.usage ?? null,
+      decision: {
+        wake: Boolean(parsed.wake),
+        owner: safeWakeOwner(parsed.owner, decision.owner),
+        urgency: ["low", "normal", "high", "urgent"].includes(parsed.urgency) ? parsed.urgency : decision.urgency,
+        reason: compactText(parsed.reason || decision.reason, 240),
         eventCreatedAt: decision.eventCreatedAt,
       },
     };
@@ -622,6 +658,8 @@ function writeLedger({ eventId, event, decision, triage, result, reliability, ha
     cheap_triage: {
       used: Boolean(triage.used),
       model: triage.model || null,
+      skipped: triage.skipped || null,
+      provider_decision: triage.provider_decision || null,
       error: triage.error || null,
       usage: triage.usage || null,
     },
@@ -671,7 +709,7 @@ function writeLedger({ eventId, event, decision, triage, result, reliability, ha
     `- Event-to-router: ${eventSeconds === null ? "unknown" : `${eventSeconds}s`}`,
     `- Boardroom posted: ${result?.posted ? "yes" : result?.dry_run ? "dry run" : "no"}`,
     `- Reliability dispatch: ${reliability?.registered ? reliability.dispatch_id : reliability?.dry_run ? "dry run" : "not registered"}`,
-    `- Cheap triage: ${triage.used ? triage.error ? `error (${triage.error})` : "used" : "skipped"}`,
+    `- Cheap triage: ${triage.used ? triage.error ? `error (${triage.error})` : "used" : triage.skipped || "skipped"}`,
     "",
   ].join("\n");
 

--- a/scripts/event-wake-router.test.mjs
+++ b/scripts/event-wake-router.test.mjs
@@ -9,8 +9,12 @@ import { fileURLToPath } from "node:url";
 import {
   buildReliabilityDispatchHandoffSyncRequest,
   buildReliabilityDispatchRequest,
+  cheapTriage,
   deriveAckThresholds,
+  decideWakeOpenRouterProviderCall,
   deriveWakeStatus,
+  isFreeOpenRouterModel,
+  isWakeOpenRouterPaidEnabled,
   normalizeHandoffMessageId,
   normalizeDispatchOwner,
   shouldFailMissingHandoffMessageId,
@@ -79,6 +83,85 @@ describe("event wake router reliability dispatch", () => {
 
     assert.equal(first, second);
     assert.match(first, /^dispatch_[a-f0-9]{32}$/);
+  });
+
+  it("labels OpenRouter free wake models as default-allowed", () => {
+    const decision = decideWakeOpenRouterProviderCall("liquid/lfm-2.5-1.2b-instruct:free");
+
+    assert.equal(isFreeOpenRouterModel("openrouter/free"), true);
+    assert.equal(isFreeOpenRouterModel("liquid/lfm-2.5-1.2b-instruct:free"), true);
+    assert.equal(isFreeOpenRouterModel("openai/gpt-4o-mini"), false);
+    assert.equal(decision.allowed, true);
+    assert.equal(decision.path_id, "event-wake-router.openrouter.classifier");
+    assert.equal(decision.provider, "OpenRouter");
+    assert.equal(decision.cost_tier, "free");
+    assert.equal(decision.reason, "free_default_allowed");
+    assert.equal(decision.allow_paid_flag, "OPENROUTER_WAKE_ALLOW_PAID");
+  });
+
+  it("blocks OpenRouter paid or unknown wake models until explicitly allowed", () => {
+    const blocked = decideWakeOpenRouterProviderCall("anthropic/claude-3.5-sonnet", false);
+    const allowed = decideWakeOpenRouterProviderCall("anthropic/claude-3.5-sonnet", true);
+
+    assert.equal(blocked.allowed, false);
+    assert.equal(blocked.cost_tier, "paid_or_unknown");
+    assert.equal(blocked.reason, "paid_or_unknown_blocked");
+    assert.equal(allowed.allowed, true);
+    assert.equal(allowed.reason, "explicit_paid_allowed");
+  });
+
+  it("treats only true or 1 as explicit OpenRouter wake paid opt-in", () => {
+    assert.equal(isWakeOpenRouterPaidEnabled(undefined), false);
+    assert.equal(isWakeOpenRouterPaidEnabled(""), false);
+    assert.equal(isWakeOpenRouterPaidEnabled("0"), false);
+    assert.equal(isWakeOpenRouterPaidEnabled("false"), false);
+    assert.equal(isWakeOpenRouterPaidEnabled("1"), true);
+    assert.equal(isWakeOpenRouterPaidEnabled("true"), true);
+    assert.equal(isWakeOpenRouterPaidEnabled(" TRUE "), true);
+  });
+
+  it("does not fetch OpenRouter when paid wake triage is blocked by spend guardrail", async () => {
+    const savedKey = process.env.OPENROUTER_API_KEY;
+    const savedModel = process.env.OPENROUTER_WAKE_MODEL;
+    const savedAllow = process.env.OPENROUTER_WAKE_ALLOW_PAID;
+    const savedFetch = globalThis.fetch;
+    let fetched = false;
+
+    process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+    process.env.OPENROUTER_WAKE_MODEL = "anthropic/claude-3.5-sonnet";
+    delete process.env.OPENROUTER_WAKE_ALLOW_PAID;
+    globalThis.fetch = async () => {
+      fetched = true;
+      throw new Error("fetch should not run");
+    };
+
+    try {
+      const triage = await cheapTriage(
+        { event_name: "issue_comment" },
+        {
+          wake: true,
+          owner: "🧭",
+          urgency: "high",
+          reason: "Manual wake needs model triage",
+          eventCreatedAt: "2026-04-30T15:00:00Z",
+          needsTriage: true,
+        },
+      );
+
+      assert.equal(fetched, false);
+      assert.equal(triage.used, false);
+      assert.equal(triage.skipped, "spend_guardrail");
+      assert.equal(triage.provider_decision.reason, "paid_or_unknown_blocked");
+      assert.equal(triage.provider_decision.allow_paid_flag, "OPENROUTER_WAKE_ALLOW_PAID");
+    } finally {
+      if (savedKey === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = savedKey;
+      if (savedModel === undefined) delete process.env.OPENROUTER_WAKE_MODEL;
+      else process.env.OPENROUTER_WAKE_MODEL = savedModel;
+      if (savedAllow === undefined) delete process.env.OPENROUTER_WAKE_ALLOW_PAID;
+      else process.env.OPENROUTER_WAKE_ALLOW_PAID = savedAllow;
+      globalThis.fetch = savedFetch;
+    }
   });
 
   it("marks wake handoffs as ACK-required WakePass dispatches", () => {


### PR DESCRIPTION
Summary:
- Adds a default-off spend guardrail around the event wake OpenRouter classifier.
- Allows explicitly free wake models by default, including models ending in :free and openrouter/free.
- Blocks paid or unknown wake classifier models unless OPENROUTER_WAKE_ALLOW_PAID is true or 1, and records the provider decision in the wake ledger.

Scope:
- Owned files: scripts/event-wake-router.mjs, scripts/event-wake-router.test.mjs, api/lib/ai-provider-inventory.ts
- Linked todo: 6408ff7b-7629-471b-b745-318ebb82b7a0 AI spend guardrails

Non-overlap:
- Did not touch Worker self-healing, Security api_keys_legacy, Queue picker, Skills Library, DNS, billing, data deletion, deploys, or secrets.
- Did not change the selected OpenRouter model or any API key handling.

Verification:
- node --test scripts/event-wake-router.test.mjs
- npx vitest run api/ai-provider-inventory.test.ts
- git diff --check
- npx eslint scripts/event-wake-router.mjs scripts/event-wake-router.test.mjs api/lib/ai-provider-inventory.ts
- npm run build

Risk:
- Low. Existing free wake classifier behavior remains available for explicitly free models. Paid or unknown wake classifier calls now fail closed unless an explicit allow-paid flag is set.
- No secrets, billing configuration, DNS, migrations, production deploys, or data writes.

Follow-up:
- Continue closing any remaining model, embedding, or classifier call sites through the provider inventory and explicit opt-in pattern.

Draft PR. Not merge-ready until GitHub checks complete.