### PR TITLE
Separate top of mind recall facts

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -340,6 +340,32 @@ function getClampedLimit(value: unknown, fallback = 50, max = 200): number {
   return Math.min(Math.floor(parsed), max);
 }
 
+const BACKGROUND_RECALL_CATEGORIES = new Set(["identity", "preference", "standing_rule"]);
+const BACKGROUND_RECALL_PATTERNS = [
+  /^chris('s)?\s/i,
+  /^user\s/i,
+  /should always/i,
+  /never use/i,
+  /operator timezone/i,
+  /standing rule/i,
+  /profile/i,
+  /preference/i,
+];
+
+function annotateRecallFact<T extends { category?: string | null; fact?: string | null; access_count?: number | null }>(fact: T) {
+  const category = String(fact.category ?? "").toLowerCase();
+  const text = String(fact.fact ?? "");
+  const accessCount = Number(fact.access_count ?? 0);
+  const looksStatic = BACKGROUND_RECALL_CATEGORIES.has(category) || BACKGROUND_RECALL_PATTERNS.some((pattern) => pattern.test(text));
+  const isBackgroundHeavy = accessCount >= 100 && looksStatic;
+
+  return {
+    ...fact,
+    recall_signal: isBackgroundHeavy ? "background-heavy" : "top-of-mind",
+    recall_note: isBackgroundHeavy ? "Startup or heartbeat reads" : "Human-facing recall",
+  };
+}
+
 function getRequestBaseUrl(req: VercelRequest): string | null {
   const explicit = process.env.EMBED_API_URL?.replace(/\/$/, "");
   if (explicit) return explicit;
@@ -3864,6 +3890,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("status", "active")
           .order("access_count", { ascending: false })
           .limit(topFactsLimit);
+        const annotatedTopFacts = (topFacts ?? []).map(annotateRecallFact);
+        const topOfMindFacts = annotatedTopFacts
+          .filter((fact) => fact.recall_signal === "top-of-mind")
+          .slice(0, 10);
+        const backgroundHeavyCount = annotatedTopFacts.filter((fact) => fact.recall_signal === "background-heavy").length;
 
         return res.status(200).json({
           facts_by_day: factsByDay,
@@ -3878,8 +3909,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                    (facts.count ?? 0) + (convos.count ?? 0) + (code.count ?? 0),
           },
           top_facts_limit: topFactsLimit,
+          recall_diagnostics: {
+            inspected_top_facts: annotatedTopFacts.length,
+            background_heavy_count: backgroundHeavyCount,
+          },
           recent_decay: recentDecay ?? [],
-          top_facts: topFacts ?? [],
+          top_of_mind_facts: topOfMindFacts,
+          top_facts: annotatedTopFacts,
         });
       }
 

--- a/src/pages/admin/memory/MemoryActivityTab.test.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.test.tsx
@@ -3,7 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import MemoryActivityTab from "./MemoryActivityTab";
 
+type ActivityResponse = ReturnType<typeof makeActivity>;
+
 function makeActivity(topFactCount: number) {
+  const topFacts = Array.from({ length: topFactCount }, (_, index) => ({
+    id: `fact-${index + 1}`,
+    fact: `fact ${index + 1}`,
+    category: "technical",
+    access_count: topFactCount - index,
+    decay_tier: "hot",
+    recall_signal: "top-of-mind",
+    recall_note: "Human-facing recall",
+  }));
+
   return {
     facts_by_day: {},
     storage: {
@@ -16,21 +28,22 @@ function makeActivity(topFactCount: number) {
       total: topFactCount,
     },
     recent_decay: [],
-    top_facts: Array.from({ length: topFactCount }, (_, index) => ({
-      id: `fact-${index + 1}`,
-      fact: `fact ${index + 1}`,
-      category: "technical",
-      access_count: topFactCount - index,
-      decay_tier: "hot",
-    })),
+    recall_diagnostics: {
+      inspected_top_facts: topFactCount,
+      background_heavy_count: 0,
+    },
+    top_of_mind_facts: topFacts.slice(0, 10),
+    top_facts: topFacts,
   };
 }
 
 describe("MemoryActivityTab", () => {
   const fetchCalls: string[] = [];
+  let activityFactory: (topFactCount: number) => ActivityResponse = makeActivity;
 
   beforeEach(() => {
     fetchCalls.length = 0;
+    activityFactory = makeActivity;
     vi.stubGlobal(
       "fetch",
       vi.fn((input: RequestInfo | URL) => {
@@ -40,7 +53,7 @@ describe("MemoryActivityTab", () => {
 
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve(makeActivity(topFactCount)),
+          json: () => Promise.resolve(activityFactory(topFactCount)),
         });
       }),
     );
@@ -57,7 +70,7 @@ describe("MemoryActivityTab", () => {
     await screen.findByText("Most Accessed Facts");
 
     expect(fetchCalls[0]).toContain("top_facts_limit=10");
-    expect(screen.getByText("fact 10")).toBeInTheDocument();
+    expect(screen.getAllByText("fact 10").length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: /Show 100 more/i }));
 
@@ -65,5 +78,46 @@ describe("MemoryActivityTab", () => {
       expect(fetchCalls.some((url) => url.includes("top_facts_limit=110"))).toBe(true);
     });
     expect(await screen.findByText("fact 110")).toBeInTheDocument();
+  });
+
+  it("separates top of mind facts from background-heavy access counts", async () => {
+    activityFactory = () => {
+      const backgroundFact = {
+        id: "static-profile",
+        fact: "Chris prefers concise worker updates",
+        category: "preference",
+        access_count: 2080,
+        decay_tier: "hot",
+        recall_signal: "background-heavy",
+        recall_note: "Startup or heartbeat reads",
+      };
+      const activeFact = {
+        id: "active-project",
+        fact: "PR #898 added the Recall Check see more path",
+        category: "technical",
+        access_count: 42,
+        decay_tier: "hot",
+        recall_signal: "top-of-mind",
+        recall_note: "Human-facing recall",
+      };
+
+      return {
+        ...makeActivity(2),
+        recall_diagnostics: {
+          inspected_top_facts: 2,
+          background_heavy_count: 1,
+        },
+        top_of_mind_facts: [activeFact],
+        top_facts: [backgroundFact, activeFact],
+      };
+    };
+
+    render(<MemoryActivityTab apiKey="test-token" />);
+
+    await screen.findByText("Top of Mind");
+
+    expect(screen.getAllByText("PR #898 added the Recall Check see more path").length).toBeGreaterThan(0);
+    expect(screen.getByText("Background-heavy")).toBeInTheDocument();
+    expect(screen.getByText("Startup or heartbeat reads")).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/memory/MemoryActivityTab.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.tsx
@@ -2,6 +2,18 @@ import { useEffect, useState, useCallback } from "react";
 import { Activity, ChevronsDown, TrendingUp, Zap } from "lucide-react";
 import EmptyState from "./EmptyState";
 
+type RecallSignal = "top-of-mind" | "background-heavy";
+
+interface RecallFact {
+  id: string;
+  fact: string;
+  category: string;
+  access_count: number;
+  decay_tier: string;
+  recall_signal?: RecallSignal;
+  recall_note?: string;
+}
+
 interface ActivityData {
   facts_by_day: Record<string, number>;
   storage: {
@@ -20,13 +32,12 @@ interface ActivityData {
     decay_tier: string;
     updated_at: string;
   }>;
-  top_facts: Array<{
-    id: string;
-    fact: string;
-    category: string;
-    access_count: number;
-    decay_tier: string;
-  }>;
+  top_of_mind_facts?: RecallFact[];
+  top_facts: RecallFact[];
+  recall_diagnostics?: {
+    inspected_top_facts: number;
+    background_heavy_count: number;
+  };
 }
 
 const DECAY_COLORS: Record<string, string> = {
@@ -40,6 +51,34 @@ const EXTENDED_TOP_FACTS_LIMIT = 110;
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function RecallFactRow({ fact, showSignal = false }: { fact: RecallFact; showSignal?: boolean }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="shrink-0 rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-mono text-white/40">
+        {fact.access_count}x
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs text-white/60 line-clamp-1">{fact.fact}</p>
+        <div className="mt-0.5 flex flex-wrap items-center gap-2">
+          <span className="text-[10px] text-white/25">{fact.category}</span>
+          <span className="flex items-center gap-1 text-[10px] text-white/25">
+            <span className={`inline-block h-1.5 w-1.5 rounded-full ${DECAY_COLORS[fact.decay_tier] ?? "bg-gray-500"}`} />
+            {fact.decay_tier}
+          </span>
+          {showSignal && fact.recall_signal === "background-heavy" && (
+            <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-200/70">
+              Background-heavy
+            </span>
+          )}
+          {showSignal && fact.recall_note && (
+            <span className="text-[10px] text-white/25">{fact.recall_note}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
@@ -84,6 +123,7 @@ export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
 
   const sortedDays = Object.entries(data.facts_by_day).sort(([a], [b]) => a.localeCompare(b));
   const maxCount = Math.max(1, ...sortedDays.map(([, c]) => c));
+  const topOfMindFacts = data.top_of_mind_facts ?? [];
 
   return (
     <div className="space-y-6">
@@ -111,6 +151,20 @@ export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
         </div>
       )}
 
+      {topOfMindFacts.length > 0 && (
+        <div className="rounded-lg border border-[#61C1C4]/20 bg-[#61C1C4]/[0.04] p-4">
+          <h3 className="flex items-center gap-2 text-xs font-semibold text-[#61C1C4]/80 uppercase tracking-wider mb-3">
+            <TrendingUp className="h-3.5 w-3.5" />
+            Top of Mind
+          </h3>
+          <div className="space-y-2">
+            {topOfMindFacts.map((fact) => (
+              <RecallFactRow key={fact.id} fact={fact} />
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Top accessed facts */}
       {data.top_facts.length > 0 && (
         <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
@@ -120,21 +174,7 @@ export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
           </h3>
           <div className="space-y-2">
             {data.top_facts.map((f) => (
-              <div key={f.id} className="flex items-start gap-3">
-                <span className="shrink-0 rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-mono text-white/40">
-                  {f.access_count}x
-                </span>
-                <div className="min-w-0 flex-1">
-                  <p className="text-xs text-white/60 line-clamp-1">{f.fact}</p>
-                  <div className="mt-0.5 flex items-center gap-2">
-                    <span className="text-[10px] text-white/25">{f.category}</span>
-                    <span className="flex items-center gap-1 text-[10px] text-white/25">
-                      <span className={`inline-block h-1.5 w-1.5 rounded-full ${DECAY_COLORS[f.decay_tier] ?? "bg-gray-500"}`} />
-                      {f.decay_tier}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              <RecallFactRow key={f.id} fact={f} showSignal />
             ))}
           </div>
           {topFactsLimit < EXTENDED_TOP_FACTS_LIMIT && data.top_facts.length >= INITIAL_TOP_FACTS_LIMIT && (


### PR DESCRIPTION
Summary
- Add read-only recall labels to admin_memory_activity for background-heavy accessed facts.
- Surface a Top of Mind section above raw Most Accessed Facts.
- Keep raw Most Accessed Facts inspectable with background-heavy labels and the existing +100 path.

Proof
- npx vitest run src/pages/admin/memory/MemoryActivityTab.test.tsx
- npm run build
- npm run brainmap:check
- npm run test:brainmap
- git diff --check

Boardroom
- Todo eb430faa-1e78-42c2-a060-fbbf01982b4d