### PR TITLE
[codex] guard autonomous runner git hygiene

### DIFF
--- a/packages/testpass/src/__tests__/anti-stomp.test.ts
+++ b/packages/testpass/src/__tests__/anti-stomp.test.ts
@@ -5,7 +5,10 @@ import {
   checkDeletedFilesMentioned,
   checkAuditRequiresArchaeology,
   checkFactHasGitLink,
+  checkGitStatusClean,
+  parseGitStatusPorcelain,
 } from "../checks/anti-stomp.js";
+import { isDeterministicCheckRegistered } from "../runner/deterministic.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PACK_PATH = path.resolve(__dirname, "../../packs/anti-stomp-v0.yaml");
@@ -177,5 +180,31 @@ describe("GIT-LINK-001: checkFactHasGitLink", () => {
   it("passes (no-op) when category is undefined", () => {
     const result = checkFactHasGitLink({});
     expect(result.pass).toBe(true);
+  });
+});
+
+// GIT-HYGIENE-001: checkGitStatusClean
+
+describe("GIT-HYGIENE-001: checkGitStatusClean", () => {
+  it("is registered with the deterministic runner", () => {
+    expect(isDeterministicCheckRegistered("GIT-HYGIENE-001")).toBe(true);
+  });
+
+  it("passes when git status porcelain output is empty", () => {
+    const result = checkGitStatusClean("");
+    expect(result.pass).toBe(true);
+  });
+
+  it("fails and names dirty files when git status porcelain has entries", () => {
+    const result = checkGitStatusClean(" M api/memory-admin.ts\n?? scripts/new-check.mjs\n");
+    expect(result.pass).toBe(false);
+    expect(result.missing).toEqual(["api/memory-admin.ts", "scripts/new-check.mjs"]);
+    expect(result.reason).toMatch(/2 uncommitted path/);
+  });
+
+  it("parses renamed paths without losing the porcelain status", () => {
+    expect(parseGitStatusPorcelain("R  old/path.ts -> new/path.ts\n")).toEqual([
+      { status: "R", path: "old/path.ts -> new/path.ts" },
+    ]);
   });
 });

--- a/packages/testpass/src/checks/anti-stomp.ts
+++ b/packages/testpass/src/checks/anti-stomp.ts
@@ -12,6 +12,11 @@ export interface CheckResult {
   reason?: string;
 }
 
+export interface GitStatusEntry {
+  status: string;
+  path: string;
+}
+
 // ── DELETE-001 ──────────────────────────────────────────────────────────────
 
 /**
@@ -90,5 +95,31 @@ export function checkFactHasGitLink(fact: FactLinkInput): CheckResult {
     reason: linked
       ? "Fact has git linkage"
       : `Fact in category "${fact.category}" has neither commit_sha nor pr_number`,
+  };
+}
+
+// GIT-HYGIENE-001
+
+export function parseGitStatusPorcelain(statusText: string): GitStatusEntry[] {
+  return String(statusText ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => ({
+      status: line.slice(0, 2).trim(),
+      path: line.slice(3).trim() || line.trim(),
+    }));
+}
+
+export function checkGitStatusClean(statusText: string): CheckResult {
+  const dirty = parseGitStatusPorcelain(statusText);
+  if (dirty.length === 0) {
+    return { pass: true, reason: "git status --porcelain returned no changes" };
+  }
+
+  return {
+    pass: false,
+    missing: dirty.map((entry) => entry.path),
+    reason: `git status --porcelain reported ${dirty.length} uncommitted path(s)`,
   };
 }

--- a/packages/testpass/src/runner/deterministic.ts
+++ b/packages/testpass/src/runner/deterministic.ts
@@ -12,7 +12,9 @@
 import type { Pack, RunProfile } from "../types.js";
 import type { RunManagerConfig } from "../run-manager.js";
 import { updateItem, createEvidence } from "../run-manager.js";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { checkGitStatusClean } from "../checks/anti-stomp.js";
 import { buildMcpHeaders, readMcpResponseBody } from "../mcp-http.js";
 
 // ─── Internal types ────────────────────────────────────────────────
@@ -62,6 +64,24 @@ function rpcReq(method: string, params: unknown, id?: number): unknown {
   const r: Record<string, unknown> = { jsonrpc: "2.0", method, params };
   if (id !== undefined) r.id = id;
   return r;
+}
+
+async function runGitStatusPorcelain(
+  cwd = process.cwd(),
+): Promise<{ ok: boolean; status: number; stdout: string; stderr: string; latency_ms: number }> {
+  const start = Date.now();
+  return new Promise((resolve) => {
+    execFile("git", ["status", "--porcelain"], { cwd }, (error, stdout, stderr) => {
+      const code = (error as { code?: unknown } | null)?.code;
+      resolve({
+        ok: !error,
+        status: !error ? 0 : typeof code === "number" ? code : 1,
+        stdout: String(stdout ?? ""),
+        stderr: String(stderr ?? ""),
+        latency_ms: Date.now() - start,
+      });
+    });
+  });
 }
 
 // ─── Check handlers ────────────────────────────────────────────────
@@ -348,7 +368,46 @@ const HANDLERS: Record<string, CheckHandler> = {
       traces: [trace],
     };
   },
+
+  // GIT-HYGIENE-001: session worktrees must be clean before handoff.
+  "GIT-HYGIENE-001": async () => {
+    const r = await runGitStatusPorcelain();
+    const trace: HttpTrace = {
+      request: {
+        url: "local:git-status",
+        body: { command: "git status --porcelain", cwd: process.cwd() },
+      },
+      response: {
+        status: r.status,
+        body: { stdout: r.stdout, stderr: r.stderr },
+        latency_ms: r.latency_ms,
+      },
+    };
+
+    if (!r.ok) {
+      if (/not a git repository/i.test(r.stderr)) {
+        return { verdict: "na", note: "git status is not available outside a git worktree", traces: [trace] };
+      }
+      return {
+        verdict: "fail",
+        note: `git status --porcelain failed: ${r.stderr || `exit ${r.status}`}`,
+        traces: [trace],
+      };
+    }
+
+    const result = checkGitStatusClean(r.stdout);
+    if (result.pass) return { verdict: "check", note: result.reason, traces: [trace] };
+    return {
+      verdict: "fail",
+      note: `${result.reason}: ${(result.missing || []).join(", ")}`,
+      traces: [trace],
+    };
+  },
 };
+
+export function isDeterministicCheckRegistered(id: string): boolean {
+  return Boolean(HANDLERS[id]);
+}
 
 // ─── Public API ─────────────────────────────────────────────────────
 

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { execFile } from "node:child_process";
 import {
   createCodingRoomJobLedger,
   createCodingRoomJob,
@@ -116,6 +117,60 @@ function compact(value, max = 240) {
 function compactMultiline(value, max = 12000) {
   const text = String(value ?? "").trim();
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+export function parseAutonomousRunnerGitStatusPorcelain(statusText = "") {
+  return String(statusText ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => ({
+      status: line.slice(0, 2).trim(),
+      path: line.slice(3).trim() || line.trim(),
+    }));
+}
+
+export async function readAutonomousRunnerGitStatus({ cwd = process.cwd() } = {}) {
+  return new Promise((resolve) => {
+    execFile("git", ["status", "--porcelain"], { cwd }, (error, stdout, stderr) => {
+      const code = error?.code;
+      resolve({
+        ok: !error,
+        status: !error ? 0 : typeof code === "number" ? code : 1,
+        stdout: String(stdout ?? ""),
+        stderr: String(stderr ?? ""),
+      });
+    });
+  });
+}
+
+export async function evaluateAutonomousRunnerGitHygiene({
+  cwd = process.cwd(),
+  gitStatusImpl = readAutonomousRunnerGitStatus,
+} = {}) {
+  const status = await gitStatusImpl({ cwd });
+  if (!status?.ok) {
+    return {
+      ok: false,
+      reason: /not a git repository/i.test(status?.stderr || "")
+        ? "git_hygiene_not_a_worktree"
+        : "git_hygiene_status_failed",
+      status: status?.status ?? 1,
+      stderr: compact(status?.stderr || status?.error || "", 500),
+    };
+  }
+
+  const dirty = parseAutonomousRunnerGitStatusPorcelain(status.stdout);
+  if (dirty.length === 0) {
+    return { ok: true, reason: "git_hygiene_clean", dirty_files: [] };
+  }
+
+  return {
+    ok: false,
+    reason: "git_hygiene_dirty_worktree",
+    dirty_files: dirty.map((entry) => entry.path),
+    dirty_count: dirty.length,
+  };
 }
 
 function memoryAdminActionUrlFromMcpUrl(mcpUrl = DEFAULT_UNCLICK_MCP_URL, action = "") {
@@ -2094,6 +2149,9 @@ export async function runAutonomousRunnerFile({
   checkedOutSha = "",
   githubToken = "",
   mainFreshnessThresholdMinutes = 20,
+  gitHygienePreflight = false,
+  gitStatusImpl = readAutonomousRunnerGitStatus,
+  worktreeCwd = process.cwd(),
 } = {}) {
   if (orchestratorProof) {
     return runOrchestratorSeatHandshakeProof({
@@ -2141,6 +2199,30 @@ export async function runAutonomousRunnerFile({
     imported: 0,
     seen: ledger.jobs?.length || 0,
   };
+
+  let gitHygiene = { ok: true, skipped: true, reason: "git_hygiene_preflight_disabled" };
+  if (gitHygienePreflight && safeMode !== "dry-run") {
+    gitHygiene = await evaluateAutonomousRunnerGitHygiene({
+      cwd: worktreeCwd,
+      gitStatusImpl,
+    });
+    if (!gitHygiene.ok) {
+      return {
+        ok: false,
+        action: "blocked",
+        reason: gitHygiene.reason,
+        mode: safeMode,
+        dry_run: false,
+        persisted: false,
+        cycles: [],
+        ledger,
+        ledger_path: ledgerPath,
+        queue_source: queueSourceResult,
+        git_hygiene: gitHygiene,
+        main_freshness_canary: mainFreshnessCanary,
+      };
+    }
+  }
 
   if (String(queueSource || "ledger").trim().toLowerCase() === "unclick") {
     queueSourceResult = {
@@ -2357,6 +2439,7 @@ export async function runAutonomousRunnerFile({
     quiet_window_autonomy_proof: quietWindowAutonomyProof,
     todo_claim_sync: todoClaimSync,
     todo_scoping_sync: todoScopingSync,
+    git_hygiene: gitHygiene,
     main_freshness_canary: mainFreshnessCanary,
   };
 }
@@ -2416,6 +2499,9 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
     mainFreshnessThresholdMinutes: parseIntOption(
       getArg("main-freshness-threshold-minutes", process.env.AUTONOMOUS_RUNNER_MAIN_FRESHNESS_THRESHOLD_MINUTES),
       20,
+    ),
+    gitHygienePreflight: !parseBoolean(
+      getArg("skip-git-hygiene-preflight", process.env.AUTONOMOUS_RUNNER_SKIP_GIT_HYGIENE_PREFLIGHT),
     ),
     policy: createAutonomousRunnerPolicy({
       disabled: parseBoolean(process.env.AUTONOMOUS_RUNNER_DISABLED),

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -23,7 +23,9 @@ import {
   inspectAutonomousRunnerJobSafety,
   markUnsafeJobsBlockedForAutonomousRunner,
   normalizeAutonomousRunnerMode,
+  parseAutonomousRunnerGitStatusPorcelain,
   parseMcpEventStreamPayload,
+  evaluateAutonomousRunnerGitHygiene,
   runAutonomousRunnerMainFreshnessCanary,
   runAutonomousRunnerCycle,
   runAutonomousRunnerFile,
@@ -686,6 +688,74 @@ describe("PinballWake autonomous Runner seat", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("blocks claim mode before queue import when git hygiene preflight sees dirty files", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      let fetchCalled = false;
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl: async () => {
+          fetchCalled = true;
+          return { ok: true, async json() { return { result: { content: [] } }; } };
+        },
+        gitHygienePreflight: true,
+        gitStatusImpl: async () => ({
+          ok: true,
+          status: 0,
+          stdout: " M api/memory-admin.ts\n?? scripts/scratch-proof.mjs\n",
+          stderr: "",
+        }),
+        now: "2026-05-15T22:05:00.000Z",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "git_hygiene_dirty_worktree");
+      assert.deepEqual(result.git_hygiene.dirty_files, [
+        "api/memory-admin.ts",
+        "scripts/scratch-proof.mjs",
+      ]);
+      assert.equal(fetchCalled, false);
+      assert.equal(result.persisted, false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses and evaluates autonomous runner git hygiene status", async () => {
+    assert.deepEqual(
+      parseAutonomousRunnerGitStatusPorcelain(" M api/server.ts\n?? scratch.txt\n"),
+      [
+        { status: "M", path: "api/server.ts" },
+        { status: "??", path: "scratch.txt" },
+      ],
+    );
+
+    const clean = await evaluateAutonomousRunnerGitHygiene({
+      gitStatusImpl: async () => ({ ok: true, status: 0, stdout: "", stderr: "" }),
+    });
+    assert.equal(clean.ok, true);
+
+    const dirty = await evaluateAutonomousRunnerGitHygiene({
+      gitStatusImpl: async () => ({
+        ok: true,
+        status: 0,
+        stdout: " M api/server.ts\n",
+        stderr: "",
+      }),
+    });
+    assert.equal(dirty.ok, false);
+    assert.equal(dirty.reason, "git_hygiene_dirty_worktree");
   });
 
   it("allows unassigned orchestrator ScopePacks with builder-compatible owner hints", async () => {


### PR DESCRIPTION
## Summary
- registers `GIT-HYGIENE-001` as a real deterministic Anti-Stomp handler
- parses `git status --porcelain` output and reports dirty paths as proof
- adds a CLI git hygiene preflight so autonomous runner claim or execute mode stops before queue import when the checkout is dirty
- covers the dirty checkout block in the runner test suite

## Testing
- `node --test scripts/pinballwake-autonomous-runner.test.mjs`
- `node --import tsx -e "...anti-stomp git hygiene smoke..."`
- `npx tsc --project packages/testpass/tsconfig.json --noEmit --types jest`
- `npx eslint packages/testpass/src/checks/anti-stomp.ts packages/testpass/src/runner/deterministic.ts scripts/pinballwake-autonomous-runner.mjs scripts/pinballwake-autonomous-runner.test.mjs`
- `npm run build`
- `git diff --check`

## Notes
Root Vitest does not include `packages/testpass/src/__tests__`, and the package test script points at a missing local Jest binary in `packages/testpass/node_modules/.bin`. I used the package TypeScript check plus a direct TS smoke for the new Anti-Stomp path instead.

Boardroom todo: `82a8b6c5-4899-4e9b-9d68-5d35eaa86c4f`.