### PR TITLE
feat(autopilot): add OpenHands test-mode adapter

### DIFF
--- a/.github/workflows/openhands-test-mode.yml
+++ b/.github/workflows/openhands-test-mode.yml
@@ -1,0 +1,29 @@
+name: OpenHands Test Mode
+
+on:
+  workflow_dispatch:
+    inputs:
+      openhands_test_mode:
+        description: Type 1 to run the opt-in OpenHands adapter checks.
+        required: true
+        default: "0"
+
+jobs:
+  openhands-test-mode:
+    if: ${{ inputs.openhands_test_mode == '1' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      OPENHANDS_TEST_MODE: "1"
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run adapter tests
+        run: node --test scripts/pinballwake-openhands-worker.test.mjs

--- a/docs/openhands-integration.md
+++ b/docs/openhands-integration.md
@@ -1,0 +1,52 @@
+# OpenHands Integration
+
+## Status
+
+This is the v1 test-mode adapter for the Autopilot Executor Lane. It lets UnClick prove the missing middle step: a scoped job can be handed to an OpenHands-style coder, returned as a patch, checked by the existing coding room gate, and represented as a receipt.
+
+This file does not enable production code-writing. The adapter is opt-in and requires `OPENHANDS_TEST_MODE=1` or an explicit test harness flag.
+
+## Flow
+
+1. The heartbeat or runner selects one safe, scoped todo.
+2. The job ScopePack provides `owned_files`, acceptance, and verification.
+3. `scripts/pinballwake-openhands-worker.mjs` builds a narrow task prompt.
+4. A caller-provided OpenHands runner returns a unified diff patch.
+5. The adapter submits the patch to the coding room gate.
+6. The gate accepts only changed files inside the owned set.
+7. The adapter emits `openhands_worker_pass` or `openhands_worker_hold`.
+
+## Guardrails
+
+- Test mode is required by default.
+- The adapter does not commit, push, merge, deploy, or mutate production data.
+- The default coding room submitter rejects patches outside `owned_files`.
+- Receipts redact common token, secret, password, credential, and API key shapes.
+- A caller can wrap the OpenHands invocation with a spend guard by passing `spendGuard`.
+- The GitHub workflow is manual only and default off.
+
+## Expected Environment
+
+For real OpenHands use, the worker that provides the `openHands` function should own its secrets outside the repo:
+
+- `OPENHANDS_TEST_MODE=1`
+- model provider key, stored only in CI or worker secret storage
+- repo-scoped token for draft PR creation, stored only in CI or worker secret storage
+- an external cost or spend limit guard
+
+The repository should not store OpenHands provider keys or GitHub tokens.
+
+## Acceptance
+
+- `node --test scripts/pinballwake-openhands-worker.test.mjs` passes.
+- A tiny test todo can produce a patch through the injected runner.
+- The coding room gate refuses a patch outside the todo's owned files.
+- A pass receipt contains changed files, patch size, optional PR URL, optional head SHA, and optional test run id.
+
+## Deferred
+
+- Running the real OpenHands CLI or Docker image from this repo.
+- Automatic production-mode execution.
+- Automatic merge.
+- Multi-job parallel execution.
+- Dollar-level cost accounting.

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -1,0 +1,418 @@
+// scripts/pinballwake-openhands-worker.mjs
+//
+// OpenHands adapter for the Autopilot Executor Lane.
+//
+// v1 is intentionally test-mode only. It prepares the task, calls an injected
+// OpenHands runner, and hands the patch to the coding room safety gate. The
+// default path never starts OpenHands by itself and never opens or merges PRs.
+
+import { submitCodingRoomBuildResult } from "./pinballwake-coding-room.mjs";
+
+const RECEIPT_TYPE_PASS = "openhands_worker_pass";
+const RECEIPT_TYPE_HOLD = "openhands_worker_hold";
+const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
+const MAX_PATCH_BYTES = 120_000;
+const PROOF_REQUIRED = ["pr_url", "head_sha", "test_run_id", "executor_seat_id"];
+
+export async function runOpenHandsWorker({
+  job,
+  scopePack,
+  openHands,
+  coderoom,
+  spendGuard,
+  env = process.env,
+  testMode = false,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  executorSeatId = "pinballwake-openhands-worker",
+  now = new Date(),
+} = {}) {
+  const safeNow = toDate(now);
+  const normalizedScope = normalizeScopePack(scopePack);
+  const normalizedJob = normalizeJob(job, normalizedScope);
+
+  if (!isOpenHandsTestMode({ env, testMode })) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "openhands_test_mode_required",
+      evidence: { hint: "Set OPENHANDS_TEST_MODE=1 for the opt-in adapter check." },
+    });
+  }
+
+  if (!normalizedJob) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "job_required",
+      evidence: { hint: "Pass a coding room job or todo-backed job payload." },
+    });
+  }
+
+  if (normalizedScope.owned_files.length === 0) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "owned_files_required",
+      evidence: { scope_pack_comment_id: normalizedScope.scope_pack_comment_id ?? null },
+    });
+  }
+
+  if (typeof openHands !== "function") {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "openhands_runner_not_provided",
+      evidence: { hint: "Pass openHands: async ({ prompt, job, scopePack }) => result." },
+    });
+  }
+
+  const prompt = buildOpenHandsTaskPrompt({ job: normalizedJob, scopePack: normalizedScope });
+  let result;
+  try {
+    result = await invokeWithOptionalSpendGuard({
+      spendGuard,
+      label: normalizedScope.spend_guard_label || "openhands/test-mode",
+      provider: normalizedScope.spend_guard_provider || "openai",
+      run: () =>
+        openHands({
+          job: normalizedJob,
+          scopePack: normalizedScope,
+          prompt,
+          timeoutMs,
+        }),
+    });
+  } catch (err) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: isTimeoutError(err) ? "openhands_timeout" : "openhands_threw",
+      evidence: { error_message: clip(String(err?.message ?? err), 1000) },
+    });
+  }
+
+  if (!result || result.ok === false) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "openhands_reported_failure",
+      evidence: {
+        exit_code: result?.exit_code ?? null,
+        output: clip(result?.output, 2000),
+      },
+    });
+  }
+
+  const patch = String(result.patch ?? "");
+  if (!patch.trim()) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "patch_required",
+      evidence: { output: clip(result.output, 1000) },
+    });
+  }
+
+  const patchBytes = Buffer.byteLength(patch, "utf8");
+  if (patchBytes > MAX_PATCH_BYTES) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "patch_too_large",
+      evidence: { patch_bytes: patchBytes, max_patch_bytes: MAX_PATCH_BYTES },
+    });
+  }
+
+  const changedFiles = normalizeChangedFiles(result.changed_files || extractChangedFilesFromPatch(patch));
+  if (changedFiles.length === 0) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "changed_files_required",
+      evidence: { patch_bytes: patchBytes },
+    });
+  }
+
+  const submit = coderoom || defaultCoderoomSubmit;
+  let coderoomResult;
+  try {
+    coderoomResult = await submit({
+      job: normalizedJob,
+      scopePack: normalizedScope,
+      patch,
+      changedFiles,
+      summary: clip(result.summary || "OpenHands produced a test-mode patch.", 500),
+      testRunId: result.test_run_id ?? null,
+    });
+  } catch (err) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "coderoom_threw",
+      evidence: { error_message: clip(String(err?.message ?? err), 1000) },
+    });
+  }
+
+  if (!coderoomResult || !coderoomResult.ok) {
+    return hold({
+      job: normalizedJob,
+      executorSeatId,
+      now: safeNow,
+      reason: "coderoom_rejected_patch",
+      evidence: {
+        reason: coderoomResult?.reason ?? "unknown",
+        file: coderoomResult?.file ?? null,
+        changed_files: changedFiles,
+      },
+    });
+  }
+
+  return pass({
+    job: normalizedJob,
+    executorSeatId,
+    now: safeNow,
+    evidence: {
+      changed_files: changedFiles,
+      patch_bytes: patchBytes,
+      pr_url: coderoomResult.pr_url ?? result.pr_url ?? null,
+      head_sha_after: coderoomResult.head_sha_after ?? result.head_sha_after ?? null,
+      test_run_id: coderoomResult.test_run_id ?? result.test_run_id ?? null,
+      test_exit_code: coderoomResult.test_exit_code ?? result.test_exit_code ?? null,
+      coderoom_status: coderoomResult.job?.status ?? coderoomResult.status ?? null,
+    },
+  });
+}
+
+export function buildOpenHandsTaskPrompt({ job = {}, scopePack = {} } = {}) {
+  const ownedFiles = normalizeChangedFiles(scopePack.owned_files || job.owned_files || []);
+  const acceptance = normalizeList(scopePack.acceptance || job.acceptance || job.expected_proof?.tests);
+  const verification = normalizeList(scopePack.verification || scopePack.tests || []);
+  const lines = [
+    "You are OpenHands running in UnClick test mode.",
+    "Return a unified diff patch only. Do not commit, push, merge, deploy, or touch secrets.",
+    `Job: ${compact(job.title || job.job_id || job.id || "untitled job", 300)}`,
+    `Chip: ${compact(job.chip || "none", 300)}`,
+    `Todo: ${job.todo_id || job.id || "unknown"}`,
+    "Owned files:",
+    ...ownedFiles.map((file) => `- ${file}`),
+    "Acceptance:",
+    ...(acceptance.length ? acceptance.map((item) => `- ${item}`) : ["- Produce the smallest safe patch inside owned files."]),
+  ];
+
+  if (verification.length) {
+    lines.push("Verification:");
+    lines.push(...verification.map((item) => `- ${item}`));
+  }
+
+  if (scopePack.body || scopePack.description) {
+    lines.push("ScopePack body:");
+    lines.push(compact(scopePack.body || scopePack.description, 4000));
+  }
+
+  return lines.join("\n");
+}
+
+export function isOpenHandsTestMode({ env = process.env, testMode = false } = {}) {
+  return testMode === true || String(env?.OPENHANDS_TEST_MODE ?? "").trim() === "1";
+}
+
+export function sanitizeOpenHandsReceipt(receipt) {
+  const redacted = redactSecrets(receipt);
+  return {
+    ...(redacted && typeof redacted === "object" ? redacted : {}),
+    sanitized: true,
+  };
+}
+
+async function invokeWithOptionalSpendGuard({ spendGuard, label, provider, run }) {
+  if (typeof spendGuard !== "function") {
+    return run();
+  }
+
+  return spendGuard(
+    {
+      label,
+      provider,
+      mode: "test_mode",
+    },
+    run
+  );
+}
+
+async function defaultCoderoomSubmit({ job, changedFiles, summary, testRunId }) {
+  const result = submitCodingRoomBuildResult({
+    job,
+    buildResult: {
+      result: "done",
+      changedFiles,
+      summary,
+    },
+  });
+
+  if (!result.ok) return result;
+
+  return {
+    ok: true,
+    job: result.job,
+    pr_url: null,
+    head_sha_after: null,
+    test_run_id: testRunId,
+  };
+}
+
+function pass({ job, executorSeatId, now, evidence }) {
+  return {
+    ok: true,
+    reason: "openhands_worker_pass",
+    receipt: sanitizeOpenHandsReceipt({
+      receipt_type: RECEIPT_TYPE_PASS,
+      emitted_at: now.toISOString(),
+      job_id: job?.job_id ?? null,
+      todo_id: job?.todo_id ?? job?.id ?? null,
+      executor_seat_id: executorSeatId,
+      evidence,
+      proof_required: PROOF_REQUIRED,
+      xpass_advisory: true,
+      next_action: "coderoom_review",
+    }),
+  };
+}
+
+function hold({ job, executorSeatId, now, reason, evidence }) {
+  return {
+    ok: false,
+    reason,
+    receipt: sanitizeOpenHandsReceipt({
+      receipt_type: RECEIPT_TYPE_HOLD,
+      emitted_at: now.toISOString(),
+      job_id: job?.job_id ?? null,
+      todo_id: job?.todo_id ?? job?.id ?? null,
+      executor_seat_id: executorSeatId,
+      hold_reason: reason,
+      evidence,
+      proof_required: ["scope_pack_comment_id"],
+      xpass_advisory: false,
+      next_action: "rescope_or_retry",
+    }),
+  };
+}
+
+function normalizeScopePack(scopePack = {}) {
+  return {
+    ...scopePack,
+    owned_files: normalizeChangedFiles(scopePack.owned_files || scopePack.ownedFiles || []),
+    acceptance: normalizeList(scopePack.acceptance || scopePack.acceptance_criteria),
+    verification: normalizeList(scopePack.verification || scopePack.tests),
+  };
+}
+
+function normalizeJob(job, scopePack) {
+  if (!job || typeof job !== "object") return null;
+  const ownedFiles = normalizeChangedFiles(job.owned_files || job.ownedFiles || scopePack.owned_files);
+  return {
+    ...job,
+    owned_files: ownedFiles,
+    expected_proof: job.expected_proof || {
+      tests: scopePack.verification,
+      requires_pr: true,
+      requires_changed_files: true,
+      requires_non_overlap: true,
+      requires_tests: true,
+    },
+  };
+}
+
+function normalizeChangedFiles(values) {
+  return [...new Set(normalizeList(values).map(normalizePath).filter(Boolean))];
+}
+
+function normalizeList(values) {
+  if (Array.isArray(values)) return values.map((value) => String(value ?? "").trim()).filter(Boolean);
+  if (values === undefined || values === null || values === "") return [];
+  return [String(values).trim()].filter(Boolean);
+}
+
+function normalizePath(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .trim();
+}
+
+function extractChangedFilesFromPatch(patch) {
+  const files = [];
+  for (const line of String(patch || "").split(/\r?\n/)) {
+    const diffMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (diffMatch) {
+      files.push(diffMatch[2]);
+      continue;
+    }
+
+    const plusMatch = line.match(/^\+\+\+ b\/(.+)$/);
+    if (plusMatch) files.push(plusMatch[1]);
+  }
+  return normalizeChangedFiles(files.filter((file) => file !== "/dev/null"));
+}
+
+function compact(value, max) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function clip(value, max) {
+  if (value === undefined || value === null) return null;
+  const text = String(value);
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function toDate(value) {
+  return value instanceof Date ? value : new Date(value || Date.now());
+}
+
+function isTimeoutError(err) {
+  const code = String(err?.code ?? "").toUpperCase();
+  const message = String(err?.message ?? err ?? "").toLowerCase();
+  return code === "ETIMEDOUT" || code === "TIMEOUT" || message.includes("timeout") || message.includes("timed out");
+}
+
+function redactSecrets(value, key = "") {
+  if (value === null || value === undefined) return value;
+  if (isSecretKey(key)) return "[redacted]";
+  if (typeof value === "string") return redactSecretText(value);
+  if (Array.isArray(value)) return value.map((item) => redactSecrets(item));
+  if (typeof value === "object") {
+    const out = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      out[childKey] = redactSecrets(childValue, childKey);
+    }
+    return out;
+  }
+  return value;
+}
+
+function redactSecretText(value) {
+  return String(value)
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._~+/-]+=*/gi, "$1 [redacted]")
+    .replace(/\b(api[_-]?key|token|password|secret)=([^&\s]+)/gi, "$1=[redacted]");
+}
+
+function isSecretKey(key) {
+  return /(authorization|api[_-]?key|token|password|secret|credential)/i.test(String(key || ""));
+}
+
+export const __testing__ = {
+  RECEIPT_TYPE_PASS,
+  RECEIPT_TYPE_HOLD,
+  PROOF_REQUIRED,
+  MAX_PATCH_BYTES,
+  extractChangedFilesFromPatch,
+};

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -1,0 +1,179 @@
+// scripts/pinballwake-openhands-worker.test.mjs
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildOpenHandsTaskPrompt, runOpenHandsWorker, __testing__ } from "./pinballwake-openhands-worker.mjs";
+
+const NOW = new Date("2026-05-16T15:35:00.000Z");
+
+function job(overrides = {}) {
+  return {
+    job_id: "coding-room:todo-843e669c:test",
+    todo_id: "843e669c-0ae1-4d52-b91a-23e24822d5b3",
+    title: "Autopilot Executor Lane: build_attempt/test-run receipts",
+    chip: "OpenHands worker test mode",
+    owned_files: ["docs/openhands-integration.md"],
+    ...overrides,
+  };
+}
+
+function scopePack(overrides = {}) {
+  return {
+    scope_pack_comment_id: "ecf968e0-6ba5-4d51-be48-0ddd3fae4ac3",
+    owned_files: ["docs/openhands-integration.md"],
+    acceptance: ["OpenHands adapter returns canonical receipts"],
+    verification: ["node --test scripts/pinballwake-openhands-worker.test.mjs"],
+    ...overrides,
+  };
+}
+
+function patchFor(file = "docs/openhands-integration.md") {
+  return [
+    `diff --git a/${file} b/${file}`,
+    "index 1111111..2222222 100644",
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    "@@ -1 +1,2 @@",
+    " # OpenHands Integration",
+    "+Test-mode adapter proof.",
+    "",
+  ].join("\n");
+}
+
+describe("buildOpenHandsTaskPrompt", () => {
+  test("keeps the prompt scoped to owned files and no write-side effects", () => {
+    const prompt = buildOpenHandsTaskPrompt({ job: job(), scopePack: scopePack() });
+
+    assert.match(prompt, /Return a unified diff patch only/);
+    assert.match(prompt, /docs\/openhands-integration\.md/);
+    assert.match(prompt, /node --test scripts\/pinballwake-openhands-worker\.test\.mjs/);
+  });
+});
+
+describe("runOpenHandsWorker", () => {
+  test("returns PASS when OpenHands produces a patch and coderoom accepts it", async () => {
+    let spendGuardCalls = 0;
+    let coderoomCalls = 0;
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      spendGuard: async (event, run) => {
+        spendGuardCalls += 1;
+        assert.equal(event.label, "openhands/test-mode");
+        return run();
+      },
+      openHands: async ({ prompt }) => {
+        assert.match(prompt, /OpenHands worker test mode/);
+        return {
+          ok: true,
+          patch: patchFor(),
+          summary: "Adds the test-mode integration doc line.",
+          test_run_id: "node-test-openhands-worker",
+          test_exit_code: 0,
+        };
+      },
+      coderoom: async ({ changedFiles, patch }) => {
+        coderoomCalls += 1;
+        assert.deepEqual(changedFiles, ["docs/openhands-integration.md"]);
+        assert.match(patch, /Test-mode adapter proof/);
+        return {
+          ok: true,
+          pr_url: "https://github.com/malamutemayhem/unclick/pull/873",
+          head_sha_after: "abc123def456",
+          test_run_id: "node-test-openhands-worker",
+          test_exit_code: 0,
+          status: "testing",
+        };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.receipt.receipt_type, __testing__.RECEIPT_TYPE_PASS);
+    assert.equal(result.receipt.evidence.pr_url, "https://github.com/malamutemayhem/unclick/pull/873");
+    assert.equal(result.receipt.evidence.test_run_id, "node-test-openhands-worker");
+    assert.equal(result.receipt.xpass_advisory, true);
+    assert.equal(result.receipt.sanitized, true);
+    assert.equal(spendGuardCalls, 1);
+    assert.equal(coderoomCalls, 1);
+  });
+
+  test("returns HOLD when test mode is not enabled", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      env: {},
+      openHands: async () => ({ ok: true, patch: patchFor() }),
+      now: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_test_mode_required");
+    assert.equal(result.receipt.receipt_type, __testing__.RECEIPT_TYPE_HOLD);
+  });
+
+  test("returns HOLD on OpenHands timeout", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => {
+        const err = new Error("OpenHands timed out");
+        err.code = "ETIMEDOUT";
+        throw err;
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_timeout");
+    assert.equal(result.receipt.hold_reason, "openhands_timeout");
+  });
+
+  test("returns HOLD when OpenHands reports failure", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: false, exit_code: 1, output: "tests failed" }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_reported_failure");
+    assert.equal(result.receipt.evidence.exit_code, 1);
+    assert.match(result.receipt.evidence.output, /tests failed/);
+  });
+
+  test("returns HOLD when coderoom rejects the patch", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: true, patch: patchFor("src/outside-owned.ts") }),
+      coderoom: async () => ({ ok: false, reason: "changed_file_outside_ownership", file: "src/outside-owned.ts" }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "coderoom_rejected_patch");
+    assert.equal(result.receipt.evidence.reason, "changed_file_outside_ownership");
+    assert.equal(result.receipt.evidence.file, "src/outside-owned.ts");
+  });
+
+  test("default coderoom submit enforces owned files", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: true, patch: patchFor("src/outside-owned.ts") }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "coderoom_rejected_patch");
+    assert.equal(result.receipt.evidence.reason, "changed_file_outside_ownership");
+  });
+});


### PR DESCRIPTION
## Summary
- add a test-mode-only OpenHands adapter for the Autopilot Executor Lane
- hand OpenHands-produced patches into the existing coding room ownership gate
- add focused node:test coverage plus manual-only GitHub workflow for adapter checks

## Safety
- default off unless OPENHANDS_TEST_MODE=1 or testMode is explicitly passed
- no real OpenHands CLI, secrets, production data, deploy, commit, push, merge, or auto-run path is enabled
- workflow is manual dispatch only and skips unless input openhands_test_mode is 1

## Tests
- node --test scripts/pinballwake-openhands-worker.test.mjs
- node --test scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-executor-lane.test.mjs scripts/pinballwake-coding-room.test.mjs
- git diff --check

Todo: 843e669c-0ae1-4d52-b91a-23e24822d5b3