### PR TITLE
fix(memory): flag proof-reset job cards

### DIFF
--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -133,4 +133,75 @@ describe("AdminJobs", () => {
     expect(alertsCard).not.toBeNull();
     expect(within(alertsCard as HTMLElement).getByText("1")).toBeInTheDocument();
   });
+
+  it("shows proof-reset done jobs as blocked instead of shipped", async () => {
+    currentJobs = [
+      {
+        id: "proof-reset-job",
+        title: "Memory proof reset job",
+        description: "This was reopened after proof failed.",
+        status: "done",
+        priority: "high",
+        created_by_agent_id: "tester",
+        assigned_to_agent_id: "codex-integrity-investigator",
+        created_at: "2026-05-12T12:00:00.000Z",
+        completed_at: "2026-05-13T12:00:00.000Z",
+        updated_at: "2026-05-14T12:00:00.000Z",
+        comment_count: 3,
+        pipeline_stage_count: 5,
+        pipeline_progress: 100,
+        pipeline_evidence: ["proof_missing"],
+        pipeline_source: "reopened: proof reset after audit",
+      },
+    ];
+
+    render(React.createElement(AdminJobs));
+
+    const title = await screen.findByText("Memory proof reset job");
+    const row = title.closest("li");
+
+    expect(row).not.toBeNull();
+    expect(title).not.toHaveClass("line-through");
+    expect(within(row as HTMLElement).getAllByText("blocked").length).toBeGreaterThan(0);
+    expect(within(row as HTMLElement).queryByText("ship")).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("100%")).not.toBeInTheDocument();
+    expect(
+      within(row as HTMLElement).getByLabelText(/Job needs attention: Job proof is missing or reset/i),
+    ).toBeInTheDocument();
+  });
+
+  it("caps open jobs with stale ship receipts below 100 percent", async () => {
+    currentJobs = [
+      {
+        id: "open-ship-conflict",
+        title: "Reopened job with old ship receipt",
+        description: "This job was moved back to open after the old proof failed.",
+        status: "open",
+        priority: "urgent",
+        created_by_agent_id: "tester",
+        assigned_to_agent_id: null,
+        created_at: "2026-05-12T12:00:00.000Z",
+        completed_at: null,
+        updated_at: "2026-05-14T12:00:00.000Z",
+        comment_count: 2,
+        pipeline_stage_count: 5,
+        pipeline_progress: 100,
+        pipeline_evidence: ["build", "proof", "ship"],
+        pipeline_source: "receipt: ship",
+      },
+    ];
+
+    render(React.createElement(AdminJobs));
+
+    const title = await screen.findByText("Reopened job with old ship receipt");
+    const row = title.closest("li");
+
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByText("blocked").length).toBeGreaterThan(0);
+    expect(within(row as HTMLElement).queryByText("100%")).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText("85%")).toBeInTheDocument();
+    expect(
+      within(row as HTMLElement).getByLabelText(/Job needs attention: Job is still open but the pipeline says shipped/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -113,6 +113,7 @@ const STATUS_STYLE: Record<JobTodo["status"], string> = {
 const ACTION_BUTTONS = {
   stale: ["Push workers", "(talk to owning AI seat)", "Escalate"],
   unowned: ["Claim / assign", "Push workers", "Drop priority"],
+  blocked: ["Attach proof", "Reopen", "Audit"],
 } as const;
 
 const STAGES = ["Brief", "Build", "Proof", "Review", "Ship"] as const;
@@ -259,8 +260,48 @@ function statusLabel(status: JobTodo["status"]): string {
   return status.replace("_", " ");
 }
 
+function hasProofMissingSignal(todo: JobTodo): boolean {
+  return (
+    todo.pipeline_evidence?.includes("proof_missing") === true ||
+    /proof\s*:\s*missing|proof\s+missing|reopened\s*:\s*proof\s*reset/i.test(todo.pipeline_source ?? "")
+  );
+}
+
+function hasPipelineStatusConflict(todo: JobTodo): boolean {
+  if (todo.status === "done") return false;
+  const rawProgress = Number(todo.pipeline_progress);
+  const rawStageCount = Number(todo.pipeline_stage_count);
+  return (
+    todo.pipeline_evidence?.includes("ship") === true ||
+    /receipt\s*:\s*ship/i.test(todo.pipeline_source ?? "") ||
+    (Number.isFinite(rawProgress) && rawProgress >= 100) ||
+    (Number.isFinite(rawStageCount) && rawStageCount >= STAGES.length)
+  );
+}
+
+function hasProofWarning(todo: JobTodo): boolean {
+  return hasProofMissingSignal(todo) || hasPipelineStatusConflict(todo);
+}
+
+function isVisuallyShipped(todo: JobTodo): boolean {
+  return todo.status === "done" && !hasProofWarning(todo);
+}
+
+function displayStatusLabel(todo: JobTodo): string {
+  if (hasProofWarning(todo)) return "blocked";
+  return statusLabel(todo.status);
+}
+
+function displayStatusStyle(todo: JobTodo): string {
+  if (hasProofWarning(todo)) return "border-red-300/30 bg-red-500/10 text-red-200";
+  return STATUS_STYLE[todo.status];
+}
+
 function progressFor(todo: JobTodo): number {
-  if (Number.isFinite(todo.pipeline_progress)) return Number(todo.pipeline_progress);
+  if (Number.isFinite(todo.pipeline_progress)) {
+    const progress = Number(todo.pipeline_progress);
+    return isVisuallyShipped(todo) ? progress : Math.min(progress, 85);
+  }
   if (todo.status === "done") return 100;
   if (todo.status === "in_progress") return 55;
   if (todo.assigned_to_agent_id) return 25;
@@ -268,13 +309,17 @@ function progressFor(todo: JobTodo): number {
 }
 
 function activeStageCount(todo: JobTodo): number {
-  if (Number.isFinite(todo.pipeline_stage_count)) {
-    return Math.min(Math.max(Number(todo.pipeline_stage_count), 1), STAGES.length);
-  }
-  if (todo.status === "done") return STAGES.length;
-  if (todo.status === "in_progress") return 2;
-  if (todo.assigned_to_agent_id) return 1;
-  return 1;
+  const raw = Number.isFinite(todo.pipeline_stage_count)
+    ? Number(todo.pipeline_stage_count)
+    : todo.status === "done"
+      ? STAGES.length
+      : todo.status === "in_progress"
+        ? 2
+        : todo.assigned_to_agent_id
+          ? 1
+          : 1;
+  const clamped = Math.min(Math.max(raw, 1), STAGES.length);
+  return isVisuallyShipped(todo) ? clamped : Math.min(clamped, STAGES.length - 1);
 }
 
 function StageStrip({ todo }: { todo: JobTodo }) {
@@ -293,7 +338,7 @@ function StageStrip({ todo }: { todo: JobTodo }) {
             title={stage}
             className={`flex h-4 min-w-0 items-center justify-center text-[7px] font-semibold uppercase ${
               index < active
-                ? todo.status === "done"
+                ? isVisuallyShipped(todo)
                   ? "bg-green-400/85 text-black/70"
                   : "bg-[#61C1C4]/90 text-black/70"
                 : "bg-white/[0.08] text-white/30"
@@ -434,12 +479,25 @@ function isStaleActive(todo: JobTodo): boolean {
 }
 
 function needsAttention(todo: JobTodo): boolean {
+  if (hasProofWarning(todo)) return true;
   if (todo.status === "done" || todo.status === "dropped") return false;
   if (isStaleActive(todo)) return true;
   return todo.priority === "urgent" && !todo.assigned_to_agent_id;
 }
 
 function attentionCopy(todo: JobTodo): { message: string; actions: readonly string[] } {
+  if (hasPipelineStatusConflict(todo)) {
+    return {
+      message: "Job is still open but the pipeline says shipped.",
+      actions: ACTION_BUTTONS.blocked,
+    };
+  }
+  if (hasProofMissingSignal(todo)) {
+    return {
+      message: "Job proof is missing or reset.",
+      actions: ACTION_BUTTONS.blocked,
+    };
+  }
   if (isStaleActive(todo)) {
     return {
       message: "Active job has not moved recently.",
@@ -691,7 +749,7 @@ function JobRow({
           title={todo.title}
         >
           <p
-            className={`truncate text-[11px] font-semibold leading-4 hover:text-white ${todo.status === "done" ? "text-white/35 line-through" : "text-white/85"}`}
+            className={`truncate text-[11px] font-semibold leading-4 hover:text-white ${isVisuallyShipped(todo) ? "text-white/35 line-through" : "text-white/85"}`}
             data-testid="job-row-title"
           >
             {highlightSearchText(displayCopy.title, searchQuery)}
@@ -703,9 +761,9 @@ function JobRow({
 
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 md:contents">
           <span
-            className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${STATUS_STYLE[todo.status]}`}
+            className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${displayStatusStyle(todo)}`}
           >
-            {statusLabel(todo.status)}
+            {displayStatusLabel(todo)}
           </span>
           <span
             className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${PRIORITY_STYLE[todo.priority]}`}
@@ -722,9 +780,9 @@ function JobRow({
           </span>
           <span className="flex items-center gap-1 text-[11px] text-white/45">
             <span
-              className={`h-1.5 w-1.5 rounded-full ${isStaleActive(todo) ? "bg-red-300" : todo.status === "done" ? "bg-green-300" : "bg-green-400"}`}
+              className={`h-1.5 w-1.5 rounded-full ${hasProofWarning(todo) || isStaleActive(todo) ? "bg-red-300" : isVisuallyShipped(todo) ? "bg-green-300" : "bg-green-400"}`}
             />
-            {todo.status === "done" ? "ship" : isStaleActive(todo) ? "stale" : "live"}
+            {hasProofWarning(todo) ? "blocked" : isVisuallyShipped(todo) ? "ship" : isStaleActive(todo) ? "stale" : "live"}
           </span>
           <span className="text-[11px] font-medium text-white/55">
             <StageStrip todo={todo} />


### PR DESCRIPTION
Summary:
- Jobs board now treats proof-missing and reopened proof-reset cards as blocked instead of visually shipped.
- Open jobs carrying stale ship receipts are capped below 100 percent so reopened work does not look complete.

Scope:
- Owned files: src/pages/admin/AdminJobs.tsx, src/pages/admin/AdminJobs.test.tsx.
- Linked todo: 6819cb82-bd2e-432e-a872-d0c69e3c4d8f.

Non-overlap:
- Did not change Boardroom data, pipeline inference, Memory storage, automations, secrets, billing, DNS, or deploy settings.

Verification:
- npm run test -- src/pages/admin/AdminJobs.test.tsx
- Result: 1 file passed, 5 tests passed.

Risk:
- UI-only admin Jobs display change. No migration, auth, secrets, cron, API, or production data risk.

Follow-up:
- After review, a live /admin/jobs screenshot should confirm reopened proof-reset work no longer appears as 100 percent shipped.