### PR TITLE
feat(securitypass): label web API spend

### DIFF
--- a/api/ai-provider-inventory.test.ts
+++ b/api/ai-provider-inventory.test.ts
@@ -16,7 +16,7 @@ describe("ai provider inventory", () => {
     expect(inventory.some((entry) => entry.id === "memory.mcp.openai.embeddings")).toBe(true);
     expect(inventory.some((entry) => entry.id === "memory.mcp.openai.fact-extraction")).toBe(true);
     expect(inventory.every((entry) => ["free", "paid", "paid_or_unknown"].includes(entry.cost_tier))).toBe(true);
-    expect(inventory.filter((entry) => entry.default_allowed).map((entry) => entry.cost_tier)).toEqual(["free"]);
+    expect(inventory.filter((entry) => entry.default_allowed).every((entry) => entry.cost_tier === "free")).toBe(true);
   });
 
   it("allows explicitly labelled free default paths", () => {
@@ -185,6 +185,51 @@ describe("ai provider inventory", () => {
     })).toMatchObject({
       allowed: true,
       reason: "explicit_paid_allowed",
+    });
+  });
+
+  it("labels external web API provider operations with visible cost gates", () => {
+    const expected = [
+      ["mcp.web-search.tavily.search", "Tavily", "web_search", "TAVILY_API_KEY"],
+      ["mcp.web-search.exa.search", "Exa", "web_search", "EXA_API_KEY"],
+      ["mcp.web-search.brave.search", "Brave Search", "web_search", "BRAVE_SEARCH_API_KEY"],
+      ["mcp.web-scrape.firecrawl.scrape", "Firecrawl", "web_scrape", "FIRECRAWL_API_KEY"],
+      ["mcp.web-scrape.tavily.extract", "Tavily", "web_scrape", "TAVILY_API_KEY"],
+    ] as const;
+
+    for (const [pathId, provider, callKind, allowPaidFlag] of expected) {
+      expect(getAiProviderInventoryEntry(pathId)).toMatchObject({
+        provider,
+        surface: "packages/mcp-server/src/web-tools.ts",
+        call_kind: callKind,
+        cost_tier: "paid_or_unknown",
+        default_allowed: false,
+        allow_paid_flag: allowPaidFlag,
+      });
+      expect(decideAiProviderCall({ path_id: pathId })).toMatchObject({
+        allowed: false,
+        provider,
+        reason: "paid_or_unknown_blocked",
+        allow_paid_flag: allowPaidFlag,
+      });
+      expect(decideAiProviderCall({ path_id: pathId, allow_paid: true })).toMatchObject({
+        allowed: true,
+        provider,
+        reason: "explicit_paid_allowed",
+      });
+    }
+
+    expect(getAiProviderInventoryEntry("mcp.search-docs.context7.lookup")).toMatchObject({
+      provider: "Context7",
+      surface: "packages/mcp-server/src/web-tools.ts",
+      call_kind: "web_search",
+      cost_tier: "free",
+      default_allowed: true,
+    });
+    expect(decideAiProviderCall({ path_id: "mcp.search-docs.context7.lookup" })).toMatchObject({
+      allowed: true,
+      provider: "Context7",
+      reason: "free_default_allowed",
     });
   });
 

--- a/api/lib/ai-provider-inventory.ts
+++ b/api/lib/ai-provider-inventory.ts
@@ -11,7 +11,9 @@ export type AiProviderCallKind =
   | "classification"
   | "reranking"
   | "prediction"
-  | "model_listing";
+  | "model_listing"
+  | "web_search"
+  | "web_scrape";
 
 export interface AiProviderInventoryEntry {
   id: string;
@@ -775,6 +777,71 @@ export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
     default_allowed: false,
     allow_paid_flag: "api_key argument",
     notes: "MCP Kling AI task status reaches provider run state and requires an explicit caller key.",
+  },
+  {
+    id: "mcp.web-search.tavily.search",
+    provider: "Tavily",
+    surface: "packages/mcp-server/src/web-tools.ts",
+    call_kind: "web_search",
+    model: "Tavily /search",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "TAVILY_API_KEY",
+    notes: "webSearch can call Tavily when TAVILY_API_KEY is present, so external search API spend stays labelled and blocked by default.",
+  },
+  {
+    id: "mcp.web-search.exa.search",
+    provider: "Exa",
+    surface: "packages/mcp-server/src/web-tools.ts",
+    call_kind: "web_search",
+    model: "Exa /search",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "EXA_API_KEY",
+    notes: "webSearch can call Exa when EXA_API_KEY is present, so external search API spend stays labelled and blocked by default.",
+  },
+  {
+    id: "mcp.web-search.brave.search",
+    provider: "Brave Search",
+    surface: "packages/mcp-server/src/web-tools.ts",
+    call_kind: "web_search",
+    model: "Brave Search /res/v1/web/search",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "BRAVE_SEARCH_API_KEY",
+    notes: "webSearch can call Brave Search when BRAVE_SEARCH_API_KEY is present, so external search API spend stays labelled and blocked by default.",
+  },
+  {
+    id: "mcp.web-scrape.firecrawl.scrape",
+    provider: "Firecrawl",
+    surface: "packages/mcp-server/src/web-tools.ts",
+    call_kind: "web_scrape",
+    model: "Firecrawl /scrape",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "FIRECRAWL_API_KEY",
+    notes: "webScrape can call Firecrawl when FIRECRAWL_API_KEY is present, so external scrape API spend stays labelled and blocked by default.",
+  },
+  {
+    id: "mcp.web-scrape.tavily.extract",
+    provider: "Tavily",
+    surface: "packages/mcp-server/src/web-tools.ts",
+    call_kind: "web_scrape",
+    model: "Tavily /extract",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "TAVILY_API_KEY",
+    notes: "webScrape can call Tavily extract when TAVILY_API_KEY is present, so external scrape API spend stays labelled and blocked by default.",
+  },
+  {
+    id: "mcp.search-docs.context7.lookup",
+    provider: "Context7",
+    surface: "packages/mcp-server/src/web-tools.ts",
+    call_kind: "web_search",
+    model: "Context7 resolve-library-id and get-library-docs",
+    cost_tier: "free",
+    default_allowed: true,
+    notes: "searchDocs uses Context7 without a configured key and remains visible as a free documentation lookup.",
   },
 ] as const;
 


### PR DESCRIPTION
Summary:
Adds visible AI spend inventory labels for external web/search/scrape MCP web tools: Tavily search, Exa search, Brave Search, Firecrawl scrape, Tavily extract, and Context7 docs lookup.

Scope:
- api/lib/ai-provider-inventory.ts
- api/ai-provider-inventory.test.ts
- Todo: 6408ff7b-7629-471b-b745-318ebb82b7a0
- Owned slice: web API provider inventory coverage

Non-overlap:
Does not change runtime web tool behavior, env handling, billing, secrets, migrations, DNS, data deletion, or unrelated AI spend runtime gates. Leaves packages/channel-plugin/index.js unstaged because it only showed a line-ending normalization status from npm install with no content diff.

Verification:
- npm ci
- npx vitest run api/ai-provider-inventory.test.ts
- git diff --check
- npx eslint api/lib/ai-provider-inventory.ts api/ai-provider-inventory.test.ts
- npx tsc --noEmit --pretty false
- npm run build

Risk:
Low. Registry and tests only. New paid or unknown web API labels remain blocked by default unless a caller explicitly allows paid provider use. Context7 remains labelled as free because the live searchDocs path uses no configured key.

Follow-up:
Continue AI spend guardrail inventory coverage for any remaining external API call sites discovered outside the MCP web tools.