### PR TITLE
[codex] streamline runner ScopePack comment intake

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -339,6 +339,23 @@ function recentTodoCommentText(todo = {}) {
   ].join("\n");
 }
 
+function hasRecentTodoBlockerMarker(todo = {}) {
+  const comments = Array.isArray(todo.recent_comments)
+    ? todo.recent_comments
+    : Array.isArray(todo.comments)
+      ? todo.comments
+      : [];
+  const structuredText = [
+    todo.latest_comment_result,
+    todo.latest_comment_status,
+    todo.recent_blocker_comment,
+    ...comments.map((comment) => `${comment?.result || ""} ${comment?.status || ""}`),
+  ].join("\n");
+  if (/\b(blocker|blocked)\b/i.test(structuredText)) return true;
+
+  return /(?:^|\n)\s*(blocker|blocked)\s*:/i.test(recentTodoCommentText(todo));
+}
+
 function extractMcpTextJson(payload) {
   const content = payload?.result?.content;
   if (Array.isArray(content)) {
@@ -417,6 +434,23 @@ function listFromUnknown(value) {
   return [];
 }
 
+function boardroomTodoScopeTextSources(todo = {}) {
+  const comments = Array.isArray(todo.recent_comments)
+    ? todo.recent_comments
+    : Array.isArray(todo.comments)
+      ? todo.comments
+      : [];
+
+  return [
+    todo.description,
+    todo.body,
+    todo.notes,
+    todo.latest_comment_text,
+    todo.last_comment_text,
+    ...comments.map((comment) => `${comment?.body || ""}\n${comment?.text || ""}`),
+  ];
+}
+
 function extractBoardroomTodoScopePack(todo = {}) {
   const scope = firstPresentObject(
     todo.scope_pack,
@@ -427,9 +461,7 @@ function extractBoardroomTodoScopePack(todo = {}) {
     todo.autonomousScope,
     todo.coding_room_scope,
     todo.codingRoomScope,
-    parseLabeledJsonObjectFromText(todo.description),
-    parseLabeledJsonObjectFromText(todo.body),
-    parseLabeledJsonObjectFromText(todo.notes),
+    ...boardroomTodoScopeTextSources(todo).map(parseLabeledJsonObjectFromText),
   );
 
   if (!scope) {
@@ -458,6 +490,9 @@ function extractBoardroomTodoScopePack(todo = {}) {
   );
   const tests = listFromUnknown(
     scope.tests ??
+      scope.verification ??
+      scope.verification_commands ??
+      scope.verificationCommands ??
       expectedProof.tests,
   );
 
@@ -1803,7 +1838,7 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
     return { ok: false, reason: "boardroom_todo_hold_or_blocker_marker" };
   }
 
-  if (/\b(blocker|blocked)\b/i.test(recentTodoCommentText(todo))) {
+  if (hasRecentTodoBlockerMarker(todo)) {
     return { ok: false, reason: "boardroom_todo_recent_blocker_comment" };
   }
 
@@ -1961,6 +1996,8 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
         runner_scope: todo.runner_scope ?? todo.runnerScope ?? null,
         recent_comments: Array.isArray(todo.recent_comments) ? todo.recent_comments : undefined,
         comments: Array.isArray(todo.comments) ? todo.comments : undefined,
+        latest_comment_text: todo.latest_comment_text || null,
+        last_comment_text: todo.last_comment_text || null,
         description: todo.description || null,
         body: todo.body || null,
         notes: todo.notes || null,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -326,6 +326,76 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("imports a ScopePack attached in an UnClick todo comment", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const scopePack = {
+        owner_hint: "builder_or_pinballwake_build_executor",
+        owned_files: ["scripts/pinballwake-executor-packet.mjs"],
+        verification: ["node --test scripts/pinballwake-executor-packet.test.mjs"],
+      };
+
+      const fetchImpl = async () => ({
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    todos: [
+                      {
+                        id: "todo-comment-scopepack",
+                        title: "Autopilot executor packet bridge",
+                        status: "open",
+                        priority: "high",
+                        assigned_to_agent_id: null,
+                        actionability_reason: "unassigned_open",
+                        latest_comment_text: [
+                          "ScopePack:",
+                          "```json",
+                          JSON.stringify(scopePack, null, 2),
+                          "```",
+                        ].join("\n"),
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          };
+        },
+      });
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "dry-run",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-16T14:45:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "claimed");
+      assert.equal(result.queue_source.imported, 1);
+      assert.equal(result.queue_source.todos[0].scope_pack_seen, true);
+      assert.deepEqual(result.ledger.jobs[0].owned_files, ["scripts/pinballwake-executor-packet.mjs"]);
+      assert.deepEqual(result.ledger.jobs[0].expected_proof.tests, [
+        "node --test scripts/pinballwake-executor-packet.test.mjs",
+      ]);
+      assert.match(result.ledger.jobs[0].context, /scopepack=present/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("claims scoped Boardroom todos that do not include a prebuilt patch", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
@@ -1586,6 +1656,132 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.match(commentCall.body.params.arguments.text, /PASS: scopepack_hydrated/);
       assert.match(commentCall.body.params.arguments.text, /owned_modules=PinballWake Runner scope hydration/);
       assert.match(commentCall.body.params.arguments.text, /No new schedules/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("hydrates a vague Boardroom todo from a ScopePack comment", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const scopePack = {
+        lane: "autopilot_executor",
+        owner_hint: "builder_or_pinballwake_build_executor",
+        owned_modules: ["PinballWake Executor Lane comment ScopePack parsing"],
+        acceptance: ["Runner reads ScopePacks from todo comments"],
+        verification: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+        stop_conditions: ["Stop if comments are unavailable from the API response"],
+        proof_required: "Boardroom receipt with scopepack_hydrated or BLOCKER",
+        out_of_scope: ["No new schedules", "No production writes"],
+      };
+
+      const calls = [];
+      const fetchImpl = async (_url, init = {}) => {
+        calls.push({ body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-comment-hydrate",
+                            title: "Hydrate ScopePack comment into safe runner packet",
+                            status: "open",
+                            priority: "urgent",
+                            assigned_to_agent_id: null,
+                            actionability_reason: "unassigned_open",
+                            latest_comment_text: [
+                              "ScopePack:",
+                              "```json",
+                              JSON.stringify(scopePack, null, 2),
+                              "```",
+                            ].join("\n"),
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "update_todo") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todo: {
+                          id: "todo-comment-hydrate",
+                          status: "open",
+                          assigned_to_agent_id: null,
+                        },
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "comment_on") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({ comment: { id: "comment-hydrate-from-comment" } }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "claim",
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-16T14:45:00.000Z",
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "scopepack_hydrated");
+      assert.equal(result.reason, "boardroom_todo_scopepack_hydrated");
+      assert.equal(result.todo_scoping_sync.scopepack_hydration.action, "scopepack_hydrated");
+
+      const commentCall = calls.find((call) => call.body.params.name === "comment_on");
+      assert.match(commentCall.body.params.arguments.text, /PASS: scopepack_hydrated/);
+      assert.match(commentCall.body.params.arguments.text, /PinballWake Executor Lane comment ScopePack parsing/);
+      assert.match(commentCall.body.params.arguments.text, /No production writes/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/scripts/pinballwake-scopepack-hydrator.mjs
+++ b/scripts/pinballwake-scopepack-hydrator.mjs
@@ -125,6 +125,7 @@ export function extractHydratableScopePack(todo = {}) {
     parseLabeledJsonObjectFromText(todo.description),
     parseLabeledJsonObjectFromText(todo.body),
     parseLabeledJsonObjectFromText(todo.notes),
+    parseLabeledJsonObjectFromText(recentTodoText(todo)),
   );
 }
 


### PR DESCRIPTION
## Summary
- Teach the PinballWake autonomous runner to read ScopePacks from todo comments, not only todo descriptions or direct fields.
- Preserve comment text in the imported queue snapshot so later scoping/hydration can still see the ScopePack.
- Treat `verification` and `verification_commands` as runnable test hints when importing ScopePacks.
- Narrow recent blocker detection so `BLOCKER` inside a ScopePack proof-required field does not falsely block a job.

## Why
A lot of real Boardroom/Jobs work is scoped by attaching a ScopePack comment. Before this, the runner could still classify that job as missing scope, which wastes cycles and makes the 74-item backlog feel stuck. This patch lets automation consume the scope that workers are already writing.

## Proof
- `node --test scripts/pinballwake-autonomous-runner.test.mjs` passed, 52 tests.
- `node --test scripts/pinballwake-executor-packet.test.mjs scripts/pinballwake-executor-lane.test.mjs` passed, 28 tests.
- `git diff --check` passed.

## Safety
No protected surfaces changed. No secrets, billing, DNS, production DB mutation, deploy, schedules, workflow files, or merge authority changes.

Boardroom todo: `669a9c0b-67c4-4a96-80ec-a8ec3a249e73`