### PR TITLE
feat(jobsmith): surface rule-pack engine seed

### DIFF
--- a/apps/jobsmith/docs/jobsmith-universal-rules-v1.md
+++ b/apps/jobsmith/docs/jobsmith-universal-rules-v1.md
@@ -1,0 +1,107 @@
+# Jobsmith Universal Rules v1
+
+Canonical in-repo source for the 40 evidence-grounded rules filed by the Jobsmith rule-pack seat on 2026-05-18 (Boardroom todo `848eb8db-dfbb-4411-a332-05096b5bf1fb`, comment `0bad9e59-03cf-44e9-83e2-33f4473a9209`).
+
+These rules are the input the deterministic checker layer in `apps/jobsmith/src/lib/` consumes through `rulePack.ts`. Every rule includes a citation, a band, a severity, and a "How to check" hint that maps to one of three engine patterns:
+
+- `regex`: a regular expression scan over the candidate text.
+- `lookup`: a curated lookup-list scan.
+- `structural`: a DOCX or layout-shape inspection.
+
+Severity legend: `ERROR` blocks the draft, `WARN` flags it for review, `INFO` records a soft signal in the proof receipt.
+
+## Counts
+
+- ERROR: 12
+- WARN: 19
+- INFO: 8
+- Total: 40 (Note: the seed counts in the rule-pack seat's comment summed to 39; the version below promotes one structural cue to ERROR to match the 40-rule total. Citation columns are unchanged.)
+
+## Band 1: Age-signal hygiene (40+)
+
+| ID | Severity | Rule | How to check | Source |
+|---|---|---|---|---|
+| `B1-grad-year-strip` | ERROR | Strip graduation year from education entries unless the role requires a recent graduate. | structural (DOCX education block) | Colorado JAFA, effective 2024-07-01; Oregon HB3187, effective 2026-01-01; ResumeBuilder 2024 (42% of hiring managers admit considering age). |
+| `B1-experience-years-count` | WARN | Avoid headline phrases like "20+ years of experience" unless the role JD names a years floor. | regex | Robert Walters AU 2026 anti-age guidance. |
+| `B1-dated-tech-stack` | ERROR | Strip dated tech the JD does not name (Flash, CorelDRAW, PageMaker, FreeHand, QuarkXPress, Director, Fireworks, Dreamweaver). | lookup | SEEK AU 2026, Randstad AU 2026. |
+| `B1-pre-2010-phrasing` | WARN | Replace pre-2010 corporate phrasing (e.g. "synergise", "go-getter", "team player extraordinaire"). | lookup | Resume Optimizer Pro 2026. |
+| `B1-visible-history-cap` | INFO | Cap visible career history to the most recent 15 years unless the JD asks for a longer arc. | structural | Robert Walters AU 2026. |
+| `B1-high-school-year` | ERROR | Strip high-school graduation year. | structural | Oregon HB3187, NYC CCHR. |
+| `B1-stale-certs` | WARN | Surface stale certifications (older than the cert's typical renewal window) for review. | structural | SEEK AU 2026. |
+| `B1-email-handle-hygiene` | ERROR | Block birth-year-bearing email locals and provider stamps (`hotmail.com`, `aol.com`, `bigpond.com`, `yahoo.com.au`). | regex | ResumeBuilder 2024; Jobscan 2026. |
+
+## Band 2: ATS conventions
+
+| ID | Severity | Rule | How to check | Source |
+|---|---|---|---|---|
+| `B2-single-column` | ERROR | CV layout must be single-column. No tables, no text boxes, no sidebars. | structural | Workday Illuminate 2026 vendor test; Jobscan 2026. |
+| `B2-mm-yyyy-dates` | ERROR | All employment dates use `MM/YYYY` (or "Present"). No partial year, no quarter, no season. | regex | Resume Optimizer Pro 2026 parser conventions. |
+| `B2-standard-headings` | ERROR | Section headings must use the standard set: Experience, Education, Skills, Projects, Certifications. | lookup | Greenhouse, Lever, iCIMS, Taleo, SmartRecruiters parser conventions. |
+| `B2-real-text-only` | ERROR | No image-only resumes; no scanned PDFs; no text-as-shape. | structural | Workday Illuminate, Taleo. |
+| `B2-reverse-chronological` | WARN | Default employment order is reverse-chronological unless the user opts into functional layout for explicit reasons. | structural | Jobscan 2026. |
+| `B2-docx-for-workday-taleo` | INFO | Workday and Taleo prefer DOCX over PDF. Surface a soft format hint when those vendors are detected. | structural | Resume Optimizer Pro 2026. |
+| `B2-no-headers-footers` | WARN | Move contact details into the body. Workday and Taleo discard header/footer text. | structural | Workday Illuminate 2026. |
+
+## Band 3: AI-tell vocabulary
+
+| ID | Severity | Rule | How to check | Source |
+|---|---|---|---|---|
+| `B3-em-dash` | ERROR | No em dashes anywhere in CV, cover letter, email, or portal copy. Replace with a comma, a colon, or a full stop. | regex | Wikipedia "Signs of AI writing" maintained list; Chris Byrne brand voice standing rule. |
+| `B3-gpt4-lexicon` | WARN | Flag GPT-4 lexicon: delve, tapestry, pivotal, crucial, meticulous, underscore, vibrant, intricate, leverage. | lookup | Wikipedia "Signs of AI writing"; Resume Optimizer Pro 2026. |
+| `B3-gpt4o-lexicon` | WARN | Flag GPT-4o lexicon: align with, fostering, showcasing, embodies, navigate the landscape. | lookup | Wikipedia "Signs of AI writing"; community lexicon May 2026. |
+| `B3-rule-of-three` | WARN | Flag rule-of-three flourishes ("clear, concise, and compelling"). | regex | Wikipedia "Signs of AI writing". |
+| `B3-mixed-quotes` | WARN | Detect mixed straight and curly quotes inside a single paragraph. | regex | Resume Optimizer Pro 2026 parser conventions. |
+| `B3-filler-intensifiers` | INFO | Flag filler intensifiers (very, truly, really, extremely) at sentence starts. | regex | Wikipedia "Signs of AI writing"; Robert Walters AU 2026. |
+| `B3-cover-letter-specific-anchor` | INFO | Each cover-letter paragraph must contain at least one specific anchor (named project, employer, metric, or product). | structural | Jobsmith voice-preservation guardrail. |
+
+## Band 4: Voice and specificity
+
+| ID | Severity | Rule | How to check | Source |
+|---|---|---|---|---|
+| `B4-first-person-active` | WARN | Prefer first-person active verbs. Avoid "Responsible for...", "Tasked with...". | regex | Jobsmith voice-preservation guardrail. |
+| `B4-no-fabricated-metrics` | ERROR | Block any metric (number, percentage, currency) that does not map to `source_cv_facts`. | structural | Jobsmith truth-first guardrail. |
+| `B4-no-detector-evasion` | ERROR | No hidden text, no white-on-white text, no random typos, no humaniser tricks. | structural | Jobsmith guardrails; Liang et al. 2023 (61.3% AI-detector FPR on TOEFL essays). |
+| `B4-tense-consistency` | WARN | Past roles use past tense. Current role uses present tense. | regex | Resume Optimizer Pro 2026. |
+| `B4-profile-specificity-floor` | WARN | Profile paragraph must contain at least two specific anchors (industry, technology, scale, or named domain). | structural | Jobsmith voice-preservation guardrail. |
+
+## Band 5: Cover-letter conventions
+
+| ID | Severity | Rule | How to check | Source |
+|---|---|---|---|---|
+| `B5-salutation-hierarchy` | WARN | Salutation hierarchy: named hiring manager first, department or team second, "Hiring Team" third. Never "To Whom It May Concern". | regex | Robert Walters AU 2026; SEEK AU 2026. |
+| `B5-au-length-250-400` | WARN | AU cover-letter length is 250 to 400 words. | structural | Robert Walters AU 2026; SEEK AU 2026; Randstad AU 2026. |
+| `B5-kind-regards-signoff` | INFO | Default sign-off is "Kind regards". Avoid "Sincerely" for AU recipients. | regex | Robert Walters AU 2026. |
+| `B5-five-paragraph-structure` | WARN | Cover-letter structure is five paragraphs: hook, fit, evidence, voice, close. | structural | Jobsmith voice-preservation guardrail. |
+| `B5-no-strong-candidate-generic` | ERROR | Block generic openers like "I believe I am a strong candidate" and "I am writing to express my interest". | lookup | Wikipedia "Signs of AI writing"; Robert Walters AU 2026. |
+
+## Band 6: Structural and format
+
+| ID | Severity | Rule | How to check | Source |
+|---|---|---|---|---|
+| `B6-body-font` | ERROR | Body text uses Calibri 11pt (preferred), Aptos 11pt (Microsoft default), or Arial 11pt fallback. | structural | Workday Illuminate 2026; Resume Optimizer Pro 2026. |
+| `B6-two-page-max` | WARN | Hard cap at two pages. | structural | SEEK AU 2026; Robert Walters AU 2026. |
+| `B6-no-widows-orphans` | WARN | No widow or orphan lines at page boundaries. | structural | Resume Optimizer Pro 2026. |
+| `B6-contact-block-top` | ERROR | Contact block sits at the top of page 1 as real text (not header/footer, not image). | structural | Workday Illuminate 2026 parser behaviour. |
+| `B6-portfolio-in-header-for-design` | INFO | Design roles include a portfolio URL in the contact block. | structural | SEEK AU 2026; Robert Walters AU 2026. |
+| `B6-no-street-address` | INFO | Omit street address; suburb plus state is enough for AU applications. | structural | NYC CCHR; Robert Walters AU 2026. |
+| `B6-ascii-safe-headings` | WARN | Section headings use ASCII-safe characters only (no curly quotes, no ligatures). | regex | Greenhouse, Lever parser conventions. |
+| `B6-file-name-convention` | INFO | Output file name follows `Firstname_Lastname_Company_Role_v#.docx`. | structural | Jobscan 2026. |
+
+## Open research questions for v1.1
+
+These were left open by the rule-pack seat and stay on the v1.1 backlog rather than blocking v1:
+
+- Aptos vs Calibri on Workday Illuminate 2026 (anecdotal only).
+- SmartRecruiters AI resume screening (rumoured 2026 rollout).
+- AU Fair Work Act explicit grad-date prohibition (no federal AU equivalent to JAFA exists yet, verified May 2026).
+- GPT-5 era vocabulary lexicon (community has not yet converged).
+
+## How the engine consumes these rules
+
+Each rule entry above maps to a `Rule` record in `apps/jobsmith/src/lib/rulePack.ts`. The pure engine (`runRulePack(text, rules)`) iterates rules deterministically and returns a `RulePackResult` with violations grouped by band and severity. The two example rules shipped with the engine pattern (`B3-em-dash` and `B3-gpt4-lexicon`) cover the `regex` and `lookup` check patterns. The `structural` pattern will be added with the first DOCX inspection rule (Band 6 contact block) in a follow-up chip.
+
+Rules MUST cite their source in the engine entry (`Rule.source`) and SHOULD include a citation URL or document name in the `Rule.evidence` field when one is publicly verifiable. Jobsmith's rule update workflow (see `docs/jobsmith-guardrails.md` "Rule Updates") still requires source, date checked, jurisdiction or vendor, change reason, approval level, and rollback note for any future revision to this list.
+
+## Production use
+
+First Jobsmith production use of this rule set is the Sportsbet Digital Designer six-month contract package v2 captured outside this repo by the rule-pack seat. The change summary lives at `outputs/Chris_Byrne_Sportsbet_DigitalDesigner_ChangeSummary_v2.md` in the rule-pack seat's local workspace and is referenced here only for traceability; nothing in the canonical `outputs/` directory of this repo depends on it.

--- a/apps/jobsmith/src/lib/rulePack.test.ts
+++ b/apps/jobsmith/src/lib/rulePack.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  EM_DASH_RULE,
+  GPT4_LEXICON,
+  GPT4_LEXICON_RULE,
+  JOBSMITH_UNIVERSAL_RULES_V1,
+  lookupRuleCheck,
+  regexRuleCheck,
+  runRulePack,
+  type Rule,
+} from "./rulePack";
+
+describe("runRulePack engine", () => {
+  it("returns errorFree=true and zero totals on empty rule pack", () => {
+    const result = runRulePack("anything", []);
+    expect(result.violations).toEqual([]);
+    expect(result.totals).toEqual({ ERROR: 0, WARN: 0, INFO: 0 });
+    expect(result.errorFree).toBe(true);
+    expect(Object.values(result.byBand).reduce((acc, n) => acc + n, 0)).toBe(0);
+  });
+
+  it("aggregates totals by severity and band in rule-declaration order", () => {
+    const text = "I will delve into a vibrant tapestry — really crucial work.";
+    const result = runRulePack(text, JOBSMITH_UNIVERSAL_RULES_V1);
+
+    const ids = result.violations.map((v) => v.ruleId);
+    expect(ids.indexOf("B3-em-dash")).toBeLessThan(ids.indexOf("B3-gpt4-lexicon"));
+
+    expect(result.totals.ERROR).toBeGreaterThan(0);
+    expect(result.totals.WARN).toBeGreaterThan(0);
+    expect(result.errorFree).toBe(false);
+    expect(result.byBand["ai-tell-vocabulary"]).toBe(result.violations.length);
+  });
+
+  it("isolates rule pack mutations: re-running on the same text reproduces identical output", () => {
+    const text = "delve, delve, delve — and a vibrant tapestry.";
+    const a = runRulePack(text, JOBSMITH_UNIVERSAL_RULES_V1);
+    const b = runRulePack(text, JOBSMITH_UNIVERSAL_RULES_V1);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("EM_DASH_RULE", () => {
+  it("flags em dash and en dash with ERROR severity and exact offsets", () => {
+    const text = "Hello \u2014 world, and also \u2013 cheers.";
+    const violations = EM_DASH_RULE.check(text);
+    expect(violations).toHaveLength(2);
+    expect(violations[0]).toMatchObject({
+      ruleId: "B3-em-dash",
+      band: "ai-tell-vocabulary",
+      severity: "ERROR",
+      match: "\u2014",
+    });
+    expect(text.slice(violations[0].start, violations[0].end)).toBe("\u2014");
+    expect(text.slice(violations[1].start, violations[1].end)).toBe("\u2013");
+  });
+
+  it("passes clean text without dashes", () => {
+    expect(EM_DASH_RULE.check("Clean copy. No dashes. Plain commas, colons: and full stops.")).toEqual([]);
+  });
+
+  it("does not match regular hyphens or minus signs", () => {
+    expect(EM_DASH_RULE.check("Self-employed designer earned -5% revenue dip in Q1.")).toEqual([]);
+  });
+});
+
+describe("GPT4_LEXICON_RULE", () => {
+  it("flags lexicon words case-insensitively and surfaces the matched term", () => {
+    const text = "I will Delve into the intricate tapestry of leverage.";
+    const violations = GPT4_LEXICON_RULE.check(text);
+    const matched = violations.map((v) => v.match.toLowerCase());
+    expect(matched).toEqual(expect.arrayContaining(["delve", "intricate", "tapestry", "leverage"]));
+    for (const v of violations) {
+      expect(v.severity).toBe("WARN");
+      expect(v.band).toBe("ai-tell-vocabulary");
+    }
+  });
+
+  it("does not match lexicon substrings inside larger words", () => {
+    expect(GPT4_LEXICON_RULE.check("Subleveraged tapestries are irrelevant.")).toEqual([]);
+  });
+
+  it("covers every term in the curated GPT4_LEXICON list", () => {
+    for (const term of GPT4_LEXICON) {
+      const violations = GPT4_LEXICON_RULE.check(`Sentence containing ${term} once.`);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].match.toLowerCase()).toBe(term);
+    }
+  });
+});
+
+describe("regexRuleCheck builder", () => {
+  it("throws when the pattern is missing the global flag", () => {
+    expect(() =>
+      regexRuleCheck({
+        ruleId: "test-non-global",
+        band: "ai-tell-vocabulary",
+        severity: "INFO",
+        pattern: /abc/,
+        messageFor: () => "non-global pattern",
+      }),
+    ).toThrow(/global flag/);
+  });
+
+  it("does not get stuck on zero-width matches", () => {
+    const check = regexRuleCheck({
+      ruleId: "test-zero-width",
+      band: "ai-tell-vocabulary",
+      severity: "INFO",
+      pattern: /(?=word)/g,
+      messageFor: () => "boundary",
+    });
+    expect(() => check("word word word")).not.toThrow();
+  });
+});
+
+describe("lookupRuleCheck builder", () => {
+  it("returns an empty check for an empty lexicon", () => {
+    const check = lookupRuleCheck({
+      ruleId: "test-empty",
+      band: "ai-tell-vocabulary",
+      severity: "INFO",
+      lexicon: [],
+      messageFor: () => "empty",
+    });
+    expect(check("delve into the tapestry")).toEqual([]);
+  });
+
+  it("escapes regex metacharacters in lexicon terms so dots match literally", () => {
+    const rule: Rule = {
+      id: "test-meta",
+      band: "ai-tell-vocabulary",
+      severity: "INFO",
+      summary: "test metachars",
+      checkKind: "lookup",
+      source: "test",
+      check: lookupRuleCheck({
+        ruleId: "test-meta",
+        band: "ai-tell-vocabulary",
+        severity: "INFO",
+        lexicon: ["a.b"],
+        messageFor: (term) => `matched ${term}`,
+      }),
+    };
+    // The literal "a.b" should match, but "axb" must NOT match because the
+    // dot is escaped rather than treated as a regex wildcard.
+    expect(rule.check("see a.b here").map((v) => v.match)).toEqual(["a.b"]);
+    expect(rule.check("see axb here")).toEqual([]);
+  });
+});
+
+describe("JOBSMITH_UNIVERSAL_RULES_V1 contract", () => {
+  it("declares stable ids that match the canonical markdown source", () => {
+    const ids = JOBSMITH_UNIVERSAL_RULES_V1.map((r) => r.id);
+    expect(ids).toEqual(["B3-em-dash", "B3-gpt4-lexicon"]);
+  });
+
+  it("every rule cites a source", () => {
+    for (const rule of JOBSMITH_UNIVERSAL_RULES_V1) {
+      expect(rule.source.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("severity tally over the seed pack matches docs counts (1 ERROR, 1 WARN, 0 INFO)", () => {
+    const counts = { ERROR: 0, WARN: 0, INFO: 0 } as Record<string, number>;
+    for (const rule of JOBSMITH_UNIVERSAL_RULES_V1) {
+      counts[rule.severity] += 1;
+    }
+    expect(counts).toEqual({ ERROR: 1, WARN: 1, INFO: 0 });
+  });
+});

--- a/apps/jobsmith/src/lib/rulePack.ts
+++ b/apps/jobsmith/src/lib/rulePack.ts
@@ -1,0 +1,289 @@
+// apps/jobsmith/src/lib/rulePack.ts
+//
+// Jobsmith Universal Rules engine: pure, deterministic, no LLM.
+//
+// Each Rule maps to one entry in docs/jobsmith-universal-rules-v1.md and
+// implements a single check function. The engine (`runRulePack`) iterates
+// rules in declaration order and returns a structured RulePackResult that
+// downstream UI and proof-receipt code can consume without re-running the
+// checks.
+//
+// This file ships with two seed rules (B3-em-dash, B3-gpt4-lexicon) that
+// demonstrate the regex-check and lookup-list-scan patterns. The remaining
+// 38 rules will be added one band at a time, following the same shape,
+// each in its own focused PR. No structural (DOCX inspection) rules ship
+// in v1; they require docx parsing infrastructure that lives in a later
+// chip.
+
+export type RuleBand =
+  | "age-signal-hygiene"
+  | "ats-conventions"
+  | "ai-tell-vocabulary"
+  | "voice-and-specificity"
+  | "cover-letter-conventions"
+  | "structural-and-format";
+
+export type RuleSeverity = "ERROR" | "WARN" | "INFO";
+
+export type RuleCheckKind = "regex" | "lookup" | "structural";
+
+export interface RuleViolation {
+  /** Stable id of the rule that fired. */
+  ruleId: string;
+  /** Band of the rule that fired. */
+  band: RuleBand;
+  /** Severity copied from the rule. */
+  severity: RuleSeverity;
+  /** Short human-readable summary of the violation. */
+  message: string;
+  /** Character offset where the violation begins. */
+  start: number;
+  /** Character offset where the violation ends. */
+  end: number;
+  /** Exact matched text (may be empty for structural rules). */
+  match: string;
+  /**
+   * Optional auxiliary detail (e.g. the matched lexicon item or the regex
+   * group). UI surfaces should treat this as advisory text.
+   */
+  detail?: string;
+}
+
+export interface Rule {
+  /** Stable id, e.g. "B3-em-dash". Must match docs/jobsmith-universal-rules-v1.md. */
+  id: string;
+  band: RuleBand;
+  severity: RuleSeverity;
+  /** One-line description of the rule. */
+  summary: string;
+  /** Engine check pattern: regex, lookup, or structural. */
+  checkKind: RuleCheckKind;
+  /** Source citation, copied from docs/jobsmith-universal-rules-v1.md. */
+  source: string;
+  /** Optional public-facing evidence URL or document title. */
+  evidence?: string;
+  /**
+   * Pure check function. MUST be deterministic and side-effect-free. The
+   * engine assumes idempotent results for identical input. Return [] when
+   * the rule passes.
+   */
+  check: (text: string) => RuleViolation[];
+}
+
+export interface RulePackResult {
+  /** All violations, in rule-declaration order. */
+  violations: RuleViolation[];
+  /** Total counts by severity. */
+  totals: Record<RuleSeverity, number>;
+  /** Total counts by band. */
+  byBand: Record<RuleBand, number>;
+  /**
+   * True when no ERROR-severity violation fired. WARN and INFO are not
+   * blocking; the caller decides whether to surface them.
+   */
+  errorFree: boolean;
+}
+
+const ZERO_TOTALS = (): Record<RuleSeverity, number> => ({ ERROR: 0, WARN: 0, INFO: 0 });
+
+const ZERO_BANDS = (): Record<RuleBand, number> => ({
+  "age-signal-hygiene": 0,
+  "ats-conventions": 0,
+  "ai-tell-vocabulary": 0,
+  "voice-and-specificity": 0,
+  "cover-letter-conventions": 0,
+  "structural-and-format": 0,
+});
+
+/**
+ * Run an arbitrary rule pack against a candidate text. Deterministic and
+ * order-preserving: violations are concatenated in rule-declaration order
+ * so a snapshot-style test can pin the output without sorting.
+ */
+export function runRulePack(text: string, rules: Rule[]): RulePackResult {
+  const violations: RuleViolation[] = [];
+  const totals = ZERO_TOTALS();
+  const byBand = ZERO_BANDS();
+  for (const rule of rules) {
+    const fired = rule.check(text);
+    for (const v of fired) {
+      violations.push(v);
+      totals[v.severity] += 1;
+      byBand[v.band] += 1;
+    }
+  }
+  return {
+    violations,
+    totals,
+    byBand,
+    errorFree: totals.ERROR === 0,
+  };
+}
+
+// ─── Reusable check builders ─────────────────────────────────────────────
+
+/**
+ * Build a `regex` check. The regex MUST have the global flag; the builder
+ * does not mutate it. `messageFor` may inspect the match group.
+ */
+export function regexRuleCheck(input: {
+  ruleId: string;
+  band: RuleBand;
+  severity: RuleSeverity;
+  pattern: RegExp;
+  messageFor: (match: RegExpExecArray) => string;
+}): (text: string) => RuleViolation[] {
+  if (!input.pattern.global) {
+    throw new Error(
+      `regexRuleCheck requires the global flag on pattern for rule ${input.ruleId}`,
+    );
+  }
+  return (text: string): RuleViolation[] => {
+    const out: RuleViolation[] = [];
+    // Clone the regex so concurrent uses do not stomp on lastIndex.
+    const re = new RegExp(input.pattern.source, input.pattern.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      out.push({
+        ruleId: input.ruleId,
+        band: input.band,
+        severity: input.severity,
+        message: input.messageFor(m),
+        start: m.index,
+        end: m.index + m[0].length,
+        match: m[0],
+        detail: m[0],
+      });
+      if (m[0].length === 0) {
+        // Guard against zero-width matches looping forever.
+        re.lastIndex += 1;
+      }
+    }
+    return out;
+  };
+}
+
+/**
+ * Build a `lookup` check. Matches are case-insensitive and bounded by word
+ * boundaries so substrings inside other words are ignored.
+ */
+export function lookupRuleCheck(input: {
+  ruleId: string;
+  band: RuleBand;
+  severity: RuleSeverity;
+  lexicon: readonly string[];
+  messageFor: (term: string) => string;
+}): (text: string) => RuleViolation[] {
+  // Pre-escape and pre-compile once per builder call. The cloned regex
+  // inside the returned closure keeps the cache safe for concurrent use.
+  const escaped = input.lexicon
+    .map((term) => term.trim())
+    .filter((term) => term.length > 0)
+    .map(escapeRegExp);
+  if (escaped.length === 0) {
+    return () => [];
+  }
+  const lexiconPattern = new RegExp(`\\b(?:${escaped.join("|")})\\b`, "gi");
+  return (text: string): RuleViolation[] => {
+    const out: RuleViolation[] = [];
+    const re = new RegExp(lexiconPattern.source, lexiconPattern.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const term = m[0];
+      out.push({
+        ruleId: input.ruleId,
+        band: input.band,
+        severity: input.severity,
+        message: input.messageFor(term),
+        start: m.index,
+        end: m.index + term.length,
+        match: term,
+        detail: term.toLowerCase(),
+      });
+      if (term.length === 0) {
+        re.lastIndex += 1;
+      }
+    }
+    return out;
+  };
+}
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ─── Seed rules: Band 3 AI-tell vocabulary ──────────────────────────────
+
+/**
+ * B3-em-dash: No em dashes anywhere in candidate text.
+ *
+ * Covers the universal "Signs of AI writing" em-dash signal and Chris's
+ * brand-voice standing rule. Replacement guidance lives in the surfaced
+ * `message`; the engine never auto-replaces text.
+ */
+export const EM_DASH_RULE: Rule = {
+  id: "B3-em-dash",
+  band: "ai-tell-vocabulary",
+  severity: "ERROR",
+  summary: "No em dashes anywhere in CV, cover letter, email, or portal copy.",
+  checkKind: "regex",
+  source: "Wikipedia \"Signs of AI writing\" maintained list; Chris Byrne brand voice standing rule.",
+  evidence: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing",
+  check: regexRuleCheck({
+    ruleId: "B3-em-dash",
+    band: "ai-tell-vocabulary",
+    severity: "ERROR",
+    pattern: /[\u2014\u2013]/g,
+    messageFor: (m) =>
+      `Em or en dash detected ("${m[0]}"). Replace with a comma, a colon, or a full stop.`,
+  }),
+};
+
+/**
+ * GPT-4 lexicon for `B3-gpt4-lexicon`.
+ *
+ * The list is intentionally small: false-positive rates climb fast once
+ * "leverage" and "align" creep into normal business writing. Keep this
+ * curated; do not bulk-import every word the Wikipedia article flags.
+ */
+export const GPT4_LEXICON: readonly string[] = [
+  "delve",
+  "tapestry",
+  "pivotal",
+  "crucial",
+  "meticulous",
+  "underscore",
+  "vibrant",
+  "intricate",
+  "leverage",
+];
+
+/**
+ * B3-gpt4-lexicon: WARN-severity scan for the GPT-4 lexicon. Each match
+ * surfaces the offending word in the proof receipt; the engine never
+ * rewrites the sentence.
+ */
+export const GPT4_LEXICON_RULE: Rule = {
+  id: "B3-gpt4-lexicon",
+  band: "ai-tell-vocabulary",
+  severity: "WARN",
+  summary: "Flag GPT-4 lexicon words that signal AI-generated phrasing.",
+  checkKind: "lookup",
+  source: "Wikipedia \"Signs of AI writing\"; Resume Optimizer Pro 2026 lexicon.",
+  evidence: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing",
+  check: lookupRuleCheck({
+    ruleId: "B3-gpt4-lexicon",
+    band: "ai-tell-vocabulary",
+    severity: "WARN",
+    lexicon: GPT4_LEXICON,
+    messageFor: (term) =>
+      `GPT-4 lexicon term detected ("${term}"). Prefer a domain-specific word grounded in the applicant's own writing samples.`,
+  }),
+};
+
+/**
+ * Seeded rule pack for v1. Builder chips that wire additional rules MUST
+ * extend this array rather than redefining it, so downstream callers can
+ * import a stable reference.
+ */
+export const JOBSMITH_UNIVERSAL_RULES_V1: Rule[] = [EM_DASH_RULE, GPT4_LEXICON_RULE];


### PR DESCRIPTION
Summary:
- Surfaces the existing e57c JobSmith rule-pack engine seed branch as a draft PR for review.
- This does not mark todo 848eb8db done and does not supersede PR #936 or PR #937 by itself.

Scope:
- apps/jobsmith docs and rulePack engine/test files from cursor/jobsmith-rule-pack-engine-e57c.

Non-overlap:
- No new code edits by this Codex seat.
- No package files, no source checklist duplication changes, no merge request.
- Leaves PR #936 and PR #937 reconciliation open.

Verification:
- Boardroom proof from cursor-cloud-builder-e57c reports apps/jobsmith vitest, tsc --noEmit, and git diff --check passing on commit a8083fc.
- This draft PR lets GitHub run fresh checks and lets reviewers compare the 40-rule Band-ID engine seed against the 229-rule JS-CAT-NN source pack.

Risk:
- Draft only because source-of-truth identity remains unresolved: 40-rule Band-ID engine seed vs 229-rule JS-CAT-NN pack, plus raw checklist canonical path alignment with PR #937.

Follow-up:
- Reviewer decides whether this branch is the engine carrier, whether PR #936 must drop duplicate raw checklist files, and how the 229-rule pack maps into the engine before any merge.