### PR TITLE
[codex] fix queuepush duplicate wake guard

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -24,6 +24,7 @@ const runnerFreshnessGraceMinutes = parseBoundedInt(
   180,
 );
 const runnerFreshnessRunLimit = parseBoundedInt(process.env.QUEUEPUSH_RUNNER_RUN_LIMIT, 20, 5, 100);
+export const QUEUEPUSH_DUPLICATE_WAKE_WINDOW_MS = 10 * 60 * 1000;
 const agentId = "github-action-queuepush";
 const agentEmoji = "📬";
 const agentDisplayName = "QueuePush";
@@ -747,6 +748,118 @@ function messageCreatedAt(message) {
   return Number.isFinite(time) ? time : null;
 }
 
+export function extractQueuePushPacketId(text) {
+  return String(text || "").match(/\bQueuePush ID:\s*(queuepush:[^\s]+)/)?.[1] || "";
+}
+
+export function queuePushWakeStateFingerprint(packetId) {
+  const parts = String(packetId || "").split(":").filter(Boolean);
+  if (parts[0] !== "queuepush" || parts.length < 4) return "";
+  const basis =
+    parts[2]?.startsWith("pr-") && parts.length >= 5
+      ? parts.slice(2, 5).join("|")
+      : parts.slice(2, -1).join("|");
+  return createHash("sha256")
+    .update(basis || packetId)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function queuePushWakeFromPacket(packet, emittedMs = Date.now()) {
+  const id = String(packet?.packetId || "").trim();
+  const stateFingerprint = queuePushWakeStateFingerprint(id);
+  if (!id || !stateFingerprint) return null;
+  return {
+    id,
+    state_fingerprint: stateFingerprint,
+    emitted_ms: emittedMs,
+  };
+}
+
+export function recentQueuePushWakesFromMessages(messages = []) {
+  return messages
+    .map((message) => {
+      const id = extractQueuePushPacketId(message?.text);
+      const emittedMs = messageCreatedAt(message);
+      const stateFingerprint = queuePushWakeStateFingerprint(id);
+      if (!id || !stateFingerprint || !Number.isFinite(emittedMs)) return null;
+      return {
+        id,
+        state_fingerprint: stateFingerprint,
+        emitted_ms: emittedMs,
+      };
+    })
+    .filter(Boolean);
+}
+
+export function commonsensepassCheck(input = {}) {
+  if (input.claim !== "duplicate_wake") {
+    return {
+      verdict: "PASS",
+      rule_id: null,
+      reason: `Claim "${input.claim || ""}" matched no QueuePush rule; default PASS.`,
+      evidence: input.evidence ?? [],
+    };
+  }
+
+  const current = input.context?.current_wake;
+  const recent = input.context?.recent_wakes ?? [];
+  if (!current) {
+    return {
+      verdict: "HOLD",
+      rule_id: "R3",
+      reason: "duplicate_wake claim missing current_wake context.",
+      evidence: [{ kind: "context", ref: "current_wake=missing" }],
+      next_action: "include_current_wake",
+    };
+  }
+
+  const nowMs = Number(input.context?.now_ms);
+  const duplicate = recent.find(
+    (wake) =>
+      wake.id === current.id &&
+      wake.state_fingerprint === current.state_fingerprint &&
+      Number.isFinite(nowMs) &&
+      nowMs - wake.emitted_ms <= QUEUEPUSH_DUPLICATE_WAKE_WINDOW_MS,
+  );
+
+  if (duplicate) {
+    return {
+      verdict: "SUPPRESS",
+      rule_id: "R3",
+      reason: `Wake ${current.id} already emitted within 10min with matching state fingerprint.`,
+      evidence: [
+        { kind: "wake", ref: duplicate.id, note: `prior emitted_ms=${duplicate.emitted_ms}` },
+        { kind: "wake", ref: current.id, note: `now emitted_ms=${current.emitted_ms}` },
+        { kind: "fingerprint", ref: current.state_fingerprint },
+      ],
+    };
+  }
+
+  return {
+    verdict: "PASS",
+    rule_id: "R3",
+    reason: "Wake is not a duplicate of any recent wake with matching state.",
+    evidence: [{ kind: "wake", ref: current.id, note: current.state_fingerprint }],
+  };
+}
+
+export function evaluateQueuePushDuplicateWakeGuard(
+  packet,
+  fishbowlMessages = [],
+  { now = Date.now(), commonsensepassCheckFn = commonsensepassCheck } = {},
+) {
+  const currentWake = queuePushWakeFromPacket(packet, now);
+  return commonsensepassCheckFn({
+    claim: "duplicate_wake",
+    context: {
+      now_ms: now,
+      current_wake: currentWake,
+      recent_wakes: recentQueuePushWakesFromMessages(fishbowlMessages),
+    },
+  });
+}
+
 export function filterDuplicatePackets(
   packets,
   fishbowlMessages = [],
@@ -754,6 +867,8 @@ export function filterDuplicatePackets(
 ) {
   const retryMs = retryAfterMinutes * 60 * 1000;
   return packets.filter((packet) => {
+    const guard = evaluateQueuePushDuplicateWakeGuard(packet, fishbowlMessages, { now });
+    if (guard.verdict === "SUPPRESS" || guard.verdict === "HOLD") return false;
     const matches = fishbowlMessages.filter((message) => String(message.text || "").includes(packet.packetId));
     if (matches.length === 0) return true;
     const newest = Math.max(...matches.map((message) => messageCreatedAt(message) ?? now));

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -7,10 +7,13 @@ import {
   checksAreGreen,
   chooseQueuePushRunner,
   evaluateRunnerFreshnessWatchdog,
+  evaluateQueuePushDuplicateWakeGuard,
   classifyPullRequest,
+  extractQueuePushPacketId,
   filterDuplicatePackets,
   jobKindForState,
   latestCommentSignals,
+  queuePushWakeFromPacket,
   resolveQueuePushRunnerRoster,
   routeWorkerForPr,
   runnerCanAcceptQueuePushJob,
@@ -745,6 +748,62 @@ describe("QueuePush routing and packets", () => {
 
     const remaining = filterDuplicatePackets([packet], messages, { now, retryAfterMinutes: 180 });
     assert.deepEqual(remaining, []);
+  });
+
+  it("runs CommonSensePass duplicate wake guard before keeping a packet", () => {
+    const packet = buildQueuePacket({
+      pr: pr({ number: 873, draft: false, title: "feat(autopilot): add OpenHands test-mode adapter" }),
+      state: "ready_for_qc",
+      reason: "Non-draft PR is green, clean, and has proof.",
+      files: [{ filename: "scripts/pinballwake-openhands-worker.mjs" }],
+    });
+    const now = Date.parse("2026-05-16T16:20:00Z");
+    const messages = [
+      {
+        text: packet.text,
+        created_at: "2026-05-16T16:14:31Z",
+      },
+    ];
+
+    const guard = evaluateQueuePushDuplicateWakeGuard(packet, messages, { now });
+    const remaining = filterDuplicatePackets([packet], messages, { now, retryAfterMinutes: 180 });
+
+    assert.equal(guard.verdict, "SUPPRESS");
+    assert.equal(guard.rule_id, "R3");
+    assert.deepEqual(remaining, []);
+  });
+
+  it("does not suppress a changed QueuePush state with the duplicate wake guard", () => {
+    const oldPacket = buildQueuePacket({
+      pr: pr({ number: 873, draft: true, title: "feat(autopilot): add OpenHands test-mode adapter" }),
+      state: "missing_review_safety_ack",
+      reason: "Draft PR is green and clean with proof; Reviewer/Safety PASS is missing.",
+      files: [{ filename: "scripts/pinballwake-openhands-worker.mjs" }],
+    });
+    const newPacket = buildQueuePacket({
+      pr: pr({ number: 873, draft: false, title: "feat(autopilot): add OpenHands test-mode adapter" }),
+      state: "ready_for_qc",
+      reason: "Non-draft PR is green, clean, and has proof.",
+      files: [{ filename: "scripts/pinballwake-openhands-worker.mjs" }],
+    });
+    const now = Date.parse("2026-05-16T16:20:00Z");
+    const guard = evaluateQueuePushDuplicateWakeGuard(
+      newPacket,
+      [{ text: oldPacket.text, created_at: "2026-05-16T16:14:31Z" }],
+      { now },
+    );
+
+    assert.equal(extractQueuePushPacketId(oldPacket.text), oldPacket.packetId);
+    assert.notDeepEqual(queuePushWakeFromPacket(oldPacket, now), queuePushWakeFromPacket(newPacket, now));
+    assert.equal(guard.verdict, "PASS");
+  });
+
+  it("holds instead of posting when duplicate wake context cannot be built", () => {
+    const now = Date.parse("2026-05-16T16:20:00Z");
+    const guard = evaluateQueuePushDuplicateWakeGuard({ packetId: "" }, [], { now });
+
+    assert.equal(guard.verdict, "HOLD");
+    assert.deepEqual(filterDuplicatePackets([{ packetId: "" }], [], { now }), []);
   });
 
   it("prioritizes missing final QC before routine owner lift", async () => {


### PR DESCRIPTION
## What changed

- Adds a QueuePush duplicate-wake guard before posting packets.
- Builds `current_wake` and `recent_wakes` from the packet and recent Boardroom messages.
- Suppresses matching duplicate wakes inside the 10 minute CommonSensePass R3 window.
- Holds instead of posting if the wake context cannot be built.

## Why

Todo `4a549810-028e-4579-8483-5df2f8b61a09` said the CommonSensePass R3 library existed, but QueuePush still needed to call the duplicate-wake check before forwarding a wake. This reduces repeated PR wake noise like the stale PR #873 loop.

## Validation

- `node --test scripts\fleet-throughput-watch.test.mjs`, 62/62 passed
- `git diff --check`, passed