### PR TITLE
Expose memory taxonomy snapshot refresh

### DIFF
--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { ENDPOINT_MAP } from "../catalog.js";
 import { validateToolArgumentsForRuntime } from "../server.js";
 
 describe("runtime tool schema validation", () => {
@@ -103,5 +104,21 @@ describe("runtime tool schema validation", () => {
       query: "PR #890",
       max_results: 5,
     })).toBeNull();
+  });
+
+  it("exposes Memory taxonomy snapshot refresh as a dry-run-first catalog endpoint", () => {
+    const entry = ENDPOINT_MAP.get("memory.refresh_taxonomy_snapshots");
+
+    expect(entry?.tool.slug).toBe("memory");
+    expect(entry?.endpoint.path).toBe("/v1/memory/taxonomy/refresh");
+    expect(entry?.endpoint.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        dry_run: { type: "boolean", default: true },
+        max_sources: { type: "number", minimum: 1, maximum: 250, default: 80 },
+        max_snapshots: { type: "number", minimum: 1, maximum: 12, default: 12 },
+        max_sources_per_snapshot: { type: "number", minimum: 1, maximum: 12, default: 8 },
+      },
+    });
   });
 });

--- a/packages/mcp-server/src/catalog.ts
+++ b/packages/mcp-server/src/catalog.ts
@@ -2166,6 +2166,23 @@ export const CATALOG: ToolDef[] = [
         },
       },
       {
+        id: "memory.refresh_taxonomy_snapshots",
+        name: "Refresh Memory Taxonomy Snapshots",
+        description: "Refresh Memory Taxonomy Snapshots - Build source-linked Memory Library taxonomy snapshots from active facts and sessions. Defaults to dry-run; pass dry_run=false to write snapshots.",
+        method: "POST",
+        path: "/v1/memory/taxonomy/refresh",
+        requiresAuth: false,
+        inputSchema: {
+          type: "object",
+          properties: {
+            dry_run: { type: "boolean", default: true },
+            max_sources: { type: "number", minimum: 1, maximum: 250, default: 80 },
+            max_snapshots: { type: "number", minimum: 1, maximum: 12, default: 12 },
+            max_sources_per_snapshot: { type: "number", minimum: 1, maximum: 12, default: 8 },
+          },
+        },
+      },
+      {
         id: "memory.manage_decay",
         name: "Run Memory Decay",
         description: "Run Memory Decay - Run the memory decay manager. Promotes/demotes items between hot/warm/cold tiers.",

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -757,7 +757,7 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
   async refresh_taxonomy_snapshots(args) {
     const db = await getBackend();
     return db.refreshTaxonomySnapshots({
-      dry_run: bool(args.dry_run, false),
+      dry_run: bool(args.dry_run, true),
       max_sources: num(args.max_sources, 80),
       max_snapshots: num(args.max_snapshots, 12),
       max_sources_per_snapshot: num(args.max_sources_per_snapshot, 8),


### PR DESCRIPTION
## Summary
- expose the existing Memory taxonomy snapshot writer through the memory catalog as memory.refresh_taxonomy_snapshots
- make the endpoint dry-run-first by default so live writes need dry_run=false
- add catalog coverage so this does not disappear from the callable tool list again

## Tests
- npx vitest run src/__tests__/tool-schema-validation.test.ts (from packages/mcp-server)
- npx tsx --test src/memory/__tests__/snapshot-taxonomy.test.ts (from packages/mcp-server)
- npm run build (from packages/mcp-server)
- npx tsc --noEmit --pretty false