### PR TITLE
Require live results for memory retrieval eval

### DIFF
--- a/scripts/memory-retrieval-eval.mjs
+++ b/scripts/memory-retrieval-eval.mjs
@@ -195,8 +195,15 @@ export async function runMemoryRetrievalEval({
   resultSets = DEFAULT_TYPED_LINK_REPLAY_RESULTS,
   runner,
   k = DEFAULT_TOP_K,
+  allowSeededResults = false,
   clock = () => performance.now(),
 } = {}) {
+  if (!runner && resultSets === DEFAULT_TYPED_LINK_REPLAY_RESULTS && !allowSeededResults) {
+    throw new Error(
+      "seeded_replay_results_not_live_proof: pass a runner or --results from a real retrieval run",
+    );
+  }
+
   const perQuery = [];
 
   for (const fixture of fixtures.map(validateFixture)) {
@@ -244,6 +251,7 @@ function parseArgs(argv) {
     if (arg === "--fixtures") args.fixturesPath = argv[++index];
     else if (arg === "--results") args.resultsPath = argv[++index];
     else if (arg === "--k") args.k = Number.parseInt(argv[++index], 10);
+    else if (arg === "--allow-seeded-results") args.allowSeededResults = true;
     else if (arg === "--help") args.help = true;
     else throw new Error(`unknown_arg:${arg}`);
   }
@@ -253,13 +261,18 @@ function parseArgs(argv) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
-    console.log("Usage: node scripts/memory-retrieval-eval.mjs [--fixtures path.jsonl] [--results path.json] [--k 5]");
+    console.log("Usage: node scripts/memory-retrieval-eval.mjs [--fixtures path.jsonl] [--results path.json] [--k 5] [--allow-seeded-results]");
     return;
   }
 
   const fixtures = args.fixturesPath ? await loadJsonlFile(args.fixturesPath) : DEFAULT_TYPED_LINK_REPLAY_FIXTURES;
   const resultSets = args.resultsPath ? await loadResultsFile(args.resultsPath) : DEFAULT_TYPED_LINK_REPLAY_RESULTS;
-  const report = await runMemoryRetrievalEval({ fixtures, resultSets, k: args.k });
+  const report = await runMemoryRetrievalEval({
+    fixtures,
+    resultSets,
+    k: args.k,
+    allowSeededResults: args.allowSeededResults,
+  });
   console.log(JSON.stringify(report, null, 2));
   if (!report.aggregate.passed) process.exitCode = 1;
 }

--- a/scripts/memory-retrieval-eval.test.mjs
+++ b/scripts/memory-retrieval-eval.test.mjs
@@ -62,8 +62,15 @@ describe("memory retrieval eval", () => {
     assert.equal(report.ok, false);
   });
 
-  test("runs the seeded typed-link replay fixtures with deterministic results", async () => {
-    const report = await runMemoryRetrievalEval();
+  test("rejects seeded replay results as live proof by default", async () => {
+    await assert.rejects(
+      () => runMemoryRetrievalEval(),
+      /seeded_replay_results_not_live_proof/,
+    );
+  });
+
+  test("can run seeded typed-link replay fixtures when explicitly allowed", async () => {
+    const report = await runMemoryRetrievalEval({ allowSeededResults: true });
 
     assert.equal(report.aggregate.passed, true);
     assert.equal(report.aggregate.query_count, 5);


### PR DESCRIPTION
Summary
- Stop the Memory retrieval eval from passing by default on seeded answer fixtures.
- Require either real --results input, a supplied runner, or an explicit --allow-seeded-results opt-in.
- Add regression coverage so seeded replay results cannot be mistaken for live recall proof.

Tests
- node --test scripts/memory-retrieval-eval.test.mjs
- node scripts/memory-retrieval-eval.mjs exits with seeded_replay_results_not_live_proof unless real results are supplied

Refs UnClick todo: eb430faa-1e78-42c2-a060-fbbf01982b4d
Refs UnClick todo: 1b12d10a-f42f-42bd-b64a-fb14ea37717a
Refs UnClick todo: ef8f5242-f50f-412c-ab3a-163cab1a7674