### PR TITLE
feat(jobsmith): add decision card bridge

### DIFF
--- a/apps/jobsmith/src/lib/applicationManager.test.ts
+++ b/apps/jobsmith/src/lib/applicationManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildWelcomePacket } from "./applicationManager";
+import { buildDecisionCards, buildWelcomePacket } from "./applicationManager";
 
 const ruleSummary = {
   totalRules: 229,
@@ -128,5 +128,104 @@ describe("JobSmith application manager welcome packet", () => {
     expect(readyPacket.availableInputs).toContain("Source-backed claim captured");
     expect(readyPacket.availableInputs).toContain("Proof note captured");
     expect(readyPacket.missingInputs).toEqual([]);
+  });
+});
+
+describe("JobSmith application manager decision cards", () => {
+  it("turns review-needed rules into owned decision cards with proof needs", () => {
+    const cards = buildDecisionCards({
+      reviewNeeded: [
+        {
+          ruleId: "JS-COVER-08",
+          name: "Cover letter structure",
+          category: "COVER",
+          severity: "WARN",
+          action: "flags",
+          checkType: "human_review",
+          needsRefresh: false,
+        },
+        {
+          ruleId: "JS-TRUTH-05",
+          name: "Verify employment dates",
+          category: "TRUTH",
+          severity: "ERROR",
+          action: "blocks",
+          checkType: "semantic_check",
+          needsRefresh: false,
+        },
+      ],
+      findings: [],
+      missingInputs: [],
+      artifactsReady: true,
+    });
+
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toMatchObject({
+      id: "decision-card-js-truth-05",
+      owner: "human",
+      status: "blocked",
+      proofNeeded: "A human PASS/BLOCKER decision with source evidence is required before submit-ready.",
+    });
+    expect(cards[1]).toMatchObject({
+      id: "decision-card-js-cover-08",
+      owner: "human",
+      status: "needs_decision",
+      suggestedAction: "Review and either revise the draft or record an accepted risk.",
+    });
+  });
+
+  it("adds product blockers when inputs or artifacts are missing", () => {
+    const cards = buildDecisionCards({
+      reviewNeeded: [],
+      findings: [],
+      missingInputs: ["Full job ad", "Proof note"],
+      artifactsReady: false,
+    });
+
+    expect(cards.map((card) => card.ruleId)).toEqual(["jobsmith-artifacts", "jobsmith-missing-inputs"]);
+    expect(cards.every((card) => card.status === "blocked")).toBe(true);
+    expect(cards[1].reason).toContain("Full job ad");
+    expect(cards[1].reason).toContain("Proof note");
+  });
+
+  it("keeps deterministic error findings as submit-ready blockers", () => {
+    const cards = buildDecisionCards({
+      reviewNeeded: [
+        {
+          ruleId: "JS-AIDETECT-04",
+          name: "No em dash",
+          category: "AIDETECT",
+          severity: "ERROR",
+          action: "blocks",
+          checkType: "regex",
+          needsRefresh: false,
+        },
+      ],
+      findings: [
+        {
+          ruleId: "JS-AIDETECT-04",
+          name: "No em dash",
+          category: "AIDETECT",
+          severity: "ERROR",
+          action: "blocks",
+          message: "Do not use em dashes in final documents.",
+          match: "\u2014",
+          start: 16,
+          end: 17,
+          checkType: "regex",
+          needsRefresh: false,
+        },
+      ],
+      missingInputs: [],
+      artifactsReady: true,
+    });
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      owner: "jobsmith",
+      status: "blocked",
+      reason: "Do not use em dashes in final documents.",
+      proofNeeded: 'Resolve or justify the matched text: "\u2014".',
+    });
   });
 });

--- a/apps/jobsmith/src/lib/applicationManager.ts
+++ b/apps/jobsmith/src/lib/applicationManager.ts
@@ -1,4 +1,4 @@
-import type { RulePackSummary } from "./checkEngine";
+import type { ReviewNeededRule, RuleFinding, RulePackSummary, RuleSeverity } from "./checkEngine";
 
 export type WelcomePacketStatus = "loading_inputs" | "needs_job_ad" | "ready_to_generate" | "draft_ready";
 
@@ -32,6 +32,29 @@ export interface WelcomePacket {
   safestNextMove: string;
   proofExpectations: string[];
   stopConditions: string[];
+}
+
+export type DecisionCardOwner = "human" | "jobsmith" | "reviewer";
+export type DecisionCardStatus = "needs_decision" | "blocked" | "ready_for_review";
+
+export interface DecisionCard {
+  id: string;
+  ruleId: string;
+  title: string;
+  category: string;
+  severity: RuleSeverity;
+  owner: DecisionCardOwner;
+  status: DecisionCardStatus;
+  reason: string;
+  proofNeeded: string;
+  suggestedAction: string;
+}
+
+export interface DecisionCardInput {
+  reviewNeeded: ReviewNeededRule[];
+  findings: RuleFinding[];
+  missingInputs: string[];
+  artifactsReady: boolean;
 }
 
 export function buildWelcomePacket(input: ApplicationManagerInput): WelcomePacket {
@@ -112,6 +135,73 @@ export function buildWelcomePacket(input: ApplicationManagerInput): WelcomePacke
   };
 }
 
+export function buildDecisionCards(input: DecisionCardInput): DecisionCard[] {
+  const cards = new Map<string, DecisionCard>();
+
+  for (const rule of input.reviewNeeded) {
+    cards.set(rule.ruleId, {
+      id: decisionCardId(rule.ruleId),
+      ruleId: rule.ruleId,
+      title: rule.name,
+      category: rule.category,
+      severity: rule.severity,
+      owner: "human",
+      status: rule.severity === "ERROR" ? "blocked" : "needs_decision",
+      reason: reviewReason(rule),
+      proofNeeded: proofNeededForRule(rule),
+      suggestedAction: suggestedActionForRule(rule.severity),
+    });
+  }
+
+  if (input.missingInputs.length > 0) {
+    cards.set("jobsmith-missing-inputs", {
+      id: "decision-card-jobsmith-missing-inputs",
+      ruleId: "jobsmith-missing-inputs",
+      title: "Missing application inputs",
+      category: "INTAKE",
+      severity: "ERROR",
+      owner: "human",
+      status: "blocked",
+      reason: `JobSmith cannot claim submit-ready while missing: ${input.missingInputs.join(", ")}.`,
+      proofNeeded: "Provide the missing inputs or attach a no-code reason for each one.",
+      suggestedAction: "Fill the missing fields before generating or submitting the application pack.",
+    });
+  }
+
+  if (!input.artifactsReady) {
+    cards.set("jobsmith-artifacts", {
+      id: "decision-card-jobsmith-artifacts",
+      ruleId: "jobsmith-artifacts",
+      title: "Application artifacts not ready",
+      category: "ARTIFACTS",
+      severity: "ERROR",
+      owner: "jobsmith",
+      status: "blocked",
+      reason: "The CV, cover letter, or application pack artifact has not been generated yet.",
+      proofNeeded: "Attach artifact paths or an engine receipt proving the pack was generated.",
+      suggestedAction: "Generate the application pack, then rerun the rule checks.",
+    });
+  }
+
+  for (const finding of input.findings) {
+    if (finding.severity !== "ERROR") continue;
+    cards.set(finding.ruleId, {
+      id: decisionCardId(finding.ruleId),
+      ruleId: finding.ruleId,
+      title: finding.name,
+      category: finding.category,
+      severity: finding.severity,
+      owner: "jobsmith",
+      status: "blocked",
+      reason: finding.message,
+      proofNeeded: `Resolve or justify the matched text: "${finding.match}".`,
+      suggestedAction: "Fix the blocker, rerun checks, and keep the before/after receipt.",
+    });
+  }
+
+  return Array.from(cards.values()).sort(decisionCardSort);
+}
+
 function packetStatus(
   corpusReady: boolean,
   jobText: string,
@@ -163,4 +253,47 @@ function wordCount(text: string): number {
 
 function hasText(value: string): boolean {
   return value.trim().length > 0;
+}
+
+function decisionCardId(ruleId: string): string {
+  return `decision-card-${ruleId.toLowerCase()}`;
+}
+
+function reviewReason(rule: ReviewNeededRule): string {
+  if (rule.needsRefresh) {
+    return `${rule.name} needs a current human check because the rule source is stale or volatile.`;
+  }
+  if (rule.checkType === "human_review") {
+    return `${rule.name} needs judgement that the deterministic engine cannot safely automate.`;
+  }
+  if (rule.checkType === "semantic_check") {
+    return `${rule.name} needs semantic comparison against the job ad, CV, portfolio, or application intent.`;
+  }
+  return `${rule.name} needs document, format, or threshold review before submit-ready status.`;
+}
+
+function proofNeededForRule(rule: ReviewNeededRule): string {
+  if (rule.severity === "ERROR") {
+    return "A human PASS/BLOCKER decision with source evidence is required before submit-ready.";
+  }
+  if (rule.checkType === "format_check") {
+    return "DOCX/PDF render proof or metadata proof showing the format check was inspected.";
+  }
+  if (rule.checkType === "semantic_check") {
+    return "A source-linked note showing the claim matches the job ad, CV, or portfolio proof.";
+  }
+  return "A reviewer note explaining pass, accept risk, or revise.";
+}
+
+function suggestedActionForRule(severity: RuleSeverity): string {
+  if (severity === "ERROR") return "Block submit-ready until this is resolved or explicitly accepted.";
+  if (severity === "WARN") return "Review and either revise the draft or record an accepted risk.";
+  return "Review when time allows and keep the note with the final report.";
+}
+
+function decisionCardSort(a: DecisionCard, b: DecisionCard): number {
+  const severityRank: Record<RuleSeverity, number> = { ERROR: 0, WARN: 1, INFO: 2 };
+  const severityDiff = severityRank[a.severity] - severityRank[b.severity];
+  if (severityDiff !== 0) return severityDiff;
+  return a.ruleId.localeCompare(b.ruleId);
 }


### PR DESCRIPTION
## Summary
- adds a typed JobSmith decision-card bridge for review-needed rules
- turns missing inputs, missing artifacts, and deterministic ERROR findings into submit-ready blockers
- keeps this stacked on PR #949 so the Welcome Packet slice is not duplicated

## Proof
- npm run test --workspace=@unclick/jobsmith -- src/lib/applicationManager.test.ts
- npm run typecheck --workspace=@unclick/jobsmith

Boardroom job: 55766d56-ac36-476b-a6e3-81202dc5f501

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new decision-card generation and blocking logic that will affect how rule results, missing inputs, and artifact readiness gate “submit-ready” flows. Risk is moderate due to new prioritization/deduping/sorting behavior and potential UX/workflow impact if card criteria are incorrect.
> 
> **Overview**
> Adds a `buildDecisionCards` API (with new `DecisionCard*` types) that converts `reviewNeeded` rules into human-owned cards with per-check *reason*, *proofNeeded*, and *suggestedAction*, marking ERROR-severity items as `blocked`.
> 
> Also synthesizes explicit `blocked` cards when *inputs are missing* or *artifacts aren’t ready*, and turns deterministic ERROR `findings` into JobSmith-owned blocker cards; output is deduped by `ruleId` and sorted by severity then ID. Includes new unit tests covering these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057d540bebe7ed00520bc1c49c136c17246e4545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->