### PR TITLE
Keep Analytics in admin submenu only

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -16,7 +16,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
 | src/App.tsx | b02c3916f083 | 13089 |
-| src/pages/admin/AdminShell.tsx | ae5e4a8dae80 | 19137 |
+| src/pages/admin/AdminShell.tsx | fcbb1fa44f40 | 19018 |
 | .github/workflows/ci.yml | 79e43dd8e26c | 1608 |
 | .github/workflows/brainmap-auto-update.yml | 7e8b08eb16aa | 1137 |
 | package.json | 9f761ff407b1 | 4232 |

--- a/src/pages/admin/AdminShell.test.tsx
+++ b/src/pages/admin/AdminShell.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  useSession: () => ({
+    session: { access_token: "test-session-token" },
+    user: { email: "admin@example.com" },
+    loading: false,
+  }),
+  signOut: vi.fn(),
+}));
+
+function stubAdminFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("admin_profile")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ is_admin: true }),
+        });
+      }
+      if (url.includes("list_signals")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ signals: [] }),
+        });
+      }
+      if (url.includes("admin_check_connection")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              connected: true,
+              configured: true,
+              has_context: true,
+              context_count: 1,
+              fact_count: 1,
+              last_session: null,
+              last_used_at: null,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    }),
+  );
+}
+
+describe("AdminShell navigation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    stubAdminFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps Analytics only inside the yellow Admin submenu", async () => {
+    const { default: AdminShell } = await import("./AdminShell");
+
+    render(
+      <MemoryRouter initialEntries={["/admin/analytics"]}>
+        <AdminShell />
+      </MemoryRouter>,
+    );
+
+    const analyticsLinks = await screen.findAllByRole("link", { name: "Analytics" });
+    expect(analyticsLinks).toHaveLength(1);
+    expect(analyticsLinks[0]).toHaveAttribute("href", "/admin/analytics");
+    expect(screen.getAllByRole("button", { name: "Admin" }).length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -354,7 +354,6 @@ function SidebarNav({
       <SeatsNavItem onClick={onLinkClick} />
       <AutopilotNavGroup onLinkClick={onLinkClick} />
       <SurfaceLink path="/admin/signals"      label="Signals"       icon={Bell}     onClick={onLinkClick} badge={signalsUnread} />
-      {isAdmin && <SurfaceLink path="/admin/analytics" label="Analytics"    icon={BarChart3} onClick={onLinkClick} />}
       <SurfaceLink path="/admin/settings" label="Settings"                 icon={Settings}  onClick={onLinkClick} />
       <SurfaceLink path="/admin/billing"  label="Billing"                  icon={CreditCard} onClick={onLinkClick} />
       {isAdmin && <AdminSubmenu onLinkClick={onLinkClick} />}


### PR DESCRIPTION
## Summary
- remove the duplicate top-level Analytics link from the admin shell sidebar
- keep Analytics available inside the yellow Admin submenu
- add focused coverage so admin users see one Analytics nav target on /admin/analytics

## Proof
- npx vitest run src/pages/admin/AdminShell.test.tsx
- git diff --check