### PR TITLE
feat(securitypass): gate NudgeOnly custom model spend

### DIFF
--- a/api/ai-provider-inventory.test.ts
+++ b/api/ai-provider-inventory.test.ts
@@ -12,6 +12,7 @@ describe("ai provider inventory", () => {
     const inventory = listAiProviderInventory();
 
     expect(inventory.some((entry) => entry.id === "nudgeonly.openrouter.free-default")).toBe(true);
+    expect(inventory.some((entry) => entry.id === "nudgeonly.openrouter.custom-model")).toBe(true);
     expect(inventory.some((entry) => entry.id === "memory.mcp.openai.embeddings")).toBe(true);
     expect(inventory.every((entry) => ["free", "paid", "paid_or_unknown"].includes(entry.cost_tier))).toBe(true);
     expect(inventory.filter((entry) => entry.default_allowed).map((entry) => entry.cost_tier)).toEqual(["free"]);
@@ -23,6 +24,35 @@ describe("ai provider inventory", () => {
       cost_tier: "free",
       reason: "free_default_allowed",
       default_allowed: true,
+    });
+  });
+
+  it("blocks NudgeOnly custom model paths by default", () => {
+    expect(getAiProviderInventoryEntry("nudgeonly.openrouter.custom-model")).toMatchObject({
+      provider: "OpenRouter",
+      call_kind: "classification",
+      cost_tier: "paid_or_unknown",
+      default_allowed: false,
+      allow_paid_flag: "NUDGEONLY_OPENROUTER_ALLOW_PAID or allow_paid argument",
+    });
+    expect(decideAiProviderCall({
+      path_id: "nudgeonly.openrouter.custom-model",
+      model: "anthropic/claude-sonnet-4",
+    })).toMatchObject({
+      allowed: false,
+      provider: "OpenRouter",
+      model: "anthropic/claude-sonnet-4",
+      cost_tier: "paid_or_unknown",
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "NUDGEONLY_OPENROUTER_ALLOW_PAID or allow_paid argument",
+    });
+    expect(decideAiProviderCall({
+      path_id: "nudgeonly.openrouter.custom-model",
+      model: "anthropic/claude-sonnet-4",
+      allow_paid: true,
+    })).toMatchObject({
+      allowed: true,
+      reason: "explicit_paid_allowed",
     });
   });
 

--- a/api/lib/ai-provider-inventory.ts
+++ b/api/lib/ai-provider-inventory.ts
@@ -59,6 +59,17 @@ export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
     notes: "PinballWake NudgeOnly default route is explicitly labelled free and remains advisory-only.",
   },
   {
+    id: "nudgeonly.openrouter.custom-model",
+    provider: "OpenRouter",
+    surface: "packages/mcp-server/src/nudgeonly-tool.ts",
+    call_kind: "classification",
+    model: "caller supplied or NUDGEONLY_OPENROUTER_MODEL",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "NUDGEONLY_OPENROUTER_ALLOW_PAID or allow_paid argument",
+    notes: "Custom or env-selected NudgeOnly models can be paid or unknown and must require explicit paid opt-in. Free :free routes remain under nudgeonly.openrouter.free-default.",
+  },
+  {
     id: "event-wake-router.openrouter.classifier",
     provider: "OpenRouter",
     surface: "scripts/event-wake-router.mjs",

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -1,9 +1,33 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { nudgeonlyApi, nudgeonlyPolicy, nudgeonlyReceiptBridge, NUDGEONLY_POLICY } from "./nudgeonly-tool.js";
+import {
+  decideNudgeOnlyOpenRouterCall,
+  nudgeonlyApi,
+  nudgeonlyPolicy,
+  nudgeonlyReceiptBridge,
+  NUDGEONLY_POLICY,
+} from "./nudgeonly-tool.js";
+
+const ORIGINAL_NUDGEONLY_MODEL = process.env.NUDGEONLY_OPENROUTER_MODEL;
+const ORIGINAL_NUDGEONLY_ALLOW_PAID = process.env.NUDGEONLY_OPENROUTER_ALLOW_PAID;
+
+beforeEach(() => {
+  delete process.env.NUDGEONLY_OPENROUTER_MODEL;
+  delete process.env.NUDGEONLY_OPENROUTER_ALLOW_PAID;
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  if (ORIGINAL_NUDGEONLY_MODEL === undefined) {
+    delete process.env.NUDGEONLY_OPENROUTER_MODEL;
+  } else {
+    process.env.NUDGEONLY_OPENROUTER_MODEL = ORIGINAL_NUDGEONLY_MODEL;
+  }
+  if (ORIGINAL_NUDGEONLY_ALLOW_PAID === undefined) {
+    delete process.env.NUDGEONLY_OPENROUTER_ALLOW_PAID;
+  } else {
+    process.env.NUDGEONLY_OPENROUTER_ALLOW_PAID = ORIGINAL_NUDGEONLY_ALLOW_PAID;
+  }
 });
 
 describe("NudgeOnlyAPI policy", () => {
@@ -215,6 +239,75 @@ describe("NudgeOnlyAPI policy", () => {
     } else {
       process.env.OPENROUTER_API_KEY = previous;
     }
+  });
+
+  it("blocks custom paid or unknown OpenRouter models by default", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(nudgeonlyApi({
+      api_key: "test-key",
+      event_text: "wakepass stale ack",
+      model: "anthropic/claude-sonnet-4",
+    })).rejects.toThrow("paid or unknown");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(decideNudgeOnlyOpenRouterCall({ model: "anthropic/claude-sonnet-4" })).toMatchObject({
+      allowed: false,
+      provider: "OpenRouter",
+      model: "anthropic/claude-sonnet-4",
+      cost_tier: "paid_or_unknown",
+      default_allowed: false,
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "NUDGEONLY_OPENROUTER_ALLOW_PAID",
+    });
+  });
+
+  it("allows custom OpenRouter models only with explicit paid opt-in", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => ({
+      ok: true,
+      json: async () => ({
+        id: "or-nudge-paid-test",
+        model: "anthropic/claude-sonnet-4",
+        choices: [{
+          finish_reason: "stop",
+          message: {
+            content: JSON.stringify({
+              painpoint_detected: true,
+              painpoint_type: "stale_ack",
+              nudge: "Possible stale ACK. Suggest checking the WakePass receipt before taking action.",
+              suggested_check: "Run the WakePass ACK verifier for the source dispatch.",
+              confidence: "medium",
+            }),
+          },
+        }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(nudgeonlyApi({
+      api_key: "test-key",
+      event_text: "wakepass stale ack for PR #705",
+      model: "anthropic/claude-sonnet-4",
+      allow_paid: true,
+    })).resolves.toMatchObject({
+      model: "anthropic/claude-sonnet-4",
+      evidence: {
+        requested_model: "anthropic/claude-sonnet-4",
+        provider_decision: {
+          allowed: true,
+          reason: "explicit_paid_allowed",
+          allow_paid_flag: "NUDGEONLY_OPENROUTER_ALLOW_PAID",
+        },
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(String(init?.body));
+    expect(body).toMatchObject({
+      model: "anthropic/claude-sonnet-4",
+    });
   });
 
   it("uses the free OpenRouter nudge lane without granting authority", async () => {

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 
 const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 const DEFAULT_MODEL = "liquid/lfm-2.5-1.2b-instruct:free";
+const NUDGEONLY_OPENROUTER_ALLOW_PAID_FLAG = "NUDGEONLY_OPENROUTER_ALLOW_PAID";
 const DEFAULT_MAX_TOKENS = 260;
 const MAX_INPUT_CHARS = 6000;
 const PAINPOINT_TYPES = [
@@ -312,6 +313,37 @@ function apiKeyFrom(args: Record<string, unknown>): string {
     throw new Error("api_key is required unless OPENROUTER_API_KEY is set.");
   }
   return key;
+}
+
+export function isNudgeOnlyFreeOpenRouterModel(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return normalized.endsWith(":free") || normalized === "openrouter/free" || normalized.startsWith("openrouter/free/");
+}
+
+function isExplicitSpendOptIn(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+export function decideNudgeOnlyOpenRouterCall(args: {
+  model?: unknown;
+  allow_paid?: unknown;
+} = {}) {
+  const model = String(args.model ?? process.env.NUDGEONLY_OPENROUTER_MODEL ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+  const freeDefault = isNudgeOnlyFreeOpenRouterModel(model);
+  const explicitPaid = isExplicitSpendOptIn(args.allow_paid ?? process.env[NUDGEONLY_OPENROUTER_ALLOW_PAID_FLAG]);
+  const costTier = freeDefault ? "free" : "paid_or_unknown";
+
+  return {
+    allowed: freeDefault || explicitPaid,
+    provider: "OpenRouter",
+    model,
+    cost_tier: costTier,
+    default_allowed: freeDefault,
+    reason: freeDefault ? "free_default_allowed" : explicitPaid ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
+    allow_paid_flag: freeDefault ? undefined : NUDGEONLY_OPENROUTER_ALLOW_PAID_FLAG,
+  } as const;
 }
 
 function trimInput(value: unknown): string {
@@ -718,7 +750,16 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
   const painpointHint = trimInput(args.painpoint_hint);
   const sourceId = trimInput(args.source_id);
   const sourceUrl = trimInput(args.source_url);
-  const model = String(args.model ?? process.env.NUDGEONLY_OPENROUTER_MODEL ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+  const providerDecision = decideNudgeOnlyOpenRouterCall({
+    model: args.model,
+    allow_paid: args.allow_paid,
+  });
+  if (!providerDecision.allowed) {
+    throw new Error(
+      `NudgeOnly OpenRouter model ${providerDecision.model} is paid or unknown. Set ${NUDGEONLY_OPENROUTER_ALLOW_PAID_FLAG}=1 or pass allow_paid=true to use non-free models.`,
+    );
+  }
+  const model = providerDecision.model;
   const maxTokens = Math.min(asNumber(args.max_tokens, DEFAULT_MAX_TOKENS), 500);
   const inputDigest = shortHash(JSON.stringify({
     event_text: eventText,
@@ -791,6 +832,7 @@ export async function nudgeonlyApi(args: Record<string, unknown>): Promise<unkno
       router: "OpenRouter",
       requested_model: model,
       resolved_model: result.model ?? model,
+      provider_decision: providerDecision,
       openrouter_id: result.id ?? null,
       verifier_required: true,
       verifier_rule: NUDGEONLY_POLICY.verifier_rule,

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -9577,6 +9577,7 @@ export const ADDITIONAL_TOOLS = [
         source_id: { type: "string", description: "Optional upstream event, dispatch, PR, issue, or wake identifier for trace evidence." },
         source_url: { type: "string", description: "Optional upstream URL for trace evidence." },
         model: { type: "string", description: "OpenRouter model ID. Default: liquid/lfm-2.5-1.2b-instruct:free. Use openrouter/free only when auto-rotation is desired." },
+        allow_paid: { type: "boolean", description: "Explicit opt-in required for paid or unknown OpenRouter model IDs. Free :free models do not need this." },
         max_tokens: { type: "number", description: "Maximum output tokens. Hard capped at 500. Default: 260." },
       },
       required: ["event_text"],


### PR DESCRIPTION
Summary:
- Adds a NudgeOnly OpenRouter spend decision helper so free :free routes remain allowed while custom or env-selected paid or unknown models fail closed.
- Exposes allow_paid in the NudgeOnly tool schema and records provider decision evidence in NudgeOnly outputs.
- Adds provider inventory metadata and focused tests for the custom-model path.

Scope:
- Owned files: packages/mcp-server/src/nudgeonly-tool.ts, packages/mcp-server/src/nudgeonly-tool.test.ts, packages/mcp-server/src/tool-wiring.ts, api/lib/ai-provider-inventory.ts, api/ai-provider-inventory.test.ts.
- Linked todo: 6408ff7b-7629-471b-b745-318ebb82b7a0.

Non-overlap:
- Did not touch secrets, billing settings, live environment flags, production deploys, data rows, or unrelated dirty root checkout work.
- Did not change other AI provider runtime surfaces.

Verification:
- npx vitest run packages/mcp-server/src/nudgeonly-tool.test.ts api/ai-provider-inventory.test.ts
- npx vitest run api/ai-provider-inventory.test.ts
- npx eslint packages/mcp-server/src/nudgeonly-tool.ts packages/mcp-server/src/nudgeonly-tool.test.ts packages/mcp-server/src/tool-wiring.ts api/lib/ai-provider-inventory.ts api/ai-provider-inventory.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Risk:
- Low. Non-free NudgeOnly custom model usage now needs NUDGEONLY_OPENROUTER_ALLOW_PAID=1 or allow_paid=true. Existing default free model behavior remains allowed.

Follow-up:
- Continue inventorying remaining AI chat or classifier surfaces outside NudgeOnly and Memory Admin.