### PR TITLE
Add Memory receipt redaction state

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
@@ -48,9 +48,10 @@ describe("strict-client memory response bounds", () => {
     assert.ok(text.length < 8000, `payload was ${text.length} chars`);
     assert.equal((compact as { recent_sessions: unknown[] }).recent_sessions.length, 0);
 
-    const profileCard = (compact as { profile_card: { source_receipts: unknown[] } }).profile_card;
+    const profileCard = (compact as { profile_card: { source_receipts: Array<{ redaction_state?: string }> } }).profile_card;
     assert.ok(profileCard);
     assert.ok(profileCard.source_receipts.length > 0);
+    assert.ok(profileCard.source_receipts.every((receipt) => receipt.redaction_state === "clean"));
     assert.equal(JSON.stringify(profileCard).includes(long("summary", 1000)), false);
   });
 
@@ -132,7 +133,7 @@ describe("strict-client memory response bounds", () => {
         timezone_context?: string;
         working_now: string[];
         do_not_repeat: string[];
-        source_receipts: Array<{ memory_id: string; source_kind: string }>;
+        source_receipts: Array<{ memory_id: string; source_kind: string; redaction_state?: string }>;
       };
     };
 
@@ -147,6 +148,7 @@ describe("strict-client memory response bounds", () => {
     assert.doesNotMatch(profileText, /api key token/);
     assert.doesNotMatch(profileText, /Session body should stay hidden/);
     assert.ok(profileCard.source_receipts.some((receipt) => receipt.memory_id === "fact:fact-live"));
+    assert.ok(profileCard.source_receipts.every((receipt) => receipt.redaction_state === "clean"));
     assert.equal(profileCard.source_receipts.some((receipt) => receipt.memory_id === "fact:fact-stale"), false);
     assert.equal(profileCard.source_receipts.some((receipt) => receipt.source_kind === "session_summary"), false);
   });

--- a/packages/mcp-server/src/memory/__tests__/snapshot-taxonomy.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/snapshot-taxonomy.test.ts
@@ -27,6 +27,16 @@ describe("memory taxonomy snapshots", () => {
       "04 Preferences & Taste",
     ]);
     assert.deepEqual(snapshot.source_ids, ["fact-1"]);
+    assert.deepEqual(snapshot.source_receipts, [
+      {
+        memory_id: "fact:fact-1",
+        source_kind: "fact",
+        source_uri: "/admin/memory?tab=facts",
+        confidence: 0.93,
+        redaction_state: "clean",
+        last_verified_at: "2026-05-10T10:00:00.000Z",
+      },
+    ]);
     assert.ok(snapshot.content.includes("Sources: fact:fact-1"));
   });
 
@@ -95,6 +105,7 @@ describe("memory taxonomy snapshots", () => {
     assert.equal(doc.slug, "memory-taxonomy-15-data-and-memory");
     assert.ok(doc.tags.includes("memory-taxonomy-snapshot"));
     assert.ok(doc.content.includes("Source pointers: fact:fact-memory"));
+    assert.ok(doc.content.includes("Source receipt states: fact:fact-memory clean"));
   });
 
   test("writer supports dry runs and live upserts", async () => {
@@ -120,6 +131,7 @@ describe("memory taxonomy snapshots", () => {
     assert.equal(dryRun.dry_run, true);
     assert.equal(dryRun.snapshot_count, 1);
     assert.equal(dryRun.written_count, 0);
+    assert.ok(dryRun.snapshots[0].source_receipts.every((receipt) => receipt.redaction_state === "clean"));
 
     const writtenDocs: string[] = [];
     const live = await writeMemoryTaxonomySnapshotsToLibrary({
@@ -133,6 +145,7 @@ describe("memory taxonomy snapshots", () => {
 
     assert.equal(live.dry_run, false);
     assert.equal(live.written_count, 1);
+    assert.ok(live.snapshots[0].source_receipts.every((receipt) => receipt.source_uri.startsWith("/admin/memory")));
     assert.deepEqual(writtenDocs, [live.written[0].slug]);
   });
 });

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -19,6 +19,7 @@ import type {
   MemoryProfileCard,
   MemoryProfileCardReceipt,
   MemoryProfileCardSourceKind,
+  MemoryReceiptRedactionState,
 } from "./types.js";
 
 function currentApiKeyHash(): string | null {
@@ -140,6 +141,12 @@ const PROFILE_CARD_SOURCE_PATHS: Record<MemoryProfileCardSourceKind, string> = {
 const SENSITIVE_MEMORY_PATTERN = /\b(secret|token|password|credential|private key|api[_ -]?key|plaintext)\b/i;
 const GUARDRAIL_PATTERN = /\b(do not|don't|never|avoid|blocked|blocker|owner auth|human decision|no secrets|no billing|no dns|no production deploy)\b/i;
 const CURRENT_WORK_PATTERN = /\b(active|current|now|todo|job|pr|blocker|blocked|next|in progress|priority|scope)\b/i;
+const MEMORY_REDACTION_STATES = new Set<MemoryReceiptRedactionState>([
+  "clean",
+  "redacted",
+  "sensitive-hidden",
+  "blocked",
+]);
 
 function stringifyForProfile(value: unknown, max = 120): string {
   if (typeof value === "string") return capText(value, max);
@@ -185,7 +192,11 @@ function profileReceipt(
     memory_id: memoryId,
     source_kind: sourceKind,
     source_uri: PROFILE_CARD_SOURCE_PATHS[sourceKind],
+    redaction_state: "clean",
   };
+  if (typeof row.redaction_state === "string" && MEMORY_REDACTION_STATES.has(row.redaction_state as MemoryReceiptRedactionState)) {
+    receipt.redaction_state = row.redaction_state as MemoryReceiptRedactionState;
+  }
   const lastVerified = str(row.last_verified_at) || str(row.updated_at) || str(row.created_at);
   if (lastVerified) receipt.last_verified_at = lastVerified;
   if (typeof row.confidence === "number" && Number.isFinite(row.confidence)) {
@@ -212,15 +223,15 @@ function businessProfileLine(row: Record<string, unknown>): string | null {
   if (hasSensitiveMemorySignal(row.category, row.key, row.value)) return null;
   const category = str(row.category, "context");
   const key = str(row.key, "item");
-  const value = stringifyForProfile(row.value, 60);
-  return compactProfileLine(value ? `${category}/${key}: ${value}` : `${category}/${key}`, 110);
+  const value = stringifyForProfile(row.value, 50);
+  return compactProfileLine(value ? `${category}/${key}: ${value}` : `${category}/${key}`, 96);
 }
 
 function factProfileLine(row: Record<string, unknown>): string | null {
   if (typeof row.fact !== "string" || hasSensitiveMemorySignal(row.fact, row.category)) return null;
   const category = str(row.category);
   const prefix = category ? `${category}: ` : "";
-  return compactProfileLine(`${prefix}${row.fact}`, 110);
+  return compactProfileLine(`${prefix}${row.fact}`, 96);
 }
 
 function timezoneRowScore(row: Record<string, unknown>): number {
@@ -433,7 +444,7 @@ export function compactStartupContextForStrictClients(
     : [];
   out.active_facts = facts.slice(0, 12).map((row) => {
     const r = asRecord(row) ?? {};
-    return { fact: typeof r.fact === "string" ? capText(r.fact, 80) : r.fact, category: r.category, confidence: r.confidence, created_at: r.created_at };
+    return { fact: typeof r.fact === "string" ? capText(r.fact, 74) : r.fact, category: r.category, confidence: r.confidence, created_at: r.created_at };
   });
   out.profile_card = buildMemoryProfileCard({ business, facts, sessions, includeSessionSummaries });
   out.response_bounds = {

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -27,6 +27,7 @@ import type {
   CodeInput,
   LibraryDocInput,
   MemoryTaxonomySnapshot,
+  MemoryTaxonomySnapshotSourceReceipt,
   MemoryTaxonomySnapshotWriteOptions,
   MemoryTaxonomySnapshotWriteResult,
   MemoryTaxonomySnapshotSource,
@@ -274,6 +275,23 @@ export function isSensitiveMemorySnapshotText(text: string): boolean {
   return SENSITIVE_MEMORY_PATTERN.test(text);
 }
 
+function taxonomySourceUri(kind: MemoryTaxonomySnapshotSource["kind"]): string {
+  return kind === "fact" ? "/admin/memory?tab=facts" : "/admin/memory?tab=sessions";
+}
+
+function taxonomySourceReceipt(source: MemoryTaxonomySnapshotSource): MemoryTaxonomySnapshotSourceReceipt {
+  const lastVerified = source.updated_at ?? source.valid_from ?? source.created_at ?? null;
+  const receipt: MemoryTaxonomySnapshotSourceReceipt = {
+    memory_id: `${source.kind}:${source.id}`,
+    source_kind: source.kind,
+    source_uri: taxonomySourceUri(source.kind),
+    redaction_state: "clean",
+  };
+  if (source.confidence !== undefined) receipt.confidence = source.confidence;
+  if (lastVerified) receipt.last_verified_at = lastVerified;
+  return receipt;
+}
+
 export function buildMemoryTaxonomySnapshots(
   sources: MemoryTaxonomySnapshotSource[],
   options: { maxSnapshots?: number; maxSourcesPerSnapshot?: number } = {}
@@ -362,6 +380,7 @@ export function buildMemoryTaxonomySnapshots(
         content,
         source_ids: sourceIds,
         sources: sourcesForSnapshot.map((source) => ({ id: source.id, kind: source.kind })),
+        source_receipts: sourcesForSnapshot.map(taxonomySourceReceipt),
         confidence: Number(avgConfidence.toFixed(3)),
         weight: Number(Math.min(1, avgConfidence * 0.7 + sourcesForSnapshot.length * 0.06).toFixed(3)),
         last_confirmed_at: latestIso(
@@ -391,6 +410,9 @@ export function memoryTaxonomySnapshotToLibraryDoc(snapshot: MemoryTaxonomySnaps
         ? `- Secondary: ${snapshot.secondary_categories.join(", ")}`
         : "- Secondary: none",
       `- Source pointers: ${snapshot.sources.map((source) => `${source.kind}:${source.id}`).join(", ")}`,
+      `- Source receipt states: ${snapshot.source_receipts
+        .map((receipt) => `${receipt.memory_id} ${receipt.redaction_state}`)
+        .join(", ")}`,
       snapshot.last_confirmed_at ? `- Last confirmed: ${snapshot.last_confirmed_at}` : "- Last confirmed: unknown",
     ].join("\n"),
     tags: [
@@ -423,6 +445,7 @@ export async function writeMemoryTaxonomySnapshotsToLibrary({
     title: snapshot.title,
     primary_category: snapshot.primary_category,
     source_ids: snapshot.source_ids,
+    source_receipts: snapshot.source_receipts,
   }));
 
   if (options.dry_run) {

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -32,12 +32,14 @@ export interface FactInput {
 export type StartupFactKind = "durable" | "operational" | "excluded" | "legacy_unspecified";
 
 export type MemoryProfileCardSourceKind = "business_context" | "fact" | "session_summary";
+export type MemoryReceiptRedactionState = "clean" | "redacted" | "sensitive-hidden" | "blocked";
 
 export interface MemoryProfileCardReceipt {
   memory_id: string;
   source_kind: MemoryProfileCardSourceKind;
   source_uri: string;
   confidence?: number;
+  redaction_state: MemoryReceiptRedactionState;
   last_verified_at?: string | null;
 }
 
@@ -99,6 +101,15 @@ export interface MemoryTaxonomySnapshotSource {
   valid_from?: string | null;
 }
 
+export interface MemoryTaxonomySnapshotSourceReceipt {
+  memory_id: string;
+  source_kind: MemoryTaxonomySourceKind;
+  source_uri: string;
+  confidence?: number | null;
+  redaction_state: MemoryReceiptRedactionState;
+  last_verified_at?: string | null;
+}
+
 export interface MemoryTaxonomySnapshot {
   slug: string;
   title: string;
@@ -109,6 +120,7 @@ export interface MemoryTaxonomySnapshot {
   content: string;
   source_ids: string[];
   sources: Array<{ id: string; kind: MemoryTaxonomySourceKind }>;
+  source_receipts: MemoryTaxonomySnapshotSourceReceipt[];
   confidence: number;
   weight: number;
   last_confirmed_at: string | null;
@@ -132,6 +144,7 @@ export interface MemoryTaxonomySnapshotWriteResult {
     title: string;
     primary_category: string;
     source_ids: string[];
+    source_receipts: MemoryTaxonomySnapshotSourceReceipt[];
   }>;
   written: Array<{
     slug: string;


### PR DESCRIPTION
Summary:
- Adds redaction_state to Memory Profile Card source receipts.
- Adds source_receipts with redaction_state to memory taxonomy snapshot outputs and dry-run summaries.
- Keeps compact load_memory under the existing size bound while preserving safe source pointers.

Proof:
- npm --workspace @unclick/mcp-server test
- npm --workspace @unclick/mcp-server run build
- git diff --check
- compact startup payload fixture: 7881 chars