### PR TITLE
[codex] Fix idle queue visibility

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -8144,13 +8144,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (searchPattern) {
           todosQuery = todosQuery.or(`title.ilike.${searchPattern},description.ilike.${searchPattern}`);
         }
-        const inProgressTodosQuery = supabase
+        const activeTodosQuery = supabase
           .from("mc_fishbowl_todos")
           .select(todoSelect)
           .eq("api_key_hash", apiKeyHash)
-          .eq("status", "in_progress")
+          .in("status", ["open", "in_progress"])
           .order("updated_at", { ascending: false })
-          .limit(100);
+          .limit(300);
 
         let commentsQuery = supabase
           .from("mc_fishbowl_comments")
@@ -8196,7 +8196,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           profilesResult,
           messagesResult,
           todosResult,
-          inProgressTodosResult,
+          activeTodosResult,
           commentsResult,
           dispatchesResult,
           signalsResult,
@@ -8214,7 +8214,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .limit(smallerLimit),
           messagesQuery,
           todosQuery,
-          inProgressTodosQuery,
+          activeTodosQuery,
           commentsQuery,
           supabase
             .from("mc_agent_dispatches")
@@ -8244,7 +8244,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           profilesResult.error,
           messagesResult.error,
           todosResult.error,
-          inProgressTodosResult.error,
+          activeTodosResult.error,
           commentsResult.error,
           dispatchesResult.error,
           signalsResult.error,
@@ -8283,7 +8283,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .slice(0, smallerLimit);
         const todos = mergeOrchestratorTodoRows(
           (todosResult.data ?? []) as OrchestratorTodoRow[],
-          (inProgressTodosResult.data ?? []) as OrchestratorTodoRow[],
+          (activeTodosResult.data ?? []) as OrchestratorTodoRow[],
         );
 
         return res.status(200).json({

--- a/api/orchestrator-context-health-verdict.test.ts
+++ b/api/orchestrator-context-health-verdict.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildOrchestratorContext } from "./lib/orchestrator-context.js";
+import { buildOrchestratorContext, mergeOrchestratorTodoRows } from "./lib/orchestrator-context.js";
 
 describe("orchestrator-context / current_state_card.health_verdict (CommonSensePass R1)", () => {
   const NOW = "2026-05-12T12:00:00.000Z";
@@ -56,6 +56,41 @@ describe("orchestrator-context / current_state_card.health_verdict (CommonSenseP
     // active_jobs should also be 0 (no in_progress todos), so the BLOCKER is
     // entirely driven by the actionable queue depth.
     expect(context.current_state_card.active_jobs).toBe(0);
+  });
+
+  it("keeps live queue rows in the health verdict when the visible context is search-filtered", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: NOW,
+      profiles: [],
+      messages: [],
+      todos: mergeOrchestratorTodoRows(
+        [],
+        [
+          {
+            id: "todo-live-open",
+            title: "Visible queue work",
+            status: "open",
+            priority: "high",
+            created_by_agent_id: "watcher",
+            assigned_to_agent_id: null,
+            created_at: NOW,
+          },
+        ],
+      ),
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.current_state_card.active_todo_count).toBe(1);
+    expect(context.current_state_card.health_verdict.verdict).toBe("BLOCKER");
+    expect(context.current_state_card.health_verdict.next_action).toBe(
+      "hydrate_queue_and_claim_one",
+    );
   });
 
   it("emits a PASS verdict when active_jobs matches a single fresh-owner in_progress todo", () => {

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminJobs from "./AdminJobs";
@@ -46,6 +46,8 @@ const jobs = [
   },
 ] as const;
 
+let currentJobs: unknown[] = [];
+
 function jsonResponse(body: unknown) {
   return Promise.resolve({
     ok: true,
@@ -55,6 +57,7 @@ function jsonResponse(body: unknown) {
 
 describe("AdminJobs", () => {
   beforeEach(() => {
+    currentJobs = [...jobs];
     vi.spyOn(Date, "now").mockReturnValue(new Date("2026-05-14T13:00:00.000Z").getTime());
     vi.stubGlobal(
       "fetch",
@@ -64,7 +67,7 @@ describe("AdminJobs", () => {
           return jsonResponse({ profile: { agent_id: "human-test" } });
         }
         if (url.includes("fishbowl_list_todos")) {
-          return jsonResponse({ todos: jobs });
+          return jsonResponse({ todos: currentJobs });
         }
         return jsonResponse({});
       }),
@@ -100,5 +103,34 @@ describe("AdminJobs", () => {
         "Zulu stale job",
       ]);
     });
+  });
+
+  it("flags waiting jobs as an alert when the worker belt is idle", async () => {
+    currentJobs = [
+      {
+        id: "waiting-job",
+        title: "Waiting build job",
+        description: "Ready for a worker.",
+        status: "open",
+        priority: "normal",
+        created_by_agent_id: "tester",
+        assigned_to_agent_id: null,
+        created_at: "2026-05-14T12:00:00.000Z",
+        completed_at: null,
+        updated_at: "2026-05-14T12:00:00.000Z",
+        comment_count: 0,
+        pipeline_stage_count: 1,
+        pipeline_progress: 10,
+        pipeline_evidence: [],
+      },
+    ];
+
+    render(React.createElement(AdminJobs));
+
+    expect(await screen.findByText("Worker belt is idle while jobs are waiting.")).toBeInTheDocument();
+    expect(screen.getByText("Waiting")).toBeInTheDocument();
+    const alertsCard = screen.getByText("Alerts").closest("div");
+    expect(alertsCard).not.toBeNull();
+    expect(within(alertsCard as HTMLElement).getByText("1")).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -1143,7 +1143,8 @@ export default function AdminJobs() {
   );
   const activeCount = grouped.active.length;
   const queueCount = grouped.next.length + grouped.inline.length;
-  const alertCount = filteredTodos.filter(needsAttention).length;
+  const queueHydrationBlocked = activeCount === 0 && queueCount > 0;
+  const alertCount = filteredTodos.filter(needsAttention).length + (queueHydrationBlocked ? 1 : 0);
   const initialLoading = !firstLoadDone && loading;
   const visibleJobCount = todos.length + completedHistory.filter((historyJob) => !todos.some((todo) => todo.id === historyJob.id)).length;
 
@@ -1273,7 +1274,7 @@ export default function AdminJobs() {
             </p>
           </div>
           <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2">
-            <p className="text-xs text-white/35">Queued</p>
+            <p className="text-xs text-white/35">Waiting</p>
             <p className="mt-1 flex min-h-7 items-center justify-center text-lg font-semibold text-white/80">
               {initialLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : queueCount}
             </p>
@@ -1286,6 +1287,18 @@ export default function AdminJobs() {
           </div>
         </div>
       </header>
+
+      {queueHydrationBlocked && (
+        <div className="flex items-start gap-3 rounded-lg border border-red-300/25 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-200" aria-hidden="true" />
+          <div>
+            <p className="font-medium">Worker belt is idle while jobs are waiting.</p>
+            <p className="mt-1 text-red-100/70">
+              Autopilot should pull one waiting job into active work before this board can be green.
+            </p>
+          </div>
+        </div>
+      )}
 
       {error && (
         <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">


### PR DESCRIPTION
## What changed
- Keeps open and in-progress jobs visible to the Orchestrator health verdict even when the human-facing context read is filtered by search text.
- Changes the Jobs top card from Queued to Waiting.
- Adds a red worker-belt idle warning when Active is 0 while waiting jobs exist.

## Why
The Jobs page could show Active 0, Queued 51, Alerts 0, which made a stopped worker belt look healthy. The heartbeat also showed that filtered Orchestrator reads could hide live waiting jobs.

## Checks
- npm test -- api/orchestrator-context-health-verdict.test.ts
- npm test -- src/pages/admin/AdminJobs.test.tsx
- git diff --check
