### PR TITLE
[codex] wire commonsensepass proof guards

### DIFF
--- a/api/commonsensepass-bridge.test.ts
+++ b/api/commonsensepass-bridge.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  inspectDoneClaim,
+  inspectMergeReadyClaim,
   inspectOrchestratorActiveState,
   toTodoSnapshots,
 } from "./lib/commonsensepass-bridge.js";
@@ -7,6 +9,8 @@ import {
 const NOW = Date.parse("2026-05-12T22:00:00Z");
 const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
 const twoDaysAgo = new Date(NOW - 2 * 24 * 60 * 60 * 1000).toISOString();
+const headSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const staleSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
 describe("commonsensepass-bridge / toTodoSnapshots", () => {
   it("maps orchestrator status open -> actionable", () => {
@@ -52,6 +56,15 @@ describe("commonsensepass-bridge / toTodoSnapshots", () => {
       [],
     );
     expect(snaps[0].status).toBe("done");
+  });
+
+  it("carries done proof fields into snapshots", () => {
+    const snaps = toTodoSnapshots(
+      [{ id: "t5", status: "in_progress", pipeline: 100, closing_ref: " #886 " }],
+      [],
+    );
+    expect(snaps[0].pipeline).toBe(100);
+    expect(snaps[0].closing_ref).toBe("#886");
   });
 });
 
@@ -163,5 +176,102 @@ describe("commonsensepass-bridge / inspectOrchestratorActiveState", () => {
       expect(verdict.verdict).toBe("BLOCKER");
       expect(verdict.rule_id).toBe("R1");
     }
+  });
+});
+
+describe("commonsensepass-bridge / inspectDoneClaim", () => {
+  it("BLOCKER when a done claim lacks closing proof", () => {
+    const verdict = inspectDoneClaim({
+      todos: [{ id: "done-1", status: "in_progress", pipeline: 100 }],
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("BLOCKER");
+    expect(verdict.rule_id).toBe("R4");
+    expect(verdict.next_action).toBe("attach_closing_pr_or_commit_and_set_pipeline_100");
+  });
+
+  it("PASS when a done claim has full proof", () => {
+    const verdict = inspectDoneClaim({
+      todos: [
+        { id: "other", status: "open" },
+        {
+          id: "done-2",
+          status: "in_progress",
+          pipeline: 100,
+          closing_ref: "#886",
+        },
+      ],
+      subject_todo_id: "done-2",
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("PASS");
+    expect(verdict.rule_id).toBe("R4");
+  });
+});
+
+describe("commonsensepass-bridge / inspectMergeReadyClaim", () => {
+  it("HOLD when the worker omits current head SHA", () => {
+    const verdict = inspectMergeReadyClaim({
+      pr: {
+        number: 886,
+        mergeable: true,
+        checks_state: "success",
+        reviewer_pass: { verdict: "PASS", sha: headSha },
+        safety_pass: { verdict: "PASS", sha: headSha },
+      },
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("HOLD");
+    expect(verdict.rule_id).toBe("R5");
+    expect(verdict.next_action).toBe("include_current_head_sha");
+  });
+
+  it("HOLD when Safety PASS is missing", () => {
+    const verdict = inspectMergeReadyClaim({
+      pr: {
+        number: 887,
+        head_sha: headSha,
+        mergeable: true,
+        checks_state: "green",
+        reviewer_pass: { verdict: "PASS", sha: headSha },
+      },
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("HOLD");
+    expect(verdict.rule_id).toBe("R5");
+    expect(verdict.next_action).toBe("request_safety_pass");
+  });
+
+  it("BLOCKER when Safety PASS is stale", () => {
+    const verdict = inspectMergeReadyClaim({
+      pr: {
+        number: 888,
+        head_sha: headSha,
+        mergeable: true,
+        checks_state: "success",
+        reviewer_pass: { verdict: "PASS", sha: headSha },
+        safety_pass: { verdict: "PASS", sha: staleSha },
+      },
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("BLOCKER");
+    expect(verdict.rule_id).toBe("R5");
+    expect(verdict.next_action).toBe("re_run_safety_check_on_current_head");
+  });
+
+  it("PASS when merge-ready proof is current and complete", () => {
+    const verdict = inspectMergeReadyClaim({
+      pr: {
+        number: 889,
+        head_sha: headSha,
+        mergeable: true,
+        checks_state: "passed",
+        reviewer_pass: { verdict: "PASS", sha: headSha },
+        safety_pass: { verdict: "PASS", sha: headSha },
+      },
+      now_ms: NOW,
+    });
+    expect(verdict.verdict).toBe("PASS");
+    expect(verdict.rule_id).toBe("R5");
   });
 });

--- a/api/lib/commonsensepass-bridge.ts
+++ b/api/lib/commonsensepass-bridge.ts
@@ -12,6 +12,8 @@ import {
   type ClaimContext,
   type ClaimKind,
   type CommonSensePassResult,
+  type PRSnapshot,
+  type ReviewSnapshot,
   type TodoSnapshot,
   type TodoStatus,
 } from "../../packages/commonsensepass/src/index.js";
@@ -20,6 +22,8 @@ export interface OrchestratorTodoShape {
   id: string;
   status: string;
   assigned_to_agent_id?: string | null;
+  pipeline?: number | null;
+  closing_ref?: string | null;
 }
 
 export interface OrchestratorProfileShape {
@@ -37,6 +41,36 @@ export interface InspectActiveStateInput {
   profiles: OrchestratorProfileShape[];
   /** Active_jobs count the worker is about to claim (the v9 formula output). */
   active_jobs: number;
+  /** Current timestamp in ms; defaults to Date.now() if absent. */
+  now_ms?: number;
+}
+
+export interface InspectDoneClaimInput {
+  /** Worker-shaped todos with pipeline and closing proof attached. */
+  todos: OrchestratorTodoShape[];
+  /** Target todo id for the done claim. Defaults to the first todo. */
+  subject_todo_id?: string;
+  /** Current timestamp in ms; defaults to Date.now() if absent. */
+  now_ms?: number;
+}
+
+export interface WorkerReviewShape {
+  verdict?: string | null;
+  sha?: string | null;
+}
+
+export interface WorkerPRShape {
+  number: number;
+  head_sha?: string | null;
+  mergeable?: boolean | null;
+  checks_state?: string | null;
+  reviewer_pass?: WorkerReviewShape | null;
+  safety_pass?: WorkerReviewShape | null;
+}
+
+export interface InspectMergeReadyClaimInput {
+  /** PR snapshot assembled by the worker before merge or lift. */
+  pr: WorkerPRShape;
   /** Current timestamp in ms; defaults to Date.now() if absent. */
   now_ms?: number;
 }
@@ -100,8 +134,39 @@ export function toTodoSnapshots(
     if (typeof ownerLastSeen === "number") {
       snapshot.owner_last_seen_ms = ownerLastSeen;
     }
+    if (typeof todo.pipeline === "number") {
+      snapshot.pipeline = todo.pipeline;
+    }
+    if (typeof todo.closing_ref === "string" && todo.closing_ref.trim()) {
+      snapshot.closing_ref = todo.closing_ref.trim();
+    }
     return snapshot;
   });
+}
+
+function normalizeChecksState(value: string): PRSnapshot["checks_state"] {
+  const normalized = value.trim().toLowerCase();
+  if (["success", "passed", "green"].includes(normalized)) return "success";
+  if (["failure", "failed", "cancelled", "timed_out", "action_required"].includes(normalized)) {
+    return "failure";
+  }
+  if (["neutral", "skipped"].includes(normalized)) return "neutral";
+  return "pending";
+}
+
+function toReviewSnapshot(review?: WorkerReviewShape | null): ReviewSnapshot | undefined {
+  if (!review?.sha) return undefined;
+  if (
+    review.verdict !== "PASS" &&
+    review.verdict !== "BLOCKER" &&
+    review.verdict !== "HOLD"
+  ) {
+    return undefined;
+  }
+  return {
+    verdict: review.verdict,
+    sha: review.sha,
+  };
 }
 
 /**
@@ -127,4 +192,77 @@ export function inspectOrchestratorActiveState(
     active_jobs: input.active_jobs,
   };
   return commonsensepassCheck({ claim, context });
+}
+
+/**
+ * Run R4 against worker-shaped todo proof before marking a todo done.
+ *
+ * PASS = pipeline is complete and a closing PR or commit is present.
+ * BLOCKER = do not mark done until the missing proof is attached.
+ */
+export function inspectDoneClaim(
+  input: InspectDoneClaimInput,
+): CommonSensePassResult {
+  const context: ClaimContext = {
+    now_ms: input.now_ms ?? Date.now(),
+    todos: toTodoSnapshots(input.todos, []),
+    subject_todo_id: input.subject_todo_id,
+  };
+  return commonsensepassCheck({ claim: "done", context });
+}
+
+/**
+ * Run R5 against worker-shaped PR proof before marking merge-ready.
+ *
+ * PASS = mergeable, checks green, Reviewer PASS on head, and Safety PASS on head.
+ * HOLD = required proof is missing.
+ * BLOCKER = proof contradicts the merge-ready claim.
+ */
+export function inspectMergeReadyClaim(
+  input: InspectMergeReadyClaimInput,
+): CommonSensePassResult {
+  const headSha = input.pr.head_sha?.trim();
+  if (!headSha) {
+    return {
+      verdict: "HOLD",
+      rule_id: "R5",
+      reason: `merge_ready claim on PR #${input.pr.number} missing head SHA.`,
+      evidence: [{ kind: "context", ref: "head_sha=missing" }],
+      next_action: "include_current_head_sha",
+    };
+  }
+  if (typeof input.pr.mergeable !== "boolean") {
+    return {
+      verdict: "HOLD",
+      rule_id: "R5",
+      reason: `merge_ready claim on PR #${input.pr.number} missing mergeable state.`,
+      evidence: [{ kind: "context", ref: "mergeable=missing" }],
+      next_action: "include_mergeable_state",
+    };
+  }
+  if (!input.pr.checks_state?.trim()) {
+    return {
+      verdict: "HOLD",
+      rule_id: "R5",
+      reason: `merge_ready claim on PR #${input.pr.number} missing checks state.`,
+      evidence: [{ kind: "context", ref: "checks_state=missing" }],
+      next_action: "include_checks_state",
+    };
+  }
+
+  const pr: PRSnapshot = {
+    number: input.pr.number,
+    head_sha: headSha,
+    mergeable: input.pr.mergeable,
+    checks_state: normalizeChecksState(input.pr.checks_state),
+    reviewer_pass: toReviewSnapshot(input.pr.reviewer_pass),
+    safety_pass: toReviewSnapshot(input.pr.safety_pass),
+  };
+  return commonsensepassCheck({
+    claim: "merge_ready",
+    context: {
+      now_ms: input.now_ms ?? Date.now(),
+      pr,
+    },
+  });
 }

--- a/packages/commonsensepass/README.md
+++ b/packages/commonsensepass/README.md
@@ -18,7 +18,7 @@ Rule-and-evidence sanity gate for AI/worker claims. Verdict-only: does not build
 | R2   | `pass`            | Head SHA freshness: PASS authored on `commented_on_sha` that does not match `current_head_sha` is stale. |
 | R3   | `duplicate_wake`  | Wake suppression: same `id` and `state_fingerprint` emitted within the duplicate-wake window. |
 | R4   | `done`            | Done-without-proof: requires `pipeline === 100` AND a `closing_ref` on the subject todo. |
-| R5   | `merge_ready`     | Merge-ready-without-proof: PR must be mergeable, checks green, and have a Reviewer PASS authored on the current head SHA. |
+| R5   | `merge_ready`     | Merge-ready-without-proof: PR must be mergeable, checks green, and have Reviewer PASS plus Safety PASS authored on the current head SHA. |
 
 ## Usage
 

--- a/packages/commonsensepass/src/__tests__/check.test.ts
+++ b/packages/commonsensepass/src/__tests__/check.test.ts
@@ -278,6 +278,7 @@ describe("commonsensepassCheck - R5 merge-ready without proof", () => {
           mergeable: false,
           checks_state: "success",
           reviewer_pass: { verdict: "PASS", sha: headSha },
+          safety_pass: { verdict: "PASS", sha: headSha },
         },
       }),
     });
@@ -295,6 +296,7 @@ describe("commonsensepassCheck - R5 merge-ready without proof", () => {
           mergeable: true,
           checks_state: "failure",
           reviewer_pass: { verdict: "PASS", sha: headSha },
+          safety_pass: { verdict: "PASS", sha: headSha },
         },
       }),
     });
@@ -328,6 +330,7 @@ describe("commonsensepassCheck - R5 merge-ready without proof", () => {
           mergeable: true,
           checks_state: "success",
           reviewer_pass: { verdict: "PASS", sha: staleSha },
+          safety_pass: { verdict: "PASS", sha: headSha },
         },
       }),
     });
@@ -345,11 +348,49 @@ describe("commonsensepassCheck - R5 merge-ready without proof", () => {
           mergeable: true,
           checks_state: "success",
           reviewer_pass: { verdict: "PASS", sha: headSha },
+          safety_pass: { verdict: "PASS", sha: headSha },
         },
       }),
     });
     expect(result.verdict).toBe("PASS");
     expect(result.rule_id).toBe("R5");
+  });
+
+  it("HOLD when Safety PASS is missing", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({
+        pr: {
+          number: 105,
+          head_sha: headSha,
+          mergeable: true,
+          checks_state: "success",
+          reviewer_pass: { verdict: "PASS", sha: headSha },
+        },
+      }),
+    });
+    expect(result.verdict).toBe("HOLD");
+    expect(result.rule_id).toBe("R5");
+    expect(result.next_action).toBe("request_safety_pass");
+  });
+
+  it("BLOCKER when Safety PASS is on a stale SHA", () => {
+    const result = commonsensepassCheck({
+      claim: "merge_ready",
+      context: ctx({
+        pr: {
+          number: 106,
+          head_sha: headSha,
+          mergeable: true,
+          checks_state: "success",
+          reviewer_pass: { verdict: "PASS", sha: headSha },
+          safety_pass: { verdict: "PASS", sha: staleSha },
+        },
+      }),
+    });
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.rule_id).toBe("R5");
+    expect(result.next_action).toBe("re_run_safety_check_on_current_head");
   });
 
   it("HOLD when PR snapshot is missing", () => {

--- a/packages/commonsensepass/src/rules.ts
+++ b/packages/commonsensepass/src/rules.ts
@@ -257,6 +257,7 @@ export function checkR4(input: ClaimInput): CommonSensePassResult | null {
  *   - PR is mergeable
  *   - checks_state === "success"
  *   - Reviewer PASS present and authored on the PR's current head SHA.
+ *   - Safety PASS present and authored on the PR's current head SHA.
  */
 export function checkR5(input: ClaimInput): CommonSensePassResult | null {
   if (input.claim !== "merge_ready") return null;
@@ -318,14 +319,43 @@ export function checkR5(input: ClaimInput): CommonSensePassResult | null {
       next_action: "re_review_on_current_head",
     };
   }
+  const safety = pr.safety_pass;
+  if (!safety || safety.verdict !== "PASS") {
+    return {
+      verdict: "HOLD",
+      rule_id: "R5",
+      reason: `PR #${pr.number} has no Safety PASS.`,
+      evidence: [
+        {
+          kind: "pr",
+          ref: `#${pr.number}`,
+          note: `safety=${safety?.verdict ?? "missing"}`,
+        },
+      ],
+      next_action: "request_safety_pass",
+    };
+  }
+  if (safety.sha !== pr.head_sha) {
+    return {
+      verdict: "BLOCKER",
+      rule_id: "R5",
+      reason: `Safety PASS on PR #${pr.number} authored on ${safety.sha.slice(0, 7)} but head is ${pr.head_sha.slice(0, 7)}.`,
+      evidence: [
+        { kind: "sha", ref: safety.sha, note: "safety_pass_sha" },
+        { kind: "sha", ref: pr.head_sha, note: "head_sha" },
+      ],
+      next_action: "re_run_safety_check_on_current_head",
+    };
+  }
   return {
     verdict: "PASS",
     rule_id: "R5",
-    reason: `PR #${pr.number} is merge-ready: mergeable, checks green, Reviewer PASS on head.`,
+    reason: `PR #${pr.number} is merge-ready: mergeable, checks green, Reviewer PASS and Safety PASS on head.`,
     evidence: [
       { kind: "pr", ref: `#${pr.number}`, note: "mergeable" },
       { kind: "pr", ref: `#${pr.number}`, note: "checks=success" },
       { kind: "sha", ref: pr.head_sha, note: "reviewer_pass_on_head" },
+      { kind: "sha", ref: pr.head_sha, note: "safety_pass_on_head" },
     ],
   };
 }


### PR DESCRIPTION
## Summary
- Adds worker-facing CommonSensePass bridge helpers for done and merge-ready claims.
- Requires merge-ready proof to include Reviewer PASS and Safety PASS on the current head SHA.
- Extends focused package and bridge tests for missing proof, stale proof, and supported proof receipts.

## Validation
- npx vitest run packages/commonsensepass/src/__tests__/check.test.ts api/commonsensepass-bridge.test.ts
- npx tsc --noEmit -p packages/commonsensepass/tsconfig.json
- npm run brainmap:check
- git diff --check HEAD~1..HEAD
- forbidden dash scan on touched diff returned no matches

Boardroom job: fe962700-fc35-4b68-9bd3-acbc8c1585c5