### PR TITLE
[codex] add CommonSensePass evidence receipts

### DIFF
--- a/packages/commonsensepass/README.md
+++ b/packages/commonsensepass/README.md
@@ -40,6 +40,34 @@ for (const fixture of COMMONSENSEPASS_WORKER_FIXTURES) {
 
 The pack covers PASS, BLOCKER, HOLD, SUPPRESS, and the reserved ROUTE verdict. Named scenarios include false quiet, stale proof, duplicate wake, no-work-with-backlog, merge-ready-without-proof, and done-without-proof. ROUTE is included as a reserved exemplar only; R1-R5 do not emit it yet.
 
+## Evidence Receipts
+
+Workers can wrap proof in a deterministic evidence envelope before claiming PASS, done, or merge-ready.
+
+```ts
+import {
+  checkEvidenceEnvelope,
+  finalizeEvidenceReceipt,
+} from "@unclick/commonsensepass";
+
+const receipt = finalizeEvidenceReceipt({
+  source_kind: "pr",
+  source_id: "893",
+  fetched_at: new Date().toISOString(),
+  head_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  run_id: "run-893",
+  proof_refs: ["checks:success", "pr:893"],
+  freshness_window_ms: 30 * 60 * 1000,
+});
+
+const verdict = checkEvidenceEnvelope(
+  { created_at: receipt.fetched_at, receipts: [receipt] },
+  { now_ms: Date.now(), current_head_sha: receipt.head_sha },
+);
+```
+
+The accepted receipt fields are `source_kind`, `source_id`, `fetched_at`, `head_sha`, `run_id`, `proof_refs`, `evidence_fingerprint`, and `freshness_window_ms`. Missing required proof returns `HOLD`; stale timestamps, stale head SHA, or fingerprint mismatch return `BLOCKER`.
+
 ## Usage
 
 ```ts

--- a/packages/commonsensepass/package.json
+++ b/packages/commonsensepass/package.json
@@ -8,6 +8,7 @@
     ".": "./dist/index.js",
     "./schema": "./dist/schema.js",
     "./fixtures": "./dist/fixtures.js",
+    "./evidence": "./dist/evidence.js",
     "./rules": "./dist/rules.js",
     "./check": "./dist/check.js"
   },

--- a/packages/commonsensepass/src/__tests__/evidence.test.ts
+++ b/packages/commonsensepass/src/__tests__/evidence.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkEvidenceEnvelope,
+  createEvidenceFingerprint,
+  EvidenceReceipt,
+  finalizeEvidenceReceipt,
+} from "../evidence.js";
+
+const NOW_MS = Date.parse("2026-05-16T21:45:00.000Z");
+const HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const STALE_SHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function freshReceipt(overrides: Partial<EvidenceReceipt> = {}): EvidenceReceipt {
+  return finalizeEvidenceReceipt({
+    source_kind: "pr",
+    source_id: "893",
+    fetched_at: "2026-05-16T21:40:00.000Z",
+    head_sha: HEAD_SHA,
+    run_id: "run-893",
+    proof_refs: ["checks:success", "pr:893"],
+    freshness_window_ms: 10 * 60 * 1000,
+    ...overrides,
+  });
+}
+
+describe("CommonSensePass evidence receipts", () => {
+  it("creates stable fingerprints for equivalent proof refs", () => {
+    const first = createEvidenceFingerprint({
+      source_kind: "pr",
+      source_id: "893",
+      fetched_at: "2026-05-16T21:40:00.000Z",
+      head_sha: HEAD_SHA,
+      run_id: "run-893",
+      proof_refs: ["checks:success", "pr:893"],
+      freshness_window_ms: 10 * 60 * 1000,
+    });
+    const second = createEvidenceFingerprint({
+      source_kind: "pr",
+      source_id: "893",
+      fetched_at: "2026-05-16T21:40:00.000Z",
+      head_sha: HEAD_SHA,
+      run_id: "run-893",
+      proof_refs: ["pr:893", "checks:success"],
+      freshness_window_ms: 10 * 60 * 1000,
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it("PASSes a complete fresh evidence envelope", () => {
+    const result = checkEvidenceEnvelope(
+      {
+        created_at: "2026-05-16T21:41:00.000Z",
+        receipts: [freshReceipt()],
+      },
+      { now_ms: NOW_MS, current_head_sha: HEAD_SHA },
+    );
+
+    expect(result.verdict).toBe("PASS");
+    expect(result.evidence[0].source_kind).toBe("pr");
+    expect(result.evidence[0].evidence_fingerprint).toHaveLength(64);
+  });
+
+  it("HOLDs when required evidence fields are missing", () => {
+    const receipt = {
+      ...freshReceipt(),
+      source_id: "",
+      head_sha: undefined,
+    };
+    const result = checkEvidenceEnvelope(
+      {
+        created_at: "2026-05-16T21:41:00.000Z",
+        receipts: [receipt],
+      },
+      { now_ms: NOW_MS, current_head_sha: HEAD_SHA },
+    );
+
+    expect(result.verdict).toBe("HOLD");
+    expect(result.reason).toContain("source_id");
+    expect(result.reason).toContain("head_sha");
+  });
+
+  it("BLOCKERs stale receipts outside the freshness window", () => {
+    const result = checkEvidenceEnvelope(
+      {
+        created_at: "2026-05-16T21:41:00.000Z",
+        receipts: [
+          freshReceipt({
+            fetched_at: "2026-05-16T21:00:00.000Z",
+            freshness_window_ms: 10 * 60 * 1000,
+          }),
+        ],
+      },
+      { now_ms: NOW_MS, current_head_sha: HEAD_SHA },
+    );
+
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.next_action).toBe("refresh_evidence_receipt");
+  });
+
+  it("BLOCKERs receipts fetched against a stale head SHA", () => {
+    const result = checkEvidenceEnvelope(
+      {
+        created_at: "2026-05-16T21:41:00.000Z",
+        receipts: [freshReceipt({ head_sha: STALE_SHA })],
+      },
+      { now_ms: NOW_MS, current_head_sha: HEAD_SHA },
+    );
+
+    expect(result.verdict).toBe("BLOCKER");
+    expect(result.next_action).toBe("refresh_evidence_on_current_head");
+  });
+});

--- a/packages/commonsensepass/src/evidence.ts
+++ b/packages/commonsensepass/src/evidence.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+import type { CommonSensePassResult, Evidence } from "./schema.js";
+
+export const DEFAULT_EVIDENCE_FRESHNESS_WINDOW_MS = 30 * 60 * 1000;
+
+export interface EvidenceReceiptDraft {
+  source_kind: string;
+  source_id: string;
+  fetched_at: string;
+  head_sha?: string;
+  run_id?: string;
+  proof_refs?: string[];
+  freshness_window_ms?: number;
+}
+
+export interface EvidenceReceipt extends EvidenceReceiptDraft {
+  evidence_fingerprint: string;
+}
+
+export interface EvidenceEnvelope {
+  created_at: string;
+  receipts: EvidenceReceipt[];
+}
+
+export interface EvidenceCheckContext {
+  now_ms: number;
+  current_head_sha?: string;
+  default_freshness_window_ms?: number;
+}
+
+function stableReceiptPayload(receipt: EvidenceReceiptDraft): string {
+  return JSON.stringify({
+    source_kind: receipt.source_kind,
+    source_id: receipt.source_id,
+    fetched_at: receipt.fetched_at,
+    head_sha: receipt.head_sha ?? null,
+    run_id: receipt.run_id ?? null,
+    proof_refs: [...(receipt.proof_refs ?? [])].sort(),
+    freshness_window_ms: receipt.freshness_window_ms ?? null,
+  });
+}
+
+export function createEvidenceFingerprint(receipt: EvidenceReceiptDraft): string {
+  return createHash("sha256")
+    .update(stableReceiptPayload(receipt))
+    .digest("hex");
+}
+
+export function finalizeEvidenceReceipt(
+  receipt: EvidenceReceiptDraft,
+): EvidenceReceipt {
+  return {
+    ...receipt,
+    proof_refs: receipt.proof_refs ? [...receipt.proof_refs].sort() : undefined,
+    evidence_fingerprint: createEvidenceFingerprint(receipt),
+  };
+}
+
+function toEvidence(receipt: EvidenceReceipt, note?: string): Evidence {
+  return {
+    kind: receipt.source_kind,
+    ref: receipt.source_id,
+    note,
+    source_kind: receipt.source_kind,
+    source_id: receipt.source_id,
+    fetched_at: receipt.fetched_at,
+    head_sha: receipt.head_sha,
+    run_id: receipt.run_id,
+    proof_refs: receipt.proof_refs,
+    evidence_fingerprint: receipt.evidence_fingerprint,
+    freshness_window_ms: receipt.freshness_window_ms,
+  };
+}
+
+export function checkEvidenceEnvelope(
+  envelope: EvidenceEnvelope,
+  context: EvidenceCheckContext,
+): CommonSensePassResult {
+  if (!envelope.receipts.length) {
+    return {
+      verdict: "HOLD",
+      rule_id: null,
+      reason: "Evidence envelope has no receipts.",
+      evidence: [{ kind: "evidence", ref: "receipts=empty" }],
+      next_action: "attach_evidence_receipt",
+    };
+  }
+
+  for (const receipt of envelope.receipts) {
+    const missing: string[] = [];
+    if (!receipt.source_kind) missing.push("source_kind");
+    if (!receipt.source_id) missing.push("source_id");
+    if (!receipt.fetched_at) missing.push("fetched_at");
+    if (!receipt.evidence_fingerprint) missing.push("evidence_fingerprint");
+    if (context.current_head_sha && !receipt.head_sha) missing.push("head_sha");
+
+    if (missing.length > 0) {
+      return {
+        verdict: "HOLD",
+        rule_id: null,
+        reason: `Evidence receipt ${receipt.source_id || "unknown"} missing required field(s): ${missing.join(", ")}.`,
+        evidence: [toEvidence(receipt, `missing=${missing.join(",")}`)],
+        next_action: "supply_complete_evidence_receipt",
+      };
+    }
+
+    const fetchedAtMs = Date.parse(receipt.fetched_at);
+    if (Number.isNaN(fetchedAtMs)) {
+      return {
+        verdict: "HOLD",
+        rule_id: null,
+        reason: `Evidence receipt ${receipt.source_id} has an invalid fetched_at timestamp.`,
+        evidence: [toEvidence(receipt, "fetched_at=invalid")],
+        next_action: "supply_valid_fetched_at",
+      };
+    }
+
+    const expectedFingerprint = createEvidenceFingerprint(receipt);
+    if (receipt.evidence_fingerprint !== expectedFingerprint) {
+      return {
+        verdict: "BLOCKER",
+        rule_id: null,
+        reason: `Evidence receipt ${receipt.source_id} fingerprint does not match its payload.`,
+        evidence: [toEvidence(receipt, "fingerprint=mismatch")],
+        next_action: "recompute_evidence_fingerprint",
+      };
+    }
+
+    const freshnessWindowMs =
+      receipt.freshness_window_ms ??
+      context.default_freshness_window_ms ??
+      DEFAULT_EVIDENCE_FRESHNESS_WINDOW_MS;
+
+    if (context.now_ms - fetchedAtMs > freshnessWindowMs) {
+      return {
+        verdict: "BLOCKER",
+        rule_id: null,
+        reason: `Evidence receipt ${receipt.source_id} is stale for the ${freshnessWindowMs}ms freshness window.`,
+        evidence: [toEvidence(receipt, `freshness_window_ms=${freshnessWindowMs}`)],
+        next_action: "refresh_evidence_receipt",
+      };
+    }
+
+    if (context.current_head_sha && receipt.head_sha !== context.current_head_sha) {
+      return {
+        verdict: "BLOCKER",
+        rule_id: null,
+        reason: `Evidence receipt ${receipt.source_id} was fetched for ${receipt.head_sha?.slice(0, 7)} but current head is ${context.current_head_sha.slice(0, 7)}.`,
+        evidence: [
+          toEvidence(receipt, "head_sha=stale"),
+          { kind: "sha", ref: context.current_head_sha, note: "current_head" },
+        ],
+        next_action: "refresh_evidence_on_current_head",
+      };
+    }
+  }
+
+  return {
+    verdict: "PASS",
+    rule_id: null,
+    reason: "Evidence envelope receipts are complete, fresh, and fingerprinted.",
+    evidence: envelope.receipts.map((receipt) =>
+      toEvidence(receipt, "evidence=fresh"),
+    ),
+  };
+}

--- a/packages/commonsensepass/src/index.ts
+++ b/packages/commonsensepass/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./schema.js";
 export * from "./fixtures.js";
+export * from "./evidence.js";
 export { checkR1, checkR2, checkR3, checkR4, checkR5 } from "./rules.js";
 export { commonsensepassCheck } from "./check.js";

--- a/packages/commonsensepass/src/schema.ts
+++ b/packages/commonsensepass/src/schema.ts
@@ -23,6 +23,14 @@ export interface Evidence {
   kind: string;
   ref: string;
   note?: string;
+  source_kind?: string;
+  source_id?: string;
+  fetched_at?: string;
+  head_sha?: string;
+  run_id?: string;
+  proof_refs?: string[];
+  evidence_fingerprint?: string;
+  freshness_window_ms?: number;
 }
 
 export interface CommonSensePassResult {


### PR DESCRIPTION
Summary:
- Added deterministic CommonSensePass evidence receipt envelopes with proof fingerprints, freshness windows, and stale head checks.
- Extended evidence payloads with source_kind, source_id, fetched_at, head_sha, run_id, proof_refs, evidence_fingerprint, and freshness_window_ms.
- Added focused PASS, HOLD, and BLOCKER tests plus README usage.

Verification:
- npm --prefix packages/commonsensepass test
- npx tsc --noEmit -p packages/commonsensepass/tsconfig.json
- git diff --check on touched files
- no em dash or en dash found in touched files