### PR TITLE
[codex] Add CommonSensePass protocol resolver

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -66,6 +66,10 @@ If no UnClick MCP or channel connector exists but an UnClick API key is already 
 
 After saving an accepted external turn, tethered seats should call `read_orchestrator_context` before deciding what the user meant. The safe order is Log -> Read -> Decide -> Reply -> Log reply, so a test cue or proof phrase is not mistaken for a real operator request.
 
+## Worker Sanity Gate
+
+Workers can call `commonsensepass_protocol` with no arguments to fetch the canonical CommonSensePass playbook. The response is versioned and tells workers when to run the verdict-only gate, what evidence to gather, how to interpret PASS/BLOCKER/HOLD/SUPPRESS/ROUTE, and how to write compact receipts. This lets worker prompts shrink to: "Call commonsensepass_protocol on UnClick before claiming healthy, no_work, done, merge_ready, pass, quiet, or duplicate_wake."
+
 ## Configuration
 
 | Environment Variable | Default | Description |

--- a/packages/mcp-server/src/__tests__/commonsensepass-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/commonsensepass-protocol.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  commonSensePassProtocolContentFingerprint,
+  formatCommonSensePassProtocolVersion,
+  getCommonSensePassProtocol,
+  type CommonSensePassProtocol,
+} from "../commonsensepass-protocol.js";
+
+describe("commonsensepass_protocol payload", () => {
+  it("returns the same read-only playbook across cycles", () => {
+    const first = getCommonSensePassProtocol();
+    const second = getCommonSensePassProtocol();
+
+    expect(first).toEqual(second);
+    first.procedure[0] = "mutated by caller";
+    expect(getCommonSensePassProtocol().procedure[0]).toContain("compact evidence packet");
+  });
+
+  it("keeps the public payload schema stable", () => {
+    const protocol = getCommonSensePassProtocol();
+
+    expect(Object.keys(protocol)).toEqual([
+      "version",
+      "purpose",
+      "when_to_run",
+      "tool_contract",
+      "verdicts",
+      "procedure",
+      "receipt_template",
+      "guardrails",
+      "watch_state_key",
+    ]);
+    expect(protocol.version).toMatch(/^\d{4}-\d{2}-\d{2}\.v\d+$/);
+    expect(protocol.purpose).toContain("read-only sanity gate");
+    expect(protocol.when_to_run).toContain("Before saying there is no work.");
+    expect(protocol.tool_contract).toMatchObject({
+      package_name: "@unclick/commonsensepass",
+      function_name: "commonsensepassCheck",
+    });
+    expect(protocol.verdicts.PASS).toContain("Continue");
+    expect(protocol.verdicts.BLOCKER).toContain("Stop");
+    expect(protocol.verdicts.HOLD).toContain("missing proof");
+    expect(protocol.verdicts.SUPPRESS).toContain("quiet");
+    expect(protocol.verdicts.ROUTE).toContain("another worker");
+    expect(protocol.procedure).toHaveLength(10);
+    expect(protocol.procedure[2]).toContain("deterministic evidence");
+    expect(protocol.procedure[8]).toContain("queue hydration failed");
+    expect(protocol.receipt_template.required_fields).toEqual([
+      "verdict",
+      "rule_id",
+      "reason",
+      "evidence",
+      "next_action",
+    ]);
+    expect(protocol.guardrails[0]).toContain("Verdict-only");
+    expect(protocol.watch_state_key).toBe("commonsensepass_last_state");
+  });
+
+  it("guards the version when the playbook content changes", () => {
+    const protocol = getCommonSensePassProtocol();
+    const changed: CommonSensePassProtocol = {
+      ...protocol,
+      procedure: [...protocol.procedure, "new instruction"],
+    };
+
+    expect(formatCommonSensePassProtocolVersion(1)).toBe("2026-05-17.v1");
+    expect(protocol.version).toBe("2026-05-17.v1");
+    expect(commonSensePassProtocolContentFingerprint(protocol)).toBe("a5836dc10b023004");
+    expect(commonSensePassProtocolContentFingerprint(changed)).not.toBe(
+      commonSensePassProtocolContentFingerprint(protocol),
+    );
+  });
+
+  it("does not return secrets or execution permissions", () => {
+    const serialized = JSON.stringify(getCommonSensePassProtocol()).toLowerCase();
+
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("api_key");
+    expect(serialized).not.toContain("execute mode enabled");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -19,6 +19,7 @@ describe("runtime tool schema validation", () => {
     { name: "check_signals", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
     { name: "read_orchestrator_context", args: { q: "strict schema probe", bogus_field: "should reject" } },
     { name: "heartbeat_protocol", args: { bogus_field: "should reject" } },
+    { name: "commonsensepass_protocol", args: { bogus_field: "should reject" } },
     {
       name: "ack_handoff",
       args: {
@@ -85,6 +86,7 @@ describe("runtime tool schema validation", () => {
       limit: 40,
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("heartbeat_protocol", {})).toBeNull();
+    expect(validateToolArgumentsForRuntime("commonsensepass_protocol", {})).toBeNull();
     expect(validateToolArgumentsForRuntime("ack_handoff", {
       agent_id: "strict-probe",
       thread_id: "11111111-1111-4111-8111-111111111111",

--- a/packages/mcp-server/src/commonsensepass-protocol.ts
+++ b/packages/mcp-server/src/commonsensepass-protocol.ts
@@ -1,0 +1,94 @@
+import { createHash } from "node:crypto";
+
+export type CommonSensePassProtocol = {
+  version: string;
+  purpose: string;
+  when_to_run: string[];
+  tool_contract: {
+    package_name: string;
+    function_name: string;
+    input_fields: string[];
+    output_fields: string[];
+  };
+  verdicts: Record<
+    "PASS" | "BLOCKER" | "HOLD" | "SUPPRESS" | "ROUTE",
+    string
+  >;
+  procedure: string[];
+  receipt_template: {
+    line_template: string;
+    required_fields: string[];
+  };
+  guardrails: string[];
+  watch_state_key: string;
+};
+
+export const COMMONSENSEPASS_PROTOCOL_DATE = "2026-05-17";
+export const COMMONSENSEPASS_PROTOCOL_REVISION = 1;
+
+export function formatCommonSensePassProtocolVersion(revision: number): string {
+  return `${COMMONSENSEPASS_PROTOCOL_DATE}.v${revision}`;
+}
+
+const COMMONSENSEPASS_PROTOCOL: CommonSensePassProtocol = {
+  version: formatCommonSensePassProtocolVersion(COMMONSENSEPASS_PROTOCOL_REVISION),
+  purpose:
+    "CommonSensePass is the read-only sanity gate workers run before claiming healthy, quiet, no_work, pass, done, merge_ready, or duplicate_wake.",
+  when_to_run: [
+    "Before saying there is no work.",
+    "Before saying UnClick is healthy or quiet.",
+    "Before marking a job done.",
+    "Before treating a PR as merge-ready.",
+    "Before suppressing a wake as a duplicate.",
+    "Before emitting a PASS when live queue, PR, or wake evidence may be stale.",
+  ],
+  tool_contract: {
+    package_name: "@unclick/commonsensepass",
+    function_name: "commonsensepassCheck",
+    input_fields: ["claim", "context", "evidence"],
+    output_fields: ["verdict", "rule_id", "reason", "evidence", "next_action", "route_to"],
+  },
+  verdicts: {
+    PASS: "The claim matches the evidence. Continue with the next safe action.",
+    BLOCKER: "The evidence contradicts the claim. Stop and report the smallest missing fix.",
+    HOLD: "The evidence is incomplete. Fetch the missing proof and run the check again.",
+    SUPPRESS: "The claim is a duplicate or no-op. Stay quiet unless another signal matters.",
+    ROUTE: "The claim is valid but belongs to another worker, lane, or deterministic tool.",
+  },
+  procedure: [
+    "Build a compact evidence packet from live state: queue count, active_jobs count, target todo id, PR head/checks/review state, wake id, wake fingerprint, and fetched_at where available.",
+    "Call commonsensepassCheck with the claim kind and evidence packet before emitting a PASS, BLOCKER, HOLD, SUPPRESS, or ROUTE receipt.",
+    "Use deterministic evidence for counts, PR checks, duplicate wake fingerprints, and stale-owner windows. Use model judgment only to choose the claim kind and explain the next safe step.",
+    "Treat HOLD as a prompt to fetch missing proof, not as permission to guess.",
+    "Treat BLOCKER as a stop sign for the claimed action. Do one safe unblock only if it does not cross protected surfaces.",
+    "Treat SUPPRESS as quiet unless another fresh signal is user-visible.",
+    "For merge_ready, require current PR head, green or neutral checks, mergeable state, and fresh review/safety proof on the same head.",
+    "For done, require a target todo and proof that the completing PR, commit, or receipt matches that todo.",
+    "For no_work or quiet, require both active_jobs and actionable backlog evidence. If queue hydration failed, return BLOCKER rather than PASS.",
+    "Save or post the receipt line with verdict, rule_id, evidence refs, and next_action so other seats can continue without re-checking the whole world.",
+  ],
+  receipt_template: {
+    line_template:
+      "CommonSensePass {verdict} {rule_id}: {reason}; evidence={refs}; next={next_action}",
+    required_fields: ["verdict", "rule_id", "reason", "evidence", "next_action"],
+  },
+  guardrails: [
+    "Verdict-only. Do not mutate source state, close jobs, merge PRs, change data, deploy, or wake workers from this protocol.",
+    "Never include keys, tokens, private credentials, or plaintext values in evidence or receipts.",
+    "Use source pointers, counts, timestamps, public PR links, and safe hashes instead of raw sensitive data.",
+    "Keep the evidence compact so strict clients can read the result.",
+    "If the check cannot run, return HOLD or BLOCKER with the missing capability named plainly.",
+  ],
+  watch_state_key: "commonsensepass_last_state",
+};
+
+export function commonSensePassProtocolContentFingerprint(
+  protocol = COMMONSENSEPASS_PROTOCOL,
+): string {
+  const { version: _version, ...content } = protocol;
+  return createHash("sha256").update(JSON.stringify(content)).digest("hex").slice(0, 16);
+}
+
+export function getCommonSensePassProtocol(): CommonSensePassProtocol {
+  return JSON.parse(JSON.stringify(COMMONSENSEPASS_PROTOCOL)) as CommonSensePassProtocol;
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -14,6 +14,7 @@ import { MEMORY_HANDLERS } from "./memory/handlers.js";
 import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
 import { emitSignal } from "./signals/emit.js";
 import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
+import { getCommonSensePassProtocol } from "./commonsensepass-protocol.js";
 import { createHash } from "node:crypto";
 
 // ─── Umami tool-usage tracking ──────────────────────────────────────────────
@@ -578,6 +579,18 @@ export const VISIBLE_TOOLS = [
     description:
       "Returns the canonical UnClick AI Seat heartbeat playbook. " +
       "Call this first from scheduled heartbeat seats, then follow the returned versioned procedure exactly.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+  {
+    name: "commonsensepass_protocol",
+    title: "CommonSensePass protocol",
+    description:
+      "Returns the canonical CommonSensePass worker sanity-gate playbook. " +
+      "Call this when a worker needs to decide if a healthy, no_work, done, merge_ready, pass, quiet, or duplicate_wake claim makes sense.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
@@ -1616,6 +1629,13 @@ export function createServer(): Server {
       if (name === "heartbeat_protocol") {
         return {
           content: [{ type: "text", text: JSON.stringify(getHeartbeatProtocol(), null, 2) }],
+        };
+      }
+
+      // ── CommonSensePass protocol: read-only worker sanity-gate contract ──
+      if (name === "commonsensepass_protocol") {
+        return {
+          content: [{ type: "text", text: JSON.stringify(getCommonSensePassProtocol(), null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Summary

Adds a read-only `commonsensepass_protocol` MCP resolver so workers can fetch the CommonSensePass playbook from UnClick instead of carrying the full protocol inline.

## Impact

This moves one more worker rule set into UnClick as a versioned protocol. It helps shrink worker prompts and keeps PASS/BLOCKER/HOLD/SUPPRESS/ROUTE guidance consistent across seats.

## Validation

- `npm run test --workspace=@unclick/mcp-server -- --run src/__tests__/commonsensepass-protocol.test.ts src/__tests__/tool-schema-validation.test.ts src/__tests__/heartbeat-protocol.test.ts`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run brainmap:generate`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `git diff --check`