### PR TITLE
[codex] add worker movement observe-only rollout checklist

### DIFF
--- a/docs/vercel-workflow-worker-movement-pilot.md
+++ b/docs/vercel-workflow-worker-movement-pilot.md
@@ -139,6 +139,22 @@ The proof-write gate adds a second opt-in around signal insertion:
 - If proof writes are disabled, the route does not call `hasRecentProof` or `insertProof`.
 - Focused tests cover safe PASS planning, BLOCKER refusal planning, explicit proof-write env parsing, and the existing insert path.
 
+## Observe-Only Rollout Checklist
+
+Use this checklist before enabling proof writes or adding Railway.
+
+1. Confirm the latest worker movement pilot PR is merged to `main` and deployed.
+2. Set only `WORKER_MOVEMENT_PILOT_ENABLED=1` in Vercel.
+3. Leave `WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED` unset or false.
+4. Wait for one scheduled cron tick, or call `/api/worker-movement-pilot` from a private operator shell with `CRON_SECRET`.
+5. Expected safe responses are `skip_no_candidate` or `proof_planned`.
+6. For `proof_planned`, confirm `proof_inserted=false`, `proof_deduped=false`, and the response includes one candidate id, one proof status, and a next safe step.
+7. If the candidate is security gated, owner-auth gated, billing, DNS, secrets, production deploy, data deletion, or pending a human decision, the expected proof status is BLOCKER.
+8. If the route returns `candidate_fetch_failed`, `proof_planning_failed`, a 500, or any unexpected proof insert, unset `WORKER_MOVEMENT_PILOT_ENABLED` and keep the existing cron watcher as fallback.
+9. Enable `WORKER_MOVEMENT_PILOT_PROOF_WRITES_ENABLED=1` only after the observe-only output looks safe for at least two cron ticks.
+
+This rollout does not reclaim, release, reassign, complete, or mutate todo leases. It only proves whether Vercel can keep the worker movement loop fresh enough before UnClick needs a Railway worker.
+
 ## Proof Trail
 
 - Greenlight receipt: `876f228a-38fa-45a3-8373-d24a319a0670`


### PR DESCRIPTION
## Summary
Adds an observe-only rollout checklist for the Vercel worker movement pilot.

## Why
The current code can safely plan one expired worker movement candidate, but production proof writes should stay off until the planned output has been observed. This makes the next operator step exact and keeps Railway held unless Vercel cannot keep the loop reliable.

## Scope
Owned file: `docs/vercel-workflow-worker-movement-pilot.md`.

## Safety
No runtime code, env values, secrets, billing, DNS, auth, production data, lease mutation, deploy config, or scheduler changes. The checklist explicitly says to enable only `WORKER_MOVEMENT_PILOT_ENABLED=1` first and leave proof writes off.

## Verification
- `npx vitest run api/worker-movement-pilot.test.ts`
- `git diff --check origin/main..HEAD`
- dash scan on `docs/vercel-workflow-worker-movement-pilot.md` found no matches for Unicode dash characters

## Next
After review, enable `WORKER_MOVEMENT_PILOT_ENABLED=1` only in Vercel, observe `skip_no_candidate` or `proof_planned` for at least two cron ticks, then decide whether to enable proof writes.