### PR TITLE
[codex] Expose OpenHands claim blocker

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -17,6 +17,7 @@ import {
 } from "./pinballwake-coding-room-runner.mjs";
 import { evaluateOrchestratorProofWakeGate } from "./lib/autopilotkit-liveness.mjs";
 import { processScopePackTestOnlyExecutorPacket } from "./pinballwake-executor-lane.mjs";
+import { runOpenHandsWorker } from "./pinballwake-openhands-worker.mjs";
 import { buildScopePackHydrationReceipt } from "./pinballwake-scopepack-hydrator.mjs";
 
 export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
@@ -538,6 +539,27 @@ export async function createAutonomousRunnerTestOnlyExecutorReceipt({
     fileExists,
     executorSeatId,
     now,
+  });
+}
+
+export async function createAutonomousRunnerOpenHandsClaimProbeReceipt({
+  todo = {},
+  scopePack = null,
+  executorSeatId = "pinballwake-openhands-worker",
+  now = new Date(),
+} = {}) {
+  const normalizedNow = now instanceof Date ? now : new Date(now || Date.now());
+  const extractedScopePack = scopePack || extractBoardroomTodoScopePackObject(todo) || {};
+  const job = createCodingRoomJobFromBoardroomTodo(todo, { now: normalizedNow.toISOString() });
+
+  return runOpenHandsWorker({
+    job,
+    scopePack: extractedScopePack,
+    openHands: null,
+    testMode: true,
+    env: { OPENHANDS_TEST_MODE: "1" },
+    executorSeatId,
+    now: normalizedNow,
   });
 }
 
@@ -1161,6 +1183,15 @@ export async function syncClaimedBoardroomTodoToUnClick({
     });
   }
 
+  let openHandsClaimProbeResult = null;
+  if (todo && testOnlyExecutorPacketResult) {
+    openHandsClaimProbeResult = await createAutonomousRunnerOpenHandsClaimProbeReceipt({
+      todo,
+      scopePack: extractBoardroomTodoScopePackObject(todo),
+      now: testOnlyExecutorPacket.now,
+    });
+  }
+
   if (testOnlyExecutorPacketResult) {
     const comment = await callUnClickMcpTool({
       mcpUrl,
@@ -1182,6 +1213,7 @@ export async function syncClaimedBoardroomTodoToUnClick({
             `wake_source=${job?.source_state?.wake_source || "unknown"}.`,
             `job=${job?.job_id || "unknown"}.`,
             formatTestOnlyExecutorPacketReceipt(testOnlyExecutorPacketResult),
+            formatOpenHandsClaimProbeReceipt(openHandsClaimProbeResult),
             "next=wire OpenHands or CodeRoom executor, or emit explicit blocker receipt.",
           ].filter(Boolean).join(" "),
           1000,
@@ -1197,6 +1229,7 @@ export async function syncClaimedBoardroomTodoToUnClick({
         detail: comment.reason || comment.error || null,
         status: comment.status ?? null,
         test_only_executor_packet: testOnlyExecutorPacketResult,
+        openhands_claim_probe: openHandsClaimProbeResult,
       };
     }
 
@@ -1212,6 +1245,7 @@ export async function syncClaimedBoardroomTodoToUnClick({
       comment_detail: null,
       comment_status: null,
       test_only_executor_packet: testOnlyExecutorPacketResult,
+      openhands_claim_probe: openHandsClaimProbeResult,
     };
   }
 
@@ -1897,6 +1931,20 @@ function formatTestOnlyExecutorPacketReceipt(result) {
   parts.push("build_attempt=false.");
   parts.push("execute_enabled=false.");
   return compact(parts.join(" "), 700);
+}
+
+function formatOpenHandsClaimProbeReceipt(result) {
+  if (!result) return "";
+  const receipt = result.receipt || {};
+  const parts = [
+    `openhands_probe=${receipt.receipt_type || "openhands_worker_hold"}.`,
+    `openhands_ok=${result.ok ? "true" : "false"}.`,
+  ];
+  const holdReason = receipt.hold_reason || result.reason || "";
+  if (holdReason) parts.push(`openhands_hold_reason=${holdReason}.`);
+  if (receipt.next_action) parts.push(`openhands_next=${receipt.next_action}.`);
+  parts.push("openhands_build_attempt=false.");
+  return compact(parts.join(" "), 400);
 }
 
 export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date().toISOString() } = {}) {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1382,6 +1382,9 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.match(calls[1].body.params.arguments.text, /build_attempt=false/);
       assert.match(calls[1].body.params.arguments.text, /claim_to_execute=blocked/);
       assert.match(calls[1].body.params.arguments.text, /execute_enabled=false/);
+      assert.match(calls[1].body.params.arguments.text, /openhands_probe=openhands_worker_hold/);
+      assert.match(calls[1].body.params.arguments.text, /openhands_hold_reason=openhands_runner_not_provided/);
+      assert.match(calls[1].body.params.arguments.text, /openhands_build_attempt=false/);
       assert.match(calls[1].body.params.arguments.text, /dispatch=coding-room-claim:/);
       assert.doesNotMatch(calls[1].body.params.arguments.text, /lease_token=coding-room-claim:/);
       assert.match(calls[1].body.params.arguments.text, /wake_source=queuepush/);
@@ -1391,6 +1394,8 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.todo_claim_sync.reason, "test_only_executor_packet_not_active_claim");
       assert.equal(result.todo_claim_sync.todo_id, "todo-claim-1");
       assert.equal(result.todo_claim_sync.test_only_executor_packet.receipt.receipt_type, "executor_packet_pass");
+      assert.equal(result.todo_claim_sync.openhands_claim_probe.receipt.receipt_type, "openhands_worker_hold");
+      assert.equal(result.todo_claim_sync.openhands_claim_probe.receipt.hold_reason, "openhands_runner_not_provided");
       assert.equal(result.quiet_window_autonomy_proof.verdict, "BLOCKER");
       assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "build_attempt_or_commonsense_blocker");
       assert.deepEqual(result.quiet_window_autonomy_proof.evidence.observed_rungs, [


### PR DESCRIPTION
## Summary
- Adds an OpenHands readiness probe to claim-to-execute HOLD receipts.
- Keeps the scheduled runner in non-execute mode, with no build attempt and no assignee/status change.
- Makes the blocker exact: openhands_runner_not_provided, so the next bridge work has a clear target.

## Validation
- node --test scripts\\pinballwake-autonomous-runner.test.mjs scripts\\pinballwake-openhands-worker.test.mjs
- 60 tests passed