### PR TITLE
feat(securitypass): guard Memory Admin AI chat spend

### DIFF
--- a/api/ai-provider-inventory.test.ts
+++ b/api/ai-provider-inventory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  decideMemoryAdminAiChatProviderCall,
   decideAiProviderCall,
   getAiProviderInventoryEntry,
   listAiProviderInventory,
@@ -65,6 +66,35 @@ describe("ai provider inventory", () => {
         allowed: false,
         reason: "paid_or_unknown_blocked",
         allow_paid_flag: "api_key argument",
+      });
+    }
+  });
+
+  it("labels Memory Admin AI chat provider paths with tenant-key spend gates", () => {
+    const expected = [
+      ["memory.admin.google.ai-chat", "google", "gemini-2.5-flash-lite"],
+      ["memory.admin.openai.ai-chat", "openai", "gpt-4o-mini"],
+      ["memory.admin.anthropic.ai-chat", "anthropic", "claude-haiku-4-5"],
+    ] as const;
+
+    for (const [pathId, provider, model] of expected) {
+      expect(getAiProviderInventoryEntry(pathId)).toMatchObject({
+        call_kind: "chat_completion",
+        cost_tier: "paid",
+        default_allowed: false,
+        allow_paid_flag: "AI_CHAT_ENABLED + tenant ai_chat_enabled + tenant ai_chat_api_key",
+      });
+      expect(decideMemoryAdminAiChatProviderCall({ provider, model })).toMatchObject({
+        allowed: false,
+        path_id: pathId,
+        model,
+        reason: "paid_or_unknown_blocked",
+      });
+      expect(decideMemoryAdminAiChatProviderCall({ provider, model, allow_paid: true })).toMatchObject({
+        allowed: true,
+        path_id: pathId,
+        model,
+        reason: "explicit_paid_allowed",
       });
     }
   });

--- a/api/lib/ai-provider-inventory.ts
+++ b/api/lib/ai-provider-inventory.ts
@@ -39,6 +39,14 @@ export interface AiProviderCallDecision {
   allow_paid_flag?: string;
 }
 
+export type MemoryAdminAiChatProvider = "google" | "openai" | "anthropic";
+
+const MEMORY_ADMIN_AI_CHAT_PATH_IDS: Record<MemoryAdminAiChatProvider, string> = {
+  google: "memory.admin.google.ai-chat",
+  openai: "memory.admin.openai.ai-chat",
+  anthropic: "memory.admin.anthropic.ai-chat",
+};
+
 export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
   {
     id: "nudgeonly.openrouter.free-default",
@@ -115,6 +123,39 @@ export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
     default_allowed: false,
     allow_paid_flag: "ARENA_ANTHROPIC_ENABLED",
     notes: "Arena bot solve uses Anthropic for live generated solutions and must require an explicit arena spend opt-in in addition to server-side credentials.",
+  },
+  {
+    id: "memory.admin.google.ai-chat",
+    provider: "Google",
+    surface: "api/memory-admin.ts?action=admin_ai_chat",
+    call_kind: "chat_completion",
+    model: "tenant ai_chat_model or gemini-2.5-flash-lite",
+    cost_tier: "paid",
+    default_allowed: false,
+    allow_paid_flag: "AI_CHAT_ENABLED + tenant ai_chat_enabled + tenant ai_chat_api_key",
+    notes: "Memory Admin AI chat can call Google models only after the global chat gate, tenant chat toggle, and tenant-owned API key all pass.",
+  },
+  {
+    id: "memory.admin.openai.ai-chat",
+    provider: "OpenAI",
+    surface: "api/memory-admin.ts?action=admin_ai_chat",
+    call_kind: "chat_completion",
+    model: "tenant ai_chat_model or gpt-4o-mini",
+    cost_tier: "paid",
+    default_allowed: false,
+    allow_paid_flag: "AI_CHAT_ENABLED + tenant ai_chat_enabled + tenant ai_chat_api_key",
+    notes: "Memory Admin AI chat can call OpenAI models only after the global chat gate, tenant chat toggle, and tenant-owned API key all pass.",
+  },
+  {
+    id: "memory.admin.anthropic.ai-chat",
+    provider: "Anthropic",
+    surface: "api/memory-admin.ts?action=admin_ai_chat",
+    call_kind: "chat_completion",
+    model: "tenant ai_chat_model or claude-haiku-4-5",
+    cost_tier: "paid",
+    default_allowed: false,
+    allow_paid_flag: "AI_CHAT_ENABLED + tenant ai_chat_enabled + tenant ai_chat_api_key",
+    notes: "Memory Admin AI chat can call Anthropic models only after the global chat gate, tenant chat toggle, and tenant-owned API key all pass.",
   },
   {
     id: "mcp.openai.tool.chat",
@@ -291,6 +332,10 @@ export function getAiProviderInventoryEntry(pathId: string): AiProviderInventory
   return AI_PROVIDER_INVENTORY.find((entry) => entry.id === pathId) ?? null;
 }
 
+export function getMemoryAdminAiChatPathId(provider: MemoryAdminAiChatProvider): string {
+  return MEMORY_ADMIN_AI_CHAT_PATH_IDS[provider];
+}
+
 export function classifyAiProviderPath(pathId: string, model?: string | null): AiProviderInventoryEntry {
   const known = getAiProviderInventoryEntry(pathId);
   if (known) {
@@ -341,6 +386,18 @@ export function decideAiProviderCall(input: AiProviderDecisionInput): AiProvider
     reason: allowPaid ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
     allow_paid_flag: entry.allow_paid_flag,
   };
+}
+
+export function decideMemoryAdminAiChatProviderCall(input: {
+  provider: MemoryAdminAiChatProvider;
+  model?: string | null;
+  allow_paid?: boolean;
+}): AiProviderCallDecision {
+  return decideAiProviderCall({
+    path_id: getMemoryAdminAiChatPathId(input.provider),
+    model: input.model,
+    allow_paid: input.allow_paid,
+  });
 }
 
 export function publicAiProviderCostLabels(): Array<Pick<

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -159,6 +159,7 @@ import {
 import { runRoutePacketConsumerDryRun, type VisibleWorker } from "./lib/route-packet-consumer.js";
 import { buildUnClickConnectDispatchRow } from "./lib/route-packet-dispatch.js";
 import { buildTetherRoutePacket } from "./lib/tether-route-packet.js";
+import { decideMemoryAdminAiChatProviderCall } from "./lib/ai-provider-inventory.js";
 import {
   buildWorkersToVisibleWorkers,
   fishbowlProfilesToVisibleWorkers,
@@ -182,7 +183,6 @@ import {
   isMemoryQuotaExemptEmail,
 } from "../packages/mcp-server/src/memory/quota-policy.js";
 import { streamText, tool, stepCountIs, convertToModelMessages, type UIMessage, type ModelMessage } from "ai";
-import { google } from "@ai-sdk/google";
 import { z } from "zod";
 import * as crypto from "crypto";
 import * as fs from "fs";
@@ -614,6 +614,49 @@ async function resolveSessionUser(
 
 type ChatProvider = "google" | "openai" | "anthropic";
 
+interface AiChatTenantSettingsRow {
+  ai_chat_enabled: boolean | null;
+  ai_chat_provider: string | null;
+  ai_chat_model: string | null;
+  ai_chat_system_prompt: string | null;
+  ai_chat_max_turns: number | null;
+  ai_chat_api_key_encrypted: string | null;
+}
+
+interface ResolvedAiChatTenantSettings {
+  ai_chat_enabled: boolean;
+  ai_chat_provider: ChatProvider;
+  ai_chat_model: string;
+  ai_chat_system_prompt: string | null;
+  ai_chat_max_turns: number;
+  ai_chat_api_key: string | null;
+}
+
+const DEFAULT_AI_CHAT_MODELS: Record<ChatProvider, string> = {
+  google: "gemini-2.5-flash-lite",
+  openai: "gpt-4o-mini",
+  anthropic: "claude-haiku-4-5",
+};
+
+function isChatProvider(value: unknown): value is ChatProvider {
+  return value === "google" || value === "openai" || value === "anthropic";
+}
+
+function normaliseAiChatProvider(value: unknown): ChatProvider {
+  return isChatProvider(value) ? value : "google";
+}
+
+function normaliseAiChatModel(provider: ChatProvider, value: unknown): string {
+  return typeof value === "string" && value.trim()
+    ? value.trim()
+    : DEFAULT_AI_CHAT_MODELS[provider];
+}
+
+function normaliseAiChatMaxTurns(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 20;
+  return Math.min(50, Math.max(1, Math.trunc(value)));
+}
+
 function deriveAiKeyEncryptionKey(): Buffer | null {
   const secret = process.env.AI_KEY_ENCRYPTION_SECRET;
   if (!secret) return null;
@@ -636,6 +679,34 @@ function decryptAiApiKey(payload: string | null | undefined): string | null {
   } catch {
     return null;
   }
+}
+
+async function resolveTenantAiChatSettings(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+): Promise<ResolvedAiChatTenantSettings> {
+  const { data, error } = await supabase
+    .from("tenant_settings")
+    .select(
+      "ai_chat_enabled, ai_chat_provider, ai_chat_model, ai_chat_system_prompt, ai_chat_max_turns, ai_chat_api_key_encrypted",
+    )
+    .eq("api_key_hash", apiKeyHash)
+    .maybeSingle();
+  if (error) throw error;
+
+  const row = data as AiChatTenantSettingsRow | null;
+  const provider = normaliseAiChatProvider(row?.ai_chat_provider);
+  return {
+    ai_chat_enabled: row?.ai_chat_enabled ?? true,
+    ai_chat_provider: provider,
+    ai_chat_model: normaliseAiChatModel(provider, row?.ai_chat_model),
+    ai_chat_system_prompt:
+      typeof row?.ai_chat_system_prompt === "string" && row.ai_chat_system_prompt.trim()
+        ? row.ai_chat_system_prompt.trim()
+        : null,
+    ai_chat_max_turns: normaliseAiChatMaxTurns(row?.ai_chat_max_turns),
+    ai_chat_api_key: decryptAiApiKey(row?.ai_chat_api_key_encrypted),
+  };
 }
 
 /**
@@ -1308,8 +1379,8 @@ async function resolveAiChatModel(opts: {
   model: string;
   userApiKey: string | null;
 }) {
-  const fallbackKey = process.env.AI_CHAT_DEFAULT_KEY ?? undefined;
-  const apiKey = opts.userApiKey ?? fallbackKey;
+  const apiKey = opts.userApiKey?.trim();
+  if (!apiKey) throw new Error("Admin AI chat provider API key is required.");
 
   if (opts.provider === "google") {
     const { createGoogleGenerativeAI } = await import("@ai-sdk/google");
@@ -5831,8 +5902,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           };
           if (typeof body.ai_chat_enabled === "boolean")
             update.ai_chat_enabled = body.ai_chat_enabled;
-          if (body.ai_chat_provider) update.ai_chat_provider = body.ai_chat_provider;
-          if (body.ai_chat_model) update.ai_chat_model = body.ai_chat_model;
+          if (body.ai_chat_provider !== undefined) {
+            if (!isChatProvider(body.ai_chat_provider)) {
+              return res.status(400).json({ error: "ai_chat_provider must be google, openai, or anthropic" });
+            }
+            update.ai_chat_provider = body.ai_chat_provider;
+          }
+          if (body.ai_chat_model !== undefined) {
+            if (typeof body.ai_chat_model !== "string" || !body.ai_chat_model.trim()) {
+              return res.status(400).json({ error: "ai_chat_model must be a non-empty string" });
+            }
+            update.ai_chat_model = body.ai_chat_model.trim();
+          }
           if (typeof body.ai_chat_system_prompt === "string")
             update.ai_chat_system_prompt = body.ai_chat_system_prompt;
           if (typeof body.ai_chat_max_turns === "number")
@@ -5890,10 +5971,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           env_enabled: envEnabled,
           settings: {
             ai_chat_enabled: row?.ai_chat_enabled ?? true,
-            ai_chat_provider: row?.ai_chat_provider ?? "google",
-            ai_chat_model: row?.ai_chat_model ?? "gemini-2.5-flash-lite",
+            ai_chat_provider: normaliseAiChatProvider(row?.ai_chat_provider),
+            ai_chat_model: normaliseAiChatModel(
+              normaliseAiChatProvider(row?.ai_chat_provider),
+              row?.ai_chat_model,
+            ),
             ai_chat_system_prompt: row?.ai_chat_system_prompt ?? null,
-            ai_chat_max_turns: row?.ai_chat_max_turns ?? 20,
+            ai_chat_max_turns: normaliseAiChatMaxTurns(row?.ai_chat_max_turns),
             has_api_key: Boolean(row?.ai_chat_api_key_encrypted),
           },
         });
@@ -5944,19 +6028,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       case "admin_ai_chat": {
         if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
-        if (!isAdminChatEnabled()) {
+        const envEnabled = isAdminChatEnabled();
+        if (!envEnabled) {
           return res.status(503).json({
             error: "Admin AI chat is disabled. Set AI_CHAT_ENABLED=true to turn it on.",
           });
         }
-        if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
-          return res.status(503).json({
-            error: "GOOGLE_GENERATIVE_AI_API_KEY is not configured on the server.",
-          });
-        }
 
         const body = req.body as
-          | { messages?: UIMessage[]; api_key?: string }
+          | { messages?: unknown[]; api_key?: string }
           | undefined;
         const messages = Array.isArray(body?.messages) ? body!.messages! : [];
         if (messages.length === 0) {
@@ -5971,12 +6051,52 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(401).json({ error: "Authorization header required" });
         }
 
-        const systemPrompt = await buildAdminChatSystemPrompt(supabase, apiKeyHash);
+        const tenantSettings = await resolveTenantAiChatSettings(supabase, apiKeyHash);
+        if (!tenantSettings.ai_chat_enabled) {
+          return res.status(403).json({
+            error: "Admin AI chat is turned off in tenant settings.",
+          });
+        }
+
+        const providerDecision = decideMemoryAdminAiChatProviderCall({
+          provider: tenantSettings.ai_chat_provider,
+          model: tenantSettings.ai_chat_model,
+          allow_paid: envEnabled && tenantSettings.ai_chat_enabled && Boolean(tenantSettings.ai_chat_api_key),
+        });
+        if (!providerDecision.allowed) {
+          return res.status(503).json({
+            error:
+              "Admin AI chat provider is not configured. Add a tenant API key in Settings before making paid provider calls.",
+            provider: providerDecision.provider,
+            model: providerDecision.model,
+            cost_tier: providerDecision.cost_tier,
+            allow_paid_flag: providerDecision.allow_paid_flag,
+          });
+        }
+
+        const systemPromptBase = await buildAdminChatSystemPrompt(supabase, apiKeyHash);
+        const systemPrompt = tenantSettings.ai_chat_system_prompt
+          ? [
+              systemPromptBase,
+              "",
+              "Tenant custom instructions:",
+              tenantSettings.ai_chat_system_prompt,
+            ].join("\n")
+          : systemPromptBase;
         const tools = buildAdminChatTools(supabase, apiKeyHash, req);
 
-        const modelMessages = await convertToModelMessages(messages);
+        const recentMessages = messages.slice(-tenantSettings.ai_chat_max_turns);
+        const modelMessages = await normaliseChatMessages(recentMessages);
+        if ("error" in modelMessages) {
+          return res.status(400).json({ error: modelMessages.error });
+        }
+        const model = await resolveAiChatModel({
+          provider: tenantSettings.ai_chat_provider,
+          model: tenantSettings.ai_chat_model,
+          userApiKey: tenantSettings.ai_chat_api_key,
+        });
         const result = streamText({
-          model: google("gemini-2.5-flash-lite"),
+          model,
           system: systemPrompt,
           messages: modelMessages,
           tools,


### PR DESCRIPTION
Summary:
- Adds Memory Admin AI chat to the AI provider inventory with paid cost labels for Google, OpenAI, and Anthropic.
- Routes admin_ai_chat through the provider inventory decision helper and blocks provider calls unless AI_CHAT_ENABLED, tenant ai_chat_enabled, and a tenant API key all pass.
- Uses tenant-selected provider, model, custom prompt, and max-turn settings instead of the old hard-coded Gemini path.

Scope:
- Owned files: api/memory-admin.ts, api/lib/ai-provider-inventory.ts, api/ai-provider-inventory.test.ts
- Lane: AI spend guardrails, todo 6408ff7b-7629-471b-b745-318ebb82b7a0

Non-overlap:
- Did not touch production env vars, billing settings, DNS, data deletion, or unrelated dirty root checkout work.
- Did not change the existing tenant default migration that keeps ai_chat_enabled default true.

Verification:
- npx vitest run api/ai-provider-inventory.test.ts
- npx eslint api/memory-admin.ts api/lib/ai-provider-inventory.ts api/ai-provider-inventory.test.ts
- node --test scripts/tenant-ai-chat-default.test.mjs
- git diff --check
- npx tsc --noEmit --pretty false
- npm run build

Risk:
- Low to medium product behavior risk: direct admin_ai_chat calls now require a tenant API key instead of relying on an implicit server Google key. This matches the visible admin UI unconfigured state and keeps paid calls default-off.

Follow-up:
- Inventory any remaining non-admin chat or classifier call sites outside the Memory Admin path.