### PR TITLE
[codex] persist memory typed links

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/typed-links.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/typed-links.test.ts
@@ -1,7 +1,10 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
+import { persistTypedLinksForMemoryWrite } from "../handlers.js";
 import { extractMemoryTypedLinkCandidates } from "../typed-links.js";
+import type { SaveTypedLinkCandidatesResult } from "../types.js";
+import type { MemoryTypedLinkCandidate } from "../typed-links.js";
 
 describe("memory typed-link extraction", () => {
   test("extracts deterministic references from fact text", () => {
@@ -78,6 +81,55 @@ describe("memory typed-link extraction", () => {
     };
 
     assert.deepEqual(extractMemoryTypedLinkCandidates(input), extractMemoryTypedLinkCandidates(input));
+  });
+
+  test("persists extracted links after a memory write", async () => {
+    const saved: MemoryTypedLinkCandidate[][] = [];
+    const result = await persistTypedLinksForMemoryWrite(
+      {
+        async saveTypedLinkCandidates(candidates): Promise<SaveTypedLinkCandidatesResult> {
+          saved.push(candidates);
+          return { saved: candidates.length };
+        },
+      },
+      {
+        source_kind: "fact",
+        source_id: "fact-5",
+        text: "PR #901 shipped with receipt 588aef27-646d-4359-9973-66394f2c0171.",
+      }
+    );
+
+    assert.equal(result.saved, 2);
+    assert.deepEqual(
+      saved[0].map((link) => [link.relation, link.target_kind, link.target_text]),
+      [
+        ["ships", "pr", "PR #901"],
+        ["references", "receipt", "588aef27-646d-4359-9973-66394f2c0171"],
+      ]
+    );
+  });
+
+  test("persistence helper keeps primary write safe on storage failure", async () => {
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      const result = await persistTypedLinksForMemoryWrite(
+        {
+          async saveTypedLinkCandidates(): Promise<SaveTypedLinkCandidatesResult> {
+            throw new Error("storage offline");
+          },
+        },
+        {
+          source_kind: "conversation_turn",
+          source_id: "turn-2",
+          text: "CommonSensePass referenced PR #902.",
+        }
+      );
+
+      assert.deepEqual(result, { saved: 0, skipped: "persistence_failed" });
+    } finally {
+      console.error = originalError;
+    }
   });
 });
 

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -15,13 +15,17 @@ import {
 import { resolveAgent, filterContextByLayers } from "./agent.js";
 import { emitSignal } from "../signals/emit.js";
 import { buildSearchMemoryCard } from "../cards/search-memory-card.js";
+import { extractMemoryTypedLinkCandidates } from "./typed-links.js";
 import type {
+  MemoryBackend,
   MemoryProfileCard,
   MemoryProfileCardReceipt,
   MemoryProfileCardSourceKind,
   MemoryRetrievalPlan,
   MemoryReceiptRedactionState,
+  SaveTypedLinkCandidatesResult,
 } from "./types.js";
+import type { MemoryTypedLinkSourceKind } from "./typed-links.js";
 
 function currentApiKeyHash(): string | null {
   return process.env.UNCLICK_API_KEY_HASH ?? null;
@@ -410,6 +414,21 @@ function buildMemoryRetrievalPlan(): MemoryRetrievalPlan {
   };
 }
 
+export async function persistTypedLinksForMemoryWrite(
+  db: Pick<MemoryBackend, "saveTypedLinkCandidates">,
+  input: { source_kind: MemoryTypedLinkSourceKind; source_id: string; text: string }
+): Promise<SaveTypedLinkCandidatesResult> {
+  const candidates = extractMemoryTypedLinkCandidates(input);
+  if (candidates.length === 0) return { saved: 0 };
+
+  try {
+    return await db.saveTypedLinkCandidates(candidates);
+  } catch (err) {
+    console.error("[memory] typed-link persistence failed:", err);
+    return { saved: 0, skipped: "persistence_failed" };
+  }
+}
+
 export function normalizeActiveFactsForLoadMemory(value: unknown): unknown {
   const context = asRecord(value);
   if (!context || !Array.isArray(context.active_facts)) return value;
@@ -639,6 +658,11 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       commit_sha: typeof args.commit_sha === "string" ? args.commit_sha : undefined,
       pr_number: typeof args.pr_number === "number" ? Math.floor(args.pr_number) : undefined,
     });
+    await persistTypedLinksForMemoryWrite(db, {
+      source_kind: "fact",
+      source_id: result.id,
+      text: str(args.fact),
+    });
     const hash = currentApiKeyHash();
     if (hash) {
       const preview = str(args.fact).slice(0, 80);
@@ -672,6 +696,11 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       role: str(args.role),
       content: str(args.content),
       has_code: bool(args.has_code),
+    });
+    await persistTypedLinksForMemoryWrite(db, {
+      source_kind: "conversation_turn",
+      source_id: receipt.receipt_id,
+      text: str(args.content),
     });
     return receipt;
   },

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -23,7 +23,9 @@ import type {
   MemoryTaxonomySnapshotSource,
   MemoryTaxonomySnapshotWriteOptions,
   MemoryTaxonomySnapshotWriteResult,
+  SaveTypedLinkCandidatesResult,
 } from "./types.js";
+import type { MemoryTypedLinkCandidate } from "./typed-links.js";
 import { writeMemoryTaxonomySnapshotsToLibrary } from "./supabase.js";
 
 const DATA_DIR = path.join(os.homedir(), ".unclick", "memory");
@@ -142,6 +144,21 @@ interface ConversationRow {
   role: string;
   content: string;
   has_code: boolean;
+  created_at: string;
+}
+
+interface TypedLinkRow {
+  id: string;
+  source_kind: string;
+  source_id: string;
+  relation: string;
+  target_kind: string;
+  target_text: string;
+  confidence: number;
+  evidence_start: number;
+  evidence_end: number;
+  evidence_text: string;
+  redaction_state: string;
   created_at: string;
 }
 
@@ -352,6 +369,41 @@ export class LocalBackend implements MemoryBackend {
       role: data.role,
       receipt_id: id,
     };
+  }
+
+  async saveTypedLinkCandidates(
+    candidates: MemoryTypedLinkCandidate[]
+  ): Promise<SaveTypedLinkCandidatesResult> {
+    if (candidates.length === 0) return { saved: 0 };
+
+    const rows = readTable<TypedLinkRow>("memory_typed_links");
+    const existing = new Set(rows.map(typedLinkKey));
+    let saved = 0;
+
+    for (const candidate of candidates) {
+      const row: TypedLinkRow = {
+        id: uuid(),
+        source_kind: candidate.source_kind,
+        source_id: candidate.source_id,
+        relation: candidate.relation,
+        target_kind: candidate.target_kind,
+        target_text: candidate.target_text,
+        confidence: candidate.confidence,
+        evidence_start: candidate.evidence_span.start,
+        evidence_end: candidate.evidence_span.end,
+        evidence_text: candidate.evidence_span.text,
+        redaction_state: candidate.redaction_state,
+        created_at: now(),
+      };
+      const key = typedLinkKey(row);
+      if (existing.has(key)) continue;
+      existing.add(key);
+      rows.push(row);
+      saved += 1;
+    }
+
+    if (saved > 0) writeTable("memory_typed_links", rows);
+    return { saved };
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {
@@ -565,4 +617,8 @@ export class LocalBackend implements MemoryBackend {
   async invalidateFact(_input: InvalidateFactInput): Promise<{ invalidated_at: string }> {
     throw new Error("invalidate_fact is not supported in local (zero-config) mode. Connect to Supabase to use this feature.");
   }
+}
+
+function typedLinkKey(row: Pick<TypedLinkRow, "source_kind" | "source_id" | "relation" | "target_kind" | "target_text">): string {
+  return [row.source_kind, row.source_id, row.relation, row.target_kind, row.target_text.toLowerCase()].join(":");
 }

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -31,7 +31,9 @@ import type {
   MemoryTaxonomySnapshotWriteOptions,
   MemoryTaxonomySnapshotWriteResult,
   MemoryTaxonomySnapshotSource,
+  SaveTypedLinkCandidatesResult,
 } from "./types.js";
+import type { MemoryTypedLinkCandidate } from "./typed-links.js";
 import { shouldEnforceManagedMemoryCaps } from "./quota-policy.js";
 
 function pgError(context: string, err: unknown): Error {
@@ -110,6 +112,7 @@ interface TableNames {
   session_summaries: string;
   extracted_facts: string;
   conversation_log: string;
+  memory_typed_links: string;
   code_dumps: string;
 }
 
@@ -485,6 +488,7 @@ const BYOD_TABLES: TableNames = {
   session_summaries: "session_summaries",
   extracted_facts: "extracted_facts",
   conversation_log: "conversation_log",
+  memory_typed_links: "memory_typed_links",
   code_dumps: "code_dumps",
 };
 
@@ -495,6 +499,7 @@ const MANAGED_TABLES: TableNames = {
   session_summaries: "mc_session_summaries",
   extracted_facts: "mc_extracted_facts",
   conversation_log: "mc_conversation_log",
+  memory_typed_links: "mc_memory_typed_links",
   code_dumps: "mc_code_dumps",
 };
 
@@ -504,6 +509,15 @@ function now(): string {
 
 function truncate(s: string, max = 8000): string {
   return s.length > max ? s.slice(0, max) + "\n...[truncated]" : s;
+}
+
+function isTypedLinkSchemaUnavailable(err: unknown): boolean {
+  const e = (err ?? {}) as { code?: string; message?: string };
+  return (
+    e.code === "42P01" ||
+    e.code === "42703" ||
+    /memory_typed_links|column .* does not exist/i.test(e.message ?? "")
+  );
 }
 
 // ─── Free-tier caps ──────────────────────────────────────────────────────
@@ -1071,6 +1085,43 @@ export class SupabaseBackend implements MemoryBackend {
       role: String(row.role),
       receipt_id: String(row.id),
     };
+  }
+
+  async saveTypedLinkCandidates(
+    candidates: MemoryTypedLinkCandidate[]
+  ): Promise<SaveTypedLinkCandidatesResult> {
+    if (candidates.length === 0) return { saved: 0 };
+
+    const rows = candidates.map((candidate) =>
+      this.withTenancy({
+        source_kind: candidate.source_kind,
+        source_id: candidate.source_id,
+        relation: candidate.relation,
+        target_kind: candidate.target_kind,
+        target_text: candidate.target_text,
+        confidence: candidate.confidence,
+        evidence_start: candidate.evidence_span.start,
+        evidence_end: candidate.evidence_span.end,
+        evidence_text: candidate.evidence_span.text,
+        redaction_state: candidate.redaction_state,
+      })
+    );
+
+    const onConflict =
+      this.tenancy.mode === "managed"
+        ? "api_key_hash,source_kind,source_id,relation,target_kind,target_text"
+        : "source_kind,source_id,relation,target_kind,target_text";
+    const { data, error } = await this.client
+      .from(this.tables.memory_typed_links)
+      .upsert(rows, { onConflict, ignoreDuplicates: true })
+      .select("id");
+
+    if (error) {
+      if (isTypedLinkSchemaUnavailable(error)) return { saved: 0, skipped: "schema_unavailable" };
+      throw pgError("saveTypedLinkCandidates upsert", error);
+    }
+
+    return { saved: Array.isArray(data) ? data.length : rows.length };
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -1,3 +1,5 @@
+import type { MemoryTypedLinkCandidate } from "./typed-links.js";
+
 /**
  * Shared types for UnClick Memory backends (local + Supabase).
  */
@@ -102,6 +104,11 @@ export interface LibraryDocInput {
   tags: string[];
 }
 
+export interface SaveTypedLinkCandidatesResult {
+  saved: number;
+  skipped?: "schema_unavailable" | "persistence_failed";
+}
+
 export type MemoryTaxonomySourceKind = "fact" | "session";
 
 export interface MemoryTaxonomySnapshotSource {
@@ -197,6 +204,9 @@ export interface MemoryBackend {
 
   /** Log a conversation message. */
   logConversation(data: ConversationInput): Promise<ConversationReceipt>;
+
+  /** Persist deterministic typed-link candidates extracted from Memory writes. */
+  saveTypedLinkCandidates(candidates: MemoryTypedLinkCandidate[]): Promise<SaveTypedLinkCandidatesResult>;
 
   /** Get full conversation log for a session. */
   getConversationDetail(sessionId: string): Promise<unknown>;

--- a/supabase/migrations/20260516010000_memory_typed_links.sql
+++ b/supabase/migrations/20260516010000_memory_typed_links.sql
@@ -1,0 +1,52 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS memory_typed_links (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  source_kind TEXT NOT NULL CHECK (source_kind IN ('fact', 'conversation_turn')),
+  source_id TEXT NOT NULL,
+  relation TEXT NOT NULL CHECK (relation IN ('authored', 'decided', 'references', 'ships', 'blocks', 'owns', 'relates_to')),
+  target_kind TEXT NOT NULL CHECK (target_kind IN ('person', 'todo', 'pr', 'commit', 'file', 'receipt', 'url', 'job', 'tool', 'unknown')),
+  target_text TEXT NOT NULL,
+  confidence REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+  evidence_start INTEGER NOT NULL CHECK (evidence_start >= 0),
+  evidence_end INTEGER NOT NULL CHECK (evidence_end >= evidence_start),
+  evidence_text TEXT NOT NULL,
+  redaction_state TEXT NOT NULL DEFAULT 'clean' CHECK (redaction_state IN ('clean', 'blocked_secret_risk')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_typed_links_unique
+  ON memory_typed_links(source_kind, source_id, relation, target_kind, target_text);
+CREATE INDEX IF NOT EXISTS idx_memory_typed_links_source
+  ON memory_typed_links(source_kind, source_id);
+CREATE INDEX IF NOT EXISTS idx_memory_typed_links_target
+  ON memory_typed_links(target_kind, target_text);
+
+CREATE TABLE IF NOT EXISTS mc_memory_typed_links (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  api_key_hash TEXT NOT NULL,
+  source_kind TEXT NOT NULL CHECK (source_kind IN ('fact', 'conversation_turn')),
+  source_id TEXT NOT NULL,
+  relation TEXT NOT NULL CHECK (relation IN ('authored', 'decided', 'references', 'ships', 'blocks', 'owns', 'relates_to')),
+  target_kind TEXT NOT NULL CHECK (target_kind IN ('person', 'todo', 'pr', 'commit', 'file', 'receipt', 'url', 'job', 'tool', 'unknown')),
+  target_text TEXT NOT NULL,
+  confidence REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+  evidence_start INTEGER NOT NULL CHECK (evidence_start >= 0),
+  evidence_end INTEGER NOT NULL CHECK (evidence_end >= evidence_start),
+  evidence_text TEXT NOT NULL,
+  redaction_state TEXT NOT NULL DEFAULT 'clean' CHECK (redaction_state IN ('clean', 'blocked_secret_risk')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_memory_typed_links_unique
+  ON mc_memory_typed_links(api_key_hash, source_kind, source_id, relation, target_kind, target_text);
+CREATE INDEX IF NOT EXISTS idx_mc_memory_typed_links_source
+  ON mc_memory_typed_links(api_key_hash, source_kind, source_id);
+CREATE INDEX IF NOT EXISTS idx_mc_memory_typed_links_target
+  ON mc_memory_typed_links(api_key_hash, target_kind, target_text);
+
+ALTER TABLE memory_typed_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc_memory_typed_links ENABLE ROW LEVEL SECURITY;
+
+GRANT ALL ON TABLE memory_typed_links TO service_role;
+GRANT ALL ON TABLE mc_memory_typed_links TO service_role;


### PR DESCRIPTION
## Summary
- Persists deterministic Memory typed-link candidates after fact and conversation writes.
- Adds local JSON storage plus Supabase BYOD and managed tables for typed links.
- Keeps primary Memory writes safe if the typed-link table is not migrated yet.

## Validation
- npm --prefix packages/mcp-server test
- npx tsc --noEmit -p packages/mcp-server/tsconfig.json
- git diff --check on touched files
- added-line dash scan on touched diff returned no matches

Boardroom job: d28efbdc-f7a8-4f8a-bee1-858ae5e45b26
Parent job: 6e125b76-3238-4425-940f-28a287d85f51
🤖