### PR TITLE
fix(pinballwake): mark test-only claims as execution holds

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1173,13 +1173,16 @@ export async function syncClaimedBoardroomTodoToUnClick({
         target_id: todoId,
         text: compact(
           [
-            "Autonomous Runner test-only packet checked without taking an active job claim.",
-            "No status or assignee change was made because execute_enabled=false.",
+            "Autonomous Runner claim-to-execute HOLD.",
+            "ScopePack was claimable, but no build attempt ran because execute_enabled=false.",
+            "No status or assignee change was made.",
+            "This is not build progress.",
             `dispatch=${job?.claim_id || "none"}.`,
             `source=${job?.source || "unknown"}.`,
             `wake_source=${job?.source_state?.wake_source || "unknown"}.`,
             `job=${job?.job_id || "unknown"}.`,
             formatTestOnlyExecutorPacketReceipt(testOnlyExecutorPacketResult),
+            "next=wire OpenHands or CodeRoom executor, or emit explicit blocker receipt.",
           ].filter(Boolean).join(" "),
           1000,
         ),
@@ -1890,6 +1893,8 @@ function formatTestOnlyExecutorPacketReceipt(result) {
     `packet_id=${packet.packet_id || receipt.packet_id || "none"}.`,
   ];
   if (receipt.hold_reason) parts.push(`hold_reason=${receipt.hold_reason}.`);
+  parts.push("claim_to_execute=blocked.");
+  parts.push("build_attempt=false.");
   parts.push("execute_enabled=false.");
   return compact(parts.join(" "), 700);
 }

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1377,7 +1377,10 @@ describe("PinballWake autonomous Runner seat", () => {
       ]);
       assert.equal(calls[0].body.params.arguments.include_description, true);
       assert.equal(calls[1].body.params.arguments.target_id, "todo-claim-1");
-      assert.match(calls[1].body.params.arguments.text, /without taking an active job claim/);
+      assert.match(calls[1].body.params.arguments.text, /claim-to-execute HOLD/);
+      assert.match(calls[1].body.params.arguments.text, /not build progress/);
+      assert.match(calls[1].body.params.arguments.text, /build_attempt=false/);
+      assert.match(calls[1].body.params.arguments.text, /claim_to_execute=blocked/);
       assert.match(calls[1].body.params.arguments.text, /execute_enabled=false/);
       assert.match(calls[1].body.params.arguments.text, /dispatch=coding-room-claim:/);
       assert.doesNotMatch(calls[1].body.params.arguments.text, /lease_token=coding-room-claim:/);


### PR DESCRIPTION
## Summary
- Change test-only ScopePack claim comments from neutral checked wording to a claim-to-execute HOLD.
- Add explicit proof fields: claim_to_execute=blocked and build_attempt=false.
- Update the focused runner test so false progress cannot creep back in.

## Verification
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check