### PR TITLE
Add bench readiness call-up gate

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -12,7 +12,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/agent-observability.md | bffd9f890c75 | 4629 |
 | docs/pinballwake-nudgeonly-api.md | 901e39017aa9 | 6910 |
 | docs/pinballwake-igniteonly-api.md | bea4d9c8fa21 | 7919 |
-| docs/fleet-worker-roles.md | de6d70d0d55a | 3662 |
+| docs/fleet-worker-roles.md | ed620f347d4f | 4873 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
 | src/App.tsx | b02c3916f083 | 13089 |

--- a/docs/fleet-worker-roles.md
+++ b/docs/fleet-worker-roles.md
@@ -58,6 +58,26 @@ Gatekeeper is not active unless Chris creates a new chat and registers it in Fis
 - Send stale worker nudges and queue-routing to 📣.
 - Send release-safety decisions to 🛡️ if active, otherwise to 🍿 plus 🧭.
 
+## Bench Readiness Checklist
+
+Before calling up a bench worker, check:
+
+- Identity: the worker has a known Fishbowl or Boardroom identity and a fresh enough pulse.
+- Lane: the packet matches the worker's proven lane, such as builder, reviewer, XPass proof, queue, or relay.
+- Repo context: implementation workers can read the repo, branch, and current proof trail.
+- XPass access: Pass-family workers know which XPass tool or report to use, or the packet stays context-only.
+- Proof format: the worker can reply with PASS/BLOCKER, owned files, tests, PR or receipt, and next action.
+- Stop conditions: the packet names secrets, billing, DNS, data deletion, deploy, migration, force-push, and ownership limits.
+- Next ACK wording: the worker can ACK one bounded action, not a broad project promise.
+
+Bench call-up routing is deterministic:
+
+- Implementation packets go only to `builder_ready` or `scoped_builder` runners.
+- Queue-management and owner-decision packets go to Jobs Worker first.
+- QC packets can go to review-only workers.
+- XPass and status relay packets can go to context-ready workers.
+- Needs-probe or offline workers produce a BLOCKER reason and a next probe instead of receiving the packet.
+
 ## Report format
 
 Use this shape for material work:

--- a/src/pages/admin/pinballwakeJobRunners.test.ts
+++ b/src/pages/admin/pinballwakeJobRunners.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  chooseBenchCallUp,
   choosePinballWakeJobRunner,
+  classifyBenchReadiness,
+  describeBenchReadiness,
   PINBALLWAKE_JOB_RUNNERS,
+  type PinballWakeJobRunner,
   runnerCanAcceptJob,
   summarizePinballWakeJobRunners,
 } from "./pinballwakeJobRunners";
@@ -74,5 +78,126 @@ describe("PinballWake job runners", () => {
     expect(summary.codeHands).toBeGreaterThanOrEqual(1);
     expect(summary.needsProbe).toBeGreaterThanOrEqual(1);
     expect(summary.byReadiness.context_only).toBeGreaterThanOrEqual(1);
+  });
+
+  it("classifies bench readiness from runner metadata", () => {
+    const builder = PINBALLWAKE_JOB_RUNNERS.find((runner) => runner.id === "builder-codex");
+    const reviewer = PINBALLWAKE_JOB_RUNNERS.find((runner) => runner.id === "safety-checker");
+    const repairer = PINBALLWAKE_JOB_RUNNERS.find((runner) => runner.id === "repairer-plex-unproven");
+
+    expect(builder).toBeTruthy();
+    expect(reviewer).toBeTruthy();
+    expect(repairer).toBeTruthy();
+    expect(classifyBenchReadiness(builder!)).toBe("ready");
+    expect(classifyBenchReadiness(reviewer!)).toBe("review_only");
+    expect(classifyBenchReadiness(repairer!)).toBe("needs_probe");
+    expect(describeBenchReadiness(builder!).canImplement).toBe(true);
+  });
+
+  it("uses the bench call-up gate for implementation packets", () => {
+    const decision = chooseBenchCallUp({
+      kind: "implementation",
+      lane: "wakepass tests",
+      title: "Patch WakePass tests",
+      requiresCode: true,
+    });
+
+    expect(decision.status).toBe("PASS");
+    expect(decision.runner?.id).toBe("builder-codex");
+    expect(decision.readiness).toBe("ready");
+  });
+
+  it("uses review specialists for qc review packets", () => {
+    const decision = chooseBenchCallUp({
+      kind: "qc_review",
+      lane: "release safety hold review",
+      title: "Review safe merge",
+      requiresCode: false,
+    });
+
+    expect(decision.status).toBe("PASS");
+    expect(decision.runner?.id).toBe("safety-checker");
+    expect(decision.readiness).toBe("review_only");
+  });
+
+  it("routes XPass status relay work to context-ready pass lanes", () => {
+    const decision = chooseBenchCallUp({
+      kind: "status_relay",
+      lane: "xpass dogfood proof",
+      title: "Collect XPass proof",
+      requiresCode: false,
+    });
+
+    expect(decision.status).toBe("PASS");
+    expect(decision.runner?.id).toBe("tester-product-context");
+    expect(decision.readiness).toBe("context_only");
+  });
+
+  it("routes queue-management and owner-decision packets to Jobs Worker first", () => {
+    const queueDecision = chooseBenchCallUp({
+      kind: "queue_management",
+      lane: "jobs stale queue scopepack",
+      title: "Prepare stale job",
+      requiresCode: false,
+    });
+    const ownerDecision = chooseBenchCallUp({
+      kind: "owner_decision",
+      lane: "rotatepass owner decision",
+      title: "Hold or reroute",
+      requiresCode: false,
+    });
+
+    expect(queueDecision.status).toBe("PASS");
+    expect(ownerDecision.status).toBe("PASS");
+    expect(queueDecision.runner?.id).toBe("jobs-worker");
+    expect(ownerDecision.runner?.id).toBe("jobs-worker");
+  });
+
+  it("returns a blocker when the best specialist still needs a probe", () => {
+    const repairer = PINBALLWAKE_JOB_RUNNERS.find((runner) => runner.id === "repairer-plex-unproven");
+
+    const decision = chooseBenchCallUp(
+      {
+        kind: "implementation",
+        lane: "small implementation after probe",
+        title: "Try a code packet",
+        requiresCode: true,
+      },
+      [repairer!],
+    );
+
+    expect(decision.status).toBe("BLOCKER");
+    expect(decision.runner?.id).toBe("repairer-plex-unproven");
+    expect(decision.reason).toContain("needs_probe");
+  });
+
+  it("returns a blocker when no eligible specialist exists", () => {
+    const offlineRunner: PinballWakeJobRunner = {
+      id: "offline-builder",
+      emoji: "🛠️",
+      name: "Offline Builder",
+      kind: "local-runner",
+      host: "bench",
+      readiness: "offline",
+      capabilities: ["implementation"],
+      safeFor: ["bench"],
+      notFor: ["everything until online"],
+      proof: "No pulse.",
+      nextProbe: "Wake and verify repo access.",
+    };
+
+    const decision = chooseBenchCallUp(
+      {
+        kind: "implementation",
+        lane: "bench",
+        title: "Patch code",
+        requiresCode: true,
+      },
+      [offlineRunner],
+    );
+
+    expect(decision.status).toBe("BLOCKER");
+    expect(decision.runner?.id).toBe("offline-builder");
+    expect(decision.reason).toContain("offline");
   });
 });

--- a/src/pages/admin/pinballwakeJobRunners.ts
+++ b/src/pages/admin/pinballwakeJobRunners.ts
@@ -36,11 +36,37 @@ export interface PinballWakeJobRunner {
   nextProbe: string;
 }
 
+export type BenchReadinessClass =
+  | "ready"
+  | "context_only"
+  | "review_only"
+  | "needs_probe"
+  | "offline";
+
 export interface PinballWakeJobRequest {
   kind: PinballWakeJobKind;
   lane: string;
   title: string;
   requiresCode?: boolean;
+}
+
+export interface BenchReadinessReport {
+  runnerId: string;
+  readiness: BenchReadinessClass;
+  canImplement: boolean;
+  canReview: boolean;
+  canCoordinate: boolean;
+  reason: string;
+  nextProbe: string;
+}
+
+export interface BenchCallUpDecision {
+  status: "PASS" | "BLOCKER";
+  job: PinballWakeJobRequest;
+  runner?: PinballWakeJobRunner;
+  readiness?: BenchReadinessClass;
+  reason: string;
+  nextProbe?: string;
 }
 
 export const PINBALLWAKE_JOB_RUNNERS: PinballWakeJobRunner[] = [
@@ -150,6 +176,40 @@ export const PINBALLWAKE_JOB_RUNNERS: PinballWakeJobRunner[] = [
   },
 ];
 
+export function classifyBenchReadiness(runner: PinballWakeJobRunner): BenchReadinessClass {
+  if (runner.readiness === "offline") return "offline";
+  if (runner.readiness === "needs_probe") return "needs_probe";
+  if (runner.readiness === "review_only") return "review_only";
+  if (runner.readiness === "context_only") return "context_only";
+  return "ready";
+}
+
+export function describeBenchReadiness(runner: PinballWakeJobRunner): BenchReadinessReport {
+  const readiness = classifyBenchReadiness(runner);
+
+  return {
+    runnerId: runner.id,
+    readiness,
+    canImplement: runner.readiness === "builder_ready" || runner.readiness === "scoped_builder",
+    canReview: runner.capabilities.includes("qc_review") && runner.readiness !== "offline",
+    canCoordinate:
+      runner.capabilities.includes("queue_management") ||
+      runner.capabilities.includes("owner_decision") ||
+      runner.capabilities.includes("status_relay"),
+    reason:
+      readiness === "ready"
+        ? "Ready for scoped code packets with normal proof."
+        : readiness === "needs_probe"
+          ? "Needs a no-risk repo-access probe before implementation."
+          : readiness === "offline"
+            ? "Offline or dormant. Do not route fresh packets here."
+            : readiness === "review_only"
+              ? "Ready for review, proof, and safety reads only."
+              : "Ready for context, owner decisions, queue work, and status relay.",
+    nextProbe: runner.nextProbe,
+  };
+}
+
 export function runnerCanAcceptJob(
   runner: PinballWakeJobRunner,
   job: PinballWakeJobRequest,
@@ -160,6 +220,89 @@ export function runnerCanAcceptJob(
     return runner.readiness === "builder_ready" || runner.readiness === "scoped_builder";
   }
   return runner.readiness !== "needs_probe" || job.kind === "status_relay";
+}
+
+function chooseJobsWorkerFirst(runners: PinballWakeJobRunner[]): PinballWakeJobRunner | undefined {
+  return runners.find((runner) => runner.id === "jobs-worker");
+}
+
+function choosePassContextRunner(
+  job: PinballWakeJobRequest,
+  runners: PinballWakeJobRunner[],
+): PinballWakeJobRunner | undefined {
+  const lane = job.lane.toLowerCase();
+  if (job.kind !== "status_relay" || (!lane.includes("xpass") && !lane.includes("pass"))) {
+    return undefined;
+  }
+
+  return runners.find(
+    (runner) =>
+      runner.safeFor.some((safeLane) => safeLane.toLowerCase().includes("xpass")) &&
+      runnerCanAcceptJob(runner, job),
+  );
+}
+
+function findBlockedSpecialist(
+  job: PinballWakeJobRequest,
+  runners: PinballWakeJobRunner[],
+): PinballWakeJobRunner | undefined {
+  const candidates = runners.filter((runner) => runner.capabilities.includes(job.kind));
+  const lane = job.lane.toLowerCase();
+  const laneMatch = candidates.find((runner) =>
+    runner.safeFor.some((safeLane) => lane.includes(safeLane.toLowerCase())),
+  );
+  const ordered = laneMatch ? [laneMatch, ...candidates.filter((runner) => runner !== laneMatch)] : candidates;
+
+  return (
+    ordered.find((runner) => runner.readiness === "needs_probe") ??
+    ordered.find((runner) => runner.readiness === "offline")
+  );
+}
+
+export function chooseBenchCallUp(
+  job: PinballWakeJobRequest,
+  runners = PINBALLWAKE_JOB_RUNNERS,
+): BenchCallUpDecision {
+  const jobsWorker = chooseJobsWorkerFirst(runners);
+  const passContextRunner = choosePassContextRunner(job, runners);
+  const shouldStartWithJobsWorker = job.kind === "queue_management" || job.kind === "owner_decision";
+  const runner =
+    shouldStartWithJobsWorker && jobsWorker && runnerCanAcceptJob(jobsWorker, job)
+      ? jobsWorker
+      : passContextRunner
+        ? passContextRunner
+        : choosePinballWakeJobRunner(job, runners);
+
+  if (runner) {
+    const report = describeBenchReadiness(runner);
+    return {
+      status: "PASS",
+      job,
+      runner,
+      readiness: report.readiness,
+      reason: `${runner.name} can take ${job.kind} work. ${report.reason}`,
+      nextProbe: runner.nextProbe,
+    };
+  }
+
+  const blocked = findBlockedSpecialist(job, runners);
+  if (blocked) {
+    const report = describeBenchReadiness(blocked);
+    return {
+      status: "BLOCKER",
+      job,
+      runner: blocked,
+      readiness: report.readiness,
+      reason: `BLOCKER: ${blocked.name} matches this lane but is ${report.readiness}. ${report.reason}`,
+      nextProbe: blocked.nextProbe,
+    };
+  }
+
+  return {
+    status: "BLOCKER",
+    job,
+    reason: `BLOCKER: no eligible bench specialist can take ${job.kind} work for ${job.lane}.`,
+  };
 }
 
 export function choosePinballWakeJobRunner(


### PR DESCRIPTION
## Summary
- add pure bench readiness classification and call-up decision helpers for PinballWake job runners
- route queue-management and owner-decision work to Jobs Worker first
- document the bench readiness checklist and add focused tests for build, review, XPass relay, probe, and offline cases

## Tests
- npm run test -- src/pages/admin/pinballwakeJobRunners.test.ts
- npx tsc --noEmit
- node scripts/no-emdash-docs.test.mjs
- git diff --check

Boardroom: todo 3c8723f9 ScopePack 31bcb050