### PR TITLE
feat(brainmap): add visual tool tree

### DIFF
--- a/.github/workflows/brainmap-auto-update.yml
+++ b/.github/workflows/brainmap-auto-update.yml
@@ -31,12 +31,12 @@ jobs:
         run: npm run test:brainmap
       - name: Commit generated Brainmap
         run: |
-          if git diff --quiet -- docs/UnClick-brainmap.generated.md; then
+          if git diff --quiet -- docs/UnClick-brainmap.generated.md docs/UnClick-brainmap.generated.json; then
             echo "Brainmap already current."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/UnClick-brainmap.generated.md
+          git add docs/UnClick-brainmap.generated.md docs/UnClick-brainmap.generated.json
           git commit -m "docs: auto-update ecosystem brainmap"
           git push

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -1,0 +1,6968 @@
+{
+  "schema_version": "brainmap-v2",
+  "title": "UnClick Ecosystem Brainmap",
+  "summary": "Generated sitemap, system map, and tool-worker tree for private UnClick onboarding.",
+  "owner_visibility": {
+    "route": "/admin/brainmap",
+    "audience": "private yellow admin",
+    "owner_email": "creativelead@malamutemayhem.com"
+  },
+  "counts": {
+    "divisions": 12,
+    "inventory": 470,
+    "source_manifest": 93,
+    "pages": 93,
+    "tools": 182,
+    "rooms": 23,
+    "workers": 8
+  },
+  "divisions": [
+    {
+      "id": "admin-surfaces",
+      "name": "Admin surfaces",
+      "meaning": "Private operator views and internal control panels.",
+      "count": 52
+    },
+    {
+      "id": "public-surfaces",
+      "name": "Public surfaces",
+      "meaning": "Public product, docs, marketplace, and user-facing routes.",
+      "count": 41
+    },
+    {
+      "id": "tools",
+      "name": "Tools",
+      "meaning": "MCP and gateway capabilities available to seats.",
+      "count": 182
+    },
+    {
+      "id": "rooms",
+      "name": "Rooms",
+      "meaning": "PinballWake and Boardroom lanes that route work.",
+      "count": 23
+    },
+    {
+      "id": "workers-and-seats",
+      "name": "Workers and seats",
+      "meaning": "Human and AI roles that move work through the system.",
+      "count": 11
+    },
+    {
+      "id": "passes-and-gates",
+      "name": "Passes and gates",
+      "meaning": "Quality, proof, safety, and fidelity checks.",
+      "count": 12
+    },
+    {
+      "id": "wrappers-and-protocols",
+      "name": "Wrappers and protocols",
+      "meaning": "Thin harnesses, bridges, policies, and routing helpers.",
+      "count": 3
+    },
+    {
+      "id": "automations",
+      "name": "Automations",
+      "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
+      "count": 108
+    },
+    {
+      "id": "ledgers-and-proof",
+      "name": "Ledgers and proof",
+      "meaning": "Receipts, audits, evidence, and proof-of-work surfaces.",
+      "count": 6
+    },
+    {
+      "id": "source-of-truth",
+      "name": "Source of truth",
+      "meaning": "Canonical state, queue, memory, and context surfaces.",
+      "count": 9
+    },
+    {
+      "id": "modules-and-apps",
+      "name": "Modules and apps",
+      "meaning": "Apps, packages, and product modules that make up UnClick.",
+      "count": 19
+    },
+    {
+      "id": "launch-and-onboarding",
+      "name": "Launch and onboarding",
+      "meaning": "Launchpad, Heartbeat, Brainmap, and first-seat orientation.",
+      "count": 4
+    }
+  ],
+  "inventory": [
+    {
+      "id": "admin-surfaces-admin-page-admin-activity-src-pages-admin-adminactivity-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Activity",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Activity.",
+      "source": "src/pages/admin/AdminActivity.tsx",
+      "route": "/admin/activity",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-agents-src-pages-admin-adminagents-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Agents",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Agents.",
+      "source": "src/pages/admin/AdminAgents.tsx",
+      "route": "/admin/agents",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-analytics-src-pages-admin-adminanalytics-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Analytics",
+      "kind": "admin page",
+      "meaning": "Internal analytics view for platform signals and usage.",
+      "source": "src/pages/admin/AdminAnalytics.tsx",
+      "route": "/admin/analytics",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-audit-log-src-pages-admin-adminauditlog-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Audit Log",
+      "kind": "admin page",
+      "meaning": "Internal audit trail for sensitive admin actions.",
+      "source": "src/pages/admin/AdminAuditLog.tsx",
+      "route": "/admin/audit-log",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-brainmap-src-pages-admin-adminbrainmap-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Brainmap",
+      "kind": "admin page",
+      "meaning": "Generated ecosystem map that teaches seats what UnClick is.",
+      "source": "src/pages/admin/AdminBrainmap.tsx",
+      "route": "/admin/brainmap",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-codebase-src-pages-admin-admincodebase-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Codebase",
+      "kind": "admin page",
+      "meaning": "Internal source and architecture orientation surface.",
+      "source": "src/pages/admin/AdminCodebase.tsx",
+      "route": "/admin/codebase",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-dashboard-src-pages-admin-admindashboard-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Dashboard",
+      "kind": "admin page",
+      "meaning": "Front door for current operator state.",
+      "source": "src/pages/admin/AdminDashboard.tsx",
+      "route": "/admin/dashboard",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-ecosystem-pages-src-pages-admin-adminecosystempages-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Ecosystem Pages",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Ecosystem Pages.",
+      "source": "src/pages/admin/AdminEcosystemPages.tsx",
+      "route": "/admin/ecosystem-pages",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-jobs-src-pages-admin-adminjobs-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Jobs",
+      "kind": "admin page",
+      "meaning": "Operational job and task queue.",
+      "source": "src/pages/admin/AdminJobs.tsx",
+      "route": "/admin/jobs",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-jobsmith-src-pages-admin-adminjobsmith-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Jobsmith",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Jobsmith.",
+      "source": "src/pages/admin/AdminJobsmith.tsx",
+      "route": "/admin/jobsmith",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-keychain-src-pages-admin-adminkeychain-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Keychain",
+      "kind": "admin page",
+      "meaning": "Passport and credential connection health.",
+      "source": "src/pages/admin/AdminKeychain.tsx",
+      "route": "/admin/keychain",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-memory-src-pages-admin-adminmemory-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Memory",
+      "kind": "admin page",
+      "meaning": "Admin view of persistent memory, facts, sessions, and recall.",
+      "source": "src/pages/admin/AdminMemory.tsx",
+      "route": "/admin/memory",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-moderation-src-pages-admin-adminmoderation-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Moderation",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Moderation.",
+      "source": "src/pages/admin/AdminModeration.tsx",
+      "route": "/admin/moderation",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-orchestrator-src-pages-admin-adminorchestrator-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Orchestrator",
+      "kind": "admin page",
+      "meaning": "Readable continuity stream for seats and operator context.",
+      "source": "src/pages/admin/AdminOrchestrator.tsx",
+      "route": "/admin/orchestrator",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-pinball-wake-src-pages-admin-adminpinballwake-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Pinball Wake",
+      "kind": "admin page",
+      "meaning": "PinballWake rooms, wake routes, and automation visibility.",
+      "source": "src/pages/admin/AdminPinballWake.tsx",
+      "route": "/admin/pinball-wake",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-seat-heartbeat-src-pages-admin-adminseatheartbeat-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Seat Heartbeat",
+      "kind": "admin page",
+      "meaning": "Master heartbeat copy policy for scheduled AI seats.",
+      "source": "src/pages/admin/AdminSeatHeartbeat.tsx",
+      "route": "/admin/agents/heartbeat",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-settings-src-pages-admin-adminsettings-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Settings",
+      "kind": "admin page",
+      "meaning": "Account and admin configuration.",
+      "source": "src/pages/admin/AdminSettings.tsx",
+      "route": "/admin/settings",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-shell-src-pages-admin-adminshell-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Shell",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Shell.",
+      "source": "src/pages/admin/AdminShell.tsx",
+      "route": "/admin/shell",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-system-health-src-pages-admin-adminsystemhealth-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin System Health",
+      "kind": "admin page",
+      "meaning": "Health checks and operational status.",
+      "source": "src/pages/admin/AdminSystemHealth.tsx",
+      "route": "/admin/system-health",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-test-pass-src-pages-admin-admintestpass-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Test Pass",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Test Pass.",
+      "source": "src/pages/admin/AdminTestPass.tsx",
+      "route": "/admin/test-pass",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-tools-src-pages-admin-admintools-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Tools",
+      "kind": "admin page",
+      "meaning": "Apps, tools, and connector capability surface.",
+      "source": "src/pages/admin/AdminTools.tsx",
+      "route": "/admin/tools",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-users-src-pages-admin-adminusers-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin Users",
+      "kind": "admin page",
+      "meaning": "Internal user management.",
+      "source": "src/pages/admin/AdminUsers.tsx",
+      "route": "/admin/users",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-you-src-pages-admin-adminyou-tsx",
+      "division": "Admin surfaces",
+      "name": "Admin You",
+      "kind": "admin page",
+      "meaning": "Personal account, identity, and access panel.",
+      "source": "src/pages/admin/AdminYou.tsx",
+      "route": "/admin/you",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-brain-map-src-pages-admin-brainmap-tsx",
+      "division": "Admin surfaces",
+      "name": "Brain Map",
+      "kind": "admin page",
+      "meaning": "Legacy Memory Brain Map component kept distinct from ecosystem Brainmap.",
+      "source": "src/pages/admin/BrainMap.tsx",
+      "route": "/brain-map",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-comments-src-pages-admin-fishbowl-comments-tsx",
+      "division": "Admin surfaces",
+      "name": "Comments",
+      "kind": "admin page",
+      "meaning": "Admin surface for Comments.",
+      "source": "src/pages/admin/fishbowl/Comments.tsx",
+      "route": "/comments",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-connected-services-src-pages-admin-tools-connectedservices-tsx",
+      "division": "Admin surfaces",
+      "name": "Connected Services",
+      "kind": "admin page",
+      "meaning": "Tool page for Connected Services.",
+      "source": "src/pages/admin/tools/ConnectedServices.tsx",
+      "route": "/tools/connected-services",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-context-tab-src-pages-admin-memory-contexttab-tsx",
+      "division": "Admin surfaces",
+      "name": "Context Tab",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Context Tab.",
+      "source": "src/pages/admin/memory/ContextTab.tsx",
+      "route": "/context-tab",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-copy-pass-catalog-src-pages-admin-copypass-copypasscatalog-tsx",
+      "division": "Admin surfaces",
+      "name": "Copy Pass Catalog",
+      "kind": "admin page",
+      "meaning": "Admin surface for Copy Pass Catalog.",
+      "source": "src/pages/admin/copypass/CopyPassCatalog.tsx",
+      "route": "/copy-pass-catalog",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-crew-composer-src-pages-admin-crews-crewcomposer-tsx",
+      "division": "Admin surfaces",
+      "name": "Crew Composer",
+      "kind": "admin page",
+      "meaning": "Crews admin page for Crew Composer.",
+      "source": "src/pages/admin/crews/CrewComposer.tsx",
+      "route": "/crew-composer",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-crew-run-src-pages-admin-crews-crewrun-tsx",
+      "division": "Admin surfaces",
+      "name": "Crew Run",
+      "kind": "admin page",
+      "meaning": "Crews admin page for Crew Run.",
+      "source": "src/pages/admin/crews/CrewRun.tsx",
+      "route": "/crew-run",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-crews-catalog-src-pages-admin-crews-crewscatalog-tsx",
+      "division": "Admin surfaces",
+      "name": "Crews Catalog",
+      "kind": "admin page",
+      "meaning": "Crews admin page for Crews Catalog.",
+      "source": "src/pages/admin/crews/CrewsCatalog.tsx",
+      "route": "/crews-catalog",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-crews-runs-src-pages-admin-crews-crewsruns-tsx",
+      "division": "Admin surfaces",
+      "name": "Crews Runs",
+      "kind": "admin page",
+      "meaning": "Crews admin page for Crews Runs.",
+      "source": "src/pages/admin/crews/CrewsRuns.tsx",
+      "route": "/crews-runs",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-crews-settings-src-pages-admin-crews-crewssettings-tsx",
+      "division": "Admin surfaces",
+      "name": "Crews Settings",
+      "kind": "admin page",
+      "meaning": "Crews admin page for Crews Settings.",
+      "source": "src/pages/admin/crews/CrewsSettings.tsx",
+      "route": "/crews-settings",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-empty-state-src-pages-admin-memory-emptystate-tsx",
+      "division": "Admin surfaces",
+      "name": "Empty State",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Empty State.",
+      "source": "src/pages/admin/memory/EmptyState.tsx",
+      "route": "/empty-state",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-facts-tab-src-pages-admin-memory-factstab-tsx",
+      "division": "Admin surfaces",
+      "name": "Facts Tab",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Facts Tab.",
+      "source": "src/pages/admin/memory/FactsTab.tsx",
+      "route": "/facts-tab",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-fishbowl-src-pages-admin-fishbowl-tsx",
+      "division": "Admin surfaces",
+      "name": "Fishbowl",
+      "kind": "admin page",
+      "meaning": "Boardroom discussion surface for worker coordination.",
+      "source": "src/pages/admin/Fishbowl.tsx",
+      "route": "/fishbowl",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-ideas-src-pages-admin-fishbowl-ideas-tsx",
+      "division": "Admin surfaces",
+      "name": "Ideas",
+      "kind": "admin page",
+      "meaning": "Admin surface for Ideas.",
+      "source": "src/pages/admin/fishbowl/Ideas.tsx",
+      "route": "/ideas",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-info-card-src-pages-admin-memory-infocard-tsx",
+      "division": "Admin surfaces",
+      "name": "Info Card",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Info Card.",
+      "source": "src/pages/admin/memory/InfoCard.tsx",
+      "route": "/info-card",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-library-tab-src-pages-admin-memory-librarytab-tsx",
+      "division": "Admin surfaces",
+      "name": "Library Tab",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Library Tab.",
+      "source": "src/pages/admin/memory/LibraryTab.tsx",
+      "route": "/library-tab",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-memory-activity-tab-src-pages-admin-memory-memoryactivitytab-tsx",
+      "division": "Admin surfaces",
+      "name": "Memory Activity Tab",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Memory Activity Tab.",
+      "source": "src/pages/admin/memory/MemoryActivityTab.tsx",
+      "route": "/memory-activity-tab",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-new-run-wizard-src-pages-admin-testpass-newrunwizard-tsx",
+      "division": "Admin surfaces",
+      "name": "New Run Wizard",
+      "kind": "admin page",
+      "meaning": "Admin surface for New Run Wizard.",
+      "source": "src/pages/admin/testpass/NewRunWizard.tsx",
+      "route": "/new-run-wizard",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-report-detail-src-pages-admin-testpass-reportdetail-tsx",
+      "division": "Admin surfaces",
+      "name": "Report Detail",
+      "kind": "admin page",
+      "meaning": "Admin surface for Report Detail.",
+      "source": "src/pages/admin/testpass/ReportDetail.tsx",
+      "route": "/report-detail",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-run-detail-src-pages-admin-testpass-rundetail-tsx",
+      "division": "Admin surfaces",
+      "name": "Run Detail",
+      "kind": "admin page",
+      "meaning": "Admin surface for Run Detail.",
+      "source": "src/pages/admin/testpass/RunDetail.tsx",
+      "route": "/run-detail",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-search-highlight-src-pages-admin-searchhighlight-tsx",
+      "division": "Admin surfaces",
+      "name": "search Highlight",
+      "kind": "admin page",
+      "meaning": "Admin surface for search Highlight.",
+      "source": "src/pages/admin/searchHighlight.tsx",
+      "route": "/search-highlight",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-sessions-tab-src-pages-admin-memory-sessionstab-tsx",
+      "division": "Admin surfaces",
+      "name": "Sessions Tab",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Sessions Tab.",
+      "source": "src/pages/admin/memory/SessionsTab.tsx",
+      "route": "/sessions-tab",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-settings-src-pages-admin-fishbowl-settings-tsx",
+      "division": "Admin surfaces",
+      "name": "Settings",
+      "kind": "admin page",
+      "meaning": "Admin surface for Settings.",
+      "source": "src/pages/admin/fishbowl/Settings.tsx",
+      "route": "/settings",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-signals-catalog-src-pages-admin-signals-signalscatalog-tsx",
+      "division": "Admin surfaces",
+      "name": "Signals Catalog",
+      "kind": "admin page",
+      "meaning": "Admin surface for Signals Catalog.",
+      "source": "src/pages/admin/signals/SignalsCatalog.tsx",
+      "route": "/signals-catalog",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-signals-settings-src-pages-admin-signals-signalssettings-tsx",
+      "division": "Admin surfaces",
+      "name": "Signals Settings",
+      "kind": "admin page",
+      "meaning": "Admin surface for Signals Settings.",
+      "source": "src/pages/admin/signals/SignalsSettings.tsx",
+      "route": "/signals-settings",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-storage-bar-src-pages-admin-memory-storagebar-tsx",
+      "division": "Admin surfaces",
+      "name": "Storage Bar",
+      "kind": "admin page",
+      "meaning": "Memory admin panel for Storage Bar.",
+      "source": "src/pages/admin/memory/StorageBar.tsx",
+      "route": "/storage-bar",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-test-pass-catalog-src-pages-admin-testpass-testpasscatalog-tsx",
+      "division": "Admin surfaces",
+      "name": "Test Pass Catalog",
+      "kind": "admin page",
+      "meaning": "Admin surface for Test Pass Catalog.",
+      "source": "src/pages/admin/testpass/TestPassCatalog.tsx",
+      "route": "/test-pass-catalog",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-todos-src-pages-admin-fishbowl-todos-tsx",
+      "division": "Admin surfaces",
+      "name": "Todos",
+      "kind": "admin page",
+      "meaning": "Admin surface for Todos.",
+      "source": "src/pages/admin/fishbowl/Todos.tsx",
+      "route": "/todos",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-un-click-tools-src-pages-admin-tools-unclicktools-tsx",
+      "division": "Admin surfaces",
+      "name": "Un Click Tools",
+      "kind": "admin page",
+      "meaning": "Tool page for Un Click Tools.",
+      "source": "src/pages/admin/tools/UnClickTools.tsx",
+      "route": "/tools/un-click-tools",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilot-control-ledger-api-lib-autopilot-control-ledger-ts",
+      "division": "Automations",
+      "name": "autopilot control ledger",
+      "kind": "autopilot module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/autopilot-control-ledger.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilotkit-liveness-scripts-lib-autopilotkit-liveness-mjs",
+      "division": "Automations",
+      "name": "autopilotkit liveness",
+      "kind": "autopilot module",
+      "meaning": "autopilotkit liveness shared frontend logic.",
+      "source": "scripts/lib/autopilotkit-liveness.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-pinballwake-autopilot-master-loop-scripts-pinballwake-autopilot-master-loop-mjs",
+      "division": "Automations",
+      "name": "pinballwake autopilot master loop",
+      "kind": "autopilot module",
+      "meaning": "pinballwake autopilot master loop UnClick module.",
+      "source": "scripts/pinballwake-autopilot-master-loop.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-pinballwake-autopilot-triage-scripts-pinballwake-autopilot-triage-mjs",
+      "division": "Automations",
+      "name": "pinballwake autopilot triage",
+      "kind": "autopilot module",
+      "meaning": "pinballwake autopilot triage UnClick module.",
+      "source": "scripts/pinballwake-autopilot-triage.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-autopilotkit-liveness-scripts-lib-autopilotkit-liveness-mjs",
+      "division": "Automations",
+      "name": "autopilotkit liveness",
+      "kind": "script",
+      "meaning": "Autopilot coordination, proof, or wake helper.",
+      "source": "scripts/lib/autopilotkit-liveness.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-autopilotkit-liveness-test-scripts-autopilotkit-liveness-test-mjs",
+      "division": "Automations",
+      "name": "autopilotkit liveness.test",
+      "kind": "script",
+      "meaning": "Autopilot coordination, proof, or wake helper.",
+      "source": "scripts/autopilotkit-liveness.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-enterprisepass-receipt-guard-test-scripts-enterprisepass-receipt-guard-test-mjs",
+      "division": "Automations",
+      "name": "enterprisepass receipt guard.test",
+      "kind": "script",
+      "meaning": "Receipt bridge or proof trail helper.",
+      "source": "scripts/enterprisepass-receipt-guard.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-event-wake-router-scripts-event-wake-router-mjs",
+      "division": "Automations",
+      "name": "event wake router",
+      "kind": "script",
+      "meaning": "Wake routing, ACK, or stale-handling helper.",
+      "source": "scripts/event-wake-router.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-event-wake-router-test-scripts-event-wake-router-test-mjs",
+      "division": "Automations",
+      "name": "event wake router.test",
+      "kind": "script",
+      "meaning": "Wake routing, ACK, or stale-handling helper.",
+      "source": "scripts/event-wake-router.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-ack-ledger-room-scripts-pinballwake-ack-ledger-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake ack ledger room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-ack-ledger-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-ack-ledger-room-test-scripts-pinballwake-ack-ledger-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake ack ledger room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-ack-ledger-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-autonomous-runner-scripts-pinballwake-autonomous-runner-mjs",
+      "division": "Automations",
+      "name": "pinballwake autonomous runner",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-autonomous-runner.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-autonomous-runner-test-scripts-pinballwake-autonomous-runner-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake autonomous runner.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-autonomous-runner.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-autopilot-master-loop-scripts-pinballwake-autopilot-master-loop-mjs",
+      "division": "Automations",
+      "name": "pinballwake autopilot master loop",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-autopilot-master-loop.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-autopilot-master-loop-test-scripts-pinballwake-autopilot-master-loop-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake autopilot master loop.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-autopilot-master-loop.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-autopilot-triage-scripts-pinballwake-autopilot-triage-mjs",
+      "division": "Automations",
+      "name": "pinballwake autopilot triage",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-autopilot-triage.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-autopilot-triage-test-scripts-pinballwake-autopilot-triage-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake autopilot triage.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-autopilot-triage.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-build-executor-scripts-pinballwake-build-executor-mjs",
+      "division": "Automations",
+      "name": "pinballwake build executor",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-build-executor.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-build-executor-test-scripts-pinballwake-build-executor-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake build executor.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-build-executor.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-buildbait-room-scripts-pinballwake-buildbait-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake buildbait room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-buildbait-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-buildbait-room-test-scripts-pinballwake-buildbait-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake buildbait room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-buildbait-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-close-supersede-room-scripts-pinballwake-close-supersede-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake close supersede room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-close-supersede-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-close-supersede-room-test-scripts-pinballwake-close-supersede-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake close supersede room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-close-supersede-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-coding-room-scripts-pinballwake-coding-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake coding room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-coding-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-coding-room-runner-scripts-pinballwake-coding-room-runner-mjs",
+      "division": "Automations",
+      "name": "pinballwake coding room runner",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-coding-room-runner.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-coding-room-runner-test-scripts-pinballwake-coding-room-runner-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake coding room runner.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-coding-room-runner.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-coding-room-test-scripts-pinballwake-coding-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake coding room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-coding-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-commonsense-pass-scripts-pinballwake-commonsense-pass-mjs",
+      "division": "Automations",
+      "name": "pinballwake commonsense pass",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-commonsense-pass.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-commonsense-pass-test-scripts-pinballwake-commonsense-pass-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake commonsense pass.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-commonsense-pass.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-continuous-improvement-room-scripts-pinballwake-continuous-improvement-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake continuous improvement room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-continuous-improvement-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-continuous-improvement-room-test-scripts-pinballwake-continuous-improvement-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake continuous improvement room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-continuous-improvement-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-dogfood-room-scripts-pinballwake-dogfood-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake dogfood room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-dogfood-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-dogfood-room-test-scripts-pinballwake-dogfood-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake dogfood room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-dogfood-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-event-ledger-room-scripts-pinballwake-event-ledger-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake event ledger room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-event-ledger-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-event-ledger-room-test-scripts-pinballwake-event-ledger-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake event ledger room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-event-ledger-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-executor-lane-scripts-pinballwake-executor-lane-mjs",
+      "division": "Automations",
+      "name": "pinballwake executor lane",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-executor-lane.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-executor-lane-test-scripts-pinballwake-executor-lane-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake executor lane.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-executor-lane.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-executor-packet-scripts-pinballwake-executor-packet-mjs",
+      "division": "Automations",
+      "name": "pinballwake executor packet",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-executor-packet.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-executor-packet-test-scripts-pinballwake-executor-packet-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake executor packet.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-executor-packet.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-jobs-room-scripts-pinballwake-jobs-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake jobs room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-jobs-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-jobs-room-test-scripts-pinballwake-jobs-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake jobs room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-jobs-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-launchpad-room-scripts-pinballwake-launchpad-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake launchpad room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-launchpad-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-launchpad-room-test-scripts-pinballwake-launchpad-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake launchpad room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-launchpad-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-merge-controller-scripts-pinballwake-merge-controller-mjs",
+      "division": "Automations",
+      "name": "pinballwake merge controller",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-merge-controller.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-merge-controller-test-scripts-pinballwake-merge-controller-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake merge controller.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-merge-controller.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-merge-room-scripts-pinballwake-merge-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake merge room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-merge-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-merge-room-test-scripts-pinballwake-merge-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake merge room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-merge-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-openhands-proof-runner-scripts-pinballwake-openhands-proof-runner-mjs",
+      "division": "Automations",
+      "name": "pinballwake openhands proof runner",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-openhands-proof-runner.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-openhands-proof-runner-test-scripts-pinballwake-openhands-proof-runner-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake openhands proof runner.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-openhands-proof-runner.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-openhands-worker-scripts-pinballwake-openhands-worker-mjs",
+      "division": "Automations",
+      "name": "pinballwake openhands worker",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-openhands-worker.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-openhands-worker-test-scripts-pinballwake-openhands-worker-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake openhands worker.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-openhands-worker.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-overlap-resolver-room-scripts-pinballwake-overlap-resolver-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake overlap resolver room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-overlap-resolver-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-overlap-resolver-room-test-scripts-pinballwake-overlap-resolver-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake overlap resolver room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-overlap-resolver-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-personality-room-scripts-pinballwake-personality-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake personality room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-personality-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-personality-room-test-scripts-pinballwake-personality-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake personality room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-personality-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-pipeline-dry-run-scripts-pinballwake-pipeline-dry-run-mjs",
+      "division": "Automations",
+      "name": "pinballwake pipeline dry run",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-pipeline-dry-run.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-pipeline-dry-run-test-scripts-pinballwake-pipeline-dry-run-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake pipeline dry run.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-pipeline-dry-run.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-pipeline-executor-scripts-pinballwake-pipeline-executor-mjs",
+      "division": "Automations",
+      "name": "pinballwake pipeline executor",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-pipeline-executor.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-pipeline-executor-test-scripts-pinballwake-pipeline-executor-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake pipeline executor.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-pipeline-executor.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-planning-room-scripts-pinballwake-planning-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake planning room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-planning-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-planning-room-test-scripts-pinballwake-planning-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake planning room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-planning-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-post-merge-watch-room-scripts-pinballwake-post-merge-watch-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake post merge watch room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-post-merge-watch-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-post-merge-watch-room-test-scripts-pinballwake-post-merge-watch-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake post merge watch room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-post-merge-watch-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-proof-executor-scripts-pinballwake-proof-executor-mjs",
+      "division": "Automations",
+      "name": "pinballwake proof executor",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-proof-executor.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-proof-executor-test-scripts-pinballwake-proof-executor-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake proof executor.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-proof-executor.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-publish-room-scripts-pinballwake-publish-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake publish room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-publish-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-publish-room-test-scripts-pinballwake-publish-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake publish room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-publish-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-queue-health-room-scripts-pinballwake-queue-health-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake queue health room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-queue-health-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-queue-health-room-test-scripts-pinballwake-queue-health-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake queue health room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-queue-health-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-quiet-window-proof-scripts-pinballwake-quiet-window-proof-mjs",
+      "division": "Automations",
+      "name": "pinballwake quiet window proof",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-quiet-window-proof.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-quiet-window-proof-test-scripts-pinballwake-quiet-window-proof-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake quiet window proof.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-quiet-window-proof.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-release-notes-room-scripts-pinballwake-release-notes-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake release notes room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-release-notes-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-release-notes-room-test-scripts-pinballwake-release-notes-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake release notes room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-release-notes-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-repair-room-scripts-pinballwake-repair-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake repair room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-repair-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-repair-room-test-scripts-pinballwake-repair-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake repair room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-repair-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-research-room-scripts-pinballwake-research-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake research room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-research-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-research-room-test-scripts-pinballwake-research-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake research room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-research-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-rollback-room-scripts-pinballwake-rollback-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake rollback room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-rollback-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-rollback-room-test-scripts-pinballwake-rollback-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake rollback room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-rollback-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-scopepack-hydrator-scripts-pinballwake-scopepack-hydrator-mjs",
+      "division": "Automations",
+      "name": "pinballwake scopepack hydrator",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-scopepack-hydrator.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-stale-room-scripts-pinballwake-stale-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake stale room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-stale-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-stale-room-test-scripts-pinballwake-stale-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake stale room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-stale-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-worker-registry-room-scripts-pinballwake-worker-registry-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake worker registry room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-worker-registry-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-worker-registry-room-test-scripts-pinballwake-worker-registry-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake worker registry room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-worker-registry-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-xpass-gate-room-scripts-pinballwake-xpass-gate-room-mjs",
+      "division": "Automations",
+      "name": "pinballwake xpass gate room",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-xpass-gate-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-xpass-gate-room-test-scripts-pinballwake-xpass-gate-room-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake xpass gate room.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-xpass-gate-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-tier2-auto-merge-queue-check-scripts-tier2-auto-merge-queue-check-mjs",
+      "division": "Automations",
+      "name": "tier2 auto merge queue check",
+      "kind": "script",
+      "meaning": "tier2 auto merge queue check operational script.",
+      "source": "scripts/tier2-auto-merge-queue-check.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-tier2-auto-merge-queue-check-test-scripts-tier2-auto-merge-queue-check-test-mjs",
+      "division": "Automations",
+      "name": "tier2 auto merge queue check.test",
+      "kind": "script",
+      "meaning": "tier2 auto merge queue check.test operational script.",
+      "source": "scripts/tier2-auto-merge-queue-check.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-un-click-brainmap-scripts-unclick-brainmap-mjs",
+      "division": "Automations",
+      "name": "Un Click brainmap",
+      "kind": "script",
+      "meaning": "Brainmap generator or freshness check.",
+      "source": "scripts/UnClick-brainmap.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-un-click-brainmap-test-scripts-unclick-brainmap-test-mjs",
+      "division": "Automations",
+      "name": "Un Click brainmap.test",
+      "kind": "script",
+      "meaning": "Brainmap generator or freshness check.",
+      "source": "scripts/UnClick-brainmap.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-apply-migrations-yml-github-workflows-apply-migrations-yml",
+      "division": "Automations",
+      "name": "apply migrations.yml",
+      "kind": "workflow",
+      "meaning": "apply migrations GitHub automation workflow.",
+      "source": ".github/workflows/apply-migrations.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-auto-close-fishbowl-todo-yml-github-workflows-auto-close-fishbowl-todo-yml",
+      "division": "Automations",
+      "name": "auto close fishbowl todo.yml",
+      "kind": "workflow",
+      "meaning": "auto close fishbowl todo GitHub automation workflow.",
+      "source": ".github/workflows/auto-close-fishbowl-todo.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-autonomous-runner-yml-github-workflows-autonomous-runner-yml",
+      "division": "Automations",
+      "name": "autonomous runner.yml",
+      "kind": "workflow",
+      "meaning": "autonomous runner GitHub automation workflow.",
+      "source": ".github/workflows/autonomous-runner.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-brainmap-auto-update-yml-github-workflows-brainmap-auto-update-yml",
+      "division": "Automations",
+      "name": "brainmap auto update.yml",
+      "kind": "workflow",
+      "meaning": "Scheduled workflow that regenerates the ecosystem Brainmap.",
+      "source": ".github/workflows/brainmap-auto-update.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-ci-yml-github-workflows-ci-yml",
+      "division": "Automations",
+      "name": "ci.yml",
+      "kind": "workflow",
+      "meaning": "Continuous integration checks for build, tests, and proof safety.",
+      "source": ".github/workflows/ci.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-claude-yml-github-workflows-claude-yml",
+      "division": "Automations",
+      "name": "claude.yml",
+      "kind": "workflow",
+      "meaning": "claude GitHub automation workflow.",
+      "source": ".github/workflows/claude.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-dirty-branch-hygiene-yml-github-workflows-dirty-branch-hygiene-yml",
+      "division": "Automations",
+      "name": "dirty branch hygiene.yml",
+      "kind": "workflow",
+      "meaning": "dirty branch hygiene GitHub automation workflow.",
+      "source": ".github/workflows/dirty-branch-hygiene.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-dogfood-report-yml-github-workflows-dogfood-report-yml",
+      "division": "Automations",
+      "name": "dogfood report.yml",
+      "kind": "workflow",
+      "meaning": "dogfood report GitHub automation workflow.",
+      "source": ".github/workflows/dogfood-report.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-event-wake-router-yml-github-workflows-event-wake-router-yml",
+      "division": "Automations",
+      "name": "event wake router.yml",
+      "kind": "workflow",
+      "meaning": "GitHub-triggered wake and routing workflow.",
+      "source": ".github/workflows/event-wake-router.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-fleet-throughput-watch-yml-github-workflows-fleet-throughput-watch-yml",
+      "division": "Automations",
+      "name": "fleet throughput watch.yml",
+      "kind": "workflow",
+      "meaning": "fleet throughput watch GitHub automation workflow.",
+      "source": ".github/workflows/fleet-throughput-watch.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-openhands-test-mode-yml-github-workflows-openhands-test-mode-yml",
+      "division": "Automations",
+      "name": "openhands test mode.yml",
+      "kind": "workflow",
+      "meaning": "openhands test mode GitHub automation workflow.",
+      "source": ".github/workflows/openhands-test-mode.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-publish-channel-package-yml-github-workflows-publish-channel-package-yml",
+      "division": "Automations",
+      "name": "publish channel package.yml",
+      "kind": "workflow",
+      "meaning": "publish channel package GitHub automation workflow.",
+      "source": ".github/workflows/publish-channel-package.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-publish-mcp-package-yml-github-workflows-publish-mcp-package-yml",
+      "division": "Automations",
+      "name": "publish mcp package.yml",
+      "kind": "workflow",
+      "meaning": "publish mcp package GitHub automation workflow.",
+      "source": ".github/workflows/publish-mcp-package.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-review-enforcement-warning-yml-github-workflows-review-enforcement-warning-yml",
+      "division": "Automations",
+      "name": "review enforcement warning.yml",
+      "kind": "workflow",
+      "meaning": "review enforcement warning GitHub automation workflow.",
+      "source": ".github/workflows/review-enforcement-warning.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-seed-vault-yml-github-workflows-seed-vault-yml",
+      "division": "Automations",
+      "name": "seed vault.yml",
+      "kind": "workflow",
+      "meaning": "seed vault GitHub automation workflow.",
+      "source": ".github/workflows/seed-vault.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-testpass-pr-check-yml-github-workflows-testpass-pr-check-yml",
+      "division": "Automations",
+      "name": "testpass pr check.yml",
+      "kind": "workflow",
+      "meaning": "testpass pr check GitHub automation workflow.",
+      "source": ".github/workflows/testpass-pr-check.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-testpass-scheduled-smoke-yml-github-workflows-testpass-scheduled-smoke-yml",
+      "division": "Automations",
+      "name": "testpass scheduled smoke.yml",
+      "kind": "workflow",
+      "meaning": "testpass scheduled smoke GitHub automation workflow.",
+      "source": ".github/workflows/testpass-scheduled-smoke.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-tier2-auto-merge-queue-check-yml-github-workflows-tier2-auto-merge-queue-check-yml",
+      "division": "Automations",
+      "name": "tier2 auto merge queue check.yml",
+      "kind": "workflow",
+      "meaning": "tier2 auto merge queue check GitHub automation workflow.",
+      "source": ".github/workflows/tier2-auto-merge-queue-check.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "launch-and-onboarding-brainmap-source-un-click-brainmap-scripts-unclick-brainmap-mjs",
+      "division": "Launch and onboarding",
+      "name": "Un Click brainmap",
+      "kind": "brainmap source",
+      "meaning": "Un Click brainmap UnClick module.",
+      "source": "scripts/UnClick-brainmap.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "launch-and-onboarding-map-ecosystem-brainmap-src-pages-admin-adminbrainmap-tsx",
+      "division": "Launch and onboarding",
+      "name": "Ecosystem Brainmap",
+      "kind": "map",
+      "meaning": "Generated sitemap and system map that teaches seats what UnClick contains.",
+      "source": "src/pages/admin/AdminBrainmap.tsx",
+      "route": "/admin/brainmap",
+      "tags": []
+    },
+    {
+      "id": "launch-and-onboarding-policy-heartbeat-master-src-pages-admin-adminseatheartbeat-tsx",
+      "division": "Launch and onboarding",
+      "name": "Heartbeat Master",
+      "kind": "policy",
+      "meaning": "Canonical schedule prompt and procedure for safe heartbeat seats.",
+      "source": "src/pages/admin/AdminSeatHeartbeat.tsx",
+      "route": "/admin/agents/heartbeat",
+      "tags": []
+    },
+    {
+      "id": "launch-and-onboarding-route-launchpad-scripts-pinballwake-launchpad-room-mjs",
+      "division": "Launch and onboarding",
+      "name": "Launchpad",
+      "kind": "route",
+      "meaning": "Control hub that points seats to the next safe operating lane.",
+      "source": "scripts/pinballwake-launchpad-room.mjs",
+      "route": "/admin/pinballwake",
+      "tags": []
+    },
+    {
+      "id": "ledgers-and-proof-ledger-proof-ledger-docs-agent-observability-md",
+      "division": "Ledgers and proof",
+      "name": "Proof Ledger",
+      "kind": "ledger",
+      "meaning": "Structured evidence, proof freshness, receipts, and DONE trust surface.",
+      "source": "docs/agent-observability.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "ledgers-and-proof-proof-module-pinballwake-ack-ledger-room-scripts-pinballwake-ack-ledger-room-mjs",
+      "division": "Ledgers and proof",
+      "name": "pinballwake ack ledger room",
+      "kind": "proof module",
+      "meaning": "pinballwake ack ledger room UnClick module.",
+      "source": "scripts/pinballwake-ack-ledger-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "ledgers-and-proof-proof-module-pinballwake-event-ledger-room-scripts-pinballwake-event-ledger-room-mjs",
+      "division": "Ledgers and proof",
+      "name": "pinballwake event ledger room",
+      "kind": "proof module",
+      "meaning": "pinballwake event ledger room UnClick module.",
+      "source": "scripts/pinballwake-event-ledger-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "ledgers-and-proof-proof-module-pinballwake-openhands-proof-runner-scripts-pinballwake-openhands-proof-runner-mjs",
+      "division": "Ledgers and proof",
+      "name": "pinballwake openhands proof runner",
+      "kind": "proof module",
+      "meaning": "pinballwake openhands proof runner UnClick module.",
+      "source": "scripts/pinballwake-openhands-proof-runner.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "ledgers-and-proof-proof-module-pinballwake-proof-executor-scripts-pinballwake-proof-executor-mjs",
+      "division": "Ledgers and proof",
+      "name": "pinballwake proof executor",
+      "kind": "proof module",
+      "meaning": "pinballwake proof executor UnClick module.",
+      "source": "scripts/pinballwake-proof-executor.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "ledgers-and-proof-proof-module-pinballwake-quiet-window-proof-scripts-pinballwake-quiet-window-proof-mjs",
+      "division": "Ledgers and proof",
+      "name": "pinballwake quiet window proof",
+      "kind": "proof module",
+      "meaning": "pinballwake quiet window proof UnClick module.",
+      "source": "scripts/pinballwake-quiet-window-proof.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-app-api-apps-api-package-json",
+      "division": "Modules and apps",
+      "name": "api",
+      "kind": "app",
+      "meaning": "package UnClick module.",
+      "source": "apps/api/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-app-jobsmith-apps-jobsmith-package-json",
+      "division": "Modules and apps",
+      "name": "jobsmith",
+      "kind": "app",
+      "meaning": "JobSmith application module for CV, checklist, and rule-pack work.",
+      "source": "apps/jobsmith/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-app-jobsmith-apps-jobsmith-package-json",
+      "division": "Modules and apps",
+      "name": "JobSmith",
+      "kind": "app",
+      "meaning": "CV, cover-letter, job application, and rules/checklist engine.",
+      "source": "apps/jobsmith/package.json",
+      "route": "/admin/jobsmith",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-automation-module-autopilotkit-autopilot-md",
+      "division": "Modules and apps",
+      "name": "AutoPilotKit",
+      "kind": "automation module",
+      "meaning": "Internal automation bolt-on for proof-first work motion.",
+      "source": "AUTOPILOT.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-channel-plugin-packages-channel-plugin-package-json",
+      "division": "Modules and apps",
+      "name": "channel plugin",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/channel-plugin/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-commonsensepass-packages-commonsensepass-package-json",
+      "division": "Modules and apps",
+      "name": "commonsensepass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/commonsensepass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-copypass-packages-copypass-package-json",
+      "division": "Modules and apps",
+      "name": "copypass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/copypass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-core-packages-core-package-json",
+      "division": "Modules and apps",
+      "name": "core",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/core/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-flowpass-packages-flowpass-package-json",
+      "division": "Modules and apps",
+      "name": "flowpass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/flowpass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-geopass-packages-geopass-package-json",
+      "division": "Modules and apps",
+      "name": "geopass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/geopass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-legalpass-packages-legalpass-package-json",
+      "division": "Modules and apps",
+      "name": "legalpass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/legalpass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-mcp-server-packages-mcp-server-package-json",
+      "division": "Modules and apps",
+      "name": "mcp server",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/mcp-server/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-memory-mcp-packages-memory-mcp-package-json",
+      "division": "Modules and apps",
+      "name": "memory mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/memory-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-securitypass-packages-securitypass-package-json",
+      "division": "Modules and apps",
+      "name": "securitypass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/securitypass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-seopass-packages-seopass-package-json",
+      "division": "Modules and apps",
+      "name": "seopass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/seopass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-sloppass-packages-sloppass-package-json",
+      "division": "Modules and apps",
+      "name": "sloppass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/sloppass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-testpass-packages-testpass-package-json",
+      "division": "Modules and apps",
+      "name": "testpass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/testpass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-uxpass-packages-uxpass-package-json",
+      "division": "Modules and apps",
+      "name": "uxpass",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/uxpass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-wizard-packages-wizard-package-json",
+      "division": "Modules and apps",
+      "name": "wizard",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/wizard/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-fidelity-gate-copyroom-docs-unclick-brainmap-generated-md",
+      "division": "Passes and gates",
+      "name": "CopyRoom",
+      "kind": "fidelity gate",
+      "meaning": "Exact-copy room for code, docs, tables, notes, and source text so seats do not retype drift-prone material.",
+      "source": "docs/UnClick-brainmap.generated.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-fidelity-gate-fidelitypass-scripts-fidelitycopy-test-mjs",
+      "division": "Passes and gates",
+      "name": "FidelityPass",
+      "kind": "fidelity gate",
+      "meaning": "Checks exactness and invariant preservation when copying, refactoring, or translating content.",
+      "source": "scripts/fidelitycopy.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-judgment-gate-commonsensepass-api-commonsensepass-bridge-test-ts",
+      "division": "Passes and gates",
+      "name": "CommonSensePass",
+      "kind": "judgment gate",
+      "meaning": "Plain-reasoning gate used before healthy, done, merge-ready, or PASS claims.",
+      "source": "api/commonsensepass-bridge.test.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-testpass-api-testpass-ts",
+      "division": "Passes and gates",
+      "name": "testpass",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/testpass.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-testpass-background-handoff-api-lib-testpass-background-handoff-ts",
+      "division": "Passes and gates",
+      "name": "testpass background handoff",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/testpass-background-handoff.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-testpass-boundary-api-lib-testpass-boundary-ts",
+      "division": "Passes and gates",
+      "name": "testpass boundary",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/testpass-boundary.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-testpass-run-api-testpass-run-ts",
+      "division": "Passes and gates",
+      "name": "testpass run",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/testpass-run.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-uxpass-api-uxpass-ts",
+      "division": "Passes and gates",
+      "name": "uxpass",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/uxpass.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-uxpass-run-api-uxpass-run-ts",
+      "division": "Passes and gates",
+      "name": "uxpass run",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/uxpass-run.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-uxpass-run-handoff-api-lib-uxpass-run-handoff-ts",
+      "division": "Passes and gates",
+      "name": "uxpass run handoff",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/uxpass-run-handoff.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-uxpass-site-sweep-scripts-uxpass-site-sweep-mjs",
+      "division": "Passes and gates",
+      "name": "uxpass site sweep",
+      "kind": "pass",
+      "meaning": "uxpass site sweep UnClick module.",
+      "source": "scripts/uxpass-site-sweep.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-wake-gate-wakepass-docs-pinballwake-igniteonly-api-md",
+      "division": "Passes and gates",
+      "name": "WakePass",
+      "kind": "wake gate",
+      "meaning": "Verifies ACKs, stale handoffs, and worker wake requests before motion claims.",
+      "source": "docs/pinballwake-igniteonly-api.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-admin-settings-src-pages-adminsettings-tsx",
+      "division": "Public surfaces",
+      "name": "Admin Settings",
+      "kind": "public page",
+      "meaning": "Account and admin configuration.",
+      "source": "src/pages/AdminSettings.tsx",
+      "route": "/admin/settings",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-arena-home-src-pages-arena-arenahome-tsx",
+      "division": "Public surfaces",
+      "name": "Arena Home",
+      "kind": "public page",
+      "meaning": "Arena page for Arena Home.",
+      "source": "src/pages/arena/ArenaHome.tsx",
+      "route": "/arena/arena-home",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-arena-leaderboard-src-pages-arena-arenaleaderboard-tsx",
+      "division": "Public surfaces",
+      "name": "Arena Leaderboard",
+      "kind": "public page",
+      "meaning": "Arena page for Arena Leaderboard.",
+      "source": "src/pages/arena/ArenaLeaderboard.tsx",
+      "route": "/arena/arena-leaderboard",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-arena-problem-src-pages-arena-arenaproblem-tsx",
+      "division": "Public surfaces",
+      "name": "Arena Problem",
+      "kind": "public page",
+      "meaning": "Arena page for Arena Problem.",
+      "source": "src/pages/arena/ArenaProblem.tsx",
+      "route": "/arena/arena-problem",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-arena-submit-problem-src-pages-arena-arenasubmitproblem-tsx",
+      "division": "Public surfaces",
+      "name": "Arena Submit Problem",
+      "kind": "public page",
+      "meaning": "Arena page for Arena Submit Problem.",
+      "source": "src/pages/arena/ArenaSubmitProblem.tsx",
+      "route": "/arena/arena-submit-problem",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-auth-callback-src-pages-authcallback-tsx",
+      "division": "Public surfaces",
+      "name": "Auth Callback",
+      "kind": "public page",
+      "meaning": "User-facing page for Auth Callback.",
+      "source": "src/pages/AuthCallback.tsx",
+      "route": "/auth-callback",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-backstage-pass-src-pages-backstagepass-tsx",
+      "division": "Public surfaces",
+      "name": "Backstage Pass",
+      "kind": "public page",
+      "meaning": "User-facing page for Backstage Pass.",
+      "source": "src/pages/BackstagePass.tsx",
+      "route": "/backstage-pass",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-build-desk-src-pages-builddesk-tsx",
+      "division": "Public surfaces",
+      "name": "Build Desk",
+      "kind": "public page",
+      "meaning": "Build and project work surface.",
+      "source": "src/pages/BuildDesk.tsx",
+      "route": "/build-desk",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-connect-src-pages-connect-tsx",
+      "division": "Public surfaces",
+      "name": "Connect",
+      "kind": "public page",
+      "meaning": "User-facing page for Connect.",
+      "source": "src/pages/Connect.tsx",
+      "route": "/connect",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-crews-src-pages-crews-tsx",
+      "division": "Public surfaces",
+      "name": "Crews",
+      "kind": "public page",
+      "meaning": "Public Crews explanation and entry point.",
+      "source": "src/pages/Crews.tsx",
+      "route": "/crews",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-developer-docs-src-pages-developerdocs-tsx",
+      "division": "Public surfaces",
+      "name": "Developer Docs",
+      "kind": "public page",
+      "meaning": "Developer documentation.",
+      "source": "src/pages/DeveloperDocs.tsx",
+      "route": "/developer-docs",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-developer-submit-src-pages-developersubmit-tsx",
+      "division": "Public surfaces",
+      "name": "Developer Submit",
+      "kind": "public page",
+      "meaning": "Tool submission flow.",
+      "source": "src/pages/DeveloperSubmit.tsx",
+      "route": "/developer-submit",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-developers-src-pages-developers-tsx",
+      "division": "Public surfaces",
+      "name": "Developers",
+      "kind": "public page",
+      "meaning": "Developer-facing entry point.",
+      "source": "src/pages/Developers.tsx",
+      "route": "/developers",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-dispatch-src-pages-dispatch-tsx",
+      "division": "Public surfaces",
+      "name": "Dispatch",
+      "kind": "public page",
+      "meaning": "Dispatch and message handoff surface.",
+      "source": "src/pages/Dispatch.tsx",
+      "route": "/dispatch",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-docs-src-pages-docs-tsx",
+      "division": "Public surfaces",
+      "name": "Docs",
+      "kind": "public page",
+      "meaning": "User-facing page for Docs.",
+      "source": "src/pages/Docs.tsx",
+      "route": "/docs",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-dogfood-report-src-pages-dogfoodreport-tsx",
+      "division": "Public surfaces",
+      "name": "Dogfood Report",
+      "kind": "public page",
+      "meaning": "Public dogfood proof report.",
+      "source": "src/pages/DogfoodReport.tsx",
+      "route": "/dogfood-report",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-faqpage-src-pages-faqpage-tsx",
+      "division": "Public surfaces",
+      "name": "FAQPage",
+      "kind": "public page",
+      "meaning": "User-facing page for FAQPage.",
+      "source": "src/pages/FAQPage.tsx",
+      "route": "/faqpage",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-index-src-pages-index-tsx",
+      "division": "Public surfaces",
+      "name": "Index",
+      "kind": "public page",
+      "meaning": "Public home and first explanation of UnClick.",
+      "source": "src/pages/Index.tsx",
+      "route": "/",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-install-recover-src-pages-installrecover-tsx",
+      "division": "Public surfaces",
+      "name": "Install Recover",
+      "kind": "public page",
+      "meaning": "User-facing page for Install Recover.",
+      "source": "src/pages/InstallRecover.tsx",
+      "route": "/install-recover",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-jobsmith-src-pages-jobsmith-tsx",
+      "division": "Public surfaces",
+      "name": "Jobsmith",
+      "kind": "public page",
+      "meaning": "User-facing page for Jobsmith.",
+      "source": "src/pages/Jobsmith.tsx",
+      "route": "/jobsmith",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-link-in-bio-src-pages-tools-linkinbio-tsx",
+      "division": "Public surfaces",
+      "name": "Link In Bio",
+      "kind": "public page",
+      "meaning": "Tool page for Link In Bio.",
+      "source": "src/pages/tools/LinkInBio.tsx",
+      "route": "/tools/link-in-bio",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-login-src-pages-login-tsx",
+      "division": "Public surfaces",
+      "name": "Login",
+      "kind": "public page",
+      "meaning": "Sign-in page.",
+      "source": "src/pages/Login.tsx",
+      "route": "/login",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-memory-src-pages-memory-tsx",
+      "division": "Public surfaces",
+      "name": "Memory",
+      "kind": "public page",
+      "meaning": "Public memory product page.",
+      "source": "src/pages/Memory.tsx",
+      "route": "/memory",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-memory-admin-src-pages-memoryadmin-tsx",
+      "division": "Public surfaces",
+      "name": "Memory Admin",
+      "kind": "public page",
+      "meaning": "User-facing page for Memory Admin.",
+      "source": "src/pages/MemoryAdmin.tsx",
+      "route": "/memory-admin",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-memory-connect-src-pages-memoryconnect-tsx",
+      "division": "Public surfaces",
+      "name": "Memory Connect",
+      "kind": "public page",
+      "meaning": "User-facing page for Memory Connect.",
+      "source": "src/pages/MemoryConnect.tsx",
+      "route": "/memory-connect",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-memory-setup-src-pages-memorysetup-tsx",
+      "division": "Public surfaces",
+      "name": "Memory Setup",
+      "kind": "public page",
+      "meaning": "User-facing page for Memory Setup.",
+      "source": "src/pages/MemorySetup.tsx",
+      "route": "/memory-setup",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-memory-setup-guide-src-pages-memorysetupguide-tsx",
+      "division": "Public surfaces",
+      "name": "Memory Setup Guide",
+      "kind": "public page",
+      "meaning": "User-facing page for Memory Setup Guide.",
+      "source": "src/pages/MemorySetupGuide.tsx",
+      "route": "/memory-setup-guide",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-new-to-ai-src-pages-newtoai-tsx",
+      "division": "Public surfaces",
+      "name": "New To AI",
+      "kind": "public page",
+      "meaning": "Beginner-friendly AI orientation.",
+      "source": "src/pages/NewToAI.tsx",
+      "route": "/new-to-ai",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-not-found-src-pages-notfound-tsx",
+      "division": "Public surfaces",
+      "name": "Not Found",
+      "kind": "public page",
+      "meaning": "User-facing page for Not Found.",
+      "source": "src/pages/NotFound.tsx",
+      "route": "/not-found",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-organiser-src-pages-organiser-tsx",
+      "division": "Public surfaces",
+      "name": "Organiser",
+      "kind": "public page",
+      "meaning": "User-facing page for Organiser.",
+      "source": "src/pages/Organiser.tsx",
+      "route": "/organiser",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-pricing-src-pages-pricing-tsx",
+      "division": "Public surfaces",
+      "name": "Pricing",
+      "kind": "public page",
+      "meaning": "Plans, billing, and packaging.",
+      "source": "src/pages/Pricing.tsx",
+      "route": "/pricing",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-privacy-src-pages-privacy-tsx",
+      "division": "Public surfaces",
+      "name": "Privacy",
+      "kind": "public page",
+      "meaning": "Privacy policy.",
+      "source": "src/pages/Privacy.tsx",
+      "route": "/privacy",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-scheduling-src-pages-tools-scheduling-tsx",
+      "division": "Public surfaces",
+      "name": "Scheduling",
+      "kind": "public page",
+      "meaning": "Tool page for Scheduling.",
+      "source": "src/pages/tools/Scheduling.tsx",
+      "route": "/tools/scheduling",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-settings-src-pages-settings-tsx",
+      "division": "Public surfaces",
+      "name": "Settings",
+      "kind": "public page",
+      "meaning": "User-facing page for Settings.",
+      "source": "src/pages/Settings.tsx",
+      "route": "/settings",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-signup-src-pages-signup-tsx",
+      "division": "Public surfaces",
+      "name": "Signup",
+      "kind": "public page",
+      "meaning": "Sign-up page.",
+      "source": "src/pages/Signup.tsx",
+      "route": "/signup",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-smart-home-src-pages-smarthome-tsx",
+      "division": "Public surfaces",
+      "name": "Smart Home",
+      "kind": "public page",
+      "meaning": "User-facing page for Smart Home.",
+      "source": "src/pages/SmartHome.tsx",
+      "route": "/smart-home",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-solve-src-pages-tools-solve-tsx",
+      "division": "Public surfaces",
+      "name": "Solve",
+      "kind": "public page",
+      "meaning": "Tool page for Solve.",
+      "source": "src/pages/tools/Solve.tsx",
+      "route": "/tools/solve",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-terms-src-pages-terms-tsx",
+      "division": "Public surfaces",
+      "name": "Terms",
+      "kind": "public page",
+      "meaning": "Terms of service.",
+      "source": "src/pages/Terms.tsx",
+      "route": "/terms",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-tools-src-pages-tools-tsx",
+      "division": "Public surfaces",
+      "name": "Tools",
+      "kind": "public page",
+      "meaning": "Public tools marketplace entry point.",
+      "source": "src/pages/Tools.tsx",
+      "route": "/tools",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-verify-mfa-src-pages-verifymfa-tsx",
+      "division": "Public surfaces",
+      "name": "Verify Mfa",
+      "kind": "public page",
+      "meaning": "User-facing page for Verify Mfa.",
+      "source": "src/pages/VerifyMfa.tsx",
+      "route": "/verify-mfa",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-vibe-coding-src-pages-vibecoding-tsx",
+      "division": "Public surfaces",
+      "name": "Vibe Coding",
+      "kind": "public page",
+      "meaning": "User-facing page for Vibe Coding.",
+      "source": "src/pages/VibeCoding.tsx",
+      "route": "/vibe-coding",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-ack-ledger-scripts-pinballwake-ack-ledger-room-mjs",
+      "division": "Rooms",
+      "name": "ack ledger",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-ack-ledger-room.mjs.",
+      "source": "scripts/pinballwake-ack-ledger-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-buildbait-scripts-pinballwake-buildbait-room-mjs",
+      "division": "Rooms",
+      "name": "buildbait",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-buildbait-room.mjs.",
+      "source": "scripts/pinballwake-buildbait-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-close-supersede-scripts-pinballwake-close-supersede-room-mjs",
+      "division": "Rooms",
+      "name": "close supersede",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-close-supersede-room.mjs.",
+      "source": "scripts/pinballwake-close-supersede-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-coding-scripts-pinballwake-coding-room-mjs",
+      "division": "Rooms",
+      "name": "coding",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-coding-room.mjs.",
+      "source": "scripts/pinballwake-coding-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-continuous-improvement-scripts-pinballwake-continuous-improvement-room-mjs",
+      "division": "Rooms",
+      "name": "continuous improvement",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-continuous-improvement-room.mjs.",
+      "source": "scripts/pinballwake-continuous-improvement-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-dogfood-scripts-pinballwake-dogfood-room-mjs",
+      "division": "Rooms",
+      "name": "dogfood",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-dogfood-room.mjs.",
+      "source": "scripts/pinballwake-dogfood-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-event-ledger-scripts-pinballwake-event-ledger-room-mjs",
+      "division": "Rooms",
+      "name": "event ledger",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-event-ledger-room.mjs.",
+      "source": "scripts/pinballwake-event-ledger-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-jobs-scripts-pinballwake-jobs-room-mjs",
+      "division": "Rooms",
+      "name": "jobs",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-jobs-room.mjs.",
+      "source": "scripts/pinballwake-jobs-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-launchpad-scripts-pinballwake-launchpad-room-mjs",
+      "division": "Rooms",
+      "name": "launchpad",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-launchpad-room.mjs.",
+      "source": "scripts/pinballwake-launchpad-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-merge-scripts-pinballwake-merge-room-mjs",
+      "division": "Rooms",
+      "name": "merge",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-merge-room.mjs.",
+      "source": "scripts/pinballwake-merge-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-overlap-resolver-scripts-pinballwake-overlap-resolver-room-mjs",
+      "division": "Rooms",
+      "name": "overlap resolver",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-overlap-resolver-room.mjs.",
+      "source": "scripts/pinballwake-overlap-resolver-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-personality-scripts-pinballwake-personality-room-mjs",
+      "division": "Rooms",
+      "name": "personality",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-personality-room.mjs.",
+      "source": "scripts/pinballwake-personality-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-planning-scripts-pinballwake-planning-room-mjs",
+      "division": "Rooms",
+      "name": "planning",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-planning-room.mjs.",
+      "source": "scripts/pinballwake-planning-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-post-merge-watch-scripts-pinballwake-post-merge-watch-room-mjs",
+      "division": "Rooms",
+      "name": "post merge watch",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-post-merge-watch-room.mjs.",
+      "source": "scripts/pinballwake-post-merge-watch-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-publish-scripts-pinballwake-publish-room-mjs",
+      "division": "Rooms",
+      "name": "publish",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-publish-room.mjs.",
+      "source": "scripts/pinballwake-publish-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-queue-health-scripts-pinballwake-queue-health-room-mjs",
+      "division": "Rooms",
+      "name": "queue health",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-queue-health-room.mjs.",
+      "source": "scripts/pinballwake-queue-health-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-release-notes-scripts-pinballwake-release-notes-room-mjs",
+      "division": "Rooms",
+      "name": "release notes",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-release-notes-room.mjs.",
+      "source": "scripts/pinballwake-release-notes-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-repair-scripts-pinballwake-repair-room-mjs",
+      "division": "Rooms",
+      "name": "repair",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-repair-room.mjs.",
+      "source": "scripts/pinballwake-repair-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-research-scripts-pinballwake-research-room-mjs",
+      "division": "Rooms",
+      "name": "research",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-research-room.mjs.",
+      "source": "scripts/pinballwake-research-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-rollback-scripts-pinballwake-rollback-room-mjs",
+      "division": "Rooms",
+      "name": "rollback",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-rollback-room.mjs.",
+      "source": "scripts/pinballwake-rollback-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-stale-scripts-pinballwake-stale-room-mjs",
+      "division": "Rooms",
+      "name": "stale",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-stale-room.mjs.",
+      "source": "scripts/pinballwake-stale-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-worker-registry-scripts-pinballwake-worker-registry-room-mjs",
+      "division": "Rooms",
+      "name": "worker registry",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-worker-registry-room.mjs.",
+      "source": "scripts/pinballwake-worker-registry-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "rooms-pinballwake-room-xpass-gate-scripts-pinballwake-xpass-gate-room-mjs",
+      "division": "Rooms",
+      "name": "xpass gate",
+      "kind": "PinballWake room",
+      "meaning": "PinballWake room logic generated from scripts/pinballwake-xpass-gate-room.mjs.",
+      "source": "scripts/pinballwake-xpass-gate-room.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-context-orchestrator-src-pages-admin-adminorchestrator-tsx",
+      "division": "Source of truth",
+      "name": "Orchestrator",
+      "kind": "context",
+      "meaning": "Continuity stream and story layer that helps seats understand what happened.",
+      "source": "src/pages/admin/AdminOrchestrator.tsx",
+      "route": "/admin/orchestrator",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-memory-memory-library-src-pages-admin-adminmemory-tsx",
+      "division": "Source of truth",
+      "name": "Memory Library",
+      "kind": "memory",
+      "meaning": "Source-linked facts, sessions, context, and generated memory shelves.",
+      "source": "src/pages/admin/AdminMemory.tsx",
+      "route": "/admin/memory",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-queue-boardroom-jobs-src-pages-admin-adminjobs-tsx",
+      "division": "Source of truth",
+      "name": "Boardroom Jobs",
+      "kind": "queue",
+      "meaning": "Primary work source for open, in-progress, done, and dropped chips.",
+      "source": "src/pages/admin/AdminJobs.tsx",
+      "route": "/admin/jobs",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-embed-api-memory-embed-ts",
+      "division": "Source of truth",
+      "name": "embed",
+      "kind": "state module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/memory/embed.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-memory-admin-api-memory-admin-ts",
+      "division": "Source of truth",
+      "name": "memory admin",
+      "kind": "state module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/memory-admin.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-memory-data-island-src-lib-memorydataisland-ts",
+      "division": "Source of truth",
+      "name": "memory Data Island",
+      "kind": "state module",
+      "meaning": "memory Data Island shared frontend logic.",
+      "source": "src/lib/memoryDataIsland.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-memory-retrieval-eval-scripts-memory-retrieval-eval-mjs",
+      "division": "Source of truth",
+      "name": "memory retrieval eval",
+      "kind": "state module",
+      "meaning": "memory retrieval eval UnClick module.",
+      "source": "scripts/memory-retrieval-eval.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-memory-taxonomy-src-lib-memorytaxonomy-ts",
+      "division": "Source of truth",
+      "name": "memory Taxonomy",
+      "kind": "state module",
+      "meaning": "memory Taxonomy shared frontend logic.",
+      "source": "src/lib/memoryTaxonomy.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-orchestrator-context-api-lib-orchestrator-context-ts",
+      "division": "Source of truth",
+      "name": "orchestrator context",
+      "kind": "state module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/orchestrator-context.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-abn-packages-mcp-server-src-abn-tool-ts",
+      "division": "Tools",
+      "name": "abn",
+      "kind": "MCP tool",
+      "meaning": "abn MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/abn-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-abuseipdb-packages-mcp-server-src-abuseipdb-tool-ts",
+      "division": "Tools",
+      "name": "abuseipdb",
+      "kind": "MCP tool",
+      "meaning": "abuseipdb MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/abuseipdb-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-airtable-packages-mcp-server-src-airtable-tool-ts",
+      "division": "Tools",
+      "name": "airtable",
+      "kind": "MCP tool",
+      "meaning": "airtable MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/airtable-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-algolia-packages-mcp-server-src-algolia-tool-ts",
+      "division": "Tools",
+      "name": "algolia",
+      "kind": "MCP tool",
+      "meaning": "algolia MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/algolia-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-alphavantage-packages-mcp-server-src-alphavantage-tool-ts",
+      "division": "Tools",
+      "name": "alphavantage",
+      "kind": "MCP tool",
+      "meaning": "alphavantage MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/alphavantage-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-amazon-packages-mcp-server-src-amazon-tool-ts",
+      "division": "Tools",
+      "name": "amazon",
+      "kind": "MCP tool",
+      "meaning": "amazon MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/amazon-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-amber-packages-mcp-server-src-amber-tool-ts",
+      "division": "Tools",
+      "name": "amber",
+      "kind": "MCP tool",
+      "meaning": "amber MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/amber-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-anthropic-packages-mcp-server-src-anthropic-tool-ts",
+      "division": "Tools",
+      "name": "anthropic",
+      "kind": "MCP tool",
+      "meaning": "anthropic MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/anthropic-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-asana-packages-mcp-server-src-asana-tool-ts",
+      "division": "Tools",
+      "name": "asana",
+      "kind": "MCP tool",
+      "meaning": "asana MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/asana-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-assemblyai-packages-mcp-server-src-assemblyai-tool-ts",
+      "division": "Tools",
+      "name": "assemblyai",
+      "kind": "MCP tool",
+      "meaning": "assemblyai MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/assemblyai-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-australiapost-packages-mcp-server-src-australiapost-tool-ts",
+      "division": "Tools",
+      "name": "australiapost",
+      "kind": "MCP tool",
+      "meaning": "australiapost MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/australiapost-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-bandsintown-packages-mcp-server-src-bandsintown-tool-ts",
+      "division": "Tools",
+      "name": "bandsintown",
+      "kind": "MCP tool",
+      "meaning": "bandsintown MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/bandsintown-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-bgg-packages-mcp-server-src-bgg-tool-ts",
+      "division": "Tools",
+      "name": "bgg",
+      "kind": "MCP tool",
+      "meaning": "bgg MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/bgg-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-bluesky-packages-mcp-server-src-bluesky-tool-ts",
+      "division": "Tools",
+      "name": "bluesky",
+      "kind": "MCP tool",
+      "meaning": "bluesky MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/bluesky-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-bungie-packages-mcp-server-src-bungie-tool-ts",
+      "division": "Tools",
+      "name": "bungie",
+      "kind": "MCP tool",
+      "meaning": "bungie MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/bungie-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-calculator-packages-mcp-server-src-calculator-tool-ts",
+      "division": "Tools",
+      "name": "calculator",
+      "kind": "MCP tool",
+      "meaning": "calculator MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/calculator-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-calendly-packages-mcp-server-src-calendly-tool-ts",
+      "division": "Tools",
+      "name": "calendly",
+      "kind": "MCP tool",
+      "meaning": "calendly MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/calendly-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-carboninterface-packages-mcp-server-src-carboninterface-tool-ts",
+      "division": "Tools",
+      "name": "carboninterface",
+      "kind": "MCP tool",
+      "meaning": "carboninterface MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/carboninterface-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-chessdotcom-packages-mcp-server-src-chessdotcom-tool-ts",
+      "division": "Tools",
+      "name": "chessdotcom",
+      "kind": "MCP tool",
+      "meaning": "chessdotcom MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/chessdotcom-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-circleci-packages-mcp-server-src-circleci-tool-ts",
+      "division": "Tools",
+      "name": "circleci",
+      "kind": "MCP tool",
+      "meaning": "circleci MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/circleci-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-clickup-packages-mcp-server-src-clickup-tool-ts",
+      "division": "Tools",
+      "name": "clickup",
+      "kind": "MCP tool",
+      "meaning": "clickup MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/clickup-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-clockify-packages-mcp-server-src-clockify-tool-ts",
+      "division": "Tools",
+      "name": "clockify",
+      "kind": "MCP tool",
+      "meaning": "clockify MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/clockify-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-cohere-packages-mcp-server-src-cohere-tool-ts",
+      "division": "Tools",
+      "name": "cohere",
+      "kind": "MCP tool",
+      "meaning": "cohere MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/cohere-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-coingecko-packages-mcp-server-src-coingecko-tool-ts",
+      "division": "Tools",
+      "name": "coingecko",
+      "kind": "MCP tool",
+      "meaning": "coingecko MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/coingecko-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-coinmarketcap-packages-mcp-server-src-coinmarketcap-tool-ts",
+      "division": "Tools",
+      "name": "coinmarketcap",
+      "kind": "MCP tool",
+      "meaning": "coinmarketcap MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/coinmarketcap-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-color-packages-mcp-server-src-color-tool-ts",
+      "division": "Tools",
+      "name": "color",
+      "kind": "MCP tool",
+      "meaning": "color MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/color-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-convertkit-packages-mcp-server-src-convertkit-tool-ts",
+      "division": "Tools",
+      "name": "convertkit",
+      "kind": "MCP tool",
+      "meaning": "convertkit MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/convertkit-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-copypass-packages-mcp-server-src-copypass-tool-ts",
+      "division": "Tools",
+      "name": "copypass",
+      "kind": "MCP tool",
+      "meaning": "copypass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/copypass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-crews-packages-mcp-server-src-crews-tool-ts",
+      "division": "Tools",
+      "name": "crews",
+      "kind": "MCP tool",
+      "meaning": "crews MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/crews-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-csuite-packages-mcp-server-src-csuite-tool-ts",
+      "division": "Tools",
+      "name": "csuite",
+      "kind": "MCP tool",
+      "meaning": "csuite MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/csuite-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-datadog-packages-mcp-server-src-datadog-tool-ts",
+      "division": "Tools",
+      "name": "datadog",
+      "kind": "MCP tool",
+      "meaning": "datadog MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/datadog-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-datetime-packages-mcp-server-src-datetime-tool-ts",
+      "division": "Tools",
+      "name": "datetime",
+      "kind": "MCP tool",
+      "meaning": "datetime MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/datetime-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-deepl-packages-mcp-server-src-deepl-tool-ts",
+      "division": "Tools",
+      "name": "deepl",
+      "kind": "MCP tool",
+      "meaning": "deepl MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/deepl-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-deezer-packages-mcp-server-src-deezer-tool-ts",
+      "division": "Tools",
+      "name": "deezer",
+      "kind": "MCP tool",
+      "meaning": "deezer MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/deezer-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-discogs-packages-mcp-server-src-discogs-tool-ts",
+      "division": "Tools",
+      "name": "discogs",
+      "kind": "MCP tool",
+      "meaning": "discogs MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/discogs-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-discord-packages-mcp-server-src-discord-tool-ts",
+      "division": "Tools",
+      "name": "discord",
+      "kind": "MCP tool",
+      "meaning": "discord MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/discord-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-domain-packages-mcp-server-src-domain-tool-ts",
+      "division": "Tools",
+      "name": "domain",
+      "kind": "MCP tool",
+      "meaning": "domain MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/domain-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-ebay-packages-mcp-server-src-ebay-tool-ts",
+      "division": "Tools",
+      "name": "ebay",
+      "kind": "MCP tool",
+      "meaning": "ebay MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/ebay-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-ebird-packages-mcp-server-src-ebird-tool-ts",
+      "division": "Tools",
+      "name": "ebird",
+      "kind": "MCP tool",
+      "meaning": "ebird MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/ebird-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-elevenlabs-packages-mcp-server-src-elevenlabs-tool-ts",
+      "division": "Tools",
+      "name": "elevenlabs",
+      "kind": "MCP tool",
+      "meaning": "elevenlabs MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/elevenlabs-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-email-packages-mcp-server-src-email-tool-ts",
+      "division": "Tools",
+      "name": "email",
+      "kind": "MCP tool",
+      "meaning": "email MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/email-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-espn-packages-mcp-server-src-espn-tool-ts",
+      "division": "Tools",
+      "name": "espn",
+      "kind": "MCP tool",
+      "meaning": "espn MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/espn-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-etsy-packages-mcp-server-src-etsy-tool-ts",
+      "division": "Tools",
+      "name": "etsy",
+      "kind": "MCP tool",
+      "meaning": "etsy MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/etsy-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-eventbrite-packages-mcp-server-src-eventbrite-tool-ts",
+      "division": "Tools",
+      "name": "eventbrite",
+      "kind": "MCP tool",
+      "meaning": "eventbrite MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/eventbrite-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-exchangerate-packages-mcp-server-src-exchangerate-tool-ts",
+      "division": "Tools",
+      "name": "exchangerate",
+      "kind": "MCP tool",
+      "meaning": "exchangerate MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/exchangerate-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-feedly-packages-mcp-server-src-feedly-tool-ts",
+      "division": "Tools",
+      "name": "feedly",
+      "kind": "MCP tool",
+      "meaning": "feedly MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/feedly-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-figma-packages-mcp-server-src-figma-tool-ts",
+      "division": "Tools",
+      "name": "figma",
+      "kind": "MCP tool",
+      "meaning": "figma MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/figma-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-flyio-packages-mcp-server-src-flyio-tool-ts",
+      "division": "Tools",
+      "name": "flyio",
+      "kind": "MCP tool",
+      "meaning": "flyio MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/flyio-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-foursquare-packages-mcp-server-src-foursquare-tool-ts",
+      "division": "Tools",
+      "name": "foursquare",
+      "kind": "MCP tool",
+      "meaning": "foursquare MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/foursquare-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-fpl-packages-mcp-server-src-fpl-tool-ts",
+      "division": "Tools",
+      "name": "fpl",
+      "kind": "MCP tool",
+      "meaning": "fpl MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/fpl-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-gdelt-packages-mcp-server-src-gdelt-tool-ts",
+      "division": "Tools",
+      "name": "gdelt",
+      "kind": "MCP tool",
+      "meaning": "gdelt MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/gdelt-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-genius-packages-mcp-server-src-genius-tool-ts",
+      "division": "Tools",
+      "name": "genius",
+      "kind": "MCP tool",
+      "meaning": "genius MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/genius-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-github-packages-mcp-server-src-github-tool-ts",
+      "division": "Tools",
+      "name": "github",
+      "kind": "MCP tool",
+      "meaning": "github MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/github-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-gitlab-packages-mcp-server-src-gitlab-tool-ts",
+      "division": "Tools",
+      "name": "gitlab",
+      "kind": "MCP tool",
+      "meaning": "gitlab MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/gitlab-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-groq-packages-mcp-server-src-groq-tool-ts",
+      "division": "Tools",
+      "name": "groq",
+      "kind": "MCP tool",
+      "meaning": "groq MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/groq-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-guardian-packages-mcp-server-src-guardian-tool-ts",
+      "division": "Tools",
+      "name": "guardian",
+      "kind": "MCP tool",
+      "meaning": "guardian MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/guardian-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-gumroad-packages-mcp-server-src-gumroad-tool-ts",
+      "division": "Tools",
+      "name": "gumroad",
+      "kind": "MCP tool",
+      "meaning": "gumroad MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/gumroad-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-hackernews-packages-mcp-server-src-hackernews-tool-ts",
+      "division": "Tools",
+      "name": "hackernews",
+      "kind": "MCP tool",
+      "meaning": "hackernews MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/hackernews-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-haveibeenpwned-packages-mcp-server-src-haveibeenpwned-tool-ts",
+      "division": "Tools",
+      "name": "haveibeenpwned",
+      "kind": "MCP tool",
+      "meaning": "haveibeenpwned MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/haveibeenpwned-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-heartbeat-protocol-packages-mcp-server-src-heartbeat-protocol-ts",
+      "division": "Tools",
+      "name": "Heartbeat Protocol",
+      "kind": "MCP tool",
+      "meaning": "Canonical heartbeat policy served to scheduled seats.",
+      "source": "packages/mcp-server/src/heartbeat-protocol.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-heygen-packages-mcp-server-src-heygen-tool-ts",
+      "division": "Tools",
+      "name": "heygen",
+      "kind": "MCP tool",
+      "meaning": "heygen MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/heygen-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-higgsfield-packages-mcp-server-src-higgsfield-tool-ts",
+      "division": "Tools",
+      "name": "higgsfield",
+      "kind": "MCP tool",
+      "meaning": "higgsfield MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/higgsfield-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-hunter-packages-mcp-server-src-hunter-tool-ts",
+      "division": "Tools",
+      "name": "hunter",
+      "kind": "MCP tool",
+      "meaning": "hunter MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/hunter-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-igdb-packages-mcp-server-src-igdb-tool-ts",
+      "division": "Tools",
+      "name": "igdb",
+      "kind": "MCP tool",
+      "meaning": "igdb MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/igdb-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-igniteonly-packages-mcp-server-src-igniteonly-tool-ts",
+      "division": "Tools",
+      "name": "IgniteOnly",
+      "kind": "MCP tool",
+      "meaning": "IgniteOnly verified worker wake packet bridge.",
+      "source": "packages/mcp-server/src/igniteonly-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-instapaper-packages-mcp-server-src-instapaper-tool-ts",
+      "division": "Tools",
+      "name": "instapaper",
+      "kind": "MCP tool",
+      "meaning": "instapaper MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/instapaper-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-ipapi-packages-mcp-server-src-ipapi-tool-ts",
+      "division": "Tools",
+      "name": "ipapi",
+      "kind": "MCP tool",
+      "meaning": "ipapi MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/ipapi-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-ipaustralia-packages-mcp-server-src-ipaustralia-tool-ts",
+      "division": "Tools",
+      "name": "ipaustralia",
+      "kind": "MCP tool",
+      "meaning": "ipaustralia MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/ipaustralia-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-keychain-packages-mcp-server-src-keychain-tool-ts",
+      "division": "Tools",
+      "name": "keychain",
+      "kind": "MCP tool",
+      "meaning": "keychain MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/keychain-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-kling-packages-mcp-server-src-kling-tool-ts",
+      "division": "Tools",
+      "name": "kling",
+      "kind": "MCP tool",
+      "meaning": "kling MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/kling-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-lastfm-packages-mcp-server-src-lastfm-tool-ts",
+      "division": "Tools",
+      "name": "lastfm",
+      "kind": "MCP tool",
+      "meaning": "lastfm MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/lastfm-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-legalpass-packages-mcp-server-src-legalpass-tool-ts",
+      "division": "Tools",
+      "name": "legalpass",
+      "kind": "MCP tool",
+      "meaning": "legalpass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/legalpass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-lego-packages-mcp-server-src-lego-tool-ts",
+      "division": "Tools",
+      "name": "lego",
+      "kind": "MCP tool",
+      "meaning": "lego MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/lego-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-lemonsqueezy-packages-mcp-server-src-lemonsqueezy-tool-ts",
+      "division": "Tools",
+      "name": "lemonsqueezy",
+      "kind": "MCP tool",
+      "meaning": "lemonsqueezy MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/lemonsqueezy-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-lichess-packages-mcp-server-src-lichess-tool-ts",
+      "division": "Tools",
+      "name": "lichess",
+      "kind": "MCP tool",
+      "meaning": "lichess MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/lichess-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-line-packages-mcp-server-src-line-tool-ts",
+      "division": "Tools",
+      "name": "line",
+      "kind": "MCP tool",
+      "meaning": "line MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/line-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-linear-packages-mcp-server-src-linear-tool-ts",
+      "division": "Tools",
+      "name": "linear",
+      "kind": "MCP tool",
+      "meaning": "linear MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/linear-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-mailchimp-packages-mcp-server-src-mailchimp-tool-ts",
+      "division": "Tools",
+      "name": "mailchimp",
+      "kind": "MCP tool",
+      "meaning": "mailchimp MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/mailchimp-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-mapbox-packages-mcp-server-src-mapbox-tool-ts",
+      "division": "Tools",
+      "name": "mapbox",
+      "kind": "MCP tool",
+      "meaning": "mapbox MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/mapbox-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-mastodon-packages-mcp-server-src-mastodon-tool-ts",
+      "division": "Tools",
+      "name": "mastodon",
+      "kind": "MCP tool",
+      "meaning": "mastodon MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/mastodon-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-meal-packages-mcp-server-src-meal-tool-ts",
+      "division": "Tools",
+      "name": "meal",
+      "kind": "MCP tool",
+      "meaning": "meal MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/meal-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-mistral-packages-mcp-server-src-mistral-tool-ts",
+      "division": "Tools",
+      "name": "mistral",
+      "kind": "MCP tool",
+      "meaning": "mistral MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/mistral-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-mixpanel-packages-mcp-server-src-mixpanel-tool-ts",
+      "division": "Tools",
+      "name": "mixpanel",
+      "kind": "MCP tool",
+      "meaning": "mixpanel MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/mixpanel-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-monday-packages-mcp-server-src-monday-tool-ts",
+      "division": "Tools",
+      "name": "monday",
+      "kind": "MCP tool",
+      "meaning": "monday MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/monday-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-monica-packages-mcp-server-src-monica-tool-ts",
+      "division": "Tools",
+      "name": "monica",
+      "kind": "MCP tool",
+      "meaning": "monica MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/monica-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-musicbrainz-packages-mcp-server-src-musicbrainz-tool-ts",
+      "division": "Tools",
+      "name": "musicbrainz",
+      "kind": "MCP tool",
+      "meaning": "musicbrainz MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/musicbrainz-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-nasa-packages-mcp-server-src-nasa-tool-ts",
+      "division": "Tools",
+      "name": "nasa",
+      "kind": "MCP tool",
+      "meaning": "nasa MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/nasa-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-neon-packages-mcp-server-src-neon-tool-ts",
+      "division": "Tools",
+      "name": "neon",
+      "kind": "MCP tool",
+      "meaning": "neon MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/neon-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-newsapi-packages-mcp-server-src-newsapi-tool-ts",
+      "division": "Tools",
+      "name": "newsapi",
+      "kind": "MCP tool",
+      "meaning": "newsapi MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/newsapi-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-notion-packages-mcp-server-src-notion-tool-ts",
+      "division": "Tools",
+      "name": "notion",
+      "kind": "MCP tool",
+      "meaning": "notion MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/notion-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-nudgeonly-packages-mcp-server-src-nudgeonly-tool-ts",
+      "division": "Tools",
+      "name": "NudgeOnly",
+      "kind": "MCP tool",
+      "meaning": "NudgeOnly low-token receipt bridge and advisory classifier.",
+      "source": "packages/mcp-server/src/nudgeonly-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-numbers-packages-mcp-server-src-numbers-tool-ts",
+      "division": "Tools",
+      "name": "numbers",
+      "kind": "MCP tool",
+      "meaning": "numbers MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/numbers-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-nvd-packages-mcp-server-src-nvd-tool-ts",
+      "division": "Tools",
+      "name": "nvd",
+      "kind": "MCP tool",
+      "meaning": "nvd MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/nvd-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-omdb-packages-mcp-server-src-omdb-tool-ts",
+      "division": "Tools",
+      "name": "omdb",
+      "kind": "MCP tool",
+      "meaning": "omdb MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/omdb-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-openai-packages-mcp-server-src-openai-tool-ts",
+      "division": "Tools",
+      "name": "openai",
+      "kind": "MCP tool",
+      "meaning": "openai MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/openai-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-openaq-packages-mcp-server-src-openaq-tool-ts",
+      "division": "Tools",
+      "name": "openaq",
+      "kind": "MCP tool",
+      "meaning": "openaq MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/openaq-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-openexchangerates-packages-mcp-server-src-openexchangerates-tool-ts",
+      "division": "Tools",
+      "name": "openexchangerates",
+      "kind": "MCP tool",
+      "meaning": "openexchangerates MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/openexchangerates-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-openf1-packages-mcp-server-src-openf1-tool-ts",
+      "division": "Tools",
+      "name": "openf1",
+      "kind": "MCP tool",
+      "meaning": "openf1 MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/openf1-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-openfoodfacts-packages-mcp-server-src-openfoodfacts-tool-ts",
+      "division": "Tools",
+      "name": "openfoodfacts",
+      "kind": "MCP tool",
+      "meaning": "openfoodfacts MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/openfoodfacts-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-openlibrary-packages-mcp-server-src-openlibrary-tool-ts",
+      "division": "Tools",
+      "name": "openlibrary",
+      "kind": "MCP tool",
+      "meaning": "openlibrary MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/openlibrary-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-openmeteo-packages-mcp-server-src-openmeteo-tool-ts",
+      "division": "Tools",
+      "name": "openmeteo",
+      "kind": "MCP tool",
+      "meaning": "openmeteo MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/openmeteo-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pagerduty-packages-mcp-server-src-pagerduty-tool-ts",
+      "division": "Tools",
+      "name": "pagerduty",
+      "kind": "MCP tool",
+      "meaning": "pagerduty MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pagerduty-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pandascore-packages-mcp-server-src-pandascore-tool-ts",
+      "division": "Tools",
+      "name": "pandascore",
+      "kind": "MCP tool",
+      "meaning": "pandascore MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pandascore-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-paypal-packages-mcp-server-src-paypal-tool-ts",
+      "division": "Tools",
+      "name": "paypal",
+      "kind": "MCP tool",
+      "meaning": "paypal MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/paypal-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-perplexity-packages-mcp-server-src-perplexity-tool-ts",
+      "division": "Tools",
+      "name": "perplexity",
+      "kind": "MCP tool",
+      "meaning": "perplexity MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/perplexity-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pika-packages-mcp-server-src-pika-tool-ts",
+      "division": "Tools",
+      "name": "pika",
+      "kind": "MCP tool",
+      "meaning": "pika MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pika-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pinecone-packages-mcp-server-src-pinecone-tool-ts",
+      "division": "Tools",
+      "name": "pinecone",
+      "kind": "MCP tool",
+      "meaning": "pinecone MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pinecone-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pinterest-packages-mcp-server-src-pinterest-tool-ts",
+      "division": "Tools",
+      "name": "pinterest",
+      "kind": "MCP tool",
+      "meaning": "pinterest MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pinterest-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-plaid-packages-mcp-server-src-plaid-tool-ts",
+      "division": "Tools",
+      "name": "plaid",
+      "kind": "MCP tool",
+      "meaning": "plaid MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/plaid-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-podcastindex-packages-mcp-server-src-podcastindex-tool-ts",
+      "division": "Tools",
+      "name": "podcastindex",
+      "kind": "MCP tool",
+      "meaning": "podcastindex MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/podcastindex-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-postman-packages-mcp-server-src-postman-tool-ts",
+      "division": "Tools",
+      "name": "postman",
+      "kind": "MCP tool",
+      "meaning": "postman MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/postman-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-postmark-packages-mcp-server-src-postmark-tool-ts",
+      "division": "Tools",
+      "name": "postmark",
+      "kind": "MCP tool",
+      "meaning": "postmark MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/postmark-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-ptv-packages-mcp-server-src-ptv-tool-ts",
+      "division": "Tools",
+      "name": "ptv",
+      "kind": "MCP tool",
+      "meaning": "ptv MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/ptv-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pushonly-packages-mcp-server-src-pushonly-tool-ts",
+      "division": "Tools",
+      "name": "pushonly",
+      "kind": "MCP tool",
+      "meaning": "pushonly MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pushonly-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pushover-packages-mcp-server-src-pushover-tool-ts",
+      "division": "Tools",
+      "name": "pushover",
+      "kind": "MCP tool",
+      "meaning": "pushover MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pushover-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-qc-packages-mcp-server-src-qc-tool-ts",
+      "division": "Tools",
+      "name": "qc",
+      "kind": "MCP tool",
+      "meaning": "qc MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/qc-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-quickbooks-packages-mcp-server-src-quickbooks-tool-ts",
+      "division": "Tools",
+      "name": "quickbooks",
+      "kind": "MCP tool",
+      "meaning": "quickbooks MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/quickbooks-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-radiobrowser-packages-mcp-server-src-radiobrowser-tool-ts",
+      "division": "Tools",
+      "name": "radiobrowser",
+      "kind": "MCP tool",
+      "meaning": "radiobrowser MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/radiobrowser-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-raindrop-packages-mcp-server-src-raindrop-tool-ts",
+      "division": "Tools",
+      "name": "raindrop",
+      "kind": "MCP tool",
+      "meaning": "raindrop MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/raindrop-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-random-packages-mcp-server-src-random-tool-ts",
+      "division": "Tools",
+      "name": "random",
+      "kind": "MCP tool",
+      "meaning": "random MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/random-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-rawg-packages-mcp-server-src-rawg-tool-ts",
+      "division": "Tools",
+      "name": "rawg",
+      "kind": "MCP tool",
+      "meaning": "rawg MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/rawg-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-readwise-packages-mcp-server-src-readwise-tool-ts",
+      "division": "Tools",
+      "name": "readwise",
+      "kind": "MCP tool",
+      "meaning": "readwise MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/readwise-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-reddit-packages-mcp-server-src-reddit-tool-ts",
+      "division": "Tools",
+      "name": "reddit",
+      "kind": "MCP tool",
+      "meaning": "reddit MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/reddit-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-render-packages-mcp-server-src-render-tool-ts",
+      "division": "Tools",
+      "name": "render",
+      "kind": "MCP tool",
+      "meaning": "render MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/render-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-replicate-packages-mcp-server-src-replicate-tool-ts",
+      "division": "Tools",
+      "name": "replicate",
+      "kind": "MCP tool",
+      "meaning": "replicate MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/replicate-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-resend-packages-mcp-server-src-resend-tool-ts",
+      "division": "Tools",
+      "name": "resend",
+      "kind": "MCP tool",
+      "meaning": "resend MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/resend-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-restcountries-packages-mcp-server-src-restcountries-tool-ts",
+      "division": "Tools",
+      "name": "restcountries",
+      "kind": "MCP tool",
+      "meaning": "restcountries MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/restcountries-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-riot-packages-mcp-server-src-riot-tool-ts",
+      "division": "Tools",
+      "name": "riot",
+      "kind": "MCP tool",
+      "meaning": "riot MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/riot-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-runway-packages-mcp-server-src-runway-tool-ts",
+      "division": "Tools",
+      "name": "runway",
+      "kind": "MCP tool",
+      "meaning": "runway MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/runway-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-seatgeek-packages-mcp-server-src-seatgeek-tool-ts",
+      "division": "Tools",
+      "name": "seatgeek",
+      "kind": "MCP tool",
+      "meaning": "seatgeek MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/seatgeek-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-segment-packages-mcp-server-src-segment-tool-ts",
+      "division": "Tools",
+      "name": "segment",
+      "kind": "MCP tool",
+      "meaning": "segment MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/segment-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-sendgrid-packages-mcp-server-src-sendgrid-tool-ts",
+      "division": "Tools",
+      "name": "sendgrid",
+      "kind": "MCP tool",
+      "meaning": "sendgrid MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/sendgrid-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-sendle-packages-mcp-server-src-sendle-tool-ts",
+      "division": "Tools",
+      "name": "sendle",
+      "kind": "MCP tool",
+      "meaning": "sendle MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/sendle-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-sentry-packages-mcp-server-src-sentry-tool-ts",
+      "division": "Tools",
+      "name": "sentry",
+      "kind": "MCP tool",
+      "meaning": "sentry MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/sentry-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-seopass-packages-mcp-server-src-seopass-tool-ts",
+      "division": "Tools",
+      "name": "seopass",
+      "kind": "MCP tool",
+      "meaning": "seopass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/seopass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-setlistfm-packages-mcp-server-src-setlistfm-tool-ts",
+      "division": "Tools",
+      "name": "setlistfm",
+      "kind": "MCP tool",
+      "meaning": "setlistfm MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/setlistfm-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-shodan-packages-mcp-server-src-shodan-tool-ts",
+      "division": "Tools",
+      "name": "shodan",
+      "kind": "MCP tool",
+      "meaning": "shodan MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/shodan-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-shopify-packages-mcp-server-src-shopify-tool-ts",
+      "division": "Tools",
+      "name": "shopify",
+      "kind": "MCP tool",
+      "meaning": "shopify MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/shopify-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-slack-packages-mcp-server-src-slack-tool-ts",
+      "division": "Tools",
+      "name": "slack",
+      "kind": "MCP tool",
+      "meaning": "slack MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/slack-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-sleeper-packages-mcp-server-src-sleeper-tool-ts",
+      "division": "Tools",
+      "name": "sleeper",
+      "kind": "MCP tool",
+      "meaning": "sleeper MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/sleeper-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-speedrun-packages-mcp-server-src-speedrun-tool-ts",
+      "division": "Tools",
+      "name": "speedrun",
+      "kind": "MCP tool",
+      "meaning": "speedrun MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/speedrun-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-splitwise-packages-mcp-server-src-splitwise-tool-ts",
+      "division": "Tools",
+      "name": "splitwise",
+      "kind": "MCP tool",
+      "meaning": "splitwise MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/splitwise-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-spotify-packages-mcp-server-src-spotify-tool-ts",
+      "division": "Tools",
+      "name": "spotify",
+      "kind": "MCP tool",
+      "meaning": "spotify MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/spotify-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-square-packages-mcp-server-src-square-tool-ts",
+      "division": "Tools",
+      "name": "square",
+      "kind": "MCP tool",
+      "meaning": "square MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/square-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-stability-packages-mcp-server-src-stability-tool-ts",
+      "division": "Tools",
+      "name": "stability",
+      "kind": "MCP tool",
+      "meaning": "stability MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/stability-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-steam-packages-mcp-server-src-steam-tool-ts",
+      "division": "Tools",
+      "name": "steam",
+      "kind": "MCP tool",
+      "meaning": "steam MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/steam-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-stripe-packages-mcp-server-src-stripe-tool-ts",
+      "division": "Tools",
+      "name": "stripe",
+      "kind": "MCP tool",
+      "meaning": "stripe MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/stripe-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-supercell-packages-mcp-server-src-supercell-tool-ts",
+      "division": "Tools",
+      "name": "supercell",
+      "kind": "MCP tool",
+      "meaning": "supercell MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/supercell-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-tab-packages-mcp-server-src-tab-tool-ts",
+      "division": "Tools",
+      "name": "tab",
+      "kind": "MCP tool",
+      "meaning": "tab MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/tab-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-telegram-packages-mcp-server-src-telegram-tool-ts",
+      "division": "Tools",
+      "name": "telegram",
+      "kind": "MCP tool",
+      "meaning": "telegram MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/telegram-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-testpass-packages-mcp-server-src-testpass-tool-ts",
+      "division": "Tools",
+      "name": "testpass",
+      "kind": "MCP tool",
+      "meaning": "TestPass proof and test orchestration capability.",
+      "source": "packages/mcp-server/src/testpass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-text-packages-mcp-server-src-text-tool-ts",
+      "division": "Tools",
+      "name": "text",
+      "kind": "MCP tool",
+      "meaning": "text MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/text-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-thelott-packages-mcp-server-src-thelott-tool-ts",
+      "division": "Tools",
+      "name": "thelott",
+      "kind": "MCP tool",
+      "meaning": "thelott MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/thelott-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-ticketmaster-packages-mcp-server-src-ticketmaster-tool-ts",
+      "division": "Tools",
+      "name": "ticketmaster",
+      "kind": "MCP tool",
+      "meaning": "ticketmaster MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/ticketmaster-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-tiktok-packages-mcp-server-src-tiktok-tool-ts",
+      "division": "Tools",
+      "name": "tiktok",
+      "kind": "MCP tool",
+      "meaning": "tiktok MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/tiktok-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-tmdb-packages-mcp-server-src-tmdb-tool-ts",
+      "division": "Tools",
+      "name": "tmdb",
+      "kind": "MCP tool",
+      "meaning": "tmdb MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/tmdb-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-togetherai-packages-mcp-server-src-togetherai-tool-ts",
+      "division": "Tools",
+      "name": "togetherai",
+      "kind": "MCP tool",
+      "meaning": "togetherai MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/togetherai-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-toggl-packages-mcp-server-src-toggl-tool-ts",
+      "division": "Tools",
+      "name": "toggl",
+      "kind": "MCP tool",
+      "meaning": "toggl MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/toggl-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-toilets-packages-mcp-server-src-toilets-tool-ts",
+      "division": "Tools",
+      "name": "toilets",
+      "kind": "MCP tool",
+      "meaning": "toilets MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/toilets-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-tomorrowio-packages-mcp-server-src-tomorrowio-tool-ts",
+      "division": "Tools",
+      "name": "tomorrowio",
+      "kind": "MCP tool",
+      "meaning": "tomorrowio MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/tomorrowio-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-trello-packages-mcp-server-src-trello-tool-ts",
+      "division": "Tools",
+      "name": "trello",
+      "kind": "MCP tool",
+      "meaning": "trello MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/trello-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-trivia-packages-mcp-server-src-trivia-tool-ts",
+      "division": "Tools",
+      "name": "trivia",
+      "kind": "MCP tool",
+      "meaning": "trivia MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/trivia-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-trove-packages-mcp-server-src-trove-tool-ts",
+      "division": "Tools",
+      "name": "trove",
+      "kind": "MCP tool",
+      "meaning": "trove MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/trove-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-turso-packages-mcp-server-src-turso-tool-ts",
+      "division": "Tools",
+      "name": "turso",
+      "kind": "MCP tool",
+      "meaning": "turso MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/turso-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-twilio-packages-mcp-server-src-twilio-tool-ts",
+      "division": "Tools",
+      "name": "twilio",
+      "kind": "MCP tool",
+      "meaning": "twilio MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/twilio-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-twitch-packages-mcp-server-src-twitch-tool-ts",
+      "division": "Tools",
+      "name": "twitch",
+      "kind": "MCP tool",
+      "meaning": "twitch MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/twitch-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-unit-converter-packages-mcp-server-src-unit-converter-tool-ts",
+      "division": "Tools",
+      "name": "unit converter",
+      "kind": "MCP tool",
+      "meaning": "unit converter MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/unit-converter-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-untappd-packages-mcp-server-src-untappd-tool-ts",
+      "division": "Tools",
+      "name": "untappd",
+      "kind": "MCP tool",
+      "meaning": "untappd MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/untappd-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-upstash-packages-mcp-server-src-upstash-tool-ts",
+      "division": "Tools",
+      "name": "upstash",
+      "kind": "MCP tool",
+      "meaning": "upstash MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/upstash-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-urlscan-packages-mcp-server-src-urlscan-tool-ts",
+      "division": "Tools",
+      "name": "urlscan",
+      "kind": "MCP tool",
+      "meaning": "urlscan MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/urlscan-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-usgs-packages-mcp-server-src-usgs-tool-ts",
+      "division": "Tools",
+      "name": "usgs",
+      "kind": "MCP tool",
+      "meaning": "usgs MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/usgs-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-uxpass-packages-mcp-server-src-uxpass-tool-ts",
+      "division": "Tools",
+      "name": "uxpass",
+      "kind": "MCP tool",
+      "meaning": "UXPass experience verification capability.",
+      "source": "packages/mcp-server/src/uxpass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-vault-packages-mcp-server-src-vault-tool-ts",
+      "division": "Tools",
+      "name": "vault",
+      "kind": "MCP tool",
+      "meaning": "vault MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/vault-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-vercel-packages-mcp-server-src-vercel-tool-ts",
+      "division": "Tools",
+      "name": "vercel",
+      "kind": "MCP tool",
+      "meaning": "vercel MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/vercel-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-virustotal-packages-mcp-server-src-virustotal-tool-ts",
+      "division": "Tools",
+      "name": "virustotal",
+      "kind": "MCP tool",
+      "meaning": "virustotal MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/virustotal-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-whatsapp-packages-mcp-server-src-whatsapp-tool-ts",
+      "division": "Tools",
+      "name": "whatsapp",
+      "kind": "MCP tool",
+      "meaning": "whatsapp MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/whatsapp-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-willyweather-packages-mcp-server-src-willyweather-tool-ts",
+      "division": "Tools",
+      "name": "willyweather",
+      "kind": "MCP tool",
+      "meaning": "willyweather MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/willyweather-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-wise-packages-mcp-server-src-wise-tool-ts",
+      "division": "Tools",
+      "name": "wise",
+      "kind": "MCP tool",
+      "meaning": "wise MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/wise-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-woocommerce-packages-mcp-server-src-woocommerce-tool-ts",
+      "division": "Tools",
+      "name": "woocommerce",
+      "kind": "MCP tool",
+      "meaning": "woocommerce MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/woocommerce-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-xero-packages-mcp-server-src-xero-tool-ts",
+      "division": "Tools",
+      "name": "xero",
+      "kind": "MCP tool",
+      "meaning": "xero MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/xero-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-yelp-packages-mcp-server-src-yelp-tool-ts",
+      "division": "Tools",
+      "name": "yelp",
+      "kind": "MCP tool",
+      "meaning": "yelp MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/yelp-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-youtube-packages-mcp-server-src-youtube-tool-ts",
+      "division": "Tools",
+      "name": "youtube",
+      "kind": "MCP tool",
+      "meaning": "youtube MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/youtube-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-seat-claude-reviewer-seat-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Claude Reviewer Seat",
+      "kind": "seat",
+      "meaning": "External reviewer lane used for independent checks and proof review.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-seat-codex-builder-seat-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Codex Builder Seat",
+      "kind": "seat",
+      "meaning": "Codex lane used for scoped implementation, routing, and proof updates.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-seat-cursor-builder-seat-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Cursor Builder Seat",
+      "kind": "seat",
+      "meaning": "External builder lane used for scoped code work and PRs.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-builder-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Builder",
+      "kind": "worker role",
+      "meaning": "Implements focused code or content changes from a scoped packet.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-coordinator-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Coordinator",
+      "kind": "worker role",
+      "meaning": "Routes work, chooses the next room, and keeps lanes aligned.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-improver-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Improver",
+      "kind": "worker role",
+      "meaning": "Turns repeated pain into system improvements.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-ledger-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Ledger",
+      "kind": "worker role",
+      "meaning": "Records proof, receipts, approvals, and rollback evidence.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-publisher-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Publisher",
+      "kind": "worker role",
+      "meaning": "Moves approved work toward deployment and public proof.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-reviewer-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Reviewer",
+      "kind": "worker role",
+      "meaning": "Checks quality, regressions, and missing tests.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-safety-checker-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Safety Checker",
+      "kind": "worker role",
+      "meaning": "Protects secrets, auth, destructive actions, and release gates.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "workers-and-seats-worker-role-tester-docs-fleet-worker-roles-md",
+      "division": "Workers and seats",
+      "name": "Tester",
+      "kind": "worker role",
+      "meaning": "Runs proof and reports what passed or blocked.",
+      "source": "docs/fleet-worker-roles.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "wrappers-and-protocols-bridge-igniteonly-docs-pinballwake-igniteonly-api-md",
+      "division": "Wrappers and protocols",
+      "name": "IgniteOnly",
+      "kind": "bridge",
+      "meaning": "Verified worker wake packets only, never build, merge, or completion state.",
+      "source": "docs/pinballwake-igniteonly-api.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "wrappers-and-protocols-bridge-nudgeonly-docs-pinballwake-nudgeonly-api-md",
+      "division": "Wrappers and protocols",
+      "name": "NudgeOnly",
+      "kind": "bridge",
+      "meaning": "Low-risk receipt nudges that never mutate source-of-truth state.",
+      "source": "docs/pinballwake-nudgeonly-api.md",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "wrappers-and-protocols-claim-lifecycle-seatrelay-docs-unclick-brainmap-generated-md",
+      "division": "Wrappers and protocols",
+      "name": "SeatRelay",
+      "kind": "claim lifecycle",
+      "meaning": "Stale release, smart reassignment, and bonded handoff for stuck worker claims.",
+      "source": "docs/UnClick-brainmap.generated.md",
+      "route": "",
+      "tags": []
+    }
+  ],
+  "pageRows": [
+    [
+      "/admin/activity",
+      "Admin Activity",
+      "Admin surface for Admin Activity.",
+      "src/pages/admin/AdminActivity.tsx"
+    ],
+    [
+      "/admin/agents",
+      "Admin Agents",
+      "Admin surface for Admin Agents.",
+      "src/pages/admin/AdminAgents.tsx"
+    ],
+    [
+      "/admin/analytics",
+      "Admin Analytics",
+      "Internal analytics view for platform signals and usage.",
+      "src/pages/admin/AdminAnalytics.tsx"
+    ],
+    [
+      "/admin/audit-log",
+      "Admin Audit Log",
+      "Internal audit trail for sensitive admin actions.",
+      "src/pages/admin/AdminAuditLog.tsx"
+    ],
+    [
+      "/admin/brainmap",
+      "Admin Brainmap",
+      "Generated ecosystem map that teaches seats what UnClick is.",
+      "src/pages/admin/AdminBrainmap.tsx"
+    ],
+    [
+      "/admin/codebase",
+      "Admin Codebase",
+      "Internal source and architecture orientation surface.",
+      "src/pages/admin/AdminCodebase.tsx"
+    ],
+    [
+      "/admin/dashboard",
+      "Admin Dashboard",
+      "Front door for current operator state.",
+      "src/pages/admin/AdminDashboard.tsx"
+    ],
+    [
+      "/admin/ecosystem-pages",
+      "Admin Ecosystem Pages",
+      "Admin surface for Admin Ecosystem Pages.",
+      "src/pages/admin/AdminEcosystemPages.tsx"
+    ],
+    [
+      "/admin/jobs",
+      "Admin Jobs",
+      "Operational job and task queue.",
+      "src/pages/admin/AdminJobs.tsx"
+    ],
+    [
+      "/admin/jobsmith",
+      "Admin Jobsmith",
+      "Admin surface for Admin Jobsmith.",
+      "src/pages/admin/AdminJobsmith.tsx"
+    ],
+    [
+      "/admin/keychain",
+      "Admin Keychain",
+      "Passport and credential connection health.",
+      "src/pages/admin/AdminKeychain.tsx"
+    ],
+    [
+      "/admin/memory",
+      "Admin Memory",
+      "Admin view of persistent memory, facts, sessions, and recall.",
+      "src/pages/admin/AdminMemory.tsx"
+    ],
+    [
+      "/admin/moderation",
+      "Admin Moderation",
+      "Admin surface for Admin Moderation.",
+      "src/pages/admin/AdminModeration.tsx"
+    ],
+    [
+      "/admin/orchestrator",
+      "Admin Orchestrator",
+      "Readable continuity stream for seats and operator context.",
+      "src/pages/admin/AdminOrchestrator.tsx"
+    ],
+    [
+      "/admin/pinball-wake",
+      "Admin Pinball Wake",
+      "PinballWake rooms, wake routes, and automation visibility.",
+      "src/pages/admin/AdminPinballWake.tsx"
+    ],
+    [
+      "/admin/agents/heartbeat",
+      "Admin Seat Heartbeat",
+      "Master heartbeat copy policy for scheduled AI seats.",
+      "src/pages/admin/AdminSeatHeartbeat.tsx"
+    ],
+    [
+      "/admin/settings",
+      "Admin Settings",
+      "Account and admin configuration.",
+      "src/pages/admin/AdminSettings.tsx"
+    ],
+    [
+      "/admin/shell",
+      "Admin Shell",
+      "Admin surface for Admin Shell.",
+      "src/pages/admin/AdminShell.tsx"
+    ],
+    [
+      "/admin/system-health",
+      "Admin System Health",
+      "Health checks and operational status.",
+      "src/pages/admin/AdminSystemHealth.tsx"
+    ],
+    [
+      "/admin/test-pass",
+      "Admin Test Pass",
+      "Admin surface for Admin Test Pass.",
+      "src/pages/admin/AdminTestPass.tsx"
+    ],
+    [
+      "/admin/tools",
+      "Admin Tools",
+      "Apps, tools, and connector capability surface.",
+      "src/pages/admin/AdminTools.tsx"
+    ],
+    [
+      "/admin/users",
+      "Admin Users",
+      "Internal user management.",
+      "src/pages/admin/AdminUsers.tsx"
+    ],
+    [
+      "/admin/you",
+      "Admin You",
+      "Personal account, identity, and access panel.",
+      "src/pages/admin/AdminYou.tsx"
+    ],
+    [
+      "/brain-map",
+      "Brain Map",
+      "Legacy Memory Brain Map component kept distinct from ecosystem Brainmap.",
+      "src/pages/admin/BrainMap.tsx"
+    ],
+    [
+      "/fishbowl",
+      "Fishbowl",
+      "Boardroom discussion surface for worker coordination.",
+      "src/pages/admin/Fishbowl.tsx"
+    ],
+    [
+      "/copy-pass-catalog",
+      "Copy Pass Catalog",
+      "Admin surface for Copy Pass Catalog.",
+      "src/pages/admin/copypass/CopyPassCatalog.tsx"
+    ],
+    [
+      "/crew-composer",
+      "Crew Composer",
+      "Crews admin page for Crew Composer.",
+      "src/pages/admin/crews/CrewComposer.tsx"
+    ],
+    [
+      "/crew-run",
+      "Crew Run",
+      "Crews admin page for Crew Run.",
+      "src/pages/admin/crews/CrewRun.tsx"
+    ],
+    [
+      "/crews-catalog",
+      "Crews Catalog",
+      "Crews admin page for Crews Catalog.",
+      "src/pages/admin/crews/CrewsCatalog.tsx"
+    ],
+    [
+      "/crews-runs",
+      "Crews Runs",
+      "Crews admin page for Crews Runs.",
+      "src/pages/admin/crews/CrewsRuns.tsx"
+    ],
+    [
+      "/crews-settings",
+      "Crews Settings",
+      "Crews admin page for Crews Settings.",
+      "src/pages/admin/crews/CrewsSettings.tsx"
+    ],
+    [
+      "/comments",
+      "Comments",
+      "Admin surface for Comments.",
+      "src/pages/admin/fishbowl/Comments.tsx"
+    ],
+    [
+      "/ideas",
+      "Ideas",
+      "Admin surface for Ideas.",
+      "src/pages/admin/fishbowl/Ideas.tsx"
+    ],
+    [
+      "/settings",
+      "Settings",
+      "Admin surface for Settings.",
+      "src/pages/admin/fishbowl/Settings.tsx"
+    ],
+    [
+      "/todos",
+      "Todos",
+      "Admin surface for Todos.",
+      "src/pages/admin/fishbowl/Todos.tsx"
+    ],
+    [
+      "/context-tab",
+      "Context Tab",
+      "Memory admin panel for Context Tab.",
+      "src/pages/admin/memory/ContextTab.tsx"
+    ],
+    [
+      "/empty-state",
+      "Empty State",
+      "Memory admin panel for Empty State.",
+      "src/pages/admin/memory/EmptyState.tsx"
+    ],
+    [
+      "/facts-tab",
+      "Facts Tab",
+      "Memory admin panel for Facts Tab.",
+      "src/pages/admin/memory/FactsTab.tsx"
+    ],
+    [
+      "/info-card",
+      "Info Card",
+      "Memory admin panel for Info Card.",
+      "src/pages/admin/memory/InfoCard.tsx"
+    ],
+    [
+      "/library-tab",
+      "Library Tab",
+      "Memory admin panel for Library Tab.",
+      "src/pages/admin/memory/LibraryTab.tsx"
+    ],
+    [
+      "/memory-activity-tab",
+      "Memory Activity Tab",
+      "Memory admin panel for Memory Activity Tab.",
+      "src/pages/admin/memory/MemoryActivityTab.tsx"
+    ],
+    [
+      "/sessions-tab",
+      "Sessions Tab",
+      "Memory admin panel for Sessions Tab.",
+      "src/pages/admin/memory/SessionsTab.tsx"
+    ],
+    [
+      "/storage-bar",
+      "Storage Bar",
+      "Memory admin panel for Storage Bar.",
+      "src/pages/admin/memory/StorageBar.tsx"
+    ],
+    [
+      "/search-highlight",
+      "search Highlight",
+      "Admin surface for search Highlight.",
+      "src/pages/admin/searchHighlight.tsx"
+    ],
+    [
+      "/signals-catalog",
+      "Signals Catalog",
+      "Admin surface for Signals Catalog.",
+      "src/pages/admin/signals/SignalsCatalog.tsx"
+    ],
+    [
+      "/signals-settings",
+      "Signals Settings",
+      "Admin surface for Signals Settings.",
+      "src/pages/admin/signals/SignalsSettings.tsx"
+    ],
+    [
+      "/new-run-wizard",
+      "New Run Wizard",
+      "Admin surface for New Run Wizard.",
+      "src/pages/admin/testpass/NewRunWizard.tsx"
+    ],
+    [
+      "/report-detail",
+      "Report Detail",
+      "Admin surface for Report Detail.",
+      "src/pages/admin/testpass/ReportDetail.tsx"
+    ],
+    [
+      "/run-detail",
+      "Run Detail",
+      "Admin surface for Run Detail.",
+      "src/pages/admin/testpass/RunDetail.tsx"
+    ],
+    [
+      "/test-pass-catalog",
+      "Test Pass Catalog",
+      "Admin surface for Test Pass Catalog.",
+      "src/pages/admin/testpass/TestPassCatalog.tsx"
+    ],
+    [
+      "/tools/connected-services",
+      "Connected Services",
+      "Tool page for Connected Services.",
+      "src/pages/admin/tools/ConnectedServices.tsx"
+    ],
+    [
+      "/tools/un-click-tools",
+      "Un Click Tools",
+      "Tool page for Un Click Tools.",
+      "src/pages/admin/tools/UnClickTools.tsx"
+    ],
+    [
+      "/admin/settings",
+      "Admin Settings",
+      "Account and admin configuration.",
+      "src/pages/AdminSettings.tsx"
+    ],
+    [
+      "/auth-callback",
+      "Auth Callback",
+      "User-facing page for Auth Callback.",
+      "src/pages/AuthCallback.tsx"
+    ],
+    [
+      "/backstage-pass",
+      "Backstage Pass",
+      "User-facing page for Backstage Pass.",
+      "src/pages/BackstagePass.tsx"
+    ],
+    [
+      "/build-desk",
+      "Build Desk",
+      "Build and project work surface.",
+      "src/pages/BuildDesk.tsx"
+    ],
+    [
+      "/connect",
+      "Connect",
+      "User-facing page for Connect.",
+      "src/pages/Connect.tsx"
+    ],
+    [
+      "/crews",
+      "Crews",
+      "Public Crews explanation and entry point.",
+      "src/pages/Crews.tsx"
+    ],
+    [
+      "/developer-docs",
+      "Developer Docs",
+      "Developer documentation.",
+      "src/pages/DeveloperDocs.tsx"
+    ],
+    [
+      "/developer-submit",
+      "Developer Submit",
+      "Tool submission flow.",
+      "src/pages/DeveloperSubmit.tsx"
+    ],
+    [
+      "/developers",
+      "Developers",
+      "Developer-facing entry point.",
+      "src/pages/Developers.tsx"
+    ],
+    [
+      "/dispatch",
+      "Dispatch",
+      "Dispatch and message handoff surface.",
+      "src/pages/Dispatch.tsx"
+    ],
+    [
+      "/docs",
+      "Docs",
+      "User-facing page for Docs.",
+      "src/pages/Docs.tsx"
+    ],
+    [
+      "/dogfood-report",
+      "Dogfood Report",
+      "Public dogfood proof report.",
+      "src/pages/DogfoodReport.tsx"
+    ],
+    [
+      "/faqpage",
+      "FAQPage",
+      "User-facing page for FAQPage.",
+      "src/pages/FAQPage.tsx"
+    ],
+    [
+      "/",
+      "Index",
+      "Public home and first explanation of UnClick.",
+      "src/pages/Index.tsx"
+    ],
+    [
+      "/install-recover",
+      "Install Recover",
+      "User-facing page for Install Recover.",
+      "src/pages/InstallRecover.tsx"
+    ],
+    [
+      "/jobsmith",
+      "Jobsmith",
+      "User-facing page for Jobsmith.",
+      "src/pages/Jobsmith.tsx"
+    ],
+    [
+      "/login",
+      "Login",
+      "Sign-in page.",
+      "src/pages/Login.tsx"
+    ],
+    [
+      "/memory",
+      "Memory",
+      "Public memory product page.",
+      "src/pages/Memory.tsx"
+    ],
+    [
+      "/memory-admin",
+      "Memory Admin",
+      "User-facing page for Memory Admin.",
+      "src/pages/MemoryAdmin.tsx"
+    ],
+    [
+      "/memory-connect",
+      "Memory Connect",
+      "User-facing page for Memory Connect.",
+      "src/pages/MemoryConnect.tsx"
+    ],
+    [
+      "/memory-setup",
+      "Memory Setup",
+      "User-facing page for Memory Setup.",
+      "src/pages/MemorySetup.tsx"
+    ],
+    [
+      "/memory-setup-guide",
+      "Memory Setup Guide",
+      "User-facing page for Memory Setup Guide.",
+      "src/pages/MemorySetupGuide.tsx"
+    ],
+    [
+      "/new-to-ai",
+      "New To AI",
+      "Beginner-friendly AI orientation.",
+      "src/pages/NewToAI.tsx"
+    ],
+    [
+      "/not-found",
+      "Not Found",
+      "User-facing page for Not Found.",
+      "src/pages/NotFound.tsx"
+    ],
+    [
+      "/organiser",
+      "Organiser",
+      "User-facing page for Organiser.",
+      "src/pages/Organiser.tsx"
+    ],
+    [
+      "/pricing",
+      "Pricing",
+      "Plans, billing, and packaging.",
+      "src/pages/Pricing.tsx"
+    ],
+    [
+      "/privacy",
+      "Privacy",
+      "Privacy policy.",
+      "src/pages/Privacy.tsx"
+    ],
+    [
+      "/settings",
+      "Settings",
+      "User-facing page for Settings.",
+      "src/pages/Settings.tsx"
+    ],
+    [
+      "/signup",
+      "Signup",
+      "Sign-up page.",
+      "src/pages/Signup.tsx"
+    ],
+    [
+      "/smart-home",
+      "Smart Home",
+      "User-facing page for Smart Home.",
+      "src/pages/SmartHome.tsx"
+    ],
+    [
+      "/terms",
+      "Terms",
+      "Terms of service.",
+      "src/pages/Terms.tsx"
+    ],
+    [
+      "/tools",
+      "Tools",
+      "Public tools marketplace entry point.",
+      "src/pages/Tools.tsx"
+    ],
+    [
+      "/verify-mfa",
+      "Verify Mfa",
+      "User-facing page for Verify Mfa.",
+      "src/pages/VerifyMfa.tsx"
+    ],
+    [
+      "/vibe-coding",
+      "Vibe Coding",
+      "User-facing page for Vibe Coding.",
+      "src/pages/VibeCoding.tsx"
+    ],
+    [
+      "/arena/arena-home",
+      "Arena Home",
+      "Arena page for Arena Home.",
+      "src/pages/arena/ArenaHome.tsx"
+    ],
+    [
+      "/arena/arena-leaderboard",
+      "Arena Leaderboard",
+      "Arena page for Arena Leaderboard.",
+      "src/pages/arena/ArenaLeaderboard.tsx"
+    ],
+    [
+      "/arena/arena-problem",
+      "Arena Problem",
+      "Arena page for Arena Problem.",
+      "src/pages/arena/ArenaProblem.tsx"
+    ],
+    [
+      "/arena/arena-submit-problem",
+      "Arena Submit Problem",
+      "Arena page for Arena Submit Problem.",
+      "src/pages/arena/ArenaSubmitProblem.tsx"
+    ],
+    [
+      "/tools/link-in-bio",
+      "Link In Bio",
+      "Tool page for Link In Bio.",
+      "src/pages/tools/LinkInBio.tsx"
+    ],
+    [
+      "/tools/scheduling",
+      "Scheduling",
+      "Tool page for Scheduling.",
+      "src/pages/tools/Scheduling.tsx"
+    ],
+    [
+      "/tools/solve",
+      "Solve",
+      "Tool page for Solve.",
+      "src/pages/tools/Solve.tsx"
+    ]
+  ],
+  "toolRows": [
+    [
+      "abn",
+      "abn MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/abn-tool.ts"
+    ],
+    [
+      "abuseipdb",
+      "abuseipdb MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/abuseipdb-tool.ts"
+    ],
+    [
+      "airtable",
+      "airtable MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/airtable-tool.ts"
+    ],
+    [
+      "algolia",
+      "algolia MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/algolia-tool.ts"
+    ],
+    [
+      "alphavantage",
+      "alphavantage MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/alphavantage-tool.ts"
+    ],
+    [
+      "amazon",
+      "amazon MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/amazon-tool.ts"
+    ],
+    [
+      "amber",
+      "amber MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/amber-tool.ts"
+    ],
+    [
+      "anthropic",
+      "anthropic MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/anthropic-tool.ts"
+    ],
+    [
+      "asana",
+      "asana MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/asana-tool.ts"
+    ],
+    [
+      "assemblyai",
+      "assemblyai MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/assemblyai-tool.ts"
+    ],
+    [
+      "australiapost",
+      "australiapost MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/australiapost-tool.ts"
+    ],
+    [
+      "bandsintown",
+      "bandsintown MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/bandsintown-tool.ts"
+    ],
+    [
+      "bgg",
+      "bgg MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/bgg-tool.ts"
+    ],
+    [
+      "bluesky",
+      "bluesky MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/bluesky-tool.ts"
+    ],
+    [
+      "bungie",
+      "bungie MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/bungie-tool.ts"
+    ],
+    [
+      "calculator",
+      "calculator MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/calculator-tool.ts"
+    ],
+    [
+      "calendly",
+      "calendly MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/calendly-tool.ts"
+    ],
+    [
+      "carboninterface",
+      "carboninterface MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/carboninterface-tool.ts"
+    ],
+    [
+      "chessdotcom",
+      "chessdotcom MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/chessdotcom-tool.ts"
+    ],
+    [
+      "circleci",
+      "circleci MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/circleci-tool.ts"
+    ],
+    [
+      "clickup",
+      "clickup MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/clickup-tool.ts"
+    ],
+    [
+      "clockify",
+      "clockify MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/clockify-tool.ts"
+    ],
+    [
+      "cohere",
+      "cohere MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/cohere-tool.ts"
+    ],
+    [
+      "coingecko",
+      "coingecko MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/coingecko-tool.ts"
+    ],
+    [
+      "coinmarketcap",
+      "coinmarketcap MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/coinmarketcap-tool.ts"
+    ],
+    [
+      "color",
+      "color MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/color-tool.ts"
+    ],
+    [
+      "convertkit",
+      "convertkit MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/convertkit-tool.ts"
+    ],
+    [
+      "copypass",
+      "copypass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/copypass-tool.ts"
+    ],
+    [
+      "crews",
+      "crews MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/crews-tool.ts"
+    ],
+    [
+      "csuite",
+      "csuite MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/csuite-tool.ts"
+    ],
+    [
+      "datadog",
+      "datadog MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/datadog-tool.ts"
+    ],
+    [
+      "datetime",
+      "datetime MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/datetime-tool.ts"
+    ],
+    [
+      "deepl",
+      "deepl MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/deepl-tool.ts"
+    ],
+    [
+      "deezer",
+      "deezer MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/deezer-tool.ts"
+    ],
+    [
+      "discogs",
+      "discogs MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/discogs-tool.ts"
+    ],
+    [
+      "discord",
+      "discord MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/discord-tool.ts"
+    ],
+    [
+      "domain",
+      "domain MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/domain-tool.ts"
+    ],
+    [
+      "ebay",
+      "ebay MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/ebay-tool.ts"
+    ],
+    [
+      "ebird",
+      "ebird MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/ebird-tool.ts"
+    ],
+    [
+      "elevenlabs",
+      "elevenlabs MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/elevenlabs-tool.ts"
+    ],
+    [
+      "email",
+      "email MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/email-tool.ts"
+    ],
+    [
+      "espn",
+      "espn MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/espn-tool.ts"
+    ],
+    [
+      "etsy",
+      "etsy MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/etsy-tool.ts"
+    ],
+    [
+      "eventbrite",
+      "eventbrite MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/eventbrite-tool.ts"
+    ],
+    [
+      "exchangerate",
+      "exchangerate MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/exchangerate-tool.ts"
+    ],
+    [
+      "feedly",
+      "feedly MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/feedly-tool.ts"
+    ],
+    [
+      "figma",
+      "figma MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/figma-tool.ts"
+    ],
+    [
+      "flyio",
+      "flyio MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/flyio-tool.ts"
+    ],
+    [
+      "foursquare",
+      "foursquare MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/foursquare-tool.ts"
+    ],
+    [
+      "fpl",
+      "fpl MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/fpl-tool.ts"
+    ],
+    [
+      "gdelt",
+      "gdelt MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/gdelt-tool.ts"
+    ],
+    [
+      "genius",
+      "genius MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/genius-tool.ts"
+    ],
+    [
+      "github",
+      "github MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/github-tool.ts"
+    ],
+    [
+      "gitlab",
+      "gitlab MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/gitlab-tool.ts"
+    ],
+    [
+      "groq",
+      "groq MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/groq-tool.ts"
+    ],
+    [
+      "guardian",
+      "guardian MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/guardian-tool.ts"
+    ],
+    [
+      "gumroad",
+      "gumroad MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/gumroad-tool.ts"
+    ],
+    [
+      "hackernews",
+      "hackernews MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/hackernews-tool.ts"
+    ],
+    [
+      "haveibeenpwned",
+      "haveibeenpwned MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/haveibeenpwned-tool.ts"
+    ],
+    [
+      "Heartbeat Protocol",
+      "Canonical heartbeat policy served to scheduled seats.",
+      "packages/mcp-server/src/heartbeat-protocol.ts"
+    ],
+    [
+      "heygen",
+      "heygen MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/heygen-tool.ts"
+    ],
+    [
+      "higgsfield",
+      "higgsfield MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/higgsfield-tool.ts"
+    ],
+    [
+      "hunter",
+      "hunter MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/hunter-tool.ts"
+    ],
+    [
+      "igdb",
+      "igdb MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/igdb-tool.ts"
+    ],
+    [
+      "IgniteOnly",
+      "IgniteOnly verified worker wake packet bridge.",
+      "packages/mcp-server/src/igniteonly-tool.ts"
+    ],
+    [
+      "instapaper",
+      "instapaper MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/instapaper-tool.ts"
+    ],
+    [
+      "ipapi",
+      "ipapi MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/ipapi-tool.ts"
+    ],
+    [
+      "ipaustralia",
+      "ipaustralia MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/ipaustralia-tool.ts"
+    ],
+    [
+      "keychain",
+      "keychain MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/keychain-tool.ts"
+    ],
+    [
+      "kling",
+      "kling MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/kling-tool.ts"
+    ],
+    [
+      "lastfm",
+      "lastfm MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/lastfm-tool.ts"
+    ],
+    [
+      "legalpass",
+      "legalpass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/legalpass-tool.ts"
+    ],
+    [
+      "lego",
+      "lego MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/lego-tool.ts"
+    ],
+    [
+      "lemonsqueezy",
+      "lemonsqueezy MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/lemonsqueezy-tool.ts"
+    ],
+    [
+      "lichess",
+      "lichess MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/lichess-tool.ts"
+    ],
+    [
+      "line",
+      "line MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/line-tool.ts"
+    ],
+    [
+      "linear",
+      "linear MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/linear-tool.ts"
+    ],
+    [
+      "mailchimp",
+      "mailchimp MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/mailchimp-tool.ts"
+    ],
+    [
+      "mapbox",
+      "mapbox MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/mapbox-tool.ts"
+    ],
+    [
+      "mastodon",
+      "mastodon MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/mastodon-tool.ts"
+    ],
+    [
+      "meal",
+      "meal MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/meal-tool.ts"
+    ],
+    [
+      "mistral",
+      "mistral MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/mistral-tool.ts"
+    ],
+    [
+      "mixpanel",
+      "mixpanel MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/mixpanel-tool.ts"
+    ],
+    [
+      "monday",
+      "monday MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/monday-tool.ts"
+    ],
+    [
+      "monica",
+      "monica MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/monica-tool.ts"
+    ],
+    [
+      "musicbrainz",
+      "musicbrainz MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/musicbrainz-tool.ts"
+    ],
+    [
+      "nasa",
+      "nasa MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/nasa-tool.ts"
+    ],
+    [
+      "neon",
+      "neon MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/neon-tool.ts"
+    ],
+    [
+      "newsapi",
+      "newsapi MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/newsapi-tool.ts"
+    ],
+    [
+      "notion",
+      "notion MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/notion-tool.ts"
+    ],
+    [
+      "NudgeOnly",
+      "NudgeOnly low-token receipt bridge and advisory classifier.",
+      "packages/mcp-server/src/nudgeonly-tool.ts"
+    ],
+    [
+      "numbers",
+      "numbers MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/numbers-tool.ts"
+    ],
+    [
+      "nvd",
+      "nvd MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/nvd-tool.ts"
+    ],
+    [
+      "omdb",
+      "omdb MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/omdb-tool.ts"
+    ],
+    [
+      "openai",
+      "openai MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/openai-tool.ts"
+    ],
+    [
+      "openaq",
+      "openaq MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/openaq-tool.ts"
+    ],
+    [
+      "openexchangerates",
+      "openexchangerates MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/openexchangerates-tool.ts"
+    ],
+    [
+      "openf1",
+      "openf1 MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/openf1-tool.ts"
+    ],
+    [
+      "openfoodfacts",
+      "openfoodfacts MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/openfoodfacts-tool.ts"
+    ],
+    [
+      "openlibrary",
+      "openlibrary MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/openlibrary-tool.ts"
+    ],
+    [
+      "openmeteo",
+      "openmeteo MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/openmeteo-tool.ts"
+    ],
+    [
+      "pagerduty",
+      "pagerduty MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pagerduty-tool.ts"
+    ],
+    [
+      "pandascore",
+      "pandascore MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pandascore-tool.ts"
+    ],
+    [
+      "paypal",
+      "paypal MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/paypal-tool.ts"
+    ],
+    [
+      "perplexity",
+      "perplexity MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/perplexity-tool.ts"
+    ],
+    [
+      "pika",
+      "pika MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pika-tool.ts"
+    ],
+    [
+      "pinecone",
+      "pinecone MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pinecone-tool.ts"
+    ],
+    [
+      "pinterest",
+      "pinterest MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pinterest-tool.ts"
+    ],
+    [
+      "plaid",
+      "plaid MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/plaid-tool.ts"
+    ],
+    [
+      "podcastindex",
+      "podcastindex MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/podcastindex-tool.ts"
+    ],
+    [
+      "postman",
+      "postman MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/postman-tool.ts"
+    ],
+    [
+      "postmark",
+      "postmark MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/postmark-tool.ts"
+    ],
+    [
+      "ptv",
+      "ptv MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/ptv-tool.ts"
+    ],
+    [
+      "pushonly",
+      "pushonly MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pushonly-tool.ts"
+    ],
+    [
+      "pushover",
+      "pushover MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pushover-tool.ts"
+    ],
+    [
+      "qc",
+      "qc MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/qc-tool.ts"
+    ],
+    [
+      "quickbooks",
+      "quickbooks MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/quickbooks-tool.ts"
+    ],
+    [
+      "radiobrowser",
+      "radiobrowser MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/radiobrowser-tool.ts"
+    ],
+    [
+      "raindrop",
+      "raindrop MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/raindrop-tool.ts"
+    ],
+    [
+      "random",
+      "random MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/random-tool.ts"
+    ],
+    [
+      "rawg",
+      "rawg MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/rawg-tool.ts"
+    ],
+    [
+      "readwise",
+      "readwise MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/readwise-tool.ts"
+    ],
+    [
+      "reddit",
+      "reddit MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/reddit-tool.ts"
+    ],
+    [
+      "render",
+      "render MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/render-tool.ts"
+    ],
+    [
+      "replicate",
+      "replicate MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/replicate-tool.ts"
+    ],
+    [
+      "resend",
+      "resend MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/resend-tool.ts"
+    ],
+    [
+      "restcountries",
+      "restcountries MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/restcountries-tool.ts"
+    ],
+    [
+      "riot",
+      "riot MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/riot-tool.ts"
+    ],
+    [
+      "runway",
+      "runway MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/runway-tool.ts"
+    ],
+    [
+      "seatgeek",
+      "seatgeek MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/seatgeek-tool.ts"
+    ],
+    [
+      "segment",
+      "segment MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/segment-tool.ts"
+    ],
+    [
+      "sendgrid",
+      "sendgrid MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/sendgrid-tool.ts"
+    ],
+    [
+      "sendle",
+      "sendle MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/sendle-tool.ts"
+    ],
+    [
+      "sentry",
+      "sentry MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/sentry-tool.ts"
+    ],
+    [
+      "seopass",
+      "seopass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/seopass-tool.ts"
+    ],
+    [
+      "setlistfm",
+      "setlistfm MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/setlistfm-tool.ts"
+    ],
+    [
+      "shodan",
+      "shodan MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/shodan-tool.ts"
+    ],
+    [
+      "shopify",
+      "shopify MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/shopify-tool.ts"
+    ],
+    [
+      "slack",
+      "slack MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/slack-tool.ts"
+    ],
+    [
+      "sleeper",
+      "sleeper MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/sleeper-tool.ts"
+    ],
+    [
+      "speedrun",
+      "speedrun MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/speedrun-tool.ts"
+    ],
+    [
+      "splitwise",
+      "splitwise MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/splitwise-tool.ts"
+    ],
+    [
+      "spotify",
+      "spotify MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/spotify-tool.ts"
+    ],
+    [
+      "square",
+      "square MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/square-tool.ts"
+    ],
+    [
+      "stability",
+      "stability MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/stability-tool.ts"
+    ],
+    [
+      "steam",
+      "steam MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/steam-tool.ts"
+    ],
+    [
+      "stripe",
+      "stripe MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/stripe-tool.ts"
+    ],
+    [
+      "supercell",
+      "supercell MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/supercell-tool.ts"
+    ],
+    [
+      "tab",
+      "tab MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/tab-tool.ts"
+    ],
+    [
+      "telegram",
+      "telegram MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/telegram-tool.ts"
+    ],
+    [
+      "testpass",
+      "TestPass proof and test orchestration capability.",
+      "packages/mcp-server/src/testpass-tool.ts"
+    ],
+    [
+      "text",
+      "text MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/text-tool.ts"
+    ],
+    [
+      "thelott",
+      "thelott MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/thelott-tool.ts"
+    ],
+    [
+      "ticketmaster",
+      "ticketmaster MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/ticketmaster-tool.ts"
+    ],
+    [
+      "tiktok",
+      "tiktok MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/tiktok-tool.ts"
+    ],
+    [
+      "tmdb",
+      "tmdb MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/tmdb-tool.ts"
+    ],
+    [
+      "togetherai",
+      "togetherai MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/togetherai-tool.ts"
+    ],
+    [
+      "toggl",
+      "toggl MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/toggl-tool.ts"
+    ],
+    [
+      "toilets",
+      "toilets MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/toilets-tool.ts"
+    ],
+    [
+      "tomorrowio",
+      "tomorrowio MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/tomorrowio-tool.ts"
+    ],
+    [
+      "trello",
+      "trello MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/trello-tool.ts"
+    ],
+    [
+      "trivia",
+      "trivia MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/trivia-tool.ts"
+    ],
+    [
+      "trove",
+      "trove MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/trove-tool.ts"
+    ],
+    [
+      "turso",
+      "turso MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/turso-tool.ts"
+    ],
+    [
+      "twilio",
+      "twilio MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/twilio-tool.ts"
+    ],
+    [
+      "twitch",
+      "twitch MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/twitch-tool.ts"
+    ],
+    [
+      "unit converter",
+      "unit converter MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/unit-converter-tool.ts"
+    ],
+    [
+      "untappd",
+      "untappd MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/untappd-tool.ts"
+    ],
+    [
+      "upstash",
+      "upstash MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/upstash-tool.ts"
+    ],
+    [
+      "urlscan",
+      "urlscan MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/urlscan-tool.ts"
+    ],
+    [
+      "usgs",
+      "usgs MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/usgs-tool.ts"
+    ],
+    [
+      "uxpass",
+      "UXPass experience verification capability.",
+      "packages/mcp-server/src/uxpass-tool.ts"
+    ],
+    [
+      "vault",
+      "vault MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/vault-tool.ts"
+    ],
+    [
+      "vercel",
+      "vercel MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/vercel-tool.ts"
+    ],
+    [
+      "virustotal",
+      "virustotal MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/virustotal-tool.ts"
+    ],
+    [
+      "whatsapp",
+      "whatsapp MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/whatsapp-tool.ts"
+    ],
+    [
+      "willyweather",
+      "willyweather MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/willyweather-tool.ts"
+    ],
+    [
+      "wise",
+      "wise MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/wise-tool.ts"
+    ],
+    [
+      "woocommerce",
+      "woocommerce MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/woocommerce-tool.ts"
+    ],
+    [
+      "xero",
+      "xero MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/xero-tool.ts"
+    ],
+    [
+      "yelp",
+      "yelp MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/yelp-tool.ts"
+    ],
+    [
+      "youtube",
+      "youtube MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/youtube-tool.ts"
+    ]
+  ],
+  "roomRows": [
+    [
+      "ack ledger",
+      "PinballWake room logic generated from scripts/pinballwake-ack-ledger-room.mjs.",
+      "scripts/pinballwake-ack-ledger-room.mjs"
+    ],
+    [
+      "buildbait",
+      "PinballWake room logic generated from scripts/pinballwake-buildbait-room.mjs.",
+      "scripts/pinballwake-buildbait-room.mjs"
+    ],
+    [
+      "close supersede",
+      "PinballWake room logic generated from scripts/pinballwake-close-supersede-room.mjs.",
+      "scripts/pinballwake-close-supersede-room.mjs"
+    ],
+    [
+      "coding",
+      "PinballWake room logic generated from scripts/pinballwake-coding-room.mjs.",
+      "scripts/pinballwake-coding-room.mjs"
+    ],
+    [
+      "continuous improvement",
+      "PinballWake room logic generated from scripts/pinballwake-continuous-improvement-room.mjs.",
+      "scripts/pinballwake-continuous-improvement-room.mjs"
+    ],
+    [
+      "dogfood",
+      "PinballWake room logic generated from scripts/pinballwake-dogfood-room.mjs.",
+      "scripts/pinballwake-dogfood-room.mjs"
+    ],
+    [
+      "event ledger",
+      "PinballWake room logic generated from scripts/pinballwake-event-ledger-room.mjs.",
+      "scripts/pinballwake-event-ledger-room.mjs"
+    ],
+    [
+      "jobs",
+      "PinballWake room logic generated from scripts/pinballwake-jobs-room.mjs.",
+      "scripts/pinballwake-jobs-room.mjs"
+    ],
+    [
+      "launchpad",
+      "PinballWake room logic generated from scripts/pinballwake-launchpad-room.mjs.",
+      "scripts/pinballwake-launchpad-room.mjs"
+    ],
+    [
+      "merge",
+      "PinballWake room logic generated from scripts/pinballwake-merge-room.mjs.",
+      "scripts/pinballwake-merge-room.mjs"
+    ],
+    [
+      "overlap resolver",
+      "PinballWake room logic generated from scripts/pinballwake-overlap-resolver-room.mjs.",
+      "scripts/pinballwake-overlap-resolver-room.mjs"
+    ],
+    [
+      "personality",
+      "PinballWake room logic generated from scripts/pinballwake-personality-room.mjs.",
+      "scripts/pinballwake-personality-room.mjs"
+    ],
+    [
+      "planning",
+      "PinballWake room logic generated from scripts/pinballwake-planning-room.mjs.",
+      "scripts/pinballwake-planning-room.mjs"
+    ],
+    [
+      "post merge watch",
+      "PinballWake room logic generated from scripts/pinballwake-post-merge-watch-room.mjs.",
+      "scripts/pinballwake-post-merge-watch-room.mjs"
+    ],
+    [
+      "publish",
+      "PinballWake room logic generated from scripts/pinballwake-publish-room.mjs.",
+      "scripts/pinballwake-publish-room.mjs"
+    ],
+    [
+      "queue health",
+      "PinballWake room logic generated from scripts/pinballwake-queue-health-room.mjs.",
+      "scripts/pinballwake-queue-health-room.mjs"
+    ],
+    [
+      "release notes",
+      "PinballWake room logic generated from scripts/pinballwake-release-notes-room.mjs.",
+      "scripts/pinballwake-release-notes-room.mjs"
+    ],
+    [
+      "repair",
+      "PinballWake room logic generated from scripts/pinballwake-repair-room.mjs.",
+      "scripts/pinballwake-repair-room.mjs"
+    ],
+    [
+      "research",
+      "PinballWake room logic generated from scripts/pinballwake-research-room.mjs.",
+      "scripts/pinballwake-research-room.mjs"
+    ],
+    [
+      "rollback",
+      "PinballWake room logic generated from scripts/pinballwake-rollback-room.mjs.",
+      "scripts/pinballwake-rollback-room.mjs"
+    ],
+    [
+      "stale",
+      "PinballWake room logic generated from scripts/pinballwake-stale-room.mjs.",
+      "scripts/pinballwake-stale-room.mjs"
+    ],
+    [
+      "worker registry",
+      "PinballWake room logic generated from scripts/pinballwake-worker-registry-room.mjs.",
+      "scripts/pinballwake-worker-registry-room.mjs"
+    ],
+    [
+      "xpass gate",
+      "PinballWake room logic generated from scripts/pinballwake-xpass-gate-room.mjs.",
+      "scripts/pinballwake-xpass-gate-room.mjs"
+    ]
+  ],
+  "workerRows": [
+    [
+      "Coordinator",
+      "Routes work, chooses the next room, and keeps lanes aligned."
+    ],
+    [
+      "Builder",
+      "Implements focused code or content changes from a scoped packet."
+    ],
+    [
+      "Tester",
+      "Runs proof and reports what passed or blocked."
+    ],
+    [
+      "Reviewer",
+      "Checks quality, regressions, and missing tests."
+    ],
+    [
+      "Safety Checker",
+      "Protects secrets, auth, destructive actions, and release gates."
+    ],
+    [
+      "Ledger",
+      "Records proof, receipts, approvals, and rollback evidence."
+    ],
+    [
+      "Publisher",
+      "Moves approved work toward deployment and public proof."
+    ],
+    [
+      "Improver",
+      "Turns repeated pain into system improvements."
+    ]
+  ],
+  "aliasRows": [
+    [
+      "EnterprisePass",
+      "CompliancePass",
+      "Enterprise readiness checks need a public-safe product name."
+    ],
+    [
+      "SlopPass",
+      "QualityPass",
+      "Roughness and polish checks should be framed constructively."
+    ],
+    [
+      "Fishbowl",
+      "Boardroom",
+      "Internal worker discussion becomes a user-facing room name."
+    ],
+    [
+      "To-Do List",
+      "Jobs",
+      "Task queue language maps to the current admin Jobs surface."
+    ],
+    [
+      "Heartbeat",
+      "Heartbeat Master",
+      "The copy policy that teaches scheduled seats how to pulse."
+    ],
+    [
+      "NudgeOnlyAPI",
+      "NudgeOnly",
+      "Low-risk receipt nudges, never source-of-truth mutation."
+    ],
+    [
+      "IgniteOnlyAPI",
+      "IgniteOnly",
+      "Verified worker wake packets, never build, merge, or completion state."
+    ]
+  ],
+  "ciRows": [
+    [
+      "brainmap:check",
+      "node scripts/UnClick-brainmap.mjs --check"
+    ],
+    [
+      "brainmap:generate",
+      "node scripts/UnClick-brainmap.mjs"
+    ],
+    [
+      "build",
+      "vite build"
+    ],
+    [
+      "build:dev",
+      "vite build --mode development"
+    ],
+    [
+      "lint",
+      "eslint ."
+    ],
+    [
+      "test",
+      "vitest run"
+    ],
+    [
+      "test:api",
+      "npm run test --workspace=apps/api"
+    ],
+    [
+      "test:brainmap",
+      "node --test scripts/UnClick-brainmap.test.mjs"
+    ],
+    [
+      "test:enterprisepass-receipt",
+      "node --test scripts/enterprisepass-receipt-guard.test.mjs"
+    ],
+    [
+      "test:rotatepass-redaction",
+      "node --test scripts/rotatepass-redaction-guard.test.mjs"
+    ],
+    [
+      "test:watch",
+      "vitest"
+    ]
+  ],
+  "source_manifest": [
+    {
+      "source": "AUTOPILOT.md",
+      "hash": "562ec208aa54",
+      "bytes": 16311
+    },
+    {
+      "source": "FLEET_SYNC.md",
+      "hash": "41ebcbca94b0",
+      "bytes": 13200
+    },
+    {
+      "source": "docs/unclick-context-boot-packet.md",
+      "hash": "7cf131cf22e0",
+      "bytes": 4785
+    },
+    {
+      "source": "docs/agent-observability.md",
+      "hash": "bffd9f890c75",
+      "bytes": 4629
+    },
+    {
+      "source": "docs/pinballwake-nudgeonly-api.md",
+      "hash": "901e39017aa9",
+      "bytes": 6910
+    },
+    {
+      "source": "docs/pinballwake-igniteonly-api.md",
+      "hash": "bea4d9c8fa21",
+      "bytes": 7919
+    },
+    {
+      "source": "docs/fleet-worker-roles.md",
+      "hash": "ed620f347d4f",
+      "bytes": 4873
+    },
+    {
+      "source": "docs/adr/0005-two-layer-admin-gating.md",
+      "hash": "cefe739796f2",
+      "bytes": 2186
+    },
+    {
+      "source": "docs/adr/0006-orchestrator-is-user-chat.md",
+      "hash": "bf91808d2d8d",
+      "bytes": 2169
+    },
+    {
+      "source": "src/App.tsx",
+      "hash": "b02c3916f083",
+      "bytes": 13089
+    },
+    {
+      "source": "src/pages/admin/AdminShell.tsx",
+      "hash": "fcbb1fa44f40",
+      "bytes": 19018
+    },
+    {
+      "source": ".github/workflows/ci.yml",
+      "hash": "79e43dd8e26c",
+      "bytes": 1608
+    },
+    {
+      "source": ".github/workflows/brainmap-auto-update.yml",
+      "hash": "4771ebdbdba3",
+      "bytes": 1211
+    },
+    {
+      "source": "package.json",
+      "hash": "9f761ff407b1",
+      "bytes": 4232
+    },
+    {
+      "source": "scripts/pinballwake-ack-ledger-room.mjs",
+      "hash": "e7dcb642bc75",
+      "bytes": 12719
+    },
+    {
+      "source": "scripts/pinballwake-buildbait-room.mjs",
+      "hash": "42445fca7b1e",
+      "bytes": 4811
+    },
+    {
+      "source": "scripts/pinballwake-close-supersede-room.mjs",
+      "hash": "4d31f6a6a8c2",
+      "bytes": 3891
+    },
+    {
+      "source": "scripts/pinballwake-coding-room.mjs",
+      "hash": "9fa5689c555e",
+      "bytes": 25310
+    },
+    {
+      "source": "scripts/pinballwake-continuous-improvement-room.mjs",
+      "hash": "c41cf0bacf97",
+      "bytes": 14872
+    },
+    {
+      "source": "scripts/pinballwake-dogfood-room.mjs",
+      "hash": "d161028d1382",
+      "bytes": 2782
+    },
+    {
+      "source": "scripts/pinballwake-event-ledger-room.mjs",
+      "hash": "e8f8f9f84123",
+      "bytes": 16104
+    },
+    {
+      "source": "scripts/pinballwake-jobs-room.mjs",
+      "hash": "c77c394081c2",
+      "bytes": 14217
+    },
+    {
+      "source": "scripts/pinballwake-launchpad-room.mjs",
+      "hash": "64cc89cd3253",
+      "bytes": 12693
+    },
+    {
+      "source": "scripts/pinballwake-merge-room.mjs",
+      "hash": "3645da5c0c93",
+      "bytes": 8431
+    },
+    {
+      "source": "scripts/pinballwake-overlap-resolver-room.mjs",
+      "hash": "14d03ef6acd3",
+      "bytes": 6787
+    },
+    {
+      "source": "scripts/pinballwake-personality-room.mjs",
+      "hash": "c1ca769346f1",
+      "bytes": 9644
+    },
+    {
+      "source": "scripts/pinballwake-planning-room.mjs",
+      "hash": "080c2946a794",
+      "bytes": 9714
+    },
+    {
+      "source": "scripts/pinballwake-post-merge-watch-room.mjs",
+      "hash": "144227650844",
+      "bytes": 5462
+    },
+    {
+      "source": "scripts/pinballwake-publish-room.mjs",
+      "hash": "ec1dbd36ed22",
+      "bytes": 7526
+    },
+    {
+      "source": "scripts/pinballwake-queue-health-room.mjs",
+      "hash": "ddefab91d886",
+      "bytes": 2842
+    },
+    {
+      "source": "scripts/pinballwake-release-notes-room.mjs",
+      "hash": "b13cc2fdf23f",
+      "bytes": 2598
+    },
+    {
+      "source": "scripts/pinballwake-repair-room.mjs",
+      "hash": "6404e2b40642",
+      "bytes": 3567
+    },
+    {
+      "source": "scripts/pinballwake-research-room.mjs",
+      "hash": "8307356c93c4",
+      "bytes": 7651
+    },
+    {
+      "source": "scripts/pinballwake-rollback-room.mjs",
+      "hash": "c63e73fd2716",
+      "bytes": 4158
+    },
+    {
+      "source": "scripts/pinballwake-stale-room.mjs",
+      "hash": "8927de850588",
+      "bytes": 3880
+    },
+    {
+      "source": "scripts/pinballwake-worker-registry-room.mjs",
+      "hash": "e8c9f4a764e3",
+      "bytes": 20616
+    },
+    {
+      "source": "scripts/pinballwake-xpass-gate-room.mjs",
+      "hash": "44b7d10cddc2",
+      "bytes": 14430
+    },
+    {
+      "source": "packages/mcp-server/src/abn-tool.ts",
+      "hash": "5105de2d357d",
+      "bytes": 3682
+    },
+    {
+      "source": "packages/mcp-server/src/abuseipdb-tool.ts",
+      "hash": "21d5283c8dba",
+      "bytes": 4673
+    },
+    {
+      "source": "packages/mcp-server/src/airtable-tool.ts",
+      "hash": "cca3eed693da",
+      "bytes": 7132
+    },
+    {
+      "source": "packages/mcp-server/src/algolia-tool.ts",
+      "hash": "8eb0992500f1",
+      "bytes": 4924
+    },
+    {
+      "source": "packages/mcp-server/src/alphavantage-tool.ts",
+      "hash": "98a37153078d",
+      "bytes": 7591
+    },
+    {
+      "source": "packages/mcp-server/src/amazon-tool.ts",
+      "hash": "fb1e936b7c9a",
+      "bytes": 14913
+    },
+    {
+      "source": "packages/mcp-server/src/amber-tool.ts",
+      "hash": "6d020b798469",
+      "bytes": 4138
+    },
+    {
+      "source": "packages/mcp-server/src/anthropic-tool.ts",
+      "hash": "fd197643eefb",
+      "bytes": 7766
+    },
+    {
+      "source": "packages/mcp-server/src/asana-tool.ts",
+      "hash": "3f5d880c119d",
+      "bytes": 8078
+    },
+    {
+      "source": "packages/mcp-server/src/assemblyai-tool.ts",
+      "hash": "fdc9c929ba6f",
+      "bytes": 9625
+    },
+    {
+      "source": "packages/mcp-server/src/australiapost-tool.ts",
+      "hash": "6fc5a927873d",
+      "bytes": 5148
+    },
+    {
+      "source": "packages/mcp-server/src/bandsintown-tool.ts",
+      "hash": "a77399b666e2",
+      "bytes": 3170
+    },
+    {
+      "source": "packages/mcp-server/src/bgg-tool.ts",
+      "hash": "5078cb1ae404",
+      "bytes": 10461
+    },
+    {
+      "source": "packages/mcp-server/src/bluesky-tool.ts",
+      "hash": "89b5739acca5",
+      "bytes": 14208
+    },
+    {
+      "source": "packages/mcp-server/src/bungie-tool.ts",
+      "hash": "e88c304b23f0",
+      "bytes": 6643
+    },
+    {
+      "source": "packages/mcp-server/src/calculator-tool.ts",
+      "hash": "941b010bc4f9",
+      "bytes": 7255
+    },
+    {
+      "source": "packages/mcp-server/src/calendly-tool.ts",
+      "hash": "52eb1f5b2bf2",
+      "bytes": 6392
+    },
+    {
+      "source": "packages/mcp-server/src/carboninterface-tool.ts",
+      "hash": "75827e943e9f",
+      "bytes": 6705
+    },
+    {
+      "source": "packages/mcp-server/src/chessdotcom-tool.ts",
+      "hash": "56425dde5729",
+      "bytes": 6852
+    },
+    {
+      "source": "packages/mcp-server/src/circleci-tool.ts",
+      "hash": "14729ddbb6ce",
+      "bytes": 4949
+    },
+    {
+      "source": "packages/mcp-server/src/clickup-tool.ts",
+      "hash": "3f9127777b87",
+      "bytes": 6316
+    },
+    {
+      "source": "packages/mcp-server/src/clockify-tool.ts",
+      "hash": "058798077459",
+      "bytes": 6790
+    },
+    {
+      "source": "packages/mcp-server/src/cohere-tool.ts",
+      "hash": "9ca27e0737f8",
+      "bytes": 9207
+    },
+    {
+      "source": "packages/mcp-server/src/coingecko-tool.ts",
+      "hash": "e7d8c7535112",
+      "bytes": 6827
+    },
+    {
+      "source": "packages/mcp-server/src/coinmarketcap-tool.ts",
+      "hash": "b1c5fd280acb",
+      "bytes": 6892
+    },
+    {
+      "source": "packages/mcp-server/src/color-tool.ts",
+      "hash": "f9aa9c0fec6e",
+      "bytes": 13643
+    },
+    {
+      "source": "packages/mcp-server/src/convertkit-tool.ts",
+      "hash": "2f77303a3441",
+      "bytes": 8498
+    },
+    {
+      "source": "packages/mcp-server/src/copypass-tool.ts",
+      "hash": "58487357de03",
+      "bytes": 5744
+    },
+    {
+      "source": "packages/mcp-server/src/crews-tool.ts",
+      "hash": "18a489d3ab94",
+      "bytes": 5750
+    },
+    {
+      "source": "packages/mcp-server/src/csuite-tool.ts",
+      "hash": "0ab5af89bb49",
+      "bytes": 70236
+    },
+    {
+      "source": "packages/mcp-server/src/datadog-tool.ts",
+      "hash": "802b808614cd",
+      "bytes": 5556
+    },
+    {
+      "source": "packages/mcp-server/src/datetime-tool.ts",
+      "hash": "19075fddbc55",
+      "bytes": 10618
+    },
+    {
+      "source": "packages/mcp-server/src/deepl-tool.ts",
+      "hash": "3c88cc9c44bf",
+      "bytes": 5695
+    },
+    {
+      "source": "packages/mcp-server/src/deezer-tool.ts",
+      "hash": "227805914d67",
+      "bytes": 7257
+    },
+    {
+      "source": "packages/mcp-server/src/discogs-tool.ts",
+      "hash": "547892efce07",
+      "bytes": 4956
+    },
+    {
+      "source": "packages/mcp-server/src/discord-tool.ts",
+      "hash": "c70b8ac42f28",
+      "bytes": 8191
+    },
+    {
+      "source": "packages/mcp-server/src/domain-tool.ts",
+      "hash": "1beecc106e80",
+      "bytes": 6076
+    },
+    {
+      "source": "packages/mcp-server/src/ebay-tool.ts",
+      "hash": "10dffe36315f",
+      "bytes": 7595
+    },
+    {
+      "source": "packages/mcp-server/src/ebird-tool.ts",
+      "hash": "3deedf3fde19",
+      "bytes": 6262
+    },
+    {
+      "source": "packages/mcp-server/src/elevenlabs-tool.ts",
+      "hash": "efcaeeff39d6",
+      "bytes": 10833
+    },
+    {
+      "source": ".github/workflows/apply-migrations.yml",
+      "hash": "d2ee87e75e7f",
+      "bytes": 1529
+    },
+    {
+      "source": ".github/workflows/auto-close-fishbowl-todo.yml",
+      "hash": "07564f004cb2",
+      "bytes": 11830
+    },
+    {
+      "source": ".github/workflows/autonomous-runner.yml",
+      "hash": "5aead42a5ec9",
+      "bytes": 8340
+    },
+    {
+      "source": ".github/workflows/claude.yml",
+      "hash": "e8fc79a85b6c",
+      "bytes": 1085
+    },
+    {
+      "source": ".github/workflows/dirty-branch-hygiene.yml",
+      "hash": "9d192a7da041",
+      "bytes": 2190
+    },
+    {
+      "source": ".github/workflows/dogfood-report.yml",
+      "hash": "d485b8d37111",
+      "bytes": 3987
+    },
+    {
+      "source": ".github/workflows/event-wake-router.yml",
+      "hash": "bfd53e324bb4",
+      "bytes": 1453
+    },
+    {
+      "source": ".github/workflows/fleet-throughput-watch.yml",
+      "hash": "c5a08f4edf9b",
+      "bytes": 930
+    },
+    {
+      "source": ".github/workflows/openhands-test-mode.yml",
+      "hash": "3bd5d5f48573",
+      "bytes": 1137
+    },
+    {
+      "source": ".github/workflows/publish-channel-package.yml",
+      "hash": "25c5e6a54858",
+      "bytes": 6832
+    },
+    {
+      "source": ".github/workflows/publish-mcp-package.yml",
+      "hash": "592df08439d4",
+      "bytes": 6824
+    },
+    {
+      "source": ".github/workflows/review-enforcement-warning.yml",
+      "hash": "64b27fdddfe8",
+      "bytes": 548
+    },
+    {
+      "source": ".github/workflows/seed-vault.yml",
+      "hash": "003a9bd13283",
+      "bytes": 1246
+    },
+    {
+      "source": ".github/workflows/testpass-pr-check.yml",
+      "hash": "398a44d83549",
+      "bytes": 9548
+    },
+    {
+      "source": ".github/workflows/testpass-scheduled-smoke.yml",
+      "hash": "46f9a65b1dbb",
+      "bytes": 1673
+    },
+    {
+      "source": ".github/workflows/tier2-auto-merge-queue-check.yml",
+      "hash": "4d7ed61de742",
+      "bytes": 541
+    }
+  ]
+}

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -2,6 +2,13 @@
 
 Internal admin only. Auto-generated from tracked source so new AI seats can understand UnClick without a separate handover.
 
+## Brainmap Data Contract
+
+- Schema: `brainmap-v2`.
+- This markdown is paired with `docs/UnClick-brainmap.generated.json` for the private admin visual tree.
+- The JSON inventory is grouped by division so seats can quickly discover tools, rooms, wrappers, workers, modules, passes, ledgers, and source-of-truth surfaces.
+- The generator reruns in CI and on a schedule. New tracked surfaces appear after the generator sees their source paths.
+
 ## Source Manifest
 
 | Source | Hash | Bytes |
@@ -18,7 +25,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/App.tsx | b02c3916f083 | 13089 |
 | src/pages/admin/AdminShell.tsx | fcbb1fa44f40 | 19018 |
 | .github/workflows/ci.yml | 79e43dd8e26c | 1608 |
-| .github/workflows/brainmap-auto-update.yml | 7e8b08eb16aa | 1137 |
+| .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | package.json | 9f761ff407b1 | 4232 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
 | scripts/pinballwake-buildbait-room.mjs | 42445fca7b1e | 4811 |
@@ -83,6 +90,39 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/ebay-tool.ts | 10dffe36315f | 7595 |
 | packages/mcp-server/src/ebird-tool.ts | 3deedf3fde19 | 6262 |
 | packages/mcp-server/src/elevenlabs-tool.ts | efcaeeff39d6 | 10833 |
+| .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
+| .github/workflows/auto-close-fishbowl-todo.yml | 07564f004cb2 | 11830 |
+| .github/workflows/autonomous-runner.yml | 5aead42a5ec9 | 8340 |
+| .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
+| .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |
+| .github/workflows/dogfood-report.yml | d485b8d37111 | 3987 |
+| .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
+| .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
+| .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |
+| .github/workflows/publish-channel-package.yml | 25c5e6a54858 | 6832 |
+| .github/workflows/publish-mcp-package.yml | 592df08439d4 | 6824 |
+| .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
+| .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
+| .github/workflows/testpass-pr-check.yml | 398a44d83549 | 9548 |
+| .github/workflows/testpass-scheduled-smoke.yml | 46f9a65b1dbb | 1673 |
+| .github/workflows/tier2-auto-merge-queue-check.yml | 4d7ed61de742 | 541 |
+
+## Division Index
+
+| Division | Meaning | Items |
+| --- | --- | --- |
+| Admin surfaces | Private operator views and internal control panels. | 52 |
+| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 41 |
+| Tools | MCP and gateway capabilities available to seats. | 182 |
+| Rooms | PinballWake and Boardroom lanes that route work. | 23 |
+| Workers and seats | Human and AI roles that move work through the system. | 11 |
+| Passes and gates | Quality, proof, safety, and fidelity checks. | 12 |
+| Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 108 |
+| Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
+| Source of truth | Canonical state, queue, memory, and context surfaces. | 9 |
+| Modules and apps | Apps, packages, and product modules that make up UnClick. | 19 |
+| Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 4 |
 
 ## UnClick Structure
 
@@ -377,6 +417,481 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | yelp | yelp MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/yelp-tool.ts |
 | youtube | youtube MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/youtube-tool.ts |
 
+## Tool and Worker Tree
+
+| Division | Kind | Name | Meaning | Route | Source |
+| --- | --- | --- | --- | --- | --- |
+| Admin surfaces | admin page | Admin Activity | Admin surface for Admin Activity. | /admin/activity | src/pages/admin/AdminActivity.tsx |
+| Admin surfaces | admin page | Admin Agents | Admin surface for Admin Agents. | /admin/agents | src/pages/admin/AdminAgents.tsx |
+| Admin surfaces | admin page | Admin Analytics | Internal analytics view for platform signals and usage. | /admin/analytics | src/pages/admin/AdminAnalytics.tsx |
+| Admin surfaces | admin page | Admin Audit Log | Internal audit trail for sensitive admin actions. | /admin/audit-log | src/pages/admin/AdminAuditLog.tsx |
+| Admin surfaces | admin page | Admin Brainmap | Generated ecosystem map that teaches seats what UnClick is. | /admin/brainmap | src/pages/admin/AdminBrainmap.tsx |
+| Admin surfaces | admin page | Admin Codebase | Internal source and architecture orientation surface. | /admin/codebase | src/pages/admin/AdminCodebase.tsx |
+| Admin surfaces | admin page | Admin Dashboard | Front door for current operator state. | /admin/dashboard | src/pages/admin/AdminDashboard.tsx |
+| Admin surfaces | admin page | Admin Ecosystem Pages | Admin surface for Admin Ecosystem Pages. | /admin/ecosystem-pages | src/pages/admin/AdminEcosystemPages.tsx |
+| Admin surfaces | admin page | Admin Jobs | Operational job and task queue. | /admin/jobs | src/pages/admin/AdminJobs.tsx |
+| Admin surfaces | admin page | Admin Jobsmith | Admin surface for Admin Jobsmith. | /admin/jobsmith | src/pages/admin/AdminJobsmith.tsx |
+| Admin surfaces | admin page | Admin Keychain | Passport and credential connection health. | /admin/keychain | src/pages/admin/AdminKeychain.tsx |
+| Admin surfaces | admin page | Admin Memory | Admin view of persistent memory, facts, sessions, and recall. | /admin/memory | src/pages/admin/AdminMemory.tsx |
+| Admin surfaces | admin page | Admin Moderation | Admin surface for Admin Moderation. | /admin/moderation | src/pages/admin/AdminModeration.tsx |
+| Admin surfaces | admin page | Admin Orchestrator | Readable continuity stream for seats and operator context. | /admin/orchestrator | src/pages/admin/AdminOrchestrator.tsx |
+| Admin surfaces | admin page | Admin Pinball Wake | PinballWake rooms, wake routes, and automation visibility. | /admin/pinball-wake | src/pages/admin/AdminPinballWake.tsx |
+| Admin surfaces | admin page | Admin Seat Heartbeat | Master heartbeat copy policy for scheduled AI seats. | /admin/agents/heartbeat | src/pages/admin/AdminSeatHeartbeat.tsx |
+| Admin surfaces | admin page | Admin Settings | Account and admin configuration. | /admin/settings | src/pages/admin/AdminSettings.tsx |
+| Admin surfaces | admin page | Admin Shell | Admin surface for Admin Shell. | /admin/shell | src/pages/admin/AdminShell.tsx |
+| Admin surfaces | admin page | Admin System Health | Health checks and operational status. | /admin/system-health | src/pages/admin/AdminSystemHealth.tsx |
+| Admin surfaces | admin page | Admin Test Pass | Admin surface for Admin Test Pass. | /admin/test-pass | src/pages/admin/AdminTestPass.tsx |
+| Admin surfaces | admin page | Admin Tools | Apps, tools, and connector capability surface. | /admin/tools | src/pages/admin/AdminTools.tsx |
+| Admin surfaces | admin page | Admin Users | Internal user management. | /admin/users | src/pages/admin/AdminUsers.tsx |
+| Admin surfaces | admin page | Admin You | Personal account, identity, and access panel. | /admin/you | src/pages/admin/AdminYou.tsx |
+| Admin surfaces | admin page | Brain Map | Legacy Memory Brain Map component kept distinct from ecosystem Brainmap. | /brain-map | src/pages/admin/BrainMap.tsx |
+| Admin surfaces | admin page | Comments | Admin surface for Comments. | /comments | src/pages/admin/fishbowl/Comments.tsx |
+| Admin surfaces | admin page | Connected Services | Tool page for Connected Services. | /tools/connected-services | src/pages/admin/tools/ConnectedServices.tsx |
+| Admin surfaces | admin page | Context Tab | Memory admin panel for Context Tab. | /context-tab | src/pages/admin/memory/ContextTab.tsx |
+| Admin surfaces | admin page | Copy Pass Catalog | Admin surface for Copy Pass Catalog. | /copy-pass-catalog | src/pages/admin/copypass/CopyPassCatalog.tsx |
+| Admin surfaces | admin page | Crew Composer | Crews admin page for Crew Composer. | /crew-composer | src/pages/admin/crews/CrewComposer.tsx |
+| Admin surfaces | admin page | Crew Run | Crews admin page for Crew Run. | /crew-run | src/pages/admin/crews/CrewRun.tsx |
+| Admin surfaces | admin page | Crews Catalog | Crews admin page for Crews Catalog. | /crews-catalog | src/pages/admin/crews/CrewsCatalog.tsx |
+| Admin surfaces | admin page | Crews Runs | Crews admin page for Crews Runs. | /crews-runs | src/pages/admin/crews/CrewsRuns.tsx |
+| Admin surfaces | admin page | Crews Settings | Crews admin page for Crews Settings. | /crews-settings | src/pages/admin/crews/CrewsSettings.tsx |
+| Admin surfaces | admin page | Empty State | Memory admin panel for Empty State. | /empty-state | src/pages/admin/memory/EmptyState.tsx |
+| Admin surfaces | admin page | Facts Tab | Memory admin panel for Facts Tab. | /facts-tab | src/pages/admin/memory/FactsTab.tsx |
+| Admin surfaces | admin page | Fishbowl | Boardroom discussion surface for worker coordination. | /fishbowl | src/pages/admin/Fishbowl.tsx |
+| Admin surfaces | admin page | Ideas | Admin surface for Ideas. | /ideas | src/pages/admin/fishbowl/Ideas.tsx |
+| Admin surfaces | admin page | Info Card | Memory admin panel for Info Card. | /info-card | src/pages/admin/memory/InfoCard.tsx |
+| Admin surfaces | admin page | Library Tab | Memory admin panel for Library Tab. | /library-tab | src/pages/admin/memory/LibraryTab.tsx |
+| Admin surfaces | admin page | Memory Activity Tab | Memory admin panel for Memory Activity Tab. | /memory-activity-tab | src/pages/admin/memory/MemoryActivityTab.tsx |
+| Admin surfaces | admin page | New Run Wizard | Admin surface for New Run Wizard. | /new-run-wizard | src/pages/admin/testpass/NewRunWizard.tsx |
+| Admin surfaces | admin page | Report Detail | Admin surface for Report Detail. | /report-detail | src/pages/admin/testpass/ReportDetail.tsx |
+| Admin surfaces | admin page | Run Detail | Admin surface for Run Detail. | /run-detail | src/pages/admin/testpass/RunDetail.tsx |
+| Admin surfaces | admin page | search Highlight | Admin surface for search Highlight. | /search-highlight | src/pages/admin/searchHighlight.tsx |
+| Admin surfaces | admin page | Sessions Tab | Memory admin panel for Sessions Tab. | /sessions-tab | src/pages/admin/memory/SessionsTab.tsx |
+| Admin surfaces | admin page | Settings | Admin surface for Settings. | /settings | src/pages/admin/fishbowl/Settings.tsx |
+| Admin surfaces | admin page | Signals Catalog | Admin surface for Signals Catalog. | /signals-catalog | src/pages/admin/signals/SignalsCatalog.tsx |
+| Admin surfaces | admin page | Signals Settings | Admin surface for Signals Settings. | /signals-settings | src/pages/admin/signals/SignalsSettings.tsx |
+| Admin surfaces | admin page | Storage Bar | Memory admin panel for Storage Bar. | /storage-bar | src/pages/admin/memory/StorageBar.tsx |
+| Admin surfaces | admin page | Test Pass Catalog | Admin surface for Test Pass Catalog. | /test-pass-catalog | src/pages/admin/testpass/TestPassCatalog.tsx |
+| Admin surfaces | admin page | Todos | Admin surface for Todos. | /todos | src/pages/admin/fishbowl/Todos.tsx |
+| Admin surfaces | admin page | Un Click Tools | Tool page for Un Click Tools. | /tools/un-click-tools | src/pages/admin/tools/UnClickTools.tsx |
+| Automations | autopilot module | autopilot control ledger | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilot-control-ledger.ts |
+| Automations | autopilot module | autopilotkit liveness | autopilotkit liveness shared frontend logic. | - | scripts/lib/autopilotkit-liveness.mjs |
+| Automations | autopilot module | pinballwake autopilot master loop | pinballwake autopilot master loop UnClick module. | - | scripts/pinballwake-autopilot-master-loop.mjs |
+| Automations | autopilot module | pinballwake autopilot triage | pinballwake autopilot triage UnClick module. | - | scripts/pinballwake-autopilot-triage.mjs |
+| Automations | script | autopilotkit liveness | Autopilot coordination, proof, or wake helper. | - | scripts/lib/autopilotkit-liveness.mjs |
+| Automations | script | autopilotkit liveness.test | Autopilot coordination, proof, or wake helper. | - | scripts/autopilotkit-liveness.test.mjs |
+| Automations | script | enterprisepass receipt guard.test | Receipt bridge or proof trail helper. | - | scripts/enterprisepass-receipt-guard.test.mjs |
+| Automations | script | event wake router | Wake routing, ACK, or stale-handling helper. | - | scripts/event-wake-router.mjs |
+| Automations | script | event wake router.test | Wake routing, ACK, or stale-handling helper. | - | scripts/event-wake-router.test.mjs |
+| Automations | script | pinballwake ack ledger room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-ack-ledger-room.mjs |
+| Automations | script | pinballwake ack ledger room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-ack-ledger-room.test.mjs |
+| Automations | script | pinballwake autonomous runner | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-autonomous-runner.mjs |
+| Automations | script | pinballwake autonomous runner.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-autonomous-runner.test.mjs |
+| Automations | script | pinballwake autopilot master loop | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-autopilot-master-loop.mjs |
+| Automations | script | pinballwake autopilot master loop.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-autopilot-master-loop.test.mjs |
+| Automations | script | pinballwake autopilot triage | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-autopilot-triage.mjs |
+| Automations | script | pinballwake autopilot triage.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-autopilot-triage.test.mjs |
+| Automations | script | pinballwake build executor | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-build-executor.mjs |
+| Automations | script | pinballwake build executor.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-build-executor.test.mjs |
+| Automations | script | pinballwake buildbait room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-buildbait-room.mjs |
+| Automations | script | pinballwake buildbait room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-buildbait-room.test.mjs |
+| Automations | script | pinballwake close supersede room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-close-supersede-room.mjs |
+| Automations | script | pinballwake close supersede room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-close-supersede-room.test.mjs |
+| Automations | script | pinballwake coding room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-coding-room.mjs |
+| Automations | script | pinballwake coding room runner | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-coding-room-runner.mjs |
+| Automations | script | pinballwake coding room runner.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-coding-room-runner.test.mjs |
+| Automations | script | pinballwake coding room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-coding-room.test.mjs |
+| Automations | script | pinballwake commonsense pass | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-commonsense-pass.mjs |
+| Automations | script | pinballwake commonsense pass.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-commonsense-pass.test.mjs |
+| Automations | script | pinballwake continuous improvement room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-continuous-improvement-room.mjs |
+| Automations | script | pinballwake continuous improvement room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-continuous-improvement-room.test.mjs |
+| Automations | script | pinballwake dogfood room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-dogfood-room.mjs |
+| Automations | script | pinballwake dogfood room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-dogfood-room.test.mjs |
+| Automations | script | pinballwake event ledger room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-event-ledger-room.mjs |
+| Automations | script | pinballwake event ledger room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-event-ledger-room.test.mjs |
+| Automations | script | pinballwake executor lane | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-executor-lane.mjs |
+| Automations | script | pinballwake executor lane.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-executor-lane.test.mjs |
+| Automations | script | pinballwake executor packet | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-executor-packet.mjs |
+| Automations | script | pinballwake executor packet.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-executor-packet.test.mjs |
+| Automations | script | pinballwake jobs room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-jobs-room.mjs |
+| Automations | script | pinballwake jobs room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-jobs-room.test.mjs |
+| Automations | script | pinballwake launchpad room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-launchpad-room.mjs |
+| Automations | script | pinballwake launchpad room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-launchpad-room.test.mjs |
+| Automations | script | pinballwake merge controller | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-merge-controller.mjs |
+| Automations | script | pinballwake merge controller.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-merge-controller.test.mjs |
+| Automations | script | pinballwake merge room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-merge-room.mjs |
+| Automations | script | pinballwake merge room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-merge-room.test.mjs |
+| Automations | script | pinballwake openhands proof runner | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-openhands-proof-runner.mjs |
+| Automations | script | pinballwake openhands proof runner.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-openhands-proof-runner.test.mjs |
+| Automations | script | pinballwake openhands worker | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-openhands-worker.mjs |
+| Automations | script | pinballwake openhands worker.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-openhands-worker.test.mjs |
+| Automations | script | pinballwake overlap resolver room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-overlap-resolver-room.mjs |
+| Automations | script | pinballwake overlap resolver room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-overlap-resolver-room.test.mjs |
+| Automations | script | pinballwake personality room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-personality-room.mjs |
+| Automations | script | pinballwake personality room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-personality-room.test.mjs |
+| Automations | script | pinballwake pipeline dry run | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-pipeline-dry-run.mjs |
+| Automations | script | pinballwake pipeline dry run.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-pipeline-dry-run.test.mjs |
+| Automations | script | pinballwake pipeline executor | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-pipeline-executor.mjs |
+| Automations | script | pinballwake pipeline executor.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-pipeline-executor.test.mjs |
+| Automations | script | pinballwake planning room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-planning-room.mjs |
+| Automations | script | pinballwake planning room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-planning-room.test.mjs |
+| Automations | script | pinballwake post merge watch room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-post-merge-watch-room.mjs |
+| Automations | script | pinballwake post merge watch room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-post-merge-watch-room.test.mjs |
+| Automations | script | pinballwake proof executor | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-proof-executor.mjs |
+| Automations | script | pinballwake proof executor.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-proof-executor.test.mjs |
+| Automations | script | pinballwake publish room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-publish-room.mjs |
+| Automations | script | pinballwake publish room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-publish-room.test.mjs |
+| Automations | script | pinballwake queue health room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-queue-health-room.mjs |
+| Automations | script | pinballwake queue health room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-queue-health-room.test.mjs |
+| Automations | script | pinballwake quiet window proof | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-quiet-window-proof.mjs |
+| Automations | script | pinballwake quiet window proof.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-quiet-window-proof.test.mjs |
+| Automations | script | pinballwake release notes room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-release-notes-room.mjs |
+| Automations | script | pinballwake release notes room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-release-notes-room.test.mjs |
+| Automations | script | pinballwake repair room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-repair-room.mjs |
+| Automations | script | pinballwake repair room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-repair-room.test.mjs |
+| Automations | script | pinballwake research room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-research-room.mjs |
+| Automations | script | pinballwake research room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-research-room.test.mjs |
+| Automations | script | pinballwake rollback room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-rollback-room.mjs |
+| Automations | script | pinballwake rollback room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-rollback-room.test.mjs |
+| Automations | script | pinballwake scopepack hydrator | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-scopepack-hydrator.mjs |
+| Automations | script | pinballwake stale room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-stale-room.mjs |
+| Automations | script | pinballwake stale room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-stale-room.test.mjs |
+| Automations | script | pinballwake worker registry room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-worker-registry-room.mjs |
+| Automations | script | pinballwake worker registry room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-worker-registry-room.test.mjs |
+| Automations | script | pinballwake xpass gate room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-xpass-gate-room.mjs |
+| Automations | script | pinballwake xpass gate room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-xpass-gate-room.test.mjs |
+| Automations | script | tier2 auto merge queue check | tier2 auto merge queue check operational script. | - | scripts/tier2-auto-merge-queue-check.mjs |
+| Automations | script | tier2 auto merge queue check.test | tier2 auto merge queue check.test operational script. | - | scripts/tier2-auto-merge-queue-check.test.mjs |
+| Automations | script | Un Click brainmap | Brainmap generator or freshness check. | - | scripts/UnClick-brainmap.mjs |
+| Automations | script | Un Click brainmap.test | Brainmap generator or freshness check. | - | scripts/UnClick-brainmap.test.mjs |
+| Automations | workflow | apply migrations.yml | apply migrations GitHub automation workflow. | - | .github/workflows/apply-migrations.yml |
+| Automations | workflow | auto close fishbowl todo.yml | auto close fishbowl todo GitHub automation workflow. | - | .github/workflows/auto-close-fishbowl-todo.yml |
+| Automations | workflow | autonomous runner.yml | autonomous runner GitHub automation workflow. | - | .github/workflows/autonomous-runner.yml |
+| Automations | workflow | brainmap auto update.yml | Scheduled workflow that regenerates the ecosystem Brainmap. | - | .github/workflows/brainmap-auto-update.yml |
+| Automations | workflow | ci.yml | Continuous integration checks for build, tests, and proof safety. | - | .github/workflows/ci.yml |
+| Automations | workflow | claude.yml | claude GitHub automation workflow. | - | .github/workflows/claude.yml |
+| Automations | workflow | dirty branch hygiene.yml | dirty branch hygiene GitHub automation workflow. | - | .github/workflows/dirty-branch-hygiene.yml |
+| Automations | workflow | dogfood report.yml | dogfood report GitHub automation workflow. | - | .github/workflows/dogfood-report.yml |
+| Automations | workflow | event wake router.yml | GitHub-triggered wake and routing workflow. | - | .github/workflows/event-wake-router.yml |
+| Automations | workflow | fleet throughput watch.yml | fleet throughput watch GitHub automation workflow. | - | .github/workflows/fleet-throughput-watch.yml |
+| Automations | workflow | openhands test mode.yml | openhands test mode GitHub automation workflow. | - | .github/workflows/openhands-test-mode.yml |
+| Automations | workflow | publish channel package.yml | publish channel package GitHub automation workflow. | - | .github/workflows/publish-channel-package.yml |
+| Automations | workflow | publish mcp package.yml | publish mcp package GitHub automation workflow. | - | .github/workflows/publish-mcp-package.yml |
+| Automations | workflow | review enforcement warning.yml | review enforcement warning GitHub automation workflow. | - | .github/workflows/review-enforcement-warning.yml |
+| Automations | workflow | seed vault.yml | seed vault GitHub automation workflow. | - | .github/workflows/seed-vault.yml |
+| Automations | workflow | testpass pr check.yml | testpass pr check GitHub automation workflow. | - | .github/workflows/testpass-pr-check.yml |
+| Automations | workflow | testpass scheduled smoke.yml | testpass scheduled smoke GitHub automation workflow. | - | .github/workflows/testpass-scheduled-smoke.yml |
+| Automations | workflow | tier2 auto merge queue check.yml | tier2 auto merge queue check GitHub automation workflow. | - | .github/workflows/tier2-auto-merge-queue-check.yml |
+| Launch and onboarding | brainmap source | Un Click brainmap | Un Click brainmap UnClick module. | - | scripts/UnClick-brainmap.mjs |
+| Launch and onboarding | map | Ecosystem Brainmap | Generated sitemap and system map that teaches seats what UnClick contains. | /admin/brainmap | src/pages/admin/AdminBrainmap.tsx |
+| Launch and onboarding | policy | Heartbeat Master | Canonical schedule prompt and procedure for safe heartbeat seats. | /admin/agents/heartbeat | src/pages/admin/AdminSeatHeartbeat.tsx |
+| Launch and onboarding | route | Launchpad | Control hub that points seats to the next safe operating lane. | /admin/pinballwake | scripts/pinballwake-launchpad-room.mjs |
+| Ledgers and proof | ledger | Proof Ledger | Structured evidence, proof freshness, receipts, and DONE trust surface. | - | docs/agent-observability.md |
+| Ledgers and proof | proof module | pinballwake ack ledger room | pinballwake ack ledger room UnClick module. | - | scripts/pinballwake-ack-ledger-room.mjs |
+| Ledgers and proof | proof module | pinballwake event ledger room | pinballwake event ledger room UnClick module. | - | scripts/pinballwake-event-ledger-room.mjs |
+| Ledgers and proof | proof module | pinballwake openhands proof runner | pinballwake openhands proof runner UnClick module. | - | scripts/pinballwake-openhands-proof-runner.mjs |
+| Ledgers and proof | proof module | pinballwake proof executor | pinballwake proof executor UnClick module. | - | scripts/pinballwake-proof-executor.mjs |
+| Ledgers and proof | proof module | pinballwake quiet window proof | pinballwake quiet window proof UnClick module. | - | scripts/pinballwake-quiet-window-proof.mjs |
+| Modules and apps | app | api | package UnClick module. | - | apps/api/package.json |
+| Modules and apps | app | jobsmith | JobSmith application module for CV, checklist, and rule-pack work. | - | apps/jobsmith/package.json |
+| Modules and apps | app | JobSmith | CV, cover-letter, job application, and rules/checklist engine. | /admin/jobsmith | apps/jobsmith/package.json |
+| Modules and apps | automation module | AutoPilotKit | Internal automation bolt-on for proof-first work motion. | - | AUTOPILOT.md |
+| Modules and apps | package | channel plugin | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/channel-plugin/package.json |
+| Modules and apps | package | commonsensepass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/commonsensepass/package.json |
+| Modules and apps | package | copypass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/copypass/package.json |
+| Modules and apps | package | core | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/core/package.json |
+| Modules and apps | package | flowpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/flowpass/package.json |
+| Modules and apps | package | geopass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/geopass/package.json |
+| Modules and apps | package | legalpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/legalpass/package.json |
+| Modules and apps | package | mcp server | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/mcp-server/package.json |
+| Modules and apps | package | memory mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/memory-mcp/package.json |
+| Modules and apps | package | securitypass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/securitypass/package.json |
+| Modules and apps | package | seopass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/seopass/package.json |
+| Modules and apps | package | sloppass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/sloppass/package.json |
+| Modules and apps | package | testpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/testpass/package.json |
+| Modules and apps | package | uxpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/uxpass/package.json |
+| Modules and apps | package | wizard | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/wizard/package.json |
+| Passes and gates | fidelity gate | CopyRoom | Exact-copy room for code, docs, tables, notes, and source text so seats do not retype drift-prone material. | - | docs/UnClick-brainmap.generated.md |
+| Passes and gates | fidelity gate | FidelityPass | Checks exactness and invariant preservation when copying, refactoring, or translating content. | - | scripts/fidelitycopy.test.mjs |
+| Passes and gates | judgment gate | CommonSensePass | Plain-reasoning gate used before healthy, done, merge-ready, or PASS claims. | - | api/commonsensepass-bridge.test.ts |
+| Passes and gates | pass | testpass | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/testpass.ts |
+| Passes and gates | pass | testpass background handoff | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/testpass-background-handoff.ts |
+| Passes and gates | pass | testpass boundary | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/testpass-boundary.ts |
+| Passes and gates | pass | testpass run | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/testpass-run.ts |
+| Passes and gates | pass | uxpass | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/uxpass.ts |
+| Passes and gates | pass | uxpass run | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/uxpass-run.ts |
+| Passes and gates | pass | uxpass run handoff | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/uxpass-run-handoff.ts |
+| Passes and gates | pass | uxpass site sweep | uxpass site sweep UnClick module. | - | scripts/uxpass-site-sweep.mjs |
+| Passes and gates | wake gate | WakePass | Verifies ACKs, stale handoffs, and worker wake requests before motion claims. | - | docs/pinballwake-igniteonly-api.md |
+| Public surfaces | public page | Admin Settings | Account and admin configuration. | /admin/settings | src/pages/AdminSettings.tsx |
+| Public surfaces | public page | Arena Home | Arena page for Arena Home. | /arena/arena-home | src/pages/arena/ArenaHome.tsx |
+| Public surfaces | public page | Arena Leaderboard | Arena page for Arena Leaderboard. | /arena/arena-leaderboard | src/pages/arena/ArenaLeaderboard.tsx |
+| Public surfaces | public page | Arena Problem | Arena page for Arena Problem. | /arena/arena-problem | src/pages/arena/ArenaProblem.tsx |
+| Public surfaces | public page | Arena Submit Problem | Arena page for Arena Submit Problem. | /arena/arena-submit-problem | src/pages/arena/ArenaSubmitProblem.tsx |
+| Public surfaces | public page | Auth Callback | User-facing page for Auth Callback. | /auth-callback | src/pages/AuthCallback.tsx |
+| Public surfaces | public page | Backstage Pass | User-facing page for Backstage Pass. | /backstage-pass | src/pages/BackstagePass.tsx |
+| Public surfaces | public page | Build Desk | Build and project work surface. | /build-desk | src/pages/BuildDesk.tsx |
+| Public surfaces | public page | Connect | User-facing page for Connect. | /connect | src/pages/Connect.tsx |
+| Public surfaces | public page | Crews | Public Crews explanation and entry point. | /crews | src/pages/Crews.tsx |
+| Public surfaces | public page | Developer Docs | Developer documentation. | /developer-docs | src/pages/DeveloperDocs.tsx |
+| Public surfaces | public page | Developer Submit | Tool submission flow. | /developer-submit | src/pages/DeveloperSubmit.tsx |
+| Public surfaces | public page | Developers | Developer-facing entry point. | /developers | src/pages/Developers.tsx |
+| Public surfaces | public page | Dispatch | Dispatch and message handoff surface. | /dispatch | src/pages/Dispatch.tsx |
+| Public surfaces | public page | Docs | User-facing page for Docs. | /docs | src/pages/Docs.tsx |
+| Public surfaces | public page | Dogfood Report | Public dogfood proof report. | /dogfood-report | src/pages/DogfoodReport.tsx |
+| Public surfaces | public page | FAQPage | User-facing page for FAQPage. | /faqpage | src/pages/FAQPage.tsx |
+| Public surfaces | public page | Index | Public home and first explanation of UnClick. | / | src/pages/Index.tsx |
+| Public surfaces | public page | Install Recover | User-facing page for Install Recover. | /install-recover | src/pages/InstallRecover.tsx |
+| Public surfaces | public page | Jobsmith | User-facing page for Jobsmith. | /jobsmith | src/pages/Jobsmith.tsx |
+| Public surfaces | public page | Link In Bio | Tool page for Link In Bio. | /tools/link-in-bio | src/pages/tools/LinkInBio.tsx |
+| Public surfaces | public page | Login | Sign-in page. | /login | src/pages/Login.tsx |
+| Public surfaces | public page | Memory | Public memory product page. | /memory | src/pages/Memory.tsx |
+| Public surfaces | public page | Memory Admin | User-facing page for Memory Admin. | /memory-admin | src/pages/MemoryAdmin.tsx |
+| Public surfaces | public page | Memory Connect | User-facing page for Memory Connect. | /memory-connect | src/pages/MemoryConnect.tsx |
+| Public surfaces | public page | Memory Setup | User-facing page for Memory Setup. | /memory-setup | src/pages/MemorySetup.tsx |
+| Public surfaces | public page | Memory Setup Guide | User-facing page for Memory Setup Guide. | /memory-setup-guide | src/pages/MemorySetupGuide.tsx |
+| Public surfaces | public page | New To AI | Beginner-friendly AI orientation. | /new-to-ai | src/pages/NewToAI.tsx |
+| Public surfaces | public page | Not Found | User-facing page for Not Found. | /not-found | src/pages/NotFound.tsx |
+| Public surfaces | public page | Organiser | User-facing page for Organiser. | /organiser | src/pages/Organiser.tsx |
+| Public surfaces | public page | Pricing | Plans, billing, and packaging. | /pricing | src/pages/Pricing.tsx |
+| Public surfaces | public page | Privacy | Privacy policy. | /privacy | src/pages/Privacy.tsx |
+| Public surfaces | public page | Scheduling | Tool page for Scheduling. | /tools/scheduling | src/pages/tools/Scheduling.tsx |
+| Public surfaces | public page | Settings | User-facing page for Settings. | /settings | src/pages/Settings.tsx |
+| Public surfaces | public page | Signup | Sign-up page. | /signup | src/pages/Signup.tsx |
+| Public surfaces | public page | Smart Home | User-facing page for Smart Home. | /smart-home | src/pages/SmartHome.tsx |
+| Public surfaces | public page | Solve | Tool page for Solve. | /tools/solve | src/pages/tools/Solve.tsx |
+| Public surfaces | public page | Terms | Terms of service. | /terms | src/pages/Terms.tsx |
+| Public surfaces | public page | Tools | Public tools marketplace entry point. | /tools | src/pages/Tools.tsx |
+| Public surfaces | public page | Verify Mfa | User-facing page for Verify Mfa. | /verify-mfa | src/pages/VerifyMfa.tsx |
+| Public surfaces | public page | Vibe Coding | User-facing page for Vibe Coding. | /vibe-coding | src/pages/VibeCoding.tsx |
+| Rooms | PinballWake room | ack ledger | PinballWake room logic generated from scripts/pinballwake-ack-ledger-room.mjs. | - | scripts/pinballwake-ack-ledger-room.mjs |
+| Rooms | PinballWake room | buildbait | PinballWake room logic generated from scripts/pinballwake-buildbait-room.mjs. | - | scripts/pinballwake-buildbait-room.mjs |
+| Rooms | PinballWake room | close supersede | PinballWake room logic generated from scripts/pinballwake-close-supersede-room.mjs. | - | scripts/pinballwake-close-supersede-room.mjs |
+| Rooms | PinballWake room | coding | PinballWake room logic generated from scripts/pinballwake-coding-room.mjs. | - | scripts/pinballwake-coding-room.mjs |
+| Rooms | PinballWake room | continuous improvement | PinballWake room logic generated from scripts/pinballwake-continuous-improvement-room.mjs. | - | scripts/pinballwake-continuous-improvement-room.mjs |
+| Rooms | PinballWake room | dogfood | PinballWake room logic generated from scripts/pinballwake-dogfood-room.mjs. | - | scripts/pinballwake-dogfood-room.mjs |
+| Rooms | PinballWake room | event ledger | PinballWake room logic generated from scripts/pinballwake-event-ledger-room.mjs. | - | scripts/pinballwake-event-ledger-room.mjs |
+| Rooms | PinballWake room | jobs | PinballWake room logic generated from scripts/pinballwake-jobs-room.mjs. | - | scripts/pinballwake-jobs-room.mjs |
+| Rooms | PinballWake room | launchpad | PinballWake room logic generated from scripts/pinballwake-launchpad-room.mjs. | - | scripts/pinballwake-launchpad-room.mjs |
+| Rooms | PinballWake room | merge | PinballWake room logic generated from scripts/pinballwake-merge-room.mjs. | - | scripts/pinballwake-merge-room.mjs |
+| Rooms | PinballWake room | overlap resolver | PinballWake room logic generated from scripts/pinballwake-overlap-resolver-room.mjs. | - | scripts/pinballwake-overlap-resolver-room.mjs |
+| Rooms | PinballWake room | personality | PinballWake room logic generated from scripts/pinballwake-personality-room.mjs. | - | scripts/pinballwake-personality-room.mjs |
+| Rooms | PinballWake room | planning | PinballWake room logic generated from scripts/pinballwake-planning-room.mjs. | - | scripts/pinballwake-planning-room.mjs |
+| Rooms | PinballWake room | post merge watch | PinballWake room logic generated from scripts/pinballwake-post-merge-watch-room.mjs. | - | scripts/pinballwake-post-merge-watch-room.mjs |
+| Rooms | PinballWake room | publish | PinballWake room logic generated from scripts/pinballwake-publish-room.mjs. | - | scripts/pinballwake-publish-room.mjs |
+| Rooms | PinballWake room | queue health | PinballWake room logic generated from scripts/pinballwake-queue-health-room.mjs. | - | scripts/pinballwake-queue-health-room.mjs |
+| Rooms | PinballWake room | release notes | PinballWake room logic generated from scripts/pinballwake-release-notes-room.mjs. | - | scripts/pinballwake-release-notes-room.mjs |
+| Rooms | PinballWake room | repair | PinballWake room logic generated from scripts/pinballwake-repair-room.mjs. | - | scripts/pinballwake-repair-room.mjs |
+| Rooms | PinballWake room | research | PinballWake room logic generated from scripts/pinballwake-research-room.mjs. | - | scripts/pinballwake-research-room.mjs |
+| Rooms | PinballWake room | rollback | PinballWake room logic generated from scripts/pinballwake-rollback-room.mjs. | - | scripts/pinballwake-rollback-room.mjs |
+| Rooms | PinballWake room | stale | PinballWake room logic generated from scripts/pinballwake-stale-room.mjs. | - | scripts/pinballwake-stale-room.mjs |
+| Rooms | PinballWake room | worker registry | PinballWake room logic generated from scripts/pinballwake-worker-registry-room.mjs. | - | scripts/pinballwake-worker-registry-room.mjs |
+| Rooms | PinballWake room | xpass gate | PinballWake room logic generated from scripts/pinballwake-xpass-gate-room.mjs. | - | scripts/pinballwake-xpass-gate-room.mjs |
+| Source of truth | context | Orchestrator | Continuity stream and story layer that helps seats understand what happened. | /admin/orchestrator | src/pages/admin/AdminOrchestrator.tsx |
+| Source of truth | memory | Memory Library | Source-linked facts, sessions, context, and generated memory shelves. | /admin/memory | src/pages/admin/AdminMemory.tsx |
+| Source of truth | queue | Boardroom Jobs | Primary work source for open, in-progress, done, and dropped chips. | /admin/jobs | src/pages/admin/AdminJobs.tsx |
+| Source of truth | state module | embed | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory/embed.ts |
+| Source of truth | state module | memory admin | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory-admin.ts |
+| Source of truth | state module | memory Data Island | memory Data Island shared frontend logic. | - | src/lib/memoryDataIsland.ts |
+| Source of truth | state module | memory retrieval eval | memory retrieval eval UnClick module. | - | scripts/memory-retrieval-eval.mjs |
+| Source of truth | state module | memory Taxonomy | memory Taxonomy shared frontend logic. | - | src/lib/memoryTaxonomy.ts |
+| Source of truth | state module | orchestrator context | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/orchestrator-context.ts |
+| Tools | MCP tool | abn | abn MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/abn-tool.ts |
+| Tools | MCP tool | abuseipdb | abuseipdb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/abuseipdb-tool.ts |
+| Tools | MCP tool | airtable | airtable MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/airtable-tool.ts |
+| Tools | MCP tool | algolia | algolia MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/algolia-tool.ts |
+| Tools | MCP tool | alphavantage | alphavantage MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/alphavantage-tool.ts |
+| Tools | MCP tool | amazon | amazon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/amazon-tool.ts |
+| Tools | MCP tool | amber | amber MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/amber-tool.ts |
+| Tools | MCP tool | anthropic | anthropic MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/anthropic-tool.ts |
+| Tools | MCP tool | asana | asana MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/asana-tool.ts |
+| Tools | MCP tool | assemblyai | assemblyai MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/assemblyai-tool.ts |
+| Tools | MCP tool | australiapost | australiapost MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/australiapost-tool.ts |
+| Tools | MCP tool | bandsintown | bandsintown MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bandsintown-tool.ts |
+| Tools | MCP tool | bgg | bgg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bgg-tool.ts |
+| Tools | MCP tool | bluesky | bluesky MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bluesky-tool.ts |
+| Tools | MCP tool | bungie | bungie MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bungie-tool.ts |
+| Tools | MCP tool | calculator | calculator MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/calculator-tool.ts |
+| Tools | MCP tool | calendly | calendly MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/calendly-tool.ts |
+| Tools | MCP tool | carboninterface | carboninterface MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/carboninterface-tool.ts |
+| Tools | MCP tool | chessdotcom | chessdotcom MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/chessdotcom-tool.ts |
+| Tools | MCP tool | circleci | circleci MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/circleci-tool.ts |
+| Tools | MCP tool | clickup | clickup MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/clickup-tool.ts |
+| Tools | MCP tool | clockify | clockify MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/clockify-tool.ts |
+| Tools | MCP tool | cohere | cohere MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/cohere-tool.ts |
+| Tools | MCP tool | coingecko | coingecko MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/coingecko-tool.ts |
+| Tools | MCP tool | coinmarketcap | coinmarketcap MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/coinmarketcap-tool.ts |
+| Tools | MCP tool | color | color MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/color-tool.ts |
+| Tools | MCP tool | convertkit | convertkit MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/convertkit-tool.ts |
+| Tools | MCP tool | copypass | copypass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/copypass-tool.ts |
+| Tools | MCP tool | crews | crews MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/crews-tool.ts |
+| Tools | MCP tool | csuite | csuite MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/csuite-tool.ts |
+| Tools | MCP tool | datadog | datadog MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/datadog-tool.ts |
+| Tools | MCP tool | datetime | datetime MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/datetime-tool.ts |
+| Tools | MCP tool | deepl | deepl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/deepl-tool.ts |
+| Tools | MCP tool | deezer | deezer MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/deezer-tool.ts |
+| Tools | MCP tool | discogs | discogs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/discogs-tool.ts |
+| Tools | MCP tool | discord | discord MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/discord-tool.ts |
+| Tools | MCP tool | domain | domain MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/domain-tool.ts |
+| Tools | MCP tool | ebay | ebay MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ebay-tool.ts |
+| Tools | MCP tool | ebird | ebird MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ebird-tool.ts |
+| Tools | MCP tool | elevenlabs | elevenlabs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/elevenlabs-tool.ts |
+| Tools | MCP tool | email | email MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/email-tool.ts |
+| Tools | MCP tool | espn | espn MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/espn-tool.ts |
+| Tools | MCP tool | etsy | etsy MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/etsy-tool.ts |
+| Tools | MCP tool | eventbrite | eventbrite MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/eventbrite-tool.ts |
+| Tools | MCP tool | exchangerate | exchangerate MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/exchangerate-tool.ts |
+| Tools | MCP tool | feedly | feedly MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/feedly-tool.ts |
+| Tools | MCP tool | figma | figma MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/figma-tool.ts |
+| Tools | MCP tool | flyio | flyio MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/flyio-tool.ts |
+| Tools | MCP tool | foursquare | foursquare MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/foursquare-tool.ts |
+| Tools | MCP tool | fpl | fpl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fpl-tool.ts |
+| Tools | MCP tool | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gdelt-tool.ts |
+| Tools | MCP tool | genius | genius MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/genius-tool.ts |
+| Tools | MCP tool | github | github MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/github-tool.ts |
+| Tools | MCP tool | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gitlab-tool.ts |
+| Tools | MCP tool | groq | groq MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/groq-tool.ts |
+| Tools | MCP tool | guardian | guardian MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/guardian-tool.ts |
+| Tools | MCP tool | gumroad | gumroad MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gumroad-tool.ts |
+| Tools | MCP tool | hackernews | hackernews MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/hackernews-tool.ts |
+| Tools | MCP tool | haveibeenpwned | haveibeenpwned MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/haveibeenpwned-tool.ts |
+| Tools | MCP tool | Heartbeat Protocol | Canonical heartbeat policy served to scheduled seats. | - | packages/mcp-server/src/heartbeat-protocol.ts |
+| Tools | MCP tool | heygen | heygen MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/heygen-tool.ts |
+| Tools | MCP tool | higgsfield | higgsfield MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/higgsfield-tool.ts |
+| Tools | MCP tool | hunter | hunter MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/hunter-tool.ts |
+| Tools | MCP tool | igdb | igdb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/igdb-tool.ts |
+| Tools | MCP tool | IgniteOnly | IgniteOnly verified worker wake packet bridge. | - | packages/mcp-server/src/igniteonly-tool.ts |
+| Tools | MCP tool | instapaper | instapaper MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/instapaper-tool.ts |
+| Tools | MCP tool | ipapi | ipapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ipapi-tool.ts |
+| Tools | MCP tool | ipaustralia | ipaustralia MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ipaustralia-tool.ts |
+| Tools | MCP tool | keychain | keychain MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/keychain-tool.ts |
+| Tools | MCP tool | kling | kling MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/kling-tool.ts |
+| Tools | MCP tool | lastfm | lastfm MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lastfm-tool.ts |
+| Tools | MCP tool | legalpass | legalpass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/legalpass-tool.ts |
+| Tools | MCP tool | lego | lego MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lego-tool.ts |
+| Tools | MCP tool | lemonsqueezy | lemonsqueezy MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lemonsqueezy-tool.ts |
+| Tools | MCP tool | lichess | lichess MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lichess-tool.ts |
+| Tools | MCP tool | line | line MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/line-tool.ts |
+| Tools | MCP tool | linear | linear MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/linear-tool.ts |
+| Tools | MCP tool | mailchimp | mailchimp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mailchimp-tool.ts |
+| Tools | MCP tool | mapbox | mapbox MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mapbox-tool.ts |
+| Tools | MCP tool | mastodon | mastodon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mastodon-tool.ts |
+| Tools | MCP tool | meal | meal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/meal-tool.ts |
+| Tools | MCP tool | mistral | mistral MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mistral-tool.ts |
+| Tools | MCP tool | mixpanel | mixpanel MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mixpanel-tool.ts |
+| Tools | MCP tool | monday | monday MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/monday-tool.ts |
+| Tools | MCP tool | monica | monica MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/monica-tool.ts |
+| Tools | MCP tool | musicbrainz | musicbrainz MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/musicbrainz-tool.ts |
+| Tools | MCP tool | nasa | nasa MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nasa-tool.ts |
+| Tools | MCP tool | neon | neon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/neon-tool.ts |
+| Tools | MCP tool | newsapi | newsapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/newsapi-tool.ts |
+| Tools | MCP tool | notion | notion MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/notion-tool.ts |
+| Tools | MCP tool | NudgeOnly | NudgeOnly low-token receipt bridge and advisory classifier. | - | packages/mcp-server/src/nudgeonly-tool.ts |
+| Tools | MCP tool | numbers | numbers MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/numbers-tool.ts |
+| Tools | MCP tool | nvd | nvd MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nvd-tool.ts |
+| Tools | MCP tool | omdb | omdb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/omdb-tool.ts |
+| Tools | MCP tool | openai | openai MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/openai-tool.ts |
+| Tools | MCP tool | openaq | openaq MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/openaq-tool.ts |
+| Tools | MCP tool | openexchangerates | openexchangerates MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/openexchangerates-tool.ts |
+| Tools | MCP tool | openf1 | openf1 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/openf1-tool.ts |
+| Tools | MCP tool | openfoodfacts | openfoodfacts MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/openfoodfacts-tool.ts |
+| Tools | MCP tool | openlibrary | openlibrary MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/openlibrary-tool.ts |
+| Tools | MCP tool | openmeteo | openmeteo MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/openmeteo-tool.ts |
+| Tools | MCP tool | pagerduty | pagerduty MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pagerduty-tool.ts |
+| Tools | MCP tool | pandascore | pandascore MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pandascore-tool.ts |
+| Tools | MCP tool | paypal | paypal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/paypal-tool.ts |
+| Tools | MCP tool | perplexity | perplexity MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/perplexity-tool.ts |
+| Tools | MCP tool | pika | pika MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pika-tool.ts |
+| Tools | MCP tool | pinecone | pinecone MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pinecone-tool.ts |
+| Tools | MCP tool | pinterest | pinterest MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pinterest-tool.ts |
+| Tools | MCP tool | plaid | plaid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/plaid-tool.ts |
+| Tools | MCP tool | podcastindex | podcastindex MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/podcastindex-tool.ts |
+| Tools | MCP tool | postman | postman MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/postman-tool.ts |
+| Tools | MCP tool | postmark | postmark MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/postmark-tool.ts |
+| Tools | MCP tool | ptv | ptv MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ptv-tool.ts |
+| Tools | MCP tool | pushonly | pushonly MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pushonly-tool.ts |
+| Tools | MCP tool | pushover | pushover MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pushover-tool.ts |
+| Tools | MCP tool | qc | qc MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/qc-tool.ts |
+| Tools | MCP tool | quickbooks | quickbooks MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/quickbooks-tool.ts |
+| Tools | MCP tool | radiobrowser | radiobrowser MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/radiobrowser-tool.ts |
+| Tools | MCP tool | raindrop | raindrop MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/raindrop-tool.ts |
+| Tools | MCP tool | random | random MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/random-tool.ts |
+| Tools | MCP tool | rawg | rawg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rawg-tool.ts |
+| Tools | MCP tool | readwise | readwise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/readwise-tool.ts |
+| Tools | MCP tool | reddit | reddit MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/reddit-tool.ts |
+| Tools | MCP tool | render | render MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/render-tool.ts |
+| Tools | MCP tool | replicate | replicate MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/replicate-tool.ts |
+| Tools | MCP tool | resend | resend MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/resend-tool.ts |
+| Tools | MCP tool | restcountries | restcountries MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/restcountries-tool.ts |
+| Tools | MCP tool | riot | riot MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/riot-tool.ts |
+| Tools | MCP tool | runway | runway MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/runway-tool.ts |
+| Tools | MCP tool | seatgeek | seatgeek MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/seatgeek-tool.ts |
+| Tools | MCP tool | segment | segment MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/segment-tool.ts |
+| Tools | MCP tool | sendgrid | sendgrid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sendgrid-tool.ts |
+| Tools | MCP tool | sendle | sendle MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sendle-tool.ts |
+| Tools | MCP tool | sentry | sentry MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sentry-tool.ts |
+| Tools | MCP tool | seopass | seopass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/seopass-tool.ts |
+| Tools | MCP tool | setlistfm | setlistfm MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/setlistfm-tool.ts |
+| Tools | MCP tool | shodan | shodan MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shodan-tool.ts |
+| Tools | MCP tool | shopify | shopify MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shopify-tool.ts |
+| Tools | MCP tool | slack | slack MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/slack-tool.ts |
+| Tools | MCP tool | sleeper | sleeper MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sleeper-tool.ts |
+| Tools | MCP tool | speedrun | speedrun MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/speedrun-tool.ts |
+| Tools | MCP tool | splitwise | splitwise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/splitwise-tool.ts |
+| Tools | MCP tool | spotify | spotify MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/spotify-tool.ts |
+| Tools | MCP tool | square | square MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/square-tool.ts |
+| Tools | MCP tool | stability | stability MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/stability-tool.ts |
+| Tools | MCP tool | steam | steam MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/steam-tool.ts |
+| Tools | MCP tool | stripe | stripe MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/stripe-tool.ts |
+| Tools | MCP tool | supercell | supercell MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/supercell-tool.ts |
+| Tools | MCP tool | tab | tab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tab-tool.ts |
+| Tools | MCP tool | telegram | telegram MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/telegram-tool.ts |
+| Tools | MCP tool | testpass | TestPass proof and test orchestration capability. | - | packages/mcp-server/src/testpass-tool.ts |
+| Tools | MCP tool | text | text MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/text-tool.ts |
+| Tools | MCP tool | thelott | thelott MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/thelott-tool.ts |
+| Tools | MCP tool | ticketmaster | ticketmaster MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ticketmaster-tool.ts |
+| Tools | MCP tool | tiktok | tiktok MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tiktok-tool.ts |
+| Tools | MCP tool | tmdb | tmdb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tmdb-tool.ts |
+| Tools | MCP tool | togetherai | togetherai MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/togetherai-tool.ts |
+| Tools | MCP tool | toggl | toggl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/toggl-tool.ts |
+| Tools | MCP tool | toilets | toilets MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/toilets-tool.ts |
+| Tools | MCP tool | tomorrowio | tomorrowio MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tomorrowio-tool.ts |
+| Tools | MCP tool | trello | trello MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trello-tool.ts |
+| Tools | MCP tool | trivia | trivia MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trivia-tool.ts |
+| Tools | MCP tool | trove | trove MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trove-tool.ts |
+| Tools | MCP tool | turso | turso MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/turso-tool.ts |
+| Tools | MCP tool | twilio | twilio MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/twilio-tool.ts |
+| Tools | MCP tool | twitch | twitch MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/twitch-tool.ts |
+| Tools | MCP tool | unit converter | unit converter MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/unit-converter-tool.ts |
+| Tools | MCP tool | untappd | untappd MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/untappd-tool.ts |
+| Tools | MCP tool | upstash | upstash MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/upstash-tool.ts |
+| Tools | MCP tool | urlscan | urlscan MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/urlscan-tool.ts |
+| Tools | MCP tool | usgs | usgs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/usgs-tool.ts |
+| Tools | MCP tool | uxpass | UXPass experience verification capability. | - | packages/mcp-server/src/uxpass-tool.ts |
+| Tools | MCP tool | vault | vault MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/vault-tool.ts |
+| Tools | MCP tool | vercel | vercel MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/vercel-tool.ts |
+| Tools | MCP tool | virustotal | virustotal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/virustotal-tool.ts |
+| Tools | MCP tool | whatsapp | whatsapp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/whatsapp-tool.ts |
+| Tools | MCP tool | willyweather | willyweather MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/willyweather-tool.ts |
+| Tools | MCP tool | wise | wise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wise-tool.ts |
+| Tools | MCP tool | woocommerce | woocommerce MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/woocommerce-tool.ts |
+| Tools | MCP tool | xero | xero MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/xero-tool.ts |
+| Tools | MCP tool | yelp | yelp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/yelp-tool.ts |
+| Tools | MCP tool | youtube | youtube MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/youtube-tool.ts |
+| Workers and seats | seat | Claude Reviewer Seat | External reviewer lane used for independent checks and proof review. | - | docs/fleet-worker-roles.md |
+| Workers and seats | seat | Codex Builder Seat | Codex lane used for scoped implementation, routing, and proof updates. | - | docs/fleet-worker-roles.md |
+| Workers and seats | seat | Cursor Builder Seat | External builder lane used for scoped code work and PRs. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Builder | Implements focused code or content changes from a scoped packet. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Coordinator | Routes work, chooses the next room, and keeps lanes aligned. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Improver | Turns repeated pain into system improvements. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Ledger | Records proof, receipts, approvals, and rollback evidence. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Publisher | Moves approved work toward deployment and public proof. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Reviewer | Checks quality, regressions, and missing tests. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Safety Checker | Protects secrets, auth, destructive actions, and release gates. | - | docs/fleet-worker-roles.md |
+| Workers and seats | worker role | Tester | Runs proof and reports what passed or blocked. | - | docs/fleet-worker-roles.md |
+| Wrappers and protocols | bridge | IgniteOnly | Verified worker wake packets only, never build, merge, or completion state. | - | docs/pinballwake-igniteonly-api.md |
+| Wrappers and protocols | bridge | NudgeOnly | Low-risk receipt nudges that never mutate source-of-truth state. | - | docs/pinballwake-nudgeonly-api.md |
+| Wrappers and protocols | claim lifecycle | SeatRelay | Stale release, smart reassignment, and bonded handoff for stuck worker claims. | - | docs/UnClick-brainmap.generated.md |
+
 ## Public/Internal Alias Table
 
 | Internal name | Public name | Meaning |
@@ -433,10 +948,11 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 ## Safety Rules
 
 - Admin-only surfaces use `RequireAdmin` and must also be hidden from non-admin sidebar navigation.
+- Brainmap visual admin is owner-only for `creativelead@malamutemayhem.com` inside the Yellow Private Admin lane.
 - NudgeOnly can request receipt or escalation only. Trusted lanes verify before action.
 - IgniteOnly can request worker wake packets only. Trusted lanes still build, review, merge, and record proof.
 - Heartbeats must never print keys or credentials.
-- Generated Brainmap changes must come from source updates plus a regenerated artifact, not hand editing the generated file.
+- Generated Brainmap changes must come from source updates plus regenerated artifacts, not hand editing the generated files.
 - Proof should include TestPass, Reviewer, Safety Checker, and Ledger-style evidence where applicable.
 
 ## Launchpad Route
@@ -469,4 +985,5 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | test:watch | vitest |
 
 - `node scripts/UnClick-brainmap.mjs --check` fails if `docs/UnClick-brainmap.generated.md` is stale.
+- `node scripts/UnClick-brainmap.mjs --check` also fails if `docs/UnClick-brainmap.generated.json` is stale.
 - `node --test scripts/UnClick-brainmap.test.mjs` verifies required sections and meaning rows.

--- a/scripts/UnClick-brainmap.mjs
+++ b/scripts/UnClick-brainmap.mjs
@@ -8,6 +8,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 export const GENERATED_PATH = "docs/UnClick-brainmap.generated.md";
+export const GENERATED_DATA_PATH = "docs/UnClick-brainmap.generated.json";
 
 const CORE_SOURCES = [
   "AUTOPILOT.md",
@@ -45,6 +46,43 @@ const WORKERS = [
   ["Ledger", "Records proof, receipts, approvals, and rollback evidence."],
   ["Publisher", "Moves approved work toward deployment and public proof."],
   ["Improver", "Turns repeated pain into system improvements."],
+];
+
+const DIVISIONS = [
+  ["Admin surfaces", "Private operator views and internal control panels."],
+  ["Public surfaces", "Public product, docs, marketplace, and user-facing routes."],
+  ["Tools", "MCP and gateway capabilities available to seats."],
+  ["Rooms", "PinballWake and Boardroom lanes that route work."],
+  ["Workers and seats", "Human and AI roles that move work through the system."],
+  ["Passes and gates", "Quality, proof, safety, and fidelity checks."],
+  ["Wrappers and protocols", "Thin harnesses, bridges, policies, and routing helpers."],
+  ["Automations", "Scheduled jobs, wake routes, cron workflows, and recurring checks."],
+  ["Ledgers and proof", "Receipts, audits, evidence, and proof-of-work surfaces."],
+  ["Source of truth", "Canonical state, queue, memory, and context surfaces."],
+  ["Modules and apps", "Apps, packages, and product modules that make up UnClick."],
+  ["Launch and onboarding", "Launchpad, Heartbeat, Brainmap, and first-seat orientation."],
+];
+
+const STATIC_SYSTEMS = [
+  ["Launch and onboarding", "Launchpad", "route", "Control hub that points seats to the next safe operating lane.", "scripts/pinballwake-launchpad-room.mjs", "/admin/pinballwake"],
+  ["Launch and onboarding", "Heartbeat Master", "policy", "Canonical schedule prompt and procedure for safe heartbeat seats.", "src/pages/admin/AdminSeatHeartbeat.tsx", "/admin/agents/heartbeat"],
+  ["Launch and onboarding", "Ecosystem Brainmap", "map", "Generated sitemap and system map that teaches seats what UnClick contains.", "src/pages/admin/AdminBrainmap.tsx", "/admin/brainmap"],
+  ["Source of truth", "Boardroom Jobs", "queue", "Primary work source for open, in-progress, done, and dropped chips.", "src/pages/admin/AdminJobs.tsx", "/admin/jobs"],
+  ["Source of truth", "Orchestrator", "context", "Continuity stream and story layer that helps seats understand what happened.", "src/pages/admin/AdminOrchestrator.tsx", "/admin/orchestrator"],
+  ["Source of truth", "Memory Library", "memory", "Source-linked facts, sessions, context, and generated memory shelves.", "src/pages/admin/AdminMemory.tsx", "/admin/memory"],
+  ["Passes and gates", "CopyRoom", "fidelity gate", "Exact-copy room for code, docs, tables, notes, and source text so seats do not retype drift-prone material.", "docs/UnClick-brainmap.generated.md", ""],
+  ["Passes and gates", "FidelityPass", "fidelity gate", "Checks exactness and invariant preservation when copying, refactoring, or translating content.", "scripts/fidelitycopy.test.mjs", ""],
+  ["Passes and gates", "CommonSensePass", "judgment gate", "Plain-reasoning gate used before healthy, done, merge-ready, or PASS claims.", "api/commonsensepass-bridge.test.ts", ""],
+  ["Passes and gates", "WakePass", "wake gate", "Verifies ACKs, stale handoffs, and worker wake requests before motion claims.", "docs/pinballwake-igniteonly-api.md", ""],
+  ["Wrappers and protocols", "NudgeOnly", "bridge", "Low-risk receipt nudges that never mutate source-of-truth state.", "docs/pinballwake-nudgeonly-api.md", ""],
+  ["Wrappers and protocols", "IgniteOnly", "bridge", "Verified worker wake packets only, never build, merge, or completion state.", "docs/pinballwake-igniteonly-api.md", ""],
+  ["Wrappers and protocols", "SeatRelay", "claim lifecycle", "Stale release, smart reassignment, and bonded handoff for stuck worker claims.", "docs/UnClick-brainmap.generated.md", ""],
+  ["Ledgers and proof", "Proof Ledger", "ledger", "Structured evidence, proof freshness, receipts, and DONE trust surface.", "docs/agent-observability.md", ""],
+  ["Modules and apps", "JobSmith", "app", "CV, cover-letter, job application, and rules/checklist engine.", "apps/jobsmith/package.json", "/admin/jobsmith"],
+  ["Modules and apps", "AutoPilotKit", "automation module", "Internal automation bolt-on for proof-first work motion.", "AUTOPILOT.md", ""],
+  ["Workers and seats", "Cursor Builder Seat", "seat", "External builder lane used for scoped code work and PRs.", "docs/fleet-worker-roles.md", ""],
+  ["Workers and seats", "Claude Reviewer Seat", "seat", "External reviewer lane used for independent checks and proof review.", "docs/fleet-worker-roles.md", ""],
+  ["Workers and seats", "Codex Builder Seat", "seat", "Codex lane used for scoped implementation, routing, and proof updates.", "docs/fleet-worker-roles.md", ""],
 ];
 
 const PAGE_MEANINGS = {
@@ -194,15 +232,97 @@ function roomName(file) {
   return titleFromName(path.basename(file, ".mjs").replace(/^pinballwake-/, "").replace(/-room$/, ""));
 }
 
-export async function generateBrainmap({ root = process.cwd() } = {}) {
+function normalizeId(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function uniqueRows(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const row of rows) {
+    const key = [row.division, row.kind, row.name, row.source].join("|");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(row);
+  }
+  return out.sort((a, b) =>
+    `${a.division}|${a.kind}|${a.name}`.localeCompare(`${b.division}|${b.kind}|${b.name}`),
+  );
+}
+
+function inventoryItem(division, name, kind, meaning, source, route = "", tags = []) {
+  return {
+    id: normalizeId(`${division}-${kind}-${name}-${source}`),
+    division,
+    name,
+    kind,
+    meaning: sentence(meaning),
+    source,
+    route,
+    tags,
+  };
+}
+
+function meaningForScript(file) {
+  const base = path.basename(file, ".mjs");
+  if (base.includes("pinballwake")) return "PinballWake room, wake, or routing script used by the automation lane.";
+  if (base.includes("brainmap")) return "Brainmap generator or freshness check.";
+  if (base.includes("autopilot")) return "Autopilot coordination, proof, or wake helper.";
+  if (base.includes("receipt")) return "Receipt bridge or proof trail helper.";
+  if (base.includes("wake")) return "Wake routing, ACK, or stale-handling helper.";
+  return `${titleFromName(base)} operational script.`;
+}
+
+function meaningForWorkflow(file) {
+  const base = path.basename(file, path.extname(file));
+  if (base.includes("brainmap")) return "Scheduled workflow that regenerates the ecosystem Brainmap.";
+  if (base.includes("ci")) return "Continuous integration checks for build, tests, and proof safety.";
+  if (base.includes("wake")) return "GitHub-triggered wake and routing workflow.";
+  return `${titleFromName(base)} GitHub automation workflow.`;
+}
+
+function meaningForModule(file) {
+  const base = path.basename(file, path.extname(file));
+  if (file.startsWith("apps/jobsmith/")) return "JobSmith application module for CV, checklist, and rule-pack work.";
+  if (file.startsWith("api/")) return "Server endpoint or helper used by UnClick admin, memory, workers, or tools.";
+  if (file.startsWith("packages/")) return "Shared package used by UnClick tools, MCP, or worker lanes.";
+  if (file.includes("/lib/")) return `${titleFromName(base)} shared frontend logic.`;
+  return `${titleFromName(base)} UnClick module.`;
+}
+
+function classifyConceptFile(file) {
+  const lower = file.toLowerCase();
+  if (/(\.test\.|__tests__|\.spec\.)/.test(lower)) return null;
+  if (lower.includes("brainmap")) return ["Launch and onboarding", "brainmap source"];
+  if (lower.includes("heartbeat")) return ["Launch and onboarding", "heartbeat source"];
+  if (lower.includes("jobsmith")) return ["Modules and apps", "app module"];
+  if (lower.includes("autopilot")) return ["Automations", "autopilot module"];
+  if (lower.includes("nudgeonly") || lower.includes("igniteonly") || lower.includes("pushonly")) return ["Wrappers and protocols", "bridge"];
+  if (lower.includes("wakepass") || lower.includes("testpass") || lower.includes("uxpass") || lower.includes("safetypass") || lower.includes("fidelity")) return ["Passes and gates", "pass"];
+  if (lower.includes("ledger") || lower.includes("receipt") || lower.includes("proof")) return ["Ledgers and proof", "proof module"];
+  if (lower.includes("orchestrator") || lower.includes("boardroom") || lower.includes("memory")) return ["Source of truth", "state module"];
+  return null;
+}
+
+async function collectBrainmapModel(root) {
   const pages = await walk(root, "src/pages", (file) => file.endsWith(".tsx") && !file.endsWith(".test.tsx"));
   const adminPages = pages.filter((file) => file.startsWith("src/pages/admin/"));
   const publicPages = pages.filter((file) => !file.startsWith("src/pages/admin/"));
   const toolFiles = await walk(root, "packages/mcp-server/src", (file) => file.endsWith("-tool.ts") || file.endsWith("heartbeat-protocol.ts"));
   const roomScripts = await walk(root, "scripts", (file) => /pinballwake-.*-room\.mjs$/.test(file));
+  const workflowFiles = await walk(root, ".github/workflows", (file) => /\.(yml|yaml)$/.test(file));
+  const scriptFiles = await walk(root, "scripts", (file) => /\.(mjs|js|ts)$/.test(file));
+  const appPackageFiles = await walk(root, "apps", (file) => file.endsWith("package.json"));
+  const packageFiles = await walk(root, "packages", (file) => file.endsWith("package.json"));
+  const apiFiles = await walk(root, "api", (file) => /\.(ts|js)$/.test(file) && !file.endsWith(".test.ts"));
+  const srcLibFiles = await walk(root, "src/lib", (file) => /\.(ts|tsx)$/.test(file) && !file.endsWith(".test.ts"));
   const packageJson = JSON.parse(await readText(root, "package.json") || "{}");
   const packageScripts = Object.entries(packageJson.scripts || {}).sort();
-  const sourceFiles = [...new Set([...CORE_SOURCES, ...roomScripts, ...toolFiles.slice(0, 40)])];
+  const conceptFiles = [...new Set([...scriptFiles, ...apiFiles, ...srcLibFiles])];
+  const sourceFiles = [...new Set([...CORE_SOURCES, ...roomScripts, ...toolFiles.slice(0, 40), ...workflowFiles])];
   const manifest = await manifestRows(root, sourceFiles);
 
   const pageRows = [...adminPages, ...publicPages].map((file) => [
@@ -228,14 +348,127 @@ export async function generateBrainmap({ root = process.cwd() } = {}) {
     .filter(([name, command]) => /test|build|lint|brainmap/i.test(`${name} ${command}`))
     .map(([name, command]) => [name, command]);
 
+  const inventory = uniqueRows([
+    ...STATIC_SYSTEMS.map(([division, name, kind, meaning, source, route]) =>
+      inventoryItem(division, name, kind, meaning, source, route),
+    ),
+    ...adminPages.map((file) =>
+      inventoryItem("Admin surfaces", titleFromName(path.basename(file)), "admin page", meaningForPage(file), file, routeForPage(file)),
+    ),
+    ...publicPages.map((file) =>
+      inventoryItem("Public surfaces", titleFromName(path.basename(file)), "public page", meaningForPage(file), file, routeForPage(file)),
+    ),
+    ...toolFiles.map((file) =>
+      inventoryItem("Tools", displayToolName(file), "MCP tool", meaningForTool(file), file),
+    ),
+    ...roomScripts.map((file) =>
+      inventoryItem("Rooms", roomName(file), "PinballWake room", `PinballWake room logic generated from ${file}.`, file),
+    ),
+    ...WORKERS.map(([name, meaning]) =>
+      inventoryItem("Workers and seats", name, "worker role", meaning, "docs/fleet-worker-roles.md"),
+    ),
+    ...workflowFiles.map((file) =>
+      inventoryItem("Automations", titleFromName(path.basename(file)), "workflow", meaningForWorkflow(file), file),
+    ),
+    ...scriptFiles
+      .filter((file) => /(wake|autopilot|receipt|brainmap|pinballwake|queue|heartbeat)/i.test(file))
+      .map((file) => inventoryItem("Automations", titleFromName(path.basename(file)), "script", meaningForScript(file), file)),
+    ...appPackageFiles.map((file) =>
+      inventoryItem("Modules and apps", titleFromName(path.dirname(file).split("/").at(-1)), "app", meaningForModule(file), file),
+    ),
+    ...packageFiles.map((file) =>
+      inventoryItem("Modules and apps", titleFromName(path.dirname(file).split("/").at(-1)), "package", meaningForModule(file), file),
+    ),
+    ...conceptFiles
+      .map((file) => {
+        const classification = classifyConceptFile(file);
+        if (!classification) return null;
+        return inventoryItem(classification[0], titleFromName(path.basename(file)), classification[1], meaningForModule(file), file);
+      })
+      .filter(Boolean),
+  ]);
+
+  const divisionCounts = new Map(inventory.map((item) => [item.division, 0]));
+  for (const item of inventory) divisionCounts.set(item.division, (divisionCounts.get(item.division) ?? 0) + 1);
+
+  return {
+    schema_version: "brainmap-v2",
+    title: "UnClick Ecosystem Brainmap",
+    summary: "Generated sitemap, system map, and tool-worker tree for private UnClick onboarding.",
+    owner_visibility: {
+      route: "/admin/brainmap",
+      audience: "private yellow admin",
+      owner_email: "creativelead@malamutemayhem.com",
+    },
+    counts: {
+      divisions: DIVISIONS.length,
+      inventory: inventory.length,
+      source_manifest: manifest.length,
+      pages: pageRows.length,
+      tools: toolRows.length,
+      rooms: roomRows.length,
+      workers: WORKERS.length,
+    },
+    divisions: DIVISIONS.map(([name, meaning]) => ({
+      id: normalizeId(name),
+      name,
+      meaning,
+      count: divisionCounts.get(name) ?? 0,
+    })),
+    inventory,
+    pageRows,
+    toolRows,
+    roomRows,
+    workerRows: WORKERS,
+    aliasRows: ALIASES,
+    ciRows,
+    source_manifest: manifest.map(([source, sourceHash, bytes]) => ({
+      source,
+      hash: sourceHash,
+      bytes: Number(bytes),
+    })),
+  };
+}
+
+function inventoryTableRows(inventory) {
+  return inventory.map((item) => [
+    item.division,
+    item.kind,
+    item.name,
+    item.meaning,
+    item.route || "-",
+    item.source,
+  ]);
+}
+
+export async function generateBrainmapData({ root = process.cwd() } = {}) {
+  const model = await collectBrainmapModel(root);
+  return `${JSON.stringify(model, null, 2)}\n`;
+}
+
+export async function generateBrainmap({ root = process.cwd() } = {}) {
+  const model = await collectBrainmapModel(root);
+  const manifest = model.source_manifest.map(({ source, hash: sourceHash, bytes }) => [source, sourceHash, bytes]);
+
   return [
     "# UnClick Ecosystem Brainmap",
     "",
     "Internal admin only. Auto-generated from tracked source so new AI seats can understand UnClick without a separate handover.",
     "",
+    "## Brainmap Data Contract",
+    "",
+    `- Schema: \`${model.schema_version}\`.`,
+    "- This markdown is paired with `docs/UnClick-brainmap.generated.json` for the private admin visual tree.",
+    "- The JSON inventory is grouped by division so seats can quickly discover tools, rooms, wrappers, workers, modules, passes, ledgers, and source-of-truth surfaces.",
+    "- The generator reruns in CI and on a schedule. New tracked surfaces appear after the generator sees their source paths.",
+    "",
     "## Source Manifest",
     "",
     table(["Source", "Hash", "Bytes"], manifest),
+    "",
+    "## Division Index",
+    "",
+    table(["Division", "Meaning", "Items"], model.divisions.map((division) => [division.name, sentence(division.meaning), division.count])),
     "",
     "## UnClick Structure",
     "",
@@ -247,31 +480,36 @@ export async function generateBrainmap({ root = process.cwd() } = {}) {
     "",
     "## Pages and Meaning",
     "",
-    table(["Route", "Page", "Meaning", "Source"], pageRows),
+    table(["Route", "Page", "Meaning", "Source"], model.pageRows),
     "",
     "## Tool Families and Meaning",
     "",
-    table(["Tool family", "Meaning", "Source"], toolRows),
+    table(["Tool family", "Meaning", "Source"], model.toolRows),
+    "",
+    "## Tool and Worker Tree",
+    "",
+    table(["Division", "Kind", "Name", "Meaning", "Route", "Source"], inventoryTableRows(model.inventory)),
     "",
     "## Public/Internal Alias Table",
     "",
-    table(["Internal name", "Public name", "Meaning"], ALIASES),
+    table(["Internal name", "Public name", "Meaning"], model.aliasRows),
     "",
     "## Rooms List",
     "",
-    table(["Room", "Meaning", "Source"], roomRows),
+    table(["Room", "Meaning", "Source"], model.roomRows),
     "",
     "## Workers List",
     "",
-    table(["Worker", "Meaning"], WORKERS),
+    table(["Worker", "Meaning"], model.workerRows),
     "",
     "## Safety Rules",
     "",
     "- Admin-only surfaces use `RequireAdmin` and must also be hidden from non-admin sidebar navigation.",
+    "- Brainmap visual admin is owner-only for `creativelead@malamutemayhem.com` inside the Yellow Private Admin lane.",
     "- NudgeOnly can request receipt or escalation only. Trusted lanes verify before action.",
     "- IgniteOnly can request worker wake packets only. Trusted lanes still build, review, merge, and record proof.",
     "- Heartbeats must never print keys or credentials.",
-    "- Generated Brainmap changes must come from source updates plus a regenerated artifact, not hand editing the generated file.",
+    "- Generated Brainmap changes must come from source updates plus regenerated artifacts, not hand editing the generated files.",
     "- Proof should include TestPass, Reviewer, Safety Checker, and Ledger-style evidence where applicable.",
     "",
     "## Launchpad Route",
@@ -289,9 +527,10 @@ export async function generateBrainmap({ root = process.cwd() } = {}) {
     "",
     "## CI and Stale Guard",
     "",
-    table(["Script", "Command"], ciRows),
+    table(["Script", "Command"], model.ciRows),
     "",
     "- `node scripts/UnClick-brainmap.mjs --check` fails if `docs/UnClick-brainmap.generated.md` is stale.",
+    "- `node scripts/UnClick-brainmap.mjs --check` also fails if `docs/UnClick-brainmap.generated.json` is stale.",
     "- `node --test scripts/UnClick-brainmap.test.mjs` verifies required sections and meaning rows.",
     "",
   ].join("\n");
@@ -300,19 +539,30 @@ export async function generateBrainmap({ root = process.cwd() } = {}) {
 async function main() {
   const root = process.cwd();
   const target = path.join(root, GENERATED_PATH);
+  const dataTarget = path.join(root, GENERATED_DATA_PATH);
   const generated = await generateBrainmap({ root });
+  const generatedData = await generateBrainmapData({ root });
   const check = process.argv.includes("--check");
   const existing = await readText(root, GENERATED_PATH);
+  const existingData = await readText(root, GENERATED_DATA_PATH);
   if (check) {
+    let stale = false;
     if (existing !== generated) {
       console.error(`${GENERATED_PATH} is stale. Run node scripts/UnClick-brainmap.mjs.`);
-      process.exitCode = 1;
+      stale = true;
     }
+    if (existingData !== generatedData) {
+      console.error(`${GENERATED_DATA_PATH} is stale. Run node scripts/UnClick-brainmap.mjs.`);
+      stale = true;
+    }
+    if (stale) process.exitCode = 1;
     return;
   }
   await mkdir(path.dirname(target), { recursive: true });
   await writeFile(target, generated, "utf8");
+  await writeFile(dataTarget, generatedData, "utf8");
   console.log(`Wrote ${GENERATED_PATH}`);
+  console.log(`Wrote ${GENERATED_DATA_PATH}`);
 }
 
 function sameExecutablePath(left, right) {

--- a/scripts/UnClick-brainmap.test.mjs
+++ b/scripts/UnClick-brainmap.test.mjs
@@ -3,7 +3,12 @@ import { readFile } from "node:fs/promises";
 import { describe, it } from "node:test";
 import process from "node:process";
 
-import { GENERATED_PATH, generateBrainmap } from "./UnClick-brainmap.mjs";
+import {
+  GENERATED_DATA_PATH,
+  GENERATED_PATH,
+  generateBrainmap,
+  generateBrainmapData,
+} from "./UnClick-brainmap.mjs";
 
 describe("UnClick ecosystem Brainmap", () => {
   it("keeps the generated artifact fresh", async () => {
@@ -12,13 +17,22 @@ describe("UnClick ecosystem Brainmap", () => {
     assert.equal(saved, generated);
   });
 
+  it("keeps the generated visual tree data fresh", async () => {
+    const generated = await generateBrainmapData({ root: process.cwd() });
+    const saved = (await readFile(GENERATED_DATA_PATH, "utf8")).replace(/\r\n/g, "\n");
+    assert.equal(saved, generated);
+  });
+
   it("contains the load-bearing system sections", async () => {
     const generated = await generateBrainmap({ root: process.cwd() });
     for (const section of [
       "## Source Manifest",
+      "## Brainmap Data Contract",
+      "## Division Index",
       "## UnClick Structure",
       "## Pages and Meaning",
       "## Tool Families and Meaning",
+      "## Tool and Worker Tree",
       "## Public/Internal Alias Table",
       "## Rooms List",
       "## Workers List",
@@ -37,6 +51,8 @@ describe("UnClick ecosystem Brainmap", () => {
     assert.match(generated, /\| \/admin\/agents\/heartbeat \| Admin Seat Heartbeat \| Master heartbeat copy policy/);
     assert.match(generated, /\| NudgeOnly \| NudgeOnly low-token receipt bridge/);
     assert.match(generated, /\| IgniteOnly \| IgniteOnly verified worker wake packet bridge/);
+    assert.match(generated, /\| Passes and gates \| fidelity gate \| CopyRoom \| Exact-copy room/);
+    assert.match(generated, /\| Wrappers and protocols \| claim lifecycle \| SeatRelay \| Stale release/);
     assert.match(generated, /\| Coordinator \| Routes work/);
     assert.match(generated, /Admin-only surfaces use `RequireAdmin`/);
     assert.match(generated, /IgniteOnly can request worker wake packets only/);
@@ -46,5 +62,31 @@ describe("UnClick ecosystem Brainmap", () => {
     const generated = await generateBrainmap({ root: process.cwd() });
     assert.match(generated, /node scripts\/UnClick-brainmap\.mjs --check/);
     assert.match(generated, /node --test scripts\/UnClick-brainmap\.test\.mjs/);
+  });
+
+  it("emits grouped inventory data for private admin onboarding", async () => {
+    const data = JSON.parse(await generateBrainmapData({ root: process.cwd() }));
+    assert.equal(data.schema_version, "brainmap-v2");
+    assert.equal(data.owner_visibility.owner_email, "creativelead@malamutemayhem.com");
+    assert.ok(data.counts.inventory > 100);
+
+    for (const division of [
+      "Admin surfaces",
+      "Tools",
+      "Rooms",
+      "Workers and seats",
+      "Passes and gates",
+      "Wrappers and protocols",
+      "Source of truth",
+      "Modules and apps",
+      "Launch and onboarding",
+    ]) {
+      assert.ok(data.divisions.some((item) => item.name === division), `${division} division missing`);
+    }
+
+    assert.ok(data.inventory.some((item) => item.name === "SeatRelay" && item.division === "Wrappers and protocols"));
+    assert.ok(data.inventory.some((item) => item.name === "CopyRoom" && item.division === "Passes and gates"));
+    assert.ok(data.inventory.some((item) => item.name === "JobSmith" && item.division === "Modules and apps"));
+    assert.ok(data.inventory.some((item) => item.name === "Ecosystem Brainmap" && item.route === "/admin/brainmap"));
   });
 });

--- a/src/pages/admin/AdminBrainmap.test.tsx
+++ b/src/pages/admin/AdminBrainmap.test.tsx
@@ -1,17 +1,79 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import AdminBrainmap from "./AdminBrainmap";
 
+const authState = {
+  email: "creativelead@malamutemayhem.com",
+  token: "test-session-token",
+  loading: false,
+};
+
+vi.mock("@/lib/auth", () => ({
+  useSession: () => ({
+    session: authState.token ? { access_token: authState.token } : null,
+    user: authState.email ? { email: authState.email } : null,
+    loading: authState.loading,
+  }),
+}));
+
 describe("AdminBrainmap", () => {
-  it("renders the generated ecosystem Brainmap with meaning attached", () => {
+  beforeEach(() => {
+    authState.email = "creativelead@malamutemayhem.com";
+    authState.token = "test-session-token";
+    authState.loading = false;
+    vi.restoreAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ email: authState.email, is_admin: true }),
+        }),
+      ),
+    );
+  });
+
+  it("renders the private visual Brainmap tree with the key onboarding systems", () => {
     render(React.createElement(AdminBrainmap));
 
     expect(screen.getByRole("heading", { name: "Ecosystem Brainmap" })).toBeInTheDocument();
-    expect(screen.getByText("Internal admin only")).toBeInTheDocument();
+    expect(screen.getByText("Private Yellow Admin")).toBeInTheDocument();
+    expect(screen.getByText("Tool and worker tree")).toBeInTheDocument();
+    expect(screen.getByText("SeatRelay")).toBeInTheDocument();
+    expect(screen.getByText("CopyRoom")).toBeInTheDocument();
+    expect(screen.getByText("Proof Ledger")).toBeInTheDocument();
+    expect(screen.getAllByText("Source of truth").length).toBeGreaterThan(0);
+    expect(screen.getByText(/brainmap-v2/i)).toBeInTheDocument();
+  });
+
+  it("filters the tree without losing the generated inventory", () => {
+    render(React.createElement(AdminBrainmap));
+
+    fireEvent.change(screen.getByLabelText("Search Brainmap"), {
+      target: { value: "SeatRelay" },
+    });
+
+    expect(screen.getByText("SeatRelay")).toBeInTheDocument();
+    expect(screen.getByText(/stale release, smart reassignment/i)).toBeInTheDocument();
+    expect(screen.queryByText("CopyRoom")).not.toBeInTheDocument();
+  });
+
+  it("keeps the generated markdown available behind an explicit source toggle", () => {
+    render(React.createElement(AdminBrainmap));
+
+    expect(screen.queryByText("Pages and Meaning")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Show source" }));
     expect(screen.getAllByText("Pages and Meaning").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Tool Families and Meaning").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Launchpad Route").length).toBeGreaterThan(0);
-    expect(screen.getByText(/teaches seats what the system is/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Tool and Worker Tree").length).toBeGreaterThan(0);
+  });
+
+  it("blocks the private view for non-owner admins", async () => {
+    authState.email = "admin@example.com";
+
+    render(React.createElement(AdminBrainmap));
+
+    expect(await screen.findByText("Creative lead access only")).toBeInTheDocument();
+    expect(screen.queryByText("SeatRelay")).not.toBeInTheDocument();
   });
 });

--- a/src/pages/admin/AdminBrainmap.tsx
+++ b/src/pages/admin/AdminBrainmap.tsx
@@ -1,58 +1,309 @@
+import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { BookOpen, Fingerprint, Sparkles } from "lucide-react";
+import remarkGfm from "remark-gfm";
+import {
+  BookOpen,
+  Boxes,
+  Fingerprint,
+  LockKeyhole,
+  Network,
+  Search,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import { useSession } from "@/lib/auth";
 import brainmapMarkdown from "../../../docs/UnClick-brainmap.generated.md?raw";
+import brainmapDataRaw from "../../../docs/UnClick-brainmap.generated.json?raw";
 
-const sectionCount = (brainmapMarkdown.match(/^## /gm) || []).length;
-const sourceCount = (brainmapMarkdown.match(/^\| .* \| [a-f0-9]{12} \| \d+ \|$/gm) || []).length;
+const OWNER_EMAIL = "creativelead@malamutemayhem.com";
+
+type BrainmapDivision = {
+  id: string;
+  name: string;
+  meaning: string;
+  count: number;
+};
+
+type BrainmapItem = {
+  id: string;
+  division: string;
+  name: string;
+  kind: string;
+  meaning: string;
+  source: string;
+  route?: string;
+};
+
+type BrainmapData = {
+  schema_version: string;
+  summary: string;
+  counts: {
+    divisions: number;
+    inventory: number;
+    source_manifest: number;
+    pages: number;
+    tools: number;
+    rooms: number;
+    workers: number;
+  };
+  divisions: BrainmapDivision[];
+  inventory: BrainmapItem[];
+};
+
+const brainmapData = JSON.parse(brainmapDataRaw) as BrainmapData;
+
+function normalizeEmail(value: unknown) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function itemMatchesQuery(item: BrainmapItem, query: string) {
+  if (!query) return true;
+  const haystack = `${item.division} ${item.kind} ${item.name} ${item.meaning} ${item.route ?? ""} ${item.source}`.toLowerCase();
+  return haystack.includes(query.toLowerCase());
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof BookOpen;
+  label: string;
+  value: number | string;
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-3">
+      <div className="flex items-center gap-2 text-xs text-white/45">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <p className="mt-1 font-mono text-2xl text-white">{value}</p>
+    </div>
+  );
+}
+
+function OwnerOnlyNotice({ denied = false }: { denied?: boolean }) {
+  return (
+    <section className="rounded-lg border border-[#E2B93B]/20 bg-[#E2B93B]/[0.04] p-5">
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[#E2B93B]/10 text-[#E2B93B]">
+          <LockKeyhole className="h-4 w-4" />
+        </div>
+        <div>
+          <h1 className="text-lg font-semibold text-white">
+            {denied ? "Creative lead access only" : "Checking private Brainmap access"}
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
+            This Brainmap view is reserved for the private Yellow Admin lane owned by {OWNER_EMAIL}.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 export default function AdminBrainmap() {
+  const { session, user, loading } = useSession();
+  const directOwner = normalizeEmail(user?.email) === OWNER_EMAIL;
+  const [ownerStatus, setOwnerStatus] = useState<"checking" | "owner" | "denied">("checking");
+  const [query, setQuery] = useState("");
+  const [activeDivision, setActiveDivision] = useState("All");
+  const [showSource, setShowSource] = useState(false);
+
+  useEffect(() => {
+    if (directOwner) {
+      setOwnerStatus("owner");
+      return;
+    }
+
+    const token = session?.access_token;
+    if (!token) {
+      if (!loading) setOwnerStatus("denied");
+      return;
+    }
+
+    let cancelled = false;
+    fetch("/api/memory-admin?action=admin_profile", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body) => {
+        if (cancelled) return;
+        setOwnerStatus(normalizeEmail(body?.email) === OWNER_EMAIL ? "owner" : "denied");
+      })
+      .catch(() => {
+        if (!cancelled) setOwnerStatus("denied");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [directOwner, loading, session?.access_token]);
+
+  const visibleAsOwner = directOwner || ownerStatus === "owner";
+
+  const filteredGroups = useMemo(() => {
+    return brainmapData.divisions
+      .filter((division) => activeDivision === "All" || division.name === activeDivision)
+      .map((division) => ({
+        ...division,
+        items: brainmapData.inventory.filter(
+          (item) => item.division === division.name && itemMatchesQuery(item, query),
+        ),
+      }))
+      .filter((division) => division.items.length > 0);
+  }, [activeDivision, query]);
+
+  const shownCount = filteredGroups.reduce((sum, division) => sum + division.items.length, 0);
+
+  if (!visibleAsOwner) {
+    return <OwnerOnlyNotice denied={ownerStatus === "denied"} />;
+  }
+
   return (
     <div className="space-y-6">
       <header className="flex flex-col gap-4 border-b border-white/[0.06] pb-6 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-2.5 py-1 text-xs font-semibold text-[#E2B93B]">
             <Sparkles className="h-3.5 w-3.5" />
-            Internal admin only
+            Private Yellow Admin
           </div>
           <h1 className="text-2xl font-semibold tracking-tight text-white">Ecosystem Brainmap</h1>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-            Auto-generated map of UnClick pages, tools, workers, rooms, aliases, safety rules, and
-            ledger meaning. This is the system orientation pair to Heartbeat Master.
+            Auto-generated map of UnClick sections, tools, rooms, workers, wrappers, modules, proof surfaces, and source-of-truth lanes.
           </p>
         </div>
-        <div className="grid min-w-[260px] grid-cols-2 gap-3">
-          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-3">
-            <div className="flex items-center gap-2 text-xs text-white/45">
-              <BookOpen className="h-3.5 w-3.5" />
-              Sections
-            </div>
-            <p className="mt-1 font-mono text-2xl text-white">{sectionCount}</p>
-          </div>
-          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-3">
-            <div className="flex items-center gap-2 text-xs text-white/45">
-              <Fingerprint className="h-3.5 w-3.5" />
-              Sources
-            </div>
-            <p className="mt-1 font-mono text-2xl text-white">{sourceCount}</p>
-          </div>
+        <div className="grid min-w-[280px] grid-cols-2 gap-3 lg:grid-cols-4">
+          <Metric icon={Network} label="Divisions" value={brainmapData.counts.divisions} />
+          <Metric icon={Boxes} label="Items" value={brainmapData.counts.inventory} />
+          <Metric icon={BookOpen} label="Pages" value={brainmapData.counts.pages} />
+          <Metric icon={Fingerprint} label="Sources" value={brainmapData.counts.source_manifest} />
         </div>
       </header>
 
-      <section className="rounded-xl border border-white/[0.06] bg-[#111] p-4">
-        <ReactMarkdown
-          components={{
-            h1: ({ children }) => <h2 className="mb-3 text-xl font-semibold text-white">{children}</h2>,
-            h2: ({ children }) => <h3 className="mt-8 border-t border-white/[0.06] pt-5 text-lg font-semibold text-white">{children}</h3>,
-            p: ({ children }) => <p className="my-3 max-w-4xl text-sm leading-6 text-white/65">{children}</p>,
-            ul: ({ children }) => <ul className="my-3 list-disc space-y-1 pl-5 text-sm leading-6 text-white/65">{children}</ul>,
-            code: ({ children }) => <code className="rounded bg-white/[0.06] px-1 py-0.5 font-mono text-xs text-[#E2B93B]">{children}</code>,
-            table: ({ children }) => <div className="my-4 overflow-x-auto rounded-lg border border-white/[0.06]"><table className="min-w-full text-left text-xs">{children}</table></div>,
-            th: ({ children }) => <th className="border-b border-white/[0.08] bg-white/[0.04] px-3 py-2 font-semibold text-white/70">{children}</th>,
-            td: ({ children }) => <td className="border-b border-white/[0.04] px-3 py-2 align-top text-white/60">{children}</td>,
-          }}
-        >
-          {brainmapMarkdown}
-        </ReactMarkdown>
+      <section className="space-y-4 rounded-lg border border-white/[0.06] bg-white/[0.025] p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-[0.08em] text-white/55">Tool and worker tree</h2>
+            <p className="mt-1 text-sm text-white/45">
+              {shownCount} of {brainmapData.counts.inventory} items shown from {brainmapData.schema_version}.
+            </p>
+          </div>
+
+          <label className="relative block w-full max-w-md">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/30" />
+            <span className="sr-only">Search Brainmap</span>
+            <input
+              aria-label="Search Brainmap"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search tools, rooms, workers, modules..."
+              className="h-10 w-full rounded-md border border-white/[0.08] bg-black/30 pl-9 pr-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-[#61C1C4]/60"
+            />
+          </label>
+        </div>
+
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {["All", ...brainmapData.divisions.map((division) => division.name)].map((division) => {
+            const active = activeDivision === division;
+            return (
+              <button
+                key={division}
+                type="button"
+                onClick={() => setActiveDivision(division)}
+                className={`shrink-0 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  active
+                    ? "border-[#61C1C4]/50 bg-[#61C1C4]/15 text-[#8FE6E8]"
+                    : "border-white/[0.08] bg-white/[0.025] text-white/45 hover:border-white/15 hover:text-white/70"
+                }`}
+              >
+                {division}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="space-y-5">
+          {filteredGroups.map((division) => (
+            <section key={division.id} className="overflow-hidden rounded-lg border border-white/[0.06] bg-black/20">
+              <div className="flex flex-col gap-2 border-b border-white/[0.06] bg-white/[0.03] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h3 className="text-base font-semibold text-white">{division.name}</h3>
+                  <p className="mt-1 text-xs leading-5 text-white/45">{division.meaning}</p>
+                </div>
+                <span className="w-fit rounded-md bg-white/[0.05] px-2 py-1 font-mono text-xs text-white/45">
+                  {division.items.length}
+                </span>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-left text-xs">
+                  <thead>
+                    <tr className="border-b border-white/[0.06] text-white/45">
+                      <th className="w-[16rem] px-4 py-2 font-medium">Name</th>
+                      <th className="w-[8rem] px-4 py-2 font-medium">Kind</th>
+                      <th className="px-4 py-2 font-medium">What it does</th>
+                      <th className="w-[12rem] px-4 py-2 font-medium">Route</th>
+                      <th className="w-[18rem] px-4 py-2 font-medium">Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {division.items.map((item) => (
+                      <tr key={item.id} className="border-b border-white/[0.035] last:border-b-0">
+                        <td className="px-4 py-2 align-top font-medium text-white/80">{item.name}</td>
+                        <td className="px-4 py-2 align-top text-[#61C1C4]/80">{item.kind}</td>
+                        <td className="max-w-2xl px-4 py-2 align-top leading-5 text-white/55">{item.meaning}</td>
+                        <td className="px-4 py-2 align-top font-mono text-[11px] text-white/45">{item.route || "-"}</td>
+                        <td className="px-4 py-2 align-top font-mono text-[11px] text-white/35">{item.source}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-[#61C1C4]/15 bg-[#61C1C4]/[0.03] p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 h-4 w-4 text-[#61C1C4]" />
+            <div>
+              <h2 className="text-sm font-semibold text-white">Auto-updating source document</h2>
+              <p className="mt-1 max-w-3xl text-xs leading-5 text-white/45">
+                The generator writes both markdown and JSON. CI fails if either file gets stale, so new sections can keep teaching seats without a manual handover.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowSource((value) => !value)}
+            className="w-fit rounded-md border border-[#61C1C4]/25 px-3 py-2 text-xs font-medium text-[#8FE6E8] hover:bg-[#61C1C4]/10"
+          >
+            {showSource ? "Hide source" : "Show source"}
+          </button>
+        </div>
+
+        {showSource && (
+          <div className="mt-4 rounded-lg border border-white/[0.06] bg-[#111] p-4">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                h1: ({ children }) => <h2 className="mb-3 text-xl font-semibold text-white">{children}</h2>,
+                h2: ({ children }) => <h3 className="mt-8 border-t border-white/[0.06] pt-5 text-lg font-semibold text-white">{children}</h3>,
+                p: ({ children }) => <p className="my-3 max-w-4xl text-sm leading-6 text-white/65">{children}</p>,
+                ul: ({ children }) => <ul className="my-3 list-disc space-y-1 pl-5 text-sm leading-6 text-white/65">{children}</ul>,
+                code: ({ children }) => <code className="rounded bg-white/[0.06] px-1 py-0.5 font-mono text-xs text-[#E2B93B]">{children}</code>,
+                table: ({ children }) => <div className="my-4 overflow-x-auto rounded-lg border border-white/[0.06]"><table className="min-w-full text-left text-xs">{children}</table></div>,
+                th: ({ children }) => <th className="border-b border-white/[0.08] bg-white/[0.04] px-3 py-2 font-semibold text-white/70">{children}</th>,
+                td: ({ children }) => <td className="border-b border-white/[0.04] px-3 py-2 align-top text-white/60">{children}</td>,
+              }}
+            >
+              {brainmapMarkdown}
+            </ReactMarkdown>
+          </div>
+        )}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
Adds Brainmap v2 as a private admin visual directory and generated onboarding data file. The Brainmap now shows UnClick divisions, tools, rooms, workers, wrappers, modules, passes, ledgers, and source-of-truth surfaces in a searchable grouped tree.

## Scope
- Owned todo: `a8f7bbe8-28b1-4e83-8e24-5644e49b23da`
- Generator: `scripts/UnClick-brainmap.mjs`
- Generated artifacts: `docs/UnClick-brainmap.generated.md`, `docs/UnClick-brainmap.generated.json`
- Admin UI: `src/pages/admin/AdminBrainmap.tsx`
- Tests: `scripts/UnClick-brainmap.test.mjs`, `src/pages/admin/AdminBrainmap.test.tsx`
- Auto-update workflow: `.github/workflows/brainmap-auto-update.yml`

## Non-overlap
Did not touch JobSmith PR conflict files, SeatRelay lifecycle logic, unrelated channel plugin files, merge gates, auth backend, or production data. The Brainmap route remains behind `RequireAdmin`; the page adds an owner-only UI gate for `creativelead@malamutemayhem.com`.

## Verification
- `npm run brainmap:generate`
- `npm run test:brainmap`
- `npx vitest run src/pages/admin/AdminBrainmap.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`
- `npm run build`

## Risk
Low to medium. The generated JSON adds about 234 KB of static admin data to the bundle. No migrations, secrets, billing, DNS, or destructive actions.

## Follow-up
If this needs hard server-side owner-only secrecy beyond the current admin route and owner UI gate, move generated Brainmap delivery behind an owner-only API endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only affects which generated Brainmap artifacts are detected and committed; main risk is increased commit churn if the JSON output changes frequently.
> 
> **Overview**
> The scheduled `brainmap-auto-update` GitHub Action now treats `docs/UnClick-brainmap.generated.json` as a first-class generated artifact alongside the existing Markdown output.
> 
> It updates the diff check and `git add` step so the workflow commits/pushes when either the `.md` *or* `.json` Brainmap output changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d48554d0dc824c8cf3edcb06c6d45c70e9e4cd50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->