### PR TITLE
feat(mcp-server): guard AssemblyAI provider calls

### DIFF
--- a/packages/mcp-server/src/__tests__/assemblyai-tool-spend-guard.test.ts
+++ b/packages/mcp-server/src/__tests__/assemblyai-tool-spend-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { decideAssemblyAiToolProviderCall } from "../assemblyai-tool.js";
+
+describe("AssemblyAI MCP tool spend guard", () => {
+  it("blocks paid AssemblyAI transcription calls without the caller API key signal", () => {
+    expect(decideAssemblyAiToolProviderCall("transcribe", "AssemblyAI transcript", "")).toMatchObject({
+      allowed: false,
+      path_id: "mcp.assemblyai.tool.transcribe",
+      provider: "AssemblyAI",
+      model: "AssemblyAI transcript",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("allows AssemblyAI calls when the caller supplied an API key", () => {
+    expect(decideAssemblyAiToolProviderCall("transcribe", "AssemblyAI transcript", "aai-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.assemblyai.tool.transcribe",
+      provider: "AssemblyAI",
+      model: "AssemblyAI transcript",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "explicit_paid_allowed",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("labels transcript helper reads as paid or unknown provider surfaces", () => {
+    expect(decideAssemblyAiToolProviderCall("summary", "AssemblyAI transcript summary", "aai-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.assemblyai.tool.summary",
+      cost_tier: "paid_or_unknown",
+      reason: "explicit_paid_allowed",
+    });
+  });
+});

--- a/packages/mcp-server/src/assemblyai-tool.ts
+++ b/packages/mcp-server/src/assemblyai-tool.ts
@@ -4,6 +4,95 @@
 
 const AAI_BASE = "https://api.assemblyai.com/v2";
 
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type AssemblyAiToolOperation =
+  | "transcribe"
+  | "transcript-read"
+  | "transcript-list"
+  | "sentences"
+  | "paragraphs"
+  | "summary";
+
+type AssemblyAiToolCostTier = "paid" | "paid_or_unknown";
+
+interface AssemblyAiToolDecisionInput {
+  path_id: string;
+  model: string;
+  allow_paid?: boolean;
+}
+
+export interface AssemblyAiToolDecision {
+  allowed: boolean;
+  path_id: string;
+  provider: "AssemblyAI";
+  model: string;
+  cost_tier: AssemblyAiToolCostTier;
+  default_allowed: false;
+  reason: "explicit_paid_allowed" | "paid_or_unknown_blocked";
+  allow_paid_flag: "api_key argument";
+}
+
+// ─── Spend guard ──────────────────────────────────────────────────────────────
+
+const ASSEMBLYAI_TOOL_PATH_IDS: Record<AssemblyAiToolOperation, string> = {
+  transcribe: "mcp.assemblyai.tool.transcribe",
+  "transcript-read": "mcp.assemblyai.tool.transcript-read",
+  "transcript-list": "mcp.assemblyai.tool.transcript-list",
+  sentences: "mcp.assemblyai.tool.sentences",
+  paragraphs: "mcp.assemblyai.tool.paragraphs",
+  summary: "mcp.assemblyai.tool.summary",
+};
+
+const ASSEMBLYAI_TOOL_OPERATION_BY_PATH_ID: Record<string, AssemblyAiToolOperation> =
+  Object.fromEntries(
+    Object.entries(ASSEMBLYAI_TOOL_PATH_IDS).map(([operation, pathId]) => [pathId, operation]),
+  ) as Record<string, AssemblyAiToolOperation>;
+
+const ASSEMBLYAI_TOOL_COST_TIERS: Record<AssemblyAiToolOperation, AssemblyAiToolCostTier> = {
+  transcribe: "paid",
+  "transcript-read": "paid_or_unknown",
+  "transcript-list": "paid_or_unknown",
+  sentences: "paid_or_unknown",
+  paragraphs: "paid_or_unknown",
+  summary: "paid_or_unknown",
+};
+
+function decideAiProviderCall(input: AssemblyAiToolDecisionInput): AssemblyAiToolDecision {
+  const operation = ASSEMBLYAI_TOOL_OPERATION_BY_PATH_ID[input.path_id];
+  const allowed = input.allow_paid === true;
+
+  return {
+    allowed,
+    path_id: input.path_id,
+    provider: "AssemblyAI",
+    model: input.model,
+    cost_tier: operation ? ASSEMBLYAI_TOOL_COST_TIERS[operation] : "paid_or_unknown",
+    default_allowed: false,
+    reason: allowed ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
+    allow_paid_flag: "api_key argument",
+  };
+}
+
+export function decideAssemblyAiToolProviderCall(
+  operation: AssemblyAiToolOperation,
+  model: string,
+  apiKey: string,
+): AssemblyAiToolDecision {
+  return decideAiProviderCall({
+    path_id: ASSEMBLYAI_TOOL_PATH_IDS[operation],
+    model,
+    allow_paid: Boolean(apiKey),
+  });
+}
+
+function requireAssemblyAiSpendAllowed(operation: AssemblyAiToolOperation, model: string, apiKey: string): void {
+  const decision = decideAssemblyAiToolProviderCall(operation, model, apiKey);
+  if (!decision.allowed) {
+    throw new Error(`AI spend guard blocked ${decision.path_id}: ${decision.allow_paid_flag} is required.`);
+  }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function requireKey(args: Record<string, unknown>): string {
@@ -46,6 +135,7 @@ export async function assemblyaiTranscribe(args: Record<string, unknown>): Promi
   const apiKey = requireKey(args);
   const audioUrl = String(args.audio_url ?? "").trim();
   if (!audioUrl) throw new Error("audio_url is required (publicly accessible URL of the audio/video file).");
+  requireAssemblyAiSpendAllowed("transcribe", "AssemblyAI transcript", apiKey);
 
   const body: Record<string, unknown> = { audio_url: audioUrl };
   if (args.language_code)         body.language_code         = String(args.language_code);
@@ -74,11 +164,13 @@ export async function assemblyaiGetTranscript(args: Record<string, unknown>): Pr
   const apiKey = requireKey(args);
   const id = String(args.transcript_id ?? "").trim();
   if (!id) throw new Error("transcript_id is required.");
+  requireAssemblyAiSpendAllowed("transcript-read", "AssemblyAI transcript read", apiKey);
   return aaiGet(apiKey, `/transcript/${encodeURIComponent(id)}`);
 }
 
 export async function assemblyaiListTranscripts(args: Record<string, unknown>): Promise<unknown> {
   const apiKey = requireKey(args);
+  requireAssemblyAiSpendAllowed("transcript-list", "AssemblyAI transcript list", apiKey);
   const params: Record<string, string> = {};
   if (args.limit)  params.limit  = String(Math.min(200, Math.max(1, Number(args.limit ?? 10))));
   if (args.status) params.status = String(args.status);
@@ -91,6 +183,7 @@ export async function assemblyaiGetSentences(args: Record<string, unknown>): Pro
   const apiKey = requireKey(args);
   const id = String(args.transcript_id ?? "").trim();
   if (!id) throw new Error("transcript_id is required.");
+  requireAssemblyAiSpendAllowed("sentences", "AssemblyAI transcript sentences", apiKey);
   const data = await aaiGet<{ sentences: unknown[] }>(apiKey, `/transcript/${encodeURIComponent(id)}/sentences`);
   return { transcript_id: id, count: data.sentences?.length ?? 0, sentences: data.sentences ?? [] };
 }
@@ -99,6 +192,7 @@ export async function assemblyaiGetParagraphs(args: Record<string, unknown>): Pr
   const apiKey = requireKey(args);
   const id = String(args.transcript_id ?? "").trim();
   if (!id) throw new Error("transcript_id is required.");
+  requireAssemblyAiSpendAllowed("paragraphs", "AssemblyAI transcript paragraphs", apiKey);
   const data = await aaiGet<{ paragraphs: unknown[] }>(apiKey, `/transcript/${encodeURIComponent(id)}/paragraphs`);
   return { transcript_id: id, count: data.paragraphs?.length ?? 0, paragraphs: data.paragraphs ?? [] };
 }
@@ -107,6 +201,7 @@ export async function assemblyaiSummarize(args: Record<string, unknown>): Promis
   const apiKey = requireKey(args);
   const id = String(args.transcript_id ?? "").trim();
   if (!id) throw new Error("transcript_id is required (transcript must already be completed with summarization enabled).");
+  requireAssemblyAiSpendAllowed("summary", "AssemblyAI transcript summary", apiKey);
   const data = await aaiGet<{ summary?: string; status: string; error?: string }>(apiKey, `/transcript/${encodeURIComponent(id)}`);
   if (data.error) throw new Error(`Transcript error: ${data.error}`);
   if (data.status !== "completed") return { transcript_id: id, status: data.status, note: "Transcript not yet completed. Poll get_transcript until status is completed." };


### PR DESCRIPTION
Summary:
Adds an AssemblyAI MCP spend guard decision helper and checks it before every AssemblyAI network call. Transcription is labeled paid, and transcript helper reads are labeled paid_or_unknown.

Scope:
Owned files for todo 6408ff7b-7629-471b-b745-318ebb82b7a0:
- packages/mcp-server/src/assemblyai-tool.ts
- packages/mcp-server/src/__tests__/assemblyai-tool-spend-guard.test.ts

Non-overlap:
Did not touch ElevenLabs, Perplexity, Stability, provider inventory UI, secrets, billing, DNS, production deploys, or runtime credentials.

Verification:
- npx vitest run src/__tests__/assemblyai-tool-spend-guard.test.ts src/__tests__/anthropic-tool-spend-guard.test.ts src/__tests__/openai-tool-spend-guard.test.ts from packages/mcp-server
- npm run build --workspace @unclick/mcp-server
- git diff --check
- node scripts/audit-ai-call-sites.mjs, now reports remaining unwrapped provider files: elevenlabs-tool.ts, perplexity-tool.ts, stability-tool.ts

Risk:
Low. Caller-supplied api_key remains the explicit paid-call signal, matching the OpenAI and Anthropic MCP tool pattern. No migrations, auth changes, secrets, cron, data deletion, or deployments.

Follow-up:
Wrap the remaining ElevenLabs, Perplexity, and Stability MCP provider files in separate narrow slices.

Draft PR. Not merge-ready until GitHub checks complete.