### PR TITLE
[codex] align builder engine lane

### DIFF
--- a/docs/builder-engine-lane.md
+++ b/docs/builder-engine-lane.md
@@ -1,0 +1,95 @@
+# Builder Engine Lane
+
+## Intent
+
+UnClick is the factory. Builder engines are machines inside the factory.
+
+OpenHands, Codex, Claude Code, Cursor, SWE-agent-style runners, and future tools are interchangeable worker engines. They do not replace UnClick. A build still happens inside UnClick when the job, context, routing, proof, memory, and safety gates are owned by UnClick.
+
+This lane exists to remove coordination drag. Workers should spend less time saying they are claiming work and more time returning a patch, a review, a blocker, or a proof receipt.
+
+## Standard Conveyor
+
+1. Jobs room selects one high-value job.
+2. A ScopePack defines owned files, acceptance criteria, verification, safety stops, and expected proof.
+3. The router picks a builder engine by job shape and live health.
+4. The engine works in a branch, sandbox, draft PR, or controlled local workspace.
+5. Verification runs the smallest useful check first, then GitHub checks when responsive.
+6. A separate reviewer role returns PASS or BLOCKER.
+7. Risky work adds a safety role before merge or ship.
+8. The result is logged back to the job with changed files, tests, PR link, and next step.
+
+## Engine Routing
+
+Pick the engine by fit, not by brand.
+
+- OpenHands: best first open-source adapter for autonomous GitHub issue-to-PR work and reproducible proof runs.
+- Codex: strong fit for local repo surgery, integration work, and follow-through from this desktop tether.
+- Claude Code: strong fit for code edits and review when its GitHub calls and channel are responsive.
+- SWE-agent style: useful pattern for issue-to-fix loops, not necessarily the first runtime.
+- Other engines: acceptable when they can accept a ScopePack and return a patch, PR, review, or proof receipt.
+
+The first implementation can use OpenHands because the adapter already exists, but the product language must stay engine-agnostic.
+
+## Review Policy
+
+Normal work needs two roles:
+
+- Builder: creates the patch or PR.
+- Reviewer: checks scope, behavior, and proof.
+
+Risky work needs three roles:
+
+- Builder.
+- Reviewer.
+- Safety reviewer.
+
+A single subscription or tether may serve more than one role only when the role switch is explicit and logged. The important boundary is role separation inside UnClick, not how many paid accounts are involved.
+
+## GitHub Checks
+
+GitHub Actions are useful green and red lights, but they are not the whole factory.
+
+- If checks are green and fresh, treat them as proof.
+- If checks fail, route a focused fix.
+- If checks are queued, stale, or non-responsive, set a timeout.
+- After timeout, run a local targeted check, reroute, or mark BLOCKER with proof.
+
+Do not let a stalled external check freeze the lane.
+
+## Bottlenecks To Remove
+
+- Claim-only loops where no code or proof changes.
+- Repeated nudges when a builder engine could act directly.
+- Waiting for a missing coder seat after a ScopePack is already ready.
+- Stale owner holds without a narrow ScopePack.
+- Jobs that are too large for one bounded patch.
+- Reviewer waits with no fallback reviewer role.
+
+## Safety Stops
+
+Do not run autonomous mutation for:
+
+- Secrets or credentials.
+- Billing.
+- DNS.
+- Production data.
+- Owner-auth work.
+- Force pushes.
+- Destructive migrations.
+- Production deploys.
+
+Those can still be prepared, audited, and routed, but mutation needs explicit approval and proof.
+
+## First Dry Run
+
+Use a docs-only job for the first real conveyor proof:
+
+1. Create a tiny ScopePack with one owned docs file.
+2. Route it through one builder engine.
+3. Require a patch or draft PR.
+4. Run one local targeted check.
+5. Log builder PASS and reviewer PASS or BLOCKER.
+6. Record the proof link on the job.
+
+The goal is boring throughput: one clear job goes in, one safe result comes out.

--- a/docs/openhands-integration.md
+++ b/docs/openhands-integration.md
@@ -4,17 +4,21 @@
 
 This is the v1 test-mode adapter for the Autopilot Executor Lane. It lets UnClick prove the missing middle step: a scoped job can be handed to an OpenHands-style coder, returned as a patch, checked by the existing coding room gate, and represented as a receipt.
 
+OpenHands is one builder engine inside UnClick, not a replacement for UnClick and not a claim that OpenHands is always the best coder. The engine-agnostic production lane is documented in [Builder Engine Lane](builder-engine-lane.md). UnClick stays the factory: it owns the job, ScopePack, routing, memory, proof, review, and safety gates.
+
 This file does not enable production code-writing. The adapter is opt-in and requires `OPENHANDS_TEST_MODE=1` or an explicit test harness flag.
 
 ## Flow
 
 1. The heartbeat or runner selects one safe, scoped todo.
-2. The job ScopePack provides `owned_files`, acceptance, and verification.
-3. `scripts/pinballwake-openhands-worker.mjs` builds a narrow task prompt.
-4. A caller-provided OpenHands runner returns a unified diff patch.
-5. The adapter submits the patch to the coding room gate.
-6. The gate accepts only changed files inside the owned set.
-7. The adapter emits `openhands_worker_pass` or `openhands_worker_hold`.
+2. The job ScopePack provides `owned_files`, acceptance, verification, and safety stops.
+3. The UnClick router chooses OpenHands only when the job shape fits this adapter.
+4. `scripts/pinballwake-openhands-worker.mjs` builds a narrow task prompt.
+5. A caller-provided OpenHands runner returns a unified diff patch.
+6. The adapter submits the patch to the coding room gate.
+7. The gate accepts only changed files inside the owned set.
+8. The adapter emits `openhands_worker_pass` or `openhands_worker_hold`.
+9. A separate reviewer role still returns PASS or BLOCKER before ship.
 
 `scripts/pinballwake-openhands-proof-runner.mjs` is the v1 binding for proof runs. It can use a real OpenHands CLI command supplied through `OPENHANDS_COMMAND`, or a docs-only fixture runner when `OPENHANDS_PROOF_FIXTURE_PATCH=1` is set for local and workflow tests. OpenHands CLI docs describe `--task`, `--headless`, and `--json` at https://docs.openhands.dev/openhands/usage/cli/command-reference. The OpenHands environment reference is https://docs.openhands.dev/openhands/usage/environment-variables.
 
@@ -26,6 +30,7 @@ This file does not enable production code-writing. The adapter is opt-in and req
 - Receipts redact common token, secret, password, credential, and API key shapes.
 - A caller can wrap the OpenHands invocation with a spend guard by passing `spendGuard`.
 - The GitHub workflow is manual only and default off.
+- GitHub Actions are treated as proof only when checks are fresh and responsive. Stalled checks need timeout, local targeted verification, or reroute.
 
 ## Expected Environment
 

--- a/docs/prd/agents.md
+++ b/docs/prd/agents.md
@@ -1,13 +1,15 @@
 # PRD: Agents (Build Desk)
 
 **Status**: Shipped through Phase 5. Multi-backend worker support live.
-**Last updated**: 2026-04-25.
+**Last updated**: 2026-05-17.
 
 ## Problem statement
 
 A user who wants a coding task done has to choose a harness (Claude Code, Codex, Cursor, Gemini CLI), paste context into it, shepherd it through the work, and then track what it produced. Every harness is its own silo: different repo state, different context, different output format. A user who wants to use more than one is running three or four dashboards at once.
 
 Build Desk is the single orchestration surface: one desk, many engines. A user creates a task, picks a worker backend, and watches progress. Context and credentials come from UnClick. The harness is an interchangeable runtime.
+
+In product terms, UnClick is the factory. Claude Code, Codex, OpenHands, Cursor, Gemini CLI, and future tools are builder engines inside that factory. Build work still happens inside UnClick when UnClick owns the task, memory, routing, proof, review, and safety gates.
 
 ## Target user
 
@@ -35,16 +37,18 @@ Build Desk is the single orchestration surface: one desk, many engines. A user c
 ## Out-of-scope
 
 - **We do not embed a code editor.** Workers are external harnesses. Build Desk is the orchestration surface, not an IDE.
-- **We do not ship our own coding agent.** Backends are third-party. UnClick stays in the orchestration lane. See [ADR-0003](../adr/0003-stripe-model-not-windows.md).
-- **We do not auto-merge PRs from workers.** Completed tasks raise a PR; the human reviews and merges. No silent writes to `main`.
+- **We do not ship our own model runtime.** Backends are third-party or open-source engines. UnClick owns the factory layer around them: ScopePacks, routing, memory, proof, review, and safety. See [Builder Engine Lane](../builder-engine-lane.md) and [ADR-0003](../adr/0003-stripe-model-not-windows.md).
+- **We do not silently merge PRs from workers.** Completed tasks raise a PR. A human or role-separated reviewer lane can approve and merge only when policy allows, checks are responsive, and proof is logged. No silent writes to `main`.
 - **We do not store the worker's API keys beyond what BackstagePass holds.** Credentials used by a worker flow through BackstagePass; Build Desk does not duplicate them.
 
 ## Key decisions and why
 
 - **Worker registry instead of hardcoded backend list.** Tenants run whatever harness they prefer. Hardcoding `backends = ["claude-code", "cursor"]` would freeze the product against the user's environment.
+- **Engine routing by job shape, not brand.** OpenHands is useful for open-source issue-to-PR automation. Codex can be better for local repo surgery and integration. Claude Code can be better for edits or review when its channel is responsive. The router should choose the engine that fits the job and is live.
 - **`build_dispatch_events` as audit and debug.** Multi-backend orchestration fails in creative ways. An event log per dispatch is the only way to investigate a bad handoff.
-- **PR-gated completion.** Workers never push to `main` directly. Every task outcome is a PR against a branch the user can review. This mirrors Path 3 Vibe Kanban routing. See [ADR-0009](../adr/0009-path-3-vibe-kanban-routing.md).
+- **PR-gated completion.** Workers never push to `main` directly. Every task outcome is a PR against a branch that can be reviewed by the human or a role-separated reviewer lane. This mirrors Path 3 Vibe Kanban routing. See [ADR-0009](../adr/0009-path-3-vibe-kanban-routing.md).
 - **Context comes from UnClick, not the worker.** Memory facts, library docs, credentials all travel with the task. A Codex worker with the user's memory is a different product from a Codex worker without it.
+- **Role separation over account separation.** Normal work needs builder and reviewer roles. Risky work also needs a safety role. One subscription or tether can serve multiple roles only when the role switch is explicit and logged.
 - **No RLS on `build_*` tables today.** Documented in `docs/security/current-posture.md` as a known gap. Scoping is enforced at the service layer; RLS is planned in Phase 3 security work.
 
 ## Platform philosophy alignment


### PR DESCRIPTION
## Summary
- Add docs/builder-engine-lane.md as the engine-agnostic source of truth.
- Clarify OpenHands is one builder engine inside UnClick, not a replacement for UnClick.
- Update Build Desk PRD so UnClick stays the factory, engines route by job shape, reviews are role-separated, and gated autopilot merges are not silent.

## Validation
- git diff --check
- rg -n '—' docs/builder-engine-lane.md docs/openhands-integration.md docs/prd/agents.md
- node --test scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs