### PR TITLE
Guard BackstagePass AI connection probes

### DIFF
--- a/api/ai-provider-inventory.test.ts
+++ b/api/ai-provider-inventory.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  decideBackstagePassConnectionProbeProviderCall,
   decideMemoryAdminAiChatProviderCall,
   decideAiProviderCall,
+  getBackstagePassConnectionProbePathId,
   getAiProviderInventoryEntry,
   listAiProviderInventory,
   publicAiProviderCostLabels,
@@ -287,6 +289,36 @@ describe("ai provider inventory", () => {
         allowed: true,
         path_id: pathId,
         model,
+        reason: "explicit_paid_allowed",
+      });
+    }
+  });
+
+  it("labels BackstagePass connection probes as explicit owner test actions", () => {
+    const expected = [
+      ["openai", "backstagepass.openai.connection-test", "OpenAI", "OpenAI /models"],
+      ["anthropic", "backstagepass.anthropic.connection-test", "Anthropic", "Anthropic /models"],
+    ] as const;
+
+    for (const [provider, pathId, providerLabel, model] of expected) {
+      expect(getBackstagePassConnectionProbePathId(provider)).toBe(pathId);
+      expect(getAiProviderInventoryEntry(pathId)).toMatchObject({
+        provider: providerLabel,
+        surface: "api/backstagepass.ts?action=testConnection",
+        call_kind: "model_listing",
+        model,
+        cost_tier: "paid_or_unknown",
+        default_allowed: false,
+        allow_paid_flag: "testConnection allow_paid + owner api_key + stored provider api_key",
+      });
+      expect(decideBackstagePassConnectionProbeProviderCall({ provider })).toMatchObject({
+        allowed: false,
+        path_id: pathId,
+        reason: "paid_or_unknown_blocked",
+      });
+      expect(decideBackstagePassConnectionProbeProviderCall({ provider, allow_paid: true })).toMatchObject({
+        allowed: true,
+        path_id: pathId,
         reason: "explicit_paid_allowed",
       });
     }

--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -59,6 +59,10 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import * as crypto from "crypto";
+import {
+  decideBackstagePassConnectionProbeProviderCall,
+  type BackstagePassConnectionProbeProvider,
+} from "./lib/ai-provider-inventory";
 
 // ─── Crypto helpers (mirror api/credentials.ts exactly) ───────────────────
 
@@ -130,6 +134,7 @@ function decrypt(
 const PLATFORM_PROBES: Record<string, {
   url:           string;
   buildHeaders: (values: Record<string, string>) => Record<string, string>;
+  spendProvider?: BackstagePassConnectionProbeProvider;
 }> = {
   github: {
     url: "https://api.github.com/user",
@@ -141,6 +146,7 @@ const PLATFORM_PROBES: Record<string, {
   },
   anthropic: {
     url: "https://api.anthropic.com/v1/models",
+    spendProvider: "anthropic",
     buildHeaders: (v) => ({
       "x-api-key":         v.api_key ?? "",
       "anthropic-version": "2023-06-01",
@@ -148,6 +154,7 @@ const PLATFORM_PROBES: Record<string, {
   },
   openai: {
     url: "https://api.openai.com/v1/models",
+    spendProvider: "openai",
     buildHeaders: (v) => ({
       Authorization: `Bearer ${v.api_key ?? ""}`,
     }),
@@ -713,6 +720,39 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const testedAt = new Date().toISOString();
+
+    if (probe.spendProvider) {
+      const providerDecision = decideBackstagePassConnectionProbeProviderCall({
+        provider: probe.spendProvider,
+        allow_paid: body.allow_paid === true,
+      });
+      if (!providerDecision.allowed) {
+        await writeAudit({
+          supabaseUrl, serviceRoleKey, tenant, req,
+          action: "test_connection", credentialId: id,
+          platformSlug: platform, label: (row.label as string) ?? null,
+          success: false,
+          metadata: {
+            reason: "ai_spend_guard_blocked",
+            path_id: providerDecision.path_id,
+            allow_paid_flag: providerDecision.allow_paid_flag,
+          },
+        });
+        return res.status(402).json({
+          ok: false,
+          platform,
+          tested_at: testedAt,
+          message: "Connection test requires explicit AI spend confirmation.",
+          spend_guard: {
+            path_id: providerDecision.path_id,
+            provider: providerDecision.provider,
+            cost_tier: providerDecision.cost_tier,
+            allow_paid_flag: providerDecision.allow_paid_flag,
+          },
+        });
+      }
+    }
+
     let ok = false;
     let status = 0;
     let message = "";

--- a/api/lib/ai-provider-inventory.ts
+++ b/api/lib/ai-provider-inventory.ts
@@ -45,11 +45,17 @@ export interface AiProviderCallDecision {
 }
 
 export type MemoryAdminAiChatProvider = "google" | "openai" | "anthropic";
+export type BackstagePassConnectionProbeProvider = "openai" | "anthropic";
 
 const MEMORY_ADMIN_AI_CHAT_PATH_IDS: Record<MemoryAdminAiChatProvider, string> = {
   google: "memory.admin.google.ai-chat",
   openai: "memory.admin.openai.ai-chat",
   anthropic: "memory.admin.anthropic.ai-chat",
+};
+
+const BACKSTAGEPASS_CONNECTION_PROBE_PATH_IDS: Record<BackstagePassConnectionProbeProvider, string> = {
+  openai: "backstagepass.openai.connection-test",
+  anthropic: "backstagepass.anthropic.connection-test",
 };
 
 export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
@@ -150,6 +156,28 @@ export const AI_PROVIDER_INVENTORY: AiProviderInventoryEntry[] = [
     default_allowed: false,
     allow_paid_flag: "ARENA_ANTHROPIC_ENABLED",
     notes: "Arena bot solve uses Anthropic for live generated solutions and must require an explicit arena spend opt-in in addition to server-side credentials.",
+  },
+  {
+    id: "backstagepass.openai.connection-test",
+    provider: "OpenAI",
+    surface: "api/backstagepass.ts?action=testConnection",
+    call_kind: "model_listing",
+    model: "OpenAI /models",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "testConnection allow_paid + owner api_key + stored provider api_key",
+    notes: "BackstagePass OpenAI connection tests reach the provider models endpoint and must stay tied to an explicit owner test action.",
+  },
+  {
+    id: "backstagepass.anthropic.connection-test",
+    provider: "Anthropic",
+    surface: "api/backstagepass.ts?action=testConnection",
+    call_kind: "model_listing",
+    model: "Anthropic /models",
+    cost_tier: "paid_or_unknown",
+    default_allowed: false,
+    allow_paid_flag: "testConnection allow_paid + owner api_key + stored provider api_key",
+    notes: "BackstagePass Anthropic connection tests reach the provider models endpoint and must stay tied to an explicit owner test action.",
   },
   {
     id: "memory.admin.google.ai-chat",
@@ -857,6 +885,10 @@ export function getMemoryAdminAiChatPathId(provider: MemoryAdminAiChatProvider):
   return MEMORY_ADMIN_AI_CHAT_PATH_IDS[provider];
 }
 
+export function getBackstagePassConnectionProbePathId(provider: BackstagePassConnectionProbeProvider): string {
+  return BACKSTAGEPASS_CONNECTION_PROBE_PATH_IDS[provider];
+}
+
 export function classifyAiProviderPath(pathId: string, model?: string | null): AiProviderInventoryEntry {
   const known = getAiProviderInventoryEntry(pathId);
   if (known) {
@@ -917,6 +949,16 @@ export function decideMemoryAdminAiChatProviderCall(input: {
   return decideAiProviderCall({
     path_id: getMemoryAdminAiChatPathId(input.provider),
     model: input.model,
+    allow_paid: input.allow_paid,
+  });
+}
+
+export function decideBackstagePassConnectionProbeProviderCall(input: {
+  provider: BackstagePassConnectionProbeProvider;
+  allow_paid?: boolean;
+}): AiProviderCallDecision {
+  return decideAiProviderCall({
+    path_id: getBackstagePassConnectionProbePathId(input.provider),
     allow_paid: input.allow_paid,
   });
 }

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -533,7 +533,7 @@ export default function AdminKeychain() {
       const res = await fetch("/api/backstagepass?action=testConnection", {
         method:  "POST",
         headers: { ...authHeader, "Content-Type": "application/json" },
-        body:    JSON.stringify({ id: cred.id, api_key: apiKey }),
+        body:    JSON.stringify({ id: cred.id, api_key: apiKey, allow_paid: true }),
       });
       const body = await res.json().catch(() => ({}));
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- Adds BackstagePass OpenAI and Anthropic connection tests to the AI provider inventory.
- Blocks provider model-listing probes unless the request carries an explicit allow_paid test flag.
- Sends that explicit test flag from the admin keychain connection-test button only.

## Proof
- npm exec vitest run api/ai-provider-inventory.test.ts src/__tests__/admin-keychain-last-check-display.test.ts
- node scripts/audit-ai-call-sites.mjs --json, remaining unguarded runtime/provider surfaces dropped from 7 to 6
- npm run build

## Safety
- No secrets changed.
- No production data changes.
- No billing, DNS, deploy, or destructive operations.