### PR TITLE
[codex] compact orchestrator context reads

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -145,6 +145,9 @@ export interface OrchestratorOperatorTimeContext {
 export interface BuildOrchestratorContextInput {
   generatedAt: string;
   continuityLimit?: number;
+  compact?: boolean;
+  maxSummaries?: number;
+  includeRaw?: boolean;
   profiles: OrchestratorProfileRow[];
   messages: OrchestratorMessageRow[];
   todos: OrchestratorTodoRow[];
@@ -293,6 +296,20 @@ export interface OrchestratorContext {
   library_snapshots: OrchestratorLibrarySnapshot[];
   rolling_snapshot: OrchestratorRollingSnapshot;
   seat_handshake: OrchestratorSeatHandshake;
+  response_bounds: {
+    compact: boolean;
+    max_summaries: number;
+    include_raw: boolean;
+    continuity_events_returned: number;
+    continuity_events_available: number;
+    continuity_events_truncated: boolean;
+    profile_cards_returned: number;
+    profile_cards_available: number;
+    profile_cards_truncated: boolean;
+    library_snapshots_returned: number;
+    library_snapshots_available: number;
+    library_snapshots_truncated: boolean;
+  };
 }
 
 const ACTIVE_WINDOW_MS = 30 * 60 * 1000;
@@ -367,11 +384,14 @@ function compactContinuityText(input: unknown, maxChars = 240, options: { heartb
 
 export function buildOrchestratorContext(input: BuildOrchestratorContextInput): OrchestratorContext {
   const nowMs = Date.parse(input.generatedAt);
-  const continuityLimit = Math.min(Math.max(Number(input.continuityLimit ?? 36) || 36, 20), 500);
-  const profiles = input.profiles
+  const compact = input.compact !== false;
+  const maxSummaries = normalizeSummaryLimit(input.maxSummaries ?? input.continuityLimit ?? (compact ? 20 : 36));
+  const continuityLimit = compact ? maxSummaries : Math.min(Math.max(Number(input.continuityLimit ?? 36) || 36, 20), 500);
+  const allProfiles = input.profiles
     .map((profile) => buildProfileCard(profile, nowMs))
     .sort((a, b) => compareIsoDesc(a.last_seen_at, b.last_seen_at));
-  const activeSeatCount = profiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
+  const profiles = compact ? allProfiles.slice(0, maxSummaries) : allProfiles;
+  const activeSeatCount = allProfiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
   const humanOperatorTime = buildOperatorTimeContext(input.businessContext, input.generatedAt);
 
   const activeTodos = input.todos
@@ -410,7 +430,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   const conversationEvents = input.conversationTurns.map(conversationTurnToEvent);
   const sessionEvents = input.sessions.map(sessionToEvent);
 
-  const continuityEvents = [
+  const allContinuityEvents = [
     ...messageEvents,
     ...todoEvents,
     ...commentEvents,
@@ -420,8 +440,10 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     ...sessionEvents,
   ]
     .filter((event) => event.summary.length > 0)
-    .sort((a, b) => compareIsoDesc(a.created_at, b.created_at))
-    .slice(0, continuityLimit);
+    .sort((a, b) => compareIsoDesc(a.created_at, b.created_at));
+  const continuityEvents = allContinuityEvents
+    .slice(0, continuityLimit)
+    .map((event) => (compact ? compactContinuityEvent(event) : event));
 
   const blockers = continuityEvents
     .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs))
@@ -435,13 +457,19 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     })
     .slice(0, 6);
 
-  const librarySnapshots = [
+  const allLibrarySnapshots = [
     ...input.library.map(libraryToSnapshot),
     ...input.businessContext.map(businessContextToSnapshot),
     ...input.sessions.map(sessionToSnapshot),
   ]
-    .sort((a, b) => compareIsoDesc(a.updated_at ?? a.created_at, b.updated_at ?? b.created_at))
-    .slice(0, 24);
+    .sort((a, b) => compareIsoDesc(a.updated_at ?? a.created_at, b.updated_at ?? b.created_at));
+  const librarySnapshots = allLibrarySnapshots
+    .slice(0, compact ? maxSummaries : 24)
+    .map((snapshot) =>
+      compact && snapshot.summary
+        ? { ...snapshot, summary: compactText(snapshot.summary, 120) }
+        : snapshot,
+    );
 
   const newestActivityAt = newestIso([
     ...input.messages.map((row) => row.created_at),
@@ -510,6 +538,33 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     library_snapshots: librarySnapshots,
     rolling_snapshot: rollingSnapshot,
     seat_handshake: seatHandshake,
+    response_bounds: {
+      compact,
+      max_summaries: maxSummaries,
+      include_raw: input.includeRaw === true,
+      continuity_events_returned: continuityEvents.length,
+      continuity_events_available: allContinuityEvents.length,
+      continuity_events_truncated: allContinuityEvents.length > continuityEvents.length,
+      profile_cards_returned: profiles.length,
+      profile_cards_available: allProfiles.length,
+      profile_cards_truncated: allProfiles.length > profiles.length,
+      library_snapshots_returned: librarySnapshots.length,
+      library_snapshots_available: allLibrarySnapshots.length,
+      library_snapshots_truncated: allLibrarySnapshots.length > librarySnapshots.length,
+    },
+  };
+}
+
+function normalizeSummaryLimit(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 20;
+  return Math.min(Math.max(Math.floor(numeric), 1), 500);
+}
+
+function compactContinuityEvent(event: OrchestratorContinuityEvent): OrchestratorContinuityEvent {
+  return {
+    ...event,
+    summary: compactText(event.summary, 120),
   };
 }
 

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -8039,7 +8039,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           });
         }
 
-        const body = (req.body ?? {}) as { limit?: number; q?: string };
+        const body = (req.body ?? {}) as {
+          compact?: boolean | string;
+          include_raw?: boolean | string;
+          includeRaw?: boolean | string;
+          limit?: number;
+          max_summaries?: number;
+          maxSummaries?: number;
+          q?: string;
+        };
+        const parseBooleanParam = (value: unknown, fallback: boolean): boolean => {
+          if (typeof value === "boolean") return value;
+          if (typeof value === "string") {
+            const clean = value.trim().toLowerCase();
+            if (clean === "true") return true;
+            if (clean === "false") return false;
+          }
+          return fallback;
+        };
         const rawSearch =
           typeof body.q === "string"
             ? body.q
@@ -8047,6 +8064,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               ? req.query.q
               : "";
         const searchQuery = rawSearch.replace(/\s+/g, " ").trim().slice(0, 100);
+        const compact = parseBooleanParam(body.compact ?? req.query.compact, true);
+        const includeRaw = parseBooleanParam(body.include_raw ?? body.includeRaw ?? req.query.include_raw ?? req.query.includeRaw, false);
+        const rawMaxSummaries = body.max_summaries ?? body.maxSummaries ?? req.query.max_summaries ?? req.query.maxSummaries;
+        const requestedMaxSummaries = Number(rawMaxSummaries ?? (compact ? 20 : 36));
+        const maxSummaries = Math.min(
+          Math.max(Number.isFinite(requestedMaxSummaries) ? Math.floor(requestedMaxSummaries) : compact ? 20 : 36, 1),
+          500,
+        );
         const searchPattern = searchQuery ? `%${searchQuery.replace(/[%_\\]/g, "\\$&")}%` : "";
         const searchUuid = searchQuery.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i)?.[0] ?? null;
         const turnSearchFilter = searchPattern
@@ -8056,7 +8081,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               ...(searchUuid ? [`id.eq.${searchUuid}`] : []),
             ].join(",")
           : "";
-        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? 80) || 80, 20), 500);
+        const defaultLimit = compact ? Math.max(maxSummaries, 20) : 80;
+        const limit = Math.min(Math.max(Number(body.limit ?? req.query.limit ?? defaultLimit) || defaultLimit, 20), 500);
         const smallerLimit = searchQuery ? limit : Math.min(limit, 300);
         const todoSelect =
           "id, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, source_idea_id, created_at, updated_at, completed_at";
@@ -8225,6 +8251,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           context: buildOrchestratorContext({
             generatedAt: new Date().toISOString(),
             continuityLimit: limit,
+            compact,
+            maxSummaries,
+            includeRaw,
             profiles: (profilesResult.data ?? []) as OrchestratorProfileRow[],
             messages: (messagesResult.data ?? []) as OrchestratorMessageRow[],
             todos,

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -1323,4 +1323,78 @@ describe("computeActiveJobsCount (v9 definition)", () => {
       "Active job from canonical in_progress slice",
     );
   });
+
+  it("defaults Orchestrator reads to compact capped summaries", () => {
+    const messages = Array.from({ length: 25 }, (_, index) => ({
+      id: `msg-${index}`,
+      author_agent_id: "builder",
+      text: `PASS: message ${index} ${"long proof text ".repeat(20)}`,
+      tags: ["proof"],
+      created_at: new Date(Date.parse("2026-05-14T00:00:00.000Z") + index * 1000).toISOString(),
+    }));
+    const profiles = Array.from({ length: 25 }, (_, index) => ({
+      agent_id: `seat-${index}`,
+      last_seen_at: new Date(Date.parse("2026-05-14T00:00:00.000Z") + index * 1000).toISOString(),
+    }));
+    const businessContext = Array.from({ length: 25 }, (_, index) => ({
+      id: `context-${index}`,
+      category: "preference",
+      key: `pref-${index}`,
+      value: "source detail ".repeat(20),
+      priority: index,
+      updated_at: new Date(Date.parse("2026-05-14T00:00:00.000Z") + index * 1000).toISOString(),
+    }));
+
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-14T01:00:00.000Z",
+      profiles,
+      messages,
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext,
+      conversationTurns: [],
+    });
+
+    expect(context.response_bounds.compact).toBe(true);
+    expect(context.response_bounds.max_summaries).toBe(20);
+    expect(context.continuity_events).toHaveLength(20);
+    expect(context.profile_cards).toHaveLength(20);
+    expect(context.library_snapshots).toHaveLength(20);
+    expect(context.response_bounds.continuity_events_truncated).toBe(true);
+    expect(context.continuity_events.every((event) => event.summary.length <= 120)).toBe(true);
+    expect(JSON.stringify(context)).not.toContain("raw_payload");
+  });
+
+  it("honors smaller compact max summaries while preserving source pointers", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-14T01:00:00.000Z",
+      maxSummaries: 5,
+      profiles: [],
+      messages: Array.from({ length: 8 }, (_, index) => ({
+        id: `msg-${index}`,
+        author_agent_id: "builder",
+        text: `Status ${index}`,
+        tags: ["fyi"],
+        created_at: new Date(Date.parse("2026-05-14T00:00:00.000Z") + index * 1000).toISOString(),
+      })),
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.continuity_events).toHaveLength(5);
+    expect(context.response_bounds.max_summaries).toBe(5);
+    expect(context.response_bounds.continuity_events_available).toBe(8);
+    expect(context.response_bounds.continuity_events_truncated).toBe(true);
+    expect(context.rolling_snapshot.source_pointers.every((pointer) => pointer.source_id)).toBe(true);
+  });
 });

--- a/packages/channel-plugin/orchestrator-turns.js
+++ b/packages/channel-plugin/orchestrator-turns.js
@@ -72,8 +72,25 @@ export const orchestratorContextReadTool = {
         type: "number",
         minimum: 20,
         maximum: 200,
-        default: 80,
+        default: 20,
         description: "Maximum events to read.",
+      },
+      compact: {
+        type: "boolean",
+        default: true,
+        description: "Return compact source summaries by default.",
+      },
+      max_summaries: {
+        type: "number",
+        minimum: 1,
+        maximum: 200,
+        default: 20,
+        description: "Maximum compact summaries to return when compact mode is on.",
+      },
+      include_raw: {
+        type: "boolean",
+        default: false,
+        description: "Include raw fields when explicitly needed.",
       },
     },
   },
@@ -142,10 +159,25 @@ export async function saveConversationTurn(apiFetch, args) {
 
 export function buildOrchestratorContextReadQuery(args = {}) {
   const q = String(args?.q ?? "").replace(/\s+/g, " ").trim().slice(0, 100);
-  const requestedLimit = Number(args?.limit ?? 80);
+  const compact = args?.compact !== false;
+  const includeRaw = args?.include_raw === true;
+  const requestedMaxSummaries = Number(args?.max_summaries ?? 20);
+  const maxSummaries = Math.min(
+    Math.max(Number.isFinite(requestedMaxSummaries) ? Math.floor(requestedMaxSummaries) : 20, 1),
+    200
+  );
+  const requestedLimit = Number(args?.limit ?? Math.max(maxSummaries, 20));
   const maxLimit = q ? 200 : 120;
-  const limit = Math.min(Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 80, 20), maxLimit);
-  const query = { limit };
+  const limit = Math.min(
+    Math.max(Number.isFinite(requestedLimit) ? requestedLimit : Math.max(maxSummaries, 20), 20),
+    maxLimit
+  );
+  const query = {
+    limit,
+    compact,
+    max_summaries: maxSummaries,
+    include_raw: includeRaw,
+  };
   if (q) query.q = q;
   return query;
 }

--- a/packages/channel-plugin/orchestrator-turns.test.js
+++ b/packages/channel-plugin/orchestrator-turns.test.js
@@ -124,9 +124,20 @@ test("saveConversationTurn calls the existing admin ingest endpoint", async () =
 test("buildOrchestratorContextReadQuery normalizes search and clamps limits", () => {
   assert.deepEqual(
     buildOrchestratorContextReadQuery({ q: "  proof   check  ", limit: 500 }),
-    { limit: 200, q: "proof check" }
+    { limit: 200, compact: true, max_summaries: 20, include_raw: false, q: "proof check" }
   );
-  assert.deepEqual(buildOrchestratorContextReadQuery({ limit: 1 }), { limit: 20 });
+  assert.deepEqual(buildOrchestratorContextReadQuery({ limit: 1 }), {
+    limit: 20,
+    compact: true,
+    max_summaries: 20,
+    include_raw: false,
+  });
+  assert.deepEqual(buildOrchestratorContextReadQuery({ max_summaries: 5 }), {
+    limit: 20,
+    compact: true,
+    max_summaries: 5,
+    include_raw: false,
+  });
 });
 
 test("readOrchestratorContext calls the read-only context endpoint", async () => {
@@ -147,6 +158,9 @@ test("readOrchestratorContext calls the read-only context endpoint", async () =>
         method: "GET",
         query: {
           limit: 40,
+          compact: true,
+          max_summaries: 20,
+          include_raw: false,
           q: "status",
         },
       },

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -494,8 +494,25 @@ export const VISIBLE_TOOLS = [
           type: "number",
           minimum: 20,
           maximum: 200,
-          default: 80,
+          default: 20,
           description: "Maximum events to read.",
+        },
+        compact: {
+          type: "boolean",
+          default: true,
+          description: "Return compact source summaries by default.",
+        },
+        max_summaries: {
+          type: "number",
+          minimum: 1,
+          maximum: 200,
+          default: 20,
+          description: "Maximum compact summaries to return when compact mode is on.",
+        },
+        include_raw: {
+          type: "boolean",
+          default: false,
+          description: "Include raw fields when explicitly needed.",
         },
       },
     },
@@ -1613,14 +1630,24 @@ export function createServer(): Server {
           typeof args.q === "string"
             ? args.q.replace(/\s+/g, " ").trim().slice(0, 100)
             : "";
-        const requestedLimit = Number(args.limit ?? 80);
+        const compact = args.compact !== false;
+        const includeRaw = args.include_raw === true;
+        const requestedMaxSummaries = Number(args.max_summaries ?? 20);
+        const maxSummaries = Math.min(
+          Math.max(Number.isFinite(requestedMaxSummaries) ? Math.floor(requestedMaxSummaries) : 20, 1),
+          200
+        );
+        const requestedLimit = Number(args.limit ?? Math.max(maxSummaries, 20));
         const limit = Math.min(
-          Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 80, 20),
+          Math.max(Number.isFinite(requestedLimit) ? requestedLimit : Math.max(maxSummaries, 20), 20),
           q ? 200 : 120
         );
         const url = new URL(`${base.replace(/\/$/, "")}/api/memory-admin`);
         url.searchParams.set("action", "orchestrator_context_read");
         url.searchParams.set("limit", String(limit));
+        url.searchParams.set("compact", String(compact));
+        url.searchParams.set("max_summaries", String(maxSummaries));
+        url.searchParams.set("include_raw", String(includeRaw));
         if (q) url.searchParams.set("q", q);
         const resp = await fetch(url, {
           method: "GET",


### PR DESCRIPTION
Closes UnClick todo: 6697bac4-5e01-49e4-863d-e188e7f9587c

## Summary
- default Orchestrator context reads to compact mode with a 20-summary cap
- add response bounds metadata for returned, available, and truncated context sections
- expose compact, max_summaries, and include_raw through the MCP and channel-plugin read tools

## Verification
- PASS: node --test packages/channel-plugin/orchestrator-turns.test.js
- PASS: node --check packages/channel-plugin/orchestrator-turns.js
- PASS: npm exec --yes --package typescript@6.0.3 -- tsc --ignoreConfig --noEmit --allowJs --checkJs false --module NodeNext --moduleResolution NodeNext --target ES2022 packages\channel-plugin\orchestrator-turns.js
- PASS: npm exec --yes --package typescript@6.0.3 -- tsc --ignoreConfig --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck api\lib\orchestrator-context.ts
- PASS: git diff --check

## Blocked local checks
- `npx vitest run api/orchestrator-context.test.ts api/orchestrator-context-health-verdict.test.ts` could not start because this checkout is missing local Vitest/Vite dev dependencies.
- `npm run test --workspace=packages/mcp-server -- --run src/__tests__/orchestrator-tether-contract.test.ts src/__tests__/tool-schema-validation.test.ts` could not start because `tsx` is not installed in this checkout.

No production data, secrets, auth, billing, DNS, deploy, or destructive operations were touched.