### PR TITLE
[codex] gate Continuous QC with CommonSensePass

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -24,7 +24,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | scripts/pinballwake-buildbait-room.mjs | 42445fca7b1e | 4811 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |
 | scripts/pinballwake-coding-room.mjs | 9fa5689c555e | 25310 |
-| scripts/pinballwake-continuous-improvement-room.mjs | c80556b2d930 | 12439 |
+| scripts/pinballwake-continuous-improvement-room.mjs | c41cf0bacf97 | 14872 |
 | scripts/pinballwake-dogfood-room.mjs | d161028d1382 | 2782 |
 | scripts/pinballwake-event-ledger-room.mjs | e8f8f9f84123 | 16104 |
 | scripts/pinballwake-jobs-room.mjs | c77c394081c2 | 14217 |

--- a/scripts/pinballwake-commonsense-pass.mjs
+++ b/scripts/pinballwake-commonsense-pass.mjs
@@ -17,33 +17,19 @@ export const DEFAULT_ALLOWED_REQUESTER_SEATS = new Set([
   "claude-cowork-coordinator-seat",
 ]);
 
-/**
- * Run all CommonSensePass checks against a packet.
- *
- * @param {object} args
- * @param {object} args.packet                 the executor packet (post `makePacket`)
- * @param {object} [args.now]                  current Date; defaults to new Date()
- * @param {object} [args.heartbeat]            `{ tickId, emittedAt }` of the latest known tick
- * @param {Set<string>} [args.allowedRequesterSeats]
- * @param {function} [args.fileExists]         async (file) => boolean, used for owned_files presence checks. Defaults to a noop that returns true (skip the check) so this can be unit-tested without filesystem.
- * @returns {Promise<{ok: boolean, reason?: string, [k: string]: any}>}
- */
-export async function commonSensePass({
+function runStaticCommonSensePassGates({
   packet,
   now = new Date(),
   heartbeat = null,
   requireHeartbeat = false,
   allowedRequesterSeats = DEFAULT_ALLOWED_REQUESTER_SEATS,
-  fileExists = async () => true,
   heartbeatMaxAgeMs = DEFAULT_HEARTBEAT_MAX_AGE_MS,
 } = {}) {
-  // 1. Schema gate (delegates to the packet validator).
   const v = validateExecutorPacket(packet);
   if (!v.ok) {
     return { ok: false, reason: `packet_invalid:${v.reason}`, evidence: v };
   }
 
-  // 2. Authority gate: only allowlisted seats may emit packets.
   if (!allowedRequesterSeats.has(packet.requesting_seat_id)) {
     return {
       ok: false,
@@ -91,9 +77,61 @@ export async function commonSensePass({
     }
   }
 
-  // 5. Owned-files existence check (skipped when fileExists is the default noop).
-  //    For `intent: "create"`, the test target need not exist yet because that's the point.
-  //    For `intent: "modify"` or `"test_only"`, all owned_files must exist.
+  return { ok: true };
+}
+
+function runAcceptanceCommonSensePassGate(packet) {
+  if (packet.acceptance.test_command !== undefined) {
+    if (typeof packet.acceptance.test_command !== "string" || !packet.acceptance.test_command.trim()) {
+      return { ok: false, reason: "acceptance_test_command_must_be_non_empty_string" };
+    }
+    // Sanity: reject obviously dangerous shell payloads.
+    if (/[;&|`]/.test(packet.acceptance.test_command) || /rm\s+-rf/i.test(packet.acceptance.test_command)) {
+      return { ok: false, reason: "acceptance_test_command_unsafe" };
+    }
+  }
+
+  return { ok: true };
+}
+
+export function commonSensePassSync(args = {}) {
+  const staticResult = runStaticCommonSensePassGates(args);
+  if (!staticResult.ok) return staticResult;
+  return runAcceptanceCommonSensePassGate(args.packet);
+}
+
+/**
+ * Run all CommonSensePass checks against a packet.
+ *
+ * @param {object} args
+ * @param {object} args.packet                 the executor packet (post `makePacket`)
+ * @param {object} [args.now]                  current Date; defaults to new Date()
+ * @param {object} [args.heartbeat]            `{ tickId, emittedAt }` of the latest known tick
+ * @param {Set<string>} [args.allowedRequesterSeats]
+ * @param {function} [args.fileExists]         async (file) => boolean, used for owned_files presence checks. Defaults to a noop that returns true (skip the check) so this can be unit-tested without filesystem.
+ * @returns {Promise<{ok: boolean, reason?: string, [k: string]: any}>}
+ */
+export async function commonSensePass({
+  packet,
+  now = new Date(),
+  heartbeat = null,
+  requireHeartbeat = false,
+  allowedRequesterSeats = DEFAULT_ALLOWED_REQUESTER_SEATS,
+  fileExists = async () => true,
+  heartbeatMaxAgeMs = DEFAULT_HEARTBEAT_MAX_AGE_MS,
+} = {}) {
+  const staticResult = runStaticCommonSensePassGates({
+    packet,
+    now,
+    heartbeat,
+    requireHeartbeat,
+    allowedRequesterSeats,
+    heartbeatMaxAgeMs,
+  });
+  if (!staticResult.ok) return staticResult;
+
+  // For `intent: "create"`, the test target need not exist yet because that is the point.
+  // For `intent: "modify"` or `"test_only"`, all owned_files must exist.
   if (packet.intent !== "create") {
     for (const file of packet.owned_files) {
       const exists = await fileExists(file);
@@ -107,16 +145,5 @@ export async function commonSensePass({
     }
   }
 
-  // 6. Acceptance sanity: when test_command is present, it must be a string.
-  if (packet.acceptance.test_command !== undefined) {
-    if (typeof packet.acceptance.test_command !== "string" || !packet.acceptance.test_command.trim()) {
-      return { ok: false, reason: "acceptance_test_command_must_be_non_empty_string" };
-    }
-    // Sanity: reject obviously dangerous shell payloads.
-    if (/[;&|`]/.test(packet.acceptance.test_command) || /rm\s+-rf/i.test(packet.acceptance.test_command)) {
-      return { ok: false, reason: "acceptance_test_command_unsafe" };
-    }
-  }
-
-  return { ok: true };
+  return runAcceptanceCommonSensePassGate(packet);
 }

--- a/scripts/pinballwake-commonsense-pass.test.mjs
+++ b/scripts/pinballwake-commonsense-pass.test.mjs
@@ -3,7 +3,11 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { commonSensePass, DEFAULT_HEARTBEAT_MAX_AGE_MS } from "./pinballwake-commonsense-pass.mjs";
+import {
+  commonSensePass,
+  commonSensePassSync,
+  DEFAULT_HEARTBEAT_MAX_AGE_MS,
+} from "./pinballwake-commonsense-pass.mjs";
 import { makePacket } from "./pinballwake-executor-packet.mjs";
 
 function basePacket(overrides = {}) {
@@ -122,6 +126,13 @@ describe("commonSensePass", () => {
   test("PASS with criteria-only acceptance (no test_command)", async () => {
     const r = await commonSensePass({
       packet: basePacket({ acceptance: { criteria: ["lints", "types"] } }),
+    });
+    assert.equal(r.ok, true);
+  });
+
+  test("sync gate PASSes static packet checks for receipt-only callers", () => {
+    const r = commonSensePassSync({
+      packet: basePacket({ acceptance: { criteria: ["focused proof attached"] } }),
     });
     assert.equal(r.ok, true);
   });

--- a/scripts/pinballwake-continuous-improvement-room.mjs
+++ b/scripts/pinballwake-continuous-improvement-room.mjs
@@ -3,6 +3,8 @@
 import { readFile } from "node:fs/promises";
 
 import { createCodingRoomJob } from "./pinballwake-coding-room.mjs";
+import { commonSensePassSync } from "./pinballwake-commonsense-pass.mjs";
+import { makePacket } from "./pinballwake-executor-packet.mjs";
 
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -71,11 +73,12 @@ function proofRequiredFor(tests = []) {
   return `Patch, non-overlap note, Boardroom proof, and tests: ${testText}`;
 }
 
-function nativeImproverReceipt({ top, job, tests, now, source }) {
+function nativeImproverReceipt({ top, job, tests, now, source, commonsensepass }) {
   return {
     receipt_type: "native_improver_opportunity",
     emitted_at: now,
     source,
+    commonsensepass,
     improvement_kind: top.kind,
     score: top.score,
     evidence: evidenceFor(top),
@@ -85,11 +88,12 @@ function nativeImproverReceipt({ top, job, tests, now, source }) {
   };
 }
 
-function nativeImproverHoldReceipt({ top, now, source }) {
+function nativeImproverHoldReceipt({ top, now, source, commonsensepass }) {
   return {
     receipt_type: "native_improver_hold",
     emitted_at: now,
     source,
+    commonsensepass,
     improvement_kind: top.kind,
     score: top.score,
     evidence: evidenceFor(top),
@@ -229,6 +233,45 @@ function expectedTestsFor(files = []) {
     .map((file) => `node --test ${file}`);
 }
 
+function commonSenseVerdictFromResult(result = {}) {
+  return {
+    verdict: result.ok ? "PASS" : "HOLD",
+    reason_code: result.reason || "commonsensepass_pass",
+  };
+}
+
+function duplicateCoverageCommonSensePass(coverage) {
+  return {
+    verdict: "SUPPRESS",
+    rule_id: "R3",
+    reason_code: coverageReasonKey(coverage),
+    evidence: [`${coverage.kind}=${coverage.ref}`],
+  };
+}
+
+function buildCommonSensePacketForJob({ job, tests, now, source, signal = {} }) {
+  const firstTest = tests[0] || "";
+  return makePacket({
+    packet_id: `continuous-qc:${job.job_id}`,
+    emitted_at: now,
+    heartbeat_tick_id: `continuous-qc:${source}:${now}`,
+    requesting_seat_id: "unclick-heartbeat-seat",
+    todo_id: job.job_id,
+    intent: "modify",
+    owned_files: job.owned_files,
+    acceptance: firstTest
+      ? {
+          test_command: firstTest,
+          expected_exit_code: 0,
+          criteria: ["Continuous QC routed finding has owned files and focused proof."],
+        }
+      : {
+          criteria: ["Continuous QC routed finding has owned files and focused proof."],
+        },
+    head_sha_at_request: signal.head_sha || signal.headSha || "continuous-qc-snapshot",
+  });
+}
+
 function chipFor(kind, signal = {}) {
   const title = compactText(signal.title || signal.summary || signal.reason || signal.blocker || signalText(signal), 90);
   const prefix = {
@@ -286,6 +329,7 @@ export function evaluateContinuousImprovementRoom({
 
   const duplicateCoverage = signalCoverage(top.signal);
   if (duplicateCoverage) {
+    const commonsensepass = duplicateCoverageCommonSensePass(duplicateCoverage);
     return {
       ok: true,
       action: "continuous_improvement_room",
@@ -295,7 +339,8 @@ export function evaluateContinuousImprovementRoom({
       improvement_kind: top.kind,
       signal: top.signal,
       duplicate_coverage: duplicateCoverage,
-      receipt: nativeImproverHoldReceipt({ top, now, source }),
+      commonsensepass,
+      receipt: nativeImproverHoldReceipt({ top, now, source, commonsensepass }),
     };
   }
 
@@ -317,7 +362,41 @@ export function evaluateContinuousImprovementRoom({
     },
     createdAt: now,
   });
-  const receipt = nativeImproverReceipt({ top, job, tests, now, source });
+  const commonSensePacket = buildCommonSensePacketForJob({
+    job,
+    tests,
+    now,
+    source,
+    signal: top.signal,
+  });
+  const commonSenseResult = commonSensePassSync({
+    packet: commonSensePacket,
+    now: new Date(now),
+    heartbeat: {
+      tickId: commonSensePacket.heartbeat_tick_id,
+      emittedAt: now,
+    },
+  });
+  const commonsensepass = {
+    ...commonSenseVerdictFromResult(commonSenseResult),
+    packet_id: commonSensePacket.packet_id,
+  };
+
+  if (!commonSenseResult.ok) {
+    return {
+      ok: true,
+      action: "continuous_improvement_room",
+      result: "hold",
+      reason: "commonsensepass_hold",
+      highest_score: top.score,
+      improvement_kind: top.kind,
+      signal: top.signal,
+      commonsensepass,
+      receipt: nativeImproverHoldReceipt({ top, now, source, commonsensepass }),
+    };
+  }
+
+  const receipt = nativeImproverReceipt({ top, job, tests, now, source, commonsensepass });
 
   return {
     ok: true,
@@ -328,6 +407,7 @@ export function evaluateContinuousImprovementRoom({
     improvement_kind: top.kind,
     score: top.score,
     signal: top.signal,
+    commonsensepass,
     recommended_insertion: "prepend_to_coding_room_ledger",
     job,
     receipt,
@@ -340,6 +420,7 @@ export function evaluateContinuousImprovementRoom({
       next_action: receipt.next_action,
       proof_required: receipt.proof_required,
       xpass_advisory: receipt.xpass_advisory,
+      commonsensepass,
       expected_proof: tests.length
         ? `Patch the smallest safe improvement and run: ${tests.join("; ")}`
         : "Patch the smallest safe improvement and run focused proof.",

--- a/scripts/pinballwake-continuous-improvement-room.test.mjs
+++ b/scripts/pinballwake-continuous-improvement-room.test.mjs
@@ -41,6 +41,9 @@ describe("PinballWake Continuous Improvement Room", () => {
     assert.match(result.receipt.next_action, /Improve ACK handoff/);
     assert.match(result.receipt.proof_required, /pinballwake-merge-room.test.mjs/);
     assert(result.receipt.xpass_advisory.includes("CommonSensePass"));
+    assert.equal(result.commonsensepass.verdict, "PASS");
+    assert.equal(result.receipt.commonsensepass.verdict, "PASS");
+    assert.equal(result.packet.commonsensepass.verdict, "PASS");
     assert.deepEqual(result.packet.evidence, result.receipt.evidence);
     assert.equal(result.packet.next_action, result.receipt.next_action);
     assert.equal(result.packet.proof_required, result.receipt.proof_required);
@@ -70,6 +73,8 @@ describe("PinballWake Continuous Improvement Room", () => {
     assert.equal(result.job, undefined);
     assert.equal(result.receipt.receipt_type, "native_improver_hold");
     assert.equal(result.receipt.source, "heartbeat");
+    assert.equal(result.commonsensepass.verdict, "SUPPRESS");
+    assert.equal(result.receipt.commonsensepass.verdict, "SUPPRESS");
     assert.match(result.receipt.next_action, /duplicate build job/);
   });
 


### PR DESCRIPTION
Summary:
- Added a sync CommonSensePass path for receipt-only callers that need static packet gates without async file checks.
- Continuous Improvement QC now attaches a CommonSensePass PASS verdict before routing a finding into a build packet.
- Duplicate-covered QC findings now emit a SUPPRESS verdict instead of creating duplicate work.

Verification:
- node --test scripts/pinballwake-commonsense-pass.test.mjs
- node --test scripts/pinballwake-continuous-improvement-room.test.mjs
- node --test scripts/pinballwake-autopilot-master-loop.test.mjs
- git diff --check on touched files
- no em dash or en dash added in touched diff