### PR TITLE
[codex] add memory typed-link search

### DIFF
--- a/packages/mcp-server/src/catalog.ts
+++ b/packages/mcp-server/src/catalog.ts
@@ -1962,6 +1962,22 @@ export const CATALOG: ToolDef[] = [
         },
       },
       {
+        id: "memory.search_typed_links",
+        name: "Search Typed Links",
+        description: "Search Typed Links - Search stored graph-style links extracted from facts and conversation turns.",
+        method: "POST",
+        path: "/v1/memory/typed-links/search",
+        requiresAuth: false,
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+            max_results: { type: "number", minimum: 1, maximum: 50, default: 10 },
+          },
+          required: ["query"],
+        },
+      },
+      {
         id: "memory.search_library",
         name: "Search Knowledge Library",
         description: "Search Knowledge Library - Search versioned reference documents in the Knowledge Library.",

--- a/packages/mcp-server/src/memory/__tests__/typed-links.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/typed-links.test.ts
@@ -2,9 +2,13 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
 import { persistTypedLinksForMemoryWrite } from "../handlers.js";
-import { extractMemoryTypedLinkCandidates } from "../typed-links.js";
+import {
+  extractMemoryTypedLinkCandidates,
+  filterAndRankMemoryTypedLinks,
+  memoryTypedLinkStoredRowToCandidate,
+} from "../typed-links.js";
 import type { SaveTypedLinkCandidatesResult } from "../types.js";
-import type { MemoryTypedLinkCandidate } from "../typed-links.js";
+import type { MemoryTypedLinkCandidate, MemoryTypedLinkStoredRow } from "../typed-links.js";
 
 describe("memory typed-link extraction", () => {
   test("extracts deterministic references from fact text", () => {
@@ -131,6 +135,64 @@ describe("memory typed-link extraction", () => {
       console.error = originalError;
     }
   });
+
+  test("search helper ranks exact targets before evidence-only matches", () => {
+    const rows: MemoryTypedLinkStoredRow[] = [
+      storedLink({
+        id: "older-evidence",
+        target_text: "Memory",
+        evidence_text: "PR #889 persisted typed links for Memory.",
+        created_at: "2026-05-16T20:00:00.000Z",
+      }),
+      storedLink({
+        id: "exact-pr",
+        target_kind: "pr",
+        target_text: "PR #889",
+        evidence_text: "PR #889 persisted typed links.",
+        created_at: "2026-05-16T19:00:00.000Z",
+      }),
+      storedLink({
+        id: "unrelated",
+        target_text: "Passport",
+        evidence_text: "Passport owns Git connections.",
+        created_at: "2026-05-16T21:00:00.000Z",
+      }),
+    ];
+
+    const results = filterAndRankMemoryTypedLinks(rows, "PR #889", 10);
+
+    assert.deepEqual(results.map((result) => result.id), ["exact-pr", "older-evidence"]);
+    assert.equal(results[0].target_text, "PR #889");
+    assert.equal(results[0].match_score > results[1].match_score, true);
+  });
+
+  test("search helper converts stored rows back to candidate evidence", () => {
+    const row = storedLink({
+      id: "stored-1",
+      source_kind: "conversation_turn",
+      source_id: "turn-9",
+      target_kind: "receipt",
+      target_text: "588aef27-646d-4359-9973-66394f2c0171",
+      evidence_start: 4,
+      evidence_end: 58,
+      evidence_text: "Receipt 588aef27-646d-4359-9973-66394f2c0171 shipped proof.",
+    });
+
+    assert.deepEqual(memoryTypedLinkStoredRowToCandidate(row), {
+      source_kind: "conversation_turn",
+      source_id: "turn-9",
+      relation: "references",
+      target_kind: "receipt",
+      target_text: "588aef27-646d-4359-9973-66394f2c0171",
+      confidence: 0.9,
+      evidence_span: {
+        start: 4,
+        end: 58,
+        text: "Receipt 588aef27-646d-4359-9973-66394f2c0171 shipped proof.",
+      },
+      redaction_state: "clean",
+    });
+  });
 });
 
 function findTarget(
@@ -138,4 +200,22 @@ function findTarget(
   targetText: string
 ): ReturnType<typeof extractMemoryTypedLinkCandidates>[number] | undefined {
   return links.find((link) => link.target_text === targetText);
+}
+
+function storedLink(overrides: Partial<MemoryTypedLinkStoredRow>): MemoryTypedLinkStoredRow {
+  return {
+    id: "link-1",
+    source_kind: "fact",
+    source_id: "fact-1",
+    relation: "references",
+    target_kind: "tool",
+    target_text: "Memory",
+    confidence: 0.9,
+    evidence_start: 0,
+    evidence_end: 20,
+    evidence_text: "Memory references PR #889.",
+    redaction_state: "clean",
+    created_at: "2026-05-16T20:00:00.000Z",
+    ...overrides,
+  };
 }

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -603,6 +603,11 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
     return db.searchFacts(str(args.query));
   },
 
+  async search_typed_links(args) {
+    const db = await getBackend();
+    return db.searchTypedLinks(str(args.query), num(args.max_results, 10));
+  },
+
   async search_library(args) {
     const db = await getBackend();
     return db.searchLibrary(str(args.query));

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -25,7 +25,12 @@ import type {
   MemoryTaxonomySnapshotWriteResult,
   SaveTypedLinkCandidatesResult,
 } from "./types.js";
-import type { MemoryTypedLinkCandidate } from "./typed-links.js";
+import {
+  filterAndRankMemoryTypedLinks,
+  type MemoryTypedLinkCandidate,
+  type MemoryTypedLinkSearchResult,
+  type MemoryTypedLinkStoredRow,
+} from "./typed-links.js";
 import { writeMemoryTaxonomySnapshotsToLibrary } from "./supabase.js";
 
 const DATA_DIR = path.join(os.homedir(), ".unclick", "memory");
@@ -147,18 +152,18 @@ interface ConversationRow {
   created_at: string;
 }
 
-interface TypedLinkRow {
+interface TypedLinkRow extends MemoryTypedLinkStoredRow {
   id: string;
-  source_kind: string;
+  source_kind: MemoryTypedLinkStoredRow["source_kind"];
   source_id: string;
-  relation: string;
-  target_kind: string;
+  relation: MemoryTypedLinkStoredRow["relation"];
+  target_kind: MemoryTypedLinkStoredRow["target_kind"];
   target_text: string;
   confidence: number;
   evidence_start: number;
   evidence_end: number;
   evidence_text: string;
-  redaction_state: string;
+  redaction_state: MemoryTypedLinkStoredRow["redaction_state"];
   created_at: string;
 }
 
@@ -404,6 +409,10 @@ export class LocalBackend implements MemoryBackend {
 
     if (saved > 0) writeTable("memory_typed_links", rows);
     return { saved };
+  }
+
+  async searchTypedLinks(query: string, maxResults: number): Promise<MemoryTypedLinkSearchResult[]> {
+    return filterAndRankMemoryTypedLinks(readTable<TypedLinkRow>("memory_typed_links"), query, maxResults);
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -33,7 +33,12 @@ import type {
   MemoryTaxonomySnapshotSource,
   SaveTypedLinkCandidatesResult,
 } from "./types.js";
-import type { MemoryTypedLinkCandidate } from "./typed-links.js";
+import {
+  filterAndRankMemoryTypedLinks,
+  type MemoryTypedLinkCandidate,
+  type MemoryTypedLinkSearchResult,
+  type MemoryTypedLinkStoredRow,
+} from "./typed-links.js";
 import { shouldEnforceManagedMemoryCaps } from "./quota-policy.js";
 
 function pgError(context: string, err: unknown): Error {
@@ -1122,6 +1127,42 @@ export class SupabaseBackend implements MemoryBackend {
     }
 
     return { saved: Array.isArray(data) ? data.length : rows.length };
+  }
+
+  async searchTypedLinks(query: string, maxResults: number): Promise<MemoryTypedLinkSearchResult[]> {
+    const limit = Math.max(1, Math.min(Math.floor(maxResults) || 10, 50));
+    let request = this.client
+      .from(this.tables.memory_typed_links)
+      .select(
+        [
+          "id",
+          "source_kind",
+          "source_id",
+          "relation",
+          "target_kind",
+          "target_text",
+          "confidence",
+          "evidence_start",
+          "evidence_end",
+          "evidence_text",
+          "redaction_state",
+          "created_at",
+        ].join(",")
+      )
+      .order("created_at", { ascending: false })
+      .limit(Math.min(Math.max(limit * 10, 50), 250));
+
+    if (this.tenancy.mode === "managed") {
+      request = request.eq("api_key_hash", this.tenancy.apiKeyHash);
+    }
+
+    const { data, error } = await request;
+    if (error) {
+      if (isTypedLinkSchemaUnavailable(error)) return [];
+      throw pgError("searchTypedLinks select", error);
+    }
+
+    return filterAndRankMemoryTypedLinks((data ?? []) as unknown as MemoryTypedLinkStoredRow[], query, limit);
   }
 
   async getConversationDetail(sessionId: string): Promise<unknown> {

--- a/packages/mcp-server/src/memory/typed-links.ts
+++ b/packages/mcp-server/src/memory/typed-links.ts
@@ -39,6 +39,27 @@ export interface MemoryTypedLinkCandidate {
   redaction_state: MemoryTypedLinkRedactionState;
 }
 
+export interface MemoryTypedLinkStoredRow {
+  id: string;
+  source_kind: MemoryTypedLinkSourceKind;
+  source_id: string;
+  relation: MemoryTypedLinkRelation;
+  target_kind: MemoryTypedLinkTargetKind;
+  target_text: string;
+  confidence: number;
+  evidence_start: number;
+  evidence_end: number;
+  evidence_text: string;
+  redaction_state: MemoryTypedLinkRedactionState;
+  created_at: string;
+}
+
+export interface MemoryTypedLinkSearchResult extends MemoryTypedLinkCandidate {
+  id: string;
+  created_at: string;
+  match_score: number;
+}
+
 export interface ExtractMemoryTypedLinkCandidatesInput {
   source_kind: MemoryTypedLinkSourceKind;
   source_id: string;
@@ -111,6 +132,39 @@ export function extractMemoryTypedLinkCandidates(
     .map((match) => buildCandidate(input.source_kind, sourceId, text, match));
 
   return dedupeCandidates(candidates);
+}
+
+export function filterAndRankMemoryTypedLinks(
+  rows: MemoryTypedLinkStoredRow[],
+  query: string,
+  maxResults: number
+): MemoryTypedLinkSearchResult[] {
+  const normalizedQuery = normalizeSearchText(query);
+  const limit = Math.max(1, Math.min(Math.floor(maxResults) || 10, 50));
+  if (!normalizedQuery) return [];
+
+  return rows
+    .map((row) => memoryTypedLinkStoredRowToSearchResult(row, normalizedQuery))
+    .filter((row) => row.match_score > 0)
+    .sort(compareSearchResults)
+    .slice(0, limit);
+}
+
+export function memoryTypedLinkStoredRowToCandidate(row: MemoryTypedLinkStoredRow): MemoryTypedLinkCandidate {
+  return {
+    source_kind: row.source_kind,
+    source_id: row.source_id,
+    relation: row.relation,
+    target_kind: row.target_kind,
+    target_text: row.target_text,
+    confidence: row.confidence,
+    evidence_span: {
+      start: row.evidence_start,
+      end: row.evidence_end,
+      text: row.evidence_text,
+    },
+    redaction_state: row.redaction_state,
+  };
 }
 
 function extractReferenceMatches(text: string): LinkMatch[] {
@@ -353,6 +407,54 @@ function stripTrailingPunctuation(value: string): string {
 
 function normalizePerson(value: string): string {
   return value.trim().replace(/\s+/g, " ");
+}
+
+function memoryTypedLinkStoredRowToSearchResult(
+  row: MemoryTypedLinkStoredRow,
+  normalizedQuery: string
+): MemoryTypedLinkSearchResult {
+  return {
+    ...memoryTypedLinkStoredRowToCandidate(row),
+    id: row.id,
+    created_at: row.created_at,
+    match_score: scoreStoredTypedLink(row, normalizedQuery),
+  };
+}
+
+function scoreStoredTypedLink(row: MemoryTypedLinkStoredRow, normalizedQuery: string): number {
+  const target = normalizeSearchText(row.target_text);
+  const evidence = normalizeSearchText(row.evidence_text);
+  const relation = normalizeSearchText(row.relation);
+  const targetKind = normalizeSearchText(row.target_kind);
+  const sourceKind = normalizeSearchText(row.source_kind);
+  const terms = normalizedQuery.split(" ").filter(Boolean);
+  let score = 0;
+
+  if (target === normalizedQuery) score += 100;
+  if (target.includes(normalizedQuery)) score += 80;
+  if (evidence.includes(normalizedQuery)) score += 45;
+  if (relation === normalizedQuery || targetKind === normalizedQuery || sourceKind === normalizedQuery) score += 30;
+
+  for (const term of terms) {
+    if (target.includes(term)) score += 12;
+    if (evidence.includes(term)) score += 5;
+    if (relation === term || targetKind === term || sourceKind === term) score += 4;
+  }
+
+  if (score > 0) score += Math.max(0, Math.min(row.confidence, 1)) * 10;
+  return Number(score.toFixed(3));
+}
+
+function compareSearchResults(left: MemoryTypedLinkSearchResult, right: MemoryTypedLinkSearchResult): number {
+  const scoreDelta = right.match_score - left.match_score;
+  if (scoreDelta !== 0) return scoreDelta;
+  const dateDelta = new Date(right.created_at).getTime() - new Date(left.created_at).getTime();
+  if (dateDelta !== 0) return dateDelta;
+  return left.id.localeCompare(right.id);
+}
+
+function normalizeSearchText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
 function compareMatches(left: LinkMatch, right: LinkMatch): number {

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -1,4 +1,4 @@
-import type { MemoryTypedLinkCandidate } from "./typed-links.js";
+import type { MemoryTypedLinkCandidate, MemoryTypedLinkSearchResult } from "./typed-links.js";
 
 /**
  * Shared types for UnClick Memory backends (local + Supabase).
@@ -207,6 +207,9 @@ export interface MemoryBackend {
 
   /** Persist deterministic typed-link candidates extracted from Memory writes. */
   saveTypedLinkCandidates(candidates: MemoryTypedLinkCandidate[]): Promise<SaveTypedLinkCandidatesResult>;
+
+  /** Search persisted typed links extracted from Memory writes. */
+  searchTypedLinks(query: string, maxResults: number): Promise<MemoryTypedLinkSearchResult[]>;
 
   /** Get full conversation log for a session. */
   getConversationDetail(sessionId: string): Promise<unknown>;


### PR DESCRIPTION
Summary
- Adds a deterministic search helper for stored Memory typed links.
- Wires searchTypedLinks into local and Supabase Memory backends, with schema-missing fallback for older deployments.
- Exposes memory.search_typed_links so workers can search graph-style links captured from facts and conversation turns.

Validation
- npx tsx --test packages/mcp-server/src/memory/__tests__/typed-links.test.ts
- npx tsc --noEmit -p packages/mcp-server/tsconfig.json
- npm --prefix packages/mcp-server test
- git diff --check on touched files
- added-line dash scan on touched diff