### PR TITLE
[codex] Guard MCP Anthropic tool spend paths

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -50,7 +50,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/alphavantage-tool.ts | 98a37153078d | 7591 |
 | packages/mcp-server/src/amazon-tool.ts | fb1e936b7c9a | 14913 |
 | packages/mcp-server/src/amber-tool.ts | 6d020b798469 | 4138 |
-| packages/mcp-server/src/anthropic-tool.ts | 84db1d498f00 | 5308 |
+| packages/mcp-server/src/anthropic-tool.ts | fd197643eefb | 7766 |
 | packages/mcp-server/src/asana-tool.ts | 3f5d880c119d | 8078 |
 | packages/mcp-server/src/assemblyai-tool.ts | 8eaea963f072 | 6080 |
 | packages/mcp-server/src/australiapost-tool.ts | 6fc5a927873d | 5148 |

--- a/packages/mcp-server/src/__tests__/anthropic-tool-spend-guard.test.ts
+++ b/packages/mcp-server/src/__tests__/anthropic-tool-spend-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { decideAnthropicToolProviderCall } from "../anthropic-tool.js";
+
+describe("Anthropic MCP tool spend guard", () => {
+  it("blocks paid Anthropic tool calls without the caller API key signal", () => {
+    expect(decideAnthropicToolProviderCall("chat", "claude-sonnet-4-6", "")).toMatchObject({
+      allowed: false,
+      path_id: "mcp.anthropic.tool.chat",
+      provider: "Anthropic",
+      model: "claude-sonnet-4-6",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("allows Anthropic tool calls when the caller supplied an API key", () => {
+    expect(decideAnthropicToolProviderCall("chat", "claude-sonnet-4-6", "sk-ant-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.anthropic.tool.chat",
+      provider: "Anthropic",
+      model: "claude-sonnet-4-6",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "explicit_paid_allowed",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("labels model listing as a paid or unknown provider surface", () => {
+    expect(decideAnthropicToolProviderCall("model-listing", "Anthropic /models", "sk-ant-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.anthropic.tool.model-listing",
+      cost_tier: "paid_or_unknown",
+      reason: "explicit_paid_allowed",
+    });
+  });
+});

--- a/packages/mcp-server/src/anthropic-tool.ts
+++ b/packages/mcp-server/src/anthropic-tool.ts
@@ -9,6 +9,27 @@ const ANTHROPIC_VERSION = "2023-06-01";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+export type AnthropicToolOperation = "chat" | "model-listing";
+
+type AnthropicToolCostTier = "paid" | "paid_or_unknown";
+
+interface AnthropicToolDecisionInput {
+  path_id: string;
+  model: string;
+  allow_paid?: boolean;
+}
+
+export interface AnthropicToolDecision {
+  allowed: boolean;
+  path_id: string;
+  provider: "Anthropic";
+  model: string;
+  cost_tier: AnthropicToolCostTier;
+  default_allowed: false;
+  reason: "explicit_paid_allowed" | "paid_or_unknown_blocked";
+  allow_paid_flag: "api_key argument";
+}
+
 interface AnthropicMessage {
   role: "user" | "assistant";
   content: string | Array<{ type: string; text?: string }>;
@@ -38,6 +59,58 @@ interface AnthropicModel {
   id: string;
   display_name: string;
   created_at: string;
+}
+
+// ─── Spend guard ──────────────────────────────────────────────────────────────
+
+const ANTHROPIC_TOOL_PATH_IDS: Record<AnthropicToolOperation, string> = {
+  chat: "mcp.anthropic.tool.chat",
+  "model-listing": "mcp.anthropic.tool.model-listing",
+};
+
+const ANTHROPIC_TOOL_OPERATION_BY_PATH_ID: Record<string, AnthropicToolOperation> =
+  Object.fromEntries(
+    Object.entries(ANTHROPIC_TOOL_PATH_IDS).map(([operation, pathId]) => [pathId, operation]),
+  ) as Record<string, AnthropicToolOperation>;
+
+const ANTHROPIC_TOOL_COST_TIERS: Record<AnthropicToolOperation, AnthropicToolCostTier> = {
+  chat: "paid",
+  "model-listing": "paid_or_unknown",
+};
+
+function decideAiProviderCall(input: AnthropicToolDecisionInput): AnthropicToolDecision {
+  const operation = ANTHROPIC_TOOL_OPERATION_BY_PATH_ID[input.path_id];
+  const allowed = input.allow_paid === true;
+
+  return {
+    allowed,
+    path_id: input.path_id,
+    provider: "Anthropic",
+    model: input.model,
+    cost_tier: operation ? ANTHROPIC_TOOL_COST_TIERS[operation] : "paid_or_unknown",
+    default_allowed: false,
+    reason: allowed ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
+    allow_paid_flag: "api_key argument",
+  };
+}
+
+export function decideAnthropicToolProviderCall(
+  operation: AnthropicToolOperation,
+  model: string,
+  apiKey: string,
+): AnthropicToolDecision {
+  return decideAiProviderCall({
+    path_id: ANTHROPIC_TOOL_PATH_IDS[operation],
+    model,
+    allow_paid: Boolean(apiKey),
+  });
+}
+
+function requireAnthropicSpendAllowed(operation: AnthropicToolOperation, model: string, apiKey: string): void {
+  const decision = decideAnthropicToolProviderCall(operation, model, apiKey);
+  if (!decision.allowed) {
+    throw new Error(`AI spend guard blocked ${decision.path_id}: ${decision.allow_paid_flag} is required.`);
+  }
 }
 
 // ─── Auth validation ──────────────────────────────────────────────────────────
@@ -94,6 +167,7 @@ export async function anthropicCreateMessage(args: Record<string, unknown>): Pro
   const apiKey = requireKey(args);
   const model = String(args.model ?? "claude-sonnet-4-6");
   const maxTokens = Math.min(8192, Math.max(1, Number(args.max_tokens ?? 1024)));
+  requireAnthropicSpendAllowed("chat", model, apiKey);
 
   // Parse messages
   let messages: AnthropicMessage[];
@@ -145,6 +219,7 @@ export async function anthropicCreateMessage(args: Record<string, unknown>): Pro
 
 export async function anthropicListModels(args: Record<string, unknown>): Promise<unknown> {
   const apiKey = requireKey(args);
+  requireAnthropicSpendAllowed("model-listing", "Anthropic /models", apiKey);
   const data = await anthropicGet<{ data: AnthropicModel[]; has_more: boolean; first_id?: string; last_id?: string }>(
     apiKey, "/models"
   );


### PR DESCRIPTION
## Summary

Adds a local spend decision helper to the MCP Anthropic tool wrapper so message creation and model listing both make an explicit paid-provider decision before calling Anthropic.

The caller supplied `api_key` remains the explicit allow-paid signal for these MCP tools, matching the central provider inventory entries already present for `mcp.anthropic.tool.*`.

## Validation

- `npm exec --workspace=@unclick/mcp-server -- vitest run src/__tests__/anthropic-tool-spend-guard.test.ts`
- `npm run build --workspace=@unclick/mcp-server`
- `node scripts/audit-ai-call-sites.mjs --json`

## Audit result

`packages/mcp-server/src/anthropic-tool.ts` is now marked guarded by the AI call-site audit. Remaining unwrapped runtime/provider surfaces are down to 4.