### PR TITLE
feat(securitypass): label memory fact extraction spend

### DIFF
--- a/api/ai-provider-inventory.test.ts
+++ b/api/ai-provider-inventory.test.ts
@@ -14,6 +14,7 @@ describe("ai provider inventory", () => {
     expect(inventory.some((entry) => entry.id === "nudgeonly.openrouter.free-default")).toBe(true);
     expect(inventory.some((entry) => entry.id === "nudgeonly.openrouter.custom-model")).toBe(true);
     expect(inventory.some((entry) => entry.id === "memory.mcp.openai.embeddings")).toBe(true);
+    expect(inventory.some((entry) => entry.id === "memory.mcp.openai.fact-extraction")).toBe(true);
     expect(inventory.every((entry) => ["free", "paid", "paid_or_unknown"].includes(entry.cost_tier))).toBe(true);
     expect(inventory.filter((entry) => entry.default_allowed).map((entry) => entry.cost_tier)).toEqual(["free"]);
   });
@@ -64,6 +65,14 @@ describe("ai provider inventory", () => {
       cost_tier: "paid",
       reason: "paid_or_unknown_blocked",
       allow_paid_flag: "MEMORY_OPENAI_EMBEDDINGS_ENABLED",
+    });
+    expect(decideAiProviderCall({ path_id: "memory.mcp.openai.fact-extraction" })).toMatchObject({
+      allowed: false,
+      provider: "OpenAI",
+      model: "gpt-4o-mini",
+      cost_tier: "paid",
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "MEMORY_OPENAI_FACT_EXTRACTION_ENABLED or MEMORY_AI_FACT_EXTRACTION_ENABLED",
     });
   });
 
@@ -201,6 +210,14 @@ describe("ai provider inventory", () => {
   it("allows paid paths only when an explicit allow-paid decision is present", () => {
     expect(decideAiProviderCall({
       path_id: "memory.mcp.openai.embeddings",
+      allow_paid: true,
+    })).toMatchObject({
+      allowed: true,
+      cost_tier: "paid",
+      reason: "explicit_paid_allowed",
+    });
+    expect(decideAiProviderCall({
+      path_id: "memory.mcp.openai.fact-extraction",
       allow_paid: true,
     })).toMatchObject({
       allowed: true,

--- a/api/lib/ai-provider-inventory.ts
+++ b/api/lib/ai-provider-inventory.ts
@@ -94,6 +94,17 @@ export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
     notes: "Memory MCP embeddings already require an explicit true/1 opt-in before calling OpenAI.",
   },
   {
+    id: "memory.mcp.openai.fact-extraction",
+    provider: "OpenAI",
+    surface: "packages/mcp-server/src/memory/supabase.ts",
+    call_kind: "chat_completion",
+    model: "gpt-4o-mini",
+    cost_tier: "paid",
+    default_allowed: false,
+    allow_paid_flag: "MEMORY_OPENAI_FACT_EXTRACTION_ENABLED or MEMORY_AI_FACT_EXTRACTION_ENABLED",
+    notes: "Memory MCP atomic fact extraction is paid and stays disabled unless a true/1 extraction flag and OPENAI_API_KEY are both present.",
+  },
+  {
     id: "memory.package.openai.embeddings",
     provider: "OpenAI",
     surface: "packages/memory-mcp/src/embeddings.ts",


### PR DESCRIPTION
Summary:
- Adds a visible AI spend inventory entry for Memory MCP atomic fact extraction.
- Labels the OpenAI chat-completion path in packages/mcp-server/src/memory/supabase.ts as paid, default-off, and gated by MEMORY_OPENAI_FACT_EXTRACTION_ENABLED or MEMORY_AI_FACT_EXTRACTION_ENABLED.
- Extends inventory tests so the path is visible, blocked by default, and only allowed by an explicit paid decision.

Scope:
- Owned files: api/lib/ai-provider-inventory.ts, api/ai-provider-inventory.test.ts
- Linked todo: 6408ff7b-7629-471b-b745-318ebb82b7a0 AI spend guardrails
- Lane: securitypass AI spend guardrails

Non-overlap:
- Does not change the fact extraction runtime path, credentials, keychain, billing settings, production data, DNS, deployment config, or provider calls.
- Does not touch the dirty root worktree or other active PRs.

Verification:
- npm ci, to hydrate this clean worktree
- npx vitest run api/ai-provider-inventory.test.ts
- git diff --check, passed with LF to CRLF warnings
- npx eslint api/lib/ai-provider-inventory.ts api/ai-provider-inventory.test.ts
- npx tsc --noEmit --pretty false
- npm run build, passed with existing Browserslist and chunk-size warnings

Risk:
- Metadata and tests only. No migration, auth, secrets, cron, live API path, billing setting, or user data risk expected.

Follow-up:
- Continue auditing any remaining AI-adjacent server paths that are not represented in api/lib/ai-provider-inventory.ts.