### PR TITLE
feat(mcp-server): guard ElevenLabs provider calls

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -82,7 +82,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/domain-tool.ts | 1beecc106e80 | 6076 |
 | packages/mcp-server/src/ebay-tool.ts | 10dffe36315f | 7595 |
 | packages/mcp-server/src/ebird-tool.ts | 3deedf3fde19 | 6262 |
-| packages/mcp-server/src/elevenlabs-tool.ts | dcb54be4833d | 7692 |
+| packages/mcp-server/src/elevenlabs-tool.ts | efcaeeff39d6 | 10833 |
 
 ## UnClick Structure
 

--- a/packages/mcp-server/src/__tests__/elevenlabs-tool-spend-guard.test.ts
+++ b/packages/mcp-server/src/__tests__/elevenlabs-tool-spend-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { decideElevenLabsToolProviderCall } from "../elevenlabs-tool.js";
+
+describe("ElevenLabs MCP tool spend guard", () => {
+  it("blocks paid ElevenLabs tool calls without the caller API key signal", () => {
+    expect(decideElevenLabsToolProviderCall("text-to-speech", "eleven_monolingual_v1", "")).toMatchObject({
+      allowed: false,
+      path_id: "mcp.elevenlabs.tool.text-to-speech",
+      provider: "ElevenLabs",
+      model: "eleven_monolingual_v1",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("allows ElevenLabs tool calls when the caller supplied an API key", () => {
+    expect(decideElevenLabsToolProviderCall("text-to-speech", "eleven_monolingual_v1", "el-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.elevenlabs.tool.text-to-speech",
+      provider: "ElevenLabs",
+      model: "eleven_monolingual_v1",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "explicit_paid_allowed",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("labels metadata reads as paid or unknown provider surfaces", () => {
+    expect(decideElevenLabsToolProviderCall("voice-listing", "ElevenLabs /voices", "el-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.elevenlabs.tool.voice-listing",
+      cost_tier: "paid_or_unknown",
+      reason: "explicit_paid_allowed",
+    });
+  });
+});

--- a/packages/mcp-server/src/elevenlabs-tool.ts
+++ b/packages/mcp-server/src/elevenlabs-tool.ts
@@ -46,6 +46,90 @@ interface ElHistoryItem {
   state: string;
 }
 
+export type ElevenLabsToolOperation =
+  | "voice-listing"
+  | "voice-read"
+  | "text-to-speech"
+  | "model-listing"
+  | "history-listing";
+
+type ElevenLabsToolCostTier = "paid" | "paid_or_unknown";
+
+interface ElevenLabsToolDecisionInput {
+  path_id: string;
+  model: string;
+  allow_paid?: boolean;
+}
+
+export interface ElevenLabsToolDecision {
+  allowed: boolean;
+  path_id: string;
+  provider: "ElevenLabs";
+  model: string;
+  cost_tier: ElevenLabsToolCostTier;
+  default_allowed: false;
+  reason: "explicit_paid_allowed" | "paid_or_unknown_blocked";
+  allow_paid_flag: "api_key argument";
+}
+
+// ─── Spend guard ──────────────────────────────────────────────────────────────
+
+const ELEVENLABS_TOOL_PATH_IDS: Record<ElevenLabsToolOperation, string> = {
+  "voice-listing": "mcp.elevenlabs.tool.voice-listing",
+  "voice-read": "mcp.elevenlabs.tool.voice-read",
+  "text-to-speech": "mcp.elevenlabs.tool.text-to-speech",
+  "model-listing": "mcp.elevenlabs.tool.model-listing",
+  "history-listing": "mcp.elevenlabs.tool.history-listing",
+};
+
+const ELEVENLABS_TOOL_OPERATION_BY_PATH_ID: Record<string, ElevenLabsToolOperation> =
+  Object.fromEntries(
+    Object.entries(ELEVENLABS_TOOL_PATH_IDS).map(([operation, pathId]) => [pathId, operation]),
+  ) as Record<string, ElevenLabsToolOperation>;
+
+const ELEVENLABS_TOOL_COST_TIERS: Record<ElevenLabsToolOperation, ElevenLabsToolCostTier> = {
+  "voice-listing": "paid_or_unknown",
+  "voice-read": "paid_or_unknown",
+  "text-to-speech": "paid",
+  "model-listing": "paid_or_unknown",
+  "history-listing": "paid_or_unknown",
+};
+
+function decideAiProviderCall(input: ElevenLabsToolDecisionInput): ElevenLabsToolDecision {
+  const operation = ELEVENLABS_TOOL_OPERATION_BY_PATH_ID[input.path_id];
+  const allowed = input.allow_paid === true;
+
+  return {
+    allowed,
+    path_id: input.path_id,
+    provider: "ElevenLabs",
+    model: input.model,
+    cost_tier: operation ? ELEVENLABS_TOOL_COST_TIERS[operation] : "paid_or_unknown",
+    default_allowed: false,
+    reason: allowed ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
+    allow_paid_flag: "api_key argument",
+  };
+}
+
+export function decideElevenLabsToolProviderCall(
+  operation: ElevenLabsToolOperation,
+  model: string,
+  apiKey: string,
+): ElevenLabsToolDecision {
+  return decideAiProviderCall({
+    path_id: ELEVENLABS_TOOL_PATH_IDS[operation],
+    model,
+    allow_paid: Boolean(apiKey),
+  });
+}
+
+function requireElevenLabsSpendAllowed(operation: ElevenLabsToolOperation, model: string, apiKey: string): void {
+  const decision = decideElevenLabsToolProviderCall(operation, model, apiKey);
+  if (!decision.allowed) {
+    throw new Error(`AI spend guard blocked ${decision.path_id}: ${decision.allow_paid_flag} is required.`);
+  }
+}
+
 // ─── Auth validation ──────────────────────────────────────────────────────────
 
 function requireKey(args: Record<string, unknown>): string {
@@ -101,6 +185,7 @@ async function elPost<T>(apiKey: string, path: string, body: unknown): Promise<T
 
 export async function elevenlabsListVoices(args: Record<string, unknown>): Promise<unknown> {
   const apiKey = requireKey(args);
+  requireElevenLabsSpendAllowed("voice-listing", "ElevenLabs /voices", apiKey);
   const data = await elGet<{ voices: ElVoice[] }>(apiKey, "/voices");
 
   return {
@@ -122,6 +207,7 @@ export async function elevenlabsGetVoice(args: Record<string, unknown>): Promise
   if (!voiceId) throw new Error("voice_id is required.");
 
   const withSettings = args.with_settings === true;
+  requireElevenLabsSpendAllowed("voice-read", "ElevenLabs /voices/{voice_id}", apiKey);
   const path = `/voices/${encodeURIComponent(voiceId)}${withSettings ? "?with_settings=true" : ""}`;
   const voice = await elGet<ElVoice & { settings?: ElVoiceSettings }>(apiKey, path);
 
@@ -146,6 +232,7 @@ export async function elevenlabsTextToSpeech(args: Record<string, unknown>): Pro
 
   const modelId = String(args.model_id ?? "eleven_monolingual_v1");
   const outputFormat = String(args.output_format ?? "mp3_44100_128");
+  requireElevenLabsSpendAllowed("text-to-speech", modelId, apiKey);
 
   const voiceSettings: ElVoiceSettings = {
     stability: Math.min(1, Math.max(0, Number(args.stability ?? 0.5))),
@@ -180,6 +267,7 @@ export async function elevenlabsTextToSpeech(args: Record<string, unknown>): Pro
 
 export async function elevenlabsGetModels(args: Record<string, unknown>): Promise<unknown> {
   const apiKey = requireKey(args);
+  requireElevenLabsSpendAllowed("model-listing", "ElevenLabs /models", apiKey);
   const models = await elGet<ElModel[]>(apiKey, "/models");
 
   return {
@@ -197,6 +285,7 @@ export async function elevenlabsGetModels(args: Record<string, unknown>): Promis
 
 export async function elevenlabsGetHistory(args: Record<string, unknown>): Promise<unknown> {
   const apiKey = requireKey(args);
+  requireElevenLabsSpendAllowed("history-listing", "ElevenLabs /history", apiKey);
   const pageSize = Math.min(1000, Math.max(1, Number(args.page_size ?? 30)));
   const params = new URLSearchParams({ page_size: String(pageSize) });
   if (args.start_after_history_item_id) {


### PR DESCRIPTION
Summary:
Adds an ElevenLabs MCP spend guard decision helper and checks it before every ElevenLabs provider API call. Text-to-speech is labeled paid, and voice/model/history reads are labeled paid_or_unknown. Also refreshes the generated Brainmap entry required by CI for the changed MCP tool file.

Scope:
Owned files for todo 6408ff7b-7629-471b-b745-318ebb82b7a0:
- packages/mcp-server/src/elevenlabs-tool.ts
- packages/mcp-server/src/__tests__/elevenlabs-tool-spend-guard.test.ts
- docs/UnClick-brainmap.generated.md, generated CI artifact only

Non-overlap:
Did not touch Perplexity, Stability, provider inventory UI, secrets, billing, DNS, production deploys, or runtime credentials.

Verification:
- npx vitest run src/__tests__/elevenlabs-tool-spend-guard.test.ts src/__tests__/assemblyai-tool-spend-guard.test.ts src/__tests__/anthropic-tool-spend-guard.test.ts src/__tests__/openai-tool-spend-guard.test.ts from packages/mcp-server
- npm run build --workspace @unclick/mcp-server
- git diff --check
- node scripts/audit-ai-call-sites.mjs, now reports remaining unwrapped provider files: perplexity-tool.ts and stability-tool.ts
- npm run brainmap:check
- npm run test:brainmap

Risk:
Low. Caller-supplied api_key remains the explicit paid-call signal, matching the OpenAI, Anthropic, and AssemblyAI MCP tool pattern. No migrations, auth changes, secrets, cron, data deletion, or deployments.

Follow-up:
Wrap Perplexity and Stability MCP provider files in separate narrow slices.

Draft PR. Not merge-ready until GitHub checks complete.