### PR TITLE
feat(autopilot): add ScopePack test-only executor bridge

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -16,6 +16,7 @@ import {
   runCodingRoomRunnerCycle,
 } from "./pinballwake-coding-room-runner.mjs";
 import { evaluateOrchestratorProofWakeGate } from "./lib/autopilotkit-liveness.mjs";
+import { processScopePackTestOnlyExecutorPacket } from "./pinballwake-executor-lane.mjs";
 import { buildScopePackHydrationReceipt } from "./pinballwake-scopepack-hydrator.mjs";
 
 export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
@@ -418,19 +419,7 @@ function listFromUnknown(value) {
 }
 
 function extractBoardroomTodoScopePack(todo = {}) {
-  const scope = firstPresentObject(
-    todo.scope_pack,
-    todo.scopePack,
-    todo.runner_scope,
-    todo.runnerScope,
-    todo.autonomous_scope,
-    todo.autonomousScope,
-    todo.coding_room_scope,
-    todo.codingRoomScope,
-    parseLabeledJsonObjectFromText(todo.description),
-    parseLabeledJsonObjectFromText(todo.body),
-    parseLabeledJsonObjectFromText(todo.notes),
-  );
+  const scope = extractBoardroomTodoScopePackObject(todo);
 
   if (!scope) {
     return {
@@ -473,6 +462,48 @@ function extractBoardroomTodoScopePack(todo = {}) {
     lane: String(scope.lane || scope.worker_lane || scope.workerLane || "").trim(),
     owner_hint: String(scope.owner_hint || scope.ownerHint || "").trim(),
   };
+}
+
+function extractBoardroomTodoScopePackObject(todo = {}) {
+  return firstPresentObject(
+    todo.scope_pack,
+    todo.scopePack,
+    todo.runner_scope,
+    todo.runnerScope,
+    todo.autonomous_scope,
+    todo.autonomousScope,
+    todo.coding_room_scope,
+    todo.codingRoomScope,
+    parseLabeledJsonObjectFromText(todo.description),
+    parseLabeledJsonObjectFromText(todo.body),
+    parseLabeledJsonObjectFromText(todo.notes),
+  );
+}
+
+export async function createAutonomousRunnerTestOnlyExecutorReceipt({
+  todo = {},
+  scopePack = null,
+  heartbeat = null,
+  heartbeatTickId = "",
+  headShaAtRequest = "",
+  requestingSeatId = "pinballwake-job-runner",
+  scopePackCommentId = "",
+  fileExists,
+  executorSeatId = "pinballwake-build-executor",
+  now = new Date(),
+} = {}) {
+  return processScopePackTestOnlyExecutorPacket({
+    todo,
+    scopePack: scopePack || extractBoardroomTodoScopePackObject(todo) || {},
+    heartbeat,
+    heartbeatTickId,
+    headShaAtRequest,
+    requestingSeatId,
+    scopePackCommentId,
+    fileExists,
+    executorSeatId,
+    now,
+  });
 }
 
 export function parseMcpEventStreamPayload(text = "") {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
+  createAutonomousRunnerTestOnlyExecutorReceipt,
   assertRunnerOnFreshMain,
   evaluateAutonomousRunnerCommonSensePass,
   evaluateBoardroomTodoAutoClaimEligibility,
@@ -506,6 +507,30 @@ describe("PinballWake autonomous Runner seat", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("can return a sanitized test-only executor receipt from a scoped todo", async () => {
+    const now = new Date("2026-05-16T14:45:00.000Z");
+    const result = await createAutonomousRunnerTestOnlyExecutorReceipt({
+      todo: {
+        id: "todo-executor-bridge",
+        scope_pack_comment_id: "comment-bridge-1",
+        scope_pack: {
+          owned_files: ["scripts/pinballwake-autonomous-runner.mjs"],
+          acceptance: ["runner can return a test-only executor receipt"],
+        },
+      },
+      heartbeat: { tickId: "tick-1", emittedAt: now.toISOString() },
+      headShaAtRequest: "d13d2d4",
+      fileExists: async () => true,
+      now,
+    });
+
+    assert.equal(result.packet.todo_id, "todo-executor-bridge");
+    assert.equal(result.packet.intent, "test_only");
+    assert.equal(result.packet.scope_pack_comment_id, "comment-bridge-1");
+    assert.equal(result.receipt.receipt_type, "executor_packet_pass");
+    assert.equal(result.receipt.sanitized, true);
   });
 
   it("keeps a scoped todo eligible only for the builder allowlist and open unassigned queue", () => {

--- a/scripts/pinballwake-commonsense-pass.mjs
+++ b/scripts/pinballwake-commonsense-pass.mjs
@@ -32,6 +32,7 @@ export async function commonSensePass({
   packet,
   now = new Date(),
   heartbeat = null,
+  requireHeartbeat = false,
   allowedRequesterSeats = DEFAULT_ALLOWED_REQUESTER_SEATS,
   fileExists = async () => true,
   heartbeatMaxAgeMs = DEFAULT_HEARTBEAT_MAX_AGE_MS,
@@ -52,6 +53,13 @@ export async function commonSensePass({
   }
 
   // 3. Heartbeat freshness gate.
+  if (requireHeartbeat && (!heartbeat || typeof heartbeat !== "object" || !heartbeat.tickId)) {
+    return {
+      ok: false,
+      reason: "heartbeat_missing",
+      evidence: { heartbeat_required: true },
+    };
+  }
   if (heartbeat) {
     if (heartbeat.tickId !== packet.heartbeat_tick_id) {
       return {

--- a/scripts/pinballwake-commonsense-pass.test.mjs
+++ b/scripts/pinballwake-commonsense-pass.test.mjs
@@ -49,6 +49,15 @@ describe("commonSensePass", () => {
     assert.equal(r.reason, "heartbeat_stale");
   });
 
+  test("HOLD when heartbeat is required but missing", async () => {
+    const r = await commonSensePass({
+      packet: basePacket(),
+      requireHeartbeat: true,
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "heartbeat_missing");
+  });
+
   test("HOLD on heartbeat too old even when tick matches", async () => {
     const now = new Date("2026-05-15T03:00:00Z");
     const oldEmitted = new Date(now.getTime() - DEFAULT_HEARTBEAT_MAX_AGE_MS - 60_000).toISOString();

--- a/scripts/pinballwake-executor-lane.mjs
+++ b/scripts/pinballwake-executor-lane.mjs
@@ -16,6 +16,7 @@
 // See docs/autopilot-executor-lane.md for the full design.
 
 import { commonSensePass } from "./pinballwake-commonsense-pass.mjs";
+import { makeTestOnlyExecutorPacketFromScopePack } from "./pinballwake-executor-packet.mjs";
 
 const RECEIPT_TYPE_PASS = "executor_packet_pass";
 const RECEIPT_TYPE_HOLD = "executor_packet_hold";
@@ -38,6 +39,7 @@ const PROOF_REQUIRED = ["pr_url", "head_sha", "test_run_id", "executor_seat_id"]
 export async function processExecutorPacket({
   packet,
   heartbeat,
+  requireHeartbeat = false,
   fileExists,
   executor,
   executorSeatId = "pinballwake-build-executor",
@@ -47,6 +49,7 @@ export async function processExecutorPacket({
   const gate = await commonSensePass({
     packet,
     heartbeat,
+    requireHeartbeat,
     fileExists,
     now,
   });
@@ -129,6 +132,51 @@ export async function processExecutorPacket({
   });
 }
 
+export async function processScopePackTestOnlyExecutorPacket({
+  todo = {},
+  scopePack = {},
+  heartbeat = null,
+  heartbeatTickId = "",
+  headShaAtRequest = "",
+  requestingSeatId = "pinballwake-job-runner",
+  scopePackCommentId = "",
+  fileExists,
+  executorSeatId = "pinballwake-build-executor",
+  now = new Date(),
+} = {}) {
+  const packet = makeTestOnlyExecutorPacketFromScopePack({
+    todo,
+    scopePack,
+    heartbeat,
+    heartbeatTickId,
+    headShaAtRequest,
+    requestingSeatId,
+    scopePackCommentId,
+    emittedAt: now.toISOString(),
+  });
+  const receipt = await processExecutorPacket({
+    packet,
+    heartbeat,
+    requireHeartbeat: true,
+    fileExists,
+    executorSeatId,
+    now,
+  });
+
+  return {
+    packet,
+    receipt: sanitizeExecutorReceipt(receipt),
+  };
+}
+
+export function sanitizeExecutorReceipt(receipt) {
+  const redacted = redactSecrets(receipt);
+  return {
+    ...(redacted && typeof redacted === "object" ? redacted : {}),
+    sanitized: true,
+  };
+}
+
 function buildPassReceipt({ packet, executorSeatId, now, evidence, next_action }) {
   return {
     receipt_type: RECEIPT_TYPE_PASS,
@@ -169,6 +217,31 @@ function clip(value, max) {
   if (value === undefined || value === null) return null;
   const s = String(value);
   return s.length > max ? `${s.slice(0, max - 3)}...` : s;
+}
+
+function redactSecrets(value, key = "") {
+  if (value === null || value === undefined) return value;
+  if (isSecretKey(key)) return "[redacted]";
+  if (typeof value === "string") return redactSecretText(value);
+  if (Array.isArray(value)) return value.map((item) => redactSecrets(item));
+  if (typeof value === "object") {
+    const out = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      out[childKey] = redactSecrets(childValue, childKey);
+    }
+    return out;
+  }
+  return value;
+}
+
+function redactSecretText(value) {
+  return String(value)
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._~+/-]+=*/gi, "$1 [redacted]")
+    .replace(/\b(api[_-]?key|token|password|secret)=([^&\s]+)/gi, "$1=[redacted]");
+}
+
+function isSecretKey(key) {
+  return /(authorization|api[_-]?key|token|password|secret|credential)/i.test(String(key || ""));
 }
 
 export const __testing__ = {

--- a/scripts/pinballwake-executor-lane.test.mjs
+++ b/scripts/pinballwake-executor-lane.test.mjs
@@ -3,7 +3,12 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { processExecutorPacket, __testing__ } from "./pinballwake-executor-lane.mjs";
+import {
+  processExecutorPacket,
+  processScopePackTestOnlyExecutorPacket,
+  sanitizeExecutorReceipt,
+  __testing__,
+} from "./pinballwake-executor-lane.mjs";
 import { makePacket } from "./pinballwake-executor-packet.mjs";
 
 function freshPacket(overrides = {}) {
@@ -51,6 +56,78 @@ describe("processExecutorPacket test_only intent", () => {
     assert.equal(r.receipt_type, __testing__.RECEIPT_TYPE_PASS);
     assert.equal(r.evidence.intent, "test_only");
     assert.equal(r.evidence.pr_url, null);
+  });
+});
+
+describe("processScopePackTestOnlyExecutorPacket", () => {
+  test("hydrates a ScopePack and returns a sanitized PASS receipt", async () => {
+    const now = new Date("2026-05-16T14:45:00.000Z");
+    const result = await processScopePackTestOnlyExecutorPacket({
+      todo: { id: "todo-1" },
+      scopePack: {
+        owned_files: ["scripts/pinballwake-executor-lane.mjs"],
+        acceptance: ["test-only bridge can prove the lane without writing code"],
+      },
+      heartbeat: { tickId: "tick-1", emittedAt: now.toISOString() },
+      headShaAtRequest: "d13d2d4",
+      scopePackCommentId: "comment-1",
+      fileExists: async () => true,
+      now,
+    });
+
+    assert.equal(result.packet.intent, "test_only");
+    assert.equal(result.packet.scope_pack_comment_id, "comment-1");
+    assert.equal(result.receipt.receipt_type, __testing__.RECEIPT_TYPE_PASS);
+    assert.equal(result.receipt.sanitized, true);
+    assert.equal(result.receipt.evidence.intent, "test_only");
+  });
+
+  test("returns HOLD when the required heartbeat is missing", async () => {
+    const result = await processScopePackTestOnlyExecutorPacket({
+      todo: { id: "todo-1" },
+      scopePack: {
+        owned_files: ["scripts/pinballwake-executor-lane.mjs"],
+        acceptance: ["missing heartbeat should not act"],
+      },
+      heartbeatTickId: "tick-1",
+      headShaAtRequest: "d13d2d4",
+      fileExists: async () => true,
+      now: new Date("2026-05-16T14:45:00.000Z"),
+    });
+
+    assert.equal(result.receipt.receipt_type, __testing__.RECEIPT_TYPE_HOLD);
+    assert.equal(result.receipt.hold_reason, "gate_blocked:heartbeat_missing");
+  });
+
+  test("returns HOLD when ScopePack owned_files include protected paths", async () => {
+    const now = new Date("2026-05-16T14:45:00.000Z");
+    const result = await processScopePackTestOnlyExecutorPacket({
+      todo: { id: "todo-1" },
+      scopePack: {
+        owned_files: ["supabase/migrations/001.sql"],
+        acceptance: ["protected data paths must stay gated"],
+      },
+      heartbeat: { tickId: "tick-1", emittedAt: now.toISOString() },
+      headShaAtRequest: "d13d2d4",
+      now,
+    });
+
+    assert.equal(result.receipt.receipt_type, __testing__.RECEIPT_TYPE_HOLD);
+    assert.match(result.receipt.hold_reason, /^gate_blocked:packet_invalid:owned_file_protected/);
+  });
+
+  test("redacts secret-shaped receipt evidence", () => {
+    const safe = sanitizeExecutorReceipt({
+      receipt_type: "executor_packet_hold",
+      evidence: {
+        authorization: "Bearer plain-token",
+        output: "failed with api_key=plain-secret-value and token=raw-token",
+      },
+    });
+
+    assert.equal(safe.evidence.authorization, "[redacted]");
+    assert.match(safe.evidence.output, /api_key=\[redacted\]/);
+    assert.match(safe.evidence.output, /token=\[redacted\]/);
   });
 });
 

--- a/scripts/pinballwake-executor-packet.mjs
+++ b/scripts/pinballwake-executor-packet.mjs
@@ -134,6 +134,101 @@ export function makePacket(input = {}) {
   };
 }
 
+export function makeTestOnlyExecutorPacketFromScopePack({
+  todo = {},
+  scopePack = {},
+  heartbeat = null,
+  heartbeatTickId = "",
+  headShaAtRequest = "",
+  requestingSeatId = "pinballwake-job-runner",
+  scopePackCommentId = "",
+  packetId,
+  emittedAt,
+} = {}) {
+  const scope = scopePack && typeof scopePack === "object" ? scopePack : {};
+  const todoId = firstText(scope.todo_id, scope.todoId, todo.id, todo.todo_id);
+  const tickId = firstText(heartbeatTickId, heartbeat?.tickId, scope.heartbeat_tick_id, todo.heartbeat_tick_id);
+  const headSha = firstText(
+    headShaAtRequest,
+    scope.head_sha_at_request,
+    scope.head_sha,
+    scope.headSha,
+    todo.head_sha_at_request,
+    todo.head_sha,
+    todo.headSha,
+  );
+
+  return makePacket({
+    packet_id: packetId,
+    emitted_at: emittedAt,
+    heartbeat_tick_id: tickId || null,
+    requesting_seat_id: requestingSeatId,
+    todo_id: todoId || null,
+    scope_pack_comment_id:
+      firstText(
+        scopePackCommentId,
+        scope.scope_pack_comment_id,
+        scope.scopePackCommentId,
+        scope.comment_id,
+        todo.scope_pack_comment_id,
+        todo.scopePackCommentId,
+      ) || null,
+    intent: "test_only",
+    owned_files: listFromUnknown(scope.owned_files ?? scope.ownedFiles ?? scope.files ?? scope.paths),
+    acceptance: acceptanceFromScopePack(scope),
+    proof_required: ["scope_pack_comment_id", "head_sha_at_request", "test_run_id", "executor_seat_id"],
+    head_sha_at_request: headSha || null,
+  });
+}
+
+function acceptanceFromScopePack(scope = {}) {
+  const direct = scope.acceptance ?? scope.acceptance_criteria ?? scope.acceptanceCriteria;
+  if (direct && typeof direct === "object" && !Array.isArray(direct)) {
+    return { ...direct };
+  }
+
+  const criteria = listFromUnknown(direct);
+  if (criteria.length > 0) {
+    return { criteria };
+  }
+
+  const expectedProof = scope.expected_proof && typeof scope.expected_proof === "object" ? scope.expected_proof : {};
+  const tests = listFromUnknown(scope.tests ?? scope.verification ?? expectedProof.tests);
+  if (tests.length === 1) {
+    return { test_command: tests[0], expected_exit_code: 0 };
+  }
+  if (tests.length > 1) {
+    return { criteria: tests.map((test) => `verification: ${test}`) };
+  }
+
+  return {};
+}
+
+function listFromUnknown(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizePath(item)).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n|,/)
+      .map((item) => normalizePath(item))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function normalizePath(value) {
+  return String(value ?? "").replace(/\\/g, "/").trim();
+}
+
+function firstText(...values) {
+  for (const value of values) {
+    const text = String(value ?? "").trim();
+    if (text) return text;
+  }
+  return "";
+}
+
 function cryptoRandomId() {
   // Avoid pulling node:crypto for one-off id; use Math.random-shaped suffix.
   // Not security-sensitive; just disambiguation.

--- a/scripts/pinballwake-executor-packet.test.mjs
+++ b/scripts/pinballwake-executor-packet.test.mjs
@@ -7,6 +7,7 @@ import {
   isProtectedPath,
   validateExecutorPacket,
   makePacket,
+  makeTestOnlyExecutorPacketFromScopePack,
   __consts__,
 } from "./pinballwake-executor-packet.mjs";
 
@@ -162,5 +163,71 @@ describe("makePacket", () => {
     assert.equal(p.intent, "test_only");
     assert.equal(p.xpass_advisory, false);
     assert.deepEqual(p.owned_files, ["scripts/x.mjs"]);
+  });
+});
+
+describe("makeTestOnlyExecutorPacketFromScopePack", () => {
+  test("hydrates a ready ScopePack into a v0 test-only packet", () => {
+    const packet = makeTestOnlyExecutorPacketFromScopePack({
+      todo: { id: "todo-1" },
+      scopePack: {
+        owned_files: ["scripts/pinballwake-executor-packet.mjs", "docs/autopilot-executor-lane.md"],
+        acceptance: ["hydrate scopepack", "return a sanitized receipt"],
+      },
+      heartbeat: { tickId: "tick-1" },
+      headShaAtRequest: "d13d2d4",
+      scopePackCommentId: "comment-1",
+      packetId: "pkt-scopepack-1",
+      emittedAt: "2026-05-16T14:45:00.000Z",
+    });
+
+    assert.equal(packet.executor_packet_version, __consts__.PACKET_VERSION);
+    assert.equal(packet.packet_id, "pkt-scopepack-1");
+    assert.equal(packet.intent, "test_only");
+    assert.equal(packet.todo_id, "todo-1");
+    assert.equal(packet.scope_pack_comment_id, "comment-1");
+    assert.equal(packet.heartbeat_tick_id, "tick-1");
+    assert.equal(packet.head_sha_at_request, "d13d2d4");
+    assert.deepEqual(packet.owned_files, [
+      "scripts/pinballwake-executor-packet.mjs",
+      "docs/autopilot-executor-lane.md",
+    ]);
+    assert.deepEqual(packet.acceptance.criteria, ["hydrate scopepack", "return a sanitized receipt"]);
+    assert.equal(validateExecutorPacket(packet).ok, true);
+  });
+
+  test("turns a single verification command into test_command acceptance", () => {
+    const packet = makeTestOnlyExecutorPacketFromScopePack({
+      todo: { id: "todo-1" },
+      scopePack: {
+        owned_files: "scripts/pinballwake-executor-packet.mjs",
+        verification: ["node --test scripts/pinballwake-executor-packet.test.mjs"],
+      },
+      heartbeatTickId: "tick-1",
+      headShaAtRequest: "d13d2d4",
+    });
+
+    assert.deepEqual(packet.owned_files, ["scripts/pinballwake-executor-packet.mjs"]);
+    assert.deepEqual(packet.acceptance, {
+      test_command: "node --test scripts/pinballwake-executor-packet.test.mjs",
+      expected_exit_code: 0,
+    });
+    assert.equal(validateExecutorPacket(packet).ok, true);
+  });
+
+  test("keeps protected owned_files refused by packet validation", () => {
+    const packet = makeTestOnlyExecutorPacketFromScopePack({
+      todo: { id: "todo-1" },
+      scopePack: {
+        owned_files: [".github/workflows/autonomous-runner.yml"],
+        acceptance: ["do not edit protected workflows"],
+      },
+      heartbeatTickId: "tick-1",
+      headShaAtRequest: "d13d2d4",
+    });
+
+    const result = validateExecutorPacket(packet);
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "owned_file_protected");
   });
 });


### PR DESCRIPTION
## Summary
Adds the first test-only bridge for the Autopilot Executor Lane. A ready ScopePack can now hydrate into a v0 executor packet, run through `processExecutorPacket` with heartbeat-required `intent=test_only`, and return a sanitized PASS or HOLD receipt without enabling live code-writing execution.

## Scope
Owned files from todo `669a9c0b-67c4-4a96-80ec-a8ec3a249e73`:
- `scripts/pinballwake-autonomous-runner.mjs`
- `scripts/pinballwake-autonomous-runner.test.mjs`
- `scripts/pinballwake-commonsense-pass.mjs`
- `scripts/pinballwake-commonsense-pass.test.mjs`
- `scripts/pinballwake-executor-lane.mjs`
- `scripts/pinballwake-executor-lane.test.mjs`
- `scripts/pinballwake-executor-packet.mjs`
- `scripts/pinballwake-executor-packet.test.mjs`

## Non-overlap
No `.github` workflow edits, no production data, no secrets/auth/billing/DNS work, no live PR-opening executor path, no execute-mode enablement, and no changes outside the executor-lane packet and runner helper path.

## Verification
- `node --test scripts/pinballwake-commonsense-pass.test.mjs scripts/pinballwake-executor-packet.test.mjs scripts/pinballwake-executor-lane.test.mjs scripts/pinballwake-autonomous-runner.test.mjs` passed, 100 tests after merging current `origin/main`.
- `git diff --check` passed.
- PR checks are green: CI Website, MCP server package, Review dry-run warning, TestPass smoke run, Vercel Preview Comments, and Vercel. Dirty-branch hygiene skipped as expected.

## Risk
Low. This is a test-only packet and receipt bridge. Missing or stale heartbeat returns HOLD, protected owned files are refused, and receipts redact secret-shaped evidence.

## Follow-up
Wire the proven test-only bridge into the scheduled runner emission point once review confirms the packet and receipt shape.