### PR TITLE
Add cheap-first Memory retrieval plan

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
@@ -53,6 +53,13 @@ describe("strict-client memory response bounds", () => {
     assert.ok(profileCard.source_receipts.length > 0);
     assert.ok(profileCard.source_receipts.every((receipt) => receipt.redaction_state === "clean"));
     assert.equal(JSON.stringify(profileCard).includes(long("summary", 1000)), false);
+
+    const keys = Object.keys(compact as Record<string, unknown>);
+    assert.deepEqual(keys.slice(0, 4), ["business_context", "profile_card", "active_facts", "knowledge_library_index"]);
+    assert.deepEqual(
+      (compact as { retrieval_plan: { startup_order: string[] } }).retrieval_plan.startup_order,
+      ["business_context", "profile_card", "active_facts", "knowledge_library_index", "search_memory", "semantic_retrieval"]
+    );
   });
 
   test("load_memory non-lite mode returns truncated session summaries", () => {
@@ -222,6 +229,50 @@ describe("strict-client memory response bounds", () => {
       facts.slice(0, 3),
       ["durable-user-fact-0", "durable-user-fact-1", "durable-user-fact-2"]
     );
+  });
+
+  test("load_memory excludes operational self-report rows from compact startup facts", () => {
+    const compact = compactStartupContextForStrictClients({
+      active_facts: [
+        {
+          fact: "No Fishbowl write tools were available in this environment.",
+          category: "memory",
+          confidence: 0.99,
+          created_at: "2026-04-27T10:00:00Z",
+        },
+        {
+          fact: "Heartbeat resolved after scheduled cron re-run.",
+          category: "ops",
+          confidence: 0.98,
+          created_at: "2026-04-27T10:01:00Z",
+        },
+        {
+          fact: "Chris prefers compact memory first.",
+          category: "preference",
+          confidence: 0.9,
+          created_at: "2026-04-29T00:00:00Z",
+        },
+      ],
+    }) as {
+      active_facts: Array<{ fact: string }>;
+      profile_card: { working_now: string[] };
+      response_bounds: {
+        active_facts_returned: number;
+        active_facts_available_in_loaded_window: number;
+        active_facts_eligible_for_startup: number;
+        active_facts_excluded_from_startup: number;
+      };
+    };
+
+    const payload = JSON.stringify(compact);
+    assert.equal(compact.active_facts.length, 1);
+    assert.equal(compact.active_facts[0].fact, "Chris prefers compact memory first.");
+    assert.equal(payload.includes("No Fishbowl write tools"), false);
+    assert.equal(payload.includes("Heartbeat resolved after scheduled cron"), false);
+    assert.equal(compact.response_bounds.active_facts_returned, 1);
+    assert.equal(compact.response_bounds.active_facts_available_in_loaded_window, 3);
+    assert.equal(compact.response_bounds.active_facts_eligible_for_startup, 1);
+    assert.equal(compact.response_bounds.active_facts_excluded_from_startup, 2);
   });
 
   test("search_memory caps content previews by default", () => {

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -19,6 +19,7 @@ import type {
   MemoryProfileCard,
   MemoryProfileCardReceipt,
   MemoryProfileCardSourceKind,
+  MemoryRetrievalPlan,
   MemoryReceiptRedactionState,
 } from "./types.js";
 
@@ -130,6 +131,10 @@ function activeFactPenalty(value: unknown): number {
   if (typeof row.fact === "string" && textMatchesOperationalSelfReport(row.fact)) return 1;
   if (typeof row.category === "string" && textMatchesOperationalSelfReport(row.category)) return 1;
   return 0;
+}
+
+function isEligibleStartupFact(value: unknown): boolean {
+  return activeFactPenalty(value) === 0;
 }
 
 const PROFILE_CARD_SOURCE_PATHS: Record<MemoryProfileCardSourceKind, string> = {
@@ -382,6 +387,29 @@ function buildMemoryProfileCard(params: {
   };
 }
 
+function buildMemoryRetrievalPlan(): MemoryRetrievalPlan {
+  return {
+    mode: "cheap_first",
+    startup_order: [
+      "business_context",
+      "profile_card",
+      "active_facts",
+      "knowledge_library_index",
+      "search_memory",
+      "semantic_retrieval",
+    ],
+    steps: [
+      { step: 1, layer: "business_context + profile_card", use: "identity, rules, current work" },
+      { step: 2, layer: "active_facts", use: "durable facts only" },
+      { step: 3, layer: "knowledge_library_index", use: "snapshot pointers" },
+      { step: 4, layer: "search_memory", use: "raw source detail" },
+      { step: 5, layer: "semantic_retrieval", use: "only after cheap miss" },
+    ],
+    source_lookup: "search_memory after compact miss",
+    semantic_lookup: "vector or graph only after deterministic miss",
+  };
+}
+
 export function normalizeActiveFactsForLoadMemory(value: unknown): unknown {
   const context = asRecord(value);
   if (!context || !Array.isArray(context.active_facts)) return value;
@@ -414,19 +442,25 @@ export function compactStartupContextForStrictClients(
   const context = asRecord(normalizeActiveFactsForLoadMemory(value));
   if (!context) return value;
 
-  const out: Record<string, unknown> = { ...context };
+  const out: Record<string, unknown> = {};
   const business = Array.isArray(context.business_context) ? context.business_context : [];
   const library = Array.isArray(context.knowledge_library_index) ? context.knowledge_library_index : [];
   const sessions = Array.isArray(context.recent_sessions) ? context.recent_sessions : [];
   const facts = Array.isArray(context.active_facts) ? context.active_facts : [];
+  const startupFacts = facts.filter(isEligibleStartupFact);
 
   out.business_context = business.slice(0, 6).map((row) => {
     const r = asRecord(row) ?? {};
-    return { category: r.category, key: r.key, value: compactJsonValue(r.value, 150), priority: r.priority };
+    return { category: r.category, key: r.key, value: compactJsonValue(r.value, 130), priority: r.priority };
+  });
+  out.profile_card = buildMemoryProfileCard({ business, facts: startupFacts, sessions, includeSessionSummaries });
+  out.active_facts = startupFacts.slice(0, 12).map((row) => {
+    const r = asRecord(row) ?? {};
+    return { fact: typeof r.fact === "string" ? capText(r.fact, 44) : r.fact, category: r.category, confidence: r.confidence, created_at: r.created_at };
   });
   out.knowledge_library_index = library.slice(0, 6).map((row) => {
     const r = asRecord(row) ?? {};
-    return { slug: r.slug, title: typeof r.title === "string" ? capText(r.title, 90) : r.title, category: r.category, tags: compactStringArray(r.tags, 3, 32), updated_at: r.updated_at };
+    return { slug: r.slug, title: typeof r.title === "string" ? capText(r.title, 60) : r.title, category: r.category, tags: compactStringArray(r.tags, 3, 32), updated_at: r.updated_at };
   });
   out.recent_sessions = includeSessionSummaries
     ? sessions.slice(0, 3).map((row) => {
@@ -442,20 +476,21 @@ export function compactStartupContextForStrictClients(
         };
       })
     : [];
-  out.active_facts = facts.slice(0, 12).map((row) => {
-    const r = asRecord(row) ?? {};
-    return { fact: typeof r.fact === "string" ? capText(r.fact, 74) : r.fact, category: r.category, confidence: r.confidence, created_at: r.created_at };
-  });
-  out.profile_card = buildMemoryProfileCard({ business, facts, sessions, includeSessionSummaries });
+  out.retrieval_plan = buildMemoryRetrievalPlan();
   out.response_bounds = {
     compact: true,
     business_context_returned: Math.min(business.length, 6),
     knowledge_library_returned: Math.min(library.length, 6),
     recent_sessions_returned: includeSessionSummaries ? Math.min(sessions.length, 3) : 0,
     recent_sessions_available_in_loaded_window: sessions.length,
-    active_facts_returned: Math.min(facts.length, 12),
+    active_facts_returned: Math.min(startupFacts.length, 12),
     active_facts_available_in_loaded_window: facts.length,
+    active_facts_eligible_for_startup: startupFacts.length,
+    active_facts_excluded_from_startup: facts.length - startupFacts.length,
   };
+  for (const [key, value] of Object.entries(context)) {
+    if (!(key in out)) out[key] = value;
+  }
   return out;
 }
 

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -52,6 +52,20 @@ export interface MemoryProfileCard {
   source_receipts: MemoryProfileCardReceipt[];
 }
 
+export interface MemoryRetrievalPlanStep {
+  step: number;
+  layer: string;
+  use: string;
+}
+
+export interface MemoryRetrievalPlan {
+  mode: "cheap_first";
+  startup_order: string[];
+  steps: MemoryRetrievalPlanStep[];
+  source_lookup: string;
+  semantic_lookup: string;
+}
+
 export interface InvalidateFactInput {
   fact_id: string;
   reason?: string;


### PR DESCRIPTION
Summary:
- Adds a compact cheap_first retrieval_plan to bounded load_memory output.
- Orders compact startup as business_context, profile_card, active_facts, knowledge_library_index, then source and semantic lookup.
- Excludes operational self-report rows from compact startup facts and profile card fact inputs.

Proof:
- npm --workspace @unclick/mcp-server test
- npm --workspace @unclick/mcp-server run build
- git diff --check
- compact startup payload fixture: 7950 chars