### PR TITLE
Expose taxonomy refresh as visible memory tool

### DIFF
--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -8,6 +8,7 @@ describe("runtime tool schema validation", () => {
     { name: "load_memory", args: { num_sessions: 1, bogus_field: "should reject" } },
     { name: "search_memory", args: { query: "strict schema probe", bogus_field: "should reject" } },
     { name: "search_typed_links", args: { query: "PR #890", bogus_field: "should reject" } },
+    { name: "refresh_taxonomy_snapshots", args: { dry_run: true, bogus_field: "should reject" } },
     {
       name: "save_conversation_turn",
       args: {
@@ -103,6 +104,12 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("search_typed_links", {
       query: "PR #890",
       max_results: 5,
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("refresh_taxonomy_snapshots", {
+      dry_run: true,
+      max_sources: 12,
+      max_snapshots: 4,
+      max_sources_per_snapshot: 3,
     })).toBeNull();
   });
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -409,6 +409,46 @@ export const VISIBLE_TOOLS = [
     },
   },
   {
+    name: "refresh_taxonomy_snapshots",
+    title: "Refresh taxonomy snapshots",
+    description:
+      "Builds source-linked Memory Library taxonomy snapshots from active facts and sessions. " +
+      "Defaults to a dry run so workers can inspect planned snapshots before anything is written. " +
+      "Only pass dry_run=false after the dry-run output is safe and the job needs live write proof.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        dry_run: {
+          type: "boolean",
+          default: true,
+          description: "When true, preview snapshot output without writing Library docs.",
+        },
+        max_sources: {
+          type: "number",
+          minimum: 1,
+          maximum: 250,
+          default: 80,
+          description: "Maximum facts or sessions to scan.",
+        },
+        max_snapshots: {
+          type: "number",
+          minimum: 1,
+          maximum: 12,
+          default: 12,
+          description: "Maximum taxonomy snapshots to build.",
+        },
+        max_sources_per_snapshot: {
+          type: "number",
+          minimum: 1,
+          maximum: 12,
+          default: 8,
+          description: "Maximum source pointers per snapshot.",
+        },
+      },
+    },
+  },
+  {
     name: "save_identity",
     title: "Save my identity",
     description:


### PR DESCRIPTION
## Summary
- expose refresh_taxonomy_snapshots directly in MCP tools/list so worker seats can discover it
- keep the tool dry-run-first by default and document dry_run=false as an explicit write step
- add runtime validation coverage for the new visible tool

## Tests
- npx vitest run src/__tests__/tool-schema-validation.test.ts (from packages/mcp-server)
- npm run build (from packages/mcp-server)