### PR TITLE
feat(skills): add admin Skills Library preview

### DIFF
--- a/src/lib/communityTools.ts
+++ b/src/lib/communityTools.ts
@@ -23,6 +23,75 @@ export interface CommunityTool {
   submittedAt: string;
 }
 
+export type SkillRiskState = "quarantined" | "reviewed" | "native-ready";
+
+export interface CuratedSkillPreview {
+  id: string;
+  name: string;
+  category: string;
+  source: string;
+  provenance: string;
+  license: string;
+  version: string;
+  contentHash: string;
+  riskState: SkillRiskState;
+  permissions: string[];
+  installState: string;
+  description: string;
+}
+
+export const SKILL_LIBRARY_CATEGORIES = [
+  "Review",
+  "Research",
+  "Planning",
+  "Safety",
+] as const;
+
+export const CURATED_SKILL_PREVIEWS: CuratedSkillPreview[] = [
+  {
+    id: "pr-review-compat",
+    name: "PR Monitor and Reviewer",
+    category: "Review",
+    source: "OpenClaw compatibility input",
+    provenance: "External SKILL.md pattern, quarantined for UnClick review",
+    license: "License review required",
+    version: "upstream preview",
+    contentHash: "pending import hash",
+    riskState: "quarantined",
+    permissions: ["GitHub read after approval", "No write access", "No credential access"],
+    installState: "Preview only, no live install or execution",
+    description: "Turns useful PR review procedures into inspectable UnClick skill candidates before any connector power is granted.",
+  },
+  {
+    id: "research-pack",
+    name: "Research Pack",
+    category: "Research",
+    source: "AgentSkills-compatible import draft",
+    provenance: "Content-only prompt package, pending native rebuild",
+    license: "Permissive source preferred",
+    version: "v0 catalog draft",
+    contentHash: "content hash generated on import",
+    riskState: "reviewed",
+    permissions: ["Browser read after approval", "No shell", "No OAuth scopes"],
+    installState: "Forkable draft, reversible copy path",
+    description: "Collects source reading, synthesis, and proof notes without giving the package direct runtime authority.",
+  },
+  {
+    id: "skill-vetter",
+    name: "Skill Vetter",
+    category: "Safety",
+    source: "UnClick-native candidate",
+    provenance: "Built from ecosystem ideas under UnClick Safety Checker rules",
+    license: "UnClick first-party",
+    version: "native v0",
+    contentHash: "first-party tracked",
+    riskState: "native-ready",
+    permissions: ["Catalog read", "Risk labels", "No external execution"],
+    installState: "Native rebuild target",
+    description: "Explains provenance, permissions, and risk so external skills stay discovery input rather than trust authority.",
+  },
+];
+
 const STORAGE_KEY = "unclick_community_tools";
 
 export function getCommunityTools(): CommunityTool[] {

--- a/src/pages/admin/AdminTools.test.tsx
+++ b/src/pages/admin/AdminTools.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  useSession: () => ({
+    session: { access_token: "test-session-token" },
+    user: { email: "admin@example.com" },
+    loading: false,
+  }),
+}));
+
+async function renderAdminTools() {
+  const { default: AdminTools } = await import("./AdminTools");
+
+  render(
+    <MemoryRouter>
+      <AdminTools />
+    </MemoryRouter>,
+  );
+
+  await screen.findByRole("heading", { name: "Apps" });
+  await waitFor(() =>
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/memory-admin?action=admin_tools",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer test-session-token" },
+      }),
+    ),
+  );
+}
+
+describe("AdminTools", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ metering: {}, connectors: [] }),
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the curated Skills Library preview with provenance and risk state", async () => {
+    await renderAdminTools();
+
+    expect(screen.getByRole("heading", { name: "Skills Library" })).toBeInTheDocument();
+    expect(screen.getByText(/OpenClaw and similar ecosystems are discovery inputs/i)).toBeInTheDocument();
+    expect(screen.getByText("OpenClaw compatibility input")).toBeInTheDocument();
+    expect(screen.getByText("Quarantined")).toBeInTheDocument();
+    expect(screen.getByText("License review required")).toBeInTheDocument();
+    expect(screen.getByText("upstream preview")).toBeInTheDocument();
+    expect(screen.getByText(/No credential access/i)).toBeInTheDocument();
+  });
+
+  it("keeps preview and fork affordances disabled until install execution exists", async () => {
+    await renderAdminTools();
+
+    expect(screen.getByRole("button", { name: "Preview PR Monitor and Reviewer" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Install PR Monitor and Reviewer" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Fork Research Pack" })).toBeDisabled();
+    expect(screen.getByText("Preview only, no live install or execution")).toBeInTheDocument();
+    expect(screen.getByText("Forkable draft, reversible copy path")).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Wrench, Rocket, PenSquare } from "lucide-react";
+import { Eye, GitFork, PenSquare, Rocket, ShieldCheck, Wrench } from "lucide-react";
 import { useSession } from "@/lib/auth";
+import {
+  CURATED_SKILL_PREVIEWS,
+  SKILL_LIBRARY_CATEGORIES,
+  type SkillRiskState,
+} from "@/lib/communityTools";
 import { InfoCard } from "./memory/InfoCard";
 import UnClickTools from "./tools/UnClickTools";
 import ConnectedServices from "./tools/ConnectedServices";
@@ -17,6 +22,121 @@ interface Connector {
   setup_url?: string | null;
   test_endpoint?: string | null;
   credential: { is_valid: boolean; last_tested_at: string | null } | null;
+}
+
+const RISK_STATE_STYLES: Record<SkillRiskState, string> = {
+  quarantined: "bg-amber-400/10 text-amber-200",
+  reviewed: "bg-sky-400/10 text-sky-200",
+  "native-ready": "bg-emerald-400/10 text-emerald-200",
+};
+
+const RISK_STATE_LABELS: Record<SkillRiskState, string> = {
+  quarantined: "Quarantined",
+  reviewed: "Reviewed",
+  "native-ready": "Native ready",
+};
+
+function SkillsLibraryPreview() {
+  return (
+    <div className="md:col-span-2">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-[#61C1C4]" />
+            <h3 className="text-sm font-semibold text-white">Skills Library</h3>
+            <span className="rounded bg-[#61C1C4]/15 px-1.5 py-0.5 text-[10px] font-medium text-[#61C1C4]">
+              Curated
+            </span>
+          </div>
+          <p className="mt-2 max-w-2xl text-xs leading-5 text-white/50">
+            AgentSkills-compatible packages can be previewed, quarantined, and rebuilt as native UnClick skills. OpenClaw and similar ecosystems are discovery inputs, not trust authorities.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {SKILL_LIBRARY_CATEGORIES.map((category) => (
+            <span key={category} className="rounded bg-white/[0.04] px-2 py-1 text-[10px] font-medium text-white/50">
+              {category}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-3">
+        {CURATED_SKILL_PREVIEWS.map((skill) => (
+          <article key={skill.id} className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-white">{skill.name}</p>
+                <p className="mt-1 text-[11px] font-medium text-[#61C1C4]">{skill.source}</p>
+              </div>
+              <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${RISK_STATE_STYLES[skill.riskState]}`}>
+                {RISK_STATE_LABELS[skill.riskState]}
+              </span>
+            </div>
+
+            <p className="mt-3 text-xs leading-5 text-white/45">{skill.description}</p>
+
+            <dl className="mt-4 space-y-2 text-[11px] text-white/40">
+              <div>
+                <dt className="font-medium text-white/60">Provenance</dt>
+                <dd>{skill.provenance}</dd>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div>
+                  <dt className="font-medium text-white/60">License</dt>
+                  <dd>{skill.license}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-white/60">Version</dt>
+                  <dd>{skill.version}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-white/60">Hash</dt>
+                  <dd>{skill.contentHash}</dd>
+                </div>
+              </div>
+              <div>
+                <dt className="font-medium text-white/60">Permissions</dt>
+                <dd>{skill.permissions.join(", ")}</dd>
+              </div>
+            </dl>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled
+                aria-label={`Preview ${skill.name}`}
+                className="inline-flex items-center gap-1 rounded border border-white/[0.08] px-2 py-1 text-[11px] font-medium text-white/50"
+              >
+                <Eye className="h-3 w-3" />
+                Preview
+              </button>
+              <button
+                type="button"
+                disabled
+                aria-label={`Install ${skill.name}`}
+                className="inline-flex items-center gap-1 rounded border border-white/[0.08] px-2 py-1 text-[11px] font-medium text-white/50"
+              >
+                <Rocket className="h-3 w-3" />
+                Install
+              </button>
+              <button
+                type="button"
+                disabled
+                aria-label={`Fork ${skill.name}`}
+                className="inline-flex items-center gap-1 rounded border border-white/[0.08] px-2 py-1 text-[11px] font-medium text-white/50"
+              >
+                <GitFork className="h-3 w-3" />
+                Fork
+              </button>
+            </div>
+
+            <p className="mt-3 text-[11px] font-medium text-white/35">{skill.installState}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default function AdminToolsPage() {
@@ -98,6 +218,8 @@ export default function AdminToolsPage() {
         <section>
           <h2 className="mb-4 text-lg font-semibold text-white">Marketplace</h2>
           <div className="grid gap-4 md:grid-cols-2">
+            <SkillsLibraryPreview />
+
             <Link
               to="/admin/copypass"
               className="rounded-xl border border-white/[0.06] bg-[#111] p-5 transition-colors hover:border-fuchsia-400/30 hover:bg-white/[0.04]"


### PR DESCRIPTION
Summary:
Adds an admin Marketplace Skills Library preview backed by curated static skill metadata. The preview shows categories, source/provenance, license, version, hash, risk state, permissions, and disabled preview/install/fork controls.

Scope:
Owned files for todo 5c59c9a9-abd3-4f61-80c7-ab01a91012d0: src/pages/admin/AdminTools.tsx, src/pages/admin/AdminTools.test.tsx, src/lib/communityTools.ts.

Non-overlap:
No backend skill registry, no SKILL.md parser, no live install, no execution, no remote fetch, no keychain/auth/billing/migration changes, and no changes to Memory Library behavior.

Verification:
- npm ci
- npm run test -- src/pages/admin/AdminTools.test.tsx
- npx eslint src/pages/admin/AdminTools.tsx src/pages/admin/AdminTools.test.tsx src/lib/communityTools.ts
- git diff --check
- npm run build

Risk:
Admin UI only. Preview/install/fork controls are disabled, and external ecosystems are framed as discovery inputs rather than trust authorities. No secrets or production data touched.

Follow-up:
Next slices can add a read-only SKILL.md parser, normalized SkillSpec, and preview/diff import flow.

Status:
Draft PR for normal gates.