### PR TITLE
fix(pinballwake): use current OpenHands CLI package

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -136,7 +136,7 @@ jobs:
           AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && 'true' || 'false' }}
           OPENHANDS_TEST_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && '1' || '' }}
           OPENHANDS_COMMAND: ${{ vars.OPENHANDS_COMMAND || 'uvx' }}
-          OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--python 3.12 --from openhands-ai openhands --headless --json --task {prompt}' }}
+          OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--python 3.12 openhands --headless --json --task {prompt}' }}
           AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES: "false"
           AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES || 'urgent,high' }}
           AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS || 'unassigned_open' }}

--- a/docs/openhands-integration.md
+++ b/docs/openhands-integration.md
@@ -38,7 +38,7 @@ For real OpenHands use, the worker that provides the `openHands` function should
 
 - `OPENHANDS_TEST_MODE=1`
 - optional `OPENHANDS_COMMAND`, defaulting to `openhands`
-- optional `OPENHANDS_ARGS`, defaulting to `--headless --json --task {prompt}`
+- optional `OPENHANDS_ARGS`, defaulting to `--python 3.12 openhands --headless --json --task {prompt}`
 - optional `OPENHANDS_PATCH_FILE` when the runner writes a patch file instead of printing a unified diff
 - model provider key, stored only in CI or worker secret storage
 - repo-scoped token for draft PR creation, stored only in CI or worker secret storage

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -2732,7 +2732,7 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /uses:\s*astral-sh\/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b/);
     assert.match(workflow, /vars\.OPENHANDS_COMMAND == ''/);
     assert.match(workflow, /OPENHANDS_COMMAND:.*vars\.OPENHANDS_COMMAND.*uvx/);
-    assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--python 3\.12 --from openhands-ai openhands --headless --json --task \{prompt\}/);
+    assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--python 3\.12 openhands --headless --json --task \{prompt\}/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES:\s*"false"/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES:.*urgent,high/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS:.*unassigned_open/);


### PR DESCRIPTION
## Summary
- Change the default manual execute OpenHands command from the old openhands-ai package to the current openhands CLI package.
- Update runner tests and integration docs so the default stays aligned.

## Why
- Live smoke run 26006201977 proved the lane now reaches uvx and shows the real blocker: Package openhands-ai does not provide any executables.
- Current OpenHands docs list uv tool install openhands --python 3.12 and openhands --headless --task.

## Verification
- node --test scripts\pinballwake-autonomous-runner.test.mjs scripts\pinballwake-openhands-proof-runner.test.mjs
- git diff --check