### PR TITLE
[codex] add OpenHands proof binding

### DIFF
--- a/.github/workflows/openhands-test-mode.yml
+++ b/.github/workflows/openhands-test-mode.yml
@@ -7,6 +7,10 @@ on:
         description: Type 1 to run the opt-in OpenHands adapter checks.
         required: true
         default: "0"
+      openhands_fixture_proof:
+        description: Type 1 to run the docs-only proof runner in fixture mode.
+        required: true
+        default: "0"
 
 jobs:
   openhands-test-mode:
@@ -26,4 +30,11 @@ jobs:
           node-version: 20
 
       - name: Run adapter tests
-        run: node --test scripts/pinballwake-openhands-worker.test.mjs
+        run: node --test scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs
+
+      - name: Run docs-only fixture proof
+        if: ${{ inputs.openhands_fixture_proof == '1' }}
+        env:
+          OPENHANDS_TEST_MODE: "1"
+          OPENHANDS_PROOF_FIXTURE_PATCH: "1"
+        run: node scripts/pinballwake-openhands-proof-runner.mjs

--- a/docs/openhands-integration.md
+++ b/docs/openhands-integration.md
@@ -16,6 +16,8 @@ This file does not enable production code-writing. The adapter is opt-in and req
 6. The gate accepts only changed files inside the owned set.
 7. The adapter emits `openhands_worker_pass` or `openhands_worker_hold`.
 
+`scripts/pinballwake-openhands-proof-runner.mjs` is the v1 binding for proof runs. It can use a real OpenHands CLI command supplied through `OPENHANDS_COMMAND`, or a docs-only fixture runner when `OPENHANDS_PROOF_FIXTURE_PATCH=1` is set for local and workflow tests. OpenHands CLI docs describe `--task`, `--headless`, and `--json` at https://docs.openhands.dev/openhands/usage/cli/command-reference. The OpenHands environment reference is https://docs.openhands.dev/openhands/usage/environment-variables.
+
 ## Guardrails
 
 - Test mode is required by default.
@@ -30,6 +32,9 @@ This file does not enable production code-writing. The adapter is opt-in and req
 For real OpenHands use, the worker that provides the `openHands` function should own its secrets outside the repo:
 
 - `OPENHANDS_TEST_MODE=1`
+- optional `OPENHANDS_COMMAND`, defaulting to `openhands`
+- optional `OPENHANDS_ARGS`, defaulting to `--headless --json --task {prompt}`
+- optional `OPENHANDS_PATCH_FILE` when the runner writes a patch file instead of printing a unified diff
 - model provider key, stored only in CI or worker secret storage
 - repo-scoped token for draft PR creation, stored only in CI or worker secret storage
 - an external cost or spend limit guard
@@ -39,6 +44,7 @@ The repository should not store OpenHands provider keys or GitHub tokens.
 ## Acceptance
 
 - `node --test scripts/pinballwake-openhands-worker.test.mjs` passes.
+- `node --test scripts/pinballwake-openhands-proof-runner.test.mjs` passes.
 - A tiny test todo can produce a patch through the injected runner.
 - The coding room gate refuses a patch outside the todo's owned files.
 - A pass receipt contains changed files, patch size, optional PR URL, optional head SHA, and optional test run id.

--- a/docs/openhands-proof-fixture.md
+++ b/docs/openhands-proof-fixture.md
@@ -1,0 +1,6 @@
+# OpenHands Proof Fixture
+
+This fixture exists so the autopilot can prove a docs-only patch path without
+touching product code, production data, secrets, billing, DNS, or deploys.
+
+<!-- openhands-proof-lines -->

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -1,0 +1,409 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+
+import { validateCodingRoomBuildPatch } from "./pinballwake-build-executor.mjs";
+import { runOpenHandsWorker } from "./pinballwake-openhands-worker.mjs";
+
+const DEFAULT_PROOF_FILE = "docs/openhands-proof-fixture.md";
+const DEFAULT_TODO_ID = "036de894-82a1-49c7-ac19-67335950c626";
+const DEFAULT_BRANCH_PREFIX = "codex/openhands-proof";
+const DEFAULT_TITLE = "test(autopilot): prove OpenHands docs patch path";
+const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
+
+function parseBoolean(value) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function getArg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+function compactOutput(value, max = 2000) {
+  const text = String(value ?? "").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function normalizePath(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .trim();
+}
+
+function safeStamp(value = new Date()) {
+  return String(value instanceof Date ? value.toISOString() : value)
+    .replace(/[^0-9A-Za-z._:-]/g, "-")
+    .slice(0, 80);
+}
+
+export function splitArgs(value) {
+  const parts = [];
+  let current = "";
+  let quote = "";
+
+  for (const char of String(value ?? "")) {
+    if (quote) {
+      if (char === quote) {
+        quote = "";
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (quote) {
+    throw new Error("unclosed_quote");
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+export function buildOpenHandsCliArgs({ prompt, argsTemplate = "" } = {}) {
+  const template = String(argsTemplate || "--headless --json --task {prompt}").trim();
+  const parts = splitArgs(template);
+  const replaced = parts.map((part) => (part === "{prompt}" ? String(prompt ?? "") : part));
+  return replaced.includes(String(prompt ?? "")) ? replaced : [...replaced, "--task", String(prompt ?? "")];
+}
+
+export function buildDocsOnlyFixturePatch({
+  filePath = DEFAULT_PROOF_FILE,
+  proofLine = `- proof run: ${safeStamp(new Date())}`,
+} = {}) {
+  const file = normalizePath(filePath);
+  return [
+    `diff --git a/${file} b/${file}`,
+    "index 1111111..2222222 100644",
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    "@@ -3,4 +3,5 @@",
+    " This fixture exists so the autopilot can prove a docs-only patch path without",
+    " touching product code, production data, secrets, billing, DNS, or deploys.",
+    "",
+    " <!-- openhands-proof-lines -->",
+    `+${proofLine}`,
+    "",
+  ].join("\n");
+}
+
+export function createFixtureOpenHandsRunner({ filePath = DEFAULT_PROOF_FILE, now = new Date() } = {}) {
+  return async () => ({
+    ok: true,
+    patch: buildDocsOnlyFixturePatch({
+      filePath,
+      proofLine: `- proof run: ${safeStamp(now)}`,
+    }),
+    changed_files: [normalizePath(filePath)],
+    summary: "Fixture OpenHands proof produced a docs-only patch.",
+    test_run_id: `openhands-fixture-${safeStamp(now)}`,
+    test_exit_code: 0,
+  });
+}
+
+export function createOpenHandsCliRunner({
+  command,
+  argsTemplate = "",
+  cwd = process.cwd(),
+  env = process.env,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  readPatchFile = readFile,
+  runProcess = runProcessCommand,
+} = {}) {
+  const safeCommand = String(command || env.OPENHANDS_COMMAND || "openhands").trim();
+
+  return async ({ prompt, scopePack }) => {
+    const args = buildOpenHandsCliArgs({
+      prompt,
+      argsTemplate: argsTemplate || env.OPENHANDS_ARGS || "",
+    });
+    const result = await runProcess(safeCommand, args, {
+      cwd,
+      env: {
+        ...env,
+        OPENHANDS_TASK_PROMPT: prompt,
+      },
+      timeoutMs,
+    });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        exit_code: result.exit_code,
+        output: result.output,
+      };
+    }
+
+    const patchFile = String(env.OPENHANDS_PATCH_FILE || "").trim();
+    const patch = patchFile ? await readPatchFile(patchFile, "utf8") : extractUnifiedDiff(result.output);
+    return {
+      ok: Boolean(String(patch || "").trim()),
+      patch,
+      changed_files: scopePack?.owned_files || [],
+      summary: "OpenHands CLI produced a test-mode patch.",
+      test_run_id: result.run_id || "openhands-cli",
+      test_exit_code: result.exit_code,
+      output: result.output,
+    };
+  };
+}
+
+export function buildProofJob({ todoId = DEFAULT_TODO_ID, filePath = DEFAULT_PROOF_FILE } = {}) {
+  const file = normalizePath(filePath);
+  return {
+    job_id: `coding-room:openhands-proof:${todoId}`,
+    todo_id: todoId,
+    title: "OpenHands proof v1: ScopePack to draft PR, no local PowerShell",
+    chip: "OpenHands test-mode proof",
+    owned_files: [file],
+    expected_proof: {
+      requires_pr: true,
+      requires_changed_files: true,
+      requires_non_overlap: true,
+      requires_tests: true,
+      tests: ["node --test scripts/pinballwake-openhands-proof-runner.test.mjs"],
+    },
+  };
+}
+
+export function buildProofScopePack({
+  scopePackCommentId = "",
+  filePath = DEFAULT_PROOF_FILE,
+} = {}) {
+  const file = normalizePath(filePath);
+  return {
+    scope_pack_comment_id: scopePackCommentId || null,
+    owned_files: [file],
+    acceptance: [
+      "OpenHands returns a unified diff patch for a docs-only fixture.",
+      "Coderoom rejects non-docs or outside-owned-file patches.",
+      "Draft PR creation is opt-in and never auto-merges.",
+    ],
+    verification: ["node --test scripts/pinballwake-openhands-proof-runner.test.mjs"],
+    body: "Test-mode only proof for OpenHands to coderoom draft PR flow.",
+  };
+}
+
+export function createDraftPrCoderoom({
+  cwd = process.cwd(),
+  env = process.env,
+  branchName,
+  title = DEFAULT_TITLE,
+  body = "",
+  runProcess = runProcessCommand,
+} = {}) {
+  return async ({ job, patch, changedFiles, summary, testRunId }) => {
+    const normalizedChanged = (changedFiles || []).map(normalizePath);
+    const nonDocs = normalizedChanged.find((file) => !file.startsWith("docs/"));
+    if (nonDocs) {
+      return { ok: false, reason: "non_docs_patch_refused", file: nonDocs };
+    }
+
+    const validation = validateCodingRoomBuildPatch({
+      patch,
+      ownedFiles: job?.owned_files || [],
+    });
+    if (!validation.ok) {
+      return {
+        ok: false,
+        reason: validation.reason,
+        file: validation.file || null,
+      };
+    }
+
+    const status = await runProcess("git", ["status", "--porcelain"], { cwd, env });
+    if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
+    if (status.stdout.trim()) {
+      return { ok: false, reason: "dirty_worktree" };
+    }
+
+    const branch = branchName || `${DEFAULT_BRANCH_PREFIX}-${safeStamp(new Date())}`;
+    const bodyText =
+      body ||
+      [
+        "Test-mode OpenHands proof.",
+        "",
+        `Todo: ${job?.todo_id || DEFAULT_TODO_ID}`,
+        `Summary: ${summary || "Docs-only proof patch."}`,
+        `Test run: ${testRunId || "not supplied"}`,
+        "",
+        "No production data, secrets, deploy, billing, DNS, or auto-merge.",
+      ].join("\n");
+
+    const commands = [
+      ["git", ["checkout", "-b", branch]],
+      ["git", ["apply", "--whitespace=nowarn", "-"], { stdin: patch }],
+      ["git", ["add", ...normalizedChanged]],
+      ["git", ["commit", "-m", title]],
+      ["git", ["push", "-u", "origin", branch]],
+      ["gh", ["pr", "create", "--draft", "--title", title, "--body", bodyText]],
+    ];
+
+    let prUrl = "";
+    for (const [command, args, options = {}] of commands) {
+      const result = await runProcess(command, args, { cwd, env, ...options });
+      if (!result.ok) {
+        return {
+          ok: false,
+          reason: `${command}_failed`,
+          output: result.output,
+        };
+      }
+      if (command === "gh") {
+        prUrl = result.stdout.trim();
+      }
+    }
+
+    const sha = await runProcess("git", ["rev-parse", "HEAD"], { cwd, env });
+    return {
+      ok: true,
+      pr_url: prUrl || null,
+      head_sha_after: sha.stdout.trim() || null,
+      test_run_id: testRunId || null,
+      test_exit_code: 0,
+      status: "draft_pr_created",
+    };
+  };
+}
+
+export async function runOpenHandsProof({
+  env = process.env,
+  cwd = process.cwd(),
+  now = new Date(),
+  filePath = DEFAULT_PROOF_FILE,
+  openHands,
+  coderoom,
+  runProcess,
+} = {}) {
+  const safeEnv = env || {};
+  const job = buildProofJob({ filePath });
+  const scopePack = buildProofScopePack({ filePath });
+  const selectedOpenHands =
+    openHands ||
+    (parseBoolean(safeEnv.OPENHANDS_PROOF_FIXTURE_PATCH)
+      ? createFixtureOpenHandsRunner({ filePath, now })
+      : createOpenHandsCliRunner({ cwd, env: safeEnv, runProcess }));
+
+  const selectedCoderoom =
+    coderoom ||
+    (parseBoolean(safeEnv.OPENHANDS_CREATE_DRAFT_PR)
+      ? createDraftPrCoderoom({ cwd, env: safeEnv, runProcess })
+      : undefined);
+
+  return runOpenHandsWorker({
+    job,
+    scopePack,
+    openHands: selectedOpenHands,
+    coderoom: selectedCoderoom,
+    env: safeEnv,
+    testMode: parseBoolean(safeEnv.OPENHANDS_TEST_MODE),
+    now,
+  });
+}
+
+export async function runProcessCommand(command, args = [], options = {}) {
+  const { cwd = process.cwd(), env = process.env, timeoutMs = DEFAULT_TIMEOUT_MS, stdin = "" } = options;
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      shell: false,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      resolve({
+        ok: false,
+        exit_code: null,
+        stdout,
+        stderr,
+        output: compactOutput(`${stdout}\n${stderr}\nTimed out after ${timeoutMs}ms`),
+      });
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        ok: false,
+        exit_code: null,
+        stdout,
+        stderr,
+        output: compactOutput(error.message),
+      });
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        ok: code === 0,
+        exit_code: code,
+        stdout,
+        stderr,
+        output: compactOutput(`${stdout}\n${stderr}`),
+      });
+    });
+    if (stdin) {
+      child.stdin.write(stdin);
+    }
+    child.stdin.end();
+  });
+}
+
+function extractUnifiedDiff(output) {
+  const text = String(output ?? "");
+  const fenced = text.match(/```(?:diff|patch)?\s*([\s\S]*?diff --git[\s\S]*?)```/i);
+  if (fenced) return fenced[1].trim();
+  const index = text.indexOf("diff --git ");
+  return index === -1 ? "" : text.slice(index).trim();
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  runOpenHandsProof({
+    filePath: getArg("file", process.env.OPENHANDS_PROOF_FILE || DEFAULT_PROOF_FILE),
+  })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.ok ? 0 : 1;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  buildDocsOnlyFixturePatch,
+  buildOpenHandsCliArgs,
+  createDraftPrCoderoom,
+  createFixtureOpenHandsRunner,
+  runOpenHandsProof,
+  splitArgs,
+} from "./pinballwake-openhands-proof-runner.mjs";
+
+const NOW = new Date("2026-05-16T23:40:00.000Z");
+const FIXTURE = "docs/openhands-proof-fixture.md";
+
+describe("OpenHands proof runner helpers", () => {
+  test("splits quoted CLI args and injects the prompt as one argument", () => {
+    assert.deepEqual(splitArgs('--headless --json --task "{prompt}"'), ["--headless", "--json", "--task", "{prompt}"]);
+
+    const args = buildOpenHandsCliArgs({
+      prompt: "Edit docs only\nReturn a patch.",
+      argsTemplate: "--headless --json --task {prompt}",
+    });
+
+    assert.deepEqual(args, ["--headless", "--json", "--task", "Edit docs only\nReturn a patch."]);
+  });
+
+  test("builds a docs-only fixture patch inside the owned file", () => {
+    const patch = buildDocsOnlyFixturePatch({
+      filePath: FIXTURE,
+      proofLine: "- proof run: unit-test",
+    });
+
+    assert.match(patch, /diff --git a\/docs\/openhands-proof-fixture\.md b\/docs\/openhands-proof-fixture\.md/);
+    assert.match(patch, /\+[-] proof run: unit-test/);
+  });
+
+  test("runs fixture OpenHands through the worker and coderoom", async () => {
+    let coderoomCalls = 0;
+    const result = await runOpenHandsProof({
+      now: NOW,
+      env: { OPENHANDS_TEST_MODE: "1" },
+      filePath: FIXTURE,
+      openHands: createFixtureOpenHandsRunner({ filePath: FIXTURE, now: NOW }),
+      coderoom: async ({ changedFiles, patch }) => {
+        coderoomCalls += 1;
+        assert.deepEqual(changedFiles, [FIXTURE]);
+        assert.match(patch, /proof run: 2026-05-16T23:40:00.000Z/);
+        return {
+          ok: true,
+          pr_url: "https://github.com/malamutemayhem/unclick/pull/902",
+          head_sha_after: "abc123",
+          test_run_id: "openhands-fixture-2026",
+          test_exit_code: 0,
+          status: "draft_pr_created",
+        };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(coderoomCalls, 1);
+    assert.equal(result.receipt.receipt_type, "openhands_worker_pass");
+    assert.equal(result.receipt.evidence.pr_url, "https://github.com/malamutemayhem/unclick/pull/902");
+  });
+});
+
+describe("draft PR coderoom binding", () => {
+  test("refuses non-docs patches before any git write", async () => {
+    const calls = [];
+    const coderoom = createDraftPrCoderoom({
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await coderoom({
+      job: { owned_files: ["src/not-docs.ts"] },
+      changedFiles: ["src/not-docs.ts"],
+      patch: "diff --git a/src/not-docs.ts b/src/not-docs.ts\n--- a/src/not-docs.ts\n+++ b/src/not-docs.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "non_docs_patch_refused");
+    assert.deepEqual(calls, []);
+  });
+
+  test("creates a draft PR only after clean status and docs-only validation", async () => {
+    const calls = [];
+    const coderoom = createDraftPrCoderoom({
+      branchName: "codex/openhands-proof-test",
+      runProcess: async (command, args, options = {}) => {
+        calls.push([command, args, Boolean(options.stdin)]);
+        if (command === "gh") {
+          return { ok: true, stdout: "https://github.com/malamutemayhem/unclick/pull/902\n", stderr: "", output: "" };
+        }
+        if (command === "git" && args[0] === "rev-parse") {
+          return { ok: true, stdout: "abc123\n", stderr: "", output: "" };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await coderoom({
+      job: { todo_id: "todo-1", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: draft-pr-test" }),
+      summary: "Docs-only proof.",
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/902");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      [
+        "git status --porcelain",
+        "git checkout -b",
+        "git apply --whitespace=nowarn",
+        "git add docs/openhands-proof-fixture.md",
+        "git commit -m",
+        "git push -u",
+        "gh pr create",
+        "git rev-parse HEAD",
+      ],
+    );
+    assert.equal(calls[2][2], true);
+  });
+});


### PR DESCRIPTION
## What changed

Adds a small OpenHands proof runner that can turn a test-mode docs-only patch into a coderoom draft PR path.

## Why

Chris approved the recommended follow-up for the overnight speed issue: keep the speed, remove the local PowerShell shortcut, and prove the fleet can use a real coder lane safely.

## Safety

- Test mode required.
- Docs-only draft PR binding refuses non-docs patches.
- No production data, secrets, billing, DNS, deploy, or auto-merge.
- Workflow fixture proof is manual and default off.

## Proof

- node --test scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs
- git diff --check
- OPENHANDS_TEST_MODE=1 OPENHANDS_PROOF_FIXTURE_PATCH=1 node scripts/pinballwake-openhands-proof-runner.mjs

Boardroom todo: 036de894-82a1-49c7-ac19-67335950c626