### PR TITLE
[codex] add CommonSensePass worker fixtures

### DIFF
--- a/packages/commonsensepass/README.md
+++ b/packages/commonsensepass/README.md
@@ -22,6 +22,24 @@ Rule-and-evidence sanity gate for AI/worker claims. Verdict-only: does not build
 
 The worker-facing rule matrix and next candidate backlog live in `docs/commonsensepass-rule-matrix.md`.
 
+## Fixture Pack
+
+Workers can import `COMMONSENSEPASS_WORKER_FIXTURES` when they need stable local examples instead of waiting on live queue, wake, or PR state.
+
+```ts
+import {
+  COMMONSENSEPASS_WORKER_FIXTURES,
+  commonsensepassCheck,
+} from "@unclick/commonsensepass";
+
+for (const fixture of COMMONSENSEPASS_WORKER_FIXTURES) {
+  const result = fixture.reserved_result ?? commonsensepassCheck(fixture.input!);
+  console.log(fixture.id, result.verdict);
+}
+```
+
+The pack covers PASS, BLOCKER, HOLD, SUPPRESS, and the reserved ROUTE verdict. Named scenarios include false quiet, stale proof, duplicate wake, no-work-with-backlog, merge-ready-without-proof, and done-without-proof. ROUTE is included as a reserved exemplar only; R1-R5 do not emit it yet.
+
 ## Usage
 
 ```ts

--- a/packages/commonsensepass/package.json
+++ b/packages/commonsensepass/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./schema": "./dist/schema.js",
+    "./fixtures": "./dist/fixtures.js",
     "./rules": "./dist/rules.js",
     "./check": "./dist/check.js"
   },

--- a/packages/commonsensepass/src/__tests__/fixtures.test.ts
+++ b/packages/commonsensepass/src/__tests__/fixtures.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { commonsensepassCheck } from "../check.js";
+import {
+  COMMONSENSEPASS_WORKER_FIXTURES,
+  CommonSensePassFixture,
+  fixtureIdsByVerdict,
+} from "../fixtures.js";
+import { Verdict } from "../schema.js";
+
+const REQUIRED_SCENARIOS = [
+  "false-quiet-with-backlog",
+  "stale-proof-pass",
+  "duplicate-wake-suppress",
+  "no-work-with-backlog",
+  "merge-ready-without-proof",
+  "done-without-proof",
+];
+
+function resultForFixture(fixture: CommonSensePassFixture) {
+  if (fixture.reserved_result) return fixture.reserved_result;
+  if (!fixture.input) {
+    throw new Error(`Fixture ${fixture.id} has no input or reserved result.`);
+  }
+  return commonsensepassCheck(fixture.input);
+}
+
+describe("CommonSensePass worker fixtures", () => {
+  it("covers every public verdict", () => {
+    const idsByVerdict = fixtureIdsByVerdict();
+    const verdicts: Verdict[] = [
+      "PASS",
+      "BLOCKER",
+      "HOLD",
+      "SUPPRESS",
+      "ROUTE",
+    ];
+
+    for (const verdict of verdicts) {
+      expect(idsByVerdict[verdict].length, verdict).toBeGreaterThan(0);
+    }
+  });
+
+  it("deterministically produces the expected verdict and rule id", () => {
+    for (const fixture of COMMONSENSEPASS_WORKER_FIXTURES) {
+      const result = resultForFixture(fixture);
+      expect(result.verdict, fixture.id).toBe(fixture.expected_verdict);
+      expect(result.rule_id, fixture.id).toBe(fixture.expected_rule_id);
+    }
+  });
+
+  it("includes the named live worker failure modes", () => {
+    const fixtureIds = new Set(
+      COMMONSENSEPASS_WORKER_FIXTURES.map((fixture) => fixture.id),
+    );
+
+    for (const requiredScenario of REQUIRED_SCENARIOS) {
+      expect(fixtureIds.has(requiredScenario), requiredScenario).toBe(true);
+    }
+  });
+
+  it("keeps ROUTE as a reserved exemplar outside R1-R5 execution", () => {
+    const routeFixture = COMMONSENSEPASS_WORKER_FIXTURES.find(
+      (fixture) => fixture.expected_verdict === "ROUTE",
+    );
+
+    expect(routeFixture?.input).toBeUndefined();
+    expect(routeFixture?.reserved_result?.route_to).toBe("securitypass");
+  });
+});

--- a/packages/commonsensepass/src/fixtures.ts
+++ b/packages/commonsensepass/src/fixtures.ts
@@ -1,0 +1,283 @@
+import type {
+  ClaimInput,
+  CommonSensePassResult,
+  Verdict,
+} from "./schema.js";
+
+export interface CommonSensePassFixture {
+  id: string;
+  title: string;
+  expected_verdict: Verdict;
+  input?: ClaimInput;
+  expected_rule_id?: CommonSensePassResult["rule_id"];
+  reserved_result?: CommonSensePassResult;
+  notes: string;
+}
+
+const NOW_MS = 1_765_000_000_000;
+const HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const STALE_SHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+export const COMMONSENSEPASS_WORKER_FIXTURES = [
+  {
+    id: "false-quiet-with-backlog",
+    title: "False quiet while actionable work exists",
+    expected_verdict: "BLOCKER",
+    expected_rule_id: "R1",
+    input: {
+      claim: "quiet",
+      context: {
+        now_ms: NOW_MS,
+        active_jobs: 0,
+        todos: [{ id: "todo-actionable-1", status: "actionable" }],
+      },
+    },
+    notes: "Worker says quiet, but a queued todo is waiting.",
+  },
+  {
+    id: "no-work-with-backlog",
+    title: "No-work claim with backlog",
+    expected_verdict: "BLOCKER",
+    expected_rule_id: "R1",
+    input: {
+      claim: "no_work",
+      context: {
+        now_ms: NOW_MS,
+        active_jobs: 0,
+        todos: [
+          { id: "todo-actionable-2", status: "actionable" },
+          { id: "todo-queued-1", status: "queued" },
+        ],
+      },
+    },
+    notes: "Worker says there is no work, but actionable queue depth is nonzero.",
+  },
+  {
+    id: "fresh-active-job-underreported",
+    title: "Fresh in-progress job underreported as zero active jobs",
+    expected_verdict: "BLOCKER",
+    expected_rule_id: "R1",
+    input: {
+      claim: "healthy",
+      context: {
+        now_ms: NOW_MS,
+        active_jobs: 0,
+        todos: [
+          {
+            id: "todo-active-fresh",
+            status: "in_progress",
+            owner: "runner-builder",
+            owner_last_seen_ms: NOW_MS - 60_000,
+          },
+        ],
+      },
+    },
+    notes: "The pinned active_jobs formula should count fresh owned in-progress work.",
+  },
+  {
+    id: "quiet-empty-queue-pass",
+    title: "Quiet claim with empty queue",
+    expected_verdict: "PASS",
+    expected_rule_id: "R1",
+    input: {
+      claim: "quiet",
+      context: {
+        now_ms: NOW_MS,
+        active_jobs: 0,
+        todos: [],
+      },
+    },
+    notes: "Baseline PASS for a genuinely empty queue.",
+  },
+  {
+    id: "stale-proof-pass",
+    title: "PASS proof posted on a stale SHA",
+    expected_verdict: "BLOCKER",
+    expected_rule_id: "R2",
+    input: {
+      claim: "pass",
+      context: {
+        now_ms: NOW_MS,
+        current_head_sha: HEAD_SHA,
+        commented_on_sha: STALE_SHA,
+      },
+    },
+    notes: "A stale PASS must be re-reviewed on the current head.",
+  },
+  {
+    id: "pass-missing-sha-hold",
+    title: "PASS proof missing SHA evidence",
+    expected_verdict: "HOLD",
+    expected_rule_id: "R2",
+    input: {
+      claim: "pass",
+      context: {
+        now_ms: NOW_MS,
+        current_head_sha: HEAD_SHA,
+      },
+    },
+    notes: "Freshness cannot be checked until both SHA fields are present.",
+  },
+  {
+    id: "duplicate-wake-suppress",
+    title: "Duplicate wake with unchanged state",
+    expected_verdict: "SUPPRESS",
+    expected_rule_id: "R3",
+    input: {
+      claim: "duplicate_wake",
+      context: {
+        now_ms: NOW_MS,
+        current_wake: {
+          id: "wake-123",
+          state_fingerprint: "same-state",
+          emitted_ms: NOW_MS,
+        },
+        recent_wakes: [
+          {
+            id: "wake-123",
+            state_fingerprint: "same-state",
+            emitted_ms: NOW_MS - 60_000,
+          },
+        ],
+      },
+    },
+    notes: "Repeated wake adds no signal and should be suppressed.",
+  },
+  {
+    id: "done-without-proof",
+    title: "Done claim without complete proof",
+    expected_verdict: "BLOCKER",
+    expected_rule_id: "R4",
+    input: {
+      claim: "done",
+      context: {
+        now_ms: NOW_MS,
+        subject_todo_id: "todo-done-weak",
+        todos: [
+          {
+            id: "todo-done-weak",
+            status: "in_progress",
+            pipeline: 80,
+          },
+        ],
+      },
+    },
+    notes: "Done needs pipeline 100 and a closing PR or commit reference.",
+  },
+  {
+    id: "done-with-proof-pass",
+    title: "Done claim with closing proof",
+    expected_verdict: "PASS",
+    expected_rule_id: "R4",
+    input: {
+      claim: "done",
+      context: {
+        now_ms: NOW_MS,
+        subject_todo_id: "todo-done-strong",
+        todos: [
+          {
+            id: "todo-done-strong",
+            status: "in_progress",
+            pipeline: 100,
+            closing_ref: "PR #892",
+          },
+        ],
+      },
+    },
+    notes: "A done claim is acceptable when both required proof fields are present.",
+  },
+  {
+    id: "merge-ready-without-proof",
+    title: "Merge-ready claim missing Reviewer and Safety PASS",
+    expected_verdict: "HOLD",
+    expected_rule_id: "R5",
+    input: {
+      claim: "merge_ready",
+      context: {
+        now_ms: NOW_MS,
+        pr: {
+          number: 892,
+          head_sha: HEAD_SHA,
+          mergeable: true,
+          checks_state: "success",
+        },
+      },
+    },
+    notes: "A green PR still needs Reviewer PASS and Safety PASS on head.",
+  },
+  {
+    id: "merge-ready-red-checks",
+    title: "Merge-ready claim with failing checks",
+    expected_verdict: "BLOCKER",
+    expected_rule_id: "R5",
+    input: {
+      claim: "merge_ready",
+      context: {
+        now_ms: NOW_MS,
+        pr: {
+          number: 893,
+          head_sha: HEAD_SHA,
+          mergeable: true,
+          checks_state: "failure",
+          reviewer_pass: { verdict: "PASS", sha: HEAD_SHA },
+          safety_pass: { verdict: "PASS", sha: HEAD_SHA },
+        },
+      },
+    },
+    notes: "Failing checks stop autopilot merge even when review proof exists.",
+  },
+  {
+    id: "merge-ready-with-proof-pass",
+    title: "Merge-ready claim with complete proof",
+    expected_verdict: "PASS",
+    expected_rule_id: "R5",
+    input: {
+      claim: "merge_ready",
+      context: {
+        now_ms: NOW_MS,
+        pr: {
+          number: 894,
+          head_sha: HEAD_SHA,
+          mergeable: true,
+          checks_state: "success",
+          reviewer_pass: { verdict: "PASS", sha: HEAD_SHA },
+          safety_pass: { verdict: "PASS", sha: HEAD_SHA },
+        },
+      },
+    },
+    notes: "Autopilot merge proof is complete and current.",
+  },
+  {
+    id: "reserved-route-specialist",
+    title: "Reserved ROUTE exemplar for specialist lanes",
+    expected_verdict: "ROUTE",
+    expected_rule_id: null,
+    reserved_result: {
+      verdict: "ROUTE",
+      rule_id: null,
+      reason: "Reserved fixture for claims that should move to a specialist lane.",
+      evidence: [{ kind: "lane", ref: "securitypass" }],
+      next_action: "route_to_specialist",
+      route_to: "securitypass",
+    },
+    notes: "ROUTE is part of the public verdict shape but is not emitted by R1-R5 yet.",
+  },
+] satisfies readonly CommonSensePassFixture[];
+
+export function fixtureIdsByVerdict(
+  fixtures: readonly CommonSensePassFixture[] = COMMONSENSEPASS_WORKER_FIXTURES,
+): Record<Verdict, string[]> {
+  const ids: Record<Verdict, string[]> = {
+    PASS: [],
+    BLOCKER: [],
+    HOLD: [],
+    SUPPRESS: [],
+    ROUTE: [],
+  };
+
+  for (const fixture of fixtures) {
+    ids[fixture.expected_verdict].push(fixture.id);
+  }
+
+  return ids;
+}

--- a/packages/commonsensepass/src/index.ts
+++ b/packages/commonsensepass/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./schema.js";
+export * from "./fixtures.js";
 export { checkR1, checkR2, checkR3, checkR4, checkR5 } from "./rules.js";
 export { commonsensepassCheck } from "./check.js";


### PR DESCRIPTION
Summary:
- Added a deterministic CommonSensePass worker fixture pack covering PASS, BLOCKER, HOLD, SUPPRESS, and reserved ROUTE.
- Added focused tests for verdict coverage, expected rule ids, named worker failure modes, and ROUTE reservation.
- Exported fixtures from the package root and fixtures subpath.

Verification:
- npm --prefix packages/commonsensepass test
- npx tsc --noEmit -p packages/commonsensepass/tsconfig.json
- git diff --check on touched files
- no em dash or en dash added in touched files