### PR TITLE
[codex] expose memory typed-link search tool

### DIFF
--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -6,6 +6,7 @@ describe("runtime tool schema validation", () => {
   const probes: Array<{ name: string; args: Record<string, unknown> }> = [
     { name: "load_memory", args: { num_sessions: 1, bogus_field: "should reject" } },
     { name: "search_memory", args: { query: "strict schema probe", bogus_field: "should reject" } },
+    { name: "search_typed_links", args: { query: "PR #890", bogus_field: "should reject" } },
     {
       name: "save_conversation_turn",
       args: {
@@ -95,6 +96,10 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("unclick_call", {
       endpoint_id: "memory.search_memory",
       params: { query: "strict schema probe" },
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("search_typed_links", {
+      query: "PR #890",
+      max_results: 5,
     })).toBeNull();
   });
 });

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -391,6 +391,23 @@ export const VISIBLE_TOOLS = [
     },
   },
   {
+    name: "search_typed_links",
+    title: "Search typed memory links",
+    description:
+      "Searches stored graph-style links extracted from Memory facts and conversation turns. " +
+      "Use this when a worker needs to find connections between people, jobs, PRs, receipts, files, tools, and decisions. " +
+      "Prefer search_memory for broad recall and search_typed_links for relationship lookups.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string", description: "Link search query" },
+        max_results: { type: "number", minimum: 1, maximum: 50, default: 10 },
+      },
+      required: ["query"],
+    },
+  },
+  {
     name: "save_identity",
     title: "Save my identity",
     description:


### PR DESCRIPTION
Summary
- Adds search_typed_links as a direct visible Memory tool.
- Keeps the tool schema strict with capped results.
- Reuses the Memory handler and backend search path shipped in PR #890.

Validation
- npx vitest run src/__tests__/tool-schema-validation.test.ts src/__tests__/orchestrator-tether-contract.test.ts from packages/mcp-server
- npx tsc --noEmit -p packages/mcp-server/tsconfig.json
- npm --prefix packages/mcp-server test
- git diff --check on touched files
- added-line dash scan on touched diff