### PR TITLE
feat(mcp-server): guard Perplexity provider calls

### DIFF
--- a/packages/mcp-server/src/__tests__/perplexity-tool-spend-guard.test.ts
+++ b/packages/mcp-server/src/__tests__/perplexity-tool-spend-guard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { decidePerplexityToolProviderCall } from "../perplexity-tool.js";
+
+describe("Perplexity MCP tool spend guard", () => {
+  it("blocks paid Perplexity tool calls without the caller API key signal", () => {
+    expect(decidePerplexityToolProviderCall("chat-completion", "sonar", "")).toMatchObject({
+      allowed: false,
+      path_id: "mcp.perplexity.tool.chat-completion",
+      provider: "Perplexity",
+      model: "sonar",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("allows Perplexity tool calls when the caller supplied an API key", () => {
+    expect(decidePerplexityToolProviderCall("chat-completion", "sonar-pro", "pplx-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.perplexity.tool.chat-completion",
+      provider: "Perplexity",
+      model: "sonar-pro",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "explicit_paid_allowed",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+});

--- a/packages/mcp-server/src/perplexity-tool.ts
+++ b/packages/mcp-server/src/perplexity-tool.ts
@@ -32,6 +32,71 @@ interface PerplexityChatResponse {
   related_questions?: string[];
 }
 
+export type PerplexityToolOperation = "chat-completion";
+
+type PerplexityToolCostTier = "paid";
+
+interface PerplexityToolDecisionInput {
+  path_id: string;
+  model: string;
+  allow_paid?: boolean;
+}
+
+export interface PerplexityToolDecision {
+  allowed: boolean;
+  path_id: string;
+  provider: "Perplexity";
+  model: string;
+  cost_tier: PerplexityToolCostTier;
+  default_allowed: false;
+  reason: "explicit_paid_allowed" | "paid_or_unknown_blocked";
+  allow_paid_flag: "api_key argument";
+}
+
+// --- Spend guard -------------------------------------------------------------
+
+const PERPLEXITY_TOOL_PATH_IDS: Record<PerplexityToolOperation, string> = {
+  "chat-completion": "mcp.perplexity.tool.chat-completion",
+};
+
+const PERPLEXITY_TOOL_COST_TIERS: Record<PerplexityToolOperation, PerplexityToolCostTier> = {
+  "chat-completion": "paid",
+};
+
+function decideAiProviderCall(input: PerplexityToolDecisionInput): PerplexityToolDecision {
+  const allowed = input.allow_paid === true;
+
+  return {
+    allowed,
+    path_id: input.path_id,
+    provider: "Perplexity",
+    model: input.model,
+    cost_tier: PERPLEXITY_TOOL_COST_TIERS["chat-completion"],
+    default_allowed: false,
+    reason: allowed ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
+    allow_paid_flag: "api_key argument",
+  };
+}
+
+export function decidePerplexityToolProviderCall(
+  operation: PerplexityToolOperation,
+  model: string,
+  apiKey: string,
+): PerplexityToolDecision {
+  return decideAiProviderCall({
+    path_id: PERPLEXITY_TOOL_PATH_IDS[operation],
+    model,
+    allow_paid: Boolean(apiKey),
+  });
+}
+
+function requirePerplexitySpendAllowed(operation: PerplexityToolOperation, model: string, apiKey: string): void {
+  const decision = decidePerplexityToolProviderCall(operation, model, apiKey);
+  if (!decision.allowed) {
+    throw new Error(`AI spend guard blocked ${decision.path_id}: ${decision.allow_paid_flag} is required.`);
+  }
+}
+
 // --- Auth validation ---------------------------------------------------------
 
 function requireKey(args: Record<string, unknown>): string {
@@ -67,6 +132,7 @@ export async function perplexityChatCompletion(args: Record<string, unknown>): P
   try {
     const apiKey = requireKey(args);
     const model = String(args.model ?? "sonar");
+    requirePerplexitySpendAllowed("chat-completion", model, apiKey);
 
     // Parse messages
     let messages: PerplexityMessage[];


### PR DESCRIPTION
## What changed
- Added an explicit Perplexity MCP spend decision helper.
- Blocked Perplexity chat-completion provider calls unless the caller supplies an API key.
- Added focused spend-guard tests for blocked and allowed paths.

## Why
The AI spend guardrails job is reducing provider calls that can spend money without an explicit caller-owned key signal. This moves Perplexity from unwrapped to guarded.

## Validation
- npx vitest run src/__tests__/perplexity-tool-spend-guard.test.ts, from packages/mcp-server
- npm run build --workspace=@unclick/mcp-server
- node scripts/audit-ai-call-sites.mjs, need_wrapping is now 1, Stability only
- npm run brainmap:check
- npm run test:brainmap