### PR TITLE
Guard test-only runner claims

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1145,6 +1145,73 @@ export async function syncClaimedBoardroomTodoToUnClick({
     };
   }
 
+  let testOnlyExecutorPacketResult = null;
+  if (todo && testOnlyExecutorPacket?.enabled) {
+    testOnlyExecutorPacketResult = await createAutonomousRunnerTestOnlyExecutorReceipt({
+      todo,
+      scopePack: extractBoardroomTodoScopePackObject(todo),
+      heartbeat: testOnlyExecutorPacket.heartbeat,
+      heartbeatTickId: testOnlyExecutorPacket.heartbeatTickId,
+      headShaAtRequest: testOnlyExecutorPacket.headShaAtRequest,
+      requestingSeatId: testOnlyExecutorPacket.requestingSeatId,
+      scopePackCommentId: testOnlyExecutorPacket.scopePackCommentId,
+      fileExists: testOnlyExecutorPacket.fileExists,
+      executorSeatId: testOnlyExecutorPacket.executorSeatId,
+      now: testOnlyExecutorPacket.now,
+    });
+  }
+
+  if (testOnlyExecutorPacketResult) {
+    const comment = await callUnClickMcpTool({
+      mcpUrl,
+      apiKey,
+      fetchImpl,
+      toolName: "comment_on",
+      arguments: {
+        agent_id: agentId,
+        target_kind: "todo",
+        target_id: todoId,
+        text: compact(
+          [
+            "Autonomous Runner test-only packet checked without taking an active job claim.",
+            "No status or assignee change was made because execute_enabled=false.",
+            `dispatch=${job?.claim_id || "none"}.`,
+            `source=${job?.source || "unknown"}.`,
+            `wake_source=${job?.source_state?.wake_source || "unknown"}.`,
+            `job=${job?.job_id || "unknown"}.`,
+            formatTestOnlyExecutorPacketReceipt(testOnlyExecutorPacketResult),
+          ].filter(Boolean).join(" "),
+          1000,
+        ),
+      },
+    });
+
+    if (!comment.ok) {
+      return {
+        ok: false,
+        reason: "test_only_claim_comment_failed",
+        todo_id: todoId,
+        detail: comment.reason || comment.error || null,
+        status: comment.status ?? null,
+        test_only_executor_packet: testOnlyExecutorPacketResult,
+      };
+    }
+
+    return {
+      ok: true,
+      skipped: true,
+      reason: "test_only_executor_packet_not_active_claim",
+      todo_id: todoId,
+      assigned_to_agent_id: job?.source_state?.assigned_to_agent_id || null,
+      status: job?.source_state?.status || null,
+      comment_ok: true,
+      comment_id: comment.data?.comment?.id || null,
+      comment_detail: null,
+      comment_status: null,
+      test_only_executor_packet: testOnlyExecutorPacketResult,
+    };
+  }
+
   const update = await callUnClickMcpTool({
     mcpUrl,
     apiKey,
@@ -1166,22 +1233,6 @@ export async function syncClaimedBoardroomTodoToUnClick({
       detail: update.reason || update.error || null,
       status: update.status ?? null,
     };
-  }
-
-  let testOnlyExecutorPacketResult = null;
-  if (todo && testOnlyExecutorPacket?.enabled) {
-    testOnlyExecutorPacketResult = await createAutonomousRunnerTestOnlyExecutorReceipt({
-      todo,
-      scopePack: extractBoardroomTodoScopePackObject(todo),
-      heartbeat: testOnlyExecutorPacket.heartbeat,
-      heartbeatTickId: testOnlyExecutorPacket.heartbeatTickId,
-      headShaAtRequest: testOnlyExecutorPacket.headShaAtRequest,
-      requestingSeatId: testOnlyExecutorPacket.requestingSeatId,
-      scopePackCommentId: testOnlyExecutorPacket.scopePackCommentId,
-      fileExists: testOnlyExecutorPacket.fileExists,
-      executorSeatId: testOnlyExecutorPacket.executorSeatId,
-      now: testOnlyExecutorPacket.now,
-    });
   }
 
   const comment = await callUnClickMcpTool({

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1265,7 +1265,7 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(extractBoardroomTodoIdFromCodingRoomJob(safeJob()), "");
   });
 
-  it("syncs claimed UnClick todos back to in_progress in claim mode", async () => {
+  it("does not mark UnClick todos in_progress for test-only executor packets", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
     try {
@@ -1373,22 +1373,19 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.persisted, true);
       assert.deepEqual(calls.map((call) => call.body.params.name), [
         "list_actionable_todos",
-        "update_todo",
         "comment_on",
       ]);
       assert.equal(calls[0].body.params.arguments.include_description, true);
-      assert.deepEqual(calls[1].body.params.arguments, {
-        agent_id: "runner-plex-1",
-        todo_id: "todo-claim-1",
-        status: "in_progress",
-        assigned_to_agent_id: "runner-plex-1",
-      });
-      assert.equal(calls[2].body.params.arguments.target_id, "todo-claim-1");
-      assert.match(calls[2].body.params.arguments.text, /dispatch=coding-room-claim:/);
-      assert.match(calls[2].body.params.arguments.text, /lease_token=coding-room-claim:/);
-      assert.match(calls[2].body.params.arguments.text, /wake_source=queuepush/);
-      assert.match(calls[2].body.params.arguments.text, /executor_packet=executor_packet_pass/);
+      assert.equal(calls[1].body.params.arguments.target_id, "todo-claim-1");
+      assert.match(calls[1].body.params.arguments.text, /without taking an active job claim/);
+      assert.match(calls[1].body.params.arguments.text, /execute_enabled=false/);
+      assert.match(calls[1].body.params.arguments.text, /dispatch=coding-room-claim:/);
+      assert.doesNotMatch(calls[1].body.params.arguments.text, /lease_token=coding-room-claim:/);
+      assert.match(calls[1].body.params.arguments.text, /wake_source=queuepush/);
+      assert.match(calls[1].body.params.arguments.text, /executor_packet=executor_packet_pass/);
       assert.equal(result.todo_claim_sync.ok, true);
+      assert.equal(result.todo_claim_sync.skipped, true);
+      assert.equal(result.todo_claim_sync.reason, "test_only_executor_packet_not_active_claim");
       assert.equal(result.todo_claim_sync.todo_id, "todo-claim-1");
       assert.equal(result.todo_claim_sync.test_only_executor_packet.receipt.receipt_type, "executor_packet_pass");
       assert.equal(result.quiet_window_autonomy_proof.verdict, "BLOCKER");
@@ -2423,7 +2420,7 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.action, "blocked");
       assert.equal(result.reason, "todo_claim_sync_failed");
       assert.equal(result.persisted, false);
-      assert.equal(result.todo_claim_sync.reason, "update_todo_failed");
+      assert.equal(result.todo_claim_sync.reason, "test_only_claim_comment_failed");
 
       const persisted = JSON.parse(await readFile(ledgerPath, "utf8"));
       assert.equal(persisted.jobs.length, 0);


### PR DESCRIPTION
## Summary
- stop test-only executor packets from marking Boardroom todos in progress
- leave a proof comment instead when execute_enabled=false
- keep failure closed if the proof comment cannot be posted

## Verification
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check

## Proof
Commit: 65d8f81
