### PR TITLE
[codex] gate worker movement proof writes

### DIFF
--- a/api/worker-movement-pilot.test.ts
+++ b/api/worker-movement-pilot.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import handler, {
   isWorkerMovementPilotEnabled,
   isWorkerMovementPilotHttpMethodAllowed,
+  isWorkerMovementPilotProofWriteEnabled,
   runWorkerMovementPilotDryRun,
   type WorkerMovementPilotStore,
   type WorkerMovementPilotTodoRow,
@@ -150,6 +151,16 @@ describe("worker movement pilot API dry-run", () => {
     expect(isWorkerMovementPilotEnabled("enabled")).toBe(true);
   });
 
+  it("accepts only explicit enabled values for proof writes", () => {
+    expect(isWorkerMovementPilotProofWriteEnabled(undefined)).toBe(false);
+    expect(isWorkerMovementPilotProofWriteEnabled("")).toBe(false);
+    expect(isWorkerMovementPilotProofWriteEnabled("0")).toBe(false);
+    expect(isWorkerMovementPilotProofWriteEnabled("false")).toBe(false);
+    expect(isWorkerMovementPilotProofWriteEnabled("1")).toBe(true);
+    expect(isWorkerMovementPilotProofWriteEnabled("true")).toBe(true);
+    expect(isWorkerMovementPilotProofWriteEnabled("enabled")).toBe(true);
+  });
+
   it("allows only cron GET and manual POST methods", () => {
     expect(isWorkerMovementPilotHttpMethodAllowed(undefined)).toBe(true);
     expect(isWorkerMovementPilotHttpMethodAllowed("GET")).toBe(true);
@@ -269,6 +280,61 @@ describe("worker movement pilot API dry-run", () => {
       },
     });
     expect(JSON.stringify(inserted[0])).not.toContain("lease-secret");
+  });
+
+  it("plans proof without dedupe or insert when proof writes are disabled", async () => {
+    const { store, inserted, dedupeChecks } = buildStore({
+      candidate: expiredLeaseCandidate(),
+    });
+
+    const result = await runWorkerMovementPilotDryRun({
+      store,
+      nowMs,
+      proofWritesEnabled: false,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "proof_planned",
+      candidate_id: "todo-expired-lease",
+      action: "start_dry_run",
+      proof_signal_action: "worker_movement_workflow_pilot_pass",
+      proof_status: "PASS",
+      proof_inserted: false,
+      proof_deduped: false,
+      next_safe_step:
+        "enable WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED=true after planned proof looks safe",
+    });
+    expect(dedupeChecks).toEqual([]);
+    expect(inserted).toEqual([]);
+  });
+
+  it("plans blocker proof without insert when proof writes are disabled", async () => {
+    const { store, inserted, dedupeChecks } = buildStore({
+      candidate: expiredLeaseCandidate({
+        id: "todo-security",
+        title: "SECURITY: deactivate legacy plaintext api_keys_legacy rows after owner auth",
+      }),
+    });
+
+    const result = await runWorkerMovementPilotDryRun({
+      store,
+      nowMs,
+      proofWritesEnabled: false,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "proof_planned",
+      candidate_id: "todo-security",
+      action: "post_refusal_proof",
+      proof_signal_action: "worker_movement_workflow_pilot_blocker",
+      proof_status: "BLOCKER",
+      proof_inserted: false,
+      proof_deduped: false,
+    });
+    expect(dedupeChecks).toEqual([]);
+    expect(inserted).toEqual([]);
   });
 
   it("inserts BLOCKER proof for an owner or security gated candidate", async () => {

--- a/api/worker-movement-pilot.ts
+++ b/api/worker-movement-pilot.ts
@@ -38,6 +38,7 @@ export interface WorkerMovementPilotStore {
 export type WorkerMovementPilotRunStatus =
   | "skip_disabled"
   | "skip_no_candidate"
+  | "proof_planned"
   | "proof_inserted"
   | "proof_recently_emitted"
   | "candidate_fetch_failed"
@@ -59,6 +60,9 @@ export interface WorkerMovementPilotRunResult {
   next_safe_step: string;
   error?: string;
 }
+
+const PROOF_WRITE_GATE_NEXT_STEP =
+  "enable WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED=true after planned proof looks safe";
 
 export function createWorkerMovementPilotStore(
   supabase: ReturnType<typeof createClient>,
@@ -108,6 +112,11 @@ export function isWorkerMovementPilotEnabled(value: string | undefined): boolean
   return normalized === "1" || normalized === "true" || normalized === "enabled";
 }
 
+export function isWorkerMovementPilotProofWriteEnabled(value: string | undefined): boolean {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "enabled";
+}
+
 export function isWorkerMovementPilotHttpMethodAllowed(method: string | undefined): boolean {
   const normalized = String(method ?? "GET").trim().toUpperCase();
   return normalized === "GET" || normalized === "POST";
@@ -133,6 +142,7 @@ export async function runWorkerMovementPilotDryRun(params: {
   store: WorkerMovementPilotStore;
   nowMs?: number;
   enabled?: boolean;
+  proofWritesEnabled?: boolean;
 }): Promise<WorkerMovementPilotRunResult> {
   if (params.enabled === false) {
     return buildWorkerMovementPilotDisabledResult();
@@ -194,6 +204,23 @@ export async function runWorkerMovementPilotDryRun(params: {
   const proofStatus = proof.signal.action === "worker_movement_workflow_pilot_blocker"
     ? "BLOCKER"
     : "PASS";
+
+  if (params.proofWritesEnabled === false) {
+    return {
+      ok: true,
+      mode: "dry_run",
+      status: "proof_planned",
+      candidate_id: plan.candidate_id,
+      action: plan.action,
+      proof_signal_action: proof.signal.action,
+      proof_status: proofStatus,
+      proof_inserted: false,
+      proof_deduped: false,
+      summary: proof.signal.summary,
+      next_safe_step: PROOF_WRITE_GATE_NEXT_STEP,
+    };
+  }
+
   const dedupeResult = await params.store.hasRecentProof({
     apiKeyHash: candidate.api_key_hash,
     action: proof.insert.action,
@@ -287,6 +314,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const result = await runWorkerMovementPilotDryRun({
     store: createWorkerMovementPilotStore(supabase),
     enabled,
+    proofWritesEnabled: isWorkerMovementPilotProofWriteEnabled(
+      process.env.WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED,
+    ),
   });
   return res.status(result.ok ? 200 : 500).json(result);
 }
@@ -294,7 +324,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 function failureResult(params: {
   status: Exclude<
     WorkerMovementPilotRunStatus,
-    "skip_disabled" | "skip_no_candidate" | "proof_inserted" | "proof_recently_emitted"
+    | "skip_disabled"
+    | "skip_no_candidate"
+    | "proof_planned"
+    | "proof_inserted"
+    | "proof_recently_emitted"
   >;
   candidateId?: string | null;
   action?: WorkerMovementWorkflowPilotAction | null;

--- a/docs/vercel-workflow-worker-movement-pilot.md
+++ b/docs/vercel-workflow-worker-movement-pilot.md
@@ -125,8 +125,19 @@ The scheduler-ready slice adds a quiet Vercel cron call to `/api/worker-movement
 
 - The endpoint still requires `Bearer ${CRON_SECRET}`.
 - The endpoint now also requires `WORKER_MOVEMENT_PILOT_ENABLED` to be `1`, `true`, or `enabled`.
-- With the env unset, the cron call returns `skip_disabled` without querying todos or inserting proof.
-- This lets production exercise the protected route safely before Chris or an operator enables proof inserts.
+- With `WORKER_MOVEMENT_PILOT_ENABLED` unset, the cron call returns `skip_disabled` without querying todos or inserting proof.
+- With `WORKER_MOVEMENT_PILOT_ENABLED` enabled but `WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED` unset, the route can fetch and plan one expired candidate, then returns `proof_planned` without dedupe checks or `mc_signals` inserts.
+- `mc_signals` proof writes require `WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED` to be `1`, `true`, or `enabled`.
+- This lets production exercise the protected route and candidate planner safely before Chris or an operator enables proof inserts.
+
+## Proof-Write Gate Slice
+
+The proof-write gate adds a second opt-in around signal insertion:
+
+- `WORKER_MOVEMENT_PILOT_ENABLED` means the pilot may read one expired lease candidate and build a dry-run plan.
+- `WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED` means the pilot may dedupe and insert PASS or BLOCKER proof into `mc_signals`.
+- If proof writes are disabled, the route does not call `hasRecentProof` or `insertProof`.
+- Focused tests cover safe PASS planning, BLOCKER refusal planning, explicit proof-write env parsing, and the existing insert path.
 
 ## Proof Trail
 


### PR DESCRIPTION
## Summary

Adds a second explicit opt-in for the worker movement pilot before it writes proof signals.

## What changed

- Added `WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED` parsing.
- Added a `proof_planned` result so the pilot can read one expired lease candidate and build a dry-run plan without dedupe checks or `mc_signals` inserts.
- Kept existing insert behavior available when proof writes are explicitly enabled.
- Updated the worker movement pilot doc with the two-stage enablement path.

## Why

This lets production exercise the protected Vercel cron route and candidate planner before allowing Boardroom proof writes. It keeps the first live enablement quiet and reversible.

## Validation

- `npx vitest run api/worker-movement-pilot.test.ts`
- `npx eslint api/worker-movement-pilot.ts api/worker-movement-pilot.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`

Supersedes PR #826 without force-pushing the original branch.