### PR TITLE
Emit test-only ScopePack executor receipts

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -16,6 +16,7 @@ import {
   runCodingRoomRunnerCycle,
 } from "./pinballwake-coding-room-runner.mjs";
 import { evaluateOrchestratorProofWakeGate } from "./lib/autopilotkit-liveness.mjs";
+import { processScopePackTestOnlyExecutorPacket } from "./pinballwake-executor-lane.mjs";
 import { buildScopePackHydrationReceipt } from "./pinballwake-scopepack-hydrator.mjs";
 
 export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
@@ -452,17 +453,7 @@ function boardroomTodoScopeTextSources(todo = {}) {
 }
 
 function extractBoardroomTodoScopePack(todo = {}) {
-  const scope = firstPresentObject(
-    todo.scope_pack,
-    todo.scopePack,
-    todo.runner_scope,
-    todo.runnerScope,
-    todo.autonomous_scope,
-    todo.autonomousScope,
-    todo.coding_room_scope,
-    todo.codingRoomScope,
-    ...boardroomTodoScopeTextSources(todo).map(parseLabeledJsonObjectFromText),
-  );
+  const scope = extractBoardroomTodoScopePackObject(todo);
 
   if (!scope) {
     return {
@@ -508,6 +499,46 @@ function extractBoardroomTodoScopePack(todo = {}) {
     lane: String(scope.lane || scope.worker_lane || scope.workerLane || "").trim(),
     owner_hint: String(scope.owner_hint || scope.ownerHint || "").trim(),
   };
+}
+
+function extractBoardroomTodoScopePackObject(todo = {}) {
+  return firstPresentObject(
+    todo.scope_pack,
+    todo.scopePack,
+    todo.runner_scope,
+    todo.runnerScope,
+    todo.autonomous_scope,
+    todo.autonomousScope,
+    todo.coding_room_scope,
+    todo.codingRoomScope,
+    ...boardroomTodoScopeTextSources(todo).map(parseLabeledJsonObjectFromText),
+  );
+}
+
+export async function createAutonomousRunnerTestOnlyExecutorReceipt({
+  todo = {},
+  scopePack = null,
+  heartbeat = null,
+  heartbeatTickId = "",
+  headShaAtRequest = "",
+  requestingSeatId = "pinballwake-job-runner",
+  scopePackCommentId = "",
+  fileExists,
+  executorSeatId = "pinballwake-build-executor",
+  now = new Date(),
+} = {}) {
+  return processScopePackTestOnlyExecutorPacket({
+    todo,
+    scopePack: scopePack || extractBoardroomTodoScopePackObject(todo) || {},
+    heartbeat,
+    heartbeatTickId,
+    headShaAtRequest,
+    requestingSeatId,
+    scopePackCommentId,
+    fileExists,
+    executorSeatId,
+    now,
+  });
 }
 
 export function parseMcpEventStreamPayload(text = "") {
@@ -1660,6 +1691,7 @@ export async function syncBoardroomTodoScopingRequestToUnClick({
   mcpUrl = DEFAULT_UNCLICK_MCP_URL,
   apiKey = "",
   fetchImpl = globalThis.fetch,
+  testOnlyExecutorPacket = null,
 } = {}) {
   const todoId = String(todo?.id || "").trim();
   if (!todoId) {
@@ -1704,15 +1736,34 @@ export async function syncBoardroomTodoScopingRequestToUnClick({
     };
   }
 
-  const commentText = hydration.receipt || compact(
-    [
-      "Autonomous Runner could not safely build this job yet because no file-level ScopePack was attached.",
-      "Reopened for scoping instead of holding a stale active claim.",
-      "Next: attach exact owned files, proof/tests, and stop conditions, or split this into a smaller job.",
-      `reason=${todo.actionability_reason || "missing_scopepack"}.`,
-    ].join(" "),
-    700,
-  );
+  let testOnlyExecutorPacketResult = null;
+  if (hydration.action === "scopepack_hydrated" && testOnlyExecutorPacket?.enabled) {
+    testOnlyExecutorPacketResult = await createAutonomousRunnerTestOnlyExecutorReceipt({
+      todo,
+      scopePack: hydration.scopepack,
+      heartbeat: testOnlyExecutorPacket.heartbeat,
+      heartbeatTickId: testOnlyExecutorPacket.heartbeatTickId,
+      headShaAtRequest: testOnlyExecutorPacket.headShaAtRequest,
+      requestingSeatId: testOnlyExecutorPacket.requestingSeatId,
+      scopePackCommentId: testOnlyExecutorPacket.scopePackCommentId,
+      fileExists: testOnlyExecutorPacket.fileExists,
+      executorSeatId: testOnlyExecutorPacket.executorSeatId,
+      now: testOnlyExecutorPacket.now,
+    });
+  }
+
+  const commentText = [
+    hydration.receipt || compact(
+      [
+        "Autonomous Runner could not safely build this job yet because no file-level ScopePack was attached.",
+        "Reopened for scoping instead of holding a stale active claim.",
+        "Next: attach exact owned files, proof/tests, and stop conditions, or split this into a smaller job.",
+        `reason=${todo.actionability_reason || "missing_scopepack"}.`,
+      ].join(" "),
+      700,
+    ),
+    formatTestOnlyExecutorPacketReceipt(testOnlyExecutorPacketResult),
+  ].filter(Boolean).join(" ");
 
   const comment = await callUnClickMcpTool({
     mcpUrl,
@@ -1736,7 +1787,22 @@ export async function syncBoardroomTodoScopingRequestToUnClick({
     comment_id: comment.ok ? comment.data?.comment?.id || null : null,
     comment_detail: comment.ok ? null : comment.reason || comment.error || null,
     scopepack_hydration: hydration.action === "needs_manual_scoping" ? null : hydration,
+    test_only_executor_packet: testOnlyExecutorPacketResult,
   };
+}
+
+function formatTestOnlyExecutorPacketReceipt(result) {
+  if (!result) return "";
+  const packet = result.packet || {};
+  const receipt = result.receipt || {};
+  const parts = [
+    `executor_packet=${receipt.receipt_type || "executor_packet_hold"}.`,
+    `intent=${packet.intent || "test_only"}.`,
+    `packet_id=${packet.packet_id || receipt.packet_id || "none"}.`,
+  ];
+  if (receipt.hold_reason) parts.push(`hold_reason=${receipt.hold_reason}.`);
+  parts.push("execute_enabled=false.");
+  return compact(parts.join(" "), 700);
 }
 
 export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date().toISOString() } = {}) {
@@ -2415,12 +2481,24 @@ export async function runAutonomousRunnerFile({
   }
 
   if (shouldPersist && todoForScoping) {
+    const executorHeartbeatTickId = trustedFallbackId || `${wakeSource || "unknown"}:${now}`;
     todoScopingSync = await syncBoardroomTodoScopingRequestToUnClick({
       todo: todoForScoping,
       runner,
       apiKey: unclickApiKey,
       mcpUrl: unclickMcpUrl,
       fetchImpl,
+      testOnlyExecutorPacket: {
+        enabled: true,
+        heartbeat: { tickId: executorHeartbeatTickId, emittedAt: now },
+        heartbeatTickId: executorHeartbeatTickId,
+        headShaAtRequest:
+          checkedOutSha ||
+          mainFreshnessCanary?.check?.current_main_sha ||
+          mainFreshnessCanary?.check?.currentMainSha ||
+          "unknown-head-sha",
+        now,
+      },
     });
 
     if (!todoScopingSync.ok) {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
+  createAutonomousRunnerTestOnlyExecutorReceipt,
   assertRunnerOnFreshMain,
   evaluateAutonomousRunnerCommonSensePass,
   evaluateBoardroomTodoAutoClaimEligibility,
@@ -576,6 +577,30 @@ describe("PinballWake autonomous Runner seat", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("can return a sanitized test-only executor receipt from a scoped todo", async () => {
+    const now = new Date("2026-05-16T14:58:00.000Z");
+    const result = await createAutonomousRunnerTestOnlyExecutorReceipt({
+      todo: {
+        id: "todo-executor-bridge",
+        scope_pack_comment_id: "comment-bridge-1",
+        scope_pack: {
+          owned_files: ["scripts/pinballwake-autonomous-runner.mjs"],
+          acceptance: ["runner can return a test-only executor receipt"],
+          verification: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+        },
+      },
+      heartbeat: { tickId: "tick-1", emittedAt: now.toISOString() },
+      headShaAtRequest: "2e0d9c2",
+      fileExists: async () => true,
+      now,
+    });
+
+    assert.equal(result.packet.todo_id, "todo-executor-bridge");
+    assert.equal(result.packet.intent, "test_only");
+    assert.equal(result.receipt.receipt_type, "executor_packet_pass");
+    assert.equal(result.receipt.sanitized, true);
   });
 
   it("keeps a scoped todo eligible only for the builder allowlist and open unassigned queue", () => {
@@ -1777,10 +1802,12 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.action, "scopepack_hydrated");
       assert.equal(result.reason, "boardroom_todo_scopepack_hydrated");
       assert.equal(result.todo_scoping_sync.scopepack_hydration.action, "scopepack_hydrated");
+      assert.equal(result.todo_scoping_sync.test_only_executor_packet.receipt.receipt_type, "executor_packet_hold");
 
       const commentCall = calls.find((call) => call.body.params.name === "comment_on");
       assert.match(commentCall.body.params.arguments.text, /PASS: scopepack_hydrated/);
       assert.match(commentCall.body.params.arguments.text, /PinballWake Executor Lane comment ScopePack parsing/);
+      assert.match(commentCall.body.params.arguments.text, /executor_packet=executor_packet_hold/);
       assert.match(commentCall.body.params.arguments.text, /No production writes/);
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/scripts/pinballwake-commonsense-pass.mjs
+++ b/scripts/pinballwake-commonsense-pass.mjs
@@ -32,6 +32,7 @@ export async function commonSensePass({
   packet,
   now = new Date(),
   heartbeat = null,
+  requireHeartbeat = false,
   allowedRequesterSeats = DEFAULT_ALLOWED_REQUESTER_SEATS,
   fileExists = async () => true,
   heartbeatMaxAgeMs = DEFAULT_HEARTBEAT_MAX_AGE_MS,
@@ -52,6 +53,13 @@ export async function commonSensePass({
   }
 
   // 3. Heartbeat freshness gate.
+  if (requireHeartbeat && (!heartbeat || typeof heartbeat !== "object" || !heartbeat.tickId)) {
+    return {
+      ok: false,
+      reason: "heartbeat_missing",
+      evidence: { heartbeat_required: true },
+    };
+  }
   if (heartbeat) {
     if (heartbeat.tickId !== packet.heartbeat_tick_id) {
       return {

--- a/scripts/pinballwake-commonsense-pass.test.mjs
+++ b/scripts/pinballwake-commonsense-pass.test.mjs
@@ -49,6 +49,15 @@ describe("commonSensePass", () => {
     assert.equal(r.reason, "heartbeat_stale");
   });
 
+  test("HOLD when heartbeat is required but absent", async () => {
+    const r = await commonSensePass({
+      packet: basePacket({ intent: "test_only" }),
+      requireHeartbeat: true,
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "heartbeat_missing");
+  });
+
   test("HOLD on heartbeat too old even when tick matches", async () => {
     const now = new Date("2026-05-15T03:00:00Z");
     const oldEmitted = new Date(now.getTime() - DEFAULT_HEARTBEAT_MAX_AGE_MS - 60_000).toISOString();

--- a/scripts/pinballwake-executor-lane.mjs
+++ b/scripts/pinballwake-executor-lane.mjs
@@ -16,6 +16,7 @@
 // See docs/autopilot-executor-lane.md for the full design.
 
 import { commonSensePass } from "./pinballwake-commonsense-pass.mjs";
+import { makeTestOnlyPacketFromScopePack } from "./pinballwake-executor-packet.mjs";
 
 const RECEIPT_TYPE_PASS = "executor_packet_pass";
 const RECEIPT_TYPE_HOLD = "executor_packet_hold";
@@ -38,6 +39,7 @@ const PROOF_REQUIRED = ["pr_url", "head_sha", "test_run_id", "executor_seat_id"]
 export async function processExecutorPacket({
   packet,
   heartbeat,
+  requireHeartbeat = false,
   fileExists,
   executor,
   executorSeatId = "pinballwake-build-executor",
@@ -47,6 +49,7 @@ export async function processExecutorPacket({
   const gate = await commonSensePass({
     packet,
     heartbeat,
+    requireHeartbeat,
     fileExists,
     now,
   });
@@ -129,6 +132,70 @@ export async function processExecutorPacket({
   });
 }
 
+export async function processScopePackTestOnlyExecutorPacket({
+  todo = {},
+  scopePack = {},
+  heartbeat = null,
+  heartbeatTickId = "",
+  headShaAtRequest = "",
+  requestingSeatId = "pinballwake-job-runner",
+  scopePackCommentId = "",
+  fileExists,
+  executorSeatId = "pinballwake-build-executor",
+  now = new Date(),
+} = {}) {
+  const safeNow = toDate(now);
+  const built = makeTestOnlyPacketFromScopePack({
+    todo,
+    scopepack: scopePack,
+    heartbeatTickId: heartbeatTickId || heartbeat?.tickId || "",
+    headShaAtRequest,
+    requestingSeatId,
+    scopePackCommentId,
+    emittedAt: safeNow.toISOString(),
+  });
+
+  if (!built.ok) {
+    const receipt = buildHoldReceipt({
+      packet: built.packet,
+      executorSeatId,
+      now: safeNow,
+      reason: `packet_build_failed:${built.reason}`,
+      evidence: built.validation ? { validation: built.validation } : { reason: built.reason },
+    });
+    return {
+      ok: false,
+      reason: built.reason,
+      packet: built.packet ?? null,
+      receipt: sanitizeExecutorReceipt(receipt),
+    };
+  }
+
+  const receipt = await processExecutorPacket({
+    packet: built.packet,
+    heartbeat,
+    requireHeartbeat: true,
+    fileExists,
+    executorSeatId,
+    now: safeNow,
+  });
+
+  return {
+    ok: receipt.receipt_type === RECEIPT_TYPE_PASS,
+    reason: receipt.hold_reason ?? "executor_packet_pass",
+    packet: built.packet,
+    receipt: sanitizeExecutorReceipt(receipt),
+  };
+}
+
+export function sanitizeExecutorReceipt(receipt) {
+  const redacted = redactSecrets(receipt);
+  return {
+    ...(redacted && typeof redacted === "object" ? redacted : {}),
+    sanitized: true,
+  };
+}
+
 function buildPassReceipt({ packet, executorSeatId, now, evidence, next_action }) {
   return {
     receipt_type: RECEIPT_TYPE_PASS,
@@ -169,6 +236,35 @@ function clip(value, max) {
   if (value === undefined || value === null) return null;
   const s = String(value);
   return s.length > max ? `${s.slice(0, max - 3)}...` : s;
+}
+
+function toDate(value) {
+  return value instanceof Date ? value : new Date(value || Date.now());
+}
+
+function redactSecrets(value, key = "") {
+  if (value === null || value === undefined) return value;
+  if (isSecretKey(key)) return "[redacted]";
+  if (typeof value === "string") return redactSecretText(value);
+  if (Array.isArray(value)) return value.map((item) => redactSecrets(item));
+  if (typeof value === "object") {
+    const out = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      out[childKey] = redactSecrets(childValue, childKey);
+    }
+    return out;
+  }
+  return value;
+}
+
+function redactSecretText(value) {
+  return String(value)
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._~+/-]+=*/gi, "$1 [redacted]")
+    .replace(/\b(api[_-]?key|token|password|secret)=([^&\s]+)/gi, "$1=[redacted]");
+}
+
+function isSecretKey(key) {
+  return /(authorization|api[_-]?key|token|password|secret|credential)/i.test(String(key || ""));
 }
 
 export const __testing__ = {

--- a/scripts/pinballwake-executor-lane.test.mjs
+++ b/scripts/pinballwake-executor-lane.test.mjs
@@ -3,7 +3,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { processExecutorPacket, __testing__ } from "./pinballwake-executor-lane.mjs";
+import { processExecutorPacket, processScopePackTestOnlyExecutorPacket, __testing__ } from "./pinballwake-executor-lane.mjs";
 import { makePacket } from "./pinballwake-executor-packet.mjs";
 
 function freshPacket(overrides = {}) {
@@ -51,6 +51,59 @@ describe("processExecutorPacket test_only intent", () => {
     assert.equal(r.receipt_type, __testing__.RECEIPT_TYPE_PASS);
     assert.equal(r.evidence.intent, "test_only");
     assert.equal(r.evidence.pr_url, null);
+  });
+
+  test("HOLD on test_only when heartbeat is explicitly required and absent", async () => {
+    const r = await processExecutorPacket({
+      packet: freshPacket({ intent: "test_only" }),
+      requireHeartbeat: true,
+      fileExists: async () => true,
+    });
+    assert.equal(r.receipt_type, __testing__.RECEIPT_TYPE_HOLD);
+    assert.match(r.hold_reason, /^gate_blocked:heartbeat_missing/);
+  });
+});
+
+describe("processScopePackTestOnlyExecutorPacket", () => {
+  test("builds and processes a sanitized test_only packet from ScopePack", async () => {
+    const now = new Date("2026-05-16T14:58:00.000Z");
+    const result = await processScopePackTestOnlyExecutorPacket({
+      todo: { id: "todo-scopepack" },
+      scopePack: {
+        owned_files: ["scripts/pinballwake-executor-lane.mjs"],
+        acceptance: ["packet bridge passes"],
+        verification: ["node --test scripts/pinballwake-executor-lane.test.mjs"],
+      },
+      heartbeat: { tickId: "tick-1", emittedAt: now.toISOString() },
+      headShaAtRequest: "abc12345",
+      fileExists: async () => true,
+      now,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.packet.intent, "test_only");
+    assert.equal(result.packet.todo_id, "todo-scopepack");
+    assert.equal(result.receipt.receipt_type, __testing__.RECEIPT_TYPE_PASS);
+    assert.equal(result.receipt.sanitized, true);
+  });
+
+  test("returns sanitized HOLD when ScopePack packet build fails", async () => {
+    const now = new Date("2026-05-16T14:58:00.000Z");
+    const result = await processScopePackTestOnlyExecutorPacket({
+      todo: { id: "todo-protected" },
+      scopePack: {
+        owned_files: ["vercel.json"],
+        acceptance: ["packet bridge blocks protected paths"],
+      },
+      heartbeat: { tickId: "tick-1", emittedAt: now.toISOString() },
+      headShaAtRequest: "abc12345",
+      now,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.receipt.receipt_type, __testing__.RECEIPT_TYPE_HOLD);
+    assert.match(result.receipt.hold_reason, /^packet_build_failed:/);
+    assert.equal(result.receipt.sanitized, true);
   });
 });
 


### PR DESCRIPTION
## Summary
- wire the scheduled runner path to produce safe test-only executor packet receipts after ScopePack hydration
- require a fresh heartbeat when processing ScopePack test-only packets
- sanitize executor receipts before adding them to Boardroom/todo proof text

## Verification
- node --test scripts/pinballwake-commonsense-pass.test.mjs scripts/pinballwake-executor-packet.test.mjs scripts/pinballwake-executor-lane.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check

## Notes
- execute mode remains locked off
- no workflow, secret, billing, DNS, production data, or deploy surfaces changed