### PR TITLE
Fix Jobs completion integrity gates

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -8538,6 +8538,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             }
             update.status = s;
             if (s === "done") update.completed_at = new Date().toISOString();
+            if (s !== "done") update.completed_at = null;
           }
           if (body.priority != null) {
             const p = String(body.priority);
@@ -8814,6 +8815,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               .join("\n")
               .toLowerCase();
             const status = String(todo.status ?? "");
+            const isReopened = status !== "done" && (todo.completed_at != null || /\breopened\b/i.test(corpus));
             let activeCount = status === "done" ? stageRank.ship : status === "in_progress" ? stageRank.build : 1;
             let source = status === "done" ? "status: done" : status === "in_progress" ? "status: active" : "status: open";
             const evidence: string[] = [];
@@ -8860,6 +8862,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               activeCount = Math.max(activeCount, stageRank.ship);
               evidence.push("ship");
               source = "receipt: ship";
+            }
+
+            if (isReopened) {
+              activeCount = Math.min(activeCount, status === "in_progress" ? stageRank.build : stageRank.brief);
+              evidence.push("reopened");
+              source = "reopened: proof reset";
             }
 
             return {

--- a/scripts/fishbowl-todo-reconciliation.mjs
+++ b/scripts/fishbowl-todo-reconciliation.mjs
@@ -13,6 +13,12 @@ const TODO_REFERENCE_RE = new RegExp(
 const NO_TODO_RE = /^no-todo:\s*(\S.*)$/gim;
 const PR_URL_RE = /github\.com\/[^\s/)]+\/[^\s/)]+\/pull\/(\d+)/gi;
 const PR_NUMBER_RE = /\bPR\s*#(\d{1,7})\b/gi;
+const LIVE_OUTCOME_RE =
+  /\b(live proof|live outcome|verified live|browser verified|screenshot(?:s)?|api verified|production proof|visible in (?:the )?(?:app|ui|site)|live ui|live api|live product|dogfood(?:ed)?|manual qa)\b/i;
+const LIVE_OUTCOME_NEGATIVE_RE =
+  /\b(no|not|missing|needs?|needed|without|blocked|waiting for|unverified)\s+(?:live\s+)?(?:proof|outcome|verification|qa|screenshot|ui|api)\b|\b(?:live\s+)?(?:proof|outcome|verification|qa|screenshot|ui|api)\s+(?:missing|needed|unverified|blocked|incomplete)\b/i;
+const LIVE_FACING_JOB_RE =
+  /\b(live|production|ui|ux|screen|page|site|admin|dashboard|api|memory|library|recall|search|workflow|automation|autopilot|job(?:s)?|boardroom|orchestrator)\b/i;
 
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -65,6 +71,15 @@ function todoText(todo = {}) {
     todo.proof_text,
     todo.proofText,
   ).join("\n");
+}
+
+function hasLiveOutcomeProof(todo = {}) {
+  const text = todoText(todo);
+  return LIVE_OUTCOME_RE.test(text) && !LIVE_OUTCOME_NEGATIVE_RE.test(text);
+}
+
+function needsLiveOutcomeProof(todo = {}) {
+  return LIVE_FACING_JOB_RE.test(todoText(todo));
 }
 
 function dispatchText(dispatch = {}) {
@@ -248,7 +263,7 @@ export function buildInProgressReconciliationPlan({
 } = {}) {
   const nowMs = parseTime(now);
   if (nowMs === null) {
-    return { ok: false, reason: "invalid_now", auto_close: [], stale: [], unchanged: [] };
+    return { ok: false, reason: "invalid_now", auto_close: [], needs_verification: [], stale: [], unchanged: [] };
   }
 
   const mergedRefs = new Map();
@@ -270,6 +285,7 @@ export function buildInProgressReconciliationPlan({
   }
 
   const autoClose = [];
+  const needsVerification = [];
   const stale = [];
   const unchanged = [];
 
@@ -292,11 +308,12 @@ export function buildInProgressReconciliationPlan({
 
     const proofPr = findMergedPrProofForTodo(todo, pullRequests, nowMs, mergedWindowDays);
     if (proofPr) {
-      autoClose.push({
+      needsVerification.push({
         todo_id: todo.id,
         title: todo.title ?? "",
         pr: proofPr,
-        reason: "pipeline_ship_proof",
+        reason: "pipeline_ship_proof_needs_outcome_verification",
+        next: "Do not auto-close from pipeline text alone. Verify the live outcome or exact acceptance proof first.",
       });
       continue;
     }
@@ -319,6 +336,7 @@ export function buildInProgressReconciliationPlan({
     ok: true,
     reason: "reconciliation_plan",
     auto_close: autoClose,
+    needs_verification: needsVerification,
     stale,
     unchanged,
   };
@@ -424,6 +442,16 @@ export function buildJobsGithubSyncPlan({
         todo_id: todo.id,
         message: `Completed Job ${todo.id} has no visible GitHub proof link.`,
         next: "Add the PR, run, or deployment link to the Job proof so future seats can audit it.",
+      });
+    }
+
+    if (todo.status === "done" && needsLiveOutcomeProof(todo) && !hasLiveOutcomeProof(todo)) {
+      issues.push({
+        kind: "done_job_missing_live_outcome_proof",
+        severity: "high",
+        todo_id: todo.id,
+        message: `Completed Job ${todo.id} looks live-facing but has no visible live outcome proof.`,
+        next: "Attach screenshot, browser/API verification, or reopen the Job until the promised result is visible.",
       });
     }
   }

--- a/scripts/fishbowl-todo-reconciliation.test.mjs
+++ b/scripts/fishbowl-todo-reconciliation.test.mjs
@@ -77,7 +77,7 @@ describe("fishbowl todo reconciliation helpers", () => {
     assert.deepEqual(plan.unchanged.map((item) => item.todo_id), [TODO_B]);
   });
 
-  it("plans auto-close when an in-progress todo has pipeline ship proof for a merged PR", () => {
+  it("requires outcome verification when pipeline ship proof references a merged PR", () => {
     const plan = buildInProgressReconciliationPlan({
       now: "2026-05-08T12:00:00.000Z",
       todos: [
@@ -102,9 +102,10 @@ describe("fishbowl todo reconciliation helpers", () => {
     });
 
     assert.equal(plan.ok, true);
-    assert.deepEqual(plan.auto_close.map((item) => item.todo_id), [TODO_A]);
-    assert.equal(plan.auto_close[0].reason, "pipeline_ship_proof");
-    assert.equal(plan.auto_close[0].pr.number, 874);
+    assert.equal(plan.auto_close.length, 0);
+    assert.deepEqual(plan.needs_verification.map((item) => item.todo_id), [TODO_A]);
+    assert.equal(plan.needs_verification[0].reason, "pipeline_ship_proof_needs_outcome_verification");
+    assert.equal(plan.needs_verification[0].pr.number, 874);
   });
 
   it("does not auto-close pipeline ship proof when the referenced PR is unmerged", () => {
@@ -200,6 +201,25 @@ describe("fishbowl todo reconciliation helpers", () => {
 
     assert.equal(plan.linked.length, 1);
     assert.equal(plan.issues.some((issue) => issue.kind === "job_ready_to_complete"), true);
+  });
+
+  it("flags completed live-facing Jobs that lack live outcome proof", () => {
+    const plan = buildJobsGithubSyncPlan({
+      todos: [
+        {
+          id: TODO_A,
+          title: "Memory Library taxonomy snapshots",
+          status: "done",
+          description: "Proof: PR #699 merged. Unit tests passed.",
+        },
+      ],
+      pullRequests: [{ number: 699, body: `Closes UnClick todo: ${TODO_A}` }],
+    });
+
+    assert.equal(
+      plan.issues.some((issue) => issue.kind === "done_job_missing_live_outcome_proof" && issue.todo_id === TODO_A),
+      true,
+    );
   });
 
   it("suppresses stale WakePass blockers when a merged PR has completion proof", () => {


### PR DESCRIPTION
## Summary
- stop reopened Jobs from carrying a stale completed timestamp or 100 percent ship pipeline
- stop pipeline SHIP text from auto-closing Jobs without live outcome verification
- add a high-severity audit signal for DONE live-facing Jobs that lack live proof

## Tests
- node --test scripts/fishbowl-todo-reconciliation.test.mjs
- npx vitest run src/pages/admin/jobsGithubSync.test.ts
- npx tsc --noEmit --pretty false

Closes UnClick todo: 6819cb82-bd2e-432e-a872-d0c69e3c4d8f
Refs UnClick todo: 1b12d10a-f42f-42bd-b64a-fb14ea37717a
Refs UnClick todo: ef8f5242-f50f-412c-ab3a-163cab1a7674