### PR TITLE
feat(jobsmith): add AI welcome packet

### DIFF
--- a/apps/jobsmith/src/lib/applicationManager.test.ts
+++ b/apps/jobsmith/src/lib/applicationManager.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWelcomePacket } from "./applicationManager";
+
+const ruleSummary = {
+  totalRules: 229,
+  categories: ["ATS", "VOICE", "APPLICATION"],
+  bySeverity: { ERROR: 24, WARN: 120, INFO: 85 },
+  needsRefresh: 3,
+};
+
+describe("JobSmith application manager welcome packet", () => {
+  it("orients a fresh AI seat before inputs are available", () => {
+    const packet = buildWelcomePacket({
+      corpusReady: false,
+      jobText: "",
+      draftReady: false,
+      ruleSummary,
+    });
+
+    expect(packet.title).toBe("AI Welcome Packet");
+    expect(packet.status).toBe("loading_inputs");
+    expect(packet.purpose).toContain("manages a job application run");
+    expect(packet.missingInputs).toContain("Loaded CV corpus and voice profile");
+    expect(packet.missingInputs).toContain("Full job ad or role brief");
+    expect(packet.safestNextMove).toContain("corpus");
+    expect(packet.stopConditions).toContain("Do not submit an application");
+  });
+
+  it("names visible inputs and asks for the next smallest move", () => {
+    const packet = buildWelcomePacket({
+      corpusReady: true,
+      corpusStats: {
+        coverLetters: 4,
+        jobsApplied: 7,
+        roleTypes: ["Creative Lead", "Brand Strategy"],
+        pastBrands: ["Malamute Mayhem", "UnClick"],
+      },
+      jobText: "",
+      draftReady: false,
+      ruleSummary,
+    });
+
+    expect(packet.status).toBe("needs_job_ad");
+    expect(packet.availableInputs[0]).toBe("CV corpus: 4 cover letters and 7 prior applications");
+    expect(packet.availableInputs).toContain("Rule pack v1: 229 rules across 3 categories");
+    expect(packet.missingInputs).toEqual(["Full job ad or role brief", "Generated application packet artifact"]);
+    expect(packet.safestNextMove).toContain("Paste the full job ad");
+  });
+
+  it("moves from generate-ready to draft-ready without claiming submit-ready", () => {
+    const readyPacket = buildWelcomePacket({
+      corpusReady: true,
+      corpusStats: {
+        coverLetters: 4,
+        jobsApplied: 7,
+        roleTypes: [],
+        pastBrands: [],
+      },
+      jobText: "Senior product designer role for a sports wagering app.",
+      draftReady: false,
+      ruleSummary,
+    });
+
+    expect(readyPacket.status).toBe("ready_to_generate");
+    expect(readyPacket.availableInputs).toContain("Job ad: 9 words pasted");
+    expect(readyPacket.safestNextMove).toContain("Generate the starter draft");
+
+    const draftPacket = buildWelcomePacket({
+      corpusReady: true,
+      corpusStats: {
+        coverLetters: 4,
+        jobsApplied: 7,
+        roleTypes: [],
+        pastBrands: [],
+      },
+      jobText: "Senior product designer role for a sports wagering app.",
+      draftReady: true,
+      ruleSummary,
+    });
+
+    expect(draftPacket.status).toBe("draft_ready");
+    expect(draftPacket.missingInputs).toEqual([]);
+    expect(draftPacket.availableInputs).toContain("Draft artifact: application packet generated for review");
+    expect(draftPacket.safestNextMove).toContain("missing proof");
+    expect(draftPacket.stopConditions).toContain("Do not claim submit-ready while blockers or missing inputs remain");
+  });
+
+  it("treats routed application-run fields as the intake source", () => {
+    const partialPacket = buildWelcomePacket({
+      corpusReady: true,
+      applicationRun: {
+        company: "Sportsbet",
+        role: "Product Design Lead",
+        jobSource: "https://example.com/sportsbet-role",
+        sourceBackedClaim: "",
+        proofNote: "",
+      },
+      jobText: "",
+      draftReady: false,
+      ruleSummary,
+    });
+
+    expect(partialPacket.status).toBe("needs_job_ad");
+    expect(partialPacket.availableInputs).toContain("Company: Sportsbet");
+    expect(partialPacket.availableInputs).toContain("Role: Product Design Lead");
+    expect(partialPacket.missingInputs).toEqual([
+      "Source-backed claim",
+      "Proof note",
+      "Generated application packet artifact",
+    ]);
+
+    const readyPacket = buildWelcomePacket({
+      corpusReady: true,
+      applicationRun: {
+        company: "Sportsbet",
+        role: "Product Design Lead",
+        jobSource: "https://example.com/sportsbet-role",
+        sourceBackedClaim: "Led a wagering-safe UX redesign.",
+        proofNote: "Portfolio case study backs the claim.",
+      },
+      jobText: "",
+      draftReady: true,
+      ruleSummary,
+    });
+
+    expect(readyPacket.status).toBe("draft_ready");
+    expect(readyPacket.availableInputs).toContain("Source-backed claim captured");
+    expect(readyPacket.availableInputs).toContain("Proof note captured");
+    expect(readyPacket.missingInputs).toEqual([]);
+  });
+});

--- a/apps/jobsmith/src/lib/applicationManager.ts
+++ b/apps/jobsmith/src/lib/applicationManager.ts
@@ -1,0 +1,166 @@
+import type { RulePackSummary } from "./checkEngine";
+
+export type WelcomePacketStatus = "loading_inputs" | "needs_job_ad" | "ready_to_generate" | "draft_ready";
+
+export interface ApplicationManagerInput {
+  corpusReady: boolean;
+  corpusStats?: {
+    coverLetters: number;
+    jobsApplied: number;
+    roleTypes: string[];
+    pastBrands: string[];
+  };
+  applicationRun?: {
+    company: string;
+    role: string;
+    jobSource: string;
+    sourceBackedClaim: string;
+    proofNote: string;
+  };
+  jobText: string;
+  draftReady: boolean;
+  ruleSummary: Pick<RulePackSummary, "totalRules" | "categories" | "bySeverity" | "needsRefresh">;
+}
+
+export interface WelcomePacket {
+  title: string;
+  status: WelcomePacketStatus;
+  purpose: string;
+  availableInputs: string[];
+  missingInputs: string[];
+  capabilities: string[];
+  safestNextMove: string;
+  proofExpectations: string[];
+  stopConditions: string[];
+}
+
+export function buildWelcomePacket(input: ApplicationManagerInput): WelcomePacket {
+  const jobText = input.jobText.trim();
+  const run = input.applicationRun;
+  const availableInputs = [
+    `Rule pack v1: ${input.ruleSummary.totalRules} rules across ${input.ruleSummary.categories.length} categories`,
+    `${input.ruleSummary.bySeverity.ERROR} blocker rules and ${input.ruleSummary.needsRefresh} rules needing refresh`,
+  ];
+
+  if (input.corpusReady && input.corpusStats) {
+    availableInputs.unshift(
+      `CV corpus: ${input.corpusStats.coverLetters} cover letters and ${input.corpusStats.jobsApplied} prior applications`,
+    );
+    if (input.corpusStats.roleTypes.length > 0) {
+      availableInputs.push(`Role signals: ${input.corpusStats.roleTypes.slice(0, 4).join(", ")}`);
+    }
+    if (input.corpusStats.pastBrands.length > 0) {
+      availableInputs.push(`Brand signals: ${input.corpusStats.pastBrands.slice(0, 4).join(", ")}`);
+    }
+  }
+
+  if (jobText.length > 0) {
+    availableInputs.push(`Job ad: ${wordCount(jobText)} words pasted`);
+  }
+
+  if (run) {
+    if (hasText(run.company)) availableInputs.push(`Company: ${run.company.trim()}`);
+    if (hasText(run.role)) availableInputs.push(`Role: ${run.role.trim()}`);
+    if (hasText(run.jobSource)) availableInputs.push(`Job source: ${run.jobSource.trim()}`);
+    if (hasText(run.sourceBackedClaim)) availableInputs.push("Source-backed claim captured");
+    if (hasText(run.proofNote)) availableInputs.push("Proof note captured");
+  }
+
+  if (input.draftReady) {
+    availableInputs.push("Draft artifact: application packet generated for review");
+  }
+
+  const missingInputs: string[] = [];
+  if (!input.corpusReady) missingInputs.push("Loaded CV corpus and voice profile");
+  if (run) {
+    if (!hasText(run.company)) missingInputs.push("Company");
+    if (!hasText(run.role)) missingInputs.push("Role");
+    if (!hasText(run.jobSource)) missingInputs.push("Job source");
+    if (!hasText(run.sourceBackedClaim)) missingInputs.push("Source-backed claim");
+    if (!hasText(run.proofNote)) missingInputs.push("Proof note");
+  } else if (jobText.length === 0) {
+    missingInputs.push("Full job ad or role brief");
+  }
+  if (!input.draftReady) missingInputs.push("Generated application packet artifact");
+
+  const status = packetStatus(input.corpusReady, jobText, input.draftReady, run);
+
+  return {
+    title: "AI Welcome Packet",
+    status,
+    purpose:
+      "JobSmith manages a job application run from intake to proof. It keeps the AI seat oriented, checks rules, creates artifacts, and shows what still needs review before submit-ready status.",
+    availableInputs,
+    missingInputs,
+    capabilities: [
+      "Tailor CV and cover letter language from the loaded voice profile",
+      "Run deterministic rule-pack checks before claiming progress",
+      "Separate automated findings from review-needed decision cards",
+      "Track artifacts, proof, blockers, and submit-ready status for the run",
+    ],
+    safestNextMove: safestNextMove(status),
+    proofExpectations: [
+      "Record the job ad, generated artifacts, rule findings, and review-needed count",
+      "Leave tests or API output for changed logic",
+      "Leave screenshot or run proof before claiming the workflow moved",
+    ],
+    stopConditions: [
+      "Do not submit an application",
+      "Do not hide review-needed rules as passes",
+      "Do not claim submit-ready while blockers or missing inputs remain",
+    ],
+  };
+}
+
+function packetStatus(
+  corpusReady: boolean,
+  jobText: string,
+  draftReady: boolean,
+  run?: ApplicationManagerInput["applicationRun"],
+): WelcomePacketStatus {
+  if (!corpusReady) return "loading_inputs";
+  if (run && hasApplicationRunInput(run)) {
+    if (!applicationRunReady(run)) return "needs_job_ad";
+    if (!draftReady) return "ready_to_generate";
+    return "draft_ready";
+  }
+  if (jobText.length === 0) return "needs_job_ad";
+  if (!draftReady) return "ready_to_generate";
+  return "draft_ready";
+}
+
+function hasApplicationRunInput(run: ApplicationManagerInput["applicationRun"]): boolean {
+  if (!run) return false;
+  return (
+    hasText(run.company) ||
+    hasText(run.role) ||
+    hasText(run.jobSource) ||
+    hasText(run.sourceBackedClaim) ||
+    hasText(run.proofNote)
+  );
+}
+
+function applicationRunReady(run: NonNullable<ApplicationManagerInput["applicationRun"]>): boolean {
+  return (
+    hasText(run.company) &&
+    hasText(run.role) &&
+    hasText(run.jobSource) &&
+    hasText(run.sourceBackedClaim) &&
+    hasText(run.proofNote)
+  );
+}
+
+function safestNextMove(status: WelcomePacketStatus): string {
+  if (status === "loading_inputs") return "Wait for the corpus load or fix the corpus path before generating artifacts.";
+  if (status === "needs_job_ad") return "Paste the full job ad, then let JobSmith build the first draft and rule-check packet.";
+  if (status === "ready_to_generate") return "Generate the starter draft, then inspect deterministic findings and review-needed rules.";
+  return "Review the generated draft, rule findings, artifacts, and missing proof before any submit-ready claim.";
+}
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function hasText(value: string): boolean {
+  return value.trim().length > 0;
+}

--- a/src/pages/Jobsmith.test.tsx
+++ b/src/pages/Jobsmith.test.tsx
@@ -26,6 +26,13 @@ describe("JobsmithPage", () => {
 
     expect(screen.getByRole("heading", { name: "Application packet builder" })).toBeInTheDocument();
     expect(screen.getByText("Jobsmith")).toBeInTheDocument();
+    const welcomePacket = screen.getByRole("region", { name: "Jobsmith AI welcome packet" });
+    expect(welcomePacket).toHaveTextContent("AI Welcome Packet");
+    expect(welcomePacket).toHaveTextContent("JobSmith manages a job application run");
+    expect(welcomePacket).toHaveTextContent("Needs intake");
+    expect(welcomePacket).toHaveTextContent("Company");
+    expect(welcomePacket).toHaveTextContent("Source-backed claim");
+    expect(welcomePacket).toHaveTextContent("Safest next move");
     expect(screen.getByRole("region", { name: "Jobsmith universal rules" })).toHaveTextContent("Universal Rules v1");
     expect(screen.getByRole("region", { name: "Jobsmith universal rules" })).toHaveTextContent("229");
     expect(screen.getByRole("region", { name: "Jobsmith universal rules" })).toHaveTextContent("Standard headings pass");
@@ -57,6 +64,13 @@ describe("JobsmithPage", () => {
     const readiness = screen.getByRole("region", { name: "ATS and paste readiness" });
     expect(readiness).toHaveTextContent("Ready");
     expect(readiness).toHaveTextContent("No brittle ATS formatting language detected");
+
+    const welcomePacket = screen.getByRole("region", { name: "Jobsmith AI welcome packet" });
+    expect(welcomePacket).toHaveTextContent("Draft ready for review");
+    expect(welcomePacket).toHaveTextContent("Company: Example Studio");
+    expect(welcomePacket).toHaveTextContent("Source-backed claim captured");
+    expect(welcomePacket).toHaveTextContent("No missing inputs in this slice.");
+    expect(welcomePacket).toHaveTextContent("Review the generated draft");
 
     const packet = screen.getByRole("region", { name: "Starter packet" });
     const packetText = within(packet).getByTestId("jobsmith-public-packet-copy");

--- a/src/pages/Jobsmith.tsx
+++ b/src/pages/Jobsmith.tsx
@@ -14,6 +14,7 @@ import FadeIn from "@/components/FadeIn";
 import { useCanonical } from "@/hooks/use-canonical";
 import { useMetaTags } from "@/hooks/useMetaTags";
 import { JOBSMITH_RULE_PACK_V1, runJobsmithChecks, summarizeRulePack } from "../../apps/jobsmith/src/lib/checkEngine";
+import { buildWelcomePacket, type WelcomePacket } from "../../apps/jobsmith/src/lib/applicationManager";
 
 type ReadinessLevel = "blocked" | "review" | "ready";
 
@@ -62,6 +63,20 @@ const LEVEL_STYLES: Record<ReadinessLevel, string> = {
   blocked: "border-rose-300/25 bg-rose-300/10 text-rose-100",
   review: "border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#F4D36B]",
   ready: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+};
+
+const WELCOME_STATUS_LABELS: Record<WelcomePacket["status"], string> = {
+  loading_inputs: "Loading inputs",
+  needs_job_ad: "Needs intake",
+  ready_to_generate: "Ready to generate",
+  draft_ready: "Draft ready for review",
+};
+
+const WELCOME_STATUS_STYLES: Record<WelcomePacket["status"], string> = {
+  loading_inputs: "border-white/[0.08] bg-white/[0.05] text-white/70",
+  needs_job_ad: "border-rose-300/25 bg-rose-300/10 text-rose-100",
+  ready_to_generate: "border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#F4D36B]",
+  draft_ready: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
 };
 
 function hasText(value: string): boolean {
@@ -167,8 +182,83 @@ function LevelBadge({ level }: { level: ReadinessLevel }) {
   );
 }
 
-function RulePackStatus() {
-  const summary = useMemo(() => summarizeRulePack(JOBSMITH_RULE_PACK_V1), []);
+function WelcomePacketPanel({ packet }: { packet: WelcomePacket }) {
+  return (
+    <section
+      aria-label="Jobsmith AI welcome packet"
+      data-testid="jobsmith-ai-welcome-packet"
+      className="mb-4 rounded-lg border border-[#61C1C4]/20 bg-[#61C1C4]/[0.07] p-5"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#61C1C4]">AI Welcome Packet</p>
+          <h2 className="mt-1 text-xl font-semibold text-white">{packet.title}</h2>
+          <p className="mt-2 text-sm leading-6 text-white/65">{packet.purpose}</p>
+        </div>
+        <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${WELCOME_STATUS_STYLES[packet.status]}`}>
+          {WELCOME_STATUS_LABELS[packet.status]}
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)]">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-white/45">Inputs visible now</h3>
+          <ul className="mt-3 space-y-2 text-sm leading-6 text-white/70">
+            {packet.availableInputs.map((input) => (
+              <li key={input}>{input}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-white/45">Missing before submit-ready</h3>
+          {packet.missingInputs.length > 0 ? (
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-white/70">
+              {packet.missingInputs.map((input) => (
+                <li key={input}>{input}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-3 text-sm leading-6 text-emerald-100">No missing inputs in this slice.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-5 md:grid-cols-3">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-white/45">Can do</h3>
+          <ul className="mt-3 space-y-2 text-xs leading-5 text-white/60">
+            {packet.capabilities.map((capability) => (
+              <li key={capability}>{capability}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-white/45">Proof expected</h3>
+          <ul className="mt-3 space-y-2 text-xs leading-5 text-white/60">
+            {packet.proofExpectations.map((proof) => (
+              <li key={proof}>{proof}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-white/45">Stop conditions</h3>
+          <ul className="mt-3 space-y-2 text-xs leading-5 text-white/60">
+            {packet.stopConditions.map((condition) => (
+              <li key={condition}>{condition}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-5 border-t border-white/[0.08] pt-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#9EE4E6]">Safest next move</p>
+        <p className="mt-2 text-sm leading-6 text-white/75">{packet.safestNextMove}</p>
+      </div>
+    </section>
+  );
+}
+
+function RulePackStatus({ summary }: { summary: ReturnType<typeof summarizeRulePack> }) {
   const sampleResult = useMemo(() => runJobsmithChecks(STANDARD_HEADING_SAMPLE, JOBSMITH_RULE_PACK_V1), []);
   const sampleClean = sampleResult.findings.length === 0;
   const standardHeadingsSafe = sampleResult.findings.every((finding) => finding.ruleId !== "JS-ATS-03");
@@ -284,7 +374,25 @@ export default function JobsmithPage() {
 
   const checks = useMemo(() => buildReadinessChecks(draft), [draft]);
   const level = useMemo(() => overallLevel(checks), [checks]);
+  const ruleSummary = useMemo(() => summarizeRulePack(JOBSMITH_RULE_PACK_V1), []);
   const packetText = useMemo(() => buildPacketText(draft, checks, level), [checks, draft, level]);
+  const welcomePacket = useMemo(
+    () =>
+      buildWelcomePacket({
+        corpusReady: true,
+        applicationRun: {
+          company: draft.company,
+          role: draft.role,
+          jobSource: draft.jobSource,
+          sourceBackedClaim: draft.claim,
+          proofNote: draft.proofNote,
+        },
+        jobText: "",
+        draftReady: level !== "blocked",
+        ruleSummary,
+      }),
+    [draft, level, ruleSummary],
+  );
   const blockers = checks.filter((check) => check.level === "blocked");
 
   function updateField<Key extends keyof JobsmithPublicDraft>(key: Key, value: JobsmithPublicDraft[Key]) {
@@ -315,10 +423,14 @@ export default function JobsmithPage() {
         </FadeIn>
 
         <FadeIn delay={0.05}>
-          <RulePackStatus />
+          <WelcomePacketPanel packet={welcomePacket} />
         </FadeIn>
 
         <FadeIn delay={0.1}>
+          <RulePackStatus summary={ruleSummary} />
+        </FadeIn>
+
+        <FadeIn delay={0.15}>
           <section
             aria-label="Jobsmith starter packet builder"
             className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)]"


### PR DESCRIPTION
## Summary
Adds a shared JobSmith application manager welcome-packet model and renders it on the routed `/jobsmith` entry page. The packet explains what JobSmith is, visible inputs, missing inputs, capabilities, proof expectations, stop conditions, and the safest next move.

## Scope
Owned files:
- `apps/jobsmith/src/lib/applicationManager.ts`
- `apps/jobsmith/src/lib/applicationManager.test.ts`
- `src/pages/Jobsmith.tsx`
- `src/pages/Jobsmith.test.tsx`

Linked Boardroom todo: `55766d56-ac36-476b-a6e3-81202dc5f501`.

## Non-overlap
This PR only covers the AI Welcome Packet / induction UI slice. It does not implement managed checklist run state, decision cards, application log/proof JSON, Sportsbet replay fixture, final report closure, or real application submission.

## Verification
- `npx vitest run src/pages/Jobsmith.test.tsx`
- `npm run test --workspace=@unclick/jobsmith -- applicationManager.test.ts checkEngine.test.ts`
- `npx tsc --noEmit -p tsconfig.json`
- `npm run typecheck --workspace=@unclick/jobsmith`
- `git diff --check HEAD~1..HEAD`
- `npm run build`
- Browser proof at `http://127.0.0.1:4210/jobsmith`: filled a sample application run, confirmed welcome packet fields and starter packet text. Screenshot artifact: `C:\Users\creat\Documents\Codex\2026-05-19\files-mentioned-by-the-user-20260519\jobsmith-ai-welcome-packet-proof.png`.

## Risk
Low. UI/model-only change, browser-local data only. No secrets, billing, DNS, production deploy, data deletion, or actual job submission.

## Follow-up
Continue with the next independent slice, likely managed run state or review-needed decision cards. Parent JobSmith Application Manager job remains open until the managed workflow is proven end to end.

## Owner proof refresh
2026-05-19T14:17Z by unclick-builder-tether-seat: checks re-read as clean. Website, MCP server package, Review dry-run warning, TestPass smoke run, Vercel, and Vercel Preview Comments are passing. Dirty-branch hygiene is skipped as expected. Scope remains AI Welcome Packet only; no merge and no DONE claim. Draft lifted so stacked PR #950 can proceed through review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new welcome-packet model and renders it on the `/jobsmith` page; changes are isolated to UI/state derivation with no external side effects or sensitive data handling.
> 
> **Overview**
> **Adds an AI “Welcome Packet” concept to Jobsmith.** Introduces `buildWelcomePacket` (`apps/jobsmith/src/lib/applicationManager.ts`) that derives a `WelcomePacket` (status, visible/missing inputs, capabilities, proof expectations, stop conditions, and “safest next move”) from corpus/job/run fields plus a summarized rule-pack.
> 
> Updates the routed `/jobsmith` page to compute this packet from the browser-local draft and render a new `WelcomePacketPanel` above the existing rule-pack status; refactors `RulePackStatus` to accept a memoized rule summary. Adds unit tests for packet status/input logic and expands the Jobsmith page test assertions to cover the new panel content and status transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804cf76222840201a4a1cb14adae5b0f206eff72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->