### PR TITLE
feat(lib): AI spend guardrails

### DIFF
--- a/docs/ai-spend-guardrails.md
+++ b/docs/ai-spend-guardrails.md
@@ -10,13 +10,13 @@ A guard wrapper for every call site that hits an external AI provider, plus an i
 |---|---|
 | `src/lib/aiSpendGuard.ts` | `withSpendGuard()` wrapper + provider registry + spend-event recording + `summariseSpend()` reporter. |
 | `src/lib/aiSpendGuard.test.ts` | Full vitest coverage. |
-| `scripts/audit-ai-call-sites.mjs` | Lists every file using OpenAI / Anthropic / Cohere / Groq / etc — grouped by provider, with a `guarded` flag per file. |
+| `scripts/audit-ai-call-sites.mjs` | Lists every file using OpenAI / Anthropic / Cohere / Groq / etc, grouped by provider, with a `guarded` flag per file. |
 
 ## Default behaviour
 
-- **Free / local** call sites (e.g., self-hosted Ollama) → allowed by default.
-- **Metered** call sites (OpenAI, Anthropic, Cohere, Groq, Replicate, Stability, ElevenLabs, AssemblyAI, etc.) → **blocked by default**. Requires an explicit env opt-in (`UNCLICK_AISPEND_<PROVIDER>_<SHORT>=1`).
-- **Unknown** call sites (not in the registry) → blocked. Fail loud is safer than silently spending.
+- **Free / local** call sites (e.g., self-hosted Ollama) -> allowed by default.
+- **Metered** call sites (OpenAI, Anthropic, Cohere, Groq, Replicate, Stability, ElevenLabs, AssemblyAI, etc.) -> **blocked by default**. Requires an explicit env opt-in (`UNCLICK_AISPEND_<PROVIDER>_<SHORT>=1`).
+- **Unknown** call sites (not in the registry) -> blocked. Fail loud is safer than silently spending.
 
 `withSpendGuard({ label, provider }, async () => provider.call(...))` throws `SpendGuardError` when blocked. The caller decides whether to fall back to a free provider, surface to the user, or fail the request.
 
@@ -74,11 +74,11 @@ The admin UI can call `summariseSpend(globalState)` per request to render a "tod
 ## What's NOT in scope
 
 - No actual cost-in-dollars calculation. The guard only knows cost class. Per-token / per-request dollar math is a follow-up todo against the same parent ScopePack.
-- No automatic call-site swapping. The audit script lists; humans wrap.
-- No HSM / KMS-style key vault — that's separate work.
+- No automatic call-site swapping. The audit script lists; workers wrap.
+- No HSM / KMS-style key vault, that's separate work.
 - No quota enforcement (e.g., "no more than N calls/hour"). Out of scope for v0.
 
-## Acceptance (ScopePack 85% → this drop brings it to ready-for-merge)
+## Acceptance (ScopePack 85% -> this drop brings it to ready-for-merge)
 
 - [x] `aiSpendGuard.ts` exports `withSpendGuard`, `evaluateGuard`, `summariseSpend`, `createSpendState`, `SpendGuardError`.
 - [x] Default registry covers Anthropic, OpenAI (chat + embed), Cohere, Groq, Replicate, Stability, ElevenLabs, AssemblyAI + local Ollama as the free baseline.

--- a/docs/ai-spend-guardrails.md
+++ b/docs/ai-spend-guardrails.md
@@ -1,0 +1,93 @@
+# AI spend guardrails
+
+Closes UnClick todo "AI spend guardrails: provider inventory, cost labels, and default-off paid calls".
+
+## What this ships
+
+A guard wrapper for every call site that hits an external AI provider, plus an inventory script that lists all current call sites so the wrapping can be applied systematically.
+
+| File | Role |
+|---|---|
+| `src/lib/aiSpendGuard.ts` | `withSpendGuard()` wrapper + provider registry + spend-event recording + `summariseSpend()` reporter. |
+| `src/lib/aiSpendGuard.test.ts` | Full vitest coverage. |
+| `scripts/audit-ai-call-sites.mjs` | Lists every file using OpenAI / Anthropic / Cohere / Groq / etc — grouped by provider, with a `guarded` flag per file. |
+
+## Default behaviour
+
+- **Free / local** call sites (e.g., self-hosted Ollama) → allowed by default.
+- **Metered** call sites (OpenAI, Anthropic, Cohere, Groq, Replicate, Stability, ElevenLabs, AssemblyAI, etc.) → **blocked by default**. Requires an explicit env opt-in (`UNCLICK_AISPEND_<PROVIDER>_<SHORT>=1`).
+- **Unknown** call sites (not in the registry) → blocked. Fail loud is safer than silently spending.
+
+`withSpendGuard({ label, provider }, async () => provider.call(...))` throws `SpendGuardError` when blocked. The caller decides whether to fall back to a free provider, surface to the user, or fail the request.
+
+## Why default-off
+
+When tests / CI / scheduled runs hit a metered endpoint, the bill silently accrues. Default-off forces explicit env opt-in per call site so:
+
+- CI tests can't accidentally spend.
+- Local dev runs can't accidentally spend unless the dev sets the env var.
+- Production deployments set the env vars explicitly per-environment as part of the deploy config.
+
+This mirrors the rank-20 "Protected surfaces, safety deny-lists, and default-deny claim rules" pattern.
+
+## Inventory + migration recipe
+
+```bash
+node scripts/audit-ai-call-sites.mjs --json > ai-callsites.json
+```
+
+For each entry in the audit's `callSites` list with `"guarded": false`:
+
+1. Open the file.
+2. Identify the existing call:
+   ```ts
+   const result = await openai.chat.completions.create({ ... });
+   ```
+3. Wrap it:
+   ```ts
+   import { withSpendGuard } from "~/lib/aiSpendGuard";
+
+   const result = await withSpendGuard(
+     { provider: "openai", label: "openai/chat-completion" },
+     () => openai.chat.completions.create({ ... }),
+   );
+   ```
+4. Match the `label` to the entry in the default registry inside `aiSpendGuard.ts`. If a new label is needed (e.g., a finer-grained one for a specific model), add it to the registry first.
+5. The opt-in env var is documented inline in the registry; surface it in your `.env.example`.
+
+## Reporting
+
+Pass a `SpendState` through to record spend events for downstream telemetry:
+
+```ts
+import { createSpendState, withSpendGuard, summariseSpend } from "~/lib/aiSpendGuard";
+
+const state = createSpendState();
+// ... many calls ...
+await withSpendGuard(..., () => ..., { state });
+const summary = summariseSpend(state);
+// summary.allowed, summary.blocked, summary.by_provider, summary.recent_blocked
+```
+
+The admin UI can call `summariseSpend(globalState)` per request to render a "today's spend by provider" widget.
+
+## What's NOT in scope
+
+- No actual cost-in-dollars calculation. The guard only knows cost class. Per-token / per-request dollar math is a follow-up todo against the same parent ScopePack.
+- No automatic call-site swapping. The audit script lists; humans wrap.
+- No HSM / KMS-style key vault — that's separate work.
+- No quota enforcement (e.g., "no more than N calls/hour"). Out of scope for v0.
+
+## Acceptance (ScopePack 85% → this drop brings it to ready-for-merge)
+
+- [x] `aiSpendGuard.ts` exports `withSpendGuard`, `evaluateGuard`, `summariseSpend`, `createSpendState`, `SpendGuardError`.
+- [x] Default registry covers Anthropic, OpenAI (chat + embed), Cohere, Groq, Replicate, Stability, ElevenLabs, AssemblyAI + local Ollama as the free baseline.
+- [x] Metered calls require env opt-in; unknown calls default-deny.
+- [x] Spend events recorded with allowed/blocked + cost class + provider + label.
+- [x] `summariseSpend` returns counts by cost class, by provider, and recent_blocked.
+- [x] `audit-ai-call-sites.mjs` lists every file using a known provider SDK with a `guarded` flag per file.
+- [x] Tests cover happy path, default-deny, env opt-in, force_allow, unknown call, state recording, summary aggregation, recent_blocked limiting.
+
+## Source
+
+Drafted 2026-05-15 by `claude-cowork-coordinator-seat`. Files in `Z:\Other computers\My laptop\G\CV\_unclick-drafts\ai-spend-guardrails\`.

--- a/scripts/audit-ai-call-sites.mjs
+++ b/scripts/audit-ai-call-sites.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// scripts/audit-ai-call-sites.mjs
+//
+// Inventory script for the AI Spend Guardrails todo. Scans the working tree
+// for AI provider call sites (OpenAI, Anthropic, Cohere, Groq, etc.) so each
+// can be wrapped with withSpendGuard from src/lib/aiSpendGuard.ts.
+//
+// Informational only — always exits 0.
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+const PATTERNS = [
+  // SDKs and clients
+  { provider: "openai",     re: /\bnew\s+OpenAI\b|openai\.(?:chat|embeddings|completions|images|audio)/i },
+  { provider: "anthropic",  re: /\bnew\s+Anthropic\b|anthropic\.messages\.create/i },
+  { provider: "cohere",     re: /\bnew\s+CohereClient\b|cohere\.(?:chat|embed|rerank)/i },
+  { provider: "mistral",    re: /\bMistralClient\b|mistral\.chat/i },
+  { provider: "groq",       re: /\bnew\s+Groq\b|groq\.chat/i },
+  { provider: "togetherai", re: /together\.(?:chat|embeddings)/i },
+  { provider: "replicate",  re: /\bnew\s+Replicate\b|replicate\.run|replicate\.predictions/i },
+  { provider: "stability",  re: /stability\.ai|stability_api|stability\/v1/i },
+  { provider: "elevenlabs", re: /elevenlabs\b|11labs/i },
+  { provider: "assemblyai", re: /AssemblyAI|assemblyai\b/i },
+  { provider: "deepl",      re: /deepl-node|deepl\.translateText/i },
+  // Raw fetches to known model endpoints
+  { provider: "openai",     re: /api\.openai\.com/i },
+  { provider: "anthropic",  re: /api\.anthropic\.com/i },
+  { provider: "perplexity", re: /api\.perplexity\.ai/i },
+];
+
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", ".turbo", ".cache", "coverage", ".vercel"]);
+const TEXT_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".mjs", ".cjs", ".jsx"]);
+const MAX_FILE_BYTES = 2_000_000;
+
+const EXPECTED_REFS = [
+  /\baiSpendGuard\.ts$/i,
+  /\baiSpendGuard\.test\.ts$/i,
+  /\baudit-ai-call-sites\.mjs$/i,
+  /\baudit-ai-call-sites\.test\.mjs$/i,
+];
+
+function getArg(name, fallback) {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((a) => a === `--${name}` || a.startsWith(prefix));
+  if (!found) return fallback;
+  if (found === `--${name}`) {
+    const idx = process.argv.indexOf(found);
+    return process.argv[idx + 1] ?? fallback;
+  }
+  return found.slice(prefix.length);
+}
+
+function shouldScan(file) {
+  return TEXT_EXTENSIONS.has(path.extname(file).toLowerCase());
+}
+
+function isExpected(rel) {
+  return EXPECTED_REFS.some((re) => re.test(rel));
+}
+
+async function* walk(dir, root, depth = 0) {
+  if (depth > 20) return;
+  let entries;
+  try { entries = await fs.readdir(dir, { withFileTypes: true }); } catch { return; }
+  for (const e of entries) {
+    if (e.name.startsWith(".") && e.name !== ".github") continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) continue;
+      yield* walk(full, root, depth + 1);
+    } else if (e.isFile() && shouldScan(full)) {
+      yield { full, rel: path.relative(root, full) };
+    }
+  }
+}
+
+export async function auditCallSites(root) {
+  const callSites = [];     // { file, hits: [{ provider, line, excerpt }] }
+  const expectedHits = [];  // helper / tests / this script
+  let filesScanned = 0;
+
+  for await (const { full, rel } of walk(root, root)) {
+    let stat;
+    try { stat = await fs.stat(full); } catch { continue; }
+    if (stat.size > MAX_FILE_BYTES) continue;
+    let body;
+    try { body = await fs.readFile(full, "utf8"); } catch { continue; }
+    filesScanned += 1;
+
+    const fileHits = [];
+    const lines = body.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      for (const p of PATTERNS) {
+        if (p.re.test(lines[i])) {
+          fileHits.push({ provider: p.provider, line: i + 1, excerpt: lines[i].trim().slice(0, 220) });
+        }
+      }
+    }
+    if (fileHits.length === 0) continue;
+
+    // Detect whether the file ALREADY wraps with withSpendGuard.
+    const guarded = /\bwithSpendGuard\b/.test(body);
+
+    const record = { file: rel.replace(/\\/g, "/"), guarded, hits: fileHits };
+    if (isExpected(rel)) expectedHits.push(record);
+    else callSites.push(record);
+  }
+
+  // Group call sites by provider for summary.
+  const by_provider = {};
+  for (const cs of callSites) {
+    for (const h of cs.hits) {
+      by_provider[h.provider] = (by_provider[h.provider] ?? 0) + 1;
+    }
+  }
+
+  const ungarded = callSites.filter((cs) => !cs.guarded);
+
+  return {
+    root,
+    filesScanned,
+    summary: {
+      files_with_ai_calls: callSites.length,
+      already_guarded: callSites.length - ungarded.length,
+      need_wrapping: ungarded.length,
+      total_hits: callSites.reduce((acc, cs) => acc + cs.hits.length, 0),
+      by_provider,
+    },
+    callSites,
+    expectedHits,
+  };
+}
+
+function renderText(report) {
+  const lines = [];
+  lines.push(`Scanned ${report.filesScanned} files under ${report.root}`);
+  lines.push("Summary:");
+  for (const k of Object.keys(report.summary)) {
+    if (k === "by_provider") continue;
+    lines.push(`  ${k}: ${report.summary[k]}`);
+  }
+  lines.push("  by_provider:");
+  for (const [prov, n] of Object.entries(report.summary.by_provider)) {
+    lines.push(`    ${prov}: ${n}`);
+  }
+  lines.push("");
+
+  if (report.callSites.length === 0) {
+    lines.push("✔ No AI call sites detected.");
+    return lines.join("\n");
+  }
+
+  const ungarded = report.callSites.filter((cs) => !cs.guarded);
+  if (ungarded.length > 0) {
+    lines.push(`Call sites needing withSpendGuard wrapping (${ungarded.length}):`);
+    for (const cs of ungarded) {
+      lines.push("");
+      lines.push(`  ${cs.file}`);
+      for (const h of cs.hits) {
+        lines.push(`    L${h.line}  [${h.provider}]  ${h.excerpt}`);
+      }
+    }
+  } else {
+    lines.push("✔ All AI call sites are already wrapped with withSpendGuard.");
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const root = path.resolve(getArg("root", process.cwd()));
+  try { await fs.access(root); } catch {
+    console.error(`Root path does not exist: ${root}`);
+    process.exit(2);
+  }
+  const report = await auditCallSites(root);
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderText(report));
+  }
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  main();
+}
+
+export { PATTERNS, isExpected, shouldScan, renderText };

--- a/scripts/audit-ai-call-sites.mjs
+++ b/scripts/audit-ai-call-sites.mjs
@@ -5,7 +5,7 @@
 // for AI provider call sites (OpenAI, Anthropic, Cohere, Groq, etc.) so each
 // can be wrapped with withSpendGuard from src/lib/aiSpendGuard.ts.
 //
-// Informational only — always exits 0.
+// Informational only, always exits 0.
 
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
@@ -147,7 +147,7 @@ function renderText(report) {
   lines.push("");
 
   if (report.callSites.length === 0) {
-    lines.push("✔ No AI call sites detected.");
+    lines.push("[ok] No AI call sites detected.");
     return lines.join("\n");
   }
 
@@ -162,7 +162,7 @@ function renderText(report) {
       }
     }
   } else {
-    lines.push("✔ All AI call sites are already wrapped with withSpendGuard.");
+    lines.push("[ok] All AI call sites are already wrapped with withSpendGuard.");
   }
   return lines.join("\n");
 }

--- a/src/lib/aiSpendGuard.test.ts
+++ b/src/lib/aiSpendGuard.test.ts
@@ -1,0 +1,200 @@
+// src/lib/aiSpendGuard.test.ts
+
+import { describe, test, expect } from "vitest";
+import {
+  createSpendState,
+  evaluateGuard,
+  findRegistryEntry,
+  getDefaultRegistry,
+  summariseSpend,
+  withSpendGuard,
+  SpendGuardError,
+  __testing__,
+  type ProviderEntry,
+} from "./aiSpendGuard";
+
+const TEST_REGISTRY: ProviderEntry[] = [
+  { provider: "openai", label: "openai/chat", cost_class: "metered", default_enabled: false, enable_env: "TEST_OPENAI_ON" },
+  { provider: "local",  label: "local/ollama", cost_class: "free", default_enabled: true, enable_env: null },
+];
+
+describe("registry helpers", () => {
+  test("getDefaultRegistry returns a copy (mutation-safe)", () => {
+    const a = getDefaultRegistry();
+    a[0].label = "mutated";
+    const b = getDefaultRegistry();
+    expect(b[0].label).not.toBe("mutated");
+  });
+
+  test("findRegistryEntry matches by label first", () => {
+    const entry = findRegistryEntry(TEST_REGISTRY, { label: "openai/chat" });
+    expect(entry?.provider).toBe("openai");
+  });
+
+  test("findRegistryEntry falls back to provider when no label given", () => {
+    const entry = findRegistryEntry(TEST_REGISTRY, { provider: "local" });
+    expect(entry?.label).toBe("local/ollama");
+  });
+
+  test("findRegistryEntry returns null when nothing matches", () => {
+    expect(findRegistryEntry(TEST_REGISTRY, { provider: "cohere" })).toBeNull();
+  });
+});
+
+describe("evaluateGuard", () => {
+  test("free + default_enabled → allowed", () => {
+    const d = evaluateGuard({ label: "local/ollama" }, { registry: TEST_REGISTRY, env: {} });
+    expect(d.allowed).toBe(true);
+    expect(d.reason).toBe("default_enabled");
+  });
+
+  test("metered + no env opt-in → blocked", () => {
+    const d = evaluateGuard({ label: "openai/chat" }, { registry: TEST_REGISTRY, env: {} });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/^requires_env_TEST_OPENAI_ON/);
+  });
+
+  test("metered + env=1 → allowed", () => {
+    const d = evaluateGuard({ label: "openai/chat" }, { registry: TEST_REGISTRY, env: { TEST_OPENAI_ON: "1" } });
+    expect(d.allowed).toBe(true);
+    expect(d.reason).toBe("env_opt_in");
+  });
+
+  test("metered + env=0 → blocked", () => {
+    const d = evaluateGuard({ label: "openai/chat" }, { registry: TEST_REGISTRY, env: { TEST_OPENAI_ON: "0" } });
+    expect(d.allowed).toBe(false);
+  });
+
+  test("unknown call site → blocked (default-deny)", () => {
+    const d = evaluateGuard({ label: "made-up-provider" }, { registry: TEST_REGISTRY, env: {} });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe("no_registry_entry");
+  });
+
+  test("force_allow always wins", () => {
+    const d = evaluateGuard({ label: "made-up-provider" }, { registry: TEST_REGISTRY, env: {}, force_allow: true });
+    expect(d.allowed).toBe(true);
+    expect(d.reason).toBe("force_allow");
+  });
+});
+
+describe("withSpendGuard", () => {
+  test("invokes fn when allowed and records event", async () => {
+    const state = createSpendState();
+    let invoked = false;
+    const out = await withSpendGuard(
+      { label: "local/ollama" },
+      async () => { invoked = true; return "ok"; },
+      { registry: TEST_REGISTRY, env: {}, state },
+    );
+    expect(invoked).toBe(true);
+    expect(out).toBe("ok");
+    expect(state.events.length).toBe(1);
+    expect(state.events[0].allowed).toBe(true);
+    expect(state.counts.free).toBe(1);
+  });
+
+  test("throws SpendGuardError when blocked and does NOT invoke fn", async () => {
+    const state = createSpendState();
+    let invoked = false;
+    try {
+      await withSpendGuard(
+        { label: "openai/chat" },
+        async () => { invoked = true; return "should not run"; },
+        { registry: TEST_REGISTRY, env: {}, state },
+      );
+      expect.fail("expected SpendGuardError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpendGuardError);
+      expect((err as SpendGuardError).code).toMatch(/^requires_env_/);
+      expect((err as SpendGuardError).event.allowed).toBe(false);
+    }
+    expect(invoked).toBe(false);
+    expect(state.events.length).toBe(1);
+    expect(state.events[0].allowed).toBe(false);
+    expect(state.counts.metered).toBe(0);
+  });
+
+  test("force_allow lets a normally-blocked call through", async () => {
+    const state = createSpendState();
+    const out = await withSpendGuard(
+      { label: "openai/chat" },
+      async () => "yes",
+      { registry: TEST_REGISTRY, env: {}, state, force_allow: true },
+    );
+    expect(out).toBe("yes");
+    expect(state.events[0].allowed).toBe(true);
+  });
+
+  test("unknown call site → blocked, fn not invoked", async () => {
+    let invoked = false;
+    try {
+      await withSpendGuard(
+        { label: "what-is-this" },
+        async () => { invoked = true; return "x"; },
+        { registry: TEST_REGISTRY, env: {} },
+      );
+      expect.fail("expected SpendGuardError");
+    } catch (err) {
+      expect((err as SpendGuardError).code).toBe("no_registry_entry");
+    }
+    expect(invoked).toBe(false);
+  });
+});
+
+describe("summariseSpend", () => {
+  test("counts allowed vs blocked and groups by provider", async () => {
+    const state = createSpendState();
+    await withSpendGuard({ label: "local/ollama" }, async () => 1, { registry: TEST_REGISTRY, env: {}, state });
+    await withSpendGuard({ label: "local/ollama" }, async () => 1, { registry: TEST_REGISTRY, env: {}, state });
+    try {
+      await withSpendGuard({ label: "openai/chat" }, async () => 1, { registry: TEST_REGISTRY, env: {}, state });
+    } catch { /* expected block */ }
+    const s = summariseSpend(state);
+    expect(s.total_calls).toBe(3);
+    expect(s.allowed).toBe(2);
+    expect(s.blocked).toBe(1);
+    expect(s.by_provider.local).toBe(2);
+    expect(s.recent_blocked.length).toBe(1);
+  });
+
+  test("limits recent_blocked to recentBlockedLimit", async () => {
+    const state = createSpendState();
+    for (let i = 0; i < 15; i += 1) {
+      try {
+        await withSpendGuard(
+          { label: "openai/chat", call_id: `c-${i}` },
+          async () => 1,
+          { registry: TEST_REGISTRY, env: {}, state },
+        );
+      } catch { /* expected block */ }
+    }
+    const s = summariseSpend(state, 5);
+    expect(s.blocked).toBe(15);
+    expect(s.recent_blocked.length).toBe(5);
+  });
+});
+
+describe("DEFAULT_REGISTRY shape", () => {
+  test("includes anthropic and openai entries", () => {
+    const r = __testing__.DEFAULT_REGISTRY;
+    expect(r.some((e) => e.provider === "anthropic")).toBe(true);
+    expect(r.some((e) => e.provider === "openai" && e.label.includes("chat"))).toBe(true);
+  });
+
+  test("local provider is the only one default-enabled", () => {
+    const r = __testing__.DEFAULT_REGISTRY;
+    const enabled = r.filter((e) => e.default_enabled);
+    expect(enabled.length).toBeGreaterThanOrEqual(1);
+    for (const e of enabled) {
+      expect(e.cost_class).not.toBe("metered");
+    }
+  });
+
+  test("every metered entry has an enable_env", () => {
+    const r = __testing__.DEFAULT_REGISTRY;
+    for (const e of r.filter((e) => e.cost_class === "metered")) {
+      expect(e.enable_env).toMatch(/^UNCLICK_AISPEND_/);
+    }
+  });
+});

--- a/src/lib/aiSpendGuard.test.ts
+++ b/src/lib/aiSpendGuard.test.ts
@@ -42,30 +42,30 @@ describe("registry helpers", () => {
 });
 
 describe("evaluateGuard", () => {
-  test("free + default_enabled → allowed", () => {
+  test("free + default_enabled -> allowed", () => {
     const d = evaluateGuard({ label: "local/ollama" }, { registry: TEST_REGISTRY, env: {} });
     expect(d.allowed).toBe(true);
     expect(d.reason).toBe("default_enabled");
   });
 
-  test("metered + no env opt-in → blocked", () => {
+  test("metered + no env opt-in -> blocked", () => {
     const d = evaluateGuard({ label: "openai/chat" }, { registry: TEST_REGISTRY, env: {} });
     expect(d.allowed).toBe(false);
     expect(d.reason).toMatch(/^requires_env_TEST_OPENAI_ON/);
   });
 
-  test("metered + env=1 → allowed", () => {
+  test("metered + env=1 -> allowed", () => {
     const d = evaluateGuard({ label: "openai/chat" }, { registry: TEST_REGISTRY, env: { TEST_OPENAI_ON: "1" } });
     expect(d.allowed).toBe(true);
     expect(d.reason).toBe("env_opt_in");
   });
 
-  test("metered + env=0 → blocked", () => {
+  test("metered + env=0 -> blocked", () => {
     const d = evaluateGuard({ label: "openai/chat" }, { registry: TEST_REGISTRY, env: { TEST_OPENAI_ON: "0" } });
     expect(d.allowed).toBe(false);
   });
 
-  test("unknown call site → blocked (default-deny)", () => {
+  test("unknown call site -> blocked (default-deny)", () => {
     const d = evaluateGuard({ label: "made-up-provider" }, { registry: TEST_REGISTRY, env: {} });
     expect(d.allowed).toBe(false);
     expect(d.reason).toBe("no_registry_entry");
@@ -126,7 +126,7 @@ describe("withSpendGuard", () => {
     expect(state.events[0].allowed).toBe(true);
   });
 
-  test("unknown call site → blocked, fn not invoked", async () => {
+  test("unknown call site -> blocked, fn not invoked", async () => {
     let invoked = false;
     try {
       await withSpendGuard(

--- a/src/lib/aiSpendGuard.ts
+++ b/src/lib/aiSpendGuard.ts
@@ -1,0 +1,308 @@
+// src/lib/aiSpendGuard.ts
+//
+// AI spend guardrails — provider inventory, cost labels, default-off paid calls.
+//
+// Closes UnClick todo "AI spend guardrails: provider inventory, cost labels,
+// and default-off paid calls".
+//
+// What it does:
+//   1. Defines a Provider registry — every external paid call site declares its
+//      provider, cost class, and whether it's enabled.
+//   2. Wraps actual call sites with `withSpendGuard` which checks the registry,
+//      enforces default-off for paid endpoints unless explicit env opt-in,
+//      and records spend events for downstream telemetry.
+//   3. Provides `summariseSpend` for surfacing in admin UI.
+//
+// Stateless module — call sites are responsible for passing in `state` if
+// they want spend tracked across requests. Tests use an in-memory state.
+
+export type Provider =
+  | "openai"
+  | "anthropic"
+  | "cohere"
+  | "mistral"
+  | "groq"
+  | "togetherai"
+  | "replicate"
+  | "stability"
+  | "elevenlabs"
+  | "assemblyai"
+  | "deepl"
+  | "perplexity"
+  | "local" // self-hosted, no spend
+  | "unknown";
+
+export type CostClass =
+  | "free"        // genuinely zero cost (e.g., local model, free tier under quota)
+  | "metered"     // paid per-token / per-request
+  | "subscription" // covered under a flat subscription
+  | "unknown";    // not yet classified — treat as paid for safety
+
+export interface ProviderEntry {
+  provider: Provider;
+  /** Human-readable label for the specific call site (e.g., "openai/gpt-4o-mini chat"). */
+  label: string;
+  cost_class: CostClass;
+  /**
+   * Default-on means a call here proceeds without an explicit env flag. Free /
+   * local calls default to true. Anything metered defaults to false until the
+   * relevant env var is set.
+   */
+  default_enabled: boolean;
+  /**
+   * Env var that opts this call site in (when default_enabled is false).
+   * Convention: `UNCLICK_AISPEND_<PROVIDER>_<SHORT>=1`.
+   */
+  enable_env: string | null;
+  /** Free-text notes for the inventory doc. */
+  notes?: string;
+}
+
+export interface SpendEvent {
+  call_id: string;
+  provider: Provider;
+  label: string;
+  cost_class: CostClass;
+  allowed: boolean;
+  blocked_reason: string | null;
+  emitted_at: string;
+}
+
+export interface SpendState {
+  events: SpendEvent[];
+  /** Total counts by cost class (allowed only). */
+  counts: Record<CostClass, number>;
+}
+
+export function createSpendState(): SpendState {
+  return {
+    events: [],
+    counts: { free: 0, metered: 0, subscription: 0, unknown: 0 },
+  };
+}
+
+// --- Provider registry ---
+
+const DEFAULT_REGISTRY: ProviderEntry[] = [
+  {
+    provider: "anthropic",
+    label: "anthropic/claude messages",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_ANTHROPIC_MESSAGES",
+    notes: "Pay-per-token. Disable for tests by default.",
+  },
+  {
+    provider: "openai",
+    label: "openai/chat-completion",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_OPENAI_CHAT",
+  },
+  {
+    provider: "openai",
+    label: "openai/embedding",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_OPENAI_EMBED",
+  },
+  {
+    provider: "cohere",
+    label: "cohere/embed-or-rerank",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_COHERE",
+  },
+  {
+    provider: "groq",
+    label: "groq/chat-completion",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_GROQ",
+    notes: "Often free-tier in practice but classed metered for safety.",
+  },
+  {
+    provider: "replicate",
+    label: "replicate/prediction",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_REPLICATE",
+  },
+  {
+    provider: "stability",
+    label: "stability/image-gen",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_STABILITY",
+  },
+  {
+    provider: "elevenlabs",
+    label: "elevenlabs/tts",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_ELEVENLABS",
+  },
+  {
+    provider: "assemblyai",
+    label: "assemblyai/transcribe",
+    cost_class: "metered",
+    default_enabled: false,
+    enable_env: "UNCLICK_AISPEND_ASSEMBLYAI",
+  },
+  {
+    provider: "local",
+    label: "local/ollama",
+    cost_class: "free",
+    default_enabled: true,
+    enable_env: null,
+    notes: "Self-hosted; no per-call cost.",
+  },
+];
+
+export function getDefaultRegistry(): ProviderEntry[] {
+  return DEFAULT_REGISTRY.map((e) => ({ ...e }));
+}
+
+export function findRegistryEntry(
+  registry: ReadonlyArray<ProviderEntry>,
+  predicate: { provider?: Provider; label?: string },
+): ProviderEntry | null {
+  for (const e of registry) {
+    if (predicate.label && e.label === predicate.label) return e;
+    if (predicate.provider && !predicate.label && e.provider === predicate.provider) return e;
+  }
+  return null;
+}
+
+// --- Guard ---
+
+export interface GuardOptions {
+  /** Override the default registry. Useful for tests. */
+  registry?: ReadonlyArray<ProviderEntry>;
+  /** Override env lookup. Useful for tests; defaults to process.env. */
+  env?: Record<string, string | undefined>;
+  /** State to record spend events into. If omitted, no recording. */
+  state?: SpendState;
+  /** Forced override — caller asserts the call is allowed (e.g., explicit user-greenlit one-shot). */
+  force_allow?: boolean;
+}
+
+export interface GuardDecision {
+  allowed: boolean;
+  reason: string;
+  entry: ProviderEntry | null;
+}
+
+export function evaluateGuard(
+  call: { provider?: Provider; label?: string; call_id?: string },
+  options: GuardOptions = {},
+): GuardDecision {
+  const registry = options.registry ?? DEFAULT_REGISTRY;
+  const env = options.env ?? process.env;
+  const entry = findRegistryEntry(registry, call);
+
+  if (options.force_allow) {
+    return { allowed: true, reason: "force_allow", entry };
+  }
+
+  if (!entry) {
+    // Default-deny unknown call sites — safer to fail loud.
+    return {
+      allowed: false,
+      reason: "no_registry_entry",
+      entry: null,
+    };
+  }
+
+  if (entry.cost_class === "free" || entry.cost_class === "subscription") {
+    return { allowed: entry.default_enabled, reason: entry.default_enabled ? "default_enabled" : "explicit_disabled", entry };
+  }
+
+  // Metered / unknown — require env opt-in.
+  if (entry.default_enabled) {
+    return { allowed: true, reason: "registry_default_enabled", entry };
+  }
+  if (entry.enable_env && env[entry.enable_env] === "1") {
+    return { allowed: true, reason: "env_opt_in", entry };
+  }
+  return {
+    allowed: false,
+    reason: entry.enable_env ? `requires_env_${entry.enable_env}=1` : "metered_no_opt_in_env",
+    entry,
+  };
+}
+
+/**
+ * Wrap a call site. When `evaluateGuard` returns allowed:false, `fn` is NOT
+ * invoked and the returned promise rejects with a `SpendGuardError`.
+ */
+export async function withSpendGuard<T>(
+  call: { provider?: Provider; label?: string; call_id?: string },
+  fn: () => Promise<T>,
+  options: GuardOptions = {},
+): Promise<T> {
+  const decision = evaluateGuard(call, options);
+  const event: SpendEvent = {
+    call_id: call.call_id ?? `${decision.entry?.provider ?? call.provider ?? "unknown"}-${Date.now()}`,
+    provider: decision.entry?.provider ?? call.provider ?? "unknown",
+    label: decision.entry?.label ?? call.label ?? "unlabelled",
+    cost_class: decision.entry?.cost_class ?? "unknown",
+    allowed: decision.allowed,
+    blocked_reason: decision.allowed ? null : decision.reason,
+    emitted_at: new Date().toISOString(),
+  };
+  if (options.state) {
+    options.state.events.push(event);
+    if (decision.allowed) {
+      options.state.counts[event.cost_class] = (options.state.counts[event.cost_class] ?? 0) + 1;
+    }
+  }
+  if (!decision.allowed) {
+    throw new SpendGuardError(`AI spend guard blocked ${event.label}: ${decision.reason}`, decision.reason, event);
+  }
+  return await fn();
+}
+
+export class SpendGuardError extends Error {
+  code: string;
+  event: SpendEvent;
+  constructor(message: string, code: string, event: SpendEvent) {
+    super(message);
+    this.name = "SpendGuardError";
+    this.code = code;
+    this.event = event;
+  }
+}
+
+// --- Reporting ---
+
+export interface SpendSummary {
+  total_calls: number;
+  allowed: number;
+  blocked: number;
+  by_cost_class: Record<CostClass, number>;
+  by_provider: Record<string, number>;
+  recent_blocked: SpendEvent[];
+}
+
+export function summariseSpend(state: SpendState, recentBlockedLimit = 10): SpendSummary {
+  const total_calls = state.events.length;
+  const allowed = state.events.filter((e) => e.allowed).length;
+  const blocked = total_calls - allowed;
+  const by_provider: Record<string, number> = {};
+  for (const e of state.events) {
+    if (!e.allowed) continue;
+    by_provider[e.provider] = (by_provider[e.provider] ?? 0) + 1;
+  }
+  const recent_blocked = state.events.filter((e) => !e.allowed).slice(-recentBlockedLimit);
+  return {
+    total_calls,
+    allowed,
+    blocked,
+    by_cost_class: { ...state.counts },
+    by_provider,
+    recent_blocked,
+  };
+}
+
+export const __testing__ = { DEFAULT_REGISTRY };

--- a/src/lib/aiSpendGuard.ts
+++ b/src/lib/aiSpendGuard.ts
@@ -1,19 +1,19 @@
 // src/lib/aiSpendGuard.ts
 //
-// AI spend guardrails — provider inventory, cost labels, default-off paid calls.
+// AI spend guardrails: provider inventory, cost labels, default-off paid calls.
 //
 // Closes UnClick todo "AI spend guardrails: provider inventory, cost labels,
 // and default-off paid calls".
 //
 // What it does:
-//   1. Defines a Provider registry — every external paid call site declares its
+//   1. Defines a Provider registry. Every external paid call site declares its
 //      provider, cost class, and whether it's enabled.
 //   2. Wraps actual call sites with `withSpendGuard` which checks the registry,
 //      enforces default-off for paid endpoints unless explicit env opt-in,
 //      and records spend events for downstream telemetry.
 //   3. Provides `summariseSpend` for surfacing in admin UI.
 //
-// Stateless module — call sites are responsible for passing in `state` if
+// Stateless module. Call sites are responsible for passing in `state` if
 // they want spend tracked across requests. Tests use an in-memory state.
 
 export type Provider =
@@ -36,7 +36,7 @@ export type CostClass =
   | "free"        // genuinely zero cost (e.g., local model, free tier under quota)
   | "metered"     // paid per-token / per-request
   | "subscription" // covered under a flat subscription
-  | "unknown";    // not yet classified — treat as paid for safety
+  | "unknown";    // not yet classified, treat as paid for safety
 
 export interface ProviderEntry {
   provider: Provider;
@@ -183,7 +183,7 @@ export interface GuardOptions {
   env?: Record<string, string | undefined>;
   /** State to record spend events into. If omitted, no recording. */
   state?: SpendState;
-  /** Forced override — caller asserts the call is allowed (e.g., explicit user-greenlit one-shot). */
+  /** Forced override. Caller asserts the call is allowed, such as an explicit user-greenlit one-shot. */
   force_allow?: boolean;
 }
 
@@ -206,7 +206,7 @@ export function evaluateGuard(
   }
 
   if (!entry) {
-    // Default-deny unknown call sites — safer to fail loud.
+    // Default-deny unknown call sites, safer to fail loud.
     return {
       allowed: false,
       reason: "no_registry_entry",
@@ -218,7 +218,7 @@ export function evaluateGuard(
     return { allowed: entry.default_enabled, reason: entry.default_enabled ? "default_enabled" : "explicit_disabled", entry };
   }
 
-  // Metered / unknown — require env opt-in.
+  // Metered / unknown, require env opt-in.
   if (entry.default_enabled) {
     return { allowed: true, reason: "registry_default_enabled", entry };
   }


### PR DESCRIPTION
Closes AI spend guardrails. withSpendGuard wrapper, 10-provider registry, default-deny metered + unknown.