### PR TITLE
fix(wakepass): plan merged PR dispatch reconciliation

### DIFF
--- a/scripts/fishbowl-todo-reconciliation.mjs
+++ b/scripts/fishbowl-todo-reconciliation.mjs
@@ -61,6 +61,94 @@ function todoText(todo = {}) {
   ).join("\n");
 }
 
+function dispatchText(dispatch = {}) {
+  return textParts(
+    dispatch.text,
+    dispatch.summary,
+    dispatch.title,
+    dispatch.source_url,
+    dispatch.sourceUrl,
+    dispatch.payload?.source_url,
+    dispatch.payload?.sourceUrl,
+    dispatch.deep_link,
+    dispatch.deepLink,
+  ).join("\n");
+}
+
+function receiptText(receipt = {}) {
+  return textParts(
+    receipt.text,
+    receipt.summary,
+    receipt.title,
+    receipt.source_url,
+    receipt.sourceUrl,
+    receipt.payload?.source_url,
+    receipt.payload?.sourceUrl,
+  ).join("\n");
+}
+
+function normalizedTags(record = {}) {
+  return (Array.isArray(record.tags) ? record.tags : [])
+    .map((tag) => String(tag ?? "").toLowerCase())
+    .filter(Boolean);
+}
+
+function hasTag(record, tag) {
+  return normalizedTags(record).includes(String(tag).toLowerCase());
+}
+
+function firstKnown(...values) {
+  return values.find((value) => value != null && String(value).length > 0) ?? null;
+}
+
+function pullRequestNumber(pr = {}) {
+  const number = Number(pr.number ?? pr.pr_number);
+  return Number.isFinite(number) ? number : null;
+}
+
+function pullRequestMergedAt(pr = {}) {
+  return parseTime(pr.merged_at ?? pr.mergedAt);
+}
+
+function pullRequestMergeCommit(pr = {}) {
+  return firstKnown(
+    pr.merge_commit_sha,
+    pr.mergeCommitSha,
+    pr.mergeCommit?.oid,
+    pr.mergeCommit?.sha,
+    pr.merge_commit?.oid,
+    pr.merge_commit?.sha,
+  );
+}
+
+function findWakePassCompletionProof(prNumber, receipts = []) {
+  for (const receipt of Array.isArray(receipts) ? receipts : []) {
+    const text = receiptText(receipt);
+    const textLower = text.toLowerCase();
+    const tags = normalizedTags(receipt);
+    if (!extractPullRequestNumbers(text).includes(prNumber)) continue;
+
+    const wakePassLike =
+      tags.includes("wakepass") ||
+      textLower.includes("wakepass") ||
+      textLower.includes("wake-pull_request-pr");
+    const completionLike =
+      tags.includes("ack") ||
+      tags.includes("done") ||
+      tags.includes("completed") ||
+      /\b(ack|merged|completed|handoff complete)\b/i.test(text);
+
+    if (!wakePassLike || !completionLike) continue;
+
+    return {
+      receipt_id: firstKnown(receipt.id, receipt.source_id, receipt.message_id),
+      receipt_text: text.replace(/\s+/g, " ").trim().slice(0, 220),
+    };
+  }
+
+  return null;
+}
+
 export function extractPullRequestNumbers(...parts) {
   const text = textParts(...parts).join("\n");
   const numbers = new Set();
@@ -293,6 +381,97 @@ export function buildJobsGithubSyncPlan({
   };
 }
 
+export function buildMergedPrDispatchReconciliationPlan({
+  dispatches = [],
+  pullRequests = [],
+  receipts = [],
+  completionReceipts = [],
+} = {}) {
+  const safePrs = Array.isArray(pullRequests) ? pullRequests : [];
+  const prByNumber = new Map(
+    safePrs
+      .map((pr) => [pullRequestNumber(pr), pr])
+      .filter(([number]) => Number.isFinite(number)),
+  );
+  const proofReceipts = [
+    ...(Array.isArray(receipts) ? receipts : []),
+    ...(Array.isArray(completionReceipts) ? completionReceipts : []),
+  ];
+  const completeDispatches = [];
+  const suppressBlockers = [];
+  const untouched = [];
+
+  for (const dispatch of Array.isArray(dispatches) ? dispatches : []) {
+    const dispatchId = firstKnown(dispatch.id, dispatch.source_id, dispatch.dispatch_id);
+    const text = dispatchText(dispatch);
+    const prNumbers = extractPullRequestNumbers(text);
+
+    if (prNumbers.length === 0) {
+      untouched.push({ dispatch_id: dispatchId, reason: "no_pr_reference" });
+      continue;
+    }
+
+    for (const prNumber of prNumbers) {
+      const pr = prByNumber.get(prNumber);
+      if (!pr) {
+        untouched.push({ dispatch_id: dispatchId, pr_number: prNumber, reason: "missing_pr" });
+        continue;
+      }
+
+      if (pr.isDraft === true || pr.draft === true) {
+        untouched.push({ dispatch_id: dispatchId, pr_number: prNumber, reason: "pr_draft" });
+        continue;
+      }
+
+      const mergedAt = pullRequestMergedAt(pr);
+      if (mergedAt === null) {
+        untouched.push({ dispatch_id: dispatchId, pr_number: prNumber, reason: "pr_not_merged" });
+        continue;
+      }
+
+      const proof = findWakePassCompletionProof(prNumber, proofReceipts);
+      if (!proof) {
+        untouched.push({
+          dispatch_id: dispatchId,
+          pr_number: prNumber,
+          reason: "missing_wakepass_completion_proof",
+        });
+        continue;
+      }
+
+      const staleBlocker =
+        String(dispatch.kind ?? "").toLowerCase() === "blocker" ||
+        hasTag(dispatch, "blocker") ||
+        hasTag(dispatch, "stale") ||
+        /\b(blocker|stale)\b/i.test(text);
+      const item = {
+        kind: staleBlocker ? "suppress_blocker" : "complete_dispatch",
+        dispatch_id: dispatchId,
+        pr_number: prNumber,
+        pr_url: firstKnown(pr.url, pr.html_url),
+        merge_commit: pullRequestMergeCommit(pr),
+        merged_at: new Date(mergedAt).toISOString(),
+        receipt_id: proof.receipt_id,
+        receipt_text: proof.receipt_text,
+      };
+
+      if (staleBlocker) {
+        suppressBlockers.push(item);
+      } else {
+        completeDispatches.push(item);
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    reason: "merged_pr_dispatch_reconciliation_plan",
+    complete_dispatches: completeDispatches,
+    suppress_blockers: suppressBlockers,
+    untouched,
+  };
+}
+
 export async function readReconciliationInput(filePath) {
   if (!filePath) return { ok: false, reason: "missing_input_path" };
   return JSON.parse(await readFile(filePath, "utf8"));
@@ -306,6 +485,14 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
           return buildJobsGithubSyncPlan({
             todos: input.todos,
             pullRequests: input.pullRequests ?? input.pull_requests,
+          });
+        }
+        if (input.mode === "merged_pr_dispatch_reconciliation") {
+          return buildMergedPrDispatchReconciliationPlan({
+            dispatches: input.dispatches,
+            pullRequests: input.pullRequests ?? input.pull_requests,
+            receipts: input.receipts,
+            completionReceipts: input.completionReceipts ?? input.completion_receipts,
           });
         }
         return buildInProgressReconciliationPlan({

--- a/scripts/fishbowl-todo-reconciliation.test.mjs
+++ b/scripts/fishbowl-todo-reconciliation.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  buildMergedPrDispatchReconciliationPlan,
   buildInProgressReconciliationPlan,
   buildJobsGithubSyncPlan,
   evaluatePrTodoReference,
@@ -145,5 +146,105 @@ describe("fishbowl todo reconciliation helpers", () => {
 
     assert.equal(plan.linked.length, 1);
     assert.equal(plan.issues.some((issue) => issue.kind === "job_ready_to_complete"), true);
+  });
+
+  it("suppresses stale WakePass blockers when a merged PR has completion proof", () => {
+    const plan = buildMergedPrDispatchReconciliationPlan({
+      dispatches: [
+        {
+          id: "dispatch_pr_765",
+          kind: "blocker",
+          tags: ["dispatch", "wakepass", "stale"],
+          summary:
+            "wakepass stale owner-decision blocker for PR #765 https://github.com/malamutemayhem/unclick/pull/765",
+        },
+      ],
+      pullRequests: [
+        {
+          number: 765,
+          url: "https://github.com/malamutemayhem/unclick/pull/765",
+          merged_at: "2026-05-13T14:38:03.000Z",
+          merge_commit_sha: "e0b3714d8c6fdb6f989db71f2f17f117c6f754d4",
+        },
+      ],
+      receipts: [
+        {
+          id: "wakepass_ack_765",
+          tags: ["wakepass", "ack"],
+          text: "ACK wake-pull_request-pr-765 merged PR #765; WakePass handoff complete.",
+        },
+      ],
+    });
+
+    assert.equal(plan.ok, true);
+    assert.deepEqual(plan.suppress_blockers.map((item) => item.dispatch_id), ["dispatch_pr_765"]);
+    assert.equal(plan.suppress_blockers[0].kind, "suppress_blocker");
+    assert.equal(plan.suppress_blockers[0].pr_number, 765);
+    assert.equal(plan.complete_dispatches.length, 0);
+  });
+
+  it("completes leased WakePass dispatches tied to merged PRs with proof", () => {
+    const plan = buildMergedPrDispatchReconciliationPlan({
+      dispatches: [
+        {
+          source_id: "dispatch_pr_773",
+          kind: "wake",
+          tags: ["dispatch", "wakepass", "needs-doing"],
+          text: "Wake event: PR #773 is ready for review\nSource: https://github.com/malamutemayhem/unclick/pull/773",
+        },
+      ],
+      pullRequests: [
+        {
+          number: 773,
+          html_url: "https://github.com/malamutemayhem/unclick/pull/773",
+          mergedAt: "2026-05-13T12:00:00.000Z",
+          mergeCommit: { oid: "0d9a10f92ef59cdb5b18ad0de2724bcb721ff451" },
+        },
+      ],
+      completionReceipts: [
+        {
+          id: "wakepass_ack_773",
+          tags: ["wakepass", "completed"],
+          text: "WakePass completed PR #773 after merge proof was posted.",
+        },
+      ],
+    });
+
+    assert.equal(plan.complete_dispatches.length, 1);
+    assert.equal(plan.complete_dispatches[0].kind, "complete_dispatch");
+    assert.equal(plan.complete_dispatches[0].dispatch_id, "dispatch_pr_773");
+    assert.equal(plan.complete_dispatches[0].merge_commit, "0d9a10f92ef59cdb5b18ad0de2724bcb721ff451");
+    assert.equal(plan.suppress_blockers.length, 0);
+  });
+
+  it("leaves open, draft, unmerged, and no-proof PR dispatches untouched", () => {
+    const plan = buildMergedPrDispatchReconciliationPlan({
+      dispatches: [
+        { id: "open_dispatch", text: "Wake event: PR #800 is ready for review" },
+        { id: "draft_dispatch", text: "Wake event: PR #801 is ready for review" },
+        { id: "closed_unmerged_dispatch", text: "Wake event: PR #802 is ready for review" },
+        { id: "merged_no_proof_dispatch", text: "Wake event: PR #803 is ready for review" },
+      ],
+      pullRequests: [
+        { number: 800, state: "open", merged_at: null },
+        { number: 801, isDraft: true, merged_at: null },
+        { number: 802, state: "closed", merged_at: null },
+        { number: 803, state: "closed", merged_at: "2026-05-13T12:00:00.000Z" },
+      ],
+      receipts: [
+        {
+          id: "unrelated_ack",
+          tags: ["wakepass", "ack"],
+          text: "ACK wake-pull_request-pr-999 merged PR #999; WakePass handoff complete.",
+        },
+      ],
+    });
+
+    assert.equal(plan.complete_dispatches.length, 0);
+    assert.equal(plan.suppress_blockers.length, 0);
+    assert.deepEqual(
+      plan.untouched.map((item) => item.reason),
+      ["pr_not_merged", "pr_draft", "pr_not_merged", "missing_wakepass_completion_proof"],
+    );
   });
 });


### PR DESCRIPTION
Summary:
Adds a pure merged-PR dispatch reconciliation planner so stale WakePass blockers can be suppressed, and leased WakePass dispatches can be completed, only when a linked PR is merged and a WakePass completion receipt exists.

Scope:
Owned todo d9d86ea2-55a5-46e0-9471-ae5b40b0d395. Touched scripts/fishbowl-todo-reconciliation.mjs and scripts/fishbowl-todo-reconciliation.test.mjs.

Non-overlap:
No production data, secrets, auth, billing, DNS, deployments, force pushes, schedule changes, or broad orchestrator wiring. Open, draft, unmerged, missing-PR, and no-proof cases remain untouched.

Verification:
node --test scripts/fishbowl-todo-reconciliation.test.mjs passed 12/12. git diff --check passed. rg for en dash and em dash in touched files returned no matches.

Risk:
Low. This is a read-only planning helper and focused tests. It emits plan output only and does not mutate dispatches, PRs, todos, or Orchestrator state.

Follow-up:
Wire the planner into the auto-close or Orchestrator suppression path only after a reviewer accepts the fixture behavior.