### PR TITLE
[codex] centralize TestPass API imports

### DIFF
--- a/api/lib/testpass-boundary.ts
+++ b/api/lib/testpass-boundary.ts
@@ -1,0 +1,21 @@
+// API-facing TestPass boundary. Keep Vercel entrypoints off package internals
+// while preserving the existing source-backed runtime until TestPass ships dist.
+export { probeServer } from "../../packages/testpass/src/probe.js";
+export {
+  computeVerdictSummary,
+  createEvidence,
+  createRun,
+  seedPendingItems,
+  updateRunStatus,
+} from "../../packages/testpass/src/run-manager.js";
+export {
+  generateHtmlReport,
+  generateJsonReport,
+  generateMarkdownFixList,
+} from "../../packages/testpass/src/reporter.js";
+export { runDeterministicChecks } from "../../packages/testpass/src/runner/deterministic.js";
+export { runAgentChecks } from "../../packages/testpass/src/runner/agent.js";
+export { runMultiPass } from "../../packages/testpass/src/runner/controller.js";
+export { healFailedChecks } from "../../packages/testpass/src/runner/healer.js";
+export { loadPackFromFile, loadPackFromYaml, packToJsonb } from "../../packages/testpass/src/pack-loader.js";
+export type { RunProfile, RunTarget } from "../../packages/testpass/src/types.js";

--- a/api/testpass-run.ts
+++ b/api/testpass-run.ts
@@ -13,22 +13,22 @@
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { probeServer } from "../packages/testpass/src/probe.js";
 import {
-  createRun,
+  computeVerdictSummary,
   createEvidence,
+  createRun,
+  loadPackFromFile,
+  probeServer,
+  runAgentChecks,
+  runDeterministicChecks,
   seedPendingItems,
   updateRunStatus,
-  computeVerdictSummary,
-} from "../packages/testpass/src/run-manager.js";
-import { runDeterministicChecks } from "../packages/testpass/src/runner/deterministic.js";
-import { runAgentChecks } from "../packages/testpass/src/runner/agent.js";
-import { loadPackFromFile } from "../packages/testpass/src/pack-loader.js";
+} from "./lib/testpass-boundary.js";
 import { emitSignal } from "../packages/mcp-server/src/signals/emit.js";
 import * as path from "node:path";
 import * as url from "node:url";
 import { createHash } from "node:crypto";
-import type { RunProfile, RunTarget } from "../packages/testpass/src/types.js";
+import type { RunProfile, RunTarget } from "./lib/testpass-boundary.js";
 import {
   buildTestPassBackgroundFailureDispatchRow,
   DEFAULT_TESTPASS_BACKGROUND_HANDOFF_AGENT_ID,

--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -28,27 +28,27 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import * as crypto from "node:crypto";
-import { probeServer } from "../packages/testpass/src/probe.js";
 import {
-  createRun,
-  createEvidence,
-  seedPendingItems,
-  updateRunStatus,
   computeVerdictSummary,
-} from "../packages/testpass/src/run-manager.js";
-import {
+  createEvidence,
+  createRun,
   generateHtmlReport,
   generateJsonReport,
   generateMarkdownFixList,
-} from "../packages/testpass/src/reporter.js";
-import { runDeterministicChecks } from "../packages/testpass/src/runner/deterministic.js";
-import { runAgentChecks } from "../packages/testpass/src/runner/agent.js";
-import { runMultiPass } from "../packages/testpass/src/runner/controller.js";
-import { healFailedChecks } from "../packages/testpass/src/runner/healer.js";
-import { loadPackFromFile, loadPackFromYaml, packToJsonb } from "../packages/testpass/src/pack-loader.js";
+  healFailedChecks,
+  loadPackFromFile,
+  loadPackFromYaml,
+  packToJsonb,
+  probeServer,
+  runAgentChecks,
+  runDeterministicChecks,
+  runMultiPass,
+  seedPendingItems,
+  updateRunStatus,
+} from "./lib/testpass-boundary.js";
 import * as path from "node:path";
 import * as url from "node:url";
-import type { RunTarget, RunProfile } from "../packages/testpass/src/types.js";
+import type { RunTarget, RunProfile } from "./lib/testpass-boundary.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
Summary: Route api/testpass.ts and api/testpass-run.ts through a small API-facing TestPass boundary module so the entrypoints no longer import packages/testpass/src directly. Proof: npm exec -- tsc --ignoreConfig --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types node --skipLibCheck api/testpass.ts api/testpass-run.ts api/lib/testpass-boundary.ts; rg confirmed no packages/testpass/src imports remain in the two API entrypoints. Job: c41bd36f-7579-43c0-9d24-134061fc152a.