### PR TITLE
[codex] Shrink heartbeat schedule copy

### DIFF
--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -20,12 +20,11 @@ describe("AdminSeatHeartbeatPage", () => {
       buildHeartbeatSchedulePrompt("15"),
     );
     expect(HEARTBEAT_CONNECTION_PROMPT).toContain("Run UnClick Heartbeat");
+    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("heartbeat_protocol first");
+    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("commonsensepass_protocol");
+    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("Follow both returned playbooks");
     expect(HEARTBEAT_CONNECTION_PROMPT).toContain("unclick-heartbeat-seat");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("nudgeonly_receipt_bridge");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("PushOnly");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("compact public fields");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("0 active jobs is PASS only if backlog is also 0");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("Target existing Job Worker first");
+    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("Check live jobs");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("public policy must stay self-contained");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("master heartbeat");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("token-light");
@@ -37,6 +36,7 @@ describe("AdminSeatHeartbeatPage", () => {
     expect(HEARTBEAT_MASTER_PROMPT).toContain("bridge_id and receipt_line");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("Do not POST to /admin/orchestrator");
     expect(HEARTBEAT_CONNECTION_PROMPT.length).toBeLessThan(HEARTBEAT_MASTER_PROMPT.length / 2);
+    expect(HEARTBEAT_CONNECTION_PROMPT.length).toBeLessThan(400);
   });
 
   it("updates the schedule message when cadence changes", () => {

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -46,7 +46,7 @@ BLOCKER: <safe reason>; progress: <what was checked>; next: <fix>.
 If no safe task is available: BLOCKER: no clear safe task available; progress: checked live queue; next: add a scoped job.`;
 
 export const HEARTBEAT_CONNECTION_PROMPT =
-  "Run UnClick Heartbeat. Use heartbeat_protocol, then check_signals and hunt jobs with list_actionable_todos/open todos/recent dispatches. 0 active jobs is PASS only if backlog is also 0. For queue hydration failure, call nudgeonly_receipt_bridge with compact public fields, then IgniteOnly only after verified wake request, then PushOnly only with the public wake packet. Target existing Job Worker first; free API only classifies/nudges. Save one receipt to session_id='unclick-heartbeat-seat'. Never print secrets. Reply PASS/BLOCKER with brief progress.";
+  "Run UnClick Heartbeat. Call heartbeat_protocol first, then commonsensepass_protocol before any healthy, no_work, done, merge_ready, or PASS claim. Follow both returned playbooks. Check live jobs, dispatches, Boardroom, and Orchestrator before saying healthy. Save one receipt to session_id='unclick-heartbeat-seat'. Never print secrets. Reply PASS/BLOCKER with brief progress.";
 
 export function getHeartbeatCadenceLabel(value: HeartbeatCadenceValue): string {
   return HEARTBEAT_CADENCE_OPTIONS.find((option) => option.value === value)?.label ?? "15 min";


### PR DESCRIPTION
## Summary

Shrinks the Admin Seats Heartbeat schedule copy to point workers at `heartbeat_protocol` and `commonsensepass_protocol` instead of carrying the job-hunt and escalation details inline.

## Impact

Future copied heartbeat schedules stay shorter while still routing workers through the versioned UnClick playbooks and the CommonSensePass sanity gate.

## Validation

- `npm run test -- --run src/pages/admin/AdminSeatHeartbeat.test.tsx`
- `npm run build`
- `npm run brainmap:generate`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `git diff --check`