### PR TITLE
[codex] repair autoclose for pipeline ship proof

### DIFF
--- a/scripts/fishbowl-todo-reconciliation.mjs
+++ b/scripts/fishbowl-todo-reconciliation.mjs
@@ -58,6 +58,12 @@ function todoText(todo = {}) {
     todo.description,
     todo.pipeline_evidence,
     todo.pipelineEvidence,
+    todo.comments,
+    todo.comment_text,
+    todo.commentText,
+    todo.proof,
+    todo.proof_text,
+    todo.proofText,
   ).join("\n");
 }
 
@@ -143,6 +149,43 @@ function findWakePassCompletionProof(prNumber, receipts = []) {
     return {
       receipt_id: firstKnown(receipt.id, receipt.source_id, receipt.message_id),
       receipt_text: text.replace(/\s+/g, " ").trim().slice(0, 220),
+    };
+  }
+
+  return null;
+}
+
+function todoHasShipReceipt(todo = {}) {
+  const source = String(todo.pipeline_source ?? todo.pipelineSource ?? "").toLowerCase();
+  const evidence = normalizedTags({ tags: todo.pipeline_evidence ?? todo.pipelineEvidence ?? [] });
+  const progress = Number(todo.pipeline_progress ?? todo.pipelineProgress ?? 0);
+  const stageCount = Number(todo.pipeline_stage_count ?? todo.pipelineStageCount ?? 0);
+  return (
+    source.includes("receipt: ship") ||
+    evidence.includes("ship") ||
+    progress >= 100 ||
+    stageCount >= 5
+  );
+}
+
+function findMergedPrProofForTodo(todo, pullRequests, nowMs, mergedWindowDays) {
+  if (!todoHasShipReceipt(todo)) return null;
+  const mentionedPrs = extractPullRequestNumbers(todoText(todo));
+  if (mentionedPrs.length === 0) return null;
+
+  for (const pr of pullRequests) {
+    const number = Number(pr?.number ?? pr?.pr_number);
+    if (!mentionedPrs.includes(number)) continue;
+
+    const mergedAt = pr?.merged_at ?? pr?.mergedAt;
+    const mergedMs = parseTime(mergedAt);
+    if (mergedMs === null) continue;
+    if (daysBetween(nowMs, mergedMs) > mergedWindowDays) continue;
+
+    return {
+      number,
+      url: pr.url ?? pr.html_url ?? null,
+      merged_at: new Date(mergedMs).toISOString(),
     };
   }
 
@@ -242,6 +285,18 @@ export function buildInProgressReconciliationPlan({
         todo_id: todo.id,
         title: todo.title ?? "",
         pr: matchingPrs[0],
+        reason: "linked_pr_marker",
+      });
+      continue;
+    }
+
+    const proofPr = findMergedPrProofForTodo(todo, pullRequests, nowMs, mergedWindowDays);
+    if (proofPr) {
+      autoClose.push({
+        todo_id: todo.id,
+        title: todo.title ?? "",
+        pr: proofPr,
+        reason: "pipeline_ship_proof",
       });
       continue;
     }

--- a/scripts/fishbowl-todo-reconciliation.test.mjs
+++ b/scripts/fishbowl-todo-reconciliation.test.mjs
@@ -73,7 +73,61 @@ describe("fishbowl todo reconciliation helpers", () => {
 
     assert.equal(plan.ok, true);
     assert.deepEqual(plan.auto_close.map((item) => item.todo_id), [TODO_A]);
+    assert.equal(plan.auto_close[0].reason, "linked_pr_marker");
     assert.deepEqual(plan.unchanged.map((item) => item.todo_id), [TODO_B]);
+  });
+
+  it("plans auto-close when an in-progress todo has pipeline ship proof for a merged PR", () => {
+    const plan = buildInProgressReconciliationPlan({
+      now: "2026-05-08T12:00:00.000Z",
+      todos: [
+        {
+          id: TODO_A,
+          title: "proof-complete work",
+          status: "in_progress",
+          completed_at: null,
+          updated_at: "2026-05-08T08:00:00.000Z",
+          pipeline_progress: 100,
+          pipeline_source: "receipt: ship",
+          comments: ["SHIP proof: PR #874 merged to main."],
+        },
+      ],
+      pullRequests: [
+        {
+          number: 874,
+          merged_at: "2026-05-08T10:00:00.000Z",
+          body: "No explicit todo marker in this PR.",
+        },
+      ],
+    });
+
+    assert.equal(plan.ok, true);
+    assert.deepEqual(plan.auto_close.map((item) => item.todo_id), [TODO_A]);
+    assert.equal(plan.auto_close[0].reason, "pipeline_ship_proof");
+    assert.equal(plan.auto_close[0].pr.number, 874);
+  });
+
+  it("does not auto-close pipeline ship proof when the referenced PR is unmerged", () => {
+    const plan = buildInProgressReconciliationPlan({
+      now: "2026-05-08T12:00:00.000Z",
+      todos: [
+        {
+          id: TODO_A,
+          title: "proof-complete work",
+          status: "in_progress",
+          completed_at: null,
+          updated_at: "2026-05-08T08:00:00.000Z",
+          pipeline_progress: 100,
+          pipeline_source: "receipt: ship",
+          proof_text: "SHIP proof pending on PR #874.",
+        },
+      ],
+      pullRequests: [{ number: 874, merged_at: null }],
+    });
+
+    assert.equal(plan.ok, true);
+    assert.equal(plan.auto_close.length, 0);
+    assert.deepEqual(plan.unchanged.map((item) => item.todo_id), [TODO_A]);
   });
 
   it("surfaces old in-progress todos without marking them done", () => {


### PR DESCRIPTION
## What changed

- Teaches the Fishbowl todo reconciliation plan to recognize in-progress Jobs that already have pipeline ship proof.
- Allows auto-close planning when a Job has `receipt: ship`, 100 percent progress, or ship evidence and references a PR that is actually merged.
- Keeps unmerged PR references out of auto-close.

## Why

Some Jobs can reach 100 percent with SHIP proof on the Job itself even when the PR body did not carry the canonical `Closes UnClick todo` marker. This helps the cleanup lane move finished work instead of leaving proof-complete active Jobs stuck.

Closes UnClick todo: 7307aac2-fa8a-45ff-bc2c-7133034c03aa

## Validation

- `node --test scripts\fishbowl-todo-reconciliation.test.mjs`, 14/14 passed
- `git diff --check`, passed