### PR TITLE
fix(wakepass): suppress merged PR dispatch blockers

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -399,10 +399,13 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     now_ms: nowMs,
   });
 
+  const mergedPrWakePassProofs = buildMergedPrWakePassProofs(input.messages);
   const messageEvents = input.messages.map(messageToEvent);
   const todoEvents = activeTodos.map(todoToEvent);
   const commentEvents = input.comments.map(commentToEvent);
-  const dispatchEvents = input.dispatches.map(dispatchToEvent);
+  const dispatchEvents = input.dispatches.map((dispatch) =>
+    dispatchToEvent(dispatch, mergedPrWakePassProofs),
+  );
   const signalEvents = input.signals.map(signalToEvent);
   const conversationEvents = input.conversationTurns.map(conversationTurnToEvent);
   const sessionEvents = input.sessions.map(sessionToEvent);
@@ -916,8 +919,51 @@ function commentToEvent(comment: OrchestratorCommentRow): OrchestratorContinuity
   };
 }
 
-function dispatchToEvent(dispatch: OrchestratorDispatchRow): OrchestratorContinuityEvent {
+interface WakePassMergedPrProof {
+  prNumber: number;
+  receiptId: string;
+  createdAt: string;
+}
+
+function buildMergedPrWakePassProofs(messages: OrchestratorMessageRow[]): Map<number, WakePassMergedPrProof> {
+  const proofs = new Map<number, WakePassMergedPrProof>();
+
+  for (const message of messages) {
+    const tags = normalizeTags(message.tags).map((tag) => tag.toLowerCase());
+    if (!tags.includes("wakepass")) continue;
+    if (!tags.includes("ack") && !tags.includes("completed") && !tags.includes("done")) continue;
+
+    const text = message.text ?? "";
+    const mergedAck = /\bmerged\s+PR\s+#(\d+)\b/i.exec(text);
+    const completedAfterMerge = /\bWakePass\s+completed\s+PR\s+#(\d+)\b/i.exec(text);
+    const prNumber = Number(mergedAck?.[1] ?? completedAfterMerge?.[1]);
+    if (!Number.isFinite(prNumber)) continue;
+
+    const lowerText = text.toLowerCase();
+    const hasCompletionProof =
+      lowerText.includes("wakepass handoff complete") ||
+      (lowerText.includes("wakepass completed") && lowerText.includes("merge proof"));
+    if (!hasCompletionProof) continue;
+
+    const existing = proofs.get(prNumber);
+    if (!existing || compareIsoDesc(message.created_at, existing.createdAt) < 0) {
+      proofs.set(prNumber, {
+        prNumber,
+        receiptId: message.id,
+        createdAt: message.created_at,
+      });
+    }
+  }
+
+  return proofs;
+}
+
+function dispatchToEvent(
+  dispatch: OrchestratorDispatchRow,
+  mergedPrWakePassProofs: Map<number, WakePassMergedPrProof> = new Map(),
+): OrchestratorContinuityEvent {
   const payloadTags = dispatchPayloadEvidenceTags(dispatch.payload);
+  const proofTags = dispatchMergedPrProofTags(dispatch, mergedPrWakePassProofs);
   const detail = [
     dispatch.source,
     dispatch.status,
@@ -934,8 +980,59 @@ function dispatchToEvent(dispatch: OrchestratorDispatchRow): OrchestratorContinu
     kind: dispatch.status === "leased" ? "handoff" : dispatch.status === "failed" || dispatch.status === "stale" ? "blocker" : "status",
     actor_agent_id: dispatch.lease_owner ?? dispatch.target_agent_id,
     summary: compactText(detail, 240),
-    tags: ["dispatch", dispatch.source, dispatch.status, ...payloadTags],
+    tags: ["dispatch", dispatch.source, dispatch.status, ...payloadTags, ...proofTags],
   };
+}
+
+function dispatchMergedPrProofTags(
+  dispatch: OrchestratorDispatchRow,
+  proofs: Map<number, WakePassMergedPrProof>,
+): string[] {
+  if (dispatch.source !== "wakepass") return [];
+  if (dispatch.status === "completed" || dispatch.status === "cancelled") return [];
+
+  const prNumbers = extractWakePassPrNumbers(dispatch);
+  if (prNumbers.length === 0) return [];
+
+  const dispatchCreatedMs = Date.parse(dispatch.created_at);
+  for (const prNumber of prNumbers) {
+    const proof = proofs.get(prNumber);
+    if (!proof) continue;
+
+    const proofCreatedMs = Date.parse(proof.createdAt);
+    if (
+      Number.isFinite(dispatchCreatedMs) &&
+      Number.isFinite(proofCreatedMs) &&
+      proofCreatedMs < dispatchCreatedMs
+    ) {
+      continue;
+    }
+
+    return ["merged_pr_ack", "bridge_status:suppress"];
+  }
+
+  return [];
+}
+
+function extractWakePassPrNumbers(dispatch: OrchestratorDispatchRow): number[] {
+  const text = [
+    dispatch.dispatch_id,
+    dispatch.task_ref,
+    dispatch.payload ? compactText(dispatch.payload, 1000) : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const numbers = new Set<number>();
+  const patterns = [/\bPR\s*#\s*(\d+)\b/gi, /\bpr-(\d+)\b/gi, /\/pull\/(\d+)\b/gi];
+
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const number = Number(match[1]);
+      if (Number.isFinite(number)) numbers.add(number);
+    }
+  }
+
+  return Array.from(numbers);
 }
 
 function dispatchPayloadEvidenceTags(payload: OrchestratorDispatchRow["payload"]): string[] {

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -460,6 +460,121 @@ describe("orchestrator context", () => {
     expect(JSON.stringify(context.current_state_card.blockers)).not.toContain("superseded_status_comment");
   });
 
+  it("suppresses stale WakePass PR dispatch blockers after merged PR ACK proof", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-16T14:30:00.000Z",
+      profiles: [],
+      messages: [
+        {
+          id: "msg-wakepass-ack-864",
+          author_agent_id: "github-action-autoclose",
+          text: "ACK wake-pull_request-pr-864-d8bcb0c7aa0c merged PR #864; WakePass handoff complete.",
+          tags: ["wakepass", "ack"],
+          created_at: "2026-05-16T14:18:54.000Z",
+        },
+      ],
+      todos: [
+        {
+          id: "todo-active-security",
+          title: "Active security job",
+          description: "Keep active jobs visible while WakePass proof is reconciled.",
+          status: "in_progress",
+          priority: "high",
+          created_by_agent_id: "codex",
+          assigned_to_agent_id: "chatgpt-codex-fleet-seat",
+          created_at: "2026-05-16T13:00:00.000Z",
+          updated_at: "2026-05-16T14:00:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-pr-864-stale",
+          source: "wakepass",
+          target_agent_id: "reviewer",
+          task_ref: "wake-pull_request-pr-864-d8bcb0c7aa0c",
+          status: "stale",
+          payload: {
+            source_url: "https://github.com/malamutemayhem/unclick/pull/864",
+            wake_reason: "PR #864 is ready for review",
+          },
+          created_at: "2026-05-16T14:18:33.000Z",
+          updated_at: "2026-05-16T14:25:00.000Z",
+        },
+      ],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    const dispatchEvent = context.continuity_events.find((event) => event.source_id === "dispatch-pr-864-stale");
+
+    expect(dispatchEvent?.kind).toBe("blocker");
+    expect(dispatchEvent?.tags).toEqual(expect.arrayContaining(["merged_pr_ack", "bridge_status:suppress"]));
+    expect(context.rolling_snapshot.active_blockers.map((event) => event.source_id)).not.toContain(
+      "dispatch-pr-864-stale",
+    );
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.seat_handshake.active_blocker).toBeNull();
+  });
+
+  it("keeps stale WakePass PR dispatch blockers active without matching merged PR ACK proof", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-16T14:30:00.000Z",
+      profiles: [],
+      messages: [
+        {
+          id: "msg-wakepass-ack-other",
+          author_agent_id: "github-action-autoclose",
+          text: "ACK wake-pull_request-pr-863-b5cdf7f55fe9 merged PR #863; WakePass handoff complete.",
+          tags: ["wakepass", "ack"],
+          created_at: "2026-05-16T14:18:54.000Z",
+        },
+      ],
+      todos: [
+        {
+          id: "todo-active-security",
+          title: "Active security job",
+          description: "Keep active jobs visible while unrelated WakePass proof is ignored.",
+          status: "in_progress",
+          priority: "high",
+          created_by_agent_id: "codex",
+          assigned_to_agent_id: "chatgpt-codex-fleet-seat",
+          created_at: "2026-05-16T13:00:00.000Z",
+          updated_at: "2026-05-16T14:00:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-pr-864-stale",
+          source: "wakepass",
+          target_agent_id: "reviewer",
+          task_ref: "wake-pull_request-pr-864-d8bcb0c7aa0c",
+          status: "stale",
+          payload: {
+            source_url: "https://github.com/malamutemayhem/unclick/pull/864",
+            wake_reason: "PR #864 is ready for review",
+          },
+          created_at: "2026-05-16T14:18:33.000Z",
+          updated_at: "2026-05-16T14:25:00.000Z",
+        },
+      ],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.rolling_snapshot.active_blockers.map((event) => event.source_id)).toContain(
+      "dispatch-pr-864-stale",
+    );
+    expect(context.current_state_card.blocker_count).toBe(1);
+  });
+
   it("keeps heartbeat prompt bodies out of continuity summaries", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-09T23:45:00.000Z",


### PR DESCRIPTION
Summary:
Adds Orchestrator suppression for stale WakePass dispatch blockers when a later Boardroom WakePass ACK proves the linked PR merged and the handoff completed.

Scope:
Owned files: api/lib/orchestrator-context.ts and api/orchestrator-context.test.ts.
Lane: WakePass reconciliation. Refs UnClick todo d9d86ea2-55a5-46e0-9471-ae5b40b0d395.

Non-overlap:
Does not mutate reliability dispatch rows, complete leases, edit workflows, touch secrets, change billing, DNS, production deploys, or alter PR auto-close behavior. It keeps stale dispatches in history and only removes them from active blocker surfaces when matching merged-PR ACK proof exists.

Verification:
- npm run test -- api/orchestrator-context.test.ts, 28 passed
- node --test scripts/fishbowl-todo-reconciliation.test.mjs, 12 passed
- git diff --check
- rg -n "—|–" api/lib/orchestrator-context.ts api/orchestrator-context.test.ts, no matches

Risk:
Low. Read-only Orchestrator presentation change. Suppression requires WakePass tags, ACK/completed proof text, matching PR number, and proof created after the dispatch.

Follow-up:
After this lands, watch Orchestrator for PR #864 style leased or stale WakePass rows and confirm they remain historical without blocking active job selection.

Draft: true.
