### PR TITLE
Block false Fishbowl completions

### DIFF
--- a/api/fishbowl-completion-policy.test.ts
+++ b/api/fishbowl-completion-policy.test.ts
@@ -39,6 +39,58 @@ describe("evaluateFishbowlCompletionPolicy", () => {
     expect(result).toMatchObject({ allowed: true, code: "allowed" });
   });
 
+  it("blocks coding work when proof only cites tests", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "TestPass API package-boundary cleanup v1",
+        description: "Stop API routes from importing TestPass internals by relative source path.",
+      },
+      comments: [{ author_agent_id: "reviewer-seat", text: "PASS: tests passed; proof: npm test." }],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "git_proof_required" });
+  });
+
+  it("blocks coding work with screenshot proof but no Git or deploy proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "Architecture QC: Tools component split v1",
+        description: "Build component split for the Tools UI.",
+      },
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text: "PASS: before/after screenshot proof captured at C:\\G\\Screenshots\\tools-after.png.",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "git_proof_required" });
+  });
+
+  it("allows explicit no-code proof for non-code closure work", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "Automation playbook rank trigger methods",
+        description: "Policy and routing update only.",
+      },
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text: "PASS: NO_CODE_NEEDED, Boardroom policy comment posted and no repository files changed.",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: true, code: "allowed" });
+  });
+
   it("blocks UI work when proof lacks screenshots", () => {
     const result = evaluateFishbowlCompletionPolicy({
       todo: {
@@ -63,7 +115,7 @@ describe("evaluateFishbowlCompletionPolicy", () => {
       comments: [
         {
           author_agent_id: "reviewer-seat",
-          text: "PASS: before/after screenshot proof captured at C:\\G\\Screenshots\\uxpass-after.png.",
+          text: "PASS: PR #913 and before/after screenshot proof captured at C:\\G\\Screenshots\\uxpass-after.png.",
         },
       ],
       closerAgentId: "builder-seat",

--- a/api/fishbowl-completion-policy.test.ts
+++ b/api/fishbowl-completion-policy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { evaluateFishbowlCompletionPolicy } from "./lib/fishbowl-completion-policy";
+
+const baseTodo = {
+  id: "todo-1",
+  title: "Memory Recall Check pollution fix",
+  description: "Fix the repeated Most Accessed Facts list.",
+  created_by_agent_id: "builder-seat",
+};
+
+describe("evaluateFishbowlCompletionPolicy", () => {
+  it("blocks done when no proof comment exists", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: baseTodo,
+      comments: [],
+      closerAgentId: "reviewer-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "missing_proof" });
+  });
+
+  it("blocks self-created and self-closed jobs without independent proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: baseTodo,
+      comments: [{ author_agent_id: "builder-seat", text: "PASS: tests passed; proof: npm test." }],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "independent_verifier_required" });
+  });
+
+  it("allows non-UI work with independent commit or test proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: baseTodo,
+      comments: [{ author_agent_id: "reviewer-seat", text: "PASS: tests passed; proof: commit abc1234." }],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: true, code: "allowed" });
+  });
+
+  it("blocks UI work when proof lacks screenshots", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "UXPass visual polish gate",
+        description: "UI overhaul for the Jobs page.",
+      },
+      comments: [{ author_agent_id: "reviewer-seat", text: "PASS: tests passed; proof: npm test." }],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "ui_screenshot_required" });
+  });
+
+  it("allows UI work when independent screenshot proof exists", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "UXPass visual polish gate",
+        description: "UI overhaul for the Jobs page.",
+      },
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text: "PASS: before/after screenshot proof captured at C:\\G\\Screenshots\\uxpass-after.png.",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: true, code: "allowed" });
+  });
+});

--- a/api/fishbowl-job-pipeline.test.ts
+++ b/api/fishbowl-job-pipeline.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { inferFishbowlJobPipeline } from "./lib/fishbowl-job-pipeline";
+
+describe("Fishbowl job pipeline inference", () => {
+  it("shows done jobs as shipped when no proof warnings exist", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "Memory Library taxonomy snapshots",
+          status: "done",
+        },
+        ["PR #699 merged into main. Tests passed."],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["build", "proof", "ship"],
+    });
+  });
+
+  it("resets stale green stages when a job is reopened for proof", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "REOPENED: Memory Library v1 live taxonomy snapshot writer and storage proof",
+          status: "open",
+        },
+        ["Old receipt: PR #699 merged into main. Tests passed.", "BLOCKER: proof reset, live page still shows no snapshots."],
+      ),
+    ).toEqual({
+      pipeline_stage_count: 1,
+      pipeline_progress: 10,
+      pipeline_source: "reopened: proof reset",
+      pipeline_evidence: ["reopened", "proof_missing"],
+    });
+  });
+
+  it("does not treat old completed status as healthy when missing proof is recorded", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "Memory Recall Check: Most Accessed Facts dedupe",
+          status: "done",
+        },
+        ["BLOCKER: proof missing, live recall check still repeats static identity facts."],
+      ),
+    ).toEqual({
+      pipeline_stage_count: 1,
+      pipeline_progress: 10,
+      pipeline_source: "proof: missing",
+      pipeline_evidence: ["proof_missing"],
+    });
+  });
+
+  it("lets newer proof move a reopened job forward again", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "REOPENED: Memory Library v1 live taxonomy snapshot writer and storage proof",
+          status: "open",
+        },
+        [
+          {
+            text: "Old receipt: PR #699 merged into main. Tests passed.",
+            created_at: "2026-05-17T08:00:00Z",
+          },
+          {
+            text: "BLOCKER: proof reset, live page still shows no snapshots.",
+            created_at: "2026-05-17T09:00:00Z",
+          },
+          {
+            text: "PASS: fresh proof recorded. PR #914 checks green, tests passed, reviewer pass.",
+            created_at: "2026-05-17T10:00:00Z",
+          },
+        ],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 4,
+      pipeline_progress: 85,
+      pipeline_source: "receipt: review",
+      pipeline_evidence: ["build", "proof", "review"],
+    });
+  });
+});

--- a/api/lib/fishbowl-completion-policy.ts
+++ b/api/lib/fishbowl-completion-policy.ts
@@ -1,0 +1,95 @@
+export interface FishbowlCompletionTodo {
+  id: string;
+  title: string | null;
+  description: string | null;
+  created_by_agent_id: string | null;
+}
+
+export interface FishbowlCompletionComment {
+  author_agent_id: string | null;
+  text: string | null;
+}
+
+export interface FishbowlCompletionPolicyInput {
+  todo: FishbowlCompletionTodo;
+  comments: FishbowlCompletionComment[];
+  closerAgentId: string;
+  isAdminCaller?: boolean;
+}
+
+export interface FishbowlCompletionPolicyResult {
+  allowed: boolean;
+  code: "allowed" | "missing_proof" | "ui_screenshot_required" | "independent_verifier_required";
+  reason: string;
+  how_to_fix?: string;
+}
+
+const proofPositivePattern =
+  /\b(pr\s*#?\d+|pull request\s*#?\d+|commit\s+[a-f0-9]{7,40}|sha\s+[a-f0-9]{7,40}|tests?\s+passed|build\s+passed|checks?\s+(?:passed|green)|ci\s+(?:passed|green)|playwright|screenshot|screen\s?shot|actions\/runs\/\d+|proof:\s*\S+|receipt\s+[0-9a-f-]{8,})\b/i;
+
+const proofNegativePattern =
+  /\b(blocker|hold|no\s+(?:proof|screenshot|test|pr|commit)|missing\s+(?:proof|screenshot|test|pr|commit)|proof\s+(?:missing|needed|incomplete|stale|not available)|without\s+(?:proof|screenshot|test|pr|commit)|needs?\s+(?:proof|screenshot|test|pr|commit))\b/i;
+
+const screenshotPattern =
+  /\b(screenshot|screen\s?shot|before\/after|before and after|playwright|visual proof)\b|https?:\/\/\S+\.(?:png|jpe?g|webp)\b|[A-Za-z]:\\[^\n]+\.(?:png|jpe?g|webp)\b/i;
+
+const uiTodoPattern =
+  /\b(ui|ux|uxpass|visual|polish|screenshot|screen\s?shot|frontend|front-end|page|screen|layout|design)\b/i;
+
+export function evaluateFishbowlCompletionPolicy(input: FishbowlCompletionPolicyInput): FishbowlCompletionPolicyResult {
+  const closer = input.closerAgentId.trim();
+  const corpus = [input.todo.title, input.todo.description].filter(Boolean).join("\n");
+  const positiveProofComments = input.comments.filter((comment) => {
+    const text = comment.text ?? "";
+    return proofPositivePattern.test(text) && !proofNegativePattern.test(text);
+  });
+
+  if (positiveProofComments.length === 0) {
+    return {
+      allowed: false,
+      code: "missing_proof",
+      reason: "Done is blocked until the job has a real proof comment.",
+      how_to_fix: "Add a proof comment with a PR, commit, test/build result, run link, receipt, or screenshot, then close the job.",
+    };
+  }
+
+  const hasIndependentProof = positiveProofComments.some((comment) => {
+    const author = String(comment.author_agent_id ?? "").trim();
+    return author.length > 0 && author !== closer;
+  });
+  const creator = String(input.todo.created_by_agent_id ?? "").trim();
+  if (!input.isAdminCaller && creator === closer && !hasIndependentProof) {
+    return {
+      allowed: false,
+      code: "independent_verifier_required",
+      reason: "Done is blocked because the same agent created and closed the job without independent proof.",
+      how_to_fix: "Have a different UnClick agent identity add PASS/BLOCKER proof, then close the job. That verifier can live inside the same AI subscription seat.",
+    };
+  }
+  if (!input.isAdminCaller && !hasIndependentProof) {
+    return {
+      allowed: false,
+      code: "independent_verifier_required",
+      reason: "Done is blocked until proof comes from a different verifier agent.",
+      how_to_fix: "Use a separate reviewer agent_id to add PASS/BLOCKER proof before closing. It can be the same AI subscription, but not the same UnClick agent identity.",
+    };
+  }
+
+  if (uiTodoPattern.test(corpus)) {
+    const hasScreenshotProof = positiveProofComments.some((comment) => screenshotPattern.test(comment.text ?? ""));
+    if (!hasScreenshotProof) {
+      return {
+        allowed: false,
+        code: "ui_screenshot_required",
+        reason: "UI/UX jobs need screenshot proof before they can be marked done.",
+        how_to_fix: "Attach before/after screenshot proof or a Playwright screenshot path/comment, then close the job.",
+      };
+    }
+  }
+
+  return {
+    allowed: true,
+    code: "allowed",
+    reason: "Completion proof gate passed.",
+  };
+}

--- a/api/lib/fishbowl-completion-policy.ts
+++ b/api/lib/fishbowl-completion-policy.ts
@@ -19,13 +19,18 @@ export interface FishbowlCompletionPolicyInput {
 
 export interface FishbowlCompletionPolicyResult {
   allowed: boolean;
-  code: "allowed" | "missing_proof" | "ui_screenshot_required" | "independent_verifier_required";
+  code:
+    | "allowed"
+    | "missing_proof"
+    | "git_proof_required"
+    | "ui_screenshot_required"
+    | "independent_verifier_required";
   reason: string;
   how_to_fix?: string;
 }
 
 const proofPositivePattern =
-  /\b(pr\s*#?\d+|pull request\s*#?\d+|commit\s+[a-f0-9]{7,40}|sha\s+[a-f0-9]{7,40}|tests?\s+passed|build\s+passed|checks?\s+(?:passed|green)|ci\s+(?:passed|green)|playwright|screenshot|screen\s?shot|actions\/runs\/\d+|proof:\s*\S+|receipt\s+[0-9a-f-]{8,})\b/i;
+  /\b(pr\s*#?\d+|pull request\s*#?\d+|commit\s+[a-f0-9]{7,40}|sha\s+[a-f0-9]{7,40}|branch\s+[\w./-]+|git\s+diff|tests?\s+passed|build\s+passed|checks?\s+(?:passed|green)|ci\s+(?:passed|green)|playwright|screenshot|screen\s?shot|actions\/runs\/\d+|deployed|deployment|live on production|production live|no[_\s-]?code[_\s-]?needed|no code needed|proof:\s*\S+|receipt\s+[0-9a-f-]{8,})\b/i;
 
 const proofNegativePattern =
   /\b(blocker|hold|no\s+(?:proof|screenshot|test|pr|commit)|missing\s+(?:proof|screenshot|test|pr|commit)|proof\s+(?:missing|needed|incomplete|stale|not available)|without\s+(?:proof|screenshot|test|pr|commit)|needs?\s+(?:proof|screenshot|test|pr|commit))\b/i;
@@ -35,6 +40,15 @@ const screenshotPattern =
 
 const uiTodoPattern =
   /\b(ui|ux|uxpass|visual|polish|screenshot|screen\s?shot|frontend|front-end|page|screen|layout|design)\b/i;
+
+const codingTodoPattern =
+  /\b(api|backend|bug|build|code|coding|commit|component|deploy|endpoint|fix|front-end|frontend|function|implement|migration|mcp|package|patch|pr|route|runner|schema|script|storage|tsx?|tool|ui|ux|uxpass|wire|writer)\b/i;
+
+const gitProofPattern =
+  /\b(pr\s*#?\d+|pull request\s*#?\d+|commit\s+[a-f0-9]{7,40}|sha\s+[a-f0-9]{7,40}|branch\s+[\w./-]+|git\s+diff|github\.com\/\S+\/(?:pull|commit)\/\S+|actions\/runs\/\d+|deployed|deployment|live on production|production live|vercel\.app)\b/i;
+
+const noCodeNeededPattern =
+  /\b(no[_\s-]?code[_\s-]?needed|no code needed|non-code|no code change|policy only|comment only|routing only|docs only)\b/i;
 
 export function evaluateFishbowlCompletionPolicy(input: FishbowlCompletionPolicyInput): FishbowlCompletionPolicyResult {
   const closer = input.closerAgentId.trim();
@@ -83,6 +97,21 @@ export function evaluateFishbowlCompletionPolicy(input: FishbowlCompletionPolicy
         code: "ui_screenshot_required",
         reason: "UI/UX jobs need screenshot proof before they can be marked done.",
         how_to_fix: "Attach before/after screenshot proof or a Playwright screenshot path/comment, then close the job.",
+      };
+    }
+  }
+
+  if (codingTodoPattern.test(corpus)) {
+    const hasGitOrDeployProof = positiveProofComments.some((comment) =>
+      gitProofPattern.test(comment.text ?? "") || noCodeNeededPattern.test(comment.text ?? ""),
+    );
+    if (!hasGitOrDeployProof) {
+      return {
+        allowed: false,
+        code: "git_proof_required",
+        reason: "Coding jobs need Git, deploy, or no-code proof before they can be marked done.",
+        how_to_fix:
+          "Add proof with a PR, commit SHA, branch diff, deployed URL, or explicit NO_CODE_NEEDED reason, then close the job.",
       };
     }
   }

--- a/api/lib/fishbowl-job-pipeline.ts
+++ b/api/lib/fishbowl-job-pipeline.ts
@@ -1,0 +1,153 @@
+export interface FishbowlJobPipelineTodo {
+  title?: unknown;
+  description?: unknown;
+  status?: unknown;
+}
+
+export interface FishbowlJobPipelineState {
+  pipeline_stage_count: number;
+  pipeline_progress: number;
+  pipeline_source: string;
+  pipeline_evidence: string[];
+}
+
+export type FishbowlJobPipelineComment =
+  | string
+  | {
+      text?: unknown;
+      created_at?: unknown;
+    };
+
+const stageRank = {
+  brief: 1,
+  build: 2,
+  proof: 3,
+  review: 4,
+  ship: 5,
+} as const;
+
+const stageProgress: Record<number, number> = {
+  1: 10,
+  2: 55,
+  3: 70,
+  4: 85,
+  5: 100,
+};
+
+const PROOF_RESET_RE = /\b(reopened|re-opened|proof\s+reset|false\s+completion|partial\s+completion)\b/i;
+const PROOF_MISSING_RE =
+  /\b(no|missing|needs?|needed|waiting for|without|incomplete|stale)\s+(?:live\s+)?proof\b|\bproof\s+(?:missing|needed|incomplete|stale|not available)\b/i;
+
+function positiveStageHit(text: string, positive: RegExp, negative?: RegExp): boolean {
+  if (!positive.test(text)) return false;
+  return negative ? !negative.test(text) : true;
+}
+
+function commentText(comment: FishbowlJobPipelineComment): string {
+  if (typeof comment === "string") return comment;
+  return typeof comment.text === "string" ? comment.text : "";
+}
+
+function buildSegments(todo: FishbowlJobPipelineTodo, comments: FishbowlJobPipelineComment[]): string[] {
+  const commentSegments = [...comments].sort((a, b) => {
+    if (typeof a === "string" || typeof b === "string") return 0;
+    const aTime = typeof a.created_at === "string" ? Date.parse(a.created_at) : Number.NaN;
+    const bTime = typeof b.created_at === "string" ? Date.parse(b.created_at) : Number.NaN;
+    if (Number.isNaN(aTime) || Number.isNaN(bTime)) return 0;
+    return aTime - bTime;
+  });
+  return [todo.title, todo.description, ...commentSegments.map(commentText)]
+    .filter((value) => typeof value === "string" && value.trim().length > 0)
+    .map((value) => value.toLowerCase());
+}
+
+export function inferFishbowlJobPipeline(
+  todo: FishbowlJobPipelineTodo,
+  comments: FishbowlJobPipelineComment[] = [],
+): FishbowlJobPipelineState {
+  const segments = buildSegments(todo, comments);
+  const latestResetIndex = segments.reduce((latest, segment, index) => {
+    return PROOF_RESET_RE.test(segment) || PROOF_MISSING_RE.test(segment) ? index : latest;
+  }, -1);
+  const latestProgressIndex = segments.reduce((latest, segment, index) => {
+    return positiveStageHit(
+      segment,
+      /\b(implemented|built|build complete|patch applied|changes applied|pr\s*#?\d+|branch ready|commit(?:ted)?|ready for proof|build passed|checks? (?:passed|green)|tests? passed|proof (?:passed|complete|attached|submitted|recorded|current|clean)|verification (?:passed|complete)|ci passed|npm run build passed|qc pass|review(?:ed)?|reviewer pass|gatekeeper pass|safety pass|approved|ack:\s*pass|pass on #\d+|ready for review|pr\s*#?\d+\s+merged|merged\s+#?\d+|merged into main|deployed|published|shipped|live on production|production live)\b/i,
+      /\b(blocker|hold|do not merge|do not lift)\b/i,
+    )
+      ? index
+      : latest;
+  }, -1);
+
+  const status = String(todo.status ?? "");
+  if (latestResetIndex >= 0 && latestResetIndex > latestProgressIndex) {
+    const latestResetText = segments[latestResetIndex] ?? "";
+    const resetHit = PROOF_RESET_RE.test(latestResetText);
+    return {
+      pipeline_stage_count: stageRank.brief,
+      pipeline_progress: stageProgress[stageRank.brief],
+      pipeline_source: resetHit ? "reopened: proof reset" : "proof: missing",
+      pipeline_evidence: resetHit ? ["reopened", "proof_missing"] : ["proof_missing"],
+    };
+  }
+
+  const activeSegments = latestResetIndex >= 0 ? segments.slice(latestResetIndex + 1) : segments;
+  const corpus = activeSegments.join("\n");
+  let activeCount = status === "done" ? stageRank.ship : status === "in_progress" ? stageRank.build : stageRank.brief;
+  let source = status === "done" ? "status: done" : status === "in_progress" ? "status: active" : "status: open";
+  const evidence: string[] = [];
+
+  if (
+    positiveStageHit(
+      corpus,
+      /\b(implemented|built|build complete|patch applied|changes applied|pr\s*#?\d+|branch ready|commit(?:ted)?|ready for proof)\b/i,
+    )
+  ) {
+    activeCount = Math.max(activeCount, stageRank.build);
+    evidence.push("build");
+    source = "receipt: build";
+  }
+
+  if (
+    positiveStageHit(
+      corpus,
+      /\b(build passed|checks? (?:passed|green)|tests? passed|proof (?:passed|complete|attached|submitted|recorded|current|clean)|verification (?:passed|complete)|ci passed|npm run build passed)\b/i,
+      PROOF_MISSING_RE,
+    )
+  ) {
+    activeCount = Math.max(activeCount, stageRank.proof);
+    evidence.push("proof");
+    source = "receipt: proof";
+  }
+
+  if (
+    positiveStageHit(
+      corpus,
+      /\b(qc pass|review(?:ed)?|reviewer pass|gatekeeper pass|safety pass|approved|ack:\s*pass|pass on #\d+|ready for review)\b/i,
+      /\b(no|missing|needs?|needed|waiting for|without|incomplete)\s+(?:qc|review|pass)\b|\b(blocker|hold|do not merge|do not lift)\b/i,
+    )
+  ) {
+    activeCount = Math.max(activeCount, stageRank.review);
+    evidence.push("review");
+    source = "receipt: review";
+  }
+
+  if (
+    positiveStageHit(
+      corpus,
+      /\b(pr\s*#?\d+\s+merged|merged\s+#?\d+|merged into main|deployed|published|shipped|live on production|production live)\b/i,
+      /\b(not merged|unmerged|do not merge|blocked from merge|merge blocked)\b/i,
+    )
+  ) {
+    activeCount = Math.max(activeCount, stageRank.ship);
+    evidence.push("ship");
+    source = "receipt: ship";
+  }
+
+  return {
+    pipeline_stage_count: activeCount,
+    pipeline_progress: stageProgress[activeCount] ?? stageProgress[stageRank.brief],
+    pipeline_source: source,
+    pipeline_evidence: evidence,
+  };
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -103,6 +103,8 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { evaluateFishbowlCompletionPolicy } from "./lib/fishbowl-completion-policy.js";
+import { inferFishbowlJobPipeline } from "./lib/fishbowl-job-pipeline.js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import {
   buildOrchestratorContext,
@@ -8514,7 +8516,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
           const { data: beforeTodo, error: beforeErr } = await supabase
             .from("mc_fishbowl_todos")
-            .select("id,title,status,assigned_to_agent_id,priority")
+            .select("id,title,description,status,created_by_agent_id,assigned_to_agent_id,priority")
             .eq("api_key_hash", apiKeyHash)
             .eq("id", idRes)
             .maybeSingle();
@@ -8551,6 +8553,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             const a = String(body.assigned_to_agent_id ?? "").trim();
             if (a.length > 128) return res.status(400).json({ error: "assigned_to_agent_id must be at most 128 characters" });
             update.assigned_to_agent_id = a.length === 0 ? null : a;
+          }
+
+          if (update.status === "done" && beforeTodo) {
+            const { data: proofComments, error: proofErr } = await supabase
+              .from("mc_fishbowl_comments")
+              .select("author_agent_id,text")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("target_kind", "todo")
+              .eq("target_id", idRes);
+            if (proofErr) throw proofErr;
+
+            const completionGate = evaluateFishbowlCompletionPolicy({
+              todo: {
+                id: String(beforeTodo.id),
+                title: typeof update.title === "string" ? update.title : String(beforeTodo.title ?? ""),
+                description:
+                  typeof update.description === "string"
+                    ? update.description
+                    : typeof beforeTodo.description === "string"
+                      ? beforeTodo.description
+                      : null,
+                created_by_agent_id:
+                  typeof beforeTodo.created_by_agent_id === "string" ? beforeTodo.created_by_agent_id : null,
+              },
+              comments: (proofComments ?? []).map((comment) => ({
+                author_agent_id:
+                  typeof comment.author_agent_id === "string" ? comment.author_agent_id : null,
+                text: typeof comment.text === "string" ? comment.text : null,
+              })),
+              closerAgentId: agentId,
+            });
+            if (!completionGate.allowed) {
+              return res.status(409).json({
+                error: completionGate.reason,
+                code: completionGate.code,
+                how_to_fix: completionGate.how_to_fix,
+              });
+            }
           }
 
           let laneCheck: {
@@ -8648,11 +8688,43 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           if (typeof idRes !== "string") return res.status(400).json(idRes);
           const { data: beforeTodo, error: beforeErr } = await supabase
             .from("mc_fishbowl_todos")
-            .select("id,title,status,assigned_to_agent_id,priority")
+            .select("id,title,description,status,created_by_agent_id,assigned_to_agent_id,priority")
             .eq("api_key_hash", apiKeyHash)
             .eq("id", idRes)
             .maybeSingle();
           if (beforeErr) throw beforeErr;
+          if (beforeTodo) {
+            const { data: proofComments, error: proofErr } = await supabase
+              .from("mc_fishbowl_comments")
+              .select("author_agent_id,text")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("target_kind", "todo")
+              .eq("target_id", idRes);
+            if (proofErr) throw proofErr;
+
+            const completionGate = evaluateFishbowlCompletionPolicy({
+              todo: {
+                id: String(beforeTodo.id),
+                title: typeof beforeTodo.title === "string" ? beforeTodo.title : null,
+                description: typeof beforeTodo.description === "string" ? beforeTodo.description : null,
+                created_by_agent_id:
+                  typeof beforeTodo.created_by_agent_id === "string" ? beforeTodo.created_by_agent_id : null,
+              },
+              comments: (proofComments ?? []).map((comment) => ({
+                author_agent_id:
+                  typeof comment.author_agent_id === "string" ? comment.author_agent_id : null,
+                text: typeof comment.text === "string" ? comment.text : null,
+              })),
+              closerAgentId: agentId,
+            });
+            if (!completionGate.allowed) {
+              return res.status(409).json({
+                error: completionGate.reason,
+                code: completionGate.code,
+                how_to_fix: completionGate.how_to_fix,
+              });
+            }
+          }
           const nowIso = new Date().toISOString();
           const { data, error } = await supabase
             .from("mc_fishbowl_todos")
@@ -8787,119 +8859,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             countTodosByStatus("dropped"),
           ]);
 
-          const stageRank = {
-            brief: 1,
-            build: 2,
-            proof: 3,
-            review: 4,
-            ship: 5,
-          } as const;
-          const stageProgress: Record<number, number> = {
-            1: 10,
-            2: 55,
-            3: 70,
-            4: 85,
-            5: 100,
-          };
-          function positiveStageHit(text: string, positive: RegExp, negative?: RegExp): boolean {
-            if (!positive.test(text)) return false;
-            return negative ? !negative.test(text) : true;
-          }
-          function inferJobPipeline(todo: Record<string, unknown>, commentTexts: string[]) {
-            const corpus = [
-              todo.title,
-              todo.description,
-              ...commentTexts,
-            ]
-              .filter((value) => typeof value === "string" && value.trim().length > 0)
-              .join("\n")
-              .toLowerCase();
-            const status = String(todo.status ?? "");
-            const isReopened = status !== "done" && (todo.completed_at != null || /\breopened\b/i.test(corpus));
-            let activeCount = status === "done" ? stageRank.ship : status === "in_progress" ? stageRank.build : 1;
-            let source = status === "done" ? "status: done" : status === "in_progress" ? "status: active" : "status: open";
-            const evidence: string[] = [];
-
-            if (
-              positiveStageHit(
-                corpus,
-                /\b(implemented|built|build complete|patch applied|changes applied|pr\s*#?\d+|branch ready|commit(?:ted)?|ready for proof)\b/i,
-              )
-            ) {
-              activeCount = Math.max(activeCount, stageRank.build);
-              evidence.push("build");
-              source = "receipt: build";
-            }
-            if (
-              positiveStageHit(
-                corpus,
-                /\b(build passed|checks? (?:passed|green)|tests? passed|proof (?:passed|complete|attached|submitted|recorded|current|clean)|verification (?:passed|complete)|ci passed|npm run build passed)\b/i,
-                /\b(no|missing|needs?|needed|waiting for|without|incomplete|stale)\s+(?:live\s+)?proof\b|\bproof\s+(?:missing|needed|incomplete|stale|not available)\b/i,
-              )
-            ) {
-              activeCount = Math.max(activeCount, stageRank.proof);
-              evidence.push("proof");
-              source = "receipt: proof";
-            }
-            if (
-              positiveStageHit(
-                corpus,
-                /\b(qc pass|review(?:ed)?|reviewer pass|gatekeeper pass|safety pass|approved|ack:\s*pass|pass on #\d+|ready for review)\b/i,
-                /\b(no|missing|needs?|needed|waiting for|without|incomplete)\s+(?:qc|review|pass)\b|\b(blocker|hold|do not merge|do not lift)\b/i,
-              )
-            ) {
-              activeCount = Math.max(activeCount, stageRank.review);
-              evidence.push("review");
-              source = "receipt: review";
-            }
-            if (
-              positiveStageHit(
-                corpus,
-                /\b(pr\s*#?\d+\s+merged|merged\s+#?\d+|merged into main|deployed|published|shipped|live on production|production live)\b/i,
-                /\b(not merged|unmerged|do not merge|blocked from merge|merge blocked)\b/i,
-              )
-            ) {
-              activeCount = Math.max(activeCount, stageRank.ship);
-              evidence.push("ship");
-              source = "receipt: ship";
-            }
-
-            if (isReopened) {
-              activeCount = Math.min(activeCount, status === "in_progress" ? stageRank.build : stageRank.brief);
-              evidence.push("reopened");
-              source = "reopened: proof reset";
-            }
-
-            return {
-              pipeline_stage_count: activeCount,
-              pipeline_progress: stageProgress[activeCount] ?? 10,
-              pipeline_source: source,
-              pipeline_evidence: evidence,
-            };
-          }
-
           // Decorate with comment_count and stage evidence for the jobs board.
           const todos = data ?? [];
           let countMap: Record<string, number> = {};
-          let textMap: Record<string, string[]> = {};
+          let textMap: Record<string, Array<{ text: string; created_at: string | null }>> = {};
           if (todos.length > 0) {
             const ids = todos.map((t) => t.id);
             const { data: comments } = await supabase
               .from("mc_fishbowl_comments")
-              .select("target_id,text")
+              .select("target_id,text,created_at")
               .eq("api_key_hash", apiKeyHash)
               .eq("target_kind", "todo")
-              .in("target_id", ids);
+              .in("target_id", ids)
+              .order("created_at", { ascending: true });
             const commentRows = comments ?? [];
             countMap = commentRows.reduce<Record<string, number>>((acc, c) => {
               const k = c.target_id as string;
               acc[k] = (acc[k] ?? 0) + 1;
               return acc;
             }, {});
-            textMap = commentRows.reduce<Record<string, string[]>>((acc, c) => {
+            textMap = commentRows.reduce<Record<string, Array<{ text: string; created_at: string | null }>>>((acc, c) => {
               const k = c.target_id as string;
               const text = typeof c.text === "string" ? c.text : "";
-              if (text) acc[k] = [...(acc[k] ?? []), text];
+              const createdAt = typeof c.created_at === "string" ? c.created_at : null;
+              if (text) acc[k] = [...(acc[k] ?? []), { text, created_at: createdAt }];
               return acc;
             }, {});
           }
@@ -8908,7 +8891,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             return {
               ...t,
               comment_count: countMap[id] ?? 0,
-              ...inferJobPipeline(t, textMap[id] ?? []),
+              ...inferFishbowlJobPipeline(t, textMap[id] ?? []),
             };
           });
           const compactTodos = decorated.map((t) => ({

--- a/src/pages/admin/fishbowl/Todos.tsx
+++ b/src/pages/admin/fishbowl/Todos.tsx
@@ -200,30 +200,41 @@ function TodoCard({
   const [draftTitle, setDraftTitle] = useState(todo.title);
   const [draftDesc, setDraftDesc] = useState(todo.description ?? "");
   const [draftPriority, setDraftPriority] = useState<Todo["priority"]>(todo.priority);
+  const [mutationError, setMutationError] = useState<string | null>(null);
 
   const callMutation = async (action: string, payload: Record<string, unknown>) => {
-    if (!humanAgentId) return;
+    if (!humanAgentId) return false;
     setBusy(true);
+    setMutationError(null);
     try {
-      await fetch(`/api/memory-admin?action=${action}`, {
+      const res = await fetch(`/api/memory-admin?action=${action}`, {
         method: "POST",
         headers: { ...authHeader, "Content-Type": "application/json" },
         body: JSON.stringify({ agent_id: humanAgentId, ...payload }),
       });
+      const body = (await res.json().catch(() => ({}))) as { error?: string; how_to_fix?: string };
+      if (!res.ok) {
+        const detail = body.how_to_fix ? `${body.error ?? "Action blocked"} ${body.how_to_fix}` : body.error;
+        throw new Error(detail ?? "Action failed");
+      }
       onMutated();
+      return true;
+    } catch (e) {
+      setMutationError(e instanceof Error ? e.message : "Action failed");
+      return false;
     } finally {
       setBusy(false);
     }
   };
 
   const saveEdits = async () => {
-    await callMutation("fishbowl_update_todo", {
+    const saved = await callMutation("fishbowl_update_todo", {
       todo_id: todo.id,
       title: draftTitle.trim(),
       description: draftDesc.trim() || null,
       priority: draftPriority,
     });
-    setEditing(false);
+    if (saved) setEditing(false);
   };
 
   const isDone = todo.status === "done";
@@ -372,6 +383,12 @@ function TodoCard({
                 Delete
               </button>
             </div>
+          )}
+
+          {mutationError && (
+            <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+              {mutationError}
+            </p>
           )}
 
           <Comments

--- a/src/pages/admin/jobsGithubSync.test.ts
+++ b/src/pages/admin/jobsGithubSync.test.ts
@@ -3,6 +3,7 @@ import {
   buildJobGithubSyncSignal,
   extractJobGithubReferences,
   jobHasDeploymentFailure,
+  jobHasProofReset,
   type JobGithubSyncInput,
 } from "./jobsGithubSync";
 
@@ -79,6 +80,38 @@ describe("Jobs and GitHub sync helpers", () => {
       label: "Proof saved",
       detail: "Run 25590447727 is linked to this completed job.",
       tone: "done",
+    });
+  });
+
+  it("lets reopened or proof-reset state override stale GitHub links", () => {
+    const reopenedJob = {
+      ...baseJob,
+      title: "REOPENED: Memory Library taxonomy snapshot proof",
+      description: "Old PR #699 merged, but proof reset because the live Library still shows no snapshots.",
+      pipeline_evidence: ["https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/699"],
+    };
+
+    expect(jobHasProofReset(reopenedJob)).toBe(true);
+    expect(buildJobGithubSyncSignal(reopenedJob)).toEqual({
+      label: "Proof reset",
+      detail: "This job was reopened or blocked because proof is stale or missing.",
+      tone: "alert",
+    });
+  });
+
+  it("lets current pipeline proof clear old reopened wording", () => {
+    const recoveredJob = {
+      ...baseJob,
+      title: "REOPENED: Memory Library taxonomy snapshot proof",
+      description: "Old proof was reset because the live Library still shows no snapshots.",
+      pipeline_evidence: ["build", "proof", "review"],
+    };
+
+    expect(jobHasProofReset(recoveredJob)).toBe(false);
+    expect(buildJobGithubSyncSignal(recoveredJob)).toEqual({
+      label: "Job first",
+      detail: "Work starts here. Add a PR, run, or deployment link when code ships.",
+      tone: "quiet",
     });
   });
 });

--- a/src/pages/admin/jobsGithubSync.ts
+++ b/src/pages/admin/jobsGithubSync.ts
@@ -26,6 +26,9 @@ const GITHUB_RUN_URL_RE = /https:\/\/github\.com\/([^\s/)]+\/[^\s/)]+)\/actions\
 const VERCEL_URL_RE = /https:\/\/(?:vercel\.com|[^\s/)]+\.vercel\.app)[^\s)]*/gi;
 const PR_NUMBER_RE = /\bPR\s*#(\d{1,7})\b/gi;
 const FAILED_DEPLOY_RE = /\b(failed preview deployment|deployment failed|failed deployment|preview deployment failed|vercel failed)\b/i;
+const PROOF_RESET_RE = /\b(reopened|re-opened|proof\s+reset|false\s+completion|partial\s+completion|proof_missing)\b/i;
+const PROOF_MISSING_RE =
+  /\b(no|missing|needs?|needed|waiting for|without|incomplete|stale)\s+(?:live\s+)?proof\b|\bproof\s+(?:missing|needed|incomplete|stale|not available)\b/i;
 
 function uniqueByLabel(refs: JobGithubReference[]): JobGithubReference[] {
   const seen = new Set<string>();
@@ -88,6 +91,17 @@ export function jobHasDeploymentFailure(job: JobGithubSyncInput): boolean {
   return FAILED_DEPLOY_RE.test(jobSyncText(job));
 }
 
+export function jobHasProofReset(job: JobGithubSyncInput): boolean {
+  const evidence = job.pipeline_evidence ?? [];
+  const hasCurrentProgressEvidence = evidence.some((item) => /\b(build|proof|review|ship)\b/i.test(item));
+  const hasResetEvidence = evidence.some((item) => PROOF_RESET_RE.test(item) || PROOF_MISSING_RE.test(item));
+  if (hasCurrentProgressEvidence && !hasResetEvidence) return false;
+  if (hasResetEvidence) return true;
+
+  const text = jobSyncText(job);
+  return PROOF_RESET_RE.test(text) || PROOF_MISSING_RE.test(text);
+}
+
 export function buildJobGithubSyncSignal(job: JobGithubSyncInput): JobGithubSyncSignal {
   const refs = extractJobGithubReferences(job);
   const firstPr = refs.find((ref) => ref.kind === "pull_request");
@@ -101,6 +115,14 @@ export function buildJobGithubSyncSignal(job: JobGithubSyncInput): JobGithubSync
       detail: "A linked deployment needs attention.",
       tone: "alert",
       href: firstLink?.url,
+    };
+  }
+
+  if (jobHasProofReset(job)) {
+    return {
+      label: "Proof reset",
+      detail: "This job was reopened or blocked because proof is stale or missing.",
+      tone: "alert",
     };
   }
 


### PR DESCRIPTION
## Summary
- block DONE transitions unless a job has real proof from a different UnClick agent identity
- require screenshot proof for UI/UX/UXPass jobs
- reset stale green pipeline state when jobs are reopened or marked proof-missing, so old PR/test links do not keep showing as healthy
- show blocked mutation reasons in the Jobs/Fishbowl todo UI

## Verification
- npx vitest run api/fishbowl-completion-policy.test.ts api/fishbowl-job-pipeline.test.ts src/pages/admin/jobsGithubSync.test.ts
- npm run build
- git diff --check -- api/lib/fishbowl-completion-policy.ts api/fishbowl-completion-policy.test.ts api/lib/fishbowl-job-pipeline.ts api/fishbowl-job-pipeline.test.ts api/memory-admin.ts src/pages/admin/fishbowl/Todos.tsx src/pages/admin/jobsGithubSync.ts src/pages/admin/jobsGithubSync.test.ts

Boardroom: 1b12d10a-f42f-42bd-b64a-fb14ea37717a, ef8f5242-f50f-412c-ab3a-163cab1a7674