### PR TITLE
fix(memory): require live retrieval eval results

### DIFF
--- a/scripts/memory-retrieval-eval.mjs
+++ b/scripts/memory-retrieval-eval.mjs
@@ -39,59 +39,6 @@ export const DEFAULT_TYPED_LINK_REPLAY_FIXTURES = [
   },
 ];
 
-export const DEFAULT_TYPED_LINK_REPLAY_RESULTS = new Map([
-  [
-    "Which pull request shipped typed-link extraction?",
-    {
-      latency_ms: 8,
-      results: [
-        { ref: "pr:888", relation: "ships", score: 0.99 },
-        { ref: "pr:889", relation: "extends", score: 0.82 },
-      ],
-    },
-  ],
-  [
-    "Find the gbrain parent todo for typed-link graph work.",
-    {
-      latency_ms: 9,
-      results: [
-        { ref: "todo:6e125b76-3238-4425-940f-28a287d85f51", relation: "parent", score: 0.98 },
-        { ref: "todo:b7023911-cc1d-4535-bcdc-b258cc432b7b", relation: "child", score: 0.7 },
-      ],
-    },
-  ],
-  [
-    "Find proof for Memory typed-link direct tool.",
-    {
-      latency_ms: 7,
-      results: [
-        { ref: "receipt:pr-891", relation: "proof", score: 0.97 },
-        { ref: "pr:891", relation: "ships", score: 0.93 },
-      ],
-    },
-  ],
-  [
-    "Which Memory tool searches typed links?",
-    {
-      latency_ms: 6,
-      results: [
-        { ref: "tool:search_typed_links", relation: "exposes", score: 0.99 },
-        { ref: "file:packages/mcp-server/src/server.ts", relation: "registers", score: 0.78 },
-      ],
-    },
-  ],
-  [
-    "Where is typed-link extraction implemented?",
-    {
-      latency_ms: 10,
-      results: [
-        { ref: "file:packages/mcp-server/src/memory/typed-links.ts", relation: "implements", score: 0.99 },
-        { ref: "file:packages/mcp-server/src/memory/handlers.ts", relation: "uses", score: 0.77 },
-      ],
-    },
-  ],
-]);
-
 function normalizeRef(value) {
   return String(value ?? "")
     .trim()
@@ -192,15 +139,14 @@ export function scoreRetrievalFixture({ fixture, results, k = DEFAULT_TOP_K, lat
 
 export async function runMemoryRetrievalEval({
   fixtures = DEFAULT_TYPED_LINK_REPLAY_FIXTURES,
-  resultSets = DEFAULT_TYPED_LINK_REPLAY_RESULTS,
+  resultSets,
   runner,
   k = DEFAULT_TOP_K,
-  allowSeededResults = false,
   clock = () => performance.now(),
 } = {}) {
-  if (!runner && resultSets === DEFAULT_TYPED_LINK_REPLAY_RESULTS && !allowSeededResults) {
+  if (!runner && !resultSets) {
     throw new Error(
-      "seeded_replay_results_not_live_proof: pass a runner or --results from a real retrieval run",
+      "live_retrieval_results_required: pass a runner or --results from a real retrieval run",
     );
   }
 
@@ -251,7 +197,6 @@ function parseArgs(argv) {
     if (arg === "--fixtures") args.fixturesPath = argv[++index];
     else if (arg === "--results") args.resultsPath = argv[++index];
     else if (arg === "--k") args.k = Number.parseInt(argv[++index], 10);
-    else if (arg === "--allow-seeded-results") args.allowSeededResults = true;
     else if (arg === "--help") args.help = true;
     else throw new Error(`unknown_arg:${arg}`);
   }
@@ -261,17 +206,16 @@ function parseArgs(argv) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
-    console.log("Usage: node scripts/memory-retrieval-eval.mjs [--fixtures path.jsonl] [--results path.json] [--k 5] [--allow-seeded-results]");
+    console.log("Usage: node scripts/memory-retrieval-eval.mjs [--fixtures path.jsonl] --results path.json [--k 5]");
     return;
   }
 
   const fixtures = args.fixturesPath ? await loadJsonlFile(args.fixturesPath) : DEFAULT_TYPED_LINK_REPLAY_FIXTURES;
-  const resultSets = args.resultsPath ? await loadResultsFile(args.resultsPath) : DEFAULT_TYPED_LINK_REPLAY_RESULTS;
+  const resultSets = args.resultsPath ? await loadResultsFile(args.resultsPath) : undefined;
   const report = await runMemoryRetrievalEval({
     fixtures,
     resultSets,
     k: args.k,
-    allowSeededResults: args.allowSeededResults,
   });
   console.log(JSON.stringify(report, null, 2));
   if (!report.aggregate.passed) process.exitCode = 1;

--- a/scripts/memory-retrieval-eval.test.mjs
+++ b/scripts/memory-retrieval-eval.test.mjs
@@ -62,15 +62,30 @@ describe("memory retrieval eval", () => {
     assert.equal(report.ok, false);
   });
 
-  test("rejects seeded replay results as live proof by default", async () => {
+  test("requires a live runner or supplied retrieval results", async () => {
     await assert.rejects(
       () => runMemoryRetrievalEval(),
-      /seeded_replay_results_not_live_proof/,
+      /live_retrieval_results_required/,
     );
   });
 
-  test("can run seeded typed-link replay fixtures when explicitly allowed", async () => {
-    const report = await runMemoryRetrievalEval({ allowSeededResults: true });
+  test("can run supplied typed-link replay result sets", async () => {
+    const resultSets = new Map(
+      DEFAULT_TYPED_LINK_REPLAY_FIXTURES.map((fixture) => [
+        fixture.query,
+        {
+          latency_ms: 5,
+          results: [
+            {
+              ref: fixture.expected_refs[0],
+              relation: fixture.expected_relation,
+              score: 1,
+            },
+          ],
+        },
+      ]),
+    );
+    const report = await runMemoryRetrievalEval({ resultSets });
 
     assert.equal(report.aggregate.passed, true);
     assert.equal(report.aggregate.query_count, 5);


### PR DESCRIPTION
Summary:
- Removed the hardcoded typed-link replay result map from the Memory retrieval eval.
- Removed the `--allow-seeded-results` escape hatch so seeded fixtures cannot pass as live proof.
- The eval now requires either a supplied runner or `--results` from a real retrieval run.

Scope:
- Owned files: scripts/memory-retrieval-eval.mjs, scripts/memory-retrieval-eval.test.mjs.
- Linked todo: 6e125b76-3238-4425-940f-28a287d85f51.

Non-overlap:
- Did not touch Memory storage, typed-link extraction, Boardroom jobs, UI, auth, secrets, billing, DNS, deploy, or production data.

Verification:
- `node --test scripts/memory-retrieval-eval.test.mjs` passed, 6 tests.
- `node scripts/memory-retrieval-eval.mjs` now fails with `live_retrieval_results_required: pass a runner or --results from a real retrieval run`.
- `node scripts/memory-retrieval-eval.mjs --allow-seeded-results` now fails with `unknown_arg:--allow-seeded-results`.
- `git diff --check` passed.

Risk:
- Low runtime risk. This intentionally makes proof stricter, so any CI or worker path using the old seeded default must pass real `--results` or a runner.

Follow-up:
- A reviewer should run this PR and confirm no workflow still depends on seeded default eval proof before marking the job done.