### PR TITLE
fix(pinballwake): keep tail errors in runner receipts

### DIFF
--- a/scripts/pinballwake-executor-lane.mjs
+++ b/scripts/pinballwake-executor-lane.mjs
@@ -112,7 +112,7 @@ export async function processExecutorPacket({
       reason: "executor_reported_failure",
       evidence: {
         exit_code: result?.exit_code ?? null,
-        output: clip(result?.output, 2000),
+        output: clipOutput(result?.output, 2000),
       },
     });
   }
@@ -238,6 +238,17 @@ function clip(value, max) {
   return s.length > max ? `${s.slice(0, max - 3)}...` : s;
 }
 
+function clipOutput(value, max) {
+  if (value === undefined || value === null) return null;
+  const text = String(value);
+  if (text.length <= max) return text;
+  const marker = `\n... omitted ${text.length - max} chars ...\n`;
+  const budget = Math.max(0, max - marker.length);
+  const head = Math.ceil(budget * 0.35);
+  const tail = Math.max(0, budget - head);
+  return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`;
+}
+
 function toDate(value) {
   return value instanceof Date ? value : new Date(value || Date.now());
 }
@@ -271,4 +282,5 @@ export const __testing__ = {
   RECEIPT_TYPE_PASS,
   RECEIPT_TYPE_HOLD,
   PROOF_REQUIRED,
+  clipOutput,
 };

--- a/scripts/pinballwake-executor-lane.test.mjs
+++ b/scripts/pinballwake-executor-lane.test.mjs
@@ -145,6 +145,21 @@ describe("processExecutorPacket modify intent", () => {
     assert.match(r.evidence.output, /tests failed/);
   });
 
+  test("HOLD keeps the tail of long executor failure output", async () => {
+    const output = `${"installing dependency\n".repeat(400)}FINAL ERROR: runner crashed`;
+    const r = await processExecutorPacket({
+      packet: freshPacket(),
+      heartbeat: FRESH_HEARTBEAT,
+      fileExists: async () => true,
+      executor: async () => ({ ok: false, exit_code: 1, output }),
+    });
+
+    assert.equal(r.receipt_type, __testing__.RECEIPT_TYPE_HOLD);
+    assert.match(r.evidence.output, /installing dependency/);
+    assert.match(r.evidence.output, /omitted \d+ chars/);
+    assert.match(r.evidence.output, /FINAL ERROR: runner crashed/);
+  });
+
   test("PASS when executor returns ok:true with PR + sha + run id", async () => {
     const r = await processExecutorPacket({
       packet: freshPacket(),

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -23,9 +23,14 @@ function getArg(name, fallback = "") {
   return found ? found.slice(prefix.length) : fallback;
 }
 
-function compactOutput(value, max = 2000) {
+export function compactOutput(value, max = 2000) {
   const text = String(value ?? "").trim();
-  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+  if (text.length <= max) return text;
+  const marker = `\n... omitted ${text.length - max} chars ...\n`;
+  const budget = Math.max(0, max - marker.length);
+  const head = Math.ceil(budget * 0.35);
+  const tail = Math.max(0, budget - head);
+  return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`;
 }
 
 function normalizePath(value) {

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -4,6 +4,7 @@ import { describe, test } from "node:test";
 import {
   buildDocsOnlyFixturePatch,
   buildOpenHandsCliArgs,
+  compactOutput,
   createDraftPrCoderoom,
   createFixtureOpenHandsRunner,
   runOpenHandsProof,
@@ -33,6 +34,16 @@ describe("OpenHands proof runner helpers", () => {
 
     assert.match(patch, /diff --git a\/docs\/openhands-proof-fixture\.md b\/docs\/openhands-proof-fixture\.md/);
     assert.match(patch, /\+[-] proof run: unit-test/);
+  });
+
+  test("compacts long CLI output without hiding the final error", () => {
+    const output = `${"downloading package\n".repeat(400)}FINAL ERROR: OpenHands could not start`;
+    const compacted = compactOutput(output, 600);
+
+    assert.match(compacted, /downloading package/);
+    assert.match(compacted, /omitted \d+ chars/);
+    assert.match(compacted, /FINAL ERROR: OpenHands could not start/);
+    assert.ok(compacted.length <= 650);
   });
 
   test("runs fixture OpenHands through the worker and coderoom", async () => {

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -103,7 +103,7 @@ export async function runOpenHandsWorker({
       reason: "openhands_reported_failure",
       evidence: {
         exit_code: result?.exit_code ?? null,
-        output: clip(result?.output, 2000),
+        output: clipOutput(result?.output, 2000),
       },
     });
   }
@@ -115,7 +115,7 @@ export async function runOpenHandsWorker({
       executorSeatId,
       now: safeNow,
       reason: "patch_required",
-      evidence: { output: clip(result.output, 1000) },
+      evidence: { output: clipOutput(result.output, 1000) },
     });
   }
 
@@ -374,6 +374,17 @@ function clip(value, max) {
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
 }
 
+function clipOutput(value, max) {
+  if (value === undefined || value === null) return null;
+  const text = String(value);
+  if (text.length <= max) return text;
+  const marker = `\n... omitted ${text.length - max} chars ...\n`;
+  const budget = Math.max(0, max - marker.length);
+  const head = Math.ceil(budget * 0.35);
+  const tail = Math.max(0, budget - head);
+  return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`;
+}
+
 function toDate(value) {
   return value instanceof Date ? value : new Date(value || Date.now());
 }
@@ -415,4 +426,5 @@ export const __testing__ = {
   PROOF_REQUIRED,
   MAX_PATCH_BYTES,
   extractChangedFilesFromPatch,
+  clipOutput,
 };

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -147,6 +147,22 @@ describe("runOpenHandsWorker", () => {
     assert.match(result.receipt.evidence.output, /tests failed/);
   });
 
+  test("keeps the tail of long OpenHands failure output", async () => {
+    const output = `${"installing dependency\n".repeat(400)}FINAL ERROR: missing model config`;
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: false, exit_code: 1, output }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.receipt.evidence.output, /installing dependency/);
+    assert.match(result.receipt.evidence.output, /omitted \d+ chars/);
+    assert.match(result.receipt.evidence.output, /FINAL ERROR: missing model config/);
+  });
+
   test("returns HOLD when coderoom rejects the patch", async () => {
     const result = await runOpenHandsWorker({
       job: job(),


### PR DESCRIPTION
## Summary
- Preserve both the start and final error tail when OpenHands or executor output is longer than receipt limits.
- Apply the same head/tail clipping to OpenHands CLI output, OpenHands worker holds, and executor-lane holds.
- Add focused tests so long dependency-install logs still expose the final failure.

## Verification
- node --test scripts\\pinballwake-openhands-worker.test.mjs scripts\\pinballwake-openhands-proof-runner.test.mjs scripts\\pinballwake-executor-lane.test.mjs
- git diff --check