### PR TITLE
feat(autopilot-executor): emit packets for claimed todos

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1120,10 +1120,12 @@ function validateBoardroomClaimSourceState(job = {}) {
 
 export async function syncClaimedBoardroomTodoToUnClick({
   job,
+  todo = null,
   runner = DEFAULT_AUTONOMOUS_RUNNER,
   mcpUrl = DEFAULT_UNCLICK_MCP_URL,
   apiKey = "",
   fetchImpl = globalThis.fetch,
+  testOnlyExecutorPacket = null,
 } = {}) {
   const todoId = extractBoardroomTodoIdFromCodingRoomJob(job);
   if (!todoId) {
@@ -1166,6 +1168,22 @@ export async function syncClaimedBoardroomTodoToUnClick({
     };
   }
 
+  let testOnlyExecutorPacketResult = null;
+  if (todo && testOnlyExecutorPacket?.enabled) {
+    testOnlyExecutorPacketResult = await createAutonomousRunnerTestOnlyExecutorReceipt({
+      todo,
+      scopePack: extractBoardroomTodoScopePackObject(todo),
+      heartbeat: testOnlyExecutorPacket.heartbeat,
+      heartbeatTickId: testOnlyExecutorPacket.heartbeatTickId,
+      headShaAtRequest: testOnlyExecutorPacket.headShaAtRequest,
+      requestingSeatId: testOnlyExecutorPacket.requestingSeatId,
+      scopePackCommentId: testOnlyExecutorPacket.scopePackCommentId,
+      fileExists: testOnlyExecutorPacket.fileExists,
+      executorSeatId: testOnlyExecutorPacket.executorSeatId,
+      now: testOnlyExecutorPacket.now,
+    });
+  }
+
   const comment = await callUnClickMcpTool({
     mcpUrl,
     apiKey,
@@ -1184,8 +1202,9 @@ export async function syncClaimedBoardroomTodoToUnClick({
           `source=${job?.source || "unknown"}.`,
           `wake_source=${job?.source_state?.wake_source || "unknown"}.`,
           `job=${job?.job_id || "unknown"}.`,
-        ].join(" "),
-        600,
+          formatTestOnlyExecutorPacketReceipt(testOnlyExecutorPacketResult),
+        ].filter(Boolean).join(" "),
+        1000,
       ),
     },
   });
@@ -1210,6 +1229,7 @@ export async function syncClaimedBoardroomTodoToUnClick({
     status: "in_progress",
     comment_ok: true,
     comment_id: comment.data?.comment?.id || null,
+    test_only_executor_packet: testOnlyExecutorPacketResult,
   };
 }
 
@@ -1465,6 +1485,7 @@ function createQuietWindowAutonomyProofReceipt({
   finalAction = "",
   finalReason = "",
   commonsensepass = {},
+  testOnlyExecutorPacket = null,
 } = {}) {
   const triggerSource = normalizeQuietWindowToken(wakeSource || "unknown");
   const imported = numberOption(queueSourceResult.imported, 0);
@@ -1503,11 +1524,28 @@ function createQuietWindowAutonomyProofReceipt({
     });
   }
 
+  if (testOnlyExecutorPacket?.packet) {
+    events.push({
+      rung: "execution_packet",
+      at: now,
+      packet_id: testOnlyExecutorPacket.packet.packet_id || null,
+      receipt_type: testOnlyExecutorPacket.receipt?.receipt_type || null,
+    });
+  }
+
   if (blockedResult || commonsensepass.verdict !== "PASS") {
     events.push({
       rung: "commonsensepass_blocker",
       at: now,
       reason: blockedResult?.reason || commonsensepass.reason_code || finalReason || "runner_blocked",
+    });
+  }
+
+  if (testOnlyExecutorPacket?.receipt?.receipt_type === "executor_packet_hold") {
+    events.push({
+      rung: "commonsensepass_blocker",
+      at: now,
+      reason: testOnlyExecutorPacket.receipt.hold_reason || testOnlyExecutorPacket.reason || "executor_packet_hold",
     });
   }
 
@@ -2445,6 +2483,12 @@ export async function runAutonomousRunnerFile({
     finalReason,
     scopingRequested: todoForScoping && shouldPersist ? 1 : 0,
   });
+  const executorHeartbeatTickId = trustedFallbackId || `${wakeSource || "unknown"}:${now}`;
+  const executorHeadSha =
+    checkedOutSha ||
+    mainFreshnessCanary?.check?.current_main_sha ||
+    mainFreshnessCanary?.check?.currentMainSha ||
+    "unknown-head-sha";
 
   if (
     shouldPersist &&
@@ -2452,12 +2496,24 @@ export async function runAutonomousRunnerFile({
     last.action === "claimed" &&
     last.job
   ) {
+    const claimedTodoId = extractBoardroomTodoIdFromCodingRoomJob(last.job);
+    const claimedTodo = (queueSourceResult.todos || []).find((todo) =>
+      String(todo.id || todo.todo_id || "").trim() === claimedTodoId
+    );
     todoClaimSync = await syncClaimedBoardroomTodoToUnClick({
       job: last.job,
+      todo: claimedTodo || null,
       runner,
       apiKey: unclickApiKey,
       mcpUrl: unclickMcpUrl,
       fetchImpl,
+      testOnlyExecutorPacket: {
+        enabled: Boolean(claimedTodo),
+        heartbeat: { tickId: executorHeartbeatTickId, emittedAt: now },
+        heartbeatTickId: executorHeartbeatTickId,
+        headShaAtRequest: executorHeadSha,
+        now,
+      },
     });
 
     if (!todoClaimSync.ok) {
@@ -2481,7 +2537,6 @@ export async function runAutonomousRunnerFile({
   }
 
   if (shouldPersist && todoForScoping) {
-    const executorHeartbeatTickId = trustedFallbackId || `${wakeSource || "unknown"}:${now}`;
     todoScopingSync = await syncBoardroomTodoScopingRequestToUnClick({
       todo: todoForScoping,
       runner,
@@ -2492,11 +2547,7 @@ export async function runAutonomousRunnerFile({
         enabled: true,
         heartbeat: { tickId: executorHeartbeatTickId, emittedAt: now },
         heartbeatTickId: executorHeartbeatTickId,
-        headShaAtRequest:
-          checkedOutSha ||
-          mainFreshnessCanary?.check?.current_main_sha ||
-          mainFreshnessCanary?.check?.currentMainSha ||
-          "unknown-head-sha",
+        headShaAtRequest: executorHeadSha,
         now,
       },
     });
@@ -2570,6 +2621,7 @@ export async function runAutonomousRunnerFile({
     finalAction,
     finalReason,
     commonsensepass,
+    testOnlyExecutorPacket: todoClaimSync.test_only_executor_packet || todoScopingSync.test_only_executor_packet,
   });
   claimabilityScorecard = {
     ...claimabilityScorecard,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1295,6 +1295,8 @@ describe("PinballWake autonomous Runner seat", () => {
                             created_at: "2026-05-08T05:00:00.000Z",
                             scope_pack: {
                               owned_files: ["docs/runner-scope.md"],
+                              acceptance: ["Claimed scoped todo emits a test-only executor packet"],
+                              verification: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
                               patch: "diff --git a/docs/runner-scope.md b/docs/runner-scope.md\n--- a/docs/runner-scope.md\n+++ b/docs/runner-scope.md\n@@ -1 +1 @@\n-old\n+new\n",
                               tests: [],
                             },
@@ -1385,17 +1387,20 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.match(calls[2].body.params.arguments.text, /dispatch=coding-room-claim:/);
       assert.match(calls[2].body.params.arguments.text, /lease_token=coding-room-claim:/);
       assert.match(calls[2].body.params.arguments.text, /wake_source=queuepush/);
+      assert.match(calls[2].body.params.arguments.text, /executor_packet=executor_packet_pass/);
       assert.equal(result.todo_claim_sync.ok, true);
       assert.equal(result.todo_claim_sync.todo_id, "todo-claim-1");
-      assert.equal(result.quiet_window_autonomy_proof.verdict, "HOLD");
-      assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "execution_packet");
+      assert.equal(result.todo_claim_sync.test_only_executor_packet.receipt.receipt_type, "executor_packet_pass");
+      assert.equal(result.quiet_window_autonomy_proof.verdict, "BLOCKER");
+      assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "build_attempt_or_commonsense_blocker");
       assert.deepEqual(result.quiet_window_autonomy_proof.evidence.observed_rungs, [
         "tick",
         "buildbait_crumb",
         "claim_or_lease",
+        "execution_packet",
       ]);
-      assert.equal(result.claimability_scorecard.quiet_window_autonomy_verdict, "HOLD");
-      assert.equal(result.claimability_scorecard.quiet_window_first_missing_rung, "execution_packet");
+      assert.equal(result.claimability_scorecard.quiet_window_autonomy_verdict, "BLOCKER");
+      assert.equal(result.claimability_scorecard.quiet_window_first_missing_rung, "build_attempt_or_commonsense_blocker");
 
       const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
       assert.equal(persisted.jobs[0].status, "claimed");


### PR DESCRIPTION
## Summary
- Extends the merged test-only executor packet bridge to the claimed-todo path.
- When PinballWake safely claims a scoped UnClick todo, the claim comment now includes a gated test-only `executor_packet` receipt.
- Quiet-window proof records the `execution_packet` rung, so the runner no longer stops at claim-only proof for scoped claimed work.

## Scope
- Owned files: `scripts/pinballwake-autonomous-runner.mjs`, `scripts/pinballwake-autonomous-runner.test.mjs`
- Lane: Autopilot Executor Lane
- Follow-up to merged PR #870

## Non-overlap
- Does not enable execute mode.
- Does not invoke a code-writing executor.
- Does not touch workflows, secrets, billing, DNS, migrations, production data, or merge policy.
- Supersedes draft PR #871, which conflicted after #870 landed.

## Verification
- `node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-executor-lane.test.mjs scripts/pinballwake-commonsense-pass.test.mjs scripts/pinballwake-executor-packet.test.mjs` PASS, 101/101
- `git diff --check` PASS

## Risk
- Low runtime risk: the new behavior only appends a sanitized test-only executor receipt to an existing claim comment and records proof-ladder evidence.
- The next missing rung remains `build_attempt_or_commonsense_blocker`; no write authority is expanded.

## Follow-up
- Once this is reviewed, the next throughput slice is wiring a bounded test-run/build-attempt receipt while execute remains gated.