### PR TITLE
Add Memory Recall see more

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -3854,6 +3854,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .order("updated_at", { ascending: false })
           .limit(20);
 
+        const topFactsLimit = getClampedLimit(req.query.top_facts_limit, 10, 110);
+
         // Most accessed facts
         const { data: topFacts } = await supabase
           .from("mc_extracted_facts")
@@ -3861,7 +3863,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("api_key_hash", apiKeyHash)
           .eq("status", "active")
           .order("access_count", { ascending: false })
-          .limit(10);
+          .limit(topFactsLimit);
 
         return res.status(200).json({
           facts_by_day: factsByDay,
@@ -3875,6 +3877,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             total: (bc.count ?? 0) + (lib.count ?? 0) + (sessions.count ?? 0) +
                    (facts.count ?? 0) + (convos.count ?? 0) + (code.count ?? 0),
           },
+          top_facts_limit: topFactsLimit,
           recent_decay: recentDecay ?? [],
           top_facts: topFacts ?? [],
         });

--- a/src/pages/admin/memory/MemoryActivityTab.test.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import MemoryActivityTab from "./MemoryActivityTab";
+
+function makeActivity(topFactCount: number) {
+  return {
+    facts_by_day: {},
+    storage: {
+      business_context: 0,
+      knowledge_library: 0,
+      session_summaries: 0,
+      extracted_facts: topFactCount,
+      conversation_log: 0,
+      code_dumps: 0,
+      total: topFactCount,
+    },
+    recent_decay: [],
+    top_facts: Array.from({ length: topFactCount }, (_, index) => ({
+      id: `fact-${index + 1}`,
+      fact: `fact ${index + 1}`,
+      category: "technical",
+      access_count: topFactCount - index,
+      decay_tier: "hot",
+    })),
+  };
+}
+
+describe("MemoryActivityTab", () => {
+  const fetchCalls: string[] = [];
+
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        fetchCalls.push(url);
+        const topFactCount = url.includes("top_facts_limit=110") ? 110 : 10;
+
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeActivity(topFactCount)),
+        });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("loads more accessed facts on request", async () => {
+    render(<MemoryActivityTab apiKey="test-token" />);
+
+    await screen.findByText("Most Accessed Facts");
+
+    expect(fetchCalls[0]).toContain("top_facts_limit=10");
+    expect(screen.getByText("fact 10")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Show 100 more/i }));
+
+    await waitFor(() => {
+      expect(fetchCalls.some((url) => url.includes("top_facts_limit=110"))).toBe(true);
+    });
+    expect(await screen.findByText("fact 110")).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/memory/MemoryActivityTab.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { Activity, TrendingUp, Zap } from "lucide-react";
+import { Activity, ChevronsDown, TrendingUp, Zap } from "lucide-react";
 import EmptyState from "./EmptyState";
 
 interface ActivityData {
@@ -35,6 +35,9 @@ const DECAY_COLORS: Record<string, string> = {
   cold: "bg-blue-400",
 };
 
+const INITIAL_TOP_FACTS_LIMIT = 10;
+const EXTENDED_TOP_FACTS_LIMIT = 110;
+
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
@@ -42,10 +45,16 @@ function formatDate(iso: string): string {
 export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
   const [data, setData] = useState<ActivityData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [topFactsLimit, setTopFactsLimit] = useState(INITIAL_TOP_FACTS_LIMIT);
 
   const load = useCallback(async () => {
     try {
-      const res = await fetch("/api/memory-admin?action=admin_memory_activity", {
+      const params = new URLSearchParams({
+        action: "admin_memory_activity",
+        top_facts_limit: String(topFactsLimit),
+      });
+      const res = await fetch(`/api/memory-admin?${params.toString()}`, {
         headers: { Authorization: `Bearer ${apiKey}` },
       });
       if (res.ok) {
@@ -53,8 +62,9 @@ export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
       }
     } finally {
       setLoading(false);
+      setLoadingMore(false);
     }
-  }, [apiKey]);
+  }, [apiKey, topFactsLimit]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -127,6 +137,20 @@ export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
               </div>
             ))}
           </div>
+          {topFactsLimit < EXTENDED_TOP_FACTS_LIMIT && data.top_facts.length >= INITIAL_TOP_FACTS_LIMIT && (
+            <button
+              type="button"
+              onClick={() => {
+                setLoadingMore(true);
+                setTopFactsLimit(EXTENDED_TOP_FACTS_LIMIT);
+              }}
+              disabled={loadingMore}
+              className="mt-3 inline-flex items-center gap-2 rounded-md border border-white/[0.08] px-3 py-1.5 text-xs font-medium text-white/50 transition-colors hover:border-[#61C1C4]/40 hover:text-[#61C1C4] disabled:cursor-wait disabled:opacity-60"
+            >
+              <ChevronsDown className="h-3.5 w-3.5" />
+              {loadingMore ? "Loading..." : "Show 100 more"}
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Summary
- Add a capped top_facts_limit parameter to admin_memory_activity so Recall Check can fetch more accessed facts on demand.
- Add a Show 100 more control in Most Accessed Facts.
- Add a focused MemoryActivityTab test for the +100 fetch path.

Proof
- npx vitest run src/pages/admin/memory/MemoryActivityTab.test.tsx
- npm run brainmap:check
- npm run test:brainmap
- git diff --check

Boardroom
- Todo eb430faa-1e78-42c2-a060-fbbf01982b4d