### PR TITLE
fix(pinballwake): pin setup-uv action

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -121,7 +121,7 @@ jobs:
           inputs.mode == 'execute' &&
           inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' &&
           vars.OPENHANDS_COMMAND == ''
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run autonomous Runner
         env:

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -2729,7 +2729,7 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'true'.*'false'/);
     assert.match(workflow, /OPENHANDS_TEST_MODE:.*inputs\.mode == 'execute'.*inputs\.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE'.*'1'/);
     assert.match(workflow, /Set up uv for OpenHands execute/);
-    assert.match(workflow, /uses:\s*astral-sh\/setup-uv@v8/);
+    assert.match(workflow, /uses:\s*astral-sh\/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b/);
     assert.match(workflow, /vars\.OPENHANDS_COMMAND == ''/);
     assert.match(workflow, /OPENHANDS_COMMAND:.*vars\.OPENHANDS_COMMAND.*uvx/);
     assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--python 3\.12 --from openhands-ai openhands --headless --json --task \{prompt\}/);


### PR DESCRIPTION
## Summary
- fix the OpenHands execute bootstrap added in #923 by pinning setup-uv to the official v8.1.0 action SHA
- keeps the execute path manual-confirm only and leaves scheduled autopilot claim-only

## Verification
- node --test scripts\\pinballwake-autonomous-runner.test.mjs scripts\\pinballwake-openhands-worker.test.mjs scripts\\pinballwake-openhands-proof-runner.test.mjs
- git diff --check

## Live failure being fixed
- https://github.com/malamutemayhem/unclick/actions/runs/26005895451 failed because astral-sh/setup-uv@v8 is not a resolvable tag

Source checked:
- https://github.com/astral-sh/setup-uv