### PR TITLE
fix(pinballwake): gate manual OpenHands execute

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -12,13 +12,18 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Runner mode. Execute is intentionally unavailable here.
+        description: Runner mode. Execute requires the manual OpenHands confirmation gate.
         required: false
         default: "dry-run"
         type: choice
         options:
           - dry-run
           - claim
+          - execute
+      execute_confirm:
+        description: Type ENABLE_OPENHANDS_EXECUTE to let this manual run reach the OpenHands execute bridge.
+        required: false
+        default: ""
       kill_switch:
         description: Stop before any claim cycle, even if claim mode is selected.
         required: false
@@ -119,7 +124,11 @@ jobs:
           AUTONOMOUS_RUNNER_TODO_LIMIT: ${{ vars.AUTONOMOUS_RUNNER_TODO_LIMIT || '10' }}
           AUTONOMOUS_RUNNER_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || vars.AUTONOMOUS_RUNNER_MODE || 'claim' }}
           AUTONOMOUS_RUNNER_DISABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.kill_switch == 'true' && 'true' || vars.AUTONOMOUS_RUNNER_DISABLED || 'false' }}
-          AUTONOMOUS_RUNNER_ALLOW_EXECUTE: "false"
+          AUTONOMOUS_RUNNER_ALLOW_EXECUTE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && 'true' || 'false' }}
+          AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && 'true' || 'false' }}
+          OPENHANDS_TEST_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && '1' || '' }}
+          OPENHANDS_COMMAND: ${{ vars.OPENHANDS_COMMAND || 'openhands' }}
+          OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--headless --json --task {prompt}' }}
           AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES: "false"
           AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES || 'urgent,high' }}
           AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS || 'unassigned_open' }}

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -2708,6 +2708,8 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /trusted_fallback_source:/);
     assert.match(workflow, /trusted_fallback_at:/);
     assert.match(workflow, /trusted_fallback_id:/);
+    assert.match(workflow, /execute_confirm:/);
+    assert.match(workflow, /ENABLE_OPENHANDS_EXECUTE/);
     assert.match(workflow, /github\.event_name == 'schedule'/);
     assert.match(workflow, /github\.event_name == 'workflow_run' && github\.event\.workflow_run\.event == 'schedule'/);
     assert.match(workflow, /github\.event_name == 'workflow_dispatch' && inputs\.wake_source == 'trusted_unclick_fallback'/);
@@ -2723,11 +2725,15 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /AUTONOMOUS_RUNNER_WAKE_SOURCE:.*inputs\.wake_source.*queuepush/);
     assert.match(workflow, /UNCLICK_API_KEY:.*secrets\.UNCLICK_API_KEY.*secrets\.FISHBOWL_AUTOCLOSE_TOKEN.*secrets\.FISHBOWL_WAKE_TOKEN/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_MODE:.*'claim'/);
-    assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_EXECUTE:\s*"false"/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_EXECUTE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'true'.*'false'/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'true'.*'false'/);
+    assert.match(workflow, /OPENHANDS_TEST_MODE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'1'/);
+    assert.match(workflow, /OPENHANDS_COMMAND:.*vars\.OPENHANDS_COMMAND.*openhands/);
+    assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--headless --json --task \{prompt\}/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES:\s*"false"/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES:.*urgent,high/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS:.*unassigned_open/);
     assert.match(workflow, /kill_switch:/);
-    assert.doesNotMatch(workflow, /^\s+- execute$/m);
+    assert.match(workflow, /^\s+- execute$/m);
   });
 });


### PR DESCRIPTION
Summary:
- add a manual workflow_dispatch execute option guarded by the ENABLE_OPENHANDS_EXECUTE confirmation phrase
- keep scheduled and workflow_run autonomous runner executions claim-only with execute disabled
- pass OpenHands command and args through repo vars when the manual execute bridge is explicitly enabled

Verification:
- node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs
- git diff --check