### PR TITLE
[codex] fix WakePass merged PR ACK suppression

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -399,10 +399,13 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     now_ms: nowMs,
   });
 
+  const mergedPrWakePassProof = buildMergedPrWakePassProof(input);
   const messageEvents = input.messages.map(messageToEvent);
   const todoEvents = activeTodos.map(todoToEvent);
   const commentEvents = input.comments.map(commentToEvent);
-  const dispatchEvents = input.dispatches.map(dispatchToEvent);
+  const dispatchEvents = input.dispatches
+    .filter((dispatch) => !isMergedPrWakePassDispatchCompleted(dispatch, mergedPrWakePassProof))
+    .map(dispatchToEvent);
   const signalEvents = input.signals.map(signalToEvent);
   const conversationEvents = input.conversationTurns.map(conversationTurnToEvent);
   const sessionEvents = input.sessions.map(sessionToEvent);
@@ -756,6 +759,125 @@ function isHistoricalWakeOrFishbowlStale(
   const createdMs = event.created_at ? Date.parse(event.created_at) : NaN;
   if (!Number.isFinite(createdMs) || !Number.isFinite(nowMs)) return false;
   return nowMs - createdMs >= 60 * 60 * 1000;
+}
+
+interface MergedPrWakePassProof {
+  prNumbers: Set<number>;
+  wakeEventIds: Set<string>;
+}
+
+function buildMergedPrWakePassProof(input: BuildOrchestratorContextInput): MergedPrWakePassProof {
+  const proof: MergedPrWakePassProof = {
+    prNumbers: new Set(),
+    wakeEventIds: new Set(),
+  };
+  const rows = [
+    ...input.messages.map((message) => ({
+      text: message.text,
+      tags: message.tags,
+    })),
+    ...input.comments.map((comment) => ({
+      text: comment.text,
+      tags: ["comment"],
+    })),
+    ...input.conversationTurns.map((turn) => ({
+      text: turn.content,
+      tags: ["conversation", turn.role],
+    })),
+  ];
+
+  for (const row of rows) {
+    if (!isMergedPrWakePassAckText(row.text, row.tags ?? [])) continue;
+    for (const prNumber of extractPullRequestNumbersFromText(row.text)) {
+      proof.prNumbers.add(prNumber);
+    }
+    for (const wakeEventId of extractWakeEventIdsFromText(row.text)) {
+      proof.wakeEventIds.add(wakeEventId);
+    }
+  }
+
+  return proof;
+}
+
+function isMergedPrWakePassAckText(text: string, tags: string[]): boolean {
+  const lower = text.toLowerCase();
+  const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
+  const wakePassLike =
+    tagSet.has("wakepass") ||
+    lower.includes("wakepass") ||
+    lower.includes("wake-pull_request-pr");
+  const ackLike =
+    tagSet.has("ack") ||
+    lower.startsWith("ack ") ||
+    lower.includes(" handoff complete") ||
+    lower.includes(" completed ");
+  const mergedPrLike =
+    /\bmerged\s+pr\s*#?\d+\b/i.test(text) ||
+    /\bmerged\s+pull request\s*#?\d+\b/i.test(text);
+
+  return wakePassLike && ackLike && mergedPrLike;
+}
+
+function isMergedPrWakePassDispatchCompleted(
+  dispatch: OrchestratorDispatchRow,
+  proof: MergedPrWakePassProof,
+): boolean {
+  if (dispatch.source !== "wakepass") return false;
+  if (!["leased", "stale", "failed"].includes(dispatch.status.toLowerCase())) return false;
+
+  const wakeEventIds = extractDispatchWakeEventIds(dispatch);
+  if (wakeEventIds.some((wakeEventId) => proof.wakeEventIds.has(wakeEventId))) return true;
+
+  return extractDispatchPullRequestNumbers(dispatch).some((prNumber) => proof.prNumbers.has(prNumber));
+}
+
+function extractDispatchWakeEventIds(dispatch: OrchestratorDispatchRow): string[] {
+  const payload = dispatch.payload ?? {};
+  const values = [
+    dispatch.task_ref,
+    typeof payload.wake_event_id === "string" ? payload.wake_event_id : null,
+    typeof payload.fishbowl_wake_event_id === "string" ? payload.fishbowl_wake_event_id : null,
+    compactText(payload, 1000),
+  ];
+  return extractWakeEventIdsFromText(values.filter(Boolean).join(" "));
+}
+
+function extractDispatchPullRequestNumbers(dispatch: OrchestratorDispatchRow): number[] {
+  const payload = dispatch.payload ?? {};
+  const values = [
+    dispatch.task_ref,
+    typeof payload.source_url === "string" ? payload.source_url : null,
+    typeof payload.sourceUrl === "string" ? payload.sourceUrl : null,
+    compactText(payload, 1000),
+  ];
+  return extractPullRequestNumbersFromText(values.filter(Boolean).join(" "));
+}
+
+function extractPullRequestNumbersFromText(text: string): number[] {
+  const numbers = new Set<number>();
+  const patterns = [
+    /\bPR\s*#?\s*(\d+)\b/gi,
+    /\bpull request\s*#?\s*(\d+)\b/gi,
+    /\/pull\/(\d+)\b/gi,
+    /\bpull_request-pr-(\d+)\b/gi,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const number = Number(match[1]);
+      if (Number.isFinite(number)) numbers.add(number);
+    }
+  }
+
+  return Array.from(numbers);
+}
+
+function extractWakeEventIdsFromText(text: string): string[] {
+  const wakeEventIds = new Set<string>();
+  for (const match of text.matchAll(/\bwake-pull_request-pr-\d+-[a-z0-9]+\b/gi)) {
+    wakeEventIds.add(match[0]);
+  }
+  return Array.from(wakeEventIds);
 }
 
 function eventToSnapshotItem(

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -460,6 +460,93 @@ describe("orchestrator context", () => {
     expect(JSON.stringify(context.current_state_card.blockers)).not.toContain("superseded_status_comment");
   });
 
+  it("hides merged PR WakePass leased dispatches after ACK proof exists", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-16T14:20:00.000Z",
+      profiles: [],
+      messages: [
+        {
+          id: "msg-pr-864-ack",
+          author_agent_id: "github-action-autoclose",
+          text: "ACK wake-pull_request-pr-864-d8bcb0c7aa0c merged PR #864; WakePass handoff complete.",
+          tags: ["wakepass", "ack"],
+          created_at: "2026-05-16T14:18:54.000Z",
+        },
+      ],
+      todos: [],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-pr-864",
+          source: "wakepass",
+          target_agent_id: "reviewer",
+          task_ref: "wake-pull_request-pr-864-d8bcb0c7aa0c",
+          status: "leased",
+          lease_owner: "reviewer",
+          payload: {
+            wake_event_id: "wake-pull_request-pr-864-d8bcb0c7aa0c",
+            source_url: "https://github.com/malamutemayhem/unclick/pull/864",
+            wake_reason: "PR #864 is ready for review",
+          },
+          created_at: "2026-05-16T14:18:33.000Z",
+          updated_at: "2026-05-16T14:18:33.000Z",
+        },
+      ],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.continuity_events.find((event) => event.source_id === "dispatch-pr-864")).toBeUndefined();
+    expect(context.continuity_events.find((event) => event.source_id === "msg-pr-864-ack")?.kind).toBe("proof");
+    expect(context.current_state_card.live_sources.dispatches).toBe(1);
+    expect(context.rolling_snapshot.recent_continuity.map((event) => event.source_id)).not.toContain("dispatch-pr-864");
+  });
+
+  it("keeps WakePass leased dispatches when merged PR ACK proof is missing", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-16T14:20:00.000Z",
+      profiles: [],
+      messages: [
+        {
+          id: "msg-pr-865-generic-ack",
+          author_agent_id: "reviewer",
+          text: "ACK wake-pull_request-pr-865-abc123 checking PR #865.",
+          tags: ["wakepass", "ack"],
+          created_at: "2026-05-16T14:18:54.000Z",
+        },
+      ],
+      todos: [],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-pr-865",
+          source: "wakepass",
+          target_agent_id: "reviewer",
+          task_ref: "wake-pull_request-pr-865-abc123",
+          status: "leased",
+          lease_owner: "reviewer",
+          payload: {
+            wake_event_id: "wake-pull_request-pr-865-abc123",
+            source_url: "https://github.com/malamutemayhem/unclick/pull/865",
+            wake_reason: "PR #865 is ready for review",
+          },
+          created_at: "2026-05-16T14:18:33.000Z",
+          updated_at: "2026-05-16T14:18:33.000Z",
+        },
+      ],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.continuity_events.find((event) => event.source_id === "dispatch-pr-865")).toBeDefined();
+  });
+
   it("keeps heartbeat prompt bodies out of continuity summaries", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-09T23:45:00.000Z",


### PR DESCRIPTION
## Summary
- Suppress leased, stale, or failed WakePass dispatch continuity rows after explicit merged-PR WakePass ACK proof exists.
- Keep generic WakePass ACKs visible until merge/handoff proof is present.
- Preserve live source counts so this is read-only context filtering, not production dispatch mutation.

## Why
PR #864 proved the reconciliation planner path, but the Orchestrator could still surface the already-ACKed leased wake event `wake-pull_request-pr-864-d8bcb0c7aa0c`. This keeps the queue noisy even after GitHub auto-close proof exists.

## Scope
- `api/lib/orchestrator-context.ts`
- `api/orchestrator-context.test.ts`

## Proof
- `npm run test -- api/orchestrator-context.test.ts` passed, 28 tests.
- `node --test scripts/fishbowl-todo-reconciliation.test.mjs` passed, 12 tests.
- `git diff --check` passed.

## Safety
Read-only Orchestrator context filtering only. No production DB mutation, no secrets, no billing, no DNS, no deployment, no schedule changes.

Boardroom todo: `d9d86ea2-55a5-46e0-9471-ae5b40b0d395`