### PR TITLE
[codex] add agent observability trace packet

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -9,7 +9,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | AUTOPILOT.md | 562ec208aa54 | 16311 |
 | FLEET_SYNC.md | 41ebcbca94b0 | 13200 |
 | docs/unclick-context-boot-packet.md | 7cf131cf22e0 | 4785 |
-| docs/agent-observability.md | 88a4c8391ee3 | 3046 |
+| docs/agent-observability.md | bffd9f890c75 | 4629 |
 | docs/pinballwake-nudgeonly-api.md | 901e39017aa9 | 6910 |
 | docs/pinballwake-igniteonly-api.md | bea4d9c8fa21 | 7919 |
 | docs/fleet-worker-roles.md | de6d70d0d55a | 3662 |

--- a/docs/agent-observability.md
+++ b/docs/agent-observability.md
@@ -30,6 +30,34 @@ External-seat continuity must follow:
 
 If a seat cannot log or cannot read context after logging, it must fail loud with `UNTETHERED` or `CONTEXT_UNREAD` and include any safe receipt ids it captured.
 
+## Standard Trace Packet
+
+Every important seat action should attach or make queryable one compact packet. This packet is the shared shape for Orchestrator comments, Boardroom proof, trace rows, and dashboard summaries.
+
+Required fields:
+
+- `trace_id`: stable id for the action or wake.
+- `seat_id`: acting seat or worker.
+- `source_kind`: heartbeat, human_turn, boardroom_todo, pr, dispatch, or tool.
+- `source_id`: source row, todo, PR, run, or receipt id.
+- `accepted_at`: when the seat accepted the instruction.
+- `context_read`: sources read before action, with receipt ids where possible.
+- `owned_obligation`: lane, job, or next action the seat believed it owned.
+- `assumptions`: compact list of assumptions, empty when none.
+- `tool_attempts`: tool names, success state, and safe error class only.
+- `decision`: PASS, HOLD, BLOCKER, ROUTE, SUPPRESS, or ESCALATE.
+- `changed_surfaces`: files, todos, PRs, database tables, or docs changed.
+- `proof_refs`: tests, PRs, comments, run ids, or sanitized counts.
+- `redaction_state`: clean, redacted, or blocked_secret_risk.
+- `next_safe_step`: one bounded follow-up.
+
+Rules:
+
+- Do not store secrets, raw tokens, passwords, or plaintext key material.
+- Store counts, ids, hashes, policy names, and timestamps instead of sensitive values.
+- If a context read fails after a saved turn, emit `CONTEXT_UNREAD` with the saved receipt.
+- If no continuity write path is available, emit `UNTETHERED` with any safe proof captured.
+
 ## First Git-Synced Slice
 
 The first active slice is the heartbeat and tether observability hardening on branch `codex/master-heartbeat-self-contained`.
@@ -64,5 +92,6 @@ Visible debt states include `waiting_for_owner`, `no_live_owner`, `expired`, `ig
 
 - The Agent Observability issue has a tracked repo artifact.
 - The first implementation slice has a branch and PR linked to issue #693.
+- A standard trace packet exists so workers can prove what they knew, did, changed, and could not safely do.
 - A seat can no longer claim that the heartbeat policy lacks a write target.
 - Orchestrator can distinguish missing connector, missing auth, write failure, context unreadable, blocked work, and accepted proof.


### PR DESCRIPTION
## Summary
- Adds a Standard Trace Packet section to the Agent Observability doc.
- Defines the fields needed to explain what a seat knew, did, changed, and could not safely do.
- Adds redaction and fail-loud rules for CONTEXT_UNREAD and UNTETHERED.

## Validation
- git diff check passed for the new commit.
- Forbidden dash scan on docs/agent-observability.md returned no matches.

Boardroom job: 4ce58c4f-7b32-4490-a521-48981abeaad8