### PR TITLE
feat(mcp-server): guard Stability provider calls

### DIFF
--- a/packages/mcp-server/src/__tests__/stability-tool-spend-guard.test.ts
+++ b/packages/mcp-server/src/__tests__/stability-tool-spend-guard.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { decideStabilityToolProviderCall } from "../stability-tool.js";
+
+describe("Stability MCP tool spend guard", () => {
+  it("blocks paid Stability tool calls without the caller API key signal", () => {
+    expect(decideStabilityToolProviderCall("text-to-image", "stable-diffusion-xl-1024-v1-0", "")).toMatchObject({
+      allowed: false,
+      path_id: "mcp.stability.tool.text-to-image",
+      provider: "Stability AI",
+      model: "stable-diffusion-xl-1024-v1-0",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("allows Stability tool calls when the caller supplied an API key", () => {
+    expect(decideStabilityToolProviderCall("image-to-image", "stable-diffusion-xl-1024-v1-0", "sk-test")).toMatchObject({
+      allowed: true,
+      path_id: "mcp.stability.tool.image-to-image",
+      provider: "Stability AI",
+      model: "stable-diffusion-xl-1024-v1-0",
+      cost_tier: "paid",
+      default_allowed: false,
+      reason: "explicit_paid_allowed",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+
+  it("labels engine listing as a paid or unknown provider surface", () => {
+    expect(decideStabilityToolProviderCall("engine-listing", "Stability AI /v1/engines/list", "")).toMatchObject({
+      allowed: false,
+      path_id: "mcp.stability.tool.engine-listing",
+      provider: "Stability AI",
+      model: "Stability AI /v1/engines/list",
+      cost_tier: "paid_or_unknown",
+      default_allowed: false,
+      reason: "paid_or_unknown_blocked",
+      allow_paid_flag: "api_key argument",
+    });
+  });
+});

--- a/packages/mcp-server/src/stability-tool.ts
+++ b/packages/mcp-server/src/stability-tool.ts
@@ -25,6 +25,87 @@ interface StabilityGenerationResponse {
   artifacts: StabilityArtifact[];
 }
 
+export type StabilityToolOperation =
+  | "text-to-image"
+  | "image-to-image"
+  | "upscale"
+  | "engine-listing";
+
+type StabilityToolCostTier = "paid" | "paid_or_unknown";
+
+interface StabilityToolDecisionInput {
+  path_id: string;
+  model: string;
+  allow_paid?: boolean;
+}
+
+export interface StabilityToolDecision {
+  allowed: boolean;
+  path_id: string;
+  provider: "Stability AI";
+  model: string;
+  cost_tier: StabilityToolCostTier;
+  default_allowed: false;
+  reason: "explicit_paid_allowed" | "paid_or_unknown_blocked";
+  allow_paid_flag: "api_key argument";
+}
+
+// ─── Spend guard ──────────────────────────────────────────────────────────────
+
+const STABILITY_TOOL_PATH_IDS: Record<StabilityToolOperation, string> = {
+  "text-to-image": "mcp.stability.tool.text-to-image",
+  "image-to-image": "mcp.stability.tool.image-to-image",
+  upscale: "mcp.stability.tool.upscale",
+  "engine-listing": "mcp.stability.tool.engine-listing",
+};
+
+const STABILITY_TOOL_OPERATION_BY_PATH_ID: Record<string, StabilityToolOperation> =
+  Object.fromEntries(
+    Object.entries(STABILITY_TOOL_PATH_IDS).map(([operation, pathId]) => [pathId, operation]),
+  ) as Record<string, StabilityToolOperation>;
+
+const STABILITY_TOOL_COST_TIERS: Record<StabilityToolOperation, StabilityToolCostTier> = {
+  "text-to-image": "paid",
+  "image-to-image": "paid",
+  upscale: "paid",
+  "engine-listing": "paid_or_unknown",
+};
+
+function decideAiProviderCall(input: StabilityToolDecisionInput): StabilityToolDecision {
+  const operation = STABILITY_TOOL_OPERATION_BY_PATH_ID[input.path_id];
+  const allowed = input.allow_paid === true;
+
+  return {
+    allowed,
+    path_id: input.path_id,
+    provider: "Stability AI",
+    model: input.model,
+    cost_tier: operation ? STABILITY_TOOL_COST_TIERS[operation] : "paid_or_unknown",
+    default_allowed: false,
+    reason: allowed ? "explicit_paid_allowed" : "paid_or_unknown_blocked",
+    allow_paid_flag: "api_key argument",
+  };
+}
+
+export function decideStabilityToolProviderCall(
+  operation: StabilityToolOperation,
+  model: string,
+  apiKey: string,
+): StabilityToolDecision {
+  return decideAiProviderCall({
+    path_id: STABILITY_TOOL_PATH_IDS[operation],
+    model,
+    allow_paid: Boolean(apiKey),
+  });
+}
+
+function requireStabilitySpendAllowed(operation: StabilityToolOperation, model: string, apiKey: string): void {
+  const decision = decideStabilityToolProviderCall(operation, model, apiKey);
+  if (!decision.allowed) {
+    throw new Error(`AI spend guard blocked ${decision.path_id}: ${decision.allow_paid_flag} is required.`);
+  }
+}
+
 // ─── Auth validation ──────────────────────────────────────────────────────────
 
 function requireKey(args: Record<string, unknown>): string {
@@ -106,6 +187,7 @@ export async function stabilityTextToImage(args: Record<string, unknown>): Promi
   const prompt = String(args.prompt ?? "").trim();
   if (!prompt) throw new Error("prompt is required.");
   const engineId = String(args.engine_id ?? "stable-diffusion-xl-1024-v1-0");
+  requireStabilitySpendAllowed("text-to-image", engineId, apiKey);
   const negativePrompt = String(args.negative_prompt ?? "").trim();
 
   const width = Number(args.width ?? 1024);
@@ -153,6 +235,7 @@ export async function stabilityImageToImage(args: Record<string, unknown>): Prom
   if (!prompt) throw new Error("prompt is required.");
   if (!imageUrl) throw new Error("image_url is required (URL of the source image).");
   const engineId = String(args.engine_id ?? "stable-diffusion-xl-1024-v1-0");
+  requireStabilitySpendAllowed("image-to-image", engineId, apiKey);
   const strength = Math.min(1, Math.max(0, Number(args.strength ?? 0.35)));
   const steps = Math.min(150, Math.max(10, Number(args.steps ?? 30)));
   const cfgScale = Math.min(35, Math.max(0, Number(args.cfg_scale ?? 7)));
@@ -201,6 +284,7 @@ export async function stabilityUpscale(args: Record<string, unknown>): Promise<u
   if (!imageUrl) throw new Error("image_url is required (URL of the image to upscale).");
   const width = Number(args.width ?? 2048);
   const engineId = String(args.engine_id ?? "esrgan-v1-x2plus");
+  requireStabilitySpendAllowed("upscale", engineId, apiKey);
 
   // Fetch source image
   const imgRes = await fetch(imageUrl);
@@ -229,6 +313,7 @@ export async function stabilityUpscale(args: Record<string, unknown>): Promise<u
 
 export async function stabilityListEngines(args: Record<string, unknown>): Promise<unknown> {
   const apiKey = requireKey(args);
+  requireStabilitySpendAllowed("engine-listing", "Stability AI /v1/engines/list", apiKey);
   const engines = await stabilityGet<StabilityEngine[]>(apiKey, "/v1/engines/list");
 
   return {


### PR DESCRIPTION
## What changed
- Added explicit Stability MCP spend decision helpers.
- Blocked Stability text-to-image, image-to-image, upscale, and engine-listing provider calls unless the caller supplies an API key.
- Added focused spend-guard tests for blocked, allowed, and metadata-read paths.

## Why
This completes the AI spend guardrails provider-wrapper sweep by moving Stability from unwrapped to guarded.

## Validation
- npx vitest run src/__tests__/stability-tool-spend-guard.test.ts, from packages/mcp-server
- npm run build --workspace=@unclick/mcp-server
- node scripts/audit-ai-call-sites.mjs, need_wrapping is now 0
- npm run brainmap:check
- npm run test:brainmap