### PR TITLE
Fix raw ScopePack JSON comment parsing

### DIFF
--- a/api/lib/scope-pack-comments.ts
+++ b/api/lib/scope-pack-comments.ts
@@ -29,11 +29,52 @@ function parseJsonObject(value: unknown): Record<string, unknown> | null {
   }
 }
 
+function findJsonObjectAfterIndex(text: string, start: number): string | null {
+  const openIndex = text.indexOf("{", start);
+  if (openIndex < 0) return null;
+
+  let depth = 0;
+  let escaped = false;
+  let inString = false;
+
+  for (let index = openIndex; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = inString;
+      continue;
+    }
+
+    if (char === "\"") {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(openIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
 export function parseScopePackFromText(value: unknown): Record<string, unknown> | null {
   const text = typeof value === "string" ? value.trim() : "";
   if (!text) return null;
 
-  const label = String.raw`(?:scope[_ -]?pack|scopepack|runner[_ -]?scope|autonomous[_ -]?scope|coding[_ -]?room[_ -]?scope)`;
+  const label = String.raw`(?:scope[_ -]?pack(?:\s+json)?|scopepack|runner[_ -]?scope|autonomous[_ -]?scope|coding[_ -]?room[_ -]?scope)`;
   const fencedPatterns = [
     new RegExp(String.raw`(?:^|\n)\s*${label}\s*:?\s*\r?\n\s*` + "```(?:json)?\\s*([\\s\\S]*?)```", "gi"),
     new RegExp(String.raw`(?:^|\n)\s*${label}\s*:\s*` + "```(?:json)?\\s*([\\s\\S]*?)```", "gi"),
@@ -52,6 +93,13 @@ export function parseScopePackFromText(value: unknown): Record<string, unknown> 
   let match;
   while ((match = inlinePattern.exec(text))) {
     const parsed = parseJsonObject(match[1]);
+    if (parsed) return parsed;
+  }
+
+  const rawJsonPattern = new RegExp(String.raw`(?:^|\n)\s*${label}\s*:?\s*(?:\r?\n|\s)+`, "gi");
+  while ((match = rawJsonPattern.exec(text))) {
+    const jsonText = findJsonObjectAfterIndex(text, rawJsonPattern.lastIndex);
+    const parsed = parseJsonObject(jsonText);
     if (parsed) return parsed;
   }
 

--- a/api/scope-pack-comments.test.ts
+++ b/api/scope-pack-comments.test.ts
@@ -41,6 +41,25 @@ describe("ScopePack comment parsing", () => {
     });
   });
 
+  it("parses raw pretty JSON after a bare ScopePack label", () => {
+    const scopePack = parseScopePackFromText([
+      "ScopePack",
+      "{",
+      '  "todo_id": "b4331f02-3def-4801-99e5-7f6e31ca5b73",',
+      '  "owned_files": ["api/memory-admin.ts"],',
+      '  "verification": ["npx vitest run api/memory-admin.test.ts"],',
+      '  "proof_required": "Live Library count must increase after writer run {no raw transcripts}."',
+      "}",
+    ].join("\n"));
+
+    expect(scopePack).toEqual({
+      todo_id: "b4331f02-3def-4801-99e5-7f6e31ca5b73",
+      owned_files: ["api/memory-admin.ts"],
+      verification: ["npx vitest run api/memory-admin.test.ts"],
+      proof_required: "Live Library count must increase after writer run {no raw transcripts}.",
+    });
+  });
+
   it("ignores prose that is not explicit JSON", () => {
     expect(parseScopePackFromText("ScopePack needed: pick the right files later.")).toBeNull();
   });


### PR DESCRIPTION
Summary
- Parse raw pretty JSON ScopePack comments after a bare ScopePack label.
- Keep prose-only ScopePack mentions ignored.
- Add regression coverage for the Memory Library blocker format.

Tests
- npx vitest run api/scope-pack-comments.test.ts
- npx tsc --noEmit --pretty false

Refs UnClick todo: b4331f02-3def-4801-99e5-7f6e31ca5b73
Refs UnClick todo: ef8f5242-f50f-412c-ab3a-163cab1a7674
Refs UnClick todo: 1b12d10a-f42f-42bd-b64a-fb14ea37717a