### PR TITLE
fix(pinballwake): guard OpenHands headless settings

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -136,7 +136,11 @@ jobs:
           AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && 'true' || 'false' }}
           OPENHANDS_TEST_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'execute' && inputs.execute_confirm == 'ENABLE_OPENHANDS_EXECUTE' && '1' || '' }}
           OPENHANDS_COMMAND: ${{ vars.OPENHANDS_COMMAND || 'uvx' }}
-          OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--python 3.12 openhands --headless --json --task {prompt}' }}
+          OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--python 3.12 openhands --headless --json --override-with-envs --task {prompt}' }}
+          LLM_API_KEY: ${{ secrets.OPENHANDS_LLM_API_KEY || secrets.LLM_API_KEY || '' }}
+          LLM_MODEL: ${{ vars.OPENHANDS_LLM_MODEL || vars.LLM_MODEL || '' }}
+          LLM_BASE_URL: ${{ vars.OPENHANDS_LLM_BASE_URL || vars.LLM_BASE_URL || '' }}
+          OPENHANDS_SUPPRESS_BANNER: "1"
           AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES: "false"
           AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES || 'urgent,high' }}
           AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS: ${{ vars.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS || 'unassigned_open' }}

--- a/docs/openhands-integration.md
+++ b/docs/openhands-integration.md
@@ -22,6 +22,8 @@ This file does not enable production code-writing. The adapter is opt-in and req
 
 `scripts/pinballwake-openhands-proof-runner.mjs` is the v1 binding for proof runs. It can use a real OpenHands CLI command supplied through `OPENHANDS_COMMAND`, or a docs-only fixture runner when `OPENHANDS_PROOF_FIXTURE_PATCH=1` is set for local and workflow tests. OpenHands CLI docs describe `--task`, `--headless`, and `--json` at https://docs.openhands.dev/openhands/usage/cli/command-reference. The OpenHands environment reference is https://docs.openhands.dev/openhands/usage/environment-variables.
 
+For GitHub manual execute runs, the default OpenHands command uses `--override-with-envs` so CI can provide settings without persisting credentials. If those settings are missing, the runner stops before launching OpenHands and returns `openhands_headless_settings_required` instead of burning a full install cycle.
+
 ## Guardrails
 
 - Test mode is required by default.
@@ -38,9 +40,11 @@ For real OpenHands use, the worker that provides the `openHands` function should
 
 - `OPENHANDS_TEST_MODE=1`
 - optional `OPENHANDS_COMMAND`, defaulting to `openhands`
-- optional `OPENHANDS_ARGS`, defaulting to `--python 3.12 openhands --headless --json --task {prompt}`
+- optional `OPENHANDS_ARGS`, defaulting to `--python 3.12 openhands --headless --json --override-with-envs --task {prompt}`
 - optional `OPENHANDS_PATCH_FILE` when the runner writes a patch file instead of printing a unified diff
-- model provider key, stored only in CI or worker secret storage
+- `LLM_API_KEY`, from CI or worker secret storage only
+- `LLM_MODEL`, from CI or worker variable storage
+- optional `LLM_BASE_URL`, from CI or worker variable storage
 - repo-scoped token for draft PR creation, stored only in CI or worker secret storage
 - an external cost or spend limit guard
 

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -2732,7 +2732,10 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /uses:\s*astral-sh\/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b/);
     assert.match(workflow, /vars\.OPENHANDS_COMMAND == ''/);
     assert.match(workflow, /OPENHANDS_COMMAND:.*vars\.OPENHANDS_COMMAND.*uvx/);
-    assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--python 3\.12 openhands --headless --json --task \{prompt\}/);
+    assert.match(workflow, /OPENHANDS_ARGS:.*vars\.OPENHANDS_ARGS.*--python 3\.12 openhands --headless --json --override-with-envs --task \{prompt\}/);
+    assert.match(workflow, /LLM_API_KEY:.*secrets\.OPENHANDS_LLM_API_KEY.*secrets\.LLM_API_KEY/);
+    assert.match(workflow, /LLM_MODEL:.*vars\.OPENHANDS_LLM_MODEL.*vars\.LLM_MODEL/);
+    assert.match(workflow, /LLM_BASE_URL:.*vars\.OPENHANDS_LLM_BASE_URL.*vars\.LLM_BASE_URL/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES:\s*"false"/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES:.*urgent,high/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS:.*unassigned_open/);

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -95,6 +95,37 @@ export function buildOpenHandsCliArgs({ prompt, argsTemplate = "" } = {}) {
   return replaced.includes(String(prompt ?? "")) ? replaced : [...replaced, "--task", String(prompt ?? "")];
 }
 
+function hasValue(value) {
+  return String(value ?? "").trim().length > 0;
+}
+
+export function checkOpenHandsHeadlessSettings({ args = [], env = process.env } = {}) {
+  const safeArgs = Array.isArray(args) ? args : [];
+  if (!safeArgs.includes("--headless")) {
+    return { ok: true };
+  }
+
+  if (parseBoolean(env.OPENHANDS_ALLOW_STORED_SETTINGS) || parseBoolean(env.OPENHANDS_SETTINGS_PRESENT)) {
+    return { ok: true };
+  }
+
+  const usesEnvOverride = safeArgs.includes("--override-with-envs");
+  const hasRequiredEnv = hasValue(env.LLM_API_KEY) && hasValue(env.LLM_MODEL);
+  if (usesEnvOverride && hasRequiredEnv) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    reason: "openhands_headless_settings_required",
+    output: [
+      "OpenHands headless settings are missing.",
+      "Set saved OpenHands settings, or run with --override-with-envs plus LLM_API_KEY and LLM_MODEL.",
+      "No secret values were read or printed.",
+    ].join(" "),
+  };
+}
+
 export function buildDocsOnlyFixturePatch({
   filePath = DEFAULT_PROOF_FILE,
   proofLine = `- proof run: ${safeStamp(new Date())}`,
@@ -145,6 +176,16 @@ export function createOpenHandsCliRunner({
       prompt,
       argsTemplate: argsTemplate || env.OPENHANDS_ARGS || "",
     });
+    const settingsCheck = checkOpenHandsHeadlessSettings({ args, env });
+    if (!settingsCheck.ok) {
+      return {
+        ok: false,
+        reason: settingsCheck.reason,
+        exit_code: null,
+        output: settingsCheck.output,
+      };
+    }
+
     const result = await runProcess(safeCommand, args, {
       cwd,
       env: {

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -4,9 +4,11 @@ import { describe, test } from "node:test";
 import {
   buildDocsOnlyFixturePatch,
   buildOpenHandsCliArgs,
+  checkOpenHandsHeadlessSettings,
   compactOutput,
   createDraftPrCoderoom,
   createFixtureOpenHandsRunner,
+  createOpenHandsCliRunner,
   runOpenHandsProof,
   splitArgs,
 } from "./pinballwake-openhands-proof-runner.mjs";
@@ -44,6 +46,69 @@ describe("OpenHands proof runner helpers", () => {
     assert.match(compacted, /omitted \d+ chars/);
     assert.match(compacted, /FINAL ERROR: OpenHands could not start/);
     assert.ok(compacted.length <= 650);
+  });
+
+  test("requires explicit settings for headless env override", () => {
+    const missing = checkOpenHandsHeadlessSettings({
+      args: ["--headless", "--json", "--override-with-envs", "--task", "do work"],
+      env: {},
+    });
+
+    assert.equal(missing.ok, false);
+    assert.equal(missing.reason, "openhands_headless_settings_required");
+    assert.doesNotMatch(missing.output, /real-token-value/);
+
+    const ready = checkOpenHandsHeadlessSettings({
+      args: ["--headless", "--json", "--override-with-envs", "--task", "do work"],
+      env: { LLM_API_KEY: "secret", LLM_MODEL: "openai/gpt-5" },
+    });
+
+    assert.equal(ready.ok, true);
+  });
+
+  test("fails fast before invoking OpenHands when headless settings are absent", async () => {
+    let calls = 0;
+    const runner = createOpenHandsCliRunner({
+      env: { OPENHANDS_ARGS: "--headless --json --override-with-envs --task {prompt}" },
+      runProcess: async () => {
+        calls += 1;
+        return { ok: true, output: "" };
+      },
+    });
+
+    const result = await runner({
+      prompt: "Patch a docs file",
+      scopePack: { owned_files: [FIXTURE] },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_headless_settings_required");
+    assert.equal(calls, 0);
+  });
+
+  test("invokes OpenHands when headless env settings are present", async () => {
+    const calls = [];
+    const runner = createOpenHandsCliRunner({
+      env: {
+        OPENHANDS_ARGS: "--headless --json --override-with-envs --task {prompt}",
+        LLM_API_KEY: "secret",
+        LLM_MODEL: "openai/gpt-5",
+      },
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        return { ok: true, exit_code: 0, output: buildDocsOnlyFixturePatch({ filePath: FIXTURE }) };
+      },
+    });
+
+    const result = await runner({
+      prompt: "Patch a docs file",
+      scopePack: { owned_files: [FIXTURE] },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], "openhands");
+    assert.deepEqual(calls[0][1], ["--headless", "--json", "--override-with-envs", "--task", "Patch a docs file"]);
   });
 
   test("runs fixture OpenHands through the worker and coderoom", async () => {


### PR DESCRIPTION
## Summary
- add a fail-fast OpenHands headless settings check before launching the CLI
- default manual execute runs to --override-with-envs and wire CI LLM env names without printing values
- document the OpenHands settings path and update focused tests

## Verification
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check