### PR TITLE
feat(reviewpass): add review dry-run warning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,15 @@
 - Non-overlap:
 - Status:
 
+## Review handoff
+<!-- Required before marking ready:
+     - Name the requested reviewer or lane.
+     - State any human decision still pending, or "None".
+     - State merge policy: draft, HOLD, review-only, or autopilot-eligible. -->
+- Reviewer or lane:
+- Human decision pending:
+- Merge policy:
+
 ## Deletions
 <!-- Required: list every file, route, or component removed, with rationale.
      "None" is a valid answer if nothing was deleted.

--- a/.github/workflows/review-enforcement-warning.yml
+++ b/.github/workflows/review-enforcement-warning.yml
@@ -1,0 +1,21 @@
+name: Review enforcement warning
+
+on:
+  pull_request:
+
+concurrency:
+  group: review-enforcement-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review-dry-run:
+    name: Review dry-run warning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Check PR review and proof sections
+        run: node scripts/review-dry-run.mjs --github-event "$GITHUB_EVENT_PATH"
+        continue-on-error: true

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -19,7 +19,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminShell.tsx | fa1b64904f84 | 19137 |
 | .github/workflows/ci.yml | 79e43dd8e26c | 1608 |
 | .github/workflows/brainmap-auto-update.yml | 7e8b08eb16aa | 1137 |
-| package.json | 37074f6e60a5 | 4175 |
+| package.json | 9f761ff407b1 | 4232 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
 | scripts/pinballwake-buildbait-room.mjs | 400dccb101ba | 5214 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:rotatepass-redaction": "node --test scripts/rotatepass-redaction-guard.test.mjs",
     "test:watch": "vitest",
     "test:api": "npm run test --workspace=apps/api",
+    "review:dry-run": "node scripts/review-dry-run.mjs",
     "brainmap:generate": "node scripts/UnClick-brainmap.mjs",
     "brainmap:check": "node scripts/UnClick-brainmap.mjs --check",
     "test:brainmap": "node --test scripts/UnClick-brainmap.test.mjs"

--- a/scripts/review-dry-run.mjs
+++ b/scripts/review-dry-run.mjs
@@ -1,0 +1,137 @@
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const REQUIRED_SECTIONS = [
+  "summary",
+  "changes",
+  "owner and lift status",
+  "review handoff",
+  "testing",
+];
+
+function compact(value) {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function stripHtmlComments(value) {
+  return String(value || "").replace(/<!--[\s\S]*?-->/g, "");
+}
+
+function normaliseHeading(value) {
+  return compact(value).toLowerCase();
+}
+
+export function extractMarkdownSections(markdown) {
+  const sections = new Map();
+  let current = null;
+  let buffer = [];
+
+  for (const line of String(markdown || "").split(/\r?\n/)) {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) {
+      if (current) sections.set(current, buffer.join("\n"));
+      current = normaliseHeading(heading[1]);
+      buffer = [];
+      continue;
+    }
+    if (current) buffer.push(line);
+  }
+
+  if (current) sections.set(current, buffer.join("\n"));
+  return sections;
+}
+
+export function hasMeaningfulSectionContent(value) {
+  const stripped = stripHtmlComments(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => line !== "-")
+    .filter((line) => !/^-?\s*(owner|non-overlap|status|reviewer or lane|human decision pending|merge policy)\s*:\s*$/i.test(line));
+
+  return stripped.length > 0;
+}
+
+export function validateReviewBody(markdown, options = {}) {
+  const requiredSections = options.requiredSections || REQUIRED_SECTIONS;
+  const sections = extractMarkdownSections(markdown);
+  const missing_sections = [];
+  const empty_sections = [];
+
+  for (const section of requiredSections) {
+    if (!sections.has(section)) {
+      missing_sections.push(section);
+      continue;
+    }
+    if (!hasMeaningfulSectionContent(sections.get(section))) {
+      empty_sections.push(section);
+    }
+  }
+
+  return {
+    ok: missing_sections.length === 0 && empty_sections.length === 0,
+    required_sections: [...requiredSections],
+    missing_sections,
+    empty_sections,
+  };
+}
+
+export async function readReviewBodyFromArgs(args, cwd = process.cwd()) {
+  const bodyFileIndex = args.indexOf("--body-file");
+  if (bodyFileIndex !== -1) {
+    const file = args[bodyFileIndex + 1];
+    if (!file) throw new Error("--body-file requires a path");
+    return readFile(file, "utf8");
+  }
+
+  const githubEventIndex = args.indexOf("--github-event");
+  if (githubEventIndex !== -1) {
+    const file = args[githubEventIndex + 1];
+    if (!file) throw new Error("--github-event requires a path");
+    const event = JSON.parse(await readFile(file, "utf8"));
+    return event.pull_request?.body || "";
+  }
+
+  const templateIndex = args.indexOf("--template");
+  if (templateIndex !== -1) {
+    const file = args[templateIndex + 1] || `${cwd}/.github/PULL_REQUEST_TEMPLATE.md`;
+    return readFile(file, "utf8");
+  }
+
+  throw new Error("Usage: node scripts/review-dry-run.mjs --body-file <path> | --github-event <event.json> | --template [path]");
+}
+
+function formatList(items) {
+  return items.length ? items.join(", ") : "none";
+}
+
+function emitWarning(message) {
+  if (process.env.GITHUB_ACTIONS === "true") {
+    console.log(`::warning title=Review enforcement::${message}`);
+  }
+}
+
+export async function main(args = process.argv.slice(2)) {
+  let body;
+  try {
+    body = await readReviewBodyFromArgs(args);
+  } catch (error) {
+    console.error(error.message);
+    return 2;
+  }
+
+  const result = validateReviewBody(body);
+  if (result.ok) {
+    console.log(`PASS: review dry-run found required sections: ${formatList(result.required_sections)}`);
+    return 0;
+  }
+
+  const message = `Missing sections: ${formatList(result.missing_sections)}. Empty sections: ${formatList(result.empty_sections)}.`;
+  emitWarning(message);
+  console.error(`HOLD: review dry-run incomplete. ${message}`);
+  return 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = await main();
+}

--- a/scripts/review-dry-run.test.mjs
+++ b/scripts/review-dry-run.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it } from "node:test";
+
+import {
+  readReviewBodyFromArgs,
+  validateReviewBody,
+} from "./review-dry-run.mjs";
+
+const COMPLETE_BODY = `
+## Summary
+- Adds a review dry-run.
+
+## Changes
+- scripts/review-dry-run.mjs
+
+## Owner and lift status
+- Owner: chatgpt-codex-fleet-seat
+- Non-overlap: no runtime merge gates touched
+- Status: ready for review
+
+## Review handoff
+- Reviewer or lane: reviewer
+- Human decision pending: None
+- Merge policy: review-only
+
+## Testing
+- PASS: node --test scripts/review-dry-run.test.mjs
+`;
+
+describe("review dry-run", () => {
+  it("passes when required review and proof sections are filled", () => {
+    const result = validateReviewBody(COMPLETE_BODY);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.missing_sections, []);
+    assert.deepEqual(result.empty_sections, []);
+  });
+
+  it("fails when the review handoff section is missing", () => {
+    const result = validateReviewBody(COMPLETE_BODY.replace(/\n## Review handoff[\s\S]*?\n## Testing/, "\n## Testing"));
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.missing_sections, ["review handoff"]);
+  });
+
+  it("fails when template placeholders are not filled", () => {
+    const result = validateReviewBody(`
+## Summary
+<!-- 1-3 bullets -->
+-
+
+## Changes
+-
+
+## Owner and lift status
+- Owner:
+- Non-overlap:
+- Status:
+
+## Review handoff
+- Reviewer or lane:
+- Human decision pending:
+- Merge policy:
+
+## Testing
+-
+`);
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.empty_sections, [
+      "summary",
+      "changes",
+      "owner and lift status",
+      "review handoff",
+      "testing",
+    ]);
+  });
+
+  it("reads a pull request body from a GitHub event file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "review-dry-run-"));
+    const eventFile = join(dir, "event.json");
+    await writeFile(eventFile, JSON.stringify({ pull_request: { body: COMPLETE_BODY } }));
+
+    const body = await readReviewBodyFromArgs(["--github-event", eventFile]);
+    assert.equal(body, COMPLETE_BODY);
+    assert.equal(validateReviewBody(body).ok, true);
+  });
+});


### PR DESCRIPTION
Summary:
Adds the Build E review enforcement bundle as a warning-first guardrail: a PR body dry-run validator, focused tests, a warning-only GitHub Actions workflow, a PR template review handoff section, and the generated Brainmap refresh required by CI.

Scope:
- .github/PULL_REQUEST_TEMPLATE.md
- .github/workflows/review-enforcement-warning.yml
- scripts/review-dry-run.mjs
- scripts/review-dry-run.test.mjs
- package.json
- docs/UnClick-brainmap.generated.md
- Todo: abc66ff1-0b2a-4fd5-98e1-d349eab5aa07
- Owned slice: ReviewPass dry-run enforcement, warning-only v0

Non-overlap:
Does not change merge authority, QueuePush routing, Review Coordinator gates, production runtime code, secrets, auth, billing, DNS, migrations, data, or hard CI blocking. Leaves packages/channel-plugin/index.js unstaged because npm ci produced only a line-ending status with no content diff.

Verification:
- npm ci
- node --test scripts/review-dry-run.test.mjs
- npx eslint scripts/review-dry-run.mjs scripts/review-dry-run.test.mjs
- npm run brainmap:check
- npm run test:brainmap
- git diff --check
- npm run build
- GitHub checks green on PR #837: Website, MCP server package, Review dry-run warning, TestPass smoke run, Vercel, Vercel Preview Comments

Risk:
Low. New workflow is warning-only via continue-on-error. The local dry-run fails closed for missing or unfilled review/proof sections, while CI surfaces the issue without blocking merges in v0.

Follow-up:
Later passes can decide whether to tighten from warning to hard gate once stable.