### PR TITLE
feat(reliability): surface orchestrator harness card

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -292,6 +292,15 @@ export interface OrchestratorContext {
     // rule themselves. Verdict-only - this field does not gate any
     // downstream behavior in the builder; consumers act on it.
     health_verdict: CommonSensePassResult;
+    harness_card: {
+      source_of_truth: "Boardroom Jobs";
+      queue_state: "active_work" | "needs_claim" | "quiet";
+      queue_truth: string;
+      allowed_actions: string[];
+      required_proof: string[];
+      cleanup_rule: string;
+      recovery_path: string;
+    };
   };
   profile_cards: OrchestratorProfileCard[];
   human_operator_time: OrchestratorOperatorTimeContext | null;
@@ -538,6 +547,11 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
       next_actions: nextActions,
       blockers,
       health_verdict: healthVerdict,
+      harness_card: buildHarnessCard({
+        activeJobsCount,
+        queuedTodoCount,
+        healthVerdict,
+      }),
     },
     profile_cards: profiles,
     human_operator_time: humanOperatorTime,
@@ -559,6 +573,41 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
       library_snapshots_available: allLibrarySnapshots.length,
       library_snapshots_truncated: allLibrarySnapshots.length > librarySnapshots.length,
     },
+  };
+}
+
+function buildHarnessCard({
+  activeJobsCount,
+  queuedTodoCount,
+  healthVerdict,
+}: {
+  activeJobsCount: number;
+  queuedTodoCount: number;
+  healthVerdict: CommonSensePassResult;
+}): OrchestratorContext["current_state_card"]["harness_card"] {
+  const queueState =
+    activeJobsCount > 0 ? "active_work" : queuedTodoCount > 0 ? "needs_claim" : "quiet";
+
+  return {
+    source_of_truth: "Boardroom Jobs",
+    queue_state: queueState,
+    queue_truth:
+      "active_jobs counts in_progress work with a fresh owner; queued_todo_count is open backlog. Open backlog with active_jobs=0 needs claim/proof work and must not be treated as healthy.",
+    allowed_actions: [
+      "claim one unowned scoped job",
+      "verify proof on a completed-looking job",
+      "patch a narrow owned file slice",
+      "post BLOCKER with exact missing proof",
+    ],
+    required_proof: [
+      "coding jobs need PR, commit, deploy, or explicit NO_CODE_NEEDED proof",
+      "tests or CI must be named when code changed",
+      "UI/UX jobs need screenshot proof",
+      `health verdict is ${healthVerdict.verdict}`,
+    ],
+    cleanup_rule: "Do not mark DONE from green chips or stale receipts; close only after required proof is observable.",
+    recovery_path:
+      "If the queue is blocked or scope is unclear, add a narrow ScopePack or proof comment instead of posting a status-only wake.",
   };
 }
 

--- a/api/orchestrator-context-health-verdict.test.ts
+++ b/api/orchestrator-context-health-verdict.test.ts
@@ -22,6 +22,10 @@ describe("orchestrator-context / current_state_card.health_verdict (CommonSenseP
     });
     expect(context.current_state_card.health_verdict.verdict).toBe("PASS");
     expect(context.current_state_card.health_verdict.rule_id).toBe("R1");
+    expect(context.current_state_card.harness_card).toMatchObject({
+      source_of_truth: "Boardroom Jobs",
+      queue_state: "quiet",
+    });
   });
 
   it("emits a BLOCKER verdict when open todos sit in the queue", () => {
@@ -52,6 +56,16 @@ describe("orchestrator-context / current_state_card.health_verdict (CommonSenseP
     expect(context.current_state_card.health_verdict.rule_id).toBe("R1");
     expect(context.current_state_card.health_verdict.next_action).toBe(
       "hydrate_queue_and_claim_one",
+    );
+    expect(context.current_state_card.harness_card).toMatchObject({
+      source_of_truth: "Boardroom Jobs",
+      queue_state: "needs_claim",
+    });
+    expect(context.current_state_card.harness_card.queue_truth).toContain(
+      "Open backlog with active_jobs=0 needs claim/proof work",
+    );
+    expect(context.current_state_card.harness_card.required_proof).toContain(
+      "UI/UX jobs need screenshot proof",
     );
     // active_jobs should also be 0 (no in_progress todos), so the BLOCKER is
     // entirely driven by the actionable queue depth.
@@ -159,6 +173,7 @@ describe("orchestrator-context / current_state_card.health_verdict (CommonSenseP
     expect(context.current_state_card.active_jobs).toBe(1);
     expect(context.current_state_card.health_verdict.verdict).toBe("PASS");
     expect(context.current_state_card.health_verdict.rule_id).toBe("R1");
+    expect(context.current_state_card.harness_card.queue_state).toBe("active_work");
   });
 
   it("verdict and active_jobs are computed from the same source so they cannot disagree", () => {


### PR DESCRIPTION
Summary:
- Added a compact Orchestrator harness card to the current state card.
- The card makes Boardroom Jobs the explicit source of truth, distinguishes quiet/active/needs-claim queue states, and repeats the real proof requirements before DONE.

Scope:
- Owned files for todo 442f8f25 HarnessKit queue/proof truth slice:
  - api/lib/orchestrator-context.ts
  - api/orchestrator-context-health-verdict.test.ts

Non-overlap:
- No schema changes, auth changes, scheduler changes, deploy changes, merge automation, or live data mutation.
- Did not close the parent HarnessKit job.
- Did not touch Job UI, Memory UI, or OpenHands execution paths.

Verification:
- npm run test -- api/orchestrator-context-health-verdict.test.ts api/fishbowl-completion-policy.test.ts api/fishbowl-job-pipeline.test.ts: 18 tests passed.
- npm run test -- api/fishbowl-completion-policy.test.ts api/fishbowl-job-pipeline.test.ts api/orchestrator-context.test.ts: 42 tests passed.
- node --test scripts/pinballwake-autonomous-runner.test.mjs: 54 tests passed.
- git diff --check: passed.

Risk:
- Low. This adds a read-only field to Orchestrator context and tests it. No production write path, secrets, billing, DNS, or destructive behavior.

Follow-up:
- Reviewer should confirm the new context field is acceptable for consumers and then decide whether the broader HarnessKit parent needs a separate GitHub issue mirror.