### PR TITLE
[codex] widen autonomous runner scheduled wake chain

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -6,6 +6,7 @@ on:
   workflow_run:
     workflows:
       - Fleet Throughput Watch
+      - Tier-2 Auto-Merge Queue Check
       - TestPass Scheduled Smoke
     types: [completed]
   workflow_dispatch:

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -2344,6 +2344,7 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /cron:\s*"3,13,23,33,43,53 \* \* \* \*"/);
     assert.match(workflow, /workflow_run:/);
     assert.match(workflow, /Fleet Throughput Watch/);
+    assert.match(workflow, /Tier-2 Auto-Merge Queue Check/);
     assert.match(workflow, /Prove Orchestrator seat handoff/);
     assert.match(workflow, /github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_run' && github\.event\.workflow_run\.event == 'schedule'\)/);
     assert.doesNotMatch(workflow, /if:\s*github\.event_name == 'workflow_run'\s*$/m);


### PR DESCRIPTION
## What changed
- Added `Tier-2 Auto-Merge Queue Check` as an additional scheduled upstream workflow that can wake PinballWake through `workflow_run`.
- Updated the focused PinballWake workflow wiring test so the fallback stays covered.

## Why
After PR #861, the runner code passed a safe dry-run on current main, but the direct PinballWake schedule and Fleet schedule windows did not appear. Tier-2 Auto-Merge Queue Check is a scheduled workflow that recently fired successfully, so this gives PinballWake another scheduled-chain wake path without enabling execute mode.

## Impact
This should improve hands-off autopilot recovery by letting a known active scheduled workflow wake the autonomous runner. The runner still claims only safe work and keeps execute mode locked off.

## Validation
- `node --test scripts\pinballwake-autonomous-runner.test.mjs`