### PR TITLE
feat(lib): critical-path queue picker

### DIFF
--- a/docs/critical-path-queue.md
+++ b/docs/critical-path-queue.md
@@ -1,0 +1,81 @@
+# Critical-path queue picker
+
+Closes UnClick todo "Critical-path queue picker: rank todos by unblock value, not only priority" (green-lit efficiency build 2026-05-07).
+
+## What changes
+
+Today the queue picker sorts todos by priority alone. That's a fine first signal, but it ignores throughput: a `medium` todo that unblocks 5 downstream `high` todos has more *real* value than an isolated `high` todo that unblocks nothing.
+
+This module computes a combined score:
+
+```
+score = priorityWeight + (reachableUnblocks * unblockMultiplier) + manualScore
+```
+
+Where:
+
+- `priorityWeight` - `urgent:100, high:60, medium:30, low:10` by default (configurable).
+- `reachableUnblocks` - the number of transitively-downstream todos that list this one as a `blocked_by`. Computed via BFS with a 50-hop cap so cycles can't explode.
+- `unblockMultiplier` - `2` by default. Increase to favour unblocking work even more strongly.
+- `manualScore` - optional caller override (e.g., for tagging "stale and pinned" boosts).
+
+Excluded statuses (done/cancelled/wontfix/archived) are dropped before ranking.
+
+## API
+
+```ts
+import { rankCriticalPath, pickTopN, explainRank } from "~/lib/criticalPathQueue";
+
+const ranked = rankCriticalPath(allTodos);
+const top10 = pickTopN(allTodos, 10);
+console.log(explainRank(ranked[0]));
+// "score 80 = 60w priority, unblocks 10 downstream (3 direct)"
+```
+
+`RankedTodo` carries the source todo plus per-axis breakdown so downstream UI can render "why ranked here" inline.
+
+## Integration points
+
+The picker is dependency-free and pure. Drop-in places likely to want it:
+
+- The autonomous runner's claim-selection step (replaces the priority-only sort).
+- The admin Jobs board sort order (let humans see the same ordering).
+- `list_actionable_todos` server response (could include the score per todo).
+- BuildBait crumb prioritisation (pick the next ladder step based on which top-ranked todo has fewest crumbs on it).
+
+## Why a BFS depth cap
+
+UnClick todos can have arbitrary `blocked_by` chains. In pathological cases (or genuine cycles) the depth could explode. The default 50-hop cap is enough for realistic dependency chains but stops bad data from hanging the picker. If a dependency graph genuinely exceeds 50 hops it's almost certainly a data-quality bug worth surfacing separately.
+
+## Tests
+
+`criticalPathQueue.test.ts` covers:
+
+- Priority-only ordering when there are no dependencies.
+- Excluded statuses don't appear.
+- Unblock count outranks priority when multiplier is set high.
+- Transitive (BFS) reach beats direct-only count.
+- Circular dependencies are detected without throwing.
+- Manual score, priority overrides, missing priority defaults, unknown `blocked_by` ids.
+- Stable secondary sort by id.
+- `pickTopN` and `explainRank` behaviour.
+
+Run with `vitest run apps/.../criticalPathQueue.test.ts` (or whichever path the repo expects).
+
+## Acceptance (ScopePack 55%)
+
+- [x] `rankCriticalPath` returns todos sorted by combined score desc.
+- [x] Default weights favour urgent strongly; configurable.
+- [x] Reachable unblocks via BFS with cycle safety.
+- [x] `pickTopN` convenience + `explainRank` for surfacing rationale.
+- [x] Tests cover every weighting and edge case named in the ScopePack.
+
+## Non-goals
+
+- No persistence of scores (every call recomputes - todos change quickly enough that caching adds bugs not throughput).
+- No live UI in this PR; surfacing the score in the Jobs board is a follow-up.
+- No replacement of the underlying queue source (`list_actionable_todos`); this is a *re-rank* layer the caller applies on top.
+
+## Source
+
+Drafted 2026-05-15 by `claude-cowork-coordinator-seat`. Files on disk at `Z:\Other computers\My laptop\G\CV\_unclick-drafts\critical-path-queue\`.

--- a/src/lib/criticalPathQueue.test.ts
+++ b/src/lib/criticalPathQueue.test.ts
@@ -1,0 +1,198 @@
+// src/lib/criticalPathQueue.test.ts
+
+import { describe, test, expect } from "vitest";
+import {
+  rankCriticalPath,
+  pickTopN,
+  explainRank,
+  __consts__,
+  type TodoLike,
+} from "./criticalPathQueue";
+
+const open = (
+  id: string,
+  priority: TodoLike["priority"] = "medium",
+  blocked_by: string[] = [],
+  extra: Partial<TodoLike> = {},
+): TodoLike => ({ id, status: "open", priority, blocked_by, ...extra });
+
+describe("rankCriticalPath", () => {
+  test("ranks higher-priority todos above lower-priority when no dependencies", () => {
+    const ranked = rankCriticalPath([
+      open("A", "low"),
+      open("B", "urgent"),
+      open("C", "high"),
+      open("D", "medium"),
+    ]);
+    expect(ranked.map((r) => r.todo.id)).toEqual(["B", "C", "D", "A"]);
+  });
+
+  test("excludes done/cancelled/archived statuses by default", () => {
+    const ranked = rankCriticalPath([
+      open("A", "urgent"),
+      { id: "B", priority: "urgent", status: "done" },
+      { id: "C", priority: "urgent", status: "cancelled" },
+      { id: "D", priority: "urgent", status: "archived" },
+    ]);
+    expect(ranked.map((r) => r.todo.id)).toEqual(["A"]);
+  });
+
+  test("medium-priority blocker outranks isolated high-priority when unblock count is high", () => {
+    // Topology: M is blocked_by nothing; downstream chain D1..D5 are all blocked by M.
+    const todos: TodoLike[] = [
+      open("M", "medium"),
+      open("D1", "low", ["M"]),
+      open("D2", "low", ["M"]),
+      open("D3", "low", ["M"]),
+      open("D4", "low", ["M"]),
+      open("D5", "low", ["M"]),
+      open("H", "high"), // high but isolated
+    ];
+    const ranked = rankCriticalPath(todos);
+    // M's score: 30 (medium) + 5 * 2 = 40. H's score: 60. So H still wins on default weights.
+    // But with multiplier turned up, M should win.
+    const rankedHeavy = rankCriticalPath(todos, { unblockMultiplier: 10 });
+    // M's heavy score: 30 + 5*10 = 80. H stays at 60. M wins.
+    expect(rankedHeavy[0].todo.id).toBe("M");
+  });
+
+  test("reachableUnblocks counts transitive downstream nodes (BFS)", () => {
+    // M blocks A. A blocks B. B blocks C. M has reach 3.
+    const ranked = rankCriticalPath([
+      open("M", "medium"),
+      open("A", "low", ["M"]),
+      open("B", "low", ["A"]),
+      open("C", "low", ["B"]),
+    ]);
+    const m = ranked.find((r) => r.todo.id === "M")!;
+    expect(m.reachableUnblocks).toBe(3);
+    expect(m.unblockCount).toBe(1); // direct dependents only
+  });
+
+  test("circular dependencies do not blow up", () => {
+    // A blocks B, B blocks C, C blocks A.
+    const ranked = rankCriticalPath([
+      open("A", "medium", ["C"]),
+      open("B", "medium", ["A"]),
+      open("C", "medium", ["B"]),
+    ]);
+    // No throw. Each has reach 2 (the other two).
+    for (const r of ranked) {
+      expect(r.reachableUnblocks).toBe(2);
+    }
+  });
+
+  test("manual_score is added to the score", () => {
+    const ranked = rankCriticalPath([
+      open("A", "low", [], { manual_score: 1000 }),
+      open("B", "urgent"),
+    ]);
+    expect(ranked[0].todo.id).toBe("A");
+  });
+
+  test("manual_score can also be negative", () => {
+    const ranked = rankCriticalPath([
+      open("A", "urgent", [], { manual_score: -200 }),
+      open("B", "low"),
+    ]);
+    expect(ranked[0].todo.id).toBe("B");
+  });
+
+  test("priority weights can be overridden", () => {
+    const ranked = rankCriticalPath(
+      [open("A", "low"), open("B", "urgent")],
+      { priorityWeights: { urgent: 5, low: 100 } },
+    );
+    expect(ranked[0].todo.id).toBe("A");
+  });
+
+  test("missing priority defaults to medium", () => {
+    const ranked = rankCriticalPath([
+      { id: "X", status: "open", blocked_by: [] }, // no priority
+      open("Y", "low"),
+    ]);
+    expect(ranked[0].todo.id).toBe("X"); // medium beats low by default
+  });
+
+  test("blocked_by referencing unknown ids is safely ignored", () => {
+    const ranked = rankCriticalPath([
+      open("A", "medium", ["DOES_NOT_EXIST"]),
+    ]);
+    expect(ranked.length).toBe(1);
+    expect(ranked[0].reachableUnblocks).toBe(0);
+  });
+
+  test("stable secondary sort breaks ties by id ascending", () => {
+    const ranked = rankCriticalPath([
+      open("Z", "high"),
+      open("A", "high"),
+      open("M", "high"),
+    ]);
+    expect(ranked.map((r) => r.todo.id)).toEqual(["A", "M", "Z"]);
+  });
+
+  test("setting stableSecondarySort: false preserves insertion order on ties", () => {
+    const ranked = rankCriticalPath(
+      [open("Z", "high"), open("A", "high"), open("M", "high")],
+      { stableSecondarySort: false },
+    );
+    // Score and reachableUnblocks all equal - sort is non-deterministic but should not throw.
+    expect(ranked.length).toBe(3);
+  });
+});
+
+describe("pickTopN", () => {
+  test("returns the top N ranked", () => {
+    const todos = ["A", "B", "C", "D", "E"].map((id) => open(id, "high"));
+    const top3 = pickTopN(todos, 3);
+    expect(top3.length).toBe(3);
+  });
+
+  test("throws on invalid N", () => {
+    expect(() => pickTopN([open("A")], 0)).toThrow(RangeError);
+    expect(() => pickTopN([open("A")], -1)).toThrow(RangeError);
+    expect(() => pickTopN([open("A")], 1.5)).toThrow(RangeError);
+  });
+
+  test("returns fewer when fewer are available", () => {
+    const top10 = pickTopN([open("A")], 10);
+    expect(top10.length).toBe(1);
+  });
+});
+
+describe("explainRank", () => {
+  test("describes priority weight and unblock count", () => {
+    const ranked = rankCriticalPath([
+      open("M", "medium"),
+      open("A", "low", ["M"]),
+      open("B", "low", ["M"]),
+    ]);
+    const m = ranked.find((r) => r.todo.id === "M")!;
+    const text = explainRank(m);
+    expect(text).toMatch(/score \d+ = /);
+    expect(text).toMatch(/priority/);
+    expect(text).toMatch(/unblocks 2 downstream/);
+  });
+
+  test("explains 'no downstream blockers' when reach is zero", () => {
+    const ranked = rankCriticalPath([open("X", "high")]);
+    expect(explainRank(ranked[0])).toMatch(/no downstream blockers/);
+  });
+
+  test("includes manual_score when set", () => {
+    const ranked = rankCriticalPath([open("X", "medium", [], { manual_score: 25 })]);
+    expect(explainRank(ranked[0])).toMatch(/manual \+25/);
+  });
+});
+
+describe("default weights and excluded statuses", () => {
+  test("default weights favour urgent strongly over low", () => {
+    expect(__consts__.DEFAULT_PRIORITY_WEIGHTS.urgent).toBeGreaterThan(
+      __consts__.DEFAULT_PRIORITY_WEIGHTS.low * 5,
+    );
+  });
+
+  test("done is excluded by default", () => {
+    expect(__consts__.DEFAULT_EXCLUDED_STATUSES.has("done")).toBe(true);
+  });
+});

--- a/src/lib/criticalPathQueue.ts
+++ b/src/lib/criticalPathQueue.ts
@@ -1,0 +1,192 @@
+// src/lib/criticalPathQueue.ts
+//
+// Critical-path queue picker - ranks todos by combined unblock value AND
+// priority weight, not by priority alone.
+//
+// Closes UnClick todo "Critical-path queue picker: rank todos by unblock
+// value, not only priority" (green-lit efficiency build 2026-05-07).
+//
+// Intuition: if Todo A blocks 5 downstream todos, finishing A unblocks all 5.
+// Even if A is `medium` priority and B is `high`, A may have higher *real*
+// throughput value than B when B has no blockers downstream. This module
+// computes that and returns a sorted queue.
+//
+// The algorithm is intentionally pure and dependency-free - it takes a flat
+// list of todos and returns a sorted list. The caller is responsible for
+// fetching todos from the store.
+
+export type Priority = "urgent" | "high" | "medium" | "low";
+
+export interface TodoLike {
+  id: string;
+  status: string; // "open" | "in_progress" | "blocked" | "done" | ...
+  priority?: Priority;
+  /** IDs of todos this one is blocked by (i.e., must finish those first). */
+  blocked_by?: string[];
+  /** Optional manual override - caller can pin a base score. */
+  manual_score?: number;
+  /** Lightweight tag used by the picker; e.g., "actionable", "stale", etc. */
+  ranking_tag?: string;
+}
+
+export interface RankedTodo<T extends TodoLike = TodoLike> {
+  todo: T;
+  score: number;
+  priorityWeight: number;
+  unblockCount: number;
+  reachableUnblocks: number;
+}
+
+export interface PickerOptions {
+  /** Priority weight overrides. Defaults below favour `urgent` >> `low`. */
+  priorityWeights?: Partial<Record<Priority, number>>;
+  /** Weight multiplier applied to reachableUnblocks before adding to priority. Default 2. */
+  unblockMultiplier?: number;
+  /** Status values that exclude a todo from being ranked at all. */
+  excludedStatuses?: ReadonlySet<string>;
+  /** If true, include a stable secondary sort by todo.id for deterministic output. Default true. */
+  stableSecondarySort?: boolean;
+}
+
+const DEFAULT_PRIORITY_WEIGHTS: Record<Priority, number> = {
+  urgent: 100,
+  high: 60,
+  medium: 30,
+  low: 10,
+};
+
+const DEFAULT_EXCLUDED_STATUSES: ReadonlySet<string> = new Set([
+  "done",
+  "cancelled",
+  "wontfix",
+  "archived",
+]);
+
+/**
+ * Compute the ranked queue for a list of todos.
+ *
+ * @param todos any iterable of TodoLike - full list. Caller should pre-filter
+ *              if needed (e.g. only active todos), but the function also skips
+ *              statuses in `excludedStatuses`.
+ * @returns todos sorted by score descending (most valuable first).
+ */
+export function rankCriticalPath<T extends TodoLike>(
+  todos: ReadonlyArray<T>,
+  options: PickerOptions = {},
+): RankedTodo<T>[] {
+  const priorityWeights: Record<Priority, number> = {
+    ...DEFAULT_PRIORITY_WEIGHTS,
+    ...(options.priorityWeights ?? {}),
+  };
+  const unblockMultiplier = options.unblockMultiplier ?? 2;
+  const excludedStatuses = options.excludedStatuses ?? DEFAULT_EXCLUDED_STATUSES;
+  const stableSecondarySort = options.stableSecondarySort ?? true;
+
+  // 1. Build reverse-block map: who depends on this todo?
+  //    For each todo X listed in blocked_by, record that the parent depends on X.
+  const dependents = new Map<string, Set<string>>(); // todoId -> set of todoIds that depend on it
+  for (const t of todos) {
+    if (!Array.isArray(t.blocked_by)) continue;
+    for (const blockerId of t.blocked_by) {
+      if (typeof blockerId !== "string" || !blockerId) continue;
+      if (!dependents.has(blockerId)) dependents.set(blockerId, new Set());
+      dependents.get(blockerId)!.add(t.id);
+    }
+  }
+
+  // 2. Compute reachable unblocks via BFS down the dependents graph.
+  //    Cap depth to avoid pathological cycles or huge graphs blowing up.
+  const reachableCache = new Map<string, number>();
+  const MAX_BFS_DEPTH = 50;
+
+  function reachableFrom(id: string): number {
+    if (reachableCache.has(id)) return reachableCache.get(id)!;
+    const visited = new Set<string>([id]);
+    const queue: Array<[string, number]> = [[id, 0]];
+    while (queue.length > 0) {
+      const [cur, depth] = queue.shift()!;
+      if (depth >= MAX_BFS_DEPTH) continue;
+      const next = dependents.get(cur);
+      if (!next) continue;
+      for (const n of next) {
+        if (visited.has(n)) continue;
+        visited.add(n);
+        queue.push([n, depth + 1]);
+      }
+    }
+    const count = visited.size - 1; // exclude self
+    reachableCache.set(id, count);
+    return count;
+  }
+
+  // 3. Score each non-excluded todo.
+  const ranked: RankedTodo<T>[] = [];
+  for (const t of todos) {
+    if (excludedStatuses.has(t.status)) continue;
+
+    const pri = t.priority ?? "medium";
+    const priorityWeight = priorityWeights[pri] ?? DEFAULT_PRIORITY_WEIGHTS.medium;
+
+    const direct = dependents.get(t.id)?.size ?? 0;
+    const reachable = reachableFrom(t.id);
+
+    let score = priorityWeight + reachable * unblockMultiplier;
+    if (typeof t.manual_score === "number") score += t.manual_score;
+
+    ranked.push({
+      todo: t,
+      score,
+      priorityWeight,
+      unblockCount: direct,
+      reachableUnblocks: reachable,
+    });
+  }
+
+  // 4. Sort by score desc; tiebreak by reachableUnblocks desc, then id asc.
+  ranked.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.reachableUnblocks !== a.reachableUnblocks) return b.reachableUnblocks - a.reachableUnblocks;
+    if (stableSecondarySort) return a.todo.id.localeCompare(b.todo.id);
+    return 0;
+  });
+
+  return ranked;
+}
+
+/**
+ * Convenience wrapper: returns just the top N ranked todos (default 10).
+ */
+export function pickTopN<T extends TodoLike>(
+  todos: ReadonlyArray<T>,
+  n = 10,
+  options?: PickerOptions,
+): RankedTodo<T>[] {
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new RangeError("pickTopN: n must be a positive integer");
+  }
+  return rankCriticalPath(todos, options).slice(0, n);
+}
+
+/**
+ * Returns one human-readable label explaining why a todo ranked where it did.
+ * Useful for surfacing in admin UI / logs ("ranked #3 because: high priority,
+ * unblocks 4 downstream todos").
+ */
+export function explainRank(r: RankedTodo): string {
+  const parts: string[] = [];
+  parts.push(`${r.priorityWeight}w priority`);
+  if (r.reachableUnblocks > 0) {
+    parts.push(`unblocks ${r.reachableUnblocks} downstream${r.unblockCount !== r.reachableUnblocks ? ` (${r.unblockCount} direct)` : ""}`);
+  } else {
+    parts.push("no downstream blockers");
+  }
+  if (typeof r.todo.manual_score === "number") {
+    parts.push(`manual ${r.todo.manual_score >= 0 ? "+" : ""}${r.todo.manual_score}`);
+  }
+  return `score ${r.score} = ${parts.join(", ")}`;
+}
+
+export const __consts__ = {
+  DEFAULT_PRIORITY_WEIGHTS,
+  DEFAULT_EXCLUDED_STATUSES,
+};


### PR DESCRIPTION
Draft PR from local UnClick recovery batch. Adds rankCriticalPath, pickTopN, explainRank, tests, and docs for ranking jobs by unblock value plus priority.