### PR TITLE
feat(jobsmith): add cv checklist source manifest

### DIFF
--- a/apps/jobsmith/docs/copyroom/cv-checklists/README.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/README.md
@@ -13,6 +13,7 @@ CopyRoom rule: workers must copy these files from source and cite this receipt b
 | `cv-checklists_1b.md` | `C:/Temp/unclick temp/cv-checklists_1b.md` | `2616ec5a4858f63b35ce8b0b0cab1ad86b72e4e88e51430bb046a245ebb8b22f` | 43176 | 916 |
 | `cv-checklists_2.md` | `C:/Temp/unclick temp/cv-checklists_2.md` | `bffd24c5663d120c3c86957819bf6c0bdc4e5a46fee7ee0fb89bc1aba2c7577c` | 24907 | 313 |
 | `cv-checklists_3.md` | `C:/Temp/unclick temp/cv-checklists_3.md` | `9f651dec06874771523d41f4fe7d296998ee9beeba09051fcbeb2a1c457bf3d5` | 24500 | 266 |
+| `cv-checklists_consolidated.md` | `C:/Users/Malamutemayhem/Documents/Codex/2026-05-18/files-mentioned-by-the-user-cv-2/cv-checklists_consolidated.md` | `b09deb85f80d41cc00341f504b2894096b62b75f47d966632eb8c562380db7f2` | 34723 | 219 |
 
 ## Receipts
 

--- a/apps/jobsmith/docs/copyroom/cv-checklists/README.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/README.md
@@ -1,0 +1,30 @@
+# JobSmith CV Checklist CopyRoom Receipt
+
+This folder is the exact source handoff for UnClick todo `848eb8db-dfbb-4411-a332-05096b5bf1fb`.
+
+CopyRoom rule: workers must copy these files from source and cite this receipt before deriving JobSmith rule text. Do not retype these checklists.
+
+## Copied Sources
+
+| File | Original source | SHA256 | Bytes | Lines |
+|---|---|---:|---:|---:|
+| `cv-checklists_1.md` | `C:/Temp/unclick temp/cv-checklists_1.md` | `36e1bd88b5eaa6bbe7374681231c5a29a66676b5813bc59cf04ccd429c27fea4` | 27174 | 329 |
+| `cv-checklists_1a.md` | `C:/Temp/unclick temp/cv-checklists_1a.md` | `5a8f0593e8052f075ae7280c566bab5eef3a7415d72504caa8c6bd1e2257bf9a` | 42467 | 951 |
+| `cv-checklists_1b.md` | `C:/Temp/unclick temp/cv-checklists_1b.md` | `2616ec5a4858f63b35ce8b0b0cab1ad86b72e4e88e51430bb046a245ebb8b22f` | 43176 | 916 |
+| `cv-checklists_2.md` | `C:/Temp/unclick temp/cv-checklists_2.md` | `bffd24c5663d120c3c86957819bf6c0bdc4e5a46fee7ee0fb89bc1aba2c7577c` | 24907 | 313 |
+| `cv-checklists_3.md` | `C:/Temp/unclick temp/cv-checklists_3.md` | `9f651dec06874771523d41f4fe7d296998ee9beeba09051fcbeb2a1c457bf3d5` | 24500 | 266 |
+
+## Receipts
+
+- User source-file handoff saved to Orchestrator receipt `f1df980a-7c3a-437c-8a9c-5d4eef84720f`.
+- Boardroom target job: `848eb8db-dfbb-4411-a332-05096b5bf1fb`.
+- Codex source-manifest claim: `91906cb9-435b-4ae4-aa99-f4de3aa35fbe`.
+- FYI rule-pack handoff: `0bad9e59-03cf-44e9-83e2-33f4473a9209`.
+- Expanded Cowork rule-pack feed: `4438301e-bdd7-4573-98f6-289ffe40941b`.
+- Chris-specified ScopePack fields: `b1b49c8f-c3af-44bb-a2d4-363148b4d763`.
+
+## Build Use
+
+The matching machine manifest lives at `apps/jobsmith/src/lib/cvChecklistSources.ts`.
+
+Before a builder claims that all rules are encoded, they must reconcile the first handoff's count mismatch: it says 40 rules, but the listed severities are `12 ERROR + 19 WARN + 8 INFO = 39`.

--- a/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1.md
@@ -1,0 +1,396 @@
+# CV Checklists — Modern Best Practice + Anti-AI-Slop
+
+Working reference compiled from the two ApplyPass research files plus current (2025–2026) hiring research, ATS vendor docs, Reddit/forum sentiment, and AI-detection studies. No em dashes.
+
+---
+
+## PART 1: WHAT TO LOOK FOR IN A MODERN CV
+
+### A. ATS parsing and machinery (the silent gate)
+
+- Single column layout, no exceptions. Two-column drops Workday field completeness from 94% to 52%, and Jobscan's 2025 audit shows 93% parse rate single column vs 86% multi-column.
+- No tables, no text boxes, no headers/footers for critical info. ATS parsers strip or mangle them.
+- Standard, dictionary-matched section headings: "Work Experience", "Education", "Skills", "Certifications". Not "Career Journey", "My Toolkit", "What I Bring".
+- Date format must be MM/YYYY or Month YYYY ranges. Workday parses "05/2022 to 08/2024" with 99% accuracy vs 14% for "Summer 2023".
+- File format: DOCX is the safest default for ATS portals. Text-based PDF acceptable elsewhere. Never submit image-based PDFs from Canva/Figma.
+- Standard system fonts (Arial, Calibri, Helvetica, Garamond, Georgia, Times). Custom or display fonts can fail to render in parsers.
+- Font size between 10pt and 12pt for body, 14pt to 18pt for headings.
+- No icons, emoji, graphics, photos, charts, sparklines, or progress bars. Parsers see them as noise or skip them entirely.
+- No coloured text for parseable content. Subtle accents on headings/dividers only.
+- File name format: FirstName-LastName-Role.docx (or .pdf). Recruiters search and sort by filename.
+- Embed real text, never outlined or rasterised type from a design tool.
+- Standard bullet characters only (• or hyphen). Avoid fancy unicode glyphs.
+- Use canonical skill names matched to Workday Skills Cloud taxonomy: "JavaScript" not "JS", "Microsoft Excel" not "MS Excel", "Adobe Photoshop" not "PS".
+- Separate role entries per promotion at the same company. Don't merge into one block.
+- LinkedIn URL, portfolio URL, and email written as plain text (not hyperlinked icons).
+- One job, one column of dates aligned consistently right or left.
+- Spell out acronyms on first use, then use the acronym. ATS keyword matching catches both forms.
+- Plain-text export self-test: copy/paste your CV into Notepad. If structure collapses or content disappears, the ATS sees the same thing.
+- Test against a free Jobscan or Resume Worded scan to check parser output, but don't optimise to a score (see Part 1.K).
+
+### B. Content structure and information architecture
+
+- Contact block at top: name, city/state (not full address), phone, email, LinkedIn, portfolio/website. No DOB, no photo (in most countries; check local norms), no marital status.
+- Professional summary (3 to 5 lines) tailored to the role, not a generic "passionate professional" boilerplate.
+- Reverse chronological order for experience.
+- Most recent and most relevant role gets the most space and most bullets.
+- Cap visible experience at roughly 15 years for senior candidates. Earlier roles go into a brief "Early Career" block without dates.
+- Education near the bottom for experienced candidates; near the top for graduates.
+- Omit graduation year if you're worried about age signalling. Colorado (Job Application Fairness Act), NYC (2025), and Oregon HB3187 (May 2025) now bar employers from asking for graduation dates pre-offer.
+- 1 page for under 10 years experience, 2 pages for senior/executive. 3 pages only for academic/medical CVs.
+- White space matters. Cramped CVs read as desperate; airy CVs read as confident.
+- Consistent vertical rhythm: same spacing between roles, same indent for bullets, same heading style throughout.
+- No "References available on request" line. Wastes a row and is implicit anyway.
+- No "Objective" section. Replace with a targeted summary.
+
+### C. Bullet-point craft (the Harvard formula)
+
+- Every bullet follows: Action verb + task/context + quantified outcome.
+- Strong action verbs that show seniority: led, drove, built, shipped, owned, scaled, architected, directed, negotiated, delivered. Avoid weak verbs: helped, assisted, supported, worked on, was responsible for.
+- Quantify everything you honestly can: percentages, dollar/AUD amounts, headcount managed, time saved, throughput, conversion rates, retention, NPS, deal sizes.
+- Where you can't quantify, give scope or scale: "across 4 markets", "for a 12-person team", "with a 6-figure budget".
+- One bullet, one idea. No bullet that contains two unrelated achievements joined by "and".
+- 3 to 5 bullets per recent role, 1 to 3 for older roles.
+- Bullets should pass the "so what?" test. If a recruiter could shrug after reading it, rewrite.
+- Past tense for past roles, present tense for current role only.
+- No personal pronouns ("I", "my", "we"). The implicit subject is you.
+- No full stops at the end of bullets, OR full stops on every bullet. Pick one and be consistent.
+- Lead with the outcome where the outcome is the impressive part: "Cut onboarding time 40% by redesigning the welcome flow" reads stronger than "Redesigned the welcome flow, cutting onboarding time 40%".
+- Defensibility check: every quantified claim must be something you can explain in an interview without notes. If you can't defend "increased revenue 23%", don't write it.
+
+### D. Tailoring to the role (truthful, not deceptive)
+
+- Read the job description twice and highlight the 6 to 10 specific skills, tools, and outcomes mentioned.
+- Mirror the exact phrasing where it's truthful: if they say "stakeholder management", use "stakeholder management" not "managing relationships with stakeholders".
+- Reorder your bullets so the most role-relevant achievement is first under each role.
+- Swap or sharpen 3 to 5 bullets per CV per application. Don't rewrite the whole thing.
+- Move skills you have and they want to the top of your skills list.
+- Drop or compress skills/roles that are irrelevant. Don't delete them entirely if they show range, but shrink them.
+- Match seniority cues. If they say "led", you say "led". If they say "executed", you say "executed".
+- Industry-specific keywords: ATS systems and recruiters both scan for them. Get them from the job description, not a generic keyword list.
+- Truthfulness floor: no fabricated metrics, no inflated titles, no false credentials, no claims of tools/skills you can't demonstrate in 5 minutes.
+- Provenance check: every claim on your CV should be traceable to a real project, role, or piece of work you can point to.
+
+### E. Cover letter (when included)
+
+- One page maximum, 3 to 4 short paragraphs.
+- Opening line names the role and the company, and signals genuine interest with one specific detail (a product, a recent announcement, a value).
+- Paragraph 2: the strongest evidence you can do the job — one specific story with an outcome.
+- Paragraph 3: why this company specifically (not "I love your mission"). Reference something concrete.
+- Closing: clear next step, e.g. "Happy to share more in a conversation."
+- No "Dear Sir/Madam" unless you literally cannot find a name. "Dear Hiring Team" is acceptable.
+- Avoid restating the CV. Add context the CV can't.
+- Match the tone of the company's careers page and brand voice.
+
+### F. LinkedIn alignment (cross-check before applying)
+
+- Job titles on LinkedIn match job titles on CV exactly. Workday and some iCIMS instances cross-reference and flag diverging titles/dates for manual review.
+- Date ranges match.
+- Skills section on LinkedIn mirrors the top of your CV's skills section.
+- Profile photo on LinkedIn, none on CV.
+- LinkedIn URL on CV uses your customised slug, not the default `/in/chris-byrne-1a2b3c4d5e/`.
+
+### G. Modern hiring trends to know (2025 to 2026)
+
+- Roughly half of applicants now use AI to write CVs/cover letters (FT, July 2025).
+- 19.6% of 600 US hiring managers say they'd reject an application they believed was fully AI-written (TopResume, May 2025).
+- 33% claim they can spot an AI-written CV in under 20 seconds.
+- AI-written cover letters get rejected primarily on tone, not content.
+- Recruiters are pattern-matching humans, not running detector software. The fix is real specificity, not "humaniser" tools.
+- Auto-apply tools (LazyApply, Sonara, Jobright, AIApply, Simplify) have very low callback rates per application. High volume burns goodwill and trips ATS dedupe.
+- "Ghost jobs" are now common. Don't take silence personally.
+- Workday is the dominant ATS, used by 10,500+ orgs including more than 50% of Fortune 500. Optimise for Workday parsing as the default.
+- Skills-based hiring is rising. Lead with skills if you're a career changer.
+- Hybrid/remote signals matter. State your preference clearly if it's relevant.
+
+### H. Age and identity signal management
+
+- 42% of hiring managers admit considering age (ResumeBuilder 2024); 79% of those infer it from graduation dates.
+- Omit graduation year for senior candidates.
+- Cap visible experience at ~15 years; older roles go in "Early Career Highlights" without dates.
+- Remove outdated technologies you no longer use unless they're directly relevant.
+- Use email with your name, not a Hotmail or AOL legacy address.
+- Use a current phone format and don't write it as "(03) 9XXX XXXX" if applying internationally.
+- Standard fonts and modern (but not trendy) design read as current without screaming "millennial".
+
+### I. The Reddit/forum reality check (what real applicants report)
+
+Themes from r/EngineeringResumes, r/resumes, r/cscareerquestions, r/recruitinghell, Blind, and r/jobs during 2025 to 2026:
+
+- ATS keyword optimisation past about 75% match shows diminishing returns and produces ChatGPT-sounding copy.
+- Auto-apply tools generate "ghost job" rage and burn application allowances without callbacks.
+- Recruiters increasingly post about identifying AI-written cover letters by tone alone.
+- Older workers report higher callback rates after removing graduation dates and capping experience at 15 years.
+- Workday is the most-hated portal because of double data entry; many candidates abandon at the portal stage.
+- Resume reviews on r/EngineeringResumes consistently land on: quantify everything, single column, no fluff, no soft-skill claims without evidence.
+- One-page CVs win against multi-page CVs for under-10-years applicants in roughly 80% of recruiter feedback threads.
+- Generic "I'm a passionate, results-driven professional" openings are universally mocked.
+- Hiring managers on Blind report skimming CVs in 6 to 10 seconds. Top third of the page does the work.
+
+### J. The "human review" checks before sending
+
+- Read it out loud. If a sentence sounds robotic, it is.
+- Show it to someone who knows your work. They'll spot inflated claims faster than you will.
+- Check spelling and grammar twice. Use Grammarly or LanguageTool, but verify suggestions; tools push toward generic phrasing.
+- Check every number you wrote against a source you trust.
+- Check every employer name, date, and title for accuracy.
+- Save as the format you'll submit (DOCX/PDF) and open it fresh. Layout breaks happen during export.
+- Submit it through the actual portal, then open the application's preview. If the ATS scrambled it, fix and resubmit.
+- Keep a versioned copy of every CV you send, tagged with the company and date. Outcomes feed back into what works.
+
+### K. Tools to use (and what to ignore from them)
+
+- **Jobscan / Resume Worded**: useful for ATS parse audit. Ignore the "match score". A recruiter's 2025 account in Business Insider described winning interviews with a CV scoring badly on Jobscan; Jobscan itself frames scores as "risk assessment".
+- **Reactive Resume** (MIT, self-hostable, open source): the most mature OSS CV builder.
+- **OpenResume**: browser-local data, built-in ATS parser simulation.
+- **JSON Resume**: schema-based, dev-friendly.
+- **AwesomeCV / Resumake**: LaTeX-based, very ATS-clean.
+- **Harvard FAS Mignone Center bullet template**: still the gold standard format after 5+ years.
+- **AI tools (ChatGPT, Claude, Gemini)**: useful as a sparring partner for rewriting one bullet at a time. Dangerous when used to generate the whole CV (see Part 2).
+- **Detector tools (GPTZero, Originality, Copyleaks)**: never submit your real CV. Use only on a redacted copy, and treat the score as false-positive risk awareness, never as a writing target.
+
+### L. Legal and ethical floor
+
+- No hidden text (white-on-white, font-size-0, off-canvas). Workday, Greenhouse, and Lever detect and flag it.
+- No keyword stuffing. ATS systems and recruiters are wise to it.
+- No fabricated metrics, employers, dates, degrees, or referrals. One discovered lie torpedoes the whole application.
+- No claims of citizenship/visa status you don't hold.
+- No salary lies in pre-screening; some jurisdictions ban asking.
+- Keep your data private. Don't upload personal CVs to free public AI detector sites that may retain or train on the content.
+- GDPR/CCPA: you have a right to know what data an employer holds on you. Many ATS systems retain CVs for years.
+
+---
+
+## PART 2: ANTI-AI-SLOP — WHAT WILL TRIP DETECTORS AND HUMANS
+
+> Note: AI detectors are unreliable. Stanford's Liang et al. found 61.3% false-positive rate against non-native English writers; independent retests of GPTZero report ~18% FPR vs. vendor claim of 0.5%. **The real risk is human recruiters spotting AI tone in 20 seconds, not software.** Write to defeat the human, not the detector. These tells will trip both.
+
+### A. Era-specific vocabulary tells (the GPT word list)
+
+These words have become AI-canary indicators because they appear at unusual frequency in LLM output. Used once, fine. Used twice in a CV, suspicious. Used three times, you're cooked.
+
+**GPT-4 era vocabulary (still dominant):**
+
+- delve, delves, delving
+- tapestry, rich tapestry
+- intricate, intricacies
+- meticulous, meticulously
+- pivotal, pivotal role
+- underscore, underscores, underscoring
+- testament, a testament to
+- vibrant
+- robust, robustly
+- nuanced
+- multifaceted
+- comprehensive
+- holistic
+- realm, in the realm of
+- landscape (when used metaphorically: "the landscape of marketing")
+- paradigm, paradigm shift
+- synergy, synergies, synergistic
+- leverage, leveraging (overused as a verb)
+- spearhead, spearheaded (now a tell)
+- navigate (metaphorical: "navigate complex challenges")
+- harness, harnessing
+- foster, fostering
+- cultivate, cultivating
+- streamline, streamlined
+- empower, empowering
+- elevate, elevating
+- transformative
+- groundbreaking
+- cutting-edge
+- state-of-the-art
+- innovative (when not specific)
+- dynamic (when not specific)
+- ever-evolving
+- ever-changing
+
+**GPT-4o era additions:**
+
+- bolster, bolstered, bolstering
+- showcase, showcasing
+- enhance, enhanced, enhancing
+- optimise, optimised (when not technical)
+- facilitate, facilitating
+
+**GPT-5 era additions:**
+
+- emphasising, emphasises
+- highlighting, highlights (as a verb)
+- demonstrating (overused)
+- showcasing (still trending up)
+
+**Generic LLM filler phrases:**
+
+- "in today's fast-paced world"
+- "in today's digital age"
+- "in the ever-evolving landscape of"
+- "in the realm of"
+- "at the forefront of"
+- "play a pivotal role in"
+- "stand as a testament to"
+- "a deep dive into"
+- "a wealth of experience"
+- "results-driven professional"
+- "passionate about"
+- "driven by a passion for"
+- "with a proven track record"
+- "a track record of success"
+- "results-oriented"
+- "detail-oriented"
+- "team player"
+- "go-getter"
+- "self-starter"
+- "thinks outside the box"
+- "hit the ground running"
+- "synergise across teams"
+- "wear multiple hats"
+- "wears many hats"
+
+### B. Structural and rhetorical tells
+
+- **"Not just X but Y"** parallelism. "Not just a designer but a strategic thinker." Dead giveaway. Avoid the construction entirely.
+- **"It's not X, it's Y"** reframes. Same family. Avoid.
+- **Tricolons** (lists of three with rhetorical lift): "innovative, dynamic, and transformative". Once in a CV is fine; pattern-repeated is a tell.
+- **Self-posed rhetorical questions** inside paragraphs. "What makes a great leader? Vision." AI loves this. Humans rarely write it in a CV.
+- **Bolded lead-in for every bullet** ("**Strategic Leadership:** Led..."). One of the strongest AI tells in modern CVs. If you use it at all, use it sparingly and inconsistently.
+- **Parallel sentence structures three bullets in a row**: "Spearheaded the redesign of...", "Spearheaded the rollout of...", "Spearheaded the migration of...". Vary your openings.
+- **Summary paragraphs that start with the same word**. AI loves consistency; humans don't write that cleanly.
+- **The hourglass paragraph**: broad opening, narrow middle, broad close. Classic AI shape.
+- **Listicle creep**: AI converts everything to bullets. Some prose in a summary or cover letter signals human authorship.
+- **Concluding sentences that summarise** what was just said. Humans rarely do this in bullets or short copy.
+- **"In conclusion"**, **"in summary"**, **"to wrap up"** as transition phrases. AI relies on them; humans don't need them in short docs.
+
+### C. Punctuation and typography tells
+
+- **Em dash overuse**. The "ChatGPT dash". One em dash in a CV is fine; three or more in a one-page doc is a flag. Many recruiters now use em-dash density as a first-pass AI filter. (Note: Chris's brand standard already bans em dashes entirely. This aligns.)
+- **Curly quotes** (" " ' ') when the rest of the doc uses straight quotes, or vice versa. Inconsistency is a paste-from-AI tell.
+- **Unicode arrows** (→, ⇒, ➜). AI loves them. Use a hyphen or "to" instead.
+- **Non-breaking spaces** invisible to the eye but visible to text inspectors.
+- **Smart apostrophes** mixed with straight apostrophes in the same doc.
+- **Triple-dot ellipsis** (…) as a unicode character vs three periods (...). AI defaults to the unicode glyph.
+- **Curly bullet glyphs** (▪, ▸, ◆) that copy oddly from AI output. Use • or - only.
+- **Inconsistent spacing** around colons, dashes, and parentheses. AI sometimes outputs en-dashes (–) where humans type hyphens (-).
+- **Mid-sentence capitalisation** of "Important Concepts" (Title Case Random Words). AI does this; humans don't.
+
+### D. Tone and voice tells
+
+- **Sycophantic openers**: "Great question!", "Excellent point!" Mostly a chat-AI tell, but it bleeds into cover letters as "Thank you for the opportunity to...".
+- **Hedging phrases**: "It's worth noting that...", "It's important to note...", "It's also worth mentioning...". Humans cut these; AI multiplies them.
+- **Generic enthusiasm without a specific reason**: "I'm incredibly excited about this role." Why? AI can't say. Specify.
+- **Overly polite, overly neutral tone**. Humans have edges, opinions, preferences. AI sands them off.
+- **Diplomatic restraint** where a normal human would be direct. "I would suggest that perhaps the approach could be reconsidered" vs "I disagreed and proposed a different approach".
+- **Excessive qualification**: "may potentially help to facilitate" vs "helps". AI hedges by reflex.
+- **Praise of the company that any candidate could write**: "Your innovative approach to [industry] is inspiring." If you could send that line to any of 50 companies, delete it.
+- **Restating the prompt** in the answer. In a cover letter: "As you mentioned in your job posting, you're looking for a candidate who can..." AI does this; humans don't repeat the JD back.
+
+### E. Rhythm and grammar tells
+
+- **Every sentence the same length**. Humans vary sentence length wildly. AI defaults to a comfortable 15 to 25 word range.
+- **No sentence fragments. Ever.** Real writers use fragments. For emphasis. Like this.
+- **Comma-splice avoidance perfection**. AI almost never produces a comma splice. Humans do, especially in punchy writing. (Not advising bad grammar; observing that polished perfection is suspicious.)
+- **The "Oxford comma always, no exceptions" pattern**. AI is consistent to a fault; humans drift.
+- **Subject-verb-object always**. AI rarely fronts an adverb or inverts structure. "Quickly, the project shipped" is rare in AI prose.
+- **Conjunction at start of sentence avoidance**. AI was trained to be "correct"; it avoids starting sentences with "And" or "But". Humans do it constantly.
+- **No contractions** in informal contexts. AI defaults to "do not" where a human would write "don't". This is especially obvious in cover letters trying to sound conversational.
+- **Perfect parallel structure across all list items**. Real writers break parallelism sometimes. AI doesn't.
+
+### F. Content tells specific to CVs and cover letters
+
+- **Hallucinated metrics**. AI will invent "increased revenue 23%" or "managed a team of 12" if you give it vague input. Every number on your CV must be one you can defend.
+- **Round number cluster**: "Increased X by 25%, reduced Y by 30%, improved Z by 50%." Real metrics are rarely all round. "Cut latency 23%" reads more real than "improved performance by 50%".
+- **Achievements without context**: "Drove $2M in revenue." Over what period? On what base? With what team? AI doesn't know, so it omits. Humans add the context naturally.
+- **Skills lists that include everything**: AI dumps every possibly relevant tool. Humans curate to what they actually use.
+- **Job titles that don't match LinkedIn**: AI may "level up" your title. Check.
+- **Date ranges that don't add up**: AI can hallucinate timelines. Verify every range.
+- **Companies you didn't work at**: rare, but AI hallucinates employer names in some workflows. Always cross-check.
+- **Generic role descriptions**: "Managed projects, led teams, and drove results." AI fills space when it lacks input. Real CVs have specific projects, specific teams, specific results.
+- **Cover letters that don't mention the company by name** after the salutation. AI sometimes drops it.
+- **Cover letters that name the wrong company** because of a botched copy-paste from a previous tailoring. The single most embarrassing AI tell.
+
+### G. Formatting tells from copy-pasted AI output
+
+- **Markdown asterisks** (`**bold**`) that didn't render and got submitted as literal `**text**`.
+- **Markdown headers** (`# Heading`, `## Heading`) submitted as `# Heading` instead of formatted.
+- **Code-fence backticks** around technical terms that shouldn't be formatted: `` `Python` ``.
+- **Numbered lists with `1.` not auto-formatted** by Word, so they sit as plain text.
+- **Hyperlinks in markdown syntax** `[LinkedIn](https://...)` left unrendered.
+- **Bullet characters that don't match** the rest of the doc, because they came from a different source.
+- **Inconsistent indentation** caused by a paste from a different style.
+- **Smart-quote drift**: pasted AI text uses curly quotes, but your typed text uses straight. Mixing is a giveaway.
+- **Extra blank lines** between paragraphs that AI tends to insert.
+- **The "ChatGPT signature spacing"**: a blank line after every short paragraph, including 1-line bullets.
+
+### H. Specific patterns to avoid in summaries and openings
+
+- "Highly motivated professional with..."
+- "Results-oriented [role] with X years of experience in..."
+- "Passionate about leveraging [skill] to drive [outcome]..."
+- "Proven track record of..."
+- "A creative thinker with a knack for..."
+- "Adept at..."
+- "Seasoned [role]..."
+- "Dynamic and innovative..."
+- "Strategic thinker with hands-on experience..."
+- "A unique blend of..."
+- "Bringing a fresh perspective to..."
+- Any opener that doesn't say what you do, where, and what's true about you that's not true about a thousand others.
+
+### I. Specific patterns to avoid in cover letters
+
+- "I am writing to express my interest in..."
+- "I came across your job posting and was immediately drawn to..."
+- "I believe my skills and experience make me an ideal candidate..."
+- "I am excited about the opportunity to contribute to..."
+- "Thank you for considering my application. I look forward to the opportunity to discuss..."
+- Any sentence that starts with "I" three times in a row.
+- Any closing that contains "I am confident that I would be a valuable asset to your team."
+
+### J. Practical anti-slop workflow
+
+- Write the bones yourself first, in plain language, without an AI. Even rough is fine.
+- Use AI only to rewrite one bullet at a time, with a specific instruction: "Make this bullet more specific and quantified. Don't add words I haven't given you."
+- Never accept AI output verbatim. Pass it through your own voice: shorten, sharpen, cut hedging, add a specific.
+- Read everything out loud before sending. If it sounds like a press release, rewrite.
+- Vary sentence length deliberately. Mix 5-word and 25-word sentences.
+- Cut every word that doesn't earn its place.
+- Capture your real prior writing (3 to 5 samples of old emails, blog posts, LinkedIn posts) and compare your final CV's voice to them. If they don't match, the CV isn't yours.
+- Run a text-based diff between your draft and an AI rewrite of the same content. The differences are where your voice lives. Keep them.
+- Submit a redacted copy (no name, no employer, no project codenames) through a free detector like GPTZero or Originality only as a sanity check on FP risk, never to optimise the text.
+- If a detector flags a section, don't rewrite to evade detection. Rewrite to be more specific and defensible. That solves both the detector and the human recruiter at the same time.
+
+### K. The defensibility test (the single most important check)
+
+For every line on the CV or cover letter, ask:
+
+- Can I defend this exact wording in an interview?
+- Can I expand on this metric with context and method?
+- Is this written in language I would actually use in conversation?
+- If a recruiter asks "tell me more about this", do I have a 2-minute story?
+- If the answer to any of these is no, rewrite or cut.
+
+### L. The Chris-specific rules (from existing brand standards)
+
+- No em dashes anywhere. Period. (Brand standard.)
+- No typographic hangers or orphans (single words on their own line).
+- ATS-friendly format above all aesthetic preferences.
+- Education leads with "University Degree Equivalent (22+ Years Extensive Professional Experience)".
+- "Prompt composition" not "prompt engineering".
+- Higgsfield placement stated as "top 2%" (not "top 2 percent" or "top tier").
+- Bailey, Malamute Mayhem, UnClick lore stays out of the CV unless directly relevant to the role being applied for.
+
+---
+
+## SUMMARY: THE 10 RULES
+
+1. Single column, standard headings, DOCX default, no graphics. ATS-safe before pretty.
+2. Quantify everything you can defend. Cut everything you can't.
+3. Tailor 3 to 5 bullets per application, not the whole CV. Mirror the JD's truthful phrasing.
+4. Write in your own voice first. Use AI only to sharpen one bullet at a time.
+5. Strip the GPT vocabulary list. If a word sounds like Claude wrote it, rewrite.
+6. Vary sentence length. Use fragments. Break parallelism. Sound like a human.
+7. No em dashes. No unicode arrows. No bolded lead-ins on every bullet.
+8. Read it out loud. If you wouldn't say it in a pub, don't write it.
+9. Cross-check every claim, date, title, and number. One lie ends the application.
+10. Detectors are noisy and biased. Defeat the human recruiter, not the software.

--- a/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1a.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1a.md
@@ -1,0 +1,1053 @@
+# Modern CV Review Checklist, ATS, Human Voice, Anti AI-Slop, Detector-Risk
+
+Research date: 2026-05-18
+
+Based on:
+
+- `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\CV_research_1_2.md`
+- `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\CV_research_2_2.md`
+- Current web, search, forum, Reddit, university career-service, ATS vendor, and AI-detector research checked on 2026-05-18
+
+Important framing:
+
+- Do not treat this as an AI-detector evasion guide.
+- Treat it as a human-quality, truthfulness, specificity, privacy, and false-positive-risk checklist.
+- AI detectors are noisy signals, not proof.
+- Recruiters usually notice generic AI copy before any software does.
+- The strongest antidote to AI-slop is not deliberate mistakes.
+- The strongest antidote is specific, defensible, role-relevant evidence in the applicant's real voice.
+
+## Source Signals Used
+
+- Harvard career guidance on resumes, cover letters, and AI use.
+- MIT and Stanford career guidance on action, task, result, and quantified achievement bullets.
+- r/EngineeringResumes wiki and recurring Reddit resume-review patterns.
+- r/resumes, r/recruitinghell, r/cscareerquestions, and broader forum sentiment patterns.
+- Greenhouse, Lever, Workday, Indeed, and ATS/recruiting product documentation.
+- AI-detector research, including false positives and bias against non-native English writers.
+- Public AI-writing tell catalogues, including "Signs of AI writing" and open-source AI-tells lists.
+- Your ApplyPass research notes, especially the guardrails: truthful tailoring, no hidden text, no keyword stuffing, no fake claims, privacy-safe detector checks, and source-backed outputs.
+
+## Master CV Review Checklist
+
+### First Impression
+
+- Check whether the CV makes sense in the first 6 to 10 seconds.
+- Check whether the role target is obvious.
+- Check whether the candidate's level is obvious.
+- Check whether the strongest evidence appears in the top third.
+- Check whether the CV feels written for this job, not every job.
+- Check whether the CV sounds like a real person with real experience.
+- Check whether the page looks calm, scannable, and professional.
+- Check whether the design helps scanning rather than showing off.
+- Check whether the CV can be skimmed without reading every word.
+- Check whether the reader can answer: "What does this person do?"
+- Check whether the reader can answer: "Why might they be useful here?"
+- Check whether the reader can answer: "What have they actually delivered?"
+- Check whether the reader can answer: "Can they defend every claim in interview?"
+- Check whether any top-section wording feels generic, inflated, or AI-polished.
+- Check whether the CV opens with facts instead of vibes.
+
+### Job Fit
+
+- Check the CV against the exact job description.
+- Mark every must-have requirement.
+- Mark every nice-to-have requirement.
+- Mark every repeated keyword.
+- Mark every responsibility that appears more than once.
+- Mark every tool, platform, domain, compliance area, and methodology.
+- Check whether the CV has real evidence for each must-have.
+- Check whether the strongest matching evidence appears early.
+- Check whether the CV uses the employer's normal language where truthful.
+- Check whether keyword use is natural and contextual.
+- Check whether the CV avoids keyword dumping.
+- Check whether the CV avoids copying long phrases from the job ad.
+- Check whether the CV includes the role's seniority signals.
+- Check whether the CV avoids over-claiming seniority.
+- Check whether the CV explains adjacent experience when the match is indirect.
+- Check whether the CV handles missing requirements honestly.
+- Check whether the CV prioritises relevant work over chronological completeness.
+- Check whether the CV is tailored without becoming a different person.
+- Check whether every tailored point can be traced to source experience.
+
+### Truthfulness
+
+- Check every metric.
+- Check every title.
+- Check every date.
+- Check every employer name.
+- Check every tool claim.
+- Check every certification claim.
+- Check every education claim.
+- Check every leadership claim.
+- Check every revenue, growth, cost, user, retention, speed, or efficiency number.
+- Check whether each number has a source or defensible estimate.
+- Check whether any vague result could be made more precise.
+- Check whether any precise result is actually unsupported.
+- Check whether the candidate can explain the method behind each metric.
+- Check whether "led" really means led.
+- Check whether "owned" really means owned.
+- Check whether "architected" really means architected.
+- Check whether "strategy" means actual decision-making, not participation.
+- Check whether "managed" means people, budget, vendor, project, or process.
+- Check whether "launched" means shipped to users, internal beta, or draft.
+- Check whether "implemented" means wrote, configured, coordinated, or advised.
+- Check whether "collaborated" is hiding the candidate's actual contribution.
+- Check whether anything would embarrass the candidate if challenged.
+
+### ATS Safety
+
+- Use one column.
+- Use standard section headings.
+- Use text, not images, for all important content.
+- Use a text-based PDF, not an image PDF.
+- Prefer DOCX for older or brittle employer portals when allowed.
+- Keep a plain-text export test.
+- Confirm the plain-text version preserves the right order.
+- Confirm names, titles, companies, dates, and bullets survive copy-paste.
+- Avoid tables unless the target parser is known to handle them.
+- Avoid text boxes.
+- Avoid headers and footers for critical information.
+- Avoid icons for contact details.
+- Avoid progress bars.
+- Avoid star ratings.
+- Avoid skill meters.
+- Avoid infographic layouts.
+- Avoid two-column templates.
+- Avoid Canva-style decorative exports for ATS submissions.
+- Avoid Figma, Photoshop, or image-heavy templates for ATS submissions.
+- Avoid putting core details in sidebars.
+- Avoid nonstandard headings like "My Journey" or "Where I Create Impact".
+- Use "Experience" or "Work Experience".
+- Use "Education".
+- Use "Skills".
+- Use "Projects" where relevant.
+- Use "Certifications" where relevant.
+- Use "Volunteering" where relevant.
+- Use month and year date ranges.
+- Use consistent date formats.
+- Prefer `Jan 2024 - Mar 2026` or `01/2024 - 03/2026`.
+- Avoid vague dates like `Summer 2024`.
+- Avoid only years if month-level timing matters.
+- Avoid unexplained overlaps that look like errors.
+- Use canonical skill names.
+- Use `JavaScript`, not only `JS`.
+- Use `TypeScript`, not only `TS`.
+- Use `PostgreSQL`, not only `Postgres`, unless the job ad uses Postgres.
+- Use `Amazon Web Services (AWS)` once, then `AWS`.
+- Use `Customer Relationship Management (CRM)` once, then `CRM`.
+- Avoid hidden white text.
+- Avoid tiny keyword blocks.
+- Avoid copy-pasted keyword lists from the job ad.
+- Avoid repeated keywords with no work context.
+- Avoid using colour as the only way to convey information.
+- Check the filename is clean and professional.
+- Use a file name like `First_Last_CV_Role_Company.pdf`.
+- Avoid spaces and symbols that some portals mangle.
+- Avoid password-protected files unless requested.
+
+### Human Recruiter Scan
+
+- Check whether the top third explains the candidate's current value.
+- Check whether the most relevant job title appears near the top.
+- Check whether the summary says something a human would not already assume.
+- Check whether the summary is specific enough to belong only to this candidate.
+- Check whether the summary avoids "results-driven".
+- Check whether the summary avoids "dynamic".
+- Check whether the summary avoids "passionate".
+- Check whether the summary avoids "highly motivated".
+- Check whether the summary avoids "proven track record" unless followed by proof.
+- Check whether bullets begin with distinct action verbs.
+- Check whether bullets are easy to compare.
+- Check whether achievements beat responsibilities.
+- Check whether outcomes beat tasks.
+- Check whether the reader can see scope.
+- Check whether the reader can see complexity.
+- Check whether the reader can see judgement.
+- Check whether the reader can see collaboration.
+- Check whether the reader can see commercial impact or mission impact.
+- Check whether the reader can see technical depth where relevant.
+- Check whether the reader can see stakeholder context.
+- Check whether the CV avoids looking generated in one pass.
+
+### Structure And Length
+
+- Keep the CV as short as the evidence allows.
+- For early career, prefer 1 page unless there is a strong reason.
+- For experienced candidates, 2 pages is often acceptable.
+- For academic, medical, research, or executive CVs, longer may be normal.
+- Cut anything that does not support the target role.
+- Put the most relevant evidence before older or less relevant evidence.
+- Use reverse chronological order unless a functional format is truly required.
+- Avoid hiding weak chronology with a functional format unless there is a reason.
+- Use role grouping for multiple promotions at the same company.
+- Separate promotions if titles and responsibilities changed materially.
+- Avoid dense paragraphs.
+- Use bullets for scannability.
+- Keep most bullets to 1 or 2 lines.
+- Avoid bullets that wrap into mini-paragraphs.
+- Keep spacing consistent.
+- Keep alignment consistent.
+- Keep typography quiet.
+- Use one professional font family.
+- Use font size large enough to read.
+- Use consistent heading hierarchy.
+- Use enough white space to scan.
+- Avoid decorative dividers that break parsing.
+- Avoid colour-heavy themes.
+- Avoid tiny margins.
+- Avoid cramming just to hit a page count.
+
+### Contact Section
+
+- Include full name.
+- Include city or region if useful.
+- Include phone number where appropriate.
+- Include professional email.
+- Include LinkedIn if maintained.
+- Include portfolio or GitHub if relevant.
+- Include website if it strengthens the application.
+- Avoid full street address unless required.
+- Avoid birth date.
+- Avoid marital status.
+- Avoid photo unless local market norms require it.
+- Avoid nationality unless required or useful for work eligibility.
+- Avoid visa details unless requested or strategically useful.
+- Avoid multiple phone numbers.
+- Avoid novelty email addresses.
+- Avoid broken portfolio links.
+- Avoid unprofessional social links.
+- Check every link opens.
+- Check every link lands on a public page.
+- Check portfolio pages are current.
+- Check GitHub pins support the target role.
+- Check LinkedIn matches CV dates and titles.
+
+### Headline
+
+- Add a role-aligned headline if it clarifies fit.
+- Make the headline factual.
+- Keep it short.
+- Match the target role family.
+- Avoid "guru".
+- Avoid "ninja".
+- Avoid "rockstar".
+- Avoid "visionary" unless the evidence is exceptional.
+- Avoid stacking too many identities.
+- Avoid a headline that sounds broader than the evidence.
+- Avoid keyword stuffing in the headline.
+- Prefer `Product Designer | SaaS Onboarding | Research-Led UX`.
+- Prefer `Full-Stack Engineer | TypeScript | AI Workflow Tools`.
+- Prefer `Operations Manager | Workforce Planning | Service Delivery`.
+
+### Summary
+
+- Use a summary only if it adds targeting value.
+- Keep it to 2 to 4 lines.
+- Lead with professional identity.
+- Include years only if helpful and not age-signalling in a harmful way.
+- Include domain context.
+- Include 2 to 3 strongest strengths.
+- Include one proof point if possible.
+- Match the role's language without parroting.
+- Avoid generic career-objective statements.
+- Avoid "seeking a challenging opportunity".
+- Avoid "leverage my skills".
+- Avoid saying the candidate is passionate without proof.
+- Avoid mission statements that could fit anyone.
+- Avoid adjectives that replace evidence.
+- Avoid first-person pronouns in the CV summary unless the format calls for it.
+- Check whether the summary would still make sense if the name were removed.
+- If it would fit 1,000 other candidates, rewrite it.
+
+### Skills Section
+
+- Separate hard skills from soft skills where useful.
+- Prioritise role-critical hard skills.
+- Use exact technology names.
+- Use exact methodology names.
+- Use exact domain names.
+- Include soft skills only when backed by experience.
+- Avoid generic soft-skill lists.
+- Avoid "communication" unless shown in bullets.
+- Avoid "leadership" unless shown in bullets.
+- Avoid "teamwork" unless shown in bullets.
+- Avoid "problem solving" unless shown in bullets.
+- Avoid skill lists longer than the experience evidence can support.
+- Avoid listing beginner tools as if expert.
+- Avoid obsolete tools unless relevant.
+- Avoid every tool ever touched.
+- Group skills logically.
+- Use `Languages`, `Frameworks`, `Cloud`, `Data`, `Design`, `Methods`, or equivalent categories.
+- Check skills against the job ad.
+- Remove skills that distract from the target role.
+- Include certifications near skills if they matter to screening.
+
+### Experience Section
+
+- Use company name.
+- Use role title.
+- Use location or remote indicator if useful.
+- Use dates.
+- Add one-line context for obscure companies if helpful.
+- Add scope context when it improves understanding.
+- Mention team size only when relevant.
+- Mention budget only when relevant and permitted.
+- Mention product size, customer size, user size, territory, or operational scope where relevant.
+- Lead each role with the most relevant achievement.
+- Use 3 to 6 bullets for recent relevant roles.
+- Use fewer bullets for older or less relevant roles.
+- Avoid describing the company more than the candidate's contribution.
+- Avoid "responsible for" unless the responsibility itself is the achievement.
+- Avoid job descriptions copied from the employer.
+- Avoid bullets that only list tasks.
+- Avoid chronological clutter that hides the signal.
+- Avoid unexplained career gaps if the gap may distract.
+- Avoid over-explaining gaps when a simple treatment is enough.
+- Avoid negative reasons for leaving.
+- Avoid mentioning conflicts with managers.
+- Avoid confidential details.
+- Avoid client names if restricted.
+- Avoid internal codenames.
+- Avoid NDA-risk material.
+
+### Achievement Bullets
+
+- Use action plus context plus method plus result.
+- Use action plus task plus outcome.
+- Use problem, action, result when the problem matters.
+- Use challenge, action, result when senior judgement matters.
+- Start with a strong verb.
+- Follow with the object of the work.
+- Add scale.
+- Add method or tool.
+- Add measurable outcome.
+- Add stakeholder or customer impact where relevant.
+- Add timeframe when impressive.
+- Add baseline when meaningful.
+- Add before-and-after contrast where defensible.
+- Prefer "Reduced onboarding time from 14 days to 6 days" over "Improved onboarding".
+- Prefer "Migrated 42 workflows from spreadsheets to Airtable" over "Used Airtable".
+- Prefer "Resolved 240-ticket backlog in 5 weeks" over "Handled support tickets".
+- Prefer "Built dashboard used by 18 managers" over "Built dashboard".
+- Prefer "Interviewed 23 users and redesigned checkout" over "Improved UX".
+- Avoid orphan metrics with no context.
+- Avoid fake-looking round numbers.
+- Avoid "100% improvement" unless mathematically true.
+- Avoid claiming sole ownership for team work.
+- Avoid "increased revenue" unless contribution path is clear.
+- Avoid "saved costs" unless estimate basis is defensible.
+- Avoid every bullet starting with "Managed".
+- Avoid every bullet starting with "Led".
+- Avoid every bullet having the same rhythm.
+- Avoid bolding the first phrase of every bullet.
+- Avoid using the same formula 20 times.
+
+### Metrics
+
+- Look for revenue.
+- Look for cost reduction.
+- Look for time saved.
+- Look for cycle-time reduction.
+- Look for error reduction.
+- Look for quality improvement.
+- Look for conversion improvement.
+- Look for retention improvement.
+- Look for customer satisfaction.
+- Look for ticket reduction.
+- Look for automation rate.
+- Look for uptime.
+- Look for latency.
+- Look for throughput.
+- Look for adoption.
+- Look for users served.
+- Look for team size.
+- Look for budget scope.
+- Look for project size.
+- Look for delivery speed.
+- Look for compliance outcomes.
+- Look for safety outcomes.
+- Look for training outcomes.
+- Look for stakeholder count.
+- Look for geographic scope.
+- Look for portfolio or case-study proof.
+- If no metric exists, use credible scope.
+- If no metric exists, use qualitative outcome.
+- If no metric exists, use named deliverable.
+- If no metric exists, use frequency.
+- If no metric exists, use complexity.
+- If no metric exists, use risk avoided.
+- Avoid inventing numbers.
+- Avoid pretending estimates are audited facts.
+- Avoid metrics that expose confidential business information.
+
+### Education
+
+- Include degree, institution, and field where relevant.
+- Include graduation year only when helpful and not harmful.
+- Consider omitting graduation year for experienced candidates.
+- Include GPA only if strong and market-relevant.
+- Include honours if useful.
+- Include coursework only for early career or career changes.
+- Include thesis only if relevant.
+- Include licenses where required.
+- Include certifications where current.
+- Check certification names exactly.
+- Check expiry dates.
+- Avoid listing high school unless early career or locally expected.
+- Avoid outdated training that does not help.
+- Avoid overloading education when experience is stronger.
+
+### Projects
+
+- Include projects when they prove role-relevant skills.
+- Include live links where possible.
+- Include GitHub links where code quality helps.
+- Include case studies where decision-making matters.
+- Explain the problem solved.
+- Explain the user's role.
+- Explain the stack or method.
+- Explain the result.
+- Include adoption or usage if available.
+- Include technical constraints if impressive.
+- Include design constraints if impressive.
+- Include business constraints if impressive.
+- Avoid toy projects unless early career.
+- Avoid dead links.
+- Avoid projects with no explanation.
+- Avoid projects that distract from the target role.
+- Avoid claiming production impact for hobby work.
+
+### Portfolio
+
+- Check whether the portfolio matches the CV.
+- Check whether the top portfolio items match the target job.
+- Check whether each case study shows problem, process, decision, and result.
+- Check whether visuals are readable.
+- Check whether screenshots show real work where permitted.
+- Check whether confidential work is anonymised.
+- Check whether portfolio navigation is simple.
+- Check whether the first page loads quickly.
+- Check whether the portfolio works on mobile.
+- Check whether the portfolio has a clear contact path.
+- Avoid making the recruiter hunt.
+- Avoid password gates without instructions.
+- Avoid overly long case studies with no summary.
+- Avoid case studies that sound AI-written.
+
+### Career Gaps And Transitions
+
+- Decide whether the gap needs explanation.
+- Explain only what helps.
+- Use neutral wording.
+- Emphasise skills maintained.
+- Emphasise study, caregiving, contracting, volunteering, or projects where true.
+- Do not over-disclose medical, family, or personal details.
+- Do not apologise for a gap.
+- Do not let the gap dominate the CV.
+- For career changers, lead with transferable proof.
+- For career changers, map old work to new role requirements.
+- For career changers, show training plus applied evidence.
+- For career changers, avoid pretending the transition is complete if evidence is early.
+
+### Seniority Signals
+
+- Check whether the CV shows decision ownership.
+- Check whether the CV shows trade-offs.
+- Check whether the CV shows ambiguity handled.
+- Check whether the CV shows cross-functional influence.
+- Check whether the CV shows hiring, mentoring, or coaching where relevant.
+- Check whether the CV shows budgets or commercial accountability where relevant.
+- Check whether the CV shows governance or risk responsibility where relevant.
+- Check whether the CV shows systems thinking.
+- Check whether the CV shows scale.
+- Check whether the CV shows stakeholder trust.
+- Avoid senior language without senior evidence.
+- Avoid "strategic" as a filler word.
+- Avoid "executive presence" unless supported.
+- Avoid "thought leadership" unless externally proven.
+
+### Early Career Signals
+
+- Check internships.
+- Check coursework.
+- Check projects.
+- Check volunteering.
+- Check clubs.
+- Check hackathons.
+- Check competitions.
+- Check part-time work.
+- Check customer-facing experience.
+- Check reliability signals.
+- Check learning velocity.
+- Check practical tools.
+- Check clear role target.
+- Avoid padding.
+- Avoid school assignments framed as enterprise-scale work.
+- Avoid a summary that overstates seniority.
+- Avoid too many buzzwords.
+
+### Technical CV Checks
+
+- Check programming languages match actual usage.
+- Check frameworks match actual projects.
+- Check cloud tools match actual deployment experience.
+- Check databases match actual query, design, or admin experience.
+- Check AI and ML claims are specific.
+- Check security claims are specific.
+- Check DevOps claims are specific.
+- Check testing claims are specific.
+- Check architecture claims are specific.
+- Check scale claims include scale.
+- Check whether links to repos are clean.
+- Check whether public repos do not leak secrets.
+- Check whether pinned projects are maintained.
+- Avoid listing libraries used once.
+- Avoid claiming AI expertise for basic prompting.
+- Avoid "full-stack" if evidence is shallow.
+- Avoid acronym soup.
+- Avoid tool lists with no impact.
+
+### Non-Technical CV Checks
+
+- Check customer, stakeholder, or user outcomes.
+- Check operational scale.
+- Check process improvements.
+- Check compliance or quality outcomes.
+- Check team coordination.
+- Check commercial outcomes.
+- Check communication outputs.
+- Check training or enablement outputs.
+- Check conflict resolution where relevant.
+- Check planning and execution.
+- Avoid generic soft skills.
+- Avoid fluffy people-person wording.
+- Avoid duties-only bullets.
+- Avoid vague "supported the team" language.
+
+### Cover Letter Checks
+
+- Write it for one employer.
+- Open with the role and why it fits.
+- Include 2 to 3 specific proof points.
+- Connect the proof points to the employer's needs.
+- Mention the company only if the reference is real and specific.
+- Avoid generic admiration.
+- Avoid repeating the CV.
+- Avoid long origin stories.
+- Avoid "I am writing to express my interest" if a sharper opening is possible.
+- Avoid "your esteemed organisation".
+- Avoid AI-polished corporate filler.
+- Avoid fake enthusiasm.
+- Avoid claiming to share values without evidence.
+- Avoid overexplaining career gaps.
+- End with a direct, calm next step.
+- Keep it concise unless the sector expects more.
+- Check it sounds like the applicant would speak in interview.
+
+### LinkedIn And Online Consistency
+
+- Check title consistency.
+- Check date consistency.
+- Check employer-name consistency.
+- Check education consistency.
+- Check certification consistency.
+- Check location consistency.
+- Check portfolio consistency.
+- Check whether LinkedIn headline supports the target role.
+- Check whether LinkedIn About section sounds human.
+- Check whether featured links support the application.
+- Check whether public activity contradicts the role target.
+- Check whether old content creates risk.
+- Avoid CV claims not present anywhere else if they are major.
+- Avoid LinkedIn over-branding that conflicts with a conservative CV.
+- Avoid mismatched seniority signals.
+
+### Submission Checks
+
+- Confirm the employer's requested file type.
+- Confirm the employer's AI-use policy if stated.
+- Confirm the application deadline.
+- Confirm the role title.
+- Confirm company name spelling.
+- Confirm recruiter name spelling if used.
+- Confirm salary and location assumptions.
+- Confirm remote, hybrid, or onsite requirements.
+- Confirm work rights requirements.
+- Confirm the CV filename.
+- Confirm the cover letter filename.
+- Confirm the plain-text parse.
+- Confirm no tracked changes remain.
+- Confirm no comments remain.
+- Confirm no private notes remain.
+- Confirm PDF metadata is not embarrassing.
+- Confirm links work.
+- Confirm contact details are correct.
+- Confirm the application portal did not mangle fields.
+- Keep a copy of exactly what was submitted.
+- Log the submitted version.
+- Log the job description.
+- Log the submission date.
+- Log any recruiter contact.
+
+## Red Flags To Look For In Any CV
+
+- The CV could fit any job in the category.
+- The CV repeats the job ad without evidence.
+- The CV uses big claims with no examples.
+- The CV is all responsibilities and no outcomes.
+- The CV uses long paragraphs.
+- The CV hides important details in design elements.
+- The CV has inconsistent dates.
+- The CV has inconsistent job titles.
+- The CV includes unexplained overlapping full-time roles.
+- The CV includes unsupported metrics.
+- The CV includes too many buzzwords.
+- The CV includes too many tools.
+- The CV has no clear target role.
+- The CV sounds like a template.
+- The CV sounds like a LinkedIn influencer post.
+- The CV sounds like ChatGPT summarising a job description.
+- The CV includes hidden text.
+- The CV includes white text.
+- The CV includes keyword stuffing.
+- The CV includes made-up certifications.
+- The CV includes fake referrals.
+- The CV includes unverifiable "top 1%" claims.
+- The CV overuses "strategic".
+- The CV overuses "innovative".
+- The CV overuses "transformational".
+- The CV overuses "cross-functional".
+- The CV overuses "stakeholder management".
+- The CV overuses "data-driven" without data.
+- The CV overuses "AI-powered" without substance.
+- The CV has no human choices in wording.
+
+## Anti AI-Slop Checklist
+
+### Core Principle
+
+- Replace generic fluency with specific evidence.
+- Replace template rhythm with real sentence variation.
+- Replace buzzwords with concrete work.
+- Replace inflated adjectives with proof.
+- Replace "I helped" vagueness with actual contribution.
+- Replace "I drove impact" with the impact.
+- Replace "I leveraged" with the tool, method, and result.
+- Replace "I utilised" with "used" unless the field expects formal language.
+- Replace "robust" with the actual reliability feature.
+- Replace "seamless" with the actual friction removed.
+- Replace "transformative" with what changed.
+- Replace "innovative" with what was new.
+- Replace "strategic" with the decision made.
+- Replace "collaborative" with who was involved and how.
+- Replace "stakeholder alignment" with the disagreement resolved.
+- Replace "optimised" with what improved.
+- Replace "enhanced" with the measurable improvement.
+- Replace "streamlined" with the process before and after.
+- Replace "spearheaded" with the action if "led" is enough.
+- Replace "orchestrated" with plain language unless coordination was the point.
+
+### AI-Sounding Words To Challenge
+
+- Challenge "delve".
+- Challenge "tapestry".
+- Challenge "intricate".
+- Challenge "meticulous".
+- Challenge "pivotal".
+- Challenge "underscore".
+- Challenge "testament".
+- Challenge "vibrant".
+- Challenge "foster".
+- Challenge "bolster".
+- Challenge "showcase".
+- Challenge "enhance".
+- Challenge "elevate".
+- Challenge "leverage".
+- Challenge "utilize".
+- Challenge "synergy".
+- Challenge "realm".
+- Challenge "landscape".
+- Challenge "dynamic".
+- Challenge "multifaceted".
+- Challenge "robust".
+- Challenge "seamless".
+- Challenge "cutting-edge".
+- Challenge "game-changing".
+- Challenge "world-class".
+- Challenge "best-in-class".
+- Challenge "future-proof".
+- Challenge "holistic".
+- Challenge "impactful".
+- Challenge "empower".
+- Challenge "drive meaningful change".
+- Challenge "unlock value".
+- Challenge "navigate complexity".
+- Challenge "at the intersection of".
+- Challenge "in today's fast-paced world".
+- Challenge "ever-evolving".
+- Challenge "deep understanding".
+- Challenge "proven track record".
+- Challenge "passionate about".
+- Challenge "results-driven".
+- Challenge "highly motivated".
+- Challenge "self-starter".
+- Challenge "detail-oriented" unless backed by proof.
+
+### AI-Sounding Phrases To Remove Or Rewrite
+
+- Remove "I am excited to apply for".
+- Remove "I am writing to express my interest".
+- Remove "Your company's commitment to innovation".
+- Remove "I was immediately drawn to".
+- Remove "In today's rapidly changing world".
+- Remove "This role perfectly aligns with my background".
+- Remove "My unique blend of skills".
+- Remove "I bring a wealth of experience".
+- Remove "I thrive in fast-paced environments".
+- Remove "I am confident I would be a valuable addition".
+- Remove "Throughout my career, I have consistently".
+- Remove "I have had the privilege of".
+- Remove "I am deeply passionate about".
+- Remove "I possess a strong foundation in".
+- Remove "I have a proven ability to".
+- Remove "I would welcome the opportunity to discuss".
+- Remove "Thank you for your time and consideration" if it is only filler.
+- Rewrite any sentence that could be pasted into another applicant's letter.
+- Rewrite any paragraph that has no employer-specific detail.
+- Rewrite any claim that has no work sample, metric, or example behind it.
+
+### Structural AI Tells
+
+- Watch for every bullet having the same length.
+- Watch for every bullet using the same action-result formula.
+- Watch for every paragraph having the same cadence.
+- Watch for repeated three-part lists.
+- Watch for repeated "not only X, but also Y" framing.
+- Watch for rhetorical questions in professional documents.
+- Watch for generic opening enthusiasm.
+- Watch for a perfectly balanced paragraph that says nothing concrete.
+- Watch for bold labels at the start of every bullet.
+- Watch for excessive signposting.
+- Watch for overuse of colons.
+- Watch for overuse of semicolons.
+- Watch for overuse of parentheses.
+- Watch for overly polished transitions.
+- Watch for "Furthermore", "Moreover", and "Additionally" stacking.
+- Watch for all bullets starting with gerunds.
+- Watch for all bullets starting with "Led".
+- Watch for all bullets starting with "Managed".
+- Watch for all bullets ending in vague outcomes.
+- Watch for bullet endings like "to drive business success".
+- Watch for bullet endings like "to deliver measurable impact" with no measure.
+- Watch for paragraphs that read like a summary of the job ad.
+
+### Punctuation And Formatting AI Tells
+
+- Avoid em dashes in CVs and cover letters unless the applicant naturally uses them and the market expects them.
+- Avoid curly quotes if the rest of the document uses straight quotes.
+- Avoid decorative unicode arrows.
+- Avoid unusual bullet symbols.
+- Avoid excessive bolding.
+- Avoid bolded lead-ins on every bullet.
+- Avoid title case for every phrase.
+- Avoid over-capitalising concepts.
+- Avoid emoji.
+- Avoid icons in ATS versions.
+- Avoid overly perfect symmetry.
+- Avoid AI-looking markdown artefacts in final documents.
+- Avoid leaving headings like "Summary:" inside bullet text.
+- Avoid generated section labels that are not normal CV sections.
+
+### Tone AI Tells
+
+- Watch for generic positivity.
+- Watch for sycophantic praise.
+- Watch for exaggerated humility.
+- Watch for empty confidence.
+- Watch for too much corporate warmth.
+- Watch for phrases that sound like a productivity blog.
+- Watch for "human-centric" without an actual user.
+- Watch for "mission-driven" without a mission example.
+- Watch for "empathetic leader" without leadership evidence.
+- Watch for "customer-obsessed" without customer evidence.
+- Watch for "data-driven" without data.
+- Watch for "AI-native" without actual AI work.
+- Watch for "agentic" where ordinary automation is meant.
+- Watch for "transformational" where "improved" is accurate.
+- Watch for "strategic" where "planned" is accurate.
+- Watch for "executed flawlessly" unless it is true and provable.
+
+### Detector-Risk Patterns
+
+- Treat these as false-positive risk signals, not proof of AI use.
+- Very predictable sentence structure can raise risk.
+- Very generic vocabulary can raise risk.
+- Very smooth transitions can raise risk.
+- Low specificity can raise risk.
+- Repetition of common AI phrases can raise risk.
+- Overly uniform sentence length can raise risk.
+- Overly formal ESL-style writing can be unfairly flagged.
+- Paraphrased AI text can still sound generic.
+- Humanized AI text can become worse, not better.
+- Deliberate typos are a bad fix.
+- Random contractions are a bad fix.
+- Injecting slang is a bad fix.
+- Adding personal anecdotes unrelated to the role is a bad fix.
+- Making claims messier is a bad fix.
+- Removing all polish is a bad fix.
+- The correct fix is stronger source evidence.
+- The correct fix is applicant-specific wording.
+- The correct fix is domain-specific detail.
+- The correct fix is defensible metrics.
+- The correct fix is natural variation.
+- The correct fix is human review.
+
+### Detector And Privacy Safety
+
+- Do not upload an unredacted CV to public detector sites.
+- Do not upload names to detector sites.
+- Do not upload emails to detector sites.
+- Do not upload phone numbers to detector sites.
+- Do not upload addresses to detector sites.
+- Do not upload employer-sensitive project names to detector sites.
+- Do not upload client names to detector sites.
+- Do not upload confidential metrics to detector sites.
+- Do not upload private job-search notes to detector sites.
+- Use a redacted copy if testing false-positive risk.
+- Treat detector scores as noisy.
+- Do not optimise the CV to a detector score.
+- Do not reject good writing because one detector dislikes it.
+- Compare multiple signals if checking at all.
+- Keep the original source facts.
+- Keep the draft trail.
+- Keep the job description used for tailoring.
+- Keep a record of what was edited and why.
+- If an employer forbids AI assistance, follow the employer's rule.
+- If an employer asks for disclosure, disclose according to their instructions.
+
+### Human Voice Preservation
+
+- Compare the cover letter to the applicant's real writing.
+- Keep sentence lengths varied.
+- Keep word choice natural to the applicant.
+- Keep examples the applicant would actually mention.
+- Keep level of formality appropriate to the industry.
+- Keep the applicant's actual career logic.
+- Keep plain language where plain language works.
+- Keep technical precision where technical precision matters.
+- Use first person in cover letters where natural.
+- Avoid first person in CV bullets unless local norms allow it.
+- Avoid generic warmth.
+- Avoid over-polishing every rough edge.
+- Avoid making a practical person sound like a consultant.
+- Avoid making a technical person sound like a marketing brochure.
+- Avoid making an early-career person sound executive.
+- Avoid making a senior person sound vague.
+- Read it aloud.
+- Ask whether the applicant would say this in an interview.
+- Ask whether the applicant can defend it under follow-up questions.
+
+### AI Rewrite QA
+
+- For every AI-generated bullet, identify the source fact.
+- For every AI-generated metric, identify the source number.
+- For every AI-generated tool claim, identify where it was used.
+- For every AI-generated leadership claim, identify the actual leadership.
+- For every AI-generated company reference, verify it is true.
+- For every AI-generated cover-letter compliment, verify it is specific.
+- For every AI-generated achievement, verify it is not inflated.
+- For every AI-generated skill, verify it belongs on the CV.
+- For every AI-generated sentence, ask what it adds.
+- Delete any sentence that only sounds professional.
+- Delete any sentence that says the obvious.
+- Delete any sentence that cannot be defended.
+- Delete any sentence that could belong to any candidate.
+- Delete any sentence copied too closely from the job description.
+- Delete any sentence that hides uncertainty.
+
+## Anti-Slop Rewrite Rules
+
+- Change "Leveraged data-driven insights to enhance customer experience" to a concrete action and result.
+- Change "Drove operational excellence" to the process improved and the metric.
+- Change "Collaborated cross-functionally" to the teams involved and the output.
+- Change "Supported key stakeholders" to who, how, and why it mattered.
+- Change "Optimised workflows" to before, after, and method.
+- Change "Improved efficiency" to time saved, error reduced, or throughput increased.
+- Change "Managed multiple priorities" to workload, deadline, and result.
+- Change "Contributed to successful project delivery" to the actual contribution.
+- Change "Played a key role" to the specific role.
+- Change "Helped develop" to designed, wrote, tested, researched, coordinated, analysed, or launched, if true.
+- Change "Responsible for" to an action verb.
+- Change "Worked on" to the output created.
+- Change "Assisted with" to the task completed.
+- Change "Participated in" to the contribution made.
+- Change "Gained exposure to" to a skill only if it is genuinely usable.
+- Change "Familiar with" to remove it unless the job requires awareness-level knowledge.
+- Change "Passionate about AI" to an actual AI project, workflow, or result.
+- Change "Strong communicator" to a presentation, documentation, training, sales, negotiation, or stakeholder example.
+- Change "Natural leader" to people led, decisions made, or outcomes owned.
+
+## Role-Specific Review Angles
+
+### Software Engineering
+
+- Check code impact.
+- Check systems impact.
+- Check production usage.
+- Check scale.
+- Check reliability.
+- Check testing.
+- Check security.
+- Check performance.
+- Check maintainability.
+- Check collaboration with product, design, data, or operations.
+- Check whether tool lists are backed by project bullets.
+- Check whether AI claims are implementation-level or just prompt use.
+- Avoid stuffing every language.
+- Avoid no-context GitHub links.
+- Avoid vague "worked on backend".
+
+### Product Management
+
+- Check customer problem.
+- Check discovery method.
+- Check prioritisation.
+- Check trade-offs.
+- Check roadmap influence.
+- Check launch outcome.
+- Check metrics.
+- Check stakeholder alignment.
+- Check commercial impact.
+- Check user impact.
+- Avoid "owned roadmap" without scope.
+- Avoid "defined strategy" without choices made.
+- Avoid AI-sounding product jargon.
+
+### Design And UX
+
+- Check problem framing.
+- Check research method.
+- Check design decisions.
+- Check constraints.
+- Check iteration.
+- Check usability outcomes.
+- Check conversion or adoption outcomes.
+- Check accessibility.
+- Check handoff quality.
+- Check portfolio link quality.
+- Avoid visual-only claims.
+- Avoid "improved UX" without user evidence.
+- Avoid generic empathy language.
+
+### Operations
+
+- Check process before and after.
+- Check cost, time, quality, safety, or compliance outcomes.
+- Check volume handled.
+- Check escalation handling.
+- Check workforce or vendor coordination.
+- Check systems improved.
+- Check reporting improved.
+- Avoid "kept things running smoothly" without proof.
+- Avoid generic multi-tasking language.
+
+### Sales
+
+- Check quota.
+- Check attainment.
+- Check pipeline.
+- Check deal size.
+- Check cycle length.
+- Check territory.
+- Check vertical.
+- Check conversion.
+- Check retention or expansion.
+- Check CRM accuracy.
+- Avoid revenue claims without context.
+- Avoid vague relationship language.
+
+### Customer Support And Success
+
+- Check ticket volume.
+- Check resolution time.
+- Check CSAT, NPS, churn, retention, or expansion.
+- Check escalation complexity.
+- Check customer segment.
+- Check knowledge-base contribution.
+- Check product feedback loops.
+- Avoid "excellent customer service" without proof.
+- Avoid generic empathy language.
+
+### Marketing
+
+- Check channel.
+- Check audience.
+- Check campaign.
+- Check spend.
+- Check conversion.
+- Check attribution caveats.
+- Check content output.
+- Check pipeline or revenue influence.
+- Check brand or growth result.
+- Avoid vanity metrics alone.
+- Avoid "created engaging content" without performance evidence.
+
+### Data And Analytics
+
+- Check business question.
+- Check data source.
+- Check method.
+- Check tool.
+- Check output.
+- Check decision influenced.
+- Check adoption.
+- Check governance.
+- Check accuracy or quality improvement.
+- Avoid dashboard claims without users or decisions.
+- Avoid model claims without validation.
+
+## Final Pre-Submit Checklist
+
+- The target role is obvious.
+- The top third sells the strongest fit.
+- The CV uses one column.
+- The CV uses standard headings.
+- The CV uses text-based content.
+- The CV passes a plain-text copy test.
+- Every bullet has a purpose.
+- Most bullets show action and result.
+- Key skills match the job description.
+- Skills are not stuffed.
+- Dates are consistent.
+- LinkedIn is consistent.
+- Contact details are correct.
+- Links work.
+- No hidden text exists.
+- No private comments remain.
+- No tracked changes remain.
+- No unverified claims remain.
+- No fake metrics remain.
+- No AI-slop phrases remain.
+- No public detector received unredacted PII.
+- Cover letter sounds like the applicant.
+- Cover letter is specific to the employer.
+- The final version is saved and logged.
+
+## Source Links
+
+- Harvard FAS, AI for resumes and cover letters: https://careerservices.fas.harvard.edu/ai-resumes-and-cover-letters/
+- Harvard FAS, Create a strong resume: https://careerservices.fas.harvard.edu/channels/create-a-resume-cv-or-cover-letter/
+- MIT CAPD resume guidance: https://capd.mit.edu/resources/resumes/
+- Stanford career resume guidance: https://careered.stanford.edu/jobs-internships/resumes-cover-letters
+- r/EngineeringResumes wiki: https://www.reddit.com/r/EngineeringResumes/wiki/index/
+- Greenhouse AI features: https://support.greenhouse.io/hc/en-us/articles/33043749845403-Greenhouse-AI-features
+- Lever ATS myths: https://www.lever.co/blog/applicant-tracking-system-myths/
+- Workday Recruiting: https://www.workday.com/en-us/products/human-capital-management/recruiting.html
+- Indeed Smart Sourcing and Smart Fit: https://www.indeed.com/hire/smart-sourcing
+- OpenAI note on AI classifier discontinuation: https://openai.com/index/new-ai-classifier-for-indicating-ai-written-text/
+- Liang et al., GPT detectors are biased against non-native English writers: https://www.cell.com/patterns/fulltext/S2666-3899(23)00130-7
+- NBER, Artificial Writing and Education: https://www.nber.org/papers/w34397
+- Wikipedia, Signs of AI writing: https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
+- GitHub AI writing tells search surface: https://github.com/search?q=ai+tells+writing&type=repositories
+- Your local ApplyPass research notes: `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\CV_research_1_2.md` and `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\CV_research_2_2.md`

--- a/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1b.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1b.md
@@ -1,0 +1,1041 @@
+# Modern CV Review Checklist 2026, Round 2
+
+Research date: 2026-05-18
+
+Purpose:
+
+- This is a companion file to `CV_modern_research_checklist_2026.md`.
+- It focuses on extra checks, edge cases, forum failure modes, recruiter suspicion patterns, AI-screening realities, and advanced anti-slop cleanup.
+- It intentionally avoids repeating the main first-pass checklist where possible.
+- Use Round 1 for the broad CV checklist.
+- Use this Round 2 file for deeper review, adversarial QA, and product-rule extraction.
+
+Core stance:
+
+- A modern CV is not just a document.
+- A modern CV is an evidence packet.
+- It must satisfy a parser.
+- It must satisfy a ranking system.
+- It must satisfy a tired recruiter.
+- It must satisfy a hiring manager looking for proof.
+- It must survive interview cross-examination.
+- It must not leak private data to detector tools.
+- It must not look mass-produced.
+
+## Extra Research Takeaways
+
+- Current ATS discussion is still confused by design.
+- Many candidates use "ATS" to mean parser, ranking, knockout questions, recruiter search, AI matching, and employer workflow.
+- Separate parser risk from ranking risk.
+- Separate ranking risk from recruiter judgement.
+- Separate recruiter judgement from hiring manager judgement.
+- Separate hiring manager judgement from interview performance.
+- Do not promise that a perfect ATS score creates interviews.
+- Do not assume a rejection means the parser failed.
+- Do not assume silence means AI rejected the CV.
+- Do not assume every ATS has AI detection.
+- Treat "AI screen" claims from applicants as possible but unverified unless the employer discloses it.
+- Treat keyword matching as necessary but insufficient.
+- Treat semantic matching as increasingly important.
+- Treat career narrative as a human trust layer.
+- Treat cover letters as high effort only when they are likely to be read.
+- Treat screening questions as part of the same application evidence packet.
+- Treat LinkedIn and portfolio as verification surfaces.
+- Treat every generated line as a future interview question.
+
+## Round 2 Review Workflow
+
+- Read the job ad once for intent.
+- Read it again for hard filters.
+- Read it again for hidden seniority.
+- Read it again for domain vocabulary.
+- Read it again for evidence the employer will want in interview.
+- Build a "proof map" before editing the CV.
+- Mark claims as proven, estimated, weak, or missing.
+- Remove weak claims before adding style.
+- Fix role fit before fixing wording.
+- Fix evidence before fixing tone.
+- Fix parser output before fixing design.
+- Fix generic AI cadence before final proofreading.
+- Compare the final CV to the original applicant record.
+- Confirm the person in the CV is the person who will attend the interview.
+
+## CV As Evidence Packet
+
+- Every important claim should point to a source.
+- Every source should be acceptable to discuss.
+- Every source should be safe to reveal or paraphrase.
+- Every role should have a "why this matters" reason.
+- Every recent role should show the work level.
+- Every old role should justify the space it takes.
+- Every project should prove a requirement or remove doubt.
+- Every qualification should support the target screen.
+- Every link should support trust.
+- Every omission should be intentional.
+- Every estimate should be labelled internally as an estimate.
+- Every risky claim should have interview notes.
+- Every private claim should be sanitised.
+- Every confidential metric should have a safe version.
+- Every generated asset should store its source job ad.
+- Every generated asset should store its source CV version.
+- Every generated asset should store its rule version.
+- Every generated asset should store its human edits.
+
+## Parser Output Checks
+
+- Upload the file to the portal and inspect every populated field before submitting.
+- Check whether role titles break across lines.
+- Check whether company names merge into role titles.
+- Check whether dates attach to the wrong employer.
+- Check whether bullets lose punctuation.
+- Check whether bullets join into one block.
+- Check whether line breaks split keywords.
+- Check whether hyphenated words split into fragments.
+- Check whether links become plain text.
+- Check whether email and phone parse correctly.
+- Check whether city and country parse correctly.
+- Check whether skills land in the skills field.
+- Check whether education entries land in the education field.
+- Check whether certifications land in the right field.
+- Check whether current role is detected as current.
+- Check whether "Present" is understood.
+- Check whether contract roles appear as job hopping.
+- Check whether freelance work appears as unemployment.
+- Check whether multiple roles at one company create duplicate employers.
+- Check whether hidden metadata creates strange parser text.
+- Check whether PDF copy-paste preserves bullet order.
+- Check whether DOCX upload changes spacing.
+- Check whether mobile portal upload changes formatting.
+- Keep screenshots of broken parser output for future rule updates.
+
+## Ranking And Semantic Matching Checks
+
+- Map job ad skills to exact CV evidence.
+- Map skill synonyms to canonical names.
+- Add canonical names without removing the applicant's natural wording.
+- Include the tool family when the employer uses a broad term.
+- Include the exact tool when the employer names a tool.
+- Include equivalent tools only when the equivalence is obvious.
+- Explain adjacent experience where a semantic matcher may miss it.
+- Use both human phrasing and machine-readable terms.
+- Avoid hiding important skills inside long sentences.
+- Avoid making the skills section the only place a skill appears.
+- Put key skills in work context.
+- Pair every critical keyword with a proof bullet.
+- Pair every domain keyword with a project, employer, or outcome.
+- Use acronyms and expanded forms once when both are common.
+- Do not overfit to one keyword if the job clearly asks for a capability.
+- Do not add synonyms that imply tools the applicant has not used.
+- Do not repeat a keyword just to increase density.
+- Do not chase a 100 percent match score.
+- Do not turn a CV into search-engine spam.
+
+## Knockout And Compliance Checks
+
+- Identify mandatory licences.
+- Identify required work rights.
+- Identify required location.
+- Identify required clearance.
+- Identify required years of experience.
+- Identify required degree.
+- Identify required industry experience.
+- Identify required language ability.
+- Identify mandatory travel.
+- Identify mandatory shift patterns.
+- Identify mandatory onsite days.
+- Identify salary constraints.
+- Identify portfolio requirements.
+- Identify writing sample requirements.
+- Identify assessment requirements.
+- If a requirement is missing, do not hide it with wording.
+- If a requirement is partially met, describe the partial match honestly.
+- If a requirement is impossible, consider not applying.
+- If a requirement is discriminatory or legally questionable, flag it separately.
+- Make sure screening-question answers match the CV.
+- Make sure cover-letter claims match screening-question answers.
+
+## Job Ad Deconstruction
+
+- Highlight tasks repeated in multiple sections.
+- Highlight verbs used in responsibilities.
+- Highlight nouns used in requirements.
+- Highlight outcomes used in success criteria.
+- Highlight phrases that reveal pain.
+- Highlight phrases that reveal urgency.
+- Highlight phrases that reveal team maturity.
+- Highlight phrases that reveal process chaos.
+- Highlight phrases that reveal compliance risk.
+- Highlight phrases that reveal customer pressure.
+- Highlight phrases that reveal technical debt.
+- Highlight phrases that reveal growth stage.
+- Highlight phrases that reveal cost pressure.
+- Highlight phrases that reveal a replacement hire.
+- Highlight phrases that reveal a new role.
+- Highlight phrases that reveal leadership expectation.
+- Highlight phrases that reveal individual contributor expectation.
+- Highlight contradictions inside the ad.
+- Highlight impossible wish-list combinations.
+- Decide which requirements are likely real filters.
+- Decide which requirements are recruiter copy-paste.
+- Decide which requirements are hiring-manager pain.
+- Tailor to pain, not just keywords.
+
+## Recruiter Trust Checks
+
+- Does the CV make the recruiter's job easier?
+- Does the CV answer why this candidate belongs in the shortlist?
+- Does the CV reduce uncertainty?
+- Does the CV show enough context to believe the claims?
+- Does the CV avoid making the recruiter decode jargon?
+- Does the CV avoid forcing the recruiter to infer everything?
+- Does the CV show recent relevance?
+- Does the CV show job stability without hiding facts?
+- Does the CV show trajectory?
+- Does the CV explain unusual transitions calmly?
+- Does the CV avoid desperation signals?
+- Does the CV avoid spray-and-pray signals?
+- Does the CV avoid suspiciously perfect mirroring of the job ad?
+- Does the CV avoid sounding like the same AI builder everyone else used?
+- Does the CV have a few memorable, specific facts?
+- Does the CV give the recruiter language they can pass to the hiring manager?
+
+## Hiring Manager Trust Checks
+
+- Does the CV show how the person thinks?
+- Does the CV show what the person improves?
+- Does the CV show what the person can do without hand-holding?
+- Does the CV show what kind of problems the person has handled?
+- Does the CV show the depth behind the tools?
+- Does the CV show judgement under constraints?
+- Does the CV show ownership without exaggeration?
+- Does the CV show technical or domain taste?
+- Does the CV show the difference between participation and accountability?
+- Does the CV show examples that could be discussed for 10 minutes?
+- Does the CV make the hiring manager curious?
+- Does the CV avoid making the hiring manager suspicious?
+- Does the CV avoid vague "impact" language?
+- Does the CV avoid all polish and no substance?
+
+## Interview Cross-Examination Checks
+
+- For each bullet, ask: "What happened before this work?"
+- For each bullet, ask: "What exactly did you do?"
+- For each bullet, ask: "What did other people do?"
+- For each bullet, ask: "What was hard about it?"
+- For each bullet, ask: "What trade-off did you make?"
+- For each bullet, ask: "How do you know it worked?"
+- For each bullet, ask: "What would you do differently now?"
+- For each bullet, ask: "What tool or method mattered most?"
+- For each bullet, ask: "What part are you proud of?"
+- For each bullet, ask: "What number might they challenge?"
+- For each bullet, ask: "Can you explain it without reading the CV?"
+- Delete or soften any bullet that fails these questions.
+- Add notes for any bullet with a complex backstory.
+- Add a safer version for any bullet touching confidential work.
+
+## Claim Strength Labels
+
+- Label audited metrics as strong.
+- Label dashboard metrics as strong if the source is stable.
+- Label manager-verified outcomes as strong.
+- Label public portfolio proof as strong.
+- Label customer-visible work as strong.
+- Label estimates as medium.
+- Label self-reported improvement as medium.
+- Label anecdotal outcomes as medium or weak.
+- Label generic praise as weak.
+- Label unsupported adjectives as weak.
+- Label inferred business impact as weak unless the chain is clear.
+- Label shared team outcomes as shared, not solo.
+- Label assisted work as assisted.
+- Label exposure as exposure.
+- Label training as training.
+- Label aspiration as aspiration.
+- Keep weak claims out of prime real estate.
+
+## Evidence Upgrade Prompts
+
+- What was the starting point?
+- What changed after the work?
+- How many people used it?
+- How often did it run?
+- How much time did it save per week?
+- How many customers were affected?
+- How many staff were affected?
+- How many teams were involved?
+- What system replaced the old way?
+- What process became easier?
+- What decision did the work enable?
+- What risk was reduced?
+- What error stopped happening?
+- What manual task disappeared?
+- What deadline was met?
+- What audit was passed?
+- What stakeholder changed their behaviour?
+- What customer complaint reduced?
+- What operational bottleneck moved?
+- What part of the work can be shown publicly?
+
+## Over-Optimisation Warnings
+
+- Beware a CV that scores well but reads badly.
+- Beware a CV that matches keywords but lacks proof.
+- Beware a CV that repeats the job ad too closely.
+- Beware a CV that sounds senior but proves junior work.
+- Beware a CV that sounds technical but proves tool exposure only.
+- Beware a CV that sounds strategic but shows no decisions.
+- Beware a CV that sounds polished but cannot be interviewed.
+- Beware a CV that hides the applicant's real strengths.
+- Beware a CV that makes every role look like the target role.
+- Beware a CV that removes personality entirely.
+- Beware a CV that chases every scanner suggestion.
+- Beware a CV that includes every possible synonym.
+- Beware a CV that optimises for a fake certainty score.
+- Beware a CV that becomes less truthful after tailoring.
+
+## Forum Failure Modes To Watch
+
+- The applicant uses a fancy builder because the preview looks good.
+- The applicant trusts a scanner score more than a human read.
+- The applicant assumes every rejection is because of ATS.
+- The applicant writes a cover letter for a company that auto-rejects before reading it.
+- The applicant burns hours on applications with low fit.
+- The applicant mass-tailors weak evidence into stronger-sounding claims.
+- The applicant changes job titles to match the ad too aggressively.
+- The applicant stuffs skills into old roles where they were not used.
+- The applicant hides employment type and creates confusion.
+- The applicant lists every technology and looks unfocused.
+- The applicant removes too much context and sounds generic.
+- The applicant uses AI to generate warmth instead of adding real detail.
+- The applicant uses AI to write cover letters that repeat the CV.
+- The applicant uses AI-humanizer tools that make wording stranger.
+- The applicant copies Reddit advice without adapting it to sector, country, or level.
+
+## Low-Signal CV Patterns
+
+- "Responsible for daily operations" with no scale.
+- "Worked with stakeholders" with no stakeholder type.
+- "Supported projects" with no project output.
+- "Improved processes" with no before state.
+- "Helped customers" with no volume or outcome.
+- "Used data" with no source or decision.
+- "Built reports" with no users or action.
+- "Managed systems" with no system type.
+- "Assisted leadership" with no deliverable.
+- "Contributed to growth" with no mechanism.
+- "Handled admin" with no complexity.
+- "Maintained documentation" with no audience.
+- "Provided insights" with no decision made.
+- "Optimised campaigns" with no metric.
+- "Led meetings" with no outcome.
+- "Created content" with no audience or result.
+- "Supported compliance" with no standard.
+- "Implemented solutions" with no solution.
+
+## High-Signal Detail Types
+
+- Named problem category.
+- Specific user group.
+- Specific customer segment.
+- Specific operational bottleneck.
+- Specific technical constraint.
+- Specific compliance requirement.
+- Specific business metric.
+- Specific workflow replaced.
+- Specific decision influenced.
+- Specific team interface.
+- Specific delivery deadline.
+- Specific risk avoided.
+- Specific handoff improved.
+- Specific documentation audience.
+- Specific migration scope.
+- Specific incident response.
+- Specific sales motion.
+- Specific retention mechanism.
+- Specific design constraint.
+- Specific training outcome.
+
+## Anti AI-Slop, Round 2
+
+- Remove borrowed confidence.
+- Remove fake certainty.
+- Remove generic excellence.
+- Remove empty transformation.
+- Remove filler strategy language.
+- Remove corporate theatre.
+- Remove unfounded authority.
+- Remove universal claims.
+- Remove template empathy.
+- Remove fake warmth.
+- Remove synthetic enthusiasm.
+- Remove resume-builder sparkle.
+- Remove LinkedIn-influencer phrasing.
+- Remove "impact" when the impact is not named.
+- Remove "value" when the value is not named.
+- Remove "scale" when the scale is not named.
+- Remove "quality" when the quality measure is not named.
+- Remove "growth" when the growth path is not named.
+- Remove "innovation" when the new thing is not named.
+- Remove "efficiency" when the time, cost, or error change is not named.
+
+## AI Slop By Category
+
+### Empty Authority
+
+- Challenge "trusted advisor".
+- Challenge "subject matter expert" without evidence.
+- Challenge "go-to person" without context.
+- Challenge "key contributor" without contribution.
+- Challenge "central figure" without role proof.
+- Challenge "instrumental" without mechanism.
+- Challenge "critical role" without scope.
+- Challenge "driving force" without ownership.
+- Challenge "recognized for" without who recognized it.
+- Challenge "known for" without proof.
+
+### Fake Transformation
+
+- Challenge "transformed operations".
+- Challenge "revolutionized workflow".
+- Challenge "reimagined process".
+- Challenge "reshaped strategy".
+- Challenge "modernized the function".
+- Challenge "accelerated digital transformation".
+- Challenge "enabled a step change".
+- Challenge "created a paradigm shift".
+- Challenge "changed the way teams work".
+- Challenge "brought the business into the future".
+
+### Vague Collaboration
+
+- Challenge "partnered closely".
+- Challenge "worked hand in hand".
+- Challenge "aligned stakeholders".
+- Challenge "built consensus".
+- Challenge "bridged teams".
+- Challenge "facilitated collaboration".
+- Challenge "created alignment".
+- Challenge "engaged cross-functional partners".
+- Challenge "brought people together".
+- Challenge "strengthened relationships".
+
+### Hollow Delivery
+
+- Challenge "delivered outcomes".
+- Challenge "executed initiatives".
+- Challenge "advanced priorities".
+- Challenge "supported delivery".
+- Challenge "enabled success".
+- Challenge "drove execution".
+- Challenge "moved projects forward".
+- Challenge "ensured completion".
+- Challenge "met business needs".
+- Challenge "contributed to objectives".
+
+### Generic Customer Language
+
+- Challenge "improved customer experience".
+- Challenge "put customers first".
+- Challenge "customer-centric".
+- Challenge "enhanced satisfaction".
+- Challenge "delivered exceptional service".
+- Challenge "supported customer success".
+- Challenge "understood customer needs".
+- Challenge "built customer trust".
+- Challenge "strengthened client relationships".
+- Challenge "resolved customer issues" without volume or type.
+
+### Generic AI Language
+
+- Challenge "AI-driven".
+- Challenge "AI-powered".
+- Challenge "intelligent automation".
+- Challenge "agentic workflow".
+- Challenge "next-generation AI".
+- Challenge "LLM-enabled".
+- Challenge "machine-learning enhanced".
+- Challenge "smart automation".
+- Challenge "autonomous system".
+- Challenge "copilot-style" without describing the actual user task.
+
+## Anti-Detector-Risk Without Deception
+
+- Do not add mistakes to look human.
+- Do not add slang to look human.
+- Do not add random contractions to look human.
+- Do not add rambling personal stories to look human.
+- Do not use a humanizer output without line-by-line review.
+- Do not chase "burstiness" as a goal.
+- Do not rewrite clear content into awkward content.
+- Do not make the CV less professional for a detector.
+- Do not pass personal documents through unknown tools.
+- Do not paste live employer-sensitive details into public checkers.
+- Do not believe a detector score without context.
+- Do not let a detector override a truthful, specific, human-readable sentence.
+- Improve specificity instead.
+- Improve source grounding instead.
+- Improve sentence variety naturally instead.
+- Improve applicant voice instead.
+- Improve role relevance instead.
+- Improve proof density instead.
+
+## False Positive Risk Review
+
+- Check whether the applicant is a non-native English writer.
+- Check whether the applicant naturally writes in formal patterns.
+- Check whether the applicant works in a regulated industry with formulaic language.
+- Check whether the document is short.
+- Check whether the document has many standard phrases because the role requires them.
+- Check whether the document uses repeated certification names.
+- Check whether the document uses repeated compliance terms.
+- Check whether the cover letter is too brief for detector confidence.
+- Check whether the CV is mostly bullet fragments.
+- Check whether the text was grammar-corrected heavily.
+- Check whether the final draft lost the applicant's original rhythm.
+- Check whether a detector might penalise clear but predictable writing.
+- Add context before assuming AI misuse.
+
+## Redaction Before External Review
+
+- Replace the applicant name with `Candidate`.
+- Replace employer names with neutral labels where possible.
+- Replace client names with sector labels.
+- Replace project names with function labels.
+- Replace email with `email redacted`.
+- Replace phone with `phone redacted`.
+- Replace address with `location redacted`.
+- Replace portfolio token URLs.
+- Replace private GitHub repository names.
+- Replace internal product codenames.
+- Replace salary details.
+- Replace references.
+- Replace immigration details unless needed for the check.
+- Replace exact dates if not necessary.
+- Preserve enough structure to test writing quality.
+- Preserve enough role context to assess genericness.
+- Log what was sent outside the system.
+
+## Employer AI Policy Checks
+
+- Search the job ad for AI-use rules.
+- Search the application portal for AI-use rules.
+- Search candidate instructions for writing-sample rules.
+- Search assessment instructions for tool restrictions.
+- Search cover-letter prompts for authenticity wording.
+- Follow any explicit no-AI instruction.
+- Disclose AI assistance when requested.
+- Distinguish proofreading from ghostwriting if asked.
+- Keep a human-edit record.
+- Keep source notes.
+- Keep version history.
+- Avoid submitting AI-created answers for skill assessments unless allowed.
+- Avoid using AI during live tests unless allowed.
+- Avoid using AI during take-home tests unless allowed.
+- Avoid applying to roles where the applicant cannot meet the stated standard unaided.
+
+## Cover Letter Round 2
+
+- Only write one when it can add new evidence.
+- Only write one when the employer asks for motivation, context, or fit.
+- Only write one when the candidate has a real reason.
+- Only write one when it will not be a generic summary.
+- Use the first paragraph to create relevance, not ceremony.
+- Use the second paragraph to prove capability.
+- Use the third paragraph to show why this employer or role.
+- Mention a company detail only if it affects the candidate's fit.
+- Avoid praising the company's website copy.
+- Avoid vague excitement.
+- Avoid repeating job requirements back to the employer.
+- Avoid making the candidate sound over-rehearsed.
+- Avoid adding experience not present in the CV.
+- Avoid adding claims that create mismatch.
+- Avoid long sentences that feel generated.
+- Include one grounded sentence only the applicant could write.
+- Include one detail that proves the applicant read the role carefully.
+- Include one bridge between past work and employer pain.
+
+## Screening Question Consistency
+
+- Make sure "years of experience" answers align with the CV.
+- Make sure salary expectations align with the role level.
+- Make sure work-rights answers align with location information.
+- Make sure "willing to relocate" aligns with cover-letter wording.
+- Make sure "available start date" aligns with current employment.
+- Make sure tool proficiency answers align with skills and bullets.
+- Make sure industry experience answers align with employer history.
+- Make sure management experience answers align with direct reports.
+- Make sure budget answers align with experience bullets.
+- Make sure clearance answers are accurate.
+- Make sure education answers match the education section.
+- Make sure disability or accommodation answers are handled privately and lawfully.
+- Make sure voluntary demographic answers are not inferred into the CV.
+- Save answers with the application record.
+
+## Application Strategy Checks
+
+- Do not apply only because a CV can be tailored.
+- Check whether the candidate meets the actual floor.
+- Check whether the role is worth a high-effort application.
+- Check whether the company has recent layoffs or hiring freezes.
+- Check whether the role is reposted repeatedly.
+- Check whether the job ad is overly broad.
+- Check whether the salary is missing by design.
+- Check whether the company requires excessive unpaid work.
+- Check whether the application requires duplicate manual entry.
+- Check whether the cover letter requirement is reasonable.
+- Check whether a referral path exists.
+- Check whether direct recruiter outreach is appropriate.
+- Check whether a portfolio note would help more than a cover letter.
+- Spend more effort on high-fit roles.
+- Spend less effort on low-fit portals with poor signals.
+
+## Age And Over-Seniority Round 2
+
+- Check whether older technologies are useful proof or age noise.
+- Check whether early-career dates are necessary.
+- Check whether long-tenure roles show growth.
+- Check whether early roles can be compressed.
+- Check whether senior achievements dominate too much for a mid-level role.
+- Check whether founder experience makes the candidate look too expensive.
+- Check whether director-level language hurts an individual-contributor application.
+- Check whether "consultant" language makes the candidate look temporary.
+- Check whether "entrepreneurial" language creates flight-risk concern.
+- Check whether "overqualified" risk needs reframing as hands-on interest.
+- Check whether management-heavy history needs practical delivery evidence.
+- Check whether long career breadth needs a role-specific spine.
+
+## Career Change Round 2
+
+- Build a bridge statement from old domain to new role.
+- Translate old outcomes into new-role language.
+- Show applied learning, not just courses.
+- Show projects that prove the new skill.
+- Show why the shift is credible now.
+- Avoid pretending old experience is the same as new experience.
+- Avoid hiding the old career completely.
+- Avoid making the candidate look junior in everything.
+- Avoid making the candidate look unfocused.
+- Add a short selected-experience section if chronology buries relevance.
+- Use cover letter to explain the pivot if the CV cannot.
+- Keep the pivot honest and confident.
+
+## Freelance And Contract Work
+
+- Clarify self-employed status.
+- Clarify client type without breaching confidentiality.
+- Clarify engagement length.
+- Clarify deliverables.
+- Clarify whether work was part-time or full-time.
+- Clarify whether multiple contracts overlapped.
+- Clarify whether the candidate owned sales, delivery, or both.
+- Clarify recurring revenue only if true and relevant.
+- Clarify client outcomes safely.
+- Avoid making a collection of small gigs look like full-time roles.
+- Avoid hiding employment gaps with vague consulting.
+- Avoid listing confidential clients as if public.
+- Avoid project names that cannot be discussed.
+
+## Founder And Startup Experience
+
+- Separate founder vision from operating proof.
+- Show what was built.
+- Show what was shipped.
+- Show what was sold.
+- Show what was learned from users.
+- Show what systems were created.
+- Show what constraints were handled.
+- Show whether the candidate wants to build hands-on.
+- Show whether the candidate can work inside a larger organisation.
+- Avoid sounding impossible to manage.
+- Avoid sounding allergic to process.
+- Avoid over-indexing on fundraising if the role is delivery.
+- Avoid vague "0 to 1" unless the zero and one are named.
+- Avoid implying scale that did not happen.
+
+## Layoff And Short Tenure Handling
+
+- Do not mention layoff unless it helps or is asked.
+- Do not apologise for short tenure caused by company events.
+- Do not create suspicious gaps by deleting short roles blindly.
+- Combine short contracts where appropriate.
+- Keep acquired-company transitions clear.
+- Keep merger transitions clear.
+- Keep redundancy explanations factual and short.
+- Avoid emotional language.
+- Avoid blame.
+- Avoid defensive footnotes.
+- Use interviews for context, not the CV, unless needed.
+
+## Remote And Hybrid Signals
+
+- Show remote collaboration tools only where relevant.
+- Show asynchronous documentation where relevant.
+- Show distributed-team experience where relevant.
+- Show time-zone coordination where relevant.
+- Show self-management through outcomes.
+- Show communication rituals if they mattered.
+- Avoid listing every meeting tool.
+- Avoid "thrives remotely" with no proof.
+- Avoid implying remote-only if the role is hybrid.
+- Avoid hiding location if location is a filter.
+
+## International And Market Fit
+
+- Check local spelling conventions.
+- Check local CV length expectations.
+- Check local photo expectations.
+- Check local personal-information norms.
+- Check local date formats.
+- Check local qualification names.
+- Check local work-rights language.
+- Check whether "resume" or "CV" is the local term.
+- Check whether references are listed or "available on request".
+- Check whether salary should be included.
+- Avoid importing US advice into every market.
+- Avoid importing academic CV conventions into corporate roles.
+- Avoid importing creative portfolio conventions into government roles.
+
+## Accessibility And Readability
+
+- Check contrast for human readers.
+- Check font legibility after PDF export.
+- Check whether screen readers read content in order.
+- Check whether links have meaningful text.
+- Check whether tables damage accessibility.
+- Check whether colour-coded sections still make sense in grayscale.
+- Check whether all-caps headings reduce readability.
+- Check whether dense bullet blocks create fatigue.
+- Check whether abbreviations are explained once.
+- Check whether the CV is readable when printed.
+- Check whether the CV is readable on a laptop preview pane.
+- Check whether the first page still works at 80 percent zoom.
+
+## Document Hygiene
+
+- Remove previous employer internal comments.
+- Remove AI prompt text.
+- Remove generated placeholder lines.
+- Remove accidental markdown syntax.
+- Remove duplicated bullets after tailoring.
+- Remove outdated contact methods.
+- Remove hidden objects.
+- Remove unused styles.
+- Remove accidental blank pages.
+- Remove document properties that reveal old titles.
+- Remove old file names embedded in metadata if sensitive.
+- Remove tracked changes.
+- Remove unresolved comments.
+- Remove personal notes in footers.
+- Check final PDF page count.
+- Check final DOCX page count.
+
+## Portfolio Proof Packet
+
+- Add a one-line CV reference to the most relevant portfolio item.
+- Use portfolio links sparingly.
+- Use case-study titles that match employer problems.
+- Put the strongest case study first.
+- Add a private portfolio route for confidential work if appropriate.
+- Use screenshots only when permission is clear.
+- Use anonymised diagrams where needed.
+- Include the candidate's role in each case study.
+- Include constraints.
+- Include decisions.
+- Include outcome.
+- Avoid portfolio pages that contradict CV dates.
+- Avoid case studies that show team work as solo work.
+- Avoid "coming soon" portfolio links.
+
+## References And Social Proof
+
+- Use references only when requested.
+- Use testimonials only if credible and appropriate.
+- Use LinkedIn recommendations only if relevant.
+- Use public talks only if relevant.
+- Use publications only if relevant.
+- Use awards only if recognised.
+- Use press only if it supports role fit.
+- Avoid padding with weak endorsements.
+- Avoid unverifiable awards.
+- Avoid obscure badges that look like filler.
+- Avoid listing reference contact details publicly unless instructed.
+
+## Anti-Slop Sentence Surgery
+
+- If a sentence has no noun more specific than "solutions", rewrite it.
+- If a sentence has no verb more specific than "drive", rewrite it.
+- If a sentence has no object of work, rewrite it.
+- If a sentence has no audience, user, customer, system, or stakeholder, inspect it.
+- If a sentence could be in a motivational poster, delete it.
+- If a sentence flatters the employer without evidence, delete it.
+- If a sentence says "skills and experience" without naming either, rewrite it.
+- If a sentence says "make an impact" without naming the impact, rewrite it.
+- If a sentence says "fast-paced" without explaining pace, rewrite it.
+- If a sentence says "complex" without naming the complexity, rewrite it.
+- If a sentence says "data" without naming the data type, rewrite it.
+- If a sentence says "automation" without naming the manual task, rewrite it.
+- If a sentence says "leadership" without naming who followed, rewrite it.
+- If a sentence says "communication" without naming the communication output, rewrite it.
+
+## Anti-Slop Word Swaps
+
+- Swap "utilized" for "used" in most CVs.
+- Swap "leveraged" for the actual action.
+- Swap "facilitated" for "ran", "hosted", "coordinated", or "resolved" if true.
+- Swap "supported" for the exact support.
+- Swap "contributed" for the specific contribution.
+- Swap "assisted" for the actual task.
+- Swap "spearheaded" for "led" unless the stronger verb is justified.
+- Swap "synergized" for nothing.
+- Swap "endeavored" for nothing.
+- Swap "ameliorated" for "improved" or a better metric.
+- Swap "streamlined" for the process and result.
+- Swap "enhanced" for the before and after.
+- Swap "optimized" for the metric improved.
+- Swap "empowered" for what the audience could do afterward.
+- Swap "transformed" for what changed.
+
+## AI Builder Output Audit
+
+- Check whether bullets are too uniformly impressive.
+- Check whether the AI invented causal links.
+- Check whether the AI turned responsibilities into achievements.
+- Check whether the AI inflated participation into ownership.
+- Check whether the AI added tools from the job ad.
+- Check whether the AI added industry terms not in the source material.
+- Check whether the AI smoothed over gaps.
+- Check whether the AI removed useful weirdness.
+- Check whether the AI made the applicant sound like a different level.
+- Check whether the AI made all roles sound equally relevant.
+- Check whether the AI copied the employer's adjectives.
+- Check whether the AI inserted hidden assumptions about team size.
+- Check whether the AI inserted "data-driven" without data.
+- Check whether the AI inserted "cross-functional" without teams.
+- Check whether the AI inserted "strategic" without decisions.
+- Check whether the AI inserted "scalable" without scale.
+- Check whether the AI inserted "innovative" without novelty.
+
+## Resume-Builder Template Audit
+
+- Check whether design elements survive parsing.
+- Check whether template sections match the applicant's evidence.
+- Check whether template prompts encouraged filler.
+- Check whether the builder added generic summary text.
+- Check whether the builder used icons that replace text.
+- Check whether the builder exported selectable text.
+- Check whether the builder watermarked the file.
+- Check whether the builder stored private data.
+- Check whether the builder allows deletion.
+- Check whether the builder uses documents for model training.
+- Check whether the builder encourages fake metrics.
+- Check whether the builder encourages keyword blocks.
+- Check whether the builder hides bad defaults behind a polished preview.
+- Prefer boring export quality over impressive preview design.
+
+## Applicant Voice Calibration
+
+- Compare the final cover letter to three prior writing samples.
+- Compare the final summary to the applicant's LinkedIn About section.
+- Compare phrasing to how the applicant explains work aloud.
+- Preserve a few natural word choices.
+- Preserve directness if the applicant is direct.
+- Preserve warmth if the applicant is naturally warm.
+- Preserve technical precision if the applicant is technical.
+- Preserve plainness if the applicant is practical.
+- Remove consultant-speak if the applicant does not use it.
+- Remove startup-speak if the target employer is conservative.
+- Remove corporate-speak if the applicant is applying to a craft role.
+- Remove academic tone if the employer wants delivery.
+- Remove sales tone if the employer wants operational reliability.
+- Remove excessive humility if the role needs confidence.
+- Remove excessive confidence if the proof is thin.
+
+## Human Specificity Injectors
+
+- Add a real constraint.
+- Add a real trade-off.
+- Add a real audience.
+- Add a real system name where safe.
+- Add a real cadence.
+- Add a real handoff.
+- Add a real incident.
+- Add a real baseline.
+- Add a real improvement.
+- Add a real lesson.
+- Add a real stakeholder.
+- Add a real customer segment.
+- Add a real regulatory context.
+- Add a real operating environment.
+- Add a real decision the candidate made.
+- Add a real reason the work mattered.
+
+## Suspicion Triggers
+
+- The CV perfectly mirrors the ad but lacks source depth.
+- The cover letter praises details from the company's homepage only.
+- The summary uses too many trendy terms.
+- The skills section includes tools absent from experience.
+- The candidate claims every nice-to-have.
+- The candidate claims expert level in unrelated domains.
+- The candidate's LinkedIn does not support the CV.
+- The portfolio does not support the CV.
+- The job titles feel upgraded.
+- The metrics are all round numbers.
+- The bullets lack messiness or constraints.
+- The tone is polished but oddly impersonal.
+- The cover letter sounds more senior than the CV.
+- The screening answers contradict the CV.
+- The writing sample sounds unlike the CV.
+
+## Positive Trust Signals
+
+- Specific work examples.
+- Clear scope.
+- Honest boundaries.
+- Context-rich metrics.
+- Direct language.
+- Relevant portfolio proof.
+- Consistent public profiles.
+- Clean parser output.
+- Stable chronology.
+- Role-specific emphasis.
+- Human-edited phrasing.
+- Evidence of judgement.
+- Evidence of learning.
+- Evidence of collaboration with named functions.
+- Evidence of customer, user, or stakeholder consequence.
+- Evidence that the applicant understands the employer's problem.
+
+## Role Depth Checks, Round 2
+
+### Engineering Leadership
+
+- Show technical judgement.
+- Show people leadership only where real.
+- Show delivery under ambiguity.
+- Show incident or reliability ownership.
+- Show architecture trade-offs.
+- Show hiring or mentoring results.
+- Show business alignment without buzzwords.
+- Avoid making the CV sound like a pure manager if the role is hands-on.
+- Avoid making the CV sound hands-on if the role expects management.
+
+### AI Product And Automation
+
+- Distinguish prompting from product work.
+- Distinguish prototype from production.
+- Distinguish internal tool from customer-facing feature.
+- Distinguish workflow automation from autonomous agent.
+- Distinguish model integration from model training.
+- Distinguish evaluation from vibes.
+- Distinguish demo from shipped value.
+- Show risk controls.
+- Show user feedback.
+- Show failure handling.
+- Show privacy or security choices.
+- Avoid AI hype without system behaviour.
+
+### Government And Public Sector
+
+- Show compliance.
+- Show stakeholder governance.
+- Show writing clarity.
+- Show procurement awareness where relevant.
+- Show service outcomes.
+- Show risk management.
+- Avoid flashy language.
+- Avoid unsupported innovation claims.
+- Avoid informal tone.
+- Avoid unexplained acronyms.
+
+### Healthcare
+
+- Show patient, clinician, operational, or compliance context.
+- Show privacy awareness.
+- Show quality and safety.
+- Show documentation discipline.
+- Show stakeholder sensitivity.
+- Avoid overclaiming clinical impact.
+- Avoid naming protected information.
+- Avoid vague care language.
+
+### Education
+
+- Show learner population.
+- Show curriculum or program scope.
+- Show assessment outcomes.
+- Show accessibility and inclusion.
+- Show stakeholder communication.
+- Show pastoral or support context where relevant.
+- Avoid generic "student success" language.
+- Avoid unverified improvement claims.
+
+### Finance
+
+- Show controls.
+- Show accuracy.
+- Show compliance.
+- Show reporting cadence.
+- Show risk reduction.
+- Show stakeholder accountability.
+- Avoid vague commercial claims.
+- Avoid confidential figures where unsafe.
+- Avoid jargon without function.
+
+### Creative And Content
+
+- Show audience.
+- Show brief.
+- Show channel.
+- Show distribution.
+- Show performance.
+- Show editorial judgement.
+- Show brand constraints.
+- Avoid generic creativity language.
+- Avoid AI-polished portfolio descriptions.
+- Avoid performance numbers that impress in isolation but do not prove role fit.
+
+## Quality Bar For ApplyPass Rules
+
+- A rule should have a source.
+- A rule should have a date.
+- A rule should state whether it is stable or volatile.
+- A rule should state whether it is universal or market-specific.
+- A rule should state whether it is ATS, recruiter, legal, privacy, or tone related.
+- A rule should state the risk of following it blindly.
+- A rule should state the safe default.
+- A rule should state the exception.
+- A rule should avoid magic numbers without evidence.
+- A rule should avoid scare tactics.
+- A rule should avoid implying certainty where hiring systems are opaque.
+- A rule should be tested on real application outcomes.
+- A rule should be retired when evidence changes.
+
+## Second-Pass Final Gate
+
+- The CV does not merely pass a scanner.
+- The CV makes a truthful argument for fit.
+- The CV contains enough evidence to be trusted.
+- The CV has no obvious mass-application smell.
+- The CV has no high-risk AI-builder residue.
+- The CV has no unsupported upgrades.
+- The CV has no private leakage.
+- The CV has no parse-breaking formatting.
+- The CV has no mismatch with screening answers.
+- The cover letter adds value or is omitted.
+- The applicant can discuss every major claim.
+- The application version is saved.
+- The next improvement depends on outcome data, not more polishing.
+
+## Round 2 Source Links
+
+- Reddit, r/resumes discussion on ATS mistakes and human audience: https://www.reddit.com/r/resumes/comments/1rz5i32/5_ats_resume_mistakes_that_are_costing_you/
+- Reddit, r/recruitinghell discussion on AI screening and required cover letters: https://www.reddit.com/r/recruitinghell/comments/1t5sucv/auto_screened_out_by_ai_after_required_cover/
+- arXiv, Resume-ing Control, recruiting workflows and GenAI, 2026: https://arxiv.org/abs/2604.26851
+- arXiv, JobMatchAI, semantic matching and explainable job search, 2026: https://arxiv.org/abs/2603.14558
+- OpenAI, discontinued AI text classifier and limitations: https://openai.com/index/new-ai-classifier-for-indicating-ai-written-text/
+- Greenhouse documentation on current AI hiring features: https://support.greenhouse.io/hc/en-us/articles/33043749845403-Greenhouse-AI-features
+- Lever applicant tracking system myths: https://www.lever.co/blog/applicant-tracking-system-myths/
+- Michael Page Australia, identifying AI-created resumes: https://www.michaelpage.com.au/recruitment-expertise/employer-insights/how-identify-resumes-created-ai-or-chatgpt
+- Harvard career-service guidance on AI-assisted resumes and letters: https://careerservices.fas.harvard.edu/ai-resumes-and-cover-letters/
+- Reddit engineering resume wiki used as a forum baseline: https://www.reddit.com/r/EngineeringResumes/wiki/index/

--- a/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_2.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_2.md
@@ -1,0 +1,381 @@
+# CV Checklists — Round 2
+
+Companion to `cv-checklists.md`. Zero overlap with Round 1. Everything here is additive: deeper niches, rarer tells, harder-to-find advice, and the operational stuff most CV guides skip. No em dashes.
+
+---
+
+## PART 1: ADVANCED CV CHECKS (Round 1 didn't cover these)
+
+### A. The pre-application reconnaissance layer
+
+- Pull the company's last 6 months of news before tailoring. Mention something specific in the cover letter that's not on their About page.
+- Read the careers page tone (formal corporate, scrappy startup, government plain English) and match it.
+- Check the hiring manager's LinkedIn. Mirror seniority cues from their own profile (do they say "lead", "head", "director"?).
+- Check Glassdoor, Levels.fyi, and Blind for salary band and interview process before tailoring effort allocation.
+- Search "[Company] layoffs 2026" before applying. Don't waste a tailored CV on a sinking ship.
+- Look up the recruiter's LinkedIn. If they're new in role (<3 months), expect slower replies and process drift.
+- Check the company's RTO (return-to-office) policy. Many JDs lie or omit it; recent reviews don't.
+- Identify the ATS vendor from the application URL pattern before clicking apply:
+  - `myworkdayjobs.com` → Workday
+  - `greenhouse.io` or `boards.greenhouse.io` → Greenhouse
+  - `lever.co` or `jobs.lever.co` → Lever
+  - `icims.com` → iCIMS
+  - `taleo.net` → Taleo (legacy, parser is weakest)
+  - `successfactors.com` → SAP SuccessFactors
+  - `bamboohr.com` → BambooHR
+  - `smartrecruiters.com` → SmartRecruiters
+  - `breezy.hr` → Breezy
+  - `ashbyhq.com` → Ashby (modern, parser is strongest)
+- Adjust CV format slightly per ATS. Taleo: simpler is safer. Ashby: design tolerance is higher.
+
+### B. Geographic and cultural CV norms (often missed)
+
+- **Australia**: 2 to 3 pages acceptable for senior roles, no photo, no DOB, include "Right to Work in Australia: Citizen / PR / Visa class" near contact if not obvious from name.
+- **UK**: 2 pages standard, no photo, no DOB.
+- **US**: 1 page strict for non-executive, no photo, no DOB, no marital status. "Resume" not "CV" except for academic/medical.
+- **Germany / Austria / Switzerland**: photo expected (Bewerbungsfoto), DOB optional but common, signed declaration of truth at the end (Lebenslauf convention).
+- **Japan**: rirekisho format is a structured table, often handwritten in tradition; photo required.
+- **France**: photo common, 1 to 2 pages, more design tolerance.
+- **Netherlands / Scandinavia**: photo optional, very direct tone.
+- **Middle East / Gulf**: photo common, nationality/visa status expected, longer CVs tolerated.
+- **Canada**: very similar to US, no photo, no DOB.
+- **New Zealand**: similar to AU/UK, no photo, no DOB.
+- Don't translate role titles literally. "Geschäftsführer" is Managing Director, not "Business Leader". Look up the canonical English equivalent.
+
+### C. Industry-specific CV adjustments
+
+- **Government / public sector**: address selection criteria (KSCs) line by line in a separate document. Often 4 to 8 pages. Plain language, no jargon, conservative format.
+- **Academic**: full publication list, conferences, teaching, grants, peer review. 4+ pages expected. Order: education first.
+- **Medical / clinical**: registrations, fellowships, audits, presentations. Strict chronology expected.
+- **Legal**: bar admissions, jurisdictions, notable matters (where confidentiality allows), publications.
+- **Creative (design, copy, film, photography)**: portfolio link is the CV; the document is the appendix. Lead with the work.
+- **Trades / construction**: tickets, licences, white card, OHS, plant operated. Skills section above experience.
+- **Sales**: quotas, attainment %, deal size, cycle length, territory, club rankings. Numbers or nothing.
+- **Engineering / SWE**: tech stack per role inline, not in a separate skills block. Recent commits/repos linked. Education matters less after 3+ years.
+- **Finance / banking**: deal sheet may be required separately. Tombstones for senior roles.
+- **Startup / scale-up**: stage at join, stage at exit, ARR/MRR/headcount delta during your tenure. "Joined at Series A pre-launch, left at Series B post-PMF" beats "worked at startup".
+- **Education / teaching**: registration number, year levels, subjects, programs led, student outcomes.
+- **NGO / impact**: outcomes for beneficiaries, not just inputs. "Trained 200 teachers across 4 provinces" beats "delivered training programs".
+
+### D. The portfolio link discipline (designers, devs, makers)
+
+- One canonical URL. Not three. Pick the strongest.
+- The link works on mobile, loads in under 3 seconds, and doesn't 404.
+- The first project shown matches the role being applied for. Reorder for each application if needed.
+- Each portfolio piece has a 1-line problem, a 1-line solution, and your specific contribution if it was a team project.
+- No "Coming soon" or empty case studies visible.
+- Password-protected pieces have the password in the cover letter, not the CV.
+- Domain ownership: a personal domain reads more senior than a Behance/Dribbble subpage.
+- HTTPS, no certificate warnings.
+- Mobile responsive. Recruiters open links on phones.
+- Updated within the last 6 months. Stale portfolios signal stale career.
+- If you list a GitHub: pin your 6 best repos to the profile top. Recruiters check pinned, not all.
+
+### E. The "second-pass" CV scrub (after the first draft is done)
+
+- Spellcheck the company name. Three times. In every doc.
+- Spellcheck the hiring manager's name. Check pronouns on their LinkedIn.
+- Find-and-replace any leftover placeholder text ("[Company]", "[Role]", "Lorem ipsum").
+- Confirm the date you wrote on the cover letter matches the day you're submitting.
+- Confirm the version of the CV you're about to upload is the tailored one, not the master.
+- Check the filename. "CV-Final-FINAL-v3-actually-final.docx" tells the recruiter everything.
+- Open the PDF in a different viewer than the one you exported from. Layout shifts happen.
+- Check page count. A 2-page CV with 4 lines on page 2 should be re-flowed to 1 page.
+- Check for widow words (single word on the last line of a paragraph). Tighten or rewrite.
+- Check for orphans (single line of a paragraph at the bottom of a page). Re-flow.
+- Print the CV in black and white. If anything disappears or becomes illegible, fix it.
+- Check the metadata. Right-click → Properties. Remove the author name if it's not yours (this is where AI tools and old templates leave fingerprints). Don't leave "Jane Smith" in the Author field if Jane was a template owner.
+- Check Track Changes is fully accepted/rejected and turned off.
+- Check that hidden comments and revision marks are gone.
+- Save a clean copy with no version history.
+
+### F. Application metadata (the stuff outside the CV that gets you read)
+
+- Email subject line: "Application: [Role title] - [Your Name]". Clear and searchable.
+- Email body: 4 to 6 lines, names the role, mentions the attachment, includes the same opening hook as the cover letter, signs off with phone number.
+- Send during the company's local business hours, Tuesday to Thursday, 9 to 11am. Higher open rates than late nights and weekends.
+- Don't send Mondays before 10am (overload) or Fridays after 2pm (deferred to next week).
+- Use a signature with one phone, one email, one LinkedIn URL. No quotes, no slogans, no company logos.
+- BCC yourself for record-keeping.
+- If the portal allows additional documents: include a 1-page case study or work sample, not a 30-page portfolio.
+- Use a real email address with your real name. `chris.byrne@gmail.com` not `darklord1985@hotmail.com`.
+
+### G. Reference list management
+
+- Don't include references on the CV.
+- Prepare a separate references document, ready to send when asked. Same header style as your CV.
+- 3 to 5 references: most recent manager, a peer, a direct report (for leadership roles), a client (for client-facing roles).
+- Ask permission before listing. Confirm preferred contact method.
+- Brief your references in writing before the company calls. Give them the JD, the company name, and a 3-bullet recap of what you'd want emphasised.
+- Re-confirm references for each new application; don't burn goodwill by having them called repeatedly without warning.
+- LinkedIn recommendations are not a substitute. Don't link to them on the CV.
+
+### H. Negotiation prep that starts in the CV
+
+- Don't list current salary anywhere.
+- Don't list expected salary unless explicitly required by the portal. If forced, give a band, not a number.
+- Some US states (CA, CO, NY, WA) require posted salary bands. Read the JD; if a band is posted, anchor your expectation at the top half.
+- Australia: no legal requirement to disclose current salary. "Negotiable based on total package" is acceptable.
+- Don't undersell experience in the CV to fit a junior role. It comes up in the negotiation.
+- Note benefits you currently receive that you'd want matched: super contribution, equity vesting, RDOs, study budget, gear allowance. Doesn't go on the CV but should be in your negotiation file.
+
+### I. The career-gap and non-linear-path handling
+
+- 3+ month gap: address it briefly on the CV or cover letter. One line. Don't apologise.
+- Acceptable framings: "Career break for caregiving", "Sabbatical and travel", "Recovery from illness", "Independent study and upskilling", "Voluntary redundancy and selective job search".
+- Don't hide gaps with creative date math. Recruiters notice and lose trust.
+- Freelance or contract work during a gap: list it as a freelance period with key clients, not as a single "self-employed" line.
+- Career changers: lead with transferable skills, use a hybrid CV format (skills summary at the top), explain the change in the cover letter.
+- Multiple short stints: cluster them under one "Freelance / Contract" heading with the period and notable clients.
+- Pivot stories work better as cover letter narrative than CV bullets.
+
+### J. The dogfooding feedback loop (operationalising what works)
+
+- Log every application: date sent, company, role, ATS vendor, CV version used, cover letter version, response within 14 days (yes/no), interview yes/no, offer yes/no.
+- Reply rate baseline: in 2026, 5 to 15% reply rate is normal for tailored mid-senior applications. Below 3% means something's broken (likely the JD-match, not the CV).
+- Interview-to-offer ratio: a healthy ratio is 3:1 to 5:1 at senior levels.
+- A/B test two versions of one bullet across the next 10 applications. After 10, keep the winner.
+- Track which industries/roles convert and which don't. Adjust your search.
+- After every recruiter call, write down 2 questions you struggled to answer. Update your CV or cover letter to pre-empt them.
+- After every rejection, do not message the recruiter for feedback unless they offered it. Save the goodwill for re-application later.
+- 4-week review: if you've sent 30+ applications with <5% reply rate, the CV is the bottleneck, not the volume. Rewrite.
+
+### K. Specific bullet patterns that consistently win (recruiter-tested)
+
+- **The "before / after" bullet**: "Took monthly close from 9 days to 3 days by replacing the legacy export pipeline."
+- **The "team and outcome" bullet**: "Led a team of 6 designers across 4 product squads; shipped the redesign on time with a 22% increase in activation."
+- **The "scope and constraint" bullet**: "Delivered the rebrand in 8 weeks on a $60k budget against an industry baseline of 16 weeks at $200k."
+- **The "first / largest / fastest" bullet**: "First designer hired into the company; built the design system that 14 subsequent hires used."
+- **The "saved / made" bullet**: "Identified $480k in annual licence waste; renegotiated contracts and pocketed the savings."
+- **The "broke / fixed" bullet**: "Inherited a CSAT score of 62; restructured the support team and brought it to 84 in 6 months."
+- **The "rolled out at scale" bullet**: "Standardised the brand toolkit across 12 markets and 4 product lines, used by 200+ designers and marketers."
+- **The "owned end-to-end" bullet**: "Owned the product page redesign from research through launch; led the team that drove a 31% lift in conversion."
+
+### L. The honesty audit (separate from the defensibility test)
+
+For each line on the CV, run these checks once you have a "final" draft:
+
+- Am I using a verb that overstates my role? ("Led" vs "contributed to". "Architected" vs "worked on".)
+- Did I claim ownership of a team outcome where my actual contribution was one slice?
+- Is the metric mine, or did I borrow it from a team-wide number?
+- Did the timeframe really match what's implied? (A 6-month project shouldn't read as a 2-year flagship.)
+- Would my former manager nod or wince reading this?
+- Would a colleague who worked alongside me agree with the framing?
+- If a journalist or background-checker called my previous employer, would they confirm this?
+- If I'm laid off and a recruiter scans this in 30 seconds, do they see the real me or a polished phantom?
+
+---
+
+## PART 2: ADVANCED ANTI-AI-SLOP (Round 1 didn't cover these)
+
+### A. Second-tier AI vocabulary (newer, less obvious, still flags)
+
+These came online with GPT-4.5 to GPT-5.5 and Claude 3.5 to 4.5. Not yet on every recruiter's mental list, but on the way:
+
+- "thoughtful" (when applied to designs, processes, products)
+- "intentional" (the buzzword of 2025–2026)
+- "elevated" (as in "elevated user experience")
+- "considered" (used to mean "carefully thought out")
+- "crafted" (especially "carefully crafted")
+- "curated"
+- "orchestrate", "orchestration" (overused for project management)
+- "operationalise", "operationalised"
+- "actionable", "actionable insights"
+- "stakeholder alignment" (when you mean "got people to agree")
+- "strategic alignment"
+- "north star"
+- "single source of truth" (when overused as filler)
+- "first principles" (now a flag when not actually used technically)
+- "high-leverage"
+- "high-velocity"
+- "rapid iteration"
+- "fail fast"
+- "ship fast"
+- "10x" (as a modifier of anything)
+- "force multiplier"
+- "second-order effects"
+- "compounding"
+- "asymmetric"
+- "scrappy"
+- "lean and mean"
+- "ruthless prioritisation"
+- "obsessed with" (as in "obsessed with quality")
+- "deeply" (as a modifier: "deeply experienced", "deeply technical")
+- "uniquely positioned"
+- "well-positioned"
+- "battle-tested"
+- "production-grade"
+- "enterprise-grade"
+- "world-class"
+- "best-in-class"
+- "industry-leading"
+- "category-defining"
+- "purpose-built"
+- "white-glove"
+
+### B. AI sentence-starter patterns
+
+These constructions are AI-canary signals when they appear repeatedly:
+
+- "Imagine a world where..."
+- "Picture this:..."
+- "Here's the thing:..."
+- "The reality is..."
+- "The truth is..."
+- "What's interesting is..."
+- "What stands out is..."
+- "Let me explain..."
+- "Let's break this down..."
+- "First, let's consider..."
+- "Now, here's where it gets interesting..."
+- "To put it simply..."
+- "Simply put..."
+- "In other words..."
+- "That said..."
+- "Having said that..."
+- "On the flip side..."
+- "Conversely..."
+- "Ultimately, what matters is..."
+- "At the end of the day..."
+- "At its core..."
+- "Fundamentally..."
+- "Essentially..."
+
+### C. The "AI list shape" tells (structural giveaways in lists)
+
+- Every list item starts with a verb of the same tense and length.
+- Every list item is one full sentence, no fragments, no compound thoughts.
+- Every list item ends with a clean parallel grammatical structure.
+- The list has exactly 3, 5, or 7 items (AI loves odd numbers, especially 3 and 5).
+- The list moves general → specific → general (an AI rhetorical shape).
+- The list has a meta-summary sentence after it, restating what was just listed.
+- Sub-bullets nested under bullets in a perfectly balanced tree. Real human bullets are messier.
+- Each bullet is roughly the same character length. Human bullets vary wildly.
+
+### D. The "AI cover letter scaffolding" tells
+
+Even when individual sentences look OK, the overall shape is a giveaway:
+
+- Paragraph 1: introduces self, role, company. Always 2 to 3 sentences.
+- Paragraph 2: experience match. Always begins with "In my [X] years at [Y]..." or "Throughout my career...".
+- Paragraph 3: company-specific paragraph that could fit any company.
+- Paragraph 4: closes with "I would welcome the opportunity to discuss..." or "I am eager to bring my..."
+- Total length: 280 to 350 words. AI defaults here unless told otherwise.
+- Three paragraphs, each 4 to 5 sentences. The classic AI shape.
+
+Break it. Use two paragraphs, or five. Use a 1-sentence paragraph. Start with an anecdote, not a self-introduction.
+
+### E. Tells specific to AI-written summaries / profiles
+
+- Summary opens with role + years experience + 2 to 3 adjectives. "Senior Product Designer with 12+ years of experience in fintech and SaaS, specialising in user research, design systems, and cross-functional leadership."
+- Summary ends with what you're "passionate about" or "seeking".
+- Three adjective clusters separated by commas. ("strategic, analytical, and creative")
+- Mentions "data-driven decisions" or "user-centric design" or "results-driven approach".
+- Mentions cross-functional collaboration as if it's a differentiator.
+- Mentions stakeholder management as if it's a skill rather than a default.
+
+### F. The "fake humanising" tells (what people add to AI output to try to hide it)
+
+These are the moves people make to "make it sound more human" — and they all backfire:
+
+- Adding a folksy phrase: "at the end of the day", "long story short", "to be honest".
+- Adding contractions inconsistently: contractions in some paragraphs, not others.
+- Adding a single typo "on purpose". Recruiters notice typos and dock you for it.
+- Adding "you know" or "I think" mid-sentence. Reads as filler, not voice.
+- Adding em dashes "for personality". Now the strongest AI tell.
+- Inserting "honestly," or "frankly," before a sentence.
+- Starting a sentence with "Look," or "Listen,". Reads as fake-casual.
+- Adding emoji to a cover letter. Almost always wrong outside of creative industries.
+- Adding a P.S. with a "personal" detail. AI-generated P.S. lines are now their own genre.
+- The "controlled imperfection" rewrite: re-running output through a "humaniser" tool. Recruiters now also detect humanised AI; it has its own signature.
+
+### G. Detection-by-tooling tells (what software actually checks)
+
+- **Burstiness**: variation in sentence length and perplexity across the doc. AI is low-burst; humans are high-burst.
+- **Perplexity**: how surprising each next word is given the prior. AI is low-perplexity; human writing is higher.
+- **Function-word ratios**: AI overuses some function words ("the", "to", "and") at predictable rates.
+- **Sentence-length entropy**: humans vary; AI clusters.
+- **Vocabulary entropy**: AI uses a narrower band of synonyms than humans.
+- **Punctuation entropy**: AI's punctuation distribution is unusually regular.
+- **Stylometric fingerprint**: every writer has one; AI flattens it.
+- **Embedding distance from training corpus**: technical detectors compare your text's embedding to known AI distributions. Out of your control, but specific personal voice helps.
+
+### H. Format-level tells (PDF metadata that AI tools leave)
+
+- **PDF "Producer" field**: "ChatGPT", "Claude", "Notion AI" can show up in PDF metadata if exported directly. Always re-save through Word or Pages or a clean PDF tool.
+- **PDF "Author" field**: leftover from a template (often "AmruthPillai" from Reactive Resume, "Kickresume User", etc.). Strip it.
+- **PDF "Title" field**: don't leave "Untitled Document" or "Resume Template (1)". Set to "[Name] CV".
+- **PDF "Keywords" field**: empty or your actual relevant keywords.
+- **PDF "Creator" field**: shows what app made it. "Microsoft Word for Office 365" is fine. "Online PDF Generator" or "AI Resume Builder" is not.
+- **DOCX "comments" embedded**: from a previous reviewer. Strip them.
+- **DOCX "tracked changes"**: accept all and turn off before sending.
+- **DOCX "revision history"**: doesn't survive Save As, but old versions might show edit timestamps.
+- **Embedded fonts**: ensure standard fonts are embedded; non-standard fonts fall back and shift layout.
+
+### I. The "looks too clean" tells
+
+- Perfect alignment to within a pixel across all columns.
+- Identical bullet indent across all roles.
+- Exactly the same number of bullets per role.
+- Perfectly balanced page (no slight imbalance).
+- Identical heading sizes across the whole doc.
+- A "designed" look with no rough edges that came from real iteration.
+
+Counter-intuitively, human-written CVs have small inconsistencies that templated/AI CVs don't. You don't need to add imperfection, but you shouldn't fight every visual asymmetry.
+
+### J. Cross-modal AI tells (when the CV looks like an LLM output even visually)
+
+- Section headings rendered in `H1 / H2 / H3` markdown style after a flawed export.
+- Code-style monospace fonts used for skill names ("`Python`", "`React`").
+- Quote-block formatting around a tagline.
+- Three-dash horizontal rules (`---`) between sections that didn't render.
+- Block quotes (`>` prefix) on a personal statement.
+
+### K. The "what AI can't fake yet" advantages
+
+Lean into these. They're hard for AI to generate convincingly:
+
+- A specific anecdote with a specific person's reaction, a specific place, a specific date.
+- A bullet that includes a minor failure or learning. "Shipped v1 with a bug that affected 12% of users; led the rollback and rewrote the test pipeline within 48 hours."
+- Industry jargon used correctly, not just sprinkled. (Wrong jargon is worse than no jargon.)
+- A point of view. "Prefer monorepos for early-stage teams; tooling cost outweighs the org clarity past 30 engineers."
+- A tradeoff named honestly. "Optimised for delivery speed over technical perfection in Q3; carried tech debt into Q4 and paid it down deliberately."
+- A specific tool used in a specific way. "Used Linear for product, Notion for docs, Slack for sync, Figma for source-of-truth design files." (vs "various PM tools")
+- A real client name where confidentiality allows. AI hallucinates clients; verifiable client names defeat detectors.
+- Domain depth that requires lived experience. "Worked with WELS-rated water-efficient products under the AS/NZS 6400 standard." AI can't fake this fluency convincingly.
+
+### L. The "voice fingerprint" method (the most reliable counter to AI tone)
+
+- Collect 3 to 5 samples of your real prior writing: an old email to a colleague, a LinkedIn post, a Slack message thread you wrote, a blog post, a postcard. 200 to 500 words total.
+- Identify your idiosyncrasies: words you reuse, sentence openings you prefer, punctuation habits, how you handle hedging vs directness.
+- Identify what you don't do: words you'd never use, constructions that aren't yours.
+- Before sending any CV/cover letter, compare the final draft against the sample. If a sentence feels foreign, rewrite.
+- This is the single most reliable defence against AI tone, because it's positive (what you sound like) rather than negative (what AI sounds like). You can't be flagged for sounding like yourself.
+
+### M. The asymmetric-effort principle
+
+The reason most AI-generated CVs fail is they look like a generic candidate generated them. The reason yours can stand out is that you can invest 30 minutes of asymmetric effort that AI can't replicate:
+
+- One real anecdote per role, dropped into a bullet.
+- One specific client, project, or product name per role where confidentiality allows.
+- One real tradeoff or learning, owned honestly.
+- One number you can defend without a calculator.
+- One reference to the company that proves you spent time on their website.
+- One mention of a specific person at the company (recruiter, hiring manager, alumnus) if relevant.
+
+Six concrete additions across a CV and cover letter, and you're outside the AI-output distribution entirely.
+
+---
+
+## SUMMARY: THE 10 ADDITIONAL RULES (no overlap with Round 1)
+
+1. Identify the ATS vendor from the URL before applying. Tailor format accordingly.
+2. Match CV norms to the country you're applying in (photo, length, DOB conventions).
+3. Match CV depth to the industry (1 page for SWE, 2 to 3 for design, 4+ for academic/government).
+4. Treat the portfolio link as the CV; the document is the appendix.
+5. Strip PDF metadata before sending. Check Author, Producer, Title fields.
+6. Log every application; track reply rate, interview rate, and the CV version each used.
+7. Be honest about contributions vs team outcomes; the audit happens later.
+8. Lean into what AI can't fake: anecdotes, named projects, owned tradeoffs, lived-domain jargon.
+9. Capture 200 to 500 words of your real prior writing as a voice fingerprint; compare every draft against it.
+10. Invest 30 minutes of asymmetric effort per application that AI cannot replicate, and you exit the AI distribution entirely.

--- a/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_3.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_3.md
@@ -1,0 +1,344 @@
+# CV Checklists — Round 3
+
+Companion to `cv-checklists.md` (Round 1) and `cv-checklists-round-2.md` (Round 2). Zero overlap with either. This round covers what happens before, around, and after the CV: the channels, the prep, the long game, and the stuff that determines whether the CV even gets read. No em dashes.
+
+---
+
+## PART 1: THE STUFF AROUND THE CV (channels, prep, long game)
+
+### A. The referral channel (the one most applicants never use)
+
+- Referred candidates are 4 to 14x more likely to be hired than cold applicants, depending on the study (Jobvite, LinkedIn Talent Solutions, Greenhouse data 2025).
+- A referral converts at roughly 40 to 50% to interview vs 2 to 8% for cold applications.
+- Most companies pay employees a referral bonus ($1k to $10k). Your asker is incentivised to help, not annoyed.
+- Don't ask for a referral on first contact. Ask for a 15-minute conversation about the role.
+- The right ask: "I saw [Company] is hiring a [Role]. I'm interested but want to understand the team and what they're looking for. Would you be open to a 15-minute chat?"
+- After the call, ask: "Based on our conversation, would you feel comfortable putting me forward?" Let them say yes or no without pressure.
+- Send the referrer your tailored CV, a 3-bullet TL;DR of why you're a fit, and the JD link. They forward; you don't.
+- Track which referrals convert. Some employees have higher internal credibility than others.
+- "Weak ties" (people you barely know) often help more than close friends. LinkedIn 2nd-degree connections are the sweet spot.
+- Re-engage your network annually, not when you need something. The "I'm just letting you know I'm looking" message lands harder when you've been in touch already.
+- Alumni networks (university, prior employer, bootcamp, accelerator) are higher signal than generic LinkedIn connections.
+- Slack communities, Discord servers, and industry-specific groups (Designer Hangout, Rands Leadership Slack, Indie Hackers, etc) are referral pipelines most candidates ignore.
+
+### B. LinkedIn as a system (not just a profile)
+
+- **Headline**: most underused real estate. Don't put your current title. Put what you want to be hired for, with one differentiator. "Senior Product Designer | Design systems and zero-to-one product | 12+ years across fintech and SaaS" beats "Senior Product Designer at [Company]".
+- **About section**: 3 paragraphs maximum, written in first person, with a clear call-to-action at the bottom. Include 3 to 5 keywords from your target roles.
+- **Featured section**: pin 3 to 5 portfolio pieces, posts, or case studies that match your target role. Refresh quarterly.
+- **Experience**: mirror the CV verb-for-verb where it's truthful. Use longer descriptions on LinkedIn than the CV (LinkedIn isn't ATS-constrained).
+- **Skills**: prune ruthlessly. List 20 to 30 high-signal skills. Endorsements matter more for the top 3 (which you can pin).
+- **Recommendations**: aim for 5 to 10. Ask the day after a successful project, not years later. Provide a draft if the person asks for one.
+- **Activity**: post or comment thoughtfully once a week. Recruiters check the Activity tab to see if you're active.
+- **Open to Work** badge: visible to recruiters only (not your network) is the safer setting if you're employed.
+- **Custom URL**: change `/in/chris-byrne-1a2b3c4d5e/` to `/in/chrisbyrne/` or similar. Use it on the CV.
+- **Profile photo**: head and shoulders, neutral background, smiling but not goofy. Recent (last 3 years).
+- **Banner image**: not the LinkedIn default blue. Something role-relevant, not a stock cityscape.
+- **Connections**: 500+ unlocks the "500+" label and signals network depth. Quality > quantity past that.
+- **Following**: follow target companies; their job postings surface in your feed.
+- **Search activity**: who's viewed your profile is a leading indicator. Sudden interest from recruiters at a specific company often precedes outreach.
+- **Engagement signals**: liking a recruiter's post the week before reaching out warms the channel.
+- **InMail responses**: respond within 48 hours even if not interested. "Not the right fit right now, but please keep me in mind for [adjacent role]" keeps the door open.
+
+### C. The cold outreach play (when you don't have a referrer)
+
+- Cold-email the hiring manager directly. Their LinkedIn profile tells you who they are; tools like Hunter, RocketReach, or Apollo find the email format.
+- Subject line: specific and short. "Re: Senior Designer role - 12 years in fintech" beats "Application for Senior Designer".
+- Body: 4 to 6 lines. Name the role, name a specific thing about the team or product, drop one credibility hook ("led the redesign of [comparable product]"), include the CV, offer a call.
+- Send Tuesday to Thursday morning. Avoid weekends and Mondays.
+- One follow-up after 5 to 7 business days. No more. Two pings is the ceiling.
+- Don't send to a `careers@` or `jobs@` inbox. Send to the hiring manager or a sympathetic team member.
+- LinkedIn DM is acceptable if you can't find an email. Same brevity rules.
+- If you get no reply: don't take it personally. Hiring managers get 50+ inbound a week.
+- If you get a reply that's a "no for now": ask if they'd be open to a 15-minute call anyway. Network for the next opening.
+
+### D. The interview pipeline (what the CV needs to set up for)
+
+- **Recruiter screen** (15 to 30 min): your CV is the script. Memorise every date, metric, and project on it. The screener will pick 2 to 3 bullets to probe.
+- **Hiring manager call** (30 to 45 min): your CV becomes a launchpad for behavioural questions. Each bullet should have a 2-minute story behind it.
+- **Technical / craft interview**: doesn't reference the CV much, but inflated CV claims here are caught fast.
+- **Panel / loop**: each interviewer reads a different bullet. Inconsistency between interviewers in what you said reveals exaggeration.
+- **Reference check**: your stated achievements are confirmed (or not) by your referees. CV claims that contradict references kill offers.
+- **Background check**: dates of employment, titles, and degrees are verified. Lies discovered here rescind offers and burn industry bridges.
+- Every bullet on the CV is a promise. Every promise will be tested at one of these stages.
+
+### E. STAR-method readiness (the prep your CV implies)
+
+For every bullet on your CV, you should have a STAR story ready:
+
+- **Situation**: 2 to 3 sentences setting context. Company, team size, problem.
+- **Task**: 1 to 2 sentences naming what you specifically had to do.
+- **Action**: 4 to 6 sentences describing what you did, with specifics (tools, people, decisions, tradeoffs).
+- **Result**: 2 to 3 sentences with quantified outcome and what you learned.
+
+- Total per story: 90 to 120 seconds spoken.
+- Have 8 to 12 STAR stories prepped: leadership, conflict, failure, ambiguity, technical depth, stakeholder management, creative breakthrough, ethics, deadline pressure, team building, learning curve, biggest impact.
+- Map each story to multiple bullet types so you can reuse across questions.
+- Practice them out loud. The transition from "written on CV" to "told in person" is where most candidates fall apart.
+
+### F. Behavioural question prep (where the CV becomes a liability or an asset)
+
+Common interviewer questions, and the CV bullet that should pre-empt each:
+
+- "Tell me about a time you led through ambiguity." → A bullet showing "founded", "launched", "first" something.
+- "Tell me about a time you failed." → A bullet that owns a tradeoff or a recovered miss. AI-generated CVs never have these; yours should.
+- "Tell me about a conflict with a colleague." → A bullet involving stakeholder alignment or cross-functional work.
+- "Tell me about the hardest project you worked on." → Your largest-scope bullet.
+- "Why are you leaving your current role?" → Don't address on the CV; rehearse a 30-second neutral answer.
+- "Walk me through your CV." → 90-second arc: where you started, the pivot moments, where you are now, where you want to go.
+- "What's a skill you've developed recently?" → A bullet showing learning, not just delivery.
+
+### G. The "Why us" answer (and why it's harder than it looks)
+
+- Don't say: "I love your mission." Generic. Untrue 80% of the time.
+- Don't say: "You're a leader in the space." They know.
+- Do say: a specific recent thing (a product launch, a hire, a strategy shift, a public talk by someone there).
+- Do say: a specific aspect of how they work that aligns with how you work. "I noticed your team ships weekly; my last team did the same and I'd struggle to go back to quarterly."
+- Do say: a specific person whose work you respect. Naming the hiring manager's prior work (if you can find it) is high-trust.
+- Length: 60 to 90 seconds. Long enough to show research, short enough to not lecture.
+
+### H. The "Why are you leaving" answer (rehearse this cold)
+
+- Never: trash your current employer, manager, or team.
+- Never: a long story.
+- Always: forward-looking. "I want X" not "they don't give me X".
+- Acceptable framings: "I've grown as much as I can in this role and want a bigger scope", "the business has shifted direction and the work I want to do is elsewhere", "I'm looking for [specific thing] that this role offers".
+- Pre-empt the follow-up: "What would have made you stay?" Have an honest, short answer ready.
+
+### I. The "Tell me about yourself" answer (the 90-second narrative)
+
+- This is not the CV read aloud.
+- Structure: Past (10 sec) → Present (20 sec) → Why this role (20 sec) → 1 differentiator (20 sec) → handoff question to them (10 sec).
+- Past: "I started in [field] because [reason]."
+- Present: "Most recently at [Company] I've been [doing X]."
+- Why this role: "I'm looking at this role because [specific match]."
+- Differentiator: "One thing that's a bit unusual about me is [thing]."
+- Handoff: "What's the team's biggest priority right now?"
+- Practice until it's natural. Never read it.
+
+### J. Salary and offer conversations (where the CV's framing pays off)
+
+- First mention of money: not on the CV, not in the cover letter, not in the first call. Wait until they raise it.
+- When asked "what are you looking for?": deflect once. "I'd like to understand the role better first. Can you share the band?"
+- If pushed: give a band, not a number. "$X to $Y depending on total package and scope."
+- Anchor high but defensibly. "Based on what I've seen for this seniority in [market], $X to $Y feels right."
+- After an offer: negotiate base, equity, sign-on, RDOs, study budget, gear, title, start date. Companies expect counter-offers; not negotiating leaves money on the table.
+- Get every offer in writing before accepting verbally.
+- 48-hour deliberation window is reasonable to ask for. Faster than 24 hours is a sign of pressure tactics.
+
+### K. The "no offer" / rejection handling (long game)
+
+- Reply graciously, within 48 hours. "Thank you for letting me know. I'd appreciate any feedback you can share."
+- Most companies won't share feedback. Don't push.
+- If they do share, write it down. It's the rarest, most valuable input you'll ever get.
+- Connect with the recruiter on LinkedIn after rejection. They move companies; they'll remember you.
+- 6 months later: send a 1-line note. "Hope you're well. Still interested in [Company] if anything opens at my level."
+- 12 months later: same. People who stay in touch get re-considered.
+- Don't burn bridges. Industries are small. The recruiter who rejected you today refers you in 18 months.
+
+### L. The recruiter relationship (a different kind of network)
+
+- Internal recruiters work for the company. Their job is filling roles.
+- External recruiters / agency recruiters work for themselves. They place across companies and have long memories.
+- A good agency recruiter is worth their weight. Build relationships with 2 to 3 in your industry.
+- Don't ghost recruiters. If you're no longer interested, say so in one line.
+- Don't apply to the same role through multiple recruiters. It causes conflicts and burns trust.
+- Tell recruiters your minimum salary expectation up front. Saves everyone's time.
+- Recruiters remember candidates who close cleanly (good or bad). Be one of them.
+
+### M. The personal brand layer (the slow CV)
+
+- Posting on LinkedIn, writing, speaking, building in public, and shipping side projects is the long-tail CV. Many roles are filled by reputation before they're posted.
+- 1 LinkedIn post per week is more impactful than 1 per day if the weekly is substantial.
+- Comments on others' posts compound faster than original posts for visibility.
+- A blog, even infrequently updated, is a credibility multiplier.
+- Talks at meetups, conferences, or podcasts (your own or as a guest) move you from "applicant" to "known person".
+- Open source contributions, public datasets, public design files, or public writing all serve as portfolio extensions.
+- Don't try to be a thought leader on everything. One narrow expertise area beats five shallow ones.
+- The personal brand serves the CV: it gives recruiters something to find when they search you, and it warms cold outreach.
+
+### N. The role-fit screen (before you even apply)
+
+Before tailoring the CV, run a 5-minute screen:
+
+- Do I meet the must-haves (not the nice-to-haves)? Companies inflate JDs; aim for 60 to 70% match on must-haves.
+- Is the seniority right? Applying 1 level above current is normal; 2 levels above is a stretch.
+- Is the location/remote policy compatible?
+- Is the compensation likely to match my expectations? (Levels.fyi, Glassdoor, Blind.)
+- Is the company in growth, plateau, or decline? (Layoff history, headcount trend, recent news.)
+- Is the team I'd join healthy? (LinkedIn for hiring manager's tenure, team turnover signals.)
+- Is the visa / work authorisation aligned?
+- If 3+ of these are red flags, don't apply. Save the energy for better-fit roles.
+
+---
+
+## PART 2: THE OPERATIONAL ANTI-AI-SLOP (workflow, not just words)
+
+### A. The prompt-design floor (when you do use AI to assist)
+
+If you're going to use AI for parts of the CV, the prompts that produce the least slop:
+
+- "Rewrite this bullet using only these facts: [paste facts]. Don't add words. Don't invent metrics. Keep it under 25 words."
+- "Make this sentence 30% shorter without changing the meaning."
+- "Suggest three alternative verbs for this bullet. Don't rewrite it."
+- "Flag any words in this CV that sound generic. Don't suggest replacements."
+- "Tell me what's missing from this CV based on this JD: [paste JD]. Don't rewrite anything."
+- Bad prompts: "Make this sound more professional", "Make this sound more impressive", "Polish this", "Write me a CV for a senior designer". Every one of these produces slop.
+- The principle: AI as editor, not writer. Constrain to verbs, lengths, comparisons, gaps. Never to "improve".
+
+### B. The voice fingerprint workflow (operationalising Round 2's section L)
+
+- Collect samples: 3 to 5 of your own emails, Slack messages, posts, blog drafts. 500 to 1000 words total.
+- Identify markers: 5 to 10 words/phrases you use that AI doesn't. 3 to 5 sentence patterns. Your punctuation defaults.
+- Identify negatives: 5 to 10 words you'd never use. (For Chris: em dashes, "delve", "tapestry", anything with "leveraging".)
+- After AI assistance, run a diff on draft vs sample. Mismatches are AI residue.
+- Build a 1-page reference doc: "Words I use", "Words I don't", "Sentence shapes I prefer", "Punctuation I use".
+- Re-check every cover letter against this doc before sending.
+- Update the doc quarterly as your voice evolves.
+
+### C. The "voice transplant" check (a deeper test)
+
+- Take any sentence from your draft CV and ask: would I say this on a podcast?
+- Take any sentence from your cover letter and ask: would I say this in a coffee chat with the hiring manager?
+- If the answer is "I'd say something simpler", that's the version that should be on the page.
+- Recruiters compare written voice to interview voice. If they diverge, trust drops.
+
+### D. The "Goldilocks specificity" rule
+
+- Too vague: "Led product redesign that improved metrics." (AI-like.)
+- Too specific to be defensible: "Led the redesign of the checkout flow that resulted in a 23.471% lift in 7-day retention measured via Mixpanel cohort analysis." (Suspicious precision.)
+- Just right: "Led the checkout flow redesign; 23% retention lift over 7 days, measured the same way as our prior baseline."
+- Round numbers to 2 significant figures unless the exact number is meaningful. "23%" not "23.471%". "$2.4M" not "$2,438,902".
+- Acknowledge the methodology in 3 to 6 words if it strengthens the claim. "measured via A/B test", "across two markets", "vs prior baseline".
+
+### E. The "anti-fluency" pass
+
+After your draft is done, do one pass that deliberately roughens the surface:
+
+- Break one perfect parallel structure.
+- Drop one transitional sentence that exists only to smooth flow.
+- Combine two short bullets into one longer one that contains a tradeoff.
+- Replace one polished adjective with a plainer noun.
+- Add one sentence fragment for emphasis.
+- Remove the third item from any list of three. (AI loves tricolons; humans drop the third.)
+- Replace one passive-voice construction with active, even if it's slightly less elegant.
+- Cut one adverb that's softening a strong verb.
+
+### F. The "delete first, write second" discipline
+
+- After every draft, your first action is to cut 15% of the words.
+- AI inflates; humans cut.
+- A CV that fits one page after deliberate cuts reads stronger than a CV that fits one page because nothing was added.
+- A cover letter at 220 words reads more confident than the same letter at 320.
+- Cut: "in order to" → "to". "Due to the fact that" → "because". "At this point in time" → "now". "With regard to" → "about". "In the event that" → "if".
+- Cut every "very", "really", "quite", "extremely", "incredibly", "highly" unless they're essential.
+- Cut every adjective that doesn't add new information. "Successful project" → "project". "Strategic decision" → "decision".
+
+### G. The "claim provenance" workflow
+
+Every claim on the CV gets a provenance tag in your private working file (not on the public CV):
+
+- Source: where the number/fact came from (specific report, dashboard, conversation, document).
+- Date: when the metric was measured.
+- Method: how it was measured.
+- Witness: who else can corroborate.
+- Scope: your contribution vs team contribution.
+
+If you can fill all 5 fields for every bullet, you can defend the CV. If you can't fill them for any bullet, that bullet is risky.
+
+### H. The "AI residue scan" (a 5-minute final pass)
+
+Open your final draft and search for these:
+
+- The word "leverag*" (catches leverage, leveraging, leveraged).
+- The word "deliver*" (often AI filler when it doesn't specify what was delivered).
+- "Comprehensive", "robust", "innovative", "dynamic", "strategic" used as adjectives without specifics.
+- Any sentence with three commas (often AI's tricolon).
+- Any em dash. (Brand standard says zero.)
+- Any unicode glyph (arrows, bullets, dashes that aren't the standard).
+- Any markdown leftover (`**`, `#`, `>`, `---`, backticks).
+- The phrase "results-driven" or "results-oriented".
+- The phrase "passionate about".
+- The phrase "proven track record".
+- The phrase "go-getter" or "self-starter".
+- Any sentence longer than 35 words. (Cut or split.)
+- Any paragraph longer than 5 sentences in a cover letter.
+- Any bullet starting with "Responsible for" or "Helped with". (Weak verbs.)
+- Any bullet starting with "Spearheaded" three times in a row. (Vary openings.)
+
+### I. The "compounding evidence" tactic (anti-AI by accumulation)
+
+- One specific anecdote isn't enough; one per role is.
+- One named project is good; one named project per role is much harder for AI to fake.
+- One verifiable URL (GitHub, portfolio, published work) is a small signal; three is a strong one.
+- One client name is risky if confidential; one named industry vertical per role is safe and specific.
+- Stack 6 to 12 verifiable specifics across the whole CV. Each is small; the accumulation is decisive.
+
+### J. The "asymmetric verification" check
+
+- AI can't be verified; you can.
+- Add things that can be independently verified: published articles, GitHub commits, conference talks (with year and event), patents (with number), open source contributions, published case studies, press mentions.
+- Even one externally verifiable claim shifts the trust default. The reviewer assumes the rest is also real.
+
+### K. The format-vs-voice tradeoff (resolved)
+
+- The "looks too clean" tells in Round 2 said over-polish is suspicious.
+- But you should still format the CV cleanly. A messy CV reads as careless, not human.
+- Resolution: clean format, messy voice.
+- The structure is templated and ATS-safe; the language is yours, idiosyncratic, specific, occasionally rough at the edges.
+- Visual polish + linguistic specificity = the combination AI cannot fake.
+
+### L. The "what a recruiter actually does in 8 seconds" reality
+
+In an 8-second scan, the recruiter checks:
+
+1. **Top half of page 1**: name, location, target role match, summary tone (3 seconds).
+2. **Most recent role**: title, company, dates, top bullet (2 seconds).
+3. **Pattern matching for keywords from the JD** (2 seconds).
+4. **Gut check on layout** (1 second).
+
+The CV gets a "yes / maybe / no" verdict, then gets either filed (maybe) or rejected (no), or read in detail (yes).
+
+- Optimise the top 4 inches of page 1 above everything else.
+- Most recent role's first bullet is the most-read line on the entire CV. Make it the strongest.
+- The summary, if you have one, is the second-most-read.
+- Everything below mid-page 1 is read only by candidates who passed the 8-second scan.
+
+### M. The continuous-improvement system (the year-round CV)
+
+- Update the CV every 3 months, even when not job-hunting. Memory fades.
+- Keep a running "wins file": every project, metric, quote, recognition, learning. Capture in the moment.
+- Take a screenshot of your LinkedIn skill endorsements quarterly.
+- Save every performance review, 360 feedback, written praise from a colleague.
+- Save offer letters, contracts, and titles in writing. Companies merge, get acquired, or fold; HR records vanish.
+- Maintain a master CV that's longer than 1 page. The 1-page version is a curation of the master.
+- Maintain a "long CV" with everything: every role, every project, every metric, every reference. Pull from it for each tailored version.
+- After every job change: write a 1-page "what I learned" memo. Mine it for future cover letters.
+
+### N. The "interview-back-to-CV" loop
+
+After every interview, regardless of outcome, update the CV:
+
+- Which bullets did the interviewer probe? Strengthen them or add context.
+- Which bullets got skipped? They're either fine or not interesting; reassess.
+- Which questions did you struggle with? Add a bullet that pre-empts the question next time.
+- What stories did you tell that weren't on the CV? Add them.
+- What stories did you mean to tell but forgot? Cue them via a CV bullet next time.
+- Which words did the interviewer use repeatedly? Mirror them on future CVs for similar roles.
+
+The CV improves with every interview, not just every application.
+
+---
+
+## SUMMARY: THE 10 NEXT-LEVEL RULES (no overlap with Rounds 1 or 2)
+
+1. Referrals beat cold applications 4 to 14x. Spend more time on warm intros than on tailoring.
+2. LinkedIn is a system, not a profile. Headline, About, Featured, Activity, custom URL all do work.
+3. Every CV bullet is a promise that will be tested in interview, reference check, or background check. Plan accordingly.
+4. Prep 8 to 12 STAR stories, each mapped to multiple bullets. The CV implies them; the interview confirms them.
+5. Use AI as editor (constrained tasks), never as writer (open prompts). The prompt design determines the slop level.
+6. Clean format + messy voice = the combination AI cannot fake. Polish the structure, roughen the language.
+7. Provenance every claim privately: source, date, method, witness, scope. If you can't fill all 5, the claim is risky.
+8. The recruiter scans for 8 seconds. The top 4 inches of page 1 and the first bullet of the most recent role do 80% of the work.
+9. Stay in touch with rejections. The recruiter who said no today refers you in 18 months.
+10. Maintain the CV year-round, not just when applying. The "wins file", the master CV, and the interview-back-to-CV loop compound over time into a defensible record.

--- a/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_consolidated.md
+++ b/apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_consolidated.md
@@ -1,0 +1,219 @@
+# CV Checklists, Consolidated Single List
+
+Generated: 2026-05-18
+
+This file consolidates the five source checklists into one duplicate-reduced list. Semantically repeated guidance is represented once, with source tags preserved so nuance is not lost.
+
+Sources:
+
+- [1] `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\cv-checklists_1.md`
+- [1a] `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\cv-checklists_1a.md`
+- [1b] `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\cv-checklists_1b.md`
+- [2] `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\cv-checklists_2.md`
+- [3] `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\cv-checklists_3.md`
+
+## Single Consolidated List
+
+1. **Treat the CV as an evidence packet, not a writing exercise.** Every important claim should be traceable to a role, project, metric, work sample, source CV version, job ad, human edit, or interview story. Store provenance privately: source, date, method, witness, and scope. Sources: [1], [1a], [1b], [2], [3].
+
+2. **Optimise first for a fast human scan.** In 6 to 10 seconds, the reader should understand the target role, seniority, strongest proof, current value, and whether the document feels tailored. The top third of page 1 and the first bullet under the most recent role carry most of the load. Sources: [1], [1a], [1b], [3].
+
+3. **Run a role-fit screen before tailoring.** Check must-haves, seniority, location or remote policy, compensation range, visa or work rights, company health, team health, layoffs, reposting patterns, excessive unpaid assessments, and whether the role deserves high effort. Sources: [1b], [2], [3].
+
+4. **Deconstruct the job ad before editing.** Mark hard filters, repeated keywords, responsibilities, success criteria, tools, platforms, domains, compliance areas, hidden seniority, pain signals, urgency signals, contradictions, and likely recruiter copy-paste. Tailor to evidence and pain, not only keywords. Sources: [1], [1a], [1b].
+
+5. **Build a proof map before writing.** For each must-have or important responsibility, map exact CV evidence, adjacent experience, proof strength, missing proof, and interview story. Label claims as strong, medium, weak, shared, assisted, exposure, training, or aspiration. Sources: [1a], [1b].
+
+6. **Tailor truthfully, in small targeted moves.** Reorder and sharpen the most relevant bullets, mirror exact employer phrasing only when true, move wanted skills upward, compress irrelevant detail, and avoid becoming a different person for each job. Sources: [1], [1a], [1b].
+
+7. **Separate parser risk from ranking risk and human judgement.** Do not assume silence means an AI rejected the CV, and do not promise that a perfect ATS score creates interviews. Keyword matching is useful but insufficient; semantic matching, recruiter trust, hiring-manager proof, and interview performance all matter. Sources: [1], [1a], [1b].
+
+8. **Use ATS-safe structure by default.** Use one column, standard headings, real selectable text, consistent dates, simple bullets, plain contact text, standard fonts, and no core content in tables, text boxes, headers, footers, sidebars, icons, charts, progress bars, photos, or decorative graphics. Sources: [1], [1a], [1b], [2].
+
+9. **Choose file format by submission channel.** DOCX is the safest default for brittle portals; text-based PDF is acceptable where allowed; image PDFs from Canva, Figma, Photoshop, or decorative builders are high risk. Never submit rasterised or outlined text. Sources: [1], [1a], [1b], [2].
+
+10. **Identify the ATS vendor when possible.** Workday, Greenhouse, Lever, iCIMS, Taleo, SAP SuccessFactors, BambooHR, SmartRecruiters, Breezy, and Ashby have different tolerance levels. Taleo needs the simplest format; Ashby is usually more forgiving; always inspect parser output before submitting. Sources: [1], [1b], [2].
+
+11. **Plain-text test every final CV.** Copy the CV into a plain-text editor and confirm names, titles, companies, dates, links, bullets, skills, education, certifications, and reading order survive. Portal previews and populated fields should be checked before final submission. Sources: [1], [1a], [1b].
+
+12. **Use standard section labels.** Prefer Work Experience or Experience, Education, Skills, Certifications, Projects, Volunteering, and similar recognised labels. Avoid labels such as Career Journey, My Toolkit, Where I Create Impact, or other decorative headings in ATS versions. Sources: [1], [1a].
+
+13. **Format dates consistently and plainly.** Use Month YYYY or MM/YYYY ranges; avoid vague dates like Summer 2024; ensure Present is parsed correctly; check unexplained overlaps, contract roles, freelance periods, and multiple roles at one employer. Sources: [1], [1a], [1b].
+
+14. **Use canonical skill names without keyword stuffing.** Use exact employer terms where true, expand acronyms once, include both canonical and human phrasing when useful, and put critical skills in work context rather than only in a skills list. Do not add synonyms that imply tools the applicant has not used. Sources: [1], [1a], [1b].
+
+15. **Keep contact details professional and parseable.** Include name, city or region, phone where appropriate, professional email, LinkedIn, portfolio, GitHub, or website if relevant. Avoid full street address, DOB, marital status, novelty email, broken links, unprofessional social links, and contact icons in ATS versions. Sources: [1], [1a], [2].
+
+16. **Match geography and market norms.** Australia, UK, New Zealand, Canada, and the US usually avoid photo and DOB; US non-executive resumes are often stricter on one page; Australia and UK commonly allow two pages or more for senior roles; Germany, Austria, Switzerland, Japan, France, and Gulf markets may expect different photo, personal data, length, or format norms. Sources: [1], [1a], [1b], [2].
+
+17. **Handle work rights carefully.** Include work rights, citizenship, PR, visa class, clearance, location, relocation, travel, shift, or onsite availability only when required, strategically useful, or market-normal. Screening answers must match the CV. Sources: [1a], [1b], [2].
+
+18. **Choose length by market, sector, and evidence.** One page suits many early-career or US non-executive applications; two pages is normal for many experienced candidates; senior, executive, academic, medical, government, legal, or public-sector documents can be longer when the evidence requires it. Avoid cramming, tiny margins, or a nearly blank final page. Sources: [1], [1a], [1b], [2].
+
+19. **Use reverse chronological structure unless there is a reason not to.** Put recent and relevant evidence first, separate promotions when titles or responsibilities changed materially, group older or less relevant roles, and cap visible older experience when age signalling or relevance is a concern. Sources: [1], [1a], [1b].
+
+20. **Use a factual headline only if it clarifies fit.** Make it short, role-aligned, and evidence-backed. Avoid guru, ninja, rockstar, visionary, identity stacking, or a headline broader than the evidence. Sources: [1a], [3].
+
+21. **Write a summary only when it adds targeting value.** Keep it short, specific, role-aligned, and proof-led. Avoid objective sections, generic mission statements, highly motivated, results-driven, passionate, proven track record, unique blend, and adjectives that replace evidence. Sources: [1], [1a], [1b], [2].
+
+22. **Prioritise hard skills and defensible soft skills.** Separate categories where useful, list exact technologies, methods, domains, and certifications, and only include communication, leadership, teamwork, problem-solving, or stakeholder work when backed by bullets. Sources: [1], [1a], [1b].
+
+23. **Write experience entries with context and contribution.** Include role, employer, dates, location or remote signal if useful, company context for obscure employers, team size, budget, product, customer, territory, system, or operational scope when it improves trust. Focus on the applicant's contribution more than the employer description. Sources: [1], [1a], [1b].
+
+24. **Make achievements stronger than responsibilities.** Bullets should usually show action, context, method, scale, result, and stakeholder or customer impact. Prefer before-and-after, team-and-outcome, scope-and-constraint, first-largest-fastest, saved-or-made, fixed-a-problem, rolled-out-at-scale, and owned-end-to-end patterns. Sources: [1], [1a], [1b], [2].
+
+25. **Use strong but honest verbs.** Led, owned, built, shipped, scaled, negotiated, architected, and directed must mean what they say. Replace helped, assisted, supported, responsible for, worked on, played a key role, and contributed to with the actual task when true. Sources: [1], [1a], [1b], [2], [3].
+
+26. **Quantify what can be defended.** Use revenue, cost, time saved, cycle time, errors, quality, conversion, retention, CSAT, NPS, churn, tickets, automation rate, uptime, latency, adoption, users, team size, budget, geography, compliance outcome, training result, or delivery speed. If no metric exists, use credible scope, frequency, complexity, risk avoided, deliverable, or qualitative outcome. Sources: [1], [1a], [1b], [2], [3].
+
+27. **Avoid fake-looking metrics.** Do not invent numbers, overstate estimates, borrow team outcomes as solo wins, cluster round numbers, claim 100 percent improvement unless mathematically true, or use confidential figures unsafely. Round to sensible precision and include method where it strengthens trust. Sources: [1], [1a], [1b], [2], [3].
+
+28. **Check every claim against interview reality.** For each bullet, know what happened before, what the applicant did, what others did, what was hard, what tradeoff was made, how success was measured, what number might be challenged, and what the two-minute story is. Sources: [1], [1a], [1b], [2], [3].
+
+29. **Use evidence-upgrade prompts.** Ask what changed, who used it, how often it ran, what decision it enabled, which risk reduced, what bottleneck moved, what manual task disappeared, what deadline was met, what audit passed, and what can be shown publicly. Sources: [1a], [1b], [3].
+
+30. **Protect confidentiality.** Sanitise private claims, client names, employer-sensitive projects, internal codenames, confidential metrics, NDA material, protected health or personal information, and unpublished strategy. Use safe versions where needed. Sources: [1a], [1b], [2], [3].
+
+31. **Handle education by relevance and age signal.** Experienced candidates usually place education lower; graduates can place it higher. Include degree, institution, field, current certifications, licences, honours, coursework, thesis, or GPA only when useful. Omit graduation year when age signalling is a concern. Sources: [1], [1a], [1b].
+
+32. **Compress early career intelligently.** Older roles can become Early Career Highlights without dates, especially when they are less relevant or age-noisy. Do not delete roles in a way that creates suspicious gaps or removes useful range. Sources: [1], [1a], [1b].
+
+33. **Handle career gaps, layoffs, and short tenure calmly.** Explain only what helps, use neutral wording, do not apologise, avoid blame, and do not over-disclose medical, family, or private details. Use interviews or cover letters for nuance where the CV would overdo it. Sources: [1a], [1b], [2], [3].
+
+34. **Make career changes credible.** Lead with transferable proof, show applied learning and projects, translate old outcomes into new-role language, use a hybrid format if chronology buries relevance, and explain the pivot in the cover letter when needed. Sources: [1a], [1b], [2].
+
+35. **Represent freelance, contract, founder, and startup work precisely.** Clarify self-employed status, client type, engagement length, deliverables, overlap, sales versus delivery ownership, stage at join and exit, shipped work, revenue or user learning, constraints, and whether the candidate can work inside a larger organisation. Sources: [1a], [1b], [2].
+
+36. **Show seniority through decisions, not labels.** Demonstrate ambiguity handled, tradeoffs, systems thinking, governance, risk, budgets, hiring, mentoring, coaching, cross-functional influence, commercial accountability, scale, and stakeholder trust. Avoid executive language without evidence or over-seniority for hands-on roles. Sources: [1a], [1b], [2].
+
+37. **Include projects only when they prove role fit.** Explain the problem, role, stack or method, result, adoption, usage, constraints, and links where helpful. Avoid dead links, toy projects outside early career, distracting projects, or production claims for hobby work. Sources: [1a], [1b].
+
+38. **Treat portfolio as proof, not decoration.** Use one canonical URL, make sure it works on mobile, loads quickly, starts with the most relevant work, explains problem, solution, contribution, constraints, decisions, and outcome, and does not expose confidential work. Passwords belong in cover letters, not the CV. Sources: [1a], [1b], [2], [3].
+
+39. **Align LinkedIn with the CV.** Titles, dates, employer names, education, certifications, location, portfolio, skills, and seniority must match. LinkedIn can have longer descriptions than the CV, but major contradictions trigger distrust. Sources: [1], [1a], [1b], [3].
+
+40. **Use LinkedIn as a hiring system.** Headline should target the role, About should be short and first-person, Featured should show 3 to 5 relevant pieces, skills should be pruned to 20 to 30 high-signal items, recommendations should be current, Activity should show signs of life, and custom URL should be clean. Sources: [1], [1a], [3].
+
+41. **Use referrals before cold applications when possible.** Ask first for a short conversation, then ask whether the person is comfortable putting you forward. Send a tailored CV, 3-bullet fit summary, and JD link. Track which referral routes convert. Sources: [3].
+
+42. **Use cold outreach sparingly and specifically.** Contact the hiring manager or a relevant team member, not generic inboxes. Keep subject and body short, mention the role, one specific product or team signal, one credibility hook, attach the CV, and follow up once after 5 to 7 business days. Sources: [2], [3].
+
+43. **Use professional application metadata.** Email subject should be clear and searchable; body should be 4 to 6 lines; send during local business hours, preferably Tuesday to Thursday morning; use one phone, one email, one LinkedIn URL; BCC yourself if useful. Sources: [2], [3].
+
+44. **Keep application records.** Log date, company, role, ATS vendor, CV version, cover letter, screening answers, JD, recruiter contact, response within 14 days, interviews, offers, rejections, and outcomes. Use the data to improve, not to endlessly polish in isolation. Sources: [1], [1a], [1b], [2], [3].
+
+45. **Use cover letters only when they add value.** Keep them concise, role-specific, and company-specific. Name the role and company, include one concrete reason for interest, use one evidence story, explain why this company, and end with a calm next step. Do not restate the CV. Sources: [1], [1a], [1b], [2], [3].
+
+46. **Avoid cover-letter boilerplate.** Remove Dear Sir or Madam where a better salutation is possible, I am writing to express my interest, immediately drawn to, I believe my skills make me ideal, valuable asset, thank you for considering, and company praise that could fit 50 employers. Sources: [1], [1a], [1b], [2].
+
+47. **Make screening answers consistent.** Work rights, salary, education, management experience, budget, industry experience, tool proficiency, relocation, onsite availability, start date, clearance, and portfolio claims must match the CV, cover letter, and application record. Sources: [1b].
+
+48. **Use tools as audits, not authorities.** Jobscan and Resume Worded are useful for parser checks but their match scores are not hiring truth. Resume builders are useful only if they export clean selectable text, protect privacy, avoid generic defaults, and do not encourage fake metrics or keyword blocks. Sources: [1], [1a], [1b], [2].
+
+49. **Do not optimise for detectors.** AI detectors are noisy, biased, and prone to false positives, especially for non-native English writers, regulated-industry writing, short documents, and formal styles. Fix specificity, source grounding, and voice instead of trying to game a score. Sources: [1], [1a], [1b], [2], [3].
+
+50. **Protect privacy during external review.** Do not upload unredacted CVs, names, emails, phone numbers, addresses, employer-sensitive projects, client names, confidential metrics, or private job-search notes to public detectors or unknown tools. Use redacted copies where testing is unavoidable. Sources: [1], [1a], [1b], [2].
+
+51. **Follow employer AI policies.** If the employer forbids AI assistance, follow that rule. If disclosure is requested, disclose according to instructions. If AI is allowed, keep human review and source provenance. Sources: [1a], [1b].
+
+52. **Use AI as an editor, not a writer.** Good prompts constrain facts, length, verbs, missing evidence, or generic-word flags. Bad prompts like polish this, make it impressive, or write me a CV generate slop. Never accept AI output verbatim. Sources: [1], [1a], [1b], [3].
+
+53. **Audit AI rewrites line by line.** For each generated bullet, identify the source fact, metric, tool use, leadership proof, company reference, skill, and claim boundary. Delete anything invented, inflated, obvious, unsupported, too close to the JD, or detachable from the applicant. Sources: [1a], [1b], [3].
+
+54. **Strip known AI vocabulary and filler.** Challenge or remove delve, tapestry, intricate, meticulous, pivotal, underscore, testament, vibrant, robust, nuanced, multifaceted, holistic, realm, landscape, paradigm, synergy, leverage, spearhead, navigate, harness, foster, cultivate, streamline, empower, elevate, transformative, groundbreaking, cutting-edge, state-of-the-art, innovative, dynamic, ever-evolving, bolster, showcase, enhance, optimise, facilitate, thoughtful, intentional, curated, orchestration, actionable insights, north star, single source of truth, high-leverage, high-velocity, force multiplier, battle-tested, production-grade, enterprise-grade, world-class, best-in-class, purpose-built, and white-glove unless they are specific and natural. Sources: [1], [1a], [1b], [2], [3].
+
+55. **Remove generic AI phrases.** Cut in today's fast-paced world, digital age, ever-evolving landscape, at the forefront, pivotal role, testament to, deep dive, wealth of experience, results-driven, passionate about, proven track record, results-oriented, detail-oriented, team player, go-getter, self-starter, think outside the box, hit the ground running, wear many hats, uniquely positioned, and any sentence that could belong to another candidate. Sources: [1], [1a], [1b], [2], [3].
+
+56. **Avoid AI sentence shapes.** Watch for not just X but Y, it is not X it is Y, tricolons, self-posed rhetorical questions, hourglass paragraphs, listicle creep, repeated parallel bullets, same-length sentences, overly balanced paragraphs, exactly 3, 5, or 7 list items, and meta-summary sentences that restate the list. Sources: [1], [1a], [1b], [2], [3].
+
+57. **Avoid AI cover-letter scaffolding.** Break the predictable 3 to 4 paragraph pattern where paragraph 1 introduces self, paragraph 2 matches experience, paragraph 3 gives generic company praise, and paragraph 4 closes with eagerness. Use shape only if it genuinely serves the message. Sources: [1], [1a], [2], [3].
+
+58. **Keep punctuation and typography clean.** Use no em dashes, no decorative arrows, no unusual bullet glyphs, no mixed smart and straight quotes, no random title case, no markdown artifacts, no code fences, no blockquote markers, no invisible non-breaking spaces, and no inconsistent dash, colon, or parenthesis spacing. Sources: [1], [1a], [1b], [2], [3].
+
+59. **Avoid over-designed AI-looking format.** Do not leave markdown headers, literal bold syntax, backticks around skills, quote-block taglines, three-dash dividers, suspiciously perfect visual symmetry, or template metadata. Clean format is good; artificial gloss is not. Sources: [1], [1a], [1b], [2], [3].
+
+60. **Keep tone human and direct.** Avoid sycophantic praise, empty enthusiasm, exaggerated humility, diplomatic fog, excessive hedging, corporate warmth, productivity-blog phrasing, over-polished neutrality, and company compliments without evidence. Sources: [1], [1a], [1b], [2], [3].
+
+61. **Vary rhythm naturally.** Use sentence variety, some fragments where appropriate, direct verbs, and applicant-specific wording. Do not add typos, slang, random contractions, fake-casual openers, personal anecdotes unrelated to the role, or humanizer-tool residue. Sources: [1], [1a], [1b], [2], [3].
+
+62. **Preserve the applicant's voice.** Compare final CV and cover letter against 3 to 5 real writing samples. Identify words the applicant uses, words they never use, sentence shapes, punctuation habits, directness, warmth, technical precision, and formality. Rewrite foreign-sounding sentences. Sources: [1], [1a], [1b], [2], [3].
+
+63. **Use anti-slop sentence surgery.** If a sentence has no specific noun, no specific verb, no object of work, no audience, no data type, no system, no manual task, no decision, no communication output, or sounds like a motivational poster, rewrite or delete it. Sources: [1a], [1b], [3].
+
+64. **Use precise word swaps.** Replace leveraged with the actual action, utilised with used, facilitated with ran or coordinated if true, supported with the exact support, streamlined with the before and after, enhanced with the measured improvement, transformed with what changed, and empowered with what the audience could do afterward. Sources: [1a], [1b], [2].
+
+65. **Look for low-signal patterns.** Responsible for daily operations, worked with stakeholders, supported projects, improved processes, used data, built reports, managed systems, assisted leadership, provided insights, optimised campaigns, created content, and implemented solutions need scope, output, audience, or result. Sources: [1a], [1b].
+
+66. **Add high-signal details.** Use named problem category, user group, customer segment, operational bottleneck, technical constraint, compliance requirement, business metric, workflow replaced, decision influenced, team interface, delivery deadline, risk avoided, handoff improved, migration scope, incident response, sales motion, or design constraint. Sources: [1a], [1b], [2], [3].
+
+67. **Use what AI cannot fake.** Add real anecdotes, named projects, verifiable URLs, tradeoffs, minor failures or recoveries, lived-domain jargon, specific tools used in specific ways, client names where safe, published work, GitHub commits, talks, patents, open-source contributions, and public case studies. Sources: [1b], [2], [3].
+
+68. **Run the AI-residue scan before sending.** Search for leverag*, deliver*, comprehensive, robust, innovative, dynamic, strategic, three-comma sentences, em dashes, unicode glyphs, markdown leftovers, results-driven, passionate about, proven track record, go-getter, self-starter, sentences over 35 words, long cover-letter paragraphs, weak verb openings, and repeated spearheaded. Sources: [1], [1a], [1b], [2], [3].
+
+69. **Use clean format plus specific voice.** The format can be structured and ATS-safe; the language should be applicant-specific, occasionally rough at the edges, and grounded in lived detail. Sources: [2], [3].
+
+70. **Perform document hygiene before submission.** Remove tracked changes, comments, hidden objects, previous employer notes, AI prompt text, placeholder text, unused styles, blank pages, old metadata, private notes, version history where possible, and embarrassing PDF Author, Producer, Title, Creator, or Keywords fields. Sources: [1a], [1b], [2].
+
+71. **Check final layout in the submitted format.** Open DOCX or PDF fresh, preferably in a different viewer, check page count, black-and-white readability, line breaks, widows, orphans, broken links, and whether export changed spacing or fonts. Sources: [1], [1a], [1b], [2].
+
+72. **Keep the CV accessible and readable.** Check contrast, screen-reader order, meaningful link text, grayscale meaning, readable font size, abbreviation expansion, preview-pane readability, print readability, and whether dense bullet blocks cause fatigue. Sources: [1a], [1b].
+
+73. **Avoid legal and ethical traps.** No hidden white text, font-size-zero text, off-canvas keywords, keyword stuffing, fake credentials, fake metrics, false citizenship or visa claims, fabricated employers, invented referrals, salary lies, or claims the applicant cannot demonstrate quickly. Sources: [1], [1a], [1b].
+
+74. **Keep references separate.** Do not include references on the CV. Prepare 3 to 5 references with permission, brief them with the JD and desired emphasis, and re-confirm before each use. LinkedIn recommendations can help but do not replace reference management. Sources: [1a], [1b], [2], [3].
+
+75. **Use social proof only when credible.** Public talks, publications, awards, press, testimonials, LinkedIn recommendations, open-source work, and portfolio proof are useful when relevant and verifiable. Avoid obscure badges, unverifiable awards, and weak endorsements. Sources: [1a], [1b], [2], [3].
+
+76. **Prepare interview stories for every important bullet.** Each CV bullet is a promise. Have 8 to 12 STAR stories covering leadership, conflict, failure, ambiguity, technical depth, stakeholder work, deadline pressure, ethics, team building, learning, and biggest impact. Sources: [1], [1b], [3].
+
+77. **Practise the interview transition.** The recruiter screen uses the CV as a script; the hiring manager probes judgement; panels cross-check stories; technical or craft interviews expose inflated claims; references and background checks verify dates, titles, degrees, and achievements. Sources: [1], [1b], [3].
+
+78. **Prepare the core interview answers the CV implies.** Have concise answers for walk me through your CV, tell me about yourself, why this role, why us, why are you leaving, biggest failure, conflict, ambiguity, hardest project, and recent skill development. Sources: [1b], [3].
+
+79. **Keep salary and negotiation out of the CV.** Do not list current salary; avoid expected salary unless required; use bands if forced; know posted salary-band laws and local norms; negotiate base, equity, sign-on, benefits, title, start date, study budget, gear, and other package elements after offer. Sources: [1], [1b], [2], [3].
+
+80. **Use rejections as long-game input.** Reply graciously, ask for feedback once if appropriate, record any feedback, connect with recruiters, and stay in touch at reasonable intervals. Do not burn bridges or over-message. Sources: [2], [3].
+
+81. **Build recruiter relationships cleanly.** Internal recruiters fill roles for the company; agency recruiters place across companies. Do not ghost recruiters, do not apply through multiple recruiters for the same role, and be clear about minimum salary expectations when working with agencies. Sources: [3].
+
+82. **Maintain a personal brand that supports the CV.** LinkedIn posts, thoughtful comments, writing, talks, podcasts, open-source work, public datasets, public design files, and side projects can warm the channel before a job is posted. Focus on one narrow expertise area rather than shallow signals everywhere. Sources: [3].
+
+83. **Keep a master CV and wins file year-round.** Capture projects, metrics, quotes, recognition, learnings, reviews, feedback, contracts, titles, and "what I learned" notes while memory is fresh. Update the master CV quarterly and pull tailored versions from it. Sources: [1a], [1b], [2], [3].
+
+84. **Use interview feedback to improve the CV.** Track which bullets were probed, skipped, misunderstood, or useful; add stories told in interviews that were missing from the CV; mirror useful interviewer language in future applications. Sources: [2], [3].
+
+85. **Do not over-optimise away truth or personality.** Beware scanner-perfect but human-weak CVs, keyword-matched but proof-thin CVs, senior-sounding but junior-evidence CVs, over-polished generic copy, and versions that hide the applicant's real strengths. Sources: [1], [1a], [1b].
+
+86. **Know modern hiring realities.** Many applicants use AI; recruiters often pattern-match generic AI tone; auto-apply tools have low callback rates and can burn goodwill; ghost jobs are common; Workday is widespread; skills-based hiring is rising; hybrid and remote preferences should be handled plainly. Sources: [1], [1a], [1b], [3].
+
+87. **Use role-specific review angles.** Software engineering needs production impact, stack in context, testing, security, performance, maintainability, and AI claims beyond prompting. Product needs discovery, prioritisation, tradeoffs, roadmap influence, launch outcome, metrics, and user impact. Design needs problem framing, research, decisions, constraints, iteration, accessibility, handoff, portfolio, and outcomes. Sources: [1a], [1b].
+
+88. **Adapt for operations, sales, support, marketing, data, and analytics.** Operations needs before-and-after process, volume, cost, time, quality, safety, compliance, workforce, vendors, systems, and reporting. Sales needs quota, attainment, pipeline, deal size, cycle, territory, vertical, conversion, retention, expansion, and CRM accuracy. Support and success need ticket volume, resolution time, CSAT, NPS, churn, escalation, segment, knowledge base, and feedback loops. Marketing needs channel, audience, campaign, spend, attribution, conversion, content, pipeline, revenue, brand, and growth. Data needs question, source, method, tool, output, decision, adoption, governance, and accuracy. Sources: [1a], [1b].
+
+89. **Adapt for regulated and specialised sectors.** Government and public sector need plain language, compliance, stakeholder governance, procurement awareness, and often selection criteria. Healthcare needs patient, clinician, operational, privacy, quality, safety, and documentation context. Education needs learner population, curriculum, assessment, accessibility, inclusion, and support context. Finance needs controls, reporting cadence, accuracy, risk, and compliance. Creative and content need audience, brief, channel, distribution, performance, editorial judgement, and brand constraints. Sources: [1a], [1b], [2].
+
+90. **Distinguish AI product and automation claims.** Separate prompting from product work, prototype from production, internal tool from customer-facing feature, automation from autonomous agent, model integration from model training, evaluation from vibes, and demo from shipped value. Show controls, privacy, security, user feedback, and failure handling. Sources: [1b].
+
+91. **Use country and industry exceptions deliberately.** Academic, medical, legal, government, trades, creative, sales, engineering, finance, startup, education, NGO, and public-sector CVs have different expected proof and ordering. Do not import US corporate advice into every market or academic conventions into commercial roles. Sources: [1a], [1b], [2].
+
+92. **Prepare additional documents only when useful.** For portfolios, case studies, deal sheets, work samples, selection criteria, references, and private proof routes, keep them concise, relevant, permission-safe, and consistent with the CV. Sources: [1a], [1b], [2].
+
+93. **Use application timing and effort allocation strategically.** Spend more effort on high-fit roles, referrals, direct outreach, and warm channels; spend less on low-fit portals, poor signals, repeated reposts, vague salary, or roles with too many red flags. Sources: [1b], [2], [3].
+
+94. **Keep the top-of-page signal strong.** Put the role target, current value, most relevant proof, and strongest first bullet above the fold. If a recruiter can only read four inches, those four inches must work. Sources: [1], [1a], [3].
+
+95. **Keep bullets readable.** One bullet should usually hold one idea; recent roles can have 3 to 6 bullets; older roles need fewer; most bullets should stay to one or two lines; vary openings and rhythm; choose either full stops on every bullet or none. Sources: [1], [1a].
+
+96. **Avoid design choices that hide signal.** Cramped layouts, tiny margins, dense paragraphs, decorative dividers, colour-heavy themes, multiple columns, sidebars, and infographic templates often hurt both parsing and scanning. White space and quiet typography improve trust. Sources: [1], [1a], [2].
+
+97. **Check all links and online surfaces.** LinkedIn, portfolio, GitHub, website, Featured links, public activity, pinned repositories, case studies, profile photo, banner, and custom URLs should support the target role and not contradict the CV. Sources: [1], [1a], [1b], [2], [3].
+
+98. **Avoid mass-application smell.** Do not mirror the ad too perfectly, copy long JD phrases, make every role look like the target role, claim every nice-to-have, include every possible synonym, or use cover-letter praise from the homepage only. Sources: [1], [1a], [1b], [2], [3].
+
+99. **Use human specificity by accumulation.** A handful of small specifics across the CV, named projects, real constraints, real tradeoffs, defensible numbers, named tools, safe client or sector detail, and verifiable links, shifts the trust default more than one polished paragraph. Sources: [1a], [1b], [2], [3].
+
+100. **Apply Chris-specific and brand-specific rules where relevant.** No em dashes anywhere; avoid typographic hangers and orphans; ATS-friendly format beats aesthetics; use "prompt composition" rather than "prompt engineering"; state Higgsfield as "top 2%"; keep Bailey, Malamute Mayhem, and UnClick lore out of the CV unless directly relevant; education may lead with "University Degree Equivalent (22+ Years Extensive Professional Experience)" where appropriate. Sources: [1], [3].
+
+101. **Maintain the quality bar for productised rules.** A rule should have a source, date, stability signal, market scope, risk category, risk of blind use, safe default, exception, and retirement path when evidence changes. Avoid magic numbers, scare tactics, and false certainty about opaque hiring systems. Sources: [1b].
+
+102. **Use the final pre-submit gate.** Confirm target role, top-third signal, one-column text, standard headings, parser pass, purposeful bullets, role-matched skills, date consistency, LinkedIn consistency, working links, clean metadata, no hidden text, no private notes, no fake or unsupported claims, no AI-slop residue, employer-specific cover letter if included, and an exact saved copy of what was submitted. Sources: [1], [1a], [1b], [2], [3].

--- a/apps/jobsmith/docs/jobsmith-cv-checklist-scopepack.md
+++ b/apps/jobsmith/docs/jobsmith-cv-checklist-scopepack.md
@@ -1,0 +1,129 @@
+# JobSmith Universal Rules And CV Checklist ScopePack
+
+Target todo: `848eb8db-dfbb-4411-a332-05096b5bf1fb`
+
+Lane: JobSmith
+
+Priority: TEMP ASAP
+
+Status: build-ready source handoff, not DONE
+
+## Goal
+
+Wire the five copied CV checklist sources and the FYI JobSmith rule-pack handoff into `apps/jobsmith` so builders can implement a deterministic, evolving CV rule/checklist engine with proof.
+
+This slice preserves source truth and build shape. It does not claim that all rules are implemented.
+
+## Source Of Truth
+
+Exact source files are copied under:
+
+`apps/jobsmith/docs/copyroom/cv-checklists/`
+
+Machine-readable manifest:
+
+`apps/jobsmith/src/lib/cvChecklistSources.ts`
+
+Proof test:
+
+`apps/jobsmith/src/lib/cvChecklistSources.test.ts`
+
+## Source Inputs
+
+1. `cv-checklists_1.md`
+2. `cv-checklists_1a.md`
+3. `cv-checklists_1b.md`
+4. `cv-checklists_2.md`
+5. `cv-checklists_3.md`
+6. FYI JobSmith handoff comment `0bad9e59-03cf-44e9-83e2-33f4473a9209`
+7. Expanded rule-pack feed comment `4438301e-bdd7-4573-98f6-289ffe40941b`
+8. Chris-specified ScopePack addendum comment `b1b49c8f-c3af-44bb-a2d4-363148b4d763`
+
+## Deduped Rule Categories
+
+Use these categories for v1 import and future decay checks:
+
+1. ATS
+2. Age
+3. Truth
+4. Voice
+5. AI-detect
+6. Cover
+7. LinkedIn
+8. Visual
+9. Metadata
+10. Privacy
+11. Role-specific
+12. Interview-prep
+13. Application-strategy
+
+## Engine Contract
+
+The next builder should implement a deterministic rule engine that:
+
+1. Loads a schema-validated rule pack from `apps/jobsmith/rules/`.
+2. Keeps every rule linked to one or more source files or Boardroom comment ids.
+3. Emits `ERROR`, `WARN`, and `INFO` findings.
+4. Blocks output when `ERROR` findings exist.
+5. Flags stale rules when `decay_period_days` has passed.
+6. Shows rule-pack version in the JobSmith UI.
+
+## Required Rule Shape
+
+Each rule should keep:
+
+- `rule_id`
+- `name`
+- `category`
+- `severity`
+- `what`
+- `why`
+- `sources`
+- `applies_when`
+- `when_not_applies`
+- `check_method`
+- `decay_period_days`
+- `last_verified_at`
+- `volatile`
+- `remediation`
+
+## Build Order
+
+1. Import or generate `apps/jobsmith/rules/jobsmith-universal-rules-v1.yaml` from the verified source feed.
+2. Add schema validation for the rule file.
+3. Implement deterministic checks first: regex, keyword list, count threshold, and format checks.
+4. Add semantic or human-review checks only as flagged outputs, not as blocking hidden LLM behavior.
+5. Wire `apps/jobsmith/src/pages/JobsmithDraft.tsx` or the active JobSmith page to display rule version, findings, and stale-rule badges.
+
+## Acceptance Criteria
+
+- Five checklist files are present and hash-verified by test.
+- Builders can trace each rule back to source file or Boardroom comment.
+- The 40-rule handoff mismatch is reconciled before full encoding is claimed.
+- At least one deterministic check per category is covered by tests before marking implementation complete.
+- UI work includes screenshot proof before any UI/UX DONE claim.
+- No job is marked DONE without commit, PR, test output, and reviewer/proof-seat check.
+
+## Stop Conditions
+
+- Stop if rule-pack YAML cannot be schema validated.
+- Stop if a rule lacks source citation.
+- Stop if exact rule text is needed but only paraphrase is available.
+- Stop before touching `package.json` or `package-lock.json` unless a separate owner approves it.
+- Stop if another active builder owns the exact file you need.
+
+## Non Goals
+
+- No LLM-based checks in v1.
+- No fake metrics or claim invention.
+- No hidden text, keyword stuffing, detector evasion, or deceptive ATS tricks.
+- No production deploy or DONE transition in this source-handoff slice.
+
+## Reviewer Path
+
+Reviewer should check:
+
+1. `npm run test --workspace=@unclick/jobsmith -- cvChecklistSources`
+2. Source manifest hashes match the copied files.
+3. The 40-rule mismatch is still visible until reconciled.
+4. No existing builder-owned rulePack files were overwritten.

--- a/apps/jobsmith/docs/jobsmith-cv-checklist-scopepack.md
+++ b/apps/jobsmith/docs/jobsmith-cv-checklist-scopepack.md
@@ -10,7 +10,7 @@ Status: build-ready source handoff, not DONE
 
 ## Goal
 
-Wire the five copied CV checklist sources and the FYI JobSmith rule-pack handoff into `apps/jobsmith` so builders can implement a deterministic, evolving CV rule/checklist engine with proof.
+Wire the five copied CV checklist sources, Chris's consolidated checklist, and the FYI JobSmith rule-pack handoff into `apps/jobsmith` so builders can implement a deterministic, evolving CV rule/checklist engine with proof.
 
 This slice preserves source truth and build shape. It does not claim that all rules are implemented.
 
@@ -35,9 +35,10 @@ Proof test:
 3. `cv-checklists_1b.md`
 4. `cv-checklists_2.md`
 5. `cv-checklists_3.md`
-6. FYI JobSmith handoff comment `0bad9e59-03cf-44e9-83e2-33f4473a9209`
-7. Expanded rule-pack feed comment `4438301e-bdd7-4573-98f6-289ffe40941b`
-8. Chris-specified ScopePack addendum comment `b1b49c8f-c3af-44bb-a2d4-363148b4d763`
+6. `cv-checklists_consolidated.md`
+7. FYI JobSmith handoff comment `0bad9e59-03cf-44e9-83e2-33f4473a9209`
+8. Expanded rule-pack feed comment `4438301e-bdd7-4573-98f6-289ffe40941b`
+9. Chris-specified ScopePack addendum comment `b1b49c8f-c3af-44bb-a2d4-363148b4d763`
 
 ## Deduped Rule Categories
 
@@ -97,7 +98,7 @@ Each rule should keep:
 
 ## Acceptance Criteria
 
-- Five checklist files are present and hash-verified by test.
+- Five original checklist files plus Chris's consolidated checklist are present and hash-verified by test.
 - Builders can trace each rule back to source file or Boardroom comment.
 - The 40-rule handoff mismatch is reconciled before full encoding is claimed.
 - At least one deterministic check per category is covered by tests before marking implementation complete.

--- a/apps/jobsmith/src/lib/cvChecklistSources.test.ts
+++ b/apps/jobsmith/src/lib/cvChecklistSources.test.ts
@@ -15,13 +15,14 @@ import {
 const jobsmithRoot = process.cwd();
 
 describe("JobSmith CV checklist CopyRoom manifest", () => {
-  test("declares the five exact source files Chris supplied", () => {
+  test("declares the exact source files and consolidated checklist Chris supplied", () => {
     expect(getExpectedCvChecklistFileNames()).toEqual([
       "cv-checklists_1.md",
       "cv-checklists_1a.md",
       "cv-checklists_1b.md",
       "cv-checklists_2.md",
       "cv-checklists_3.md",
+      "cv-checklists_consolidated.md",
     ]);
   });
 

--- a/apps/jobsmith/src/lib/cvChecklistSources.test.ts
+++ b/apps/jobsmith/src/lib/cvChecklistSources.test.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  getCvChecklistSource,
+  getExpectedCvChecklistFileNames,
+  JOBSMITH_CV_CHECKLIST_SOURCES,
+  JOBSMITH_RULE_CATEGORIES,
+  JOBSMITH_RULE_PACK_HANDOFF,
+} from "./cvChecklistSources";
+
+const jobsmithRoot = process.cwd();
+
+describe("JobSmith CV checklist CopyRoom manifest", () => {
+  test("declares the five exact source files Chris supplied", () => {
+    expect(getExpectedCvChecklistFileNames()).toEqual([
+      "cv-checklists_1.md",
+      "cv-checklists_1a.md",
+      "cv-checklists_1b.md",
+      "cv-checklists_2.md",
+      "cv-checklists_3.md",
+    ]);
+  });
+
+  test("keeps source file names and hashes unique", () => {
+    const names = new Set(JOBSMITH_CV_CHECKLIST_SOURCES.map((source) => source.fileName));
+    const hashes = new Set(JOBSMITH_CV_CHECKLIST_SOURCES.map((source) => source.sha256));
+    expect(names.size).toBe(JOBSMITH_CV_CHECKLIST_SOURCES.length);
+    expect(hashes.size).toBe(JOBSMITH_CV_CHECKLIST_SOURCES.length);
+  });
+
+  test("copied source files are present and unchanged", async () => {
+    for (const source of JOBSMITH_CV_CHECKLIST_SOURCES) {
+      const absolutePath = path.join(jobsmithRoot, source.repoPath.replace("apps/jobsmith/", ""));
+      const content = await fs.readFile(absolutePath);
+      const hash = createHash("sha256").update(content).digest("hex");
+      expect(hash).toBe(source.sha256);
+      expect(content.byteLength).toBe(source.bytes);
+    }
+  });
+
+  test("tracks the FYI handoff proof gap instead of hiding it", () => {
+    const severityTotal =
+      JOBSMITH_RULE_PACK_HANDOFF.reportedSeverityCounts.error +
+      JOBSMITH_RULE_PACK_HANDOFF.reportedSeverityCounts.warn +
+      JOBSMITH_RULE_PACK_HANDOFF.reportedSeverityCounts.info;
+
+    expect(JOBSMITH_RULE_PACK_HANDOFF.reportedRuleCount).toBe(40);
+    expect(severityTotal).toBe(39);
+    expect(JOBSMITH_RULE_PACK_HANDOFF.reconciliationNeeded).toBe(true);
+    expect(JOBSMITH_RULE_PACK_HANDOFF.reconciliationNote).toMatch(/40-rule encoding/);
+  });
+
+  test("keeps the expanded 13-category rule map ready for the engine", () => {
+    expect(JOBSMITH_RULE_CATEGORIES).toEqual([
+      "ats",
+      "age",
+      "truth",
+      "voice",
+      "ai-detect",
+      "cover",
+      "linkedin",
+      "visual",
+      "metadata",
+      "privacy",
+      "role-specific",
+      "interview-prep",
+      "application-strategy",
+    ]);
+  });
+
+  test("looks up a copied source by file name", () => {
+    expect(getCvChecklistSource("cv-checklists_1b.md")?.round).toBe("round-1b");
+    expect(getCvChecklistSource("missing.md")).toBeUndefined();
+  });
+});

--- a/apps/jobsmith/src/lib/cvChecklistSources.ts
+++ b/apps/jobsmith/src/lib/cvChecklistSources.ts
@@ -1,0 +1,123 @@
+export type CvChecklistSourceRound = "base" | "round-1a" | "round-1b" | "round-2" | "round-3";
+
+export interface CvChecklistSource {
+  fileName: string;
+  repoPath: string;
+  copyRoomSourcePath: string;
+  sha256: string;
+  bytes: number;
+  lineCount: number;
+  round: CvChecklistSourceRound;
+  purpose: string;
+}
+
+export interface JobsmithRulePackHandoff {
+  todoId: string;
+  sourceCommentIds: string[];
+  reportedRuleCount: number;
+  reportedSeverityCounts: {
+    error: number;
+    warn: number;
+    info: number;
+  };
+  reconciliationNeeded: boolean;
+  reconciliationNote: string;
+}
+
+export const JOBSMITH_CV_CHECKLIST_SOURCE_DIR =
+  "apps/jobsmith/docs/copyroom/cv-checklists";
+
+export const JOBSMITH_CV_CHECKLIST_SOURCES: CvChecklistSource[] = [
+  {
+    fileName: "cv-checklists_1.md",
+    repoPath: `${JOBSMITH_CV_CHECKLIST_SOURCE_DIR}/cv-checklists_1.md`,
+    copyRoomSourcePath: "C:/Temp/unclick temp/cv-checklists_1.md",
+    sha256: "36e1bd88b5eaa6bbe7374681231c5a29a66676b5813bc59cf04ccd429c27fea4",
+    bytes: 27174,
+    lineCount: 329,
+    round: "base",
+    purpose: "Core modern CV, ATS, cover letter, anti AI-slop, and defensibility checklist.",
+  },
+  {
+    fileName: "cv-checklists_1a.md",
+    repoPath: `${JOBSMITH_CV_CHECKLIST_SOURCE_DIR}/cv-checklists_1a.md`,
+    copyRoomSourcePath: "C:/Temp/unclick temp/cv-checklists_1a.md",
+    sha256: "5a8f0593e8052f075ae7280c566bab5eef3a7415d72504caa8c6bd1e2257bf9a",
+    bytes: 42467,
+    lineCount: 951,
+    round: "round-1a",
+    purpose: "Broad master checklist with role-fit, ATS, truthfulness, recruiter scan, and rewrite rules.",
+  },
+  {
+    fileName: "cv-checklists_1b.md",
+    repoPath: `${JOBSMITH_CV_CHECKLIST_SOURCE_DIR}/cv-checklists_1b.md`,
+    copyRoomSourcePath: "C:/Temp/unclick temp/cv-checklists_1b.md",
+    sha256: "2616ec5a4858f63b35ce8b0b0cab1ad86b72e4e88e51430bb046a245ebb8b22f",
+    bytes: 43176,
+    lineCount: 916,
+    round: "round-1b",
+    purpose: "Evidence-packet, parser, knockout, claim-strength, redaction, and interview consistency pass.",
+  },
+  {
+    fileName: "cv-checklists_2.md",
+    repoPath: `${JOBSMITH_CV_CHECKLIST_SOURCE_DIR}/cv-checklists_2.md`,
+    copyRoomSourcePath: "C:/Temp/unclick temp/cv-checklists_2.md",
+    sha256: "bffd24c5663d120c3c86957819bf6c0bdc4e5a46fee7ee0fb89bc1aba2c7577c",
+    bytes: 24907,
+    lineCount: 313,
+    round: "round-2",
+    purpose: "Advanced checks for reconnaissance, local norms, portfolio discipline, metadata, and feedback loops.",
+  },
+  {
+    fileName: "cv-checklists_3.md",
+    repoPath: `${JOBSMITH_CV_CHECKLIST_SOURCE_DIR}/cv-checklists_3.md`,
+    copyRoomSourcePath: "C:/Temp/unclick temp/cv-checklists_3.md",
+    sha256: "9f651dec06874771523d41f4fe7d296998ee9beeba09051fcbeb2a1c457bf3d5",
+    bytes: 24500,
+    lineCount: 266,
+    round: "round-3",
+    purpose: "Around-the-CV workflow for referrals, LinkedIn, outreach, interview prep, and operational AI hygiene.",
+  },
+];
+
+export const JOBSMITH_RULE_PACK_HANDOFF: JobsmithRulePackHandoff = {
+  todoId: "848eb8db-dfbb-4411-a332-05096b5bf1fb",
+  sourceCommentIds: [
+    "0bad9e59-03cf-44e9-83e2-33f4473a9209",
+    "4438301e-bdd7-4573-98f6-289ffe40941b",
+    "b1b49c8f-c3af-44bb-a2d4-363148b4d763",
+  ],
+  reportedRuleCount: 40,
+  reportedSeverityCounts: {
+    error: 12,
+    warn: 19,
+    info: 8,
+  },
+  reconciliationNeeded: true,
+  reconciliationNote:
+    "The initial FYI handoff reports 40 rules, but the listed severity counts total 39. Builders must reconcile before claiming full 40-rule encoding.",
+};
+
+export const JOBSMITH_RULE_CATEGORIES = [
+  "ats",
+  "age",
+  "truth",
+  "voice",
+  "ai-detect",
+  "cover",
+  "linkedin",
+  "visual",
+  "metadata",
+  "privacy",
+  "role-specific",
+  "interview-prep",
+  "application-strategy",
+] as const;
+
+export function getCvChecklistSource(fileName: string): CvChecklistSource | undefined {
+  return JOBSMITH_CV_CHECKLIST_SOURCES.find((source) => source.fileName === fileName);
+}
+
+export function getExpectedCvChecklistFileNames(): string[] {
+  return JOBSMITH_CV_CHECKLIST_SOURCES.map((source) => source.fileName);
+}

--- a/apps/jobsmith/src/lib/cvChecklistSources.ts
+++ b/apps/jobsmith/src/lib/cvChecklistSources.ts
@@ -1,4 +1,10 @@
-export type CvChecklistSourceRound = "base" | "round-1a" | "round-1b" | "round-2" | "round-3";
+export type CvChecklistSourceRound =
+  | "base"
+  | "round-1a"
+  | "round-1b"
+  | "round-2"
+  | "round-3"
+  | "consolidated";
 
 export interface CvChecklistSource {
   fileName: string;
@@ -77,6 +83,17 @@ export const JOBSMITH_CV_CHECKLIST_SOURCES: CvChecklistSource[] = [
     lineCount: 266,
     round: "round-3",
     purpose: "Around-the-CV workflow for referrals, LinkedIn, outreach, interview prep, and operational AI hygiene.",
+  },
+  {
+    fileName: "cv-checklists_consolidated.md",
+    repoPath: `${JOBSMITH_CV_CHECKLIST_SOURCE_DIR}/cv-checklists_consolidated.md`,
+    copyRoomSourcePath:
+      "C:/Users/Malamutemayhem/Documents/Codex/2026-05-18/files-mentioned-by-the-user-cv-2/cv-checklists_consolidated.md",
+    sha256: "b09deb85f80d41cc00341f504b2894096b62b75f47d966632eb8c562380db7f2",
+    bytes: 34723,
+    lineCount: 219,
+    round: "consolidated",
+    purpose: "Chris-provided consolidated 102-rule checklist for the JobSmith v1 rule engine.",
   },
 ];
 

--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -26,7 +26,7 @@ function jsonResponse(value: unknown): Response {
   } as Response;
 }
 
-function contextWithEvents(events: Array<Record<string, unknown>>) {
+function contextWithEvents(events: Array<Record<string, unknown>>, responseBounds?: Record<string, unknown>) {
   return {
     context: {
       version: "orchestrator-context-v1",
@@ -68,6 +68,7 @@ function contextWithEvents(events: Array<Record<string, unknown>>) {
       human_operator_time: null,
       continuity_events: events,
       library_snapshots: [],
+      ...(responseBounds ? { response_bounds: responseBounds } : {}),
     },
   };
 }
@@ -253,7 +254,7 @@ describe("AdminOrchestratorPage", () => {
                     kind: "proof",
                     actor_agent_id: "codex-orchestrator-seat",
                     summary:
-                      "PASS: Orchestrator continuity proof landed. This deliberately long proof explains that the feed should be readable without hiding the source text forever, and it keeps going so the Show more button appears for humans who want the full detail instead of a clipped preview. The change should make the first sentence friendly, keep the AI natural context available, and avoid making the whole row a surprise hyperlink when someone is only trying to select or read text.",
+                      "PASS: Orchestrator continuity proof landed. This deliberately long proof explains that the feed should be readable without hiding the source text forever, and it keeps going so the Show more button appears for readers who want the full detail instead of a clipped preview. The change should make the first sentence friendly, keep the AI natural context available, and avoid making the whole row a surprise hyperlink when someone is only trying to select or read text.",
                     tags: ["done"],
                     deep_link: "/admin/jobs#todo-1",
                   },
@@ -340,6 +341,12 @@ describe("AdminOrchestratorPage", () => {
         }),
       ),
     );
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("max_summaries=240"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer session-token" }),
+      }),
+    );
   });
 
   it("keeps Story content visible while deeper history loads", async () => {
@@ -369,7 +376,7 @@ describe("AdminOrchestratorPage", () => {
     ];
     const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
       const textUrl = String(url);
-      if (textUrl.includes("orchestrator_context_read") && textUrl.includes("limit=200")) {
+      if (textUrl.includes("orchestrator_context_read") && textUrl.includes("limit=480")) {
         return deepHistoryPromise;
       }
       if (textUrl.includes("orchestrator_context_read")) {
@@ -408,6 +415,12 @@ describe("AdminOrchestratorPage", () => {
         }),
       ),
     );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("max_summaries=480"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer session-token" }),
+      }),
+    );
     expect(screen.queryByText("Writing the latest story...")).not.toBeInTheDocument();
     expect(screen.getAllByText(/Chris asked: Can Story hold more conversation by default/i).length).toBeGreaterThan(0);
 
@@ -418,7 +431,7 @@ describe("AdminOrchestratorPage", () => {
     renderOrchestrator("/admin/orchestrator/timeline");
 
     expect(await screen.findByText("Continuity Feed")).toBeInTheDocument();
-    expect(screen.getByLabelText("Easy reading for humans")).toBeChecked();
+    expect(screen.getByLabelText("Plain-language view")).toBeChecked();
     expect(screen.getByLabelText("Dripfeed Education")).toBeChecked();
     expect(screen.getByLabelText("Analogies")).toBeChecked();
     expect(screen.getByPlaceholderText("Filter Orchestrator feed")).toBeInTheDocument();
@@ -472,7 +485,7 @@ describe("AdminOrchestratorPage", () => {
     expect(screen.queryByText(/Dispatch routed the heartbeat packet/i)).not.toBeInTheDocument();
   });
 
-  it("lets humans view more loaded Orchestrator history", async () => {
+  it("lets readers view more loaded Orchestrator history", async () => {
     renderOrchestrator("/admin/orchestrator/timeline");
 
     expect(await screen.findByText("View more history")).toBeInTheDocument();
@@ -481,6 +494,78 @@ describe("AdminOrchestratorPage", () => {
     fireEvent.click(screen.getByText("View more history"));
 
     expect((await screen.findAllByText(/Archive event 24/i)).length).toBeGreaterThan(0);
+  });
+
+  it("loads deeper Timeline history when the compact response is truncated", async () => {
+    const compactEvents = Array.from({ length: 24 }, (_, index) => ({
+      source_kind: "conversation_turn",
+      source_id: `compact-${index}`,
+      created_at: `2026-05-10T05:${String(59 - index).padStart(2, "0")}:00.000Z`,
+      kind: "context",
+      role: "assistant",
+      summary: `Compact event ${index}: timeline detail.`,
+      tags: ["conversation"],
+    }));
+    const deeperEvents = [
+      ...compactEvents,
+      {
+        source_kind: "conversation_turn",
+        source_id: "compact-deeper-proof",
+        created_at: "2026-05-10T04:30:00.000Z",
+        kind: "context",
+        role: "assistant",
+        summary: "Deeper history arrived from the next source window.",
+        tags: ["conversation"],
+      },
+    ];
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      const textUrl = String(url);
+      if (textUrl.includes("orchestrator_context_read") && textUrl.includes("limit=480")) {
+        return jsonResponse(contextWithEvents(deeperEvents, { continuity_events_truncated: false }));
+      }
+      if (textUrl.includes("orchestrator_context_read")) {
+        return jsonResponse(contextWithEvents(compactEvents, { continuity_events_truncated: true }));
+      }
+      if (textUrl.includes("tenant_settings")) {
+        return jsonResponse({
+          env_enabled: true,
+          settings: {
+            ai_chat_enabled: true,
+            ai_chat_provider: "google",
+            ai_chat_model: "gemini-2.5-flash-lite",
+            ai_chat_system_prompt: null,
+            ai_chat_max_turns: 20,
+            has_api_key: true,
+          },
+        });
+      }
+      if (textUrl.includes("admin_channel_status")) {
+        return jsonResponse({ channel_active: false, last_seen: null, client_info: null });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderOrchestrator("/admin/orchestrator/timeline");
+
+    expect(await screen.findByText("Load deeper history")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Load deeper history"));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("orchestrator_context_read&limit=480"),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer session-token" }),
+        }),
+      ),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("max_summaries=480"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer session-token" }),
+      }),
+    );
+    expect((await screen.findAllByText(/Deeper history arrived/i)).length).toBeGreaterThan(0);
   });
 
   it("asks the server for deeper Orchestrator keyword matches", async () => {

--- a/src/pages/admin/AdminOrchestrator.test.tsx
+++ b/src/pages/admin/AdminOrchestrator.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AdminOrchestratorPage from "./AdminOrchestrator";
@@ -315,6 +315,8 @@ describe("AdminOrchestratorPage", () => {
     expect(screen.getAllByText(/A handoff stalled around/i).length).toBeGreaterThan(0);
     expect(screen.getByText("A Decision Sets Direction")).toBeInTheDocument();
     expect(screen.getAllByText(/Direction was set/i).length).toBeGreaterThan(0);
+    const storyList = screen.getByRole("list", { name: "Story moments" });
+    expect(within(storyList).getAllByRole("listitem").length).toBeGreaterThan(8);
     expect(screen.getAllByRole("heading", { level: 3 }).length).toBeGreaterThan(8);
     expect(screen.queryByText("Watching the scheduled runner")).not.toBeInTheDocument();
     expect(screen.queryByText("Signals in the background")).not.toBeInTheDocument();

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -111,6 +111,12 @@ interface OrchestratorContext {
     tags?: string[];
     updated_at?: string | null;
   }>;
+  response_bounds?: {
+    max_summaries?: number;
+    continuity_events_returned?: number;
+    continuity_events_available?: number;
+    continuity_events_truncated?: boolean;
+  };
 }
 
 type ConnectionTier = "channel" | "gemini" | "unconfigured";
@@ -157,6 +163,17 @@ const STORY_CHAPTER_MAX_EVENTS = 4;
 const STORY_CHAPTER_PREVIEW_CHARS = 1_450;
 const STORY_NATIVE_PREVIEW_COUNT = 5;
 const STORY_NATIVE_STORAGE_KEY = "unclick_orchestrator_story_native_v1";
+
+function orchestratorContextReadUrl(limit: number, options: { q?: string } = {}): string {
+  const params = new URLSearchParams({
+    action: "orchestrator_context_read",
+    limit: String(limit),
+    max_summaries: String(limit),
+  });
+  if (options.q) params.set("q", options.q);
+  return `/api/memory-admin?${params.toString()}`;
+}
+
 const SOURCE_VISIBILITY_FILTERS: Array<{ value: SourceVisibilityFilter; label: string }> = [
   { value: "all", label: "All" },
   { value: "work", label: "Work" },
@@ -1161,7 +1178,7 @@ export default function AdminOrchestratorPage() {
           fetch(
             `/api/memory-admin?action=admin_check_connection&api_key=${encodeURIComponent(storedApiKey)}`,
           ),
-          fetch(`/api/memory-admin?action=orchestrator_context_read&limit=${contextLimit}`, {
+          fetch(orchestratorContextReadUrl(contextLimit), {
             headers: { Authorization: `Bearer ${authToken}` },
           }),
           fetchAiChatTenantSettings(authToken),
@@ -1323,7 +1340,12 @@ function OrchestratorStoryPanel({
   );
   const visibleChapters = chapters.slice(0, visibleChapterCount);
   const hasMoreLoaded = visibleChapterCount < chapters.length;
-  const canLoadFromServer = contextLimit < maxContextLimit;
+  const hasResponseBounds = Boolean(context?.response_bounds);
+  const eventWindowIsTruncated = context?.response_bounds?.continuity_events_truncated === true;
+  const loadedEventCount = context?.continuity_events.length ?? 0;
+  const canLoadFromServer =
+    contextLimit < maxContextLimit &&
+    (!hasResponseBounds || eventWindowIsTruncated || loadedEventCount >= contextLimit);
   const { anchorRef: readMoreRef, holdPagePosition } = usePagePositionHold();
 
   const toggleNativeNotes = (value: boolean) => {
@@ -1494,7 +1516,7 @@ function OrchestratorContinuityPanel({
       void (async () => {
         try {
           const res = await fetch(
-            `/api/memory-admin?action=orchestrator_context_read&limit=120&q=${encodeURIComponent(trimmedSearchQuery)}`,
+            orchestratorContextReadUrl(120, { q: trimmedSearchQuery }),
             { headers: { Authorization: `Bearer ${authToken}` } },
           );
           if (cancelled) return;
@@ -1558,17 +1580,18 @@ function OrchestratorContinuityPanel({
   );
   const visibleEventViews = filteredEventViews.slice(0, visibleEventCount);
   const canRevealLoadedHistory = filteredEventViews.length > visibleEventCount;
+  const eventWindowIsTruncated = feedContext?.response_bounds?.continuity_events_truncated === true;
   const canLoadDeeperHistory =
     !trimmedSearchQuery &&
     !loading &&
     !serverSearchLoading &&
     contextLimit < maxContextLimit &&
-    events.length >= contextLimit;
+    (eventWindowIsTruncated || events.length >= contextLimit);
   const { anchorRef: viewMoreRef, holdPagePosition } = usePagePositionHold();
 
   useEffect(() => {
     setVisibleEventCount(CONTINUITY_VISIBLE_STEP);
-  }, [events.length, trimmedSearchQuery]);
+  }, [trimmedSearchQuery]);
 
   function toggleEasyRead(nextValue: boolean) {
     setEasyRead(nextValue);
@@ -1643,14 +1666,14 @@ function OrchestratorContinuityPanel({
 
         <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2">
           <span>
-            <span className="block text-xs font-medium text-white/75">Easy reading for humans</span>
+            <span className="block text-xs font-medium text-white/75">Plain-language view</span>
             <span className="block text-[10px] text-white/35">
               {easyRead ? "Friendly layer on" : "Natural context view"}
             </span>
           </span>
           <input
             type="checkbox"
-            aria-label="Easy reading for humans"
+            aria-label="Plain-language view"
             checked={easyRead}
             onChange={(event) => toggleEasyRead(event.target.checked)}
             className="sr-only"
@@ -1711,7 +1734,7 @@ function OrchestratorContinuityPanel({
           <span>Analogies</span>
         </label>
         <span className="text-[11px] text-white/30">
-          These only add friendly hints in Easy reading mode.
+          These only add friendly hints in Plain-language view.
         </span>
       </div>
 
@@ -1757,6 +1780,7 @@ function OrchestratorContinuityPanel({
                       return;
                     }
                     onLoadDeeperHistory();
+                    setVisibleEventCount((value) => value + CONTINUITY_VISIBLE_STEP);
                   });
                 }}
                 className="rounded-md border border-[#61C1C4]/25 bg-[#61C1C4]/10 px-3 py-2 text-xs font-semibold text-[#A9EEF0] hover:border-[#61C1C4]/40 hover:bg-[#61C1C4]/15"

--- a/src/pages/admin/AdminOrchestrator.tsx
+++ b/src/pages/admin/AdminOrchestrator.tsx
@@ -1375,7 +1375,7 @@ function OrchestratorStoryPanel({
             No story lines yet. When seats leave receipts, they will appear here as a simple read.
           </div>
         ) : (
-          <article className="mx-auto max-w-3xl space-y-9">
+          <ol aria-label="Story moments" className="mx-auto max-w-3xl border-l border-[#61C1C4]/20 pl-6">
             {visibleChapters.map((chapter) => {
               const expanded = expandedChapters.has(chapter.key);
               const preview = truncateText(chapter.narrative, STORY_CHAPTER_PREVIEW_CHARS);
@@ -1383,7 +1383,7 @@ function OrchestratorStoryPanel({
               const shownStory = showFullStory ? chapter.narrative : preview.text;
 
               return (
-                <section key={chapter.key} className="group">
+                <li key={chapter.key} className="group relative pb-9 last:pb-0">
                   <div className="flex items-start justify-between gap-4">
                     <h3 className="text-xl font-semibold leading-7 text-white sm:text-2xl">
                       <span className="mr-2">{chapter.emoji}</span>
@@ -1419,10 +1419,10 @@ function OrchestratorStoryPanel({
                       {expanded ? "Read less" : "Read more"}
                     </button>
                   )}
-                </section>
+                </li>
               );
             })}
-          </article>
+          </ol>
         )}
       </div>
 


### PR DESCRIPTION
Summary
- Adds an exact CopyRoom source handoff for the five JobSmith CV checklist files under apps/jobsmith.
- Adds a machine-readable source manifest with hashes, source paths, FYI handoff comment ids, and the known 40-rule versus 39-severity reconciliation gap.
- Adds a build-ready ScopePack doc for the deterministic JobSmith rule/checklist engine.

Scope
- Owned files: apps/jobsmith/docs/copyroom/cv-checklists/*, apps/jobsmith/docs/jobsmith-cv-checklist-scopepack.md, apps/jobsmith/src/lib/cvChecklistSources.ts, apps/jobsmith/src/lib/cvChecklistSources.test.ts.
- Linked Boardroom todo: 848eb8db-dfbb-4411-a332-05096b5bf1fb.

Non-overlap
- Does not edit the active builder-owned rulePack/checkEngine files.
- Does not modify package.json or package-lock.json.
- Does not claim all 40 rules are implemented or mark the job DONE.

Verification
- npm run test --workspace=@unclick/jobsmith -- cvChecklistSources
- npm run typecheck --workspace=@unclick/jobsmith
- git diff --cached --check before commit

Risk
- Low runtime risk. This is source preservation, docs, and a manifest test only.
- The copied checklist files are intentionally exact source artifacts, so they add repo size but prevent CopyRoom/fidelity drift.

Follow-up
- Builder should import/generate the schema-validated rule pack and reconcile the 40-rule versus 39-severity mismatch before full encoding.
- Reviewer/proof seat should verify this PR and the source hashes before any DONE claim.
