### PR TITLE
fix(pinballwake): bootstrap OpenHands execute runner

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -115,6 +115,14 @@ jobs:
           UNCLICK_API_KEY: ${{ secrets.UNCLICK_API_KEY || secrets.FISHBOWL_AUTOCLOSE_TOKEN || secrets.FISHBOWL_WAKE_TOKEN }}
         run: node scripts/pinballwake-autonomous-runner.mjs
 
+      - name: Set up uv for OpenHands execute
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.mode == 'execute' &&
+          inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' &&
+          vars.OPENHANDS_COMMAND == ''
+        uses: astral-sh/setup-uv@v8
+
       - name: Run autonomous Runner
         env:
           CODING_ROOM_LEDGER_PATH: ${{ vars.CODING_ROOM_LEDGER_PATH || '.pinballwake/coding-room-ledger.json' }}
@@ -127,8 +135,8 @@ jobs:
           AUTONOMOUS_RUNNER_ALLOW_EXECUTE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && 'true' || 'false' }}
           AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && 'true' || 'false' }}
           OPENHANDS_TEST_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && '1' || '' }}
-          OPENHANDS_COMMAND: ${{ vars.OPENHANDS_COMMAND || 'openhands' }}
-          OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--headless --json --task {prompt}' }}
+          OPENHANDS_COMMAND: ${{ vars.OPENHANDS_COMMAND || 'uvx' }}
+          OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--python 3.12 --from openhands-ai openhands --headless --json --task {prompt}' }}
           AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES: "false"
           AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES || 'urgent,high' }}
           AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS || 'unassigned_open' }}

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -2728,8 +2728,11 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_EXECUTE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'true'.*'false'/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'true'.*'false'/);
     assert.match(workflow, /OPENHANDS_TEST_MODE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'1'/);
-    assert.match(workflow, /OPENHANDS_COMMAND:.*vars\.OPENHANDS_COMMAND.*openhands/);
-    assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--headless --json --task \{prompt\}/);
+    assert.match(workflow, /Set up uv for OpenHands execute/);
+    assert.match(workflow, /uses:\s*astral-sh\/setup-uv@v8/);
+    assert.match(workflow, /vars\.OPENHANDS_COMMAND == ''/);
+    assert.match(workflow, /OPENHANDS_COMMAND:.*vars\.OPENHANDS_COMMAND.*uvx/);
+    assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--python 3\.12 --from openhands-ai openhands --headless --json --task \{prompt\}/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES:\s*"false"/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES:.*urgent,high/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS:.*unassigned_open/);


### PR DESCRIPTION
## Summary
- install uv only for the manually confirmed OpenHands execute path
- default the OpenHands runner command to uvx so GitHub-hosted runners do not need a preinstalled openhands binary
- keep scheduled and workflow-run autopilot paths claim-only with execute locked off

## Verification
- node --test scripts\\pinballwake-autonomous-runner.test.mjs scripts\\pinballwake-openhands-worker.test.mjs scripts\\pinballwake-openhands-proof-runner.test.mjs
- git diff --check

## Safety
- manual execute still requires execute_confirm=ENABLE_OPENHANDS_EXECUTE
- no auto-merge, no deploy, no production data, no secrets, no billing, no DNS

Sources checked:
- OpenHands CLI docs: https://docs.all-hands.dev/openhands/usage/run-openhands/cli-mode
- uv GitHub Actions setup: https://github.com/astral-sh/setup-uv