### PR TITLE
docs(jobsmith): add anti-AI-slop research corpus for AIDETECT rule expansion

### DIFF
--- a/apps/jobsmith/docs/copyroom/anti-ai-slop/README.md
+++ b/apps/jobsmith/docs/copyroom/anti-ai-slop/README.md
@@ -1,0 +1,36 @@
+# Anti-AI-Slop Research Corpus
+
+**Source:** Chris's research uploads, 2026-05-19
+
+**Purpose:** Feeder corpus for the new `JS-AIDETECT-31+` rule family in the JobSmith universal rules pack. Specifically supports rule-pack writer work on:
+
+- Perplexity signals
+- Burstiness signals
+- Banned-vocab cluster expansion
+- Opener and closer pattern detection
+- Sentence-rhythm / sentence-shape detection
+- Detector-specific signal lists (Pangram, GPTZero, Turnitin, Originality, Copyleaks)
+
+## Contents
+
+- `anti-ai-slop_1_2.md` — Master List: vocabulary, phrase, sentence-shape, opener/closer, structural, punctuation, logic, tone, Claude-specific, CV-specific tells, humaniser prompts, workflow fixes, detector behaviour.
+- `anti-ai-slop_2_2.md` — Megalist: current research signals, ethical detector-risk rules, evidence and provenance fixes, specificity fixes, voice fixes, structure fixes, sentence-level fixes, AI vocabulary watchlist, 2025-2026 tells, humanizer-tool residue, humanizer prompt families, safer humanizer prompts, prompts to avoid, do-not-use fixes, fast anti-slop workflow.
+
+## Related Work
+
+- **Boardroom todo:** `55766d56-ac36-476b-a6e3-81202dc5f501` (JobSmith Application Manager)
+- **Boardroom gap report comments:**
+  - `42d596a6` — round 1 gap report
+  - `db7fbc35` — round 2 gap report
+- **Why this matters:** real-world dogfood found GPTZero scoring 100% AI on text that already passed the JobSmith engine. These docs are the curated research the `JS-AIDETECT` rule family should absorb to close that gap.
+
+## Next Step (for the rule-pack writer)
+
+Extract from these documents into new rules in `apps/jobsmith/rules/jobsmith-universal-rules-v1.yaml` under category `AIDETECT`:
+
+1. Banned-vocab cluster expansions (sections A1-A10 and the AI Vocabulary Watchlist).
+2. Opener patterns (sections D1-D6, plus structure-fix opener bans).
+3. Closer patterns (sections D3, D5, plus structure-fix closer bans).
+4. Sentence-rhythm rules (section C8, C9 burstiness; sentence-level fixes for length and shape).
+5. Detector-specific signal lists (section M for false-positive context and detector signatures).
+6. Cluster-trigger rules (paragraphs with 3+ banned-vocab items, low burstiness, negative parallelism, "Bold term: explanation" lists, em-dash counts).

--- a/apps/jobsmith/docs/copyroom/anti-ai-slop/anti-ai-slop_1_2.md
+++ b/apps/jobsmith/docs/copyroom/anti-ai-slop/anti-ai-slop_1_2.md
@@ -1,0 +1,1301 @@
+# Anti-AI-Detection and Anti-Slop Master List
+
+Compiled: 2026-05-19
+
+Massive consolidated reference. Built from Wikipedia's Signs of AI Writing (WikiProject AI Cleanup), Will Francis (March 2026 Claude guide), Beutler Ink, Sabrina Ramonov, Edward Sturm, The Prompt Warrior, Dan Cleary's AI slop benchmark (April 2026), Jalaaldeen's anti-ai-slop-writing skill, Reuters Institute, Max Planck Institute studies, GPTZero research, Carnegie Mellon 2025, Cherryleaf, Embryo, HumanizeThisAI, CBS Top 25 AI Tells, Intellectual Lead, plus my own observed Claude-specific patterns and CV-context tells.
+
+Sections:
+
+- A. Vocabulary tells (single words)
+- B. Phrase tells (multi-word stock phrases)
+- C. Sentence-shape tells (constructions)
+- D. Opener and closer tells
+- E. Structural and formatting tells
+- F. Punctuation and typography tells
+- G. Logic and content tells
+- H. Tone and register tells
+- I. Claude-specific tells (what I personally do)
+- J. CV / cover letter / job application specific tells
+- K. Humaniser prompts and templates
+- L. Workflow fixes
+- M. Detector behaviour and false positives
+
+---
+
+## A. Vocabulary tells, single words
+
+A1. Era-mapped overused words (Wikipedia signs of AI writing, by model era):
+
+- 2023 to mid-2024 (GPT-4 era): additionally, boasts, bolstered, crucial, delve, emphasizing, enduring, garner, intricate, intricacies, interplay, key, landscape, meticulous, meticulously, pivotal, underscore, tapestry, testament, valuable, vibrant.
+- Mid-2024 to mid-2025 (GPT-4o era): align with, bolstered, crucial, emphasizing, enhance, enduring, fostering, highlighting, pivotal, showcasing, underscore, vibrant.
+- Mid-2025 onwards (GPT-5 era): emphasizing, enhance, highlighting, showcasing, plus undue-emphasis-on-notability words.
+
+A2. The classic banned vocabulary list, cumulative across detectors:
+
+delve, dive, deep dive, dive into, navigate, navigating (figurative), underscore, underscoring, bolster, bolstering, foster, fostering, harness, harnessing, leverage, leveraging, unpack, unpacking, shed light on, pave the way, paving the way, pivotal, groundbreaking, cutting-edge, state-of-the-art, transformative, game-changing, revolutionary, innovative, robust, comprehensive, seamless, intricate, intricacies, nuanced, multifaceted, holistic, testament, landscape (figurative), realm, paradigm, synergy, synergies, spearhead, spearheading, cultivate, cultivating, empower, empowering, elevate, elevating, streamline, streamlining, optimise, optimize, optimising, optimizing, facilitate, facilitating, showcase, showcasing, enhance, enhancing, vibrant, ever-evolving, dynamic, journey, ecosystem, tapestry, intersection, interplay, embark, embarking, unleash, unleashing, unlock, unlocking, meticulous, commendable, resonate, resonates, resonating, daunting, captivating, profound, profoundly, indispensable, paramount, treasure trove, exemplifies, exemplifying.
+
+A3. Hedge and intensifier slop:
+
+actually, genuinely, truly, simply, just, essentially, fundamentally, ultimately, notably, crucially, importantly, significantly, remarkably, particularly, especially when used as filler or empty intensifiers.
+
+A4. Approval and abstraction words used as empty praise:
+
+robust, holistic, nuanced, sophisticated, elegant, powerful, exciting, incredible, fascinating, remarkable, impressive, beautiful (applied to code or processes).
+
+A5. The promotional verbs:
+
+unlock, unleash, master, skyrocket, revolutionize, supercharge, transform, accelerate, propel, catapult, ignite, fuel.
+
+A6. Connective filler:
+
+moreover, furthermore, additionally, accordingly, consequently, thus, hence, therefore, subsequently, notably, indeed (when not actually emphatic).
+
+A7. Vague intensity modifiers:
+
+very, quite, rather, somewhat, fairly, when stacked or used as default softening.
+
+A8. Words that AI uses 50 to 269 times more than humans (GPTZero corpus research):
+
+delve, landscape (figurative), it's important to note, realm, tapestry, intricate, navigate (figurative).
+
+A9. Medical and scientific writing tells (PubMed analysis):
+
+delve into, underscore, commendable, meticulous, intricate, robust, multifaceted, garner.
+
+A10. Words to watch in 2026 that have replaced the obvious old ones:
+
+emphasize, emphasizing, highlight, highlighting, showcase, showcasing, align with, reflect, reflecting, mark, marking, signal, signaling, indicate, indicating, demonstrate, demonstrating, illustrate, illustrating.
+
+---
+
+## B. Phrase tells, multi-word stock phrases
+
+B1. The throat clearers, openers that say nothing:
+
+- In today's fast-paced world.
+- In today's rapidly evolving digital landscape.
+- In today's competitive business environment.
+- In an increasingly interconnected world.
+- In the digital age.
+- As businesses navigate the evolving landscape of.
+- In our modern era.
+- It's worth noting that.
+- It's important to note that.
+- It's worth mentioning that.
+- It cannot be overstated.
+- Without a doubt.
+- It is generally considered.
+- It is widely recognised.
+
+B2. The summary throat clearers:
+
+- In conclusion.
+- To summarise.
+- To sum up.
+- In essence.
+- Overall.
+- All in all.
+- At the end of the day.
+- When all is said and done.
+- The bottom line is.
+- To put it simply.
+
+B3. The pivot phrases:
+
+- That said.
+- With that being said.
+- Having said that.
+- On the other hand.
+- That being said.
+- Be that as it may.
+
+B4. The CV and cover letter specific cliché phrases:
+
+- I am writing to express my interest.
+- I was immediately drawn to.
+- I believe my skills make me ideal for.
+- I am a results-driven professional.
+- I have a proven track record of.
+- I am passionate about.
+- I am a self-starter.
+- I am detail-oriented.
+- I am a team player.
+- I think outside the box.
+- I hit the ground running.
+- I wear many hats.
+- I am uniquely positioned to.
+- Valuable asset to your team.
+- Thank you for considering my application.
+- Please do not hesitate to contact me.
+- I hope this email finds you well.
+- I look forward to hearing from you.
+
+B5. The promotional phrase stack:
+
+- Unlock the potential of.
+- Unleash the power of.
+- Delve into the world of.
+- Pave the way for.
+- At the forefront of.
+- Harness the power of.
+- Embark on a journey.
+- Push the boundaries of.
+- A gateway to.
+- Bridging the gap between.
+- Spearhead the initiative.
+- Capitalize on the opportunities.
+- Navigate the complexities.
+- Lay the groundwork for.
+- Foster a culture of.
+
+B6. The role and importance phrases:
+
+- Plays a crucial role in.
+- Plays a pivotal role in.
+- Plays a key role in.
+- Plays an important role in.
+- Holds significant importance.
+- Cannot be understated.
+- Of paramount importance.
+- A cornerstone of.
+- At the heart of.
+- At its core.
+- The foundation of.
+
+B7. The signpost phrases:
+
+- Let's dive in.
+- Let's delve into.
+- Let's explore.
+- Let's break it down.
+- Let's take a closer look.
+- Now let's turn to.
+- This is where X comes in.
+- That's where Y plays its part.
+- Here's the thing.
+- Here's an uncomfortable truth.
+- Here's the kicker.
+
+B8. The transition-by-restatement phrases:
+
+- Underscoring the importance of.
+- Highlighting the need for.
+- Reflecting a broader trend toward.
+- Marking a significant shift in.
+- Demonstrating the value of.
+- Illustrating how.
+- Showcasing the importance of.
+
+B9. The intimacy-faking phrases:
+
+- I'd be happy to.
+- I'm glad you asked.
+- That's a great question.
+- What a fascinating topic.
+- Excellent question.
+- Thanks for sharing.
+- I appreciate you sharing.
+
+B10. Social media presence boilerplate (Wikipedia flagged):
+
+- Maintains an active social media presence.
+- Maintains a strong digital presence.
+- Has built a robust online following.
+- Engages actively with their community.
+
+B11. Vague authority phrases (weasel wording):
+
+- Many experts agree.
+- It is widely believed.
+- Research has shown.
+- Studies indicate.
+- According to recent reports.
+- Industry leaders suggest.
+
+B12. The faux-spectrum false ranges:
+
+- From X to Y (when X and Y do not form a real spectrum).
+- From intimate gatherings to global movements.
+- From technical expertise to creative vision.
+- Whether you're A or B (when only one matters).
+
+B13. Hedge spam:
+
+- May vary depending on.
+- Can differ based on.
+- It depends on a number of factors.
+- There are several considerations.
+
+---
+
+## C. Sentence-shape tells, constructions
+
+C1. The negative parallelism (the most flagged AI tell):
+
+- It's not X, it's Y.
+- It's not just X. It's Y.
+- This isn't about X. It's about Y.
+- It's not only X but also Y.
+- Not just X, but Y.
+- Less of X, more of Y.
+
+C2. The tricolon, rule of three:
+
+- Innovative, transformative, and groundbreaking.
+- Fast, reliable, and scalable.
+- Adjective adjective adjective patterns.
+- Lists that always come in threes.
+
+C3. The hourglass paragraph:
+
+- General statement, narrow specific, general restatement.
+- Topic sentence, three points, summary sentence.
+
+C4. The rhetorical question self-answer:
+
+- So what does this mean? It means…
+- Why does this matter? Because…
+- What's the takeaway? Simple.
+
+C5. The faux-emphatic short sentence stack:
+
+- No X. No Y. Just Z.
+- Period.
+- Full stop.
+- End of story.
+
+C6. The hedging seesaw:
+
+- While X is true, Y is also true.
+- On one hand X, on the other hand Y.
+- It's both X and Y.
+
+C7. The corporate pep talk shape:
+
+- You're not alone.
+- Here's why this matters.
+- The good news is.
+
+C8. Uniform sentence length syndrome:
+
+- Every sentence roughly the same word count.
+- Metronomic rhythm with no short interruptions or messy detours.
+- Low burstiness, the technical term detectors look for.
+
+C9. Same-shape paragraphs:
+
+- Every paragraph 3 to 4 sentences.
+- Every paragraph opens with a topic sentence.
+- Every paragraph closes with a wrap-up sentence.
+
+C10. The meta-summary sentence:
+
+- A sentence at the end that restates the list just given.
+- Often phrased as "in summary, these factors all contribute to…"
+
+C11. The reframing trick:
+
+- It's about more than X. It's about Y, Z, and beyond.
+- Beyond just X, this represents Y.
+
+C12. The list-by-comma triplet:
+
+- A, B, and C, where A, B, C are loosely related and form no real category.
+
+C13. The "shape of insight without insight":
+
+- Sentences that mimic the structure of a profound point but contain no claim.
+- Example: "It's not the tools, it's how you use them" (when the prompt has nothing to do with tools).
+
+---
+
+## D. Opener and closer tells
+
+D1. Banned sentence openers:
+
+- Certainly,
+- Absolutely,
+- Of course,
+- Indeed,
+- Moreover,
+- Furthermore,
+- Additionally,
+- However, (when used to start every other sentence)
+- Notably,
+- Importantly,
+- Significantly,
+- In fact,
+- As such,
+- That said,
+- With that in mind,
+- It's worth noting,
+
+D2. Banned response openers (chat-specific):
+
+- Great question!
+- Excellent question!
+- That's a fantastic point.
+- I'd be happy to help with that.
+- Absolutely, I can help.
+- Let me help you with that.
+- Of course! Here's what I think.
+- Sure thing!
+- Happy to help!
+
+D3. Banned response closers:
+
+- I hope this helps!
+- Let me know if you have any questions.
+- Feel free to ask if you need more information.
+- Hope that clarifies things!
+- Does that make sense?
+- Let me know how else I can help.
+- Is there anything else you'd like to know?
+
+D4. The over-friendly emoji closer:
+
+- 🚀, ✨, 💪, 🎉 dropped at the end of a sentence to fake warmth.
+
+D5. The summary-bow closer:
+
+- In conclusion, X demonstrates the importance of Y.
+- Ultimately, this comes down to Z.
+- At the end of the day, what really matters is.
+
+D6. The restatement opener:
+
+- "You asked about X. Here's what I know about X."
+- "When it comes to X, there are several things to consider."
+
+---
+
+## E. Structural and formatting tells
+
+E1. The "Bold term: explanation" list format:
+
+- **Innovation:** something about innovation.
+- **Quality:** something about quality.
+- **Scalability:** something about scalability.
+- The single most recognisable AI list shape, per Will Francis and Wikipedia.
+
+E2. Excessive bolding inside paragraphs:
+
+- Every important noun in bold.
+- Every key phrase in bold.
+- Reads like a damn textbook.
+
+E3. Header overkill:
+
+- H2 every two paragraphs.
+- Numbered lists where prose would work.
+- Subheadings for sections one paragraph long.
+
+E4. Markdown bleeding into plain text:
+
+- Asterisks left in.
+- Hashes for headers in an email body.
+- Backticks around skill names.
+- Three-dash dividers.
+
+E5. Listicle creep:
+
+- Everything turned into bullets.
+- Exactly 3, 5, 7, or 10 items.
+- Lists of 3 or 5 specifically over-favoured.
+
+E6. Symmetry that screams template:
+
+- Three sections of identical length.
+- Bullet lists of identical length.
+- Two columns balancing perfectly.
+
+E7. Emoji bullet points:
+
+- ✅ Item one
+- 🎯 Item two
+- 🚀 Item three
+
+E8. Hashtag stacks at the end of a post:
+
+- #ai #marketing #leadership #productivity #growth
+
+E9. Numbered intro phrases that count themselves:
+
+- "First, …" "Second, …" "Third, …" used reflexively, not because order matters.
+
+E10. The "TL;DR" pre-fix:
+
+- AI uses TL;DR at the top of responses where the response itself is short.
+
+E11. Tables for things that aren't comparable:
+
+- Forcing comparison-table format on prose information.
+
+E12. Code blocks for things that aren't code:
+
+- Inline backticks around ordinary nouns.
+
+E13. The four-paragraph cover letter scaffold:
+
+- Para 1: introduce self.
+- Para 2: match experience.
+- Para 3: generic company praise.
+- Para 4: closing eagerness.
+
+E14. Conclusion sections in short content:
+
+- A "Conclusion" header on a 400 word piece.
+
+E15. FAQ sections nobody asked for.
+
+E16. "Key takeaways" boxes nobody asked for.
+
+---
+
+## F. Punctuation and typography tells
+
+F1. Em dash overuse:
+
+- Multiple em dashes per paragraph.
+- Em dashes where commas, parentheses, colons, or hyphens would do.
+- Most infamous tell of 2024 to 2026.
+- Note: Anthropic explicitly suppresses em dashes in newer Claude models, which means present-day Claude is less prone to this than older models or other models.
+
+F2. Missing en dashes:
+
+- AI uses hyphens for date ranges (1990-2000) where an en dash belongs (1990–2000).
+- AI uses hyphens for scores (3-2) where en dashes belong.
+
+F3. Curly quotes vs straight quotes:
+
+- ChatGPT and DeepSeek tend to output curly "smart" quotes (" " or ' ').
+- Most human web text uses straight quotes (" " or ' ').
+- Mixing both signals editing by AI.
+
+F4. Exclamation spam:
+
+- Multiple exclamation points across one response.
+- Often paired with intensifiers ("That's exciting!", "Incredible!").
+
+F5. Ellipsis abuse:
+
+- ... used to pad sentences.
+- "But here's the thing..." with trailing dots.
+
+F6. Title case in headings that should be sentence case:
+
+- Or sentence case in headings that should be title case.
+- Inconsistent capitalisation across one document.
+
+F7. Non-breaking spaces and invisible characters:
+
+- Sometimes survive copy paste from AI output.
+
+F8. Inconsistent dash spacing:
+
+- "X — Y" sometimes, "X—Y" other times, "X - Y" in a third place.
+
+F9. Quotation marks around ordinary words:
+
+- AI puts "quotes" around "key terms" "for emphasis" "constantly".
+
+F10. Random title case mid-sentence:
+
+- "We need to focus on Customer Experience and Operational Excellence."
+
+F11. Decorative arrows and Unicode glyphs:
+
+- → ✓ ★ ➜ inserted for "punch".
+
+---
+
+## G. Logic and content tells
+
+G1. Generic statements with no specifics:
+
+- Claims that could apply to 50 companies, 50 candidates, 50 articles.
+
+G2. Confident vagueness:
+
+- High confidence, low information density.
+- "This is incredibly important for businesses today."
+
+G3. Promotional tone in informational contexts:
+
+- Reads like a tourism website even when the topic is mundane.
+- Wikipedia editors flag this consistently.
+
+G4. Symmetric balance forced into asymmetric reality:
+
+- "X has both strengths and weaknesses" when only one is relevant.
+
+G5. Undue emphasis on notability and media coverage:
+
+- AI loves to mention "received critical acclaim", "garnered media attention", "has been widely covered".
+
+G6. Invented statistics:
+
+- "Studies show 73% of professionals…" with no source.
+- Round numbers that fall in suspicious clusters.
+
+G7. Fabricated quotes:
+
+- AI invents quotes from real people and real-sounding made-up people.
+
+G8. Fake anecdotes:
+
+- "I recently spoke with a CEO who told me…"
+- "A friend of mine in the industry mentioned…"
+
+G9. Hallucinated specifics:
+
+- Invented book titles, conference names, journal citations.
+
+G10. The "Wikipedia voice":
+
+- Grammatically perfect, completely soulless, vague intensifiers, no personality.
+
+G11. No actual stance:
+
+- Every viewpoint balanced.
+- No opinion, no tension, no tradeoff acknowledged.
+
+G12. Pattern-matching rather than reasoning:
+
+- Sentences that mimic the shape of analysis without analysing.
+
+G13. Surface coverage rather than depth:
+
+- Touches every topic, examines none.
+
+G14. Failure to acknowledge tradeoffs:
+
+- "X is great because A, B, and C." No mention of costs, exceptions, edge cases.
+
+G15. Mismatched specificity:
+
+- Vague generalities sit next to oddly specific numbers.
+
+G16. Ironclad certainty about contested topics:
+
+- Where humans would hedge, AI commits.
+
+G17. Repetition of the same idea in different words:
+
+- The "successful, accomplished, achieved" cluster from arXiv slop research.
+
+G18. Restating the prompt before answering:
+
+- "You're asking about X. X is an important topic. Let me explain X."
+
+G19. Hedging followed by contradiction:
+
+- "While there's no single answer… here's the single answer."
+
+---
+
+## H. Tone and register tells
+
+H1. Uniformly formal register:
+
+- No casual asides.
+- No contractions.
+- No fragments.
+- No starting sentences with And, But, So.
+
+H2. Performative enthusiasm:
+
+- "Exciting", "incredible", "powerful", "amazing" applied to mundane things.
+
+H3. Sycophancy:
+
+- Praising the user's question.
+- Praising the user's choice of topic.
+- Praising the user.
+
+H4. Excessive humility:
+
+- "I might be wrong, but…"
+- "While I'm not an expert…" before expert content.
+
+H5. Diplomatic fog:
+
+- Refusing to take any position on anything.
+- Both-sides-ing everything including unbalanced questions.
+
+H6. Productivity-blog phrasing:
+
+- "Game-changer", "leveraging", "moving the needle", "circling back".
+
+H7. LinkedIn-influencer voice:
+
+- "Here's what I've learned in 10 years of…"
+- "Most people get this wrong. Here's the truth…"
+- "Stop doing X. Start doing Y."
+
+H8. Press-release voice:
+
+- "We are thrilled to announce."
+- "Excited to share."
+- "Proud to be a part of."
+
+H9. TED-talk voice:
+
+- "Imagine for a moment…"
+- "What if I told you…"
+- "Here's the secret nobody talks about."
+
+H10. Empty warmth:
+
+- "Smart friend over coffee" tone where there is no friend, no coffee, and no specificity.
+
+H11. Persuasive register applied to neutral information:
+
+- Every paragraph trying to sell something even when nothing is being sold.
+
+---
+
+## I. Claude-specific tells (what I personally do, internal honesty)
+
+I1. The acknowledgement opener:
+
+- "I can help with that."
+- "Sure, I can do that."
+- "Happy to help."
+
+I2. The thinking-aloud preamble:
+
+- "Let me think about this…"
+- "Let me work through this…"
+- "Here's my approach…"
+
+I3. The recap closer:
+
+- A summary paragraph at the end restating what I just said.
+
+I4. The numbered-then-prose mix:
+
+- Giving 1, 2, 3 even when the items don't need ordering.
+
+I5. The "I notice" / "I see" observation:
+
+- "I notice you mentioned…"
+- "I see you're working on…"
+- Treating obvious things as worth flagging.
+
+I6. The "this is interesting" framing:
+
+- Calling questions or topics interesting, exciting, fascinating, great.
+
+I7. Confidence calibration ritual:
+
+- "I'm not 100% sure but…"
+- "I think, though I could be wrong…"
+- When the answer is solid.
+
+I8. Hedging on factual content where I shouldn't:
+
+- "It depends" as a default when there's actually a clear answer.
+
+I9. The structured response reflex:
+
+- Headers, bullets, bold for everything.
+- Refusing to write prose when prose would do.
+- Even when explicitly asked for prose.
+
+I10. The "broader context" insertion:
+
+- Adding paragraphs about why something matters before answering what was asked.
+
+I11. The triple structure on output:
+
+- Intro paragraph, body, summary paragraph, for every response.
+
+I12. Sycophantic agreement:
+
+- "That's a really good point."
+- "Yes, exactly."
+- "Great instinct."
+
+I13. The over-explanation:
+
+- 800 words where 100 would land harder.
+
+I14. The "let me know" closer:
+
+- "Let me know if you need anything else."
+- "Happy to refine further."
+
+I15. The clarification offer:
+
+- "Would you like me to expand on any of these?"
+- "Want me to dig deeper into one?"
+
+I16. The "balanced view" reflex:
+
+- Adding counterpoints to balanced statements.
+- Adding pros after every con.
+
+I17. The em dash slip:
+
+- Even with em dashes suppressed, the rhythm of em-dash-style writing leaks through as parenthetical commas everywhere.
+
+I18. The "to be clear" insertion:
+
+- "To be clear, what I mean is…"
+- "To put it another way…"
+
+I19. The "fundamentally / essentially / ultimately" intensifier:
+
+- Used as throat-clearing before a claim.
+
+I20. The format mirror:
+
+- Mirroring the user's exact format whether or not it serves them.
+
+I21. The over-caveat:
+
+- Adding "depending on context" or "for your specific situation" when the answer is universal.
+
+I22. The mid-response check-in:
+
+- "Does this make sense so far?"
+
+I23. The "happy to" verb stack:
+
+- "Happy to refine, expand, adjust, iterate, or rewrite this."
+
+I24. The transition signal abuse:
+
+- "Now let's move to…"
+- "Turning to…"
+- "Building on this…"
+
+I25. The "in essence" / "in short" / "in other words" reformulation:
+
+- Restating the same idea three different ways across one paragraph.
+
+---
+
+## J. CV, cover letter and job application specific tells
+
+J1. The generic skills paragraph:
+
+- "Excellent communication skills, strong attention to detail, proven leadership ability, and a passion for innovation."
+
+J2. The metrics that don't exist:
+
+- "Increased revenue by 47%" with no methodology or scope.
+- "Improved efficiency by 35%" with no baseline.
+- Round-number clusters (10%, 20%, 30%).
+
+J3. The level mismatch:
+
+- Entry-level candidate using C-suite strategy language.
+- Mid-career marketer using executive consulting jargon.
+- A clear sign of borrowed AI vocabulary.
+
+J4. The "results-driven professional" tell:
+
+- Per BridgeView IT February 2026, the single most flagged red flag in CVs.
+
+J5. The mirror-the-JD copy:
+
+- Lifting JD bullet points verbatim and dropping them into the CV.
+- Recruiters notice when phrasing is identical to their own ad.
+
+J6. The convergent CV problem:
+
+- When 35% of applicants use the same tool with the same prompts, CVs converge.
+- Eerily similar phrasing across candidates is a 2026 recruiter tell.
+
+J7. The polished-but-collapses-on-call CV:
+
+- Reads beautifully on paper, the candidate can't discuss the content in conversation.
+- Top recruiter tell per 2026 surveys.
+
+J8. The "in today's competitive job market" cover letter opener.
+
+J9. The "I am writing to express my strong interest" opener.
+
+J10. The four-paragraph cover letter scaffold (see E13).
+
+J11. Generic company praise that could fit any employer:
+
+- "Your innovative approach to industry challenges."
+- "Your commitment to excellence."
+- "Your reputation for quality."
+
+J12. Inflated soft-skill claims:
+
+- "Excellent leader, passionate team player, results-oriented self-starter."
+
+J13. The synonyms-for-everything skills section:
+
+- Listing five words for the same skill.
+- Adding skills you've never used because the JD mentioned them.
+
+J14. The headline statement nobody says aloud:
+
+- "Dedicated professional with a proven track record of driving impactful results across cross-functional teams."
+
+J15. Personal projects framed as enterprise-grade work:
+
+- "Architected a robust, scalable solution" describing a weekend hobby script.
+
+J16. The closing eagerness paragraph:
+
+- "I would be thrilled to bring my passion and dedication to your team."
+
+J17. Mismatched register between CV and cover letter:
+
+- CV terse and human, cover letter florid and AI-flavoured (or the reverse).
+
+J18. Achievements without context:
+
+- "Led project to completion." No team size, no constraint, no outcome.
+
+J19. Identical achievements across multiple roles:
+
+- AI tends to repeat the same verb-result patterns for every role.
+
+J20. The "passionate about" stack:
+
+- Passionate about X, passionate about Y, passionate about Z.
+
+J21. CV-specific AI vocabulary (especially flagged):
+
+- Spearheaded, orchestrated, championed, drove, executed, delivered, optimised, transformed, revolutionised.
+- These verbs aren't banned, but stacking them is a tell.
+
+J22. The "valued asset" framing:
+
+- "I would be a valuable asset to your organisation."
+
+J23. The hidden tabbed metadata:
+
+- Resume builders sometimes leave a fingerprint in document metadata.
+
+J24. The em-dash CV in a market that doesn't use them:
+
+- Australia, UK, NZ, Canada CVs typically have no em dashes. Their sudden appearance signals AI or US template.
+
+---
+
+## K. Humaniser prompts and templates
+
+K1. The Sabrina Ramonov style prompt (widely shared, July 2025):
+
+```
+# FOLLOW THIS WRITING STYLE:
+- SHOULD use clear, simple language.
+- SHOULD be spartan and informative.
+- SHOULD use short, impactful sentences.
+- SHOULD use active voice; avoid passive voice.
+- SHOULD focus on practical, actionable insights.
+- SHOULD use bullet point lists in social media posts.
+- SHOULD use data and examples to support claims when possible.
+- SHOULD use "you" and "your" to directly address the reader.
+- AVOID using em dashes (—) anywhere. Use only commas, periods, or other standard punctuation.
+- AVOID: constructions like "not just this, but this", rule-of-three lists, rhetorical questions, and uniform sentence length.
+```
+
+K2. The Edward Sturm one-liner (saves to custom instructions):
+
+```
+Write like a human. Keep it professional but conversational. Don't use em dashes or buzzwords like 'streamlined.' Avoid sounding like a press release. Be clear, direct, and natural, like you're writing to a smart friend.
+```
+
+K3. The Will Francis Claude custom instructions (full version, March 2026):
+
+```
+## Voice
+Be direct. Have opinions. Use specific examples and names, not vague claims. State your point first, then support it. Trust the reader to recognise what matters without labelling it as "significant" or "important."
+
+## Banned words
+Never use these. They are the most flagged AI-writing markers:
+delve, dive into, navigate (figurative), underscore, bolster, foster, harness, leverage, unpack, shed light on, pave the way, pivotal, groundbreaking, cutting-edge, transformative, game-changing, innovative, robust, comprehensive, seamless, intricate, nuanced (as empty praise), vibrant, multifaceted, holistic, testament, landscape (figurative), realm.
+
+Never use these phrases:
+- "In today's [fast-paced/rapidly evolving/digital] world..."
+- "It's important/worth noting that..."
+- "One of the most [important/significant/crucial]..."
+- "When it comes to..." / "At its core..." / "At the end of the day..."
+- "This is where X comes in" / "Let's break it down"
+- "Plays a crucial role in..." / "It cannot be overstated..."
+- "...underscoring the importance of..." / "...highlighting the need for..."
+- "...reflecting a broader trend toward..." / "...marking a significant shift in..."
+
+Never use these structures:
+- "It's not just X. It's Y"
+- "Not only X, but Y"
+- "This isn't about X. It's about Y."
+- "No X. No Y. Just Z."
+
+## Structure
+- Vary paragraph and sentence length. Don't write uniform blocks.
+- Never use the "Bold term: explanation sentence" list format.
+- Don't signpost ("Let's explore," "Now let's turn to"). Just make your point.
+- Don't open with a sweeping contextual statement. Don't close with a summary or inspirational wrap-up. Start and end on substance.
+- Don't restate the question back before answering.
+
+## Style
+- Use contractions. "It's," "don't," "won't."
+- Maximum one em dash per response. Use commas or parentheses instead.
+- Don't over-format. Plain prose is often clearer than headers and bullet points.
+- Drop preamble ("Great question!"), performative enthusiasm, and unsolicited caveats.
+- Match tone to context.
+
+## Before finishing, check:
+1. Read it out loud. Does any sentence sound like a press release? Rewrite it.
+2. Are you repeating the same point in different words? Say it once.
+3. Does your opening sentence set the scene with a grand statement about the state of the world? Delete it.
+```
+
+K4. The Prompt Warrior content humaniser (April 2025):
+
+```
+You are a writer humanising AI text. Apply these rules to the input:
+a) Use a conversational, direct tone.
+b) Mix sentence lengths.
+c) Use simple language. Cut adjectives.
+d) Use first-person where natural.
+e) Use bullet points only when relevant.
+f) Use analogies and concrete examples.
+g) Split up long sentences.
+h) Include personal anecdotes where appropriate (use my notes).
+i) Use bold/italic sparingly for emphasis.
+j) Do not use emojis or hashtags.
+k) Avoid words like "game-changing," "unlock," "master," "skyrocket," "revolutionize."
+```
+
+K5. The free Mukeshk humaniser:
+
+```
+Act as a human content editor. You're given a piece of AI-generated text that sounds robotic or too formal. Your job is to rewrite it so it sounds like a real person wrote it. Natural, friendly, casual. Avoid robotic tone, complex words, and overly polished grammar. Make it sound relaxed but still clear.
+
+Here's my input:
+[PASTE TEXT]
+
+About me: I write for [AUDIENCE]. My tone is usually [TONE]. Keep it simple and conversational, like I'm talking to a friend. Use contractions, questions, and relatable phrasing. Return just the humanised version. Don't explain anything.
+```
+
+K6. The persona prompt template (Intellectual Lead, November 2025):
+
+```
+You are a [role] writing for [audience]. Write in a clear, conversational tone using "you" and "your". Use short sentences and mix lengths for rhythm. Avoid clichés, buzzwords, and formal filler. Prefer concrete verbs and examples over general claims. Sound experienced but approachable.
+```
+
+K7. The stance prompt:
+
+```
+Take a clear stance on this topic. Explain your reasoning and the trade-offs. Use first person ("I") if a viewpoint helps. Include one specific example.
+
+Topic: [TOPIC]
+
+Guardrails:
+- Be direct. No hedging language.
+- Keep paragraphs under 4 lines.
+- Avoid hype, clichés, and tricolons.
+```
+
+K8. The surprising-angles prompt:
+
+```
+Give me 3 non-obvious angles on [topic]. For each: one-sentence thesis, a fresh comparison or metaphor, and one concrete example.
+```
+
+K9. The voice-sample prompt:
+
+```
+Here's a writing sample to teach you my style and tone:
+[PASTE SAMPLE]
+
+Only reply 'ok' if the extract is clear. Then wait for my next instruction.
+```
+
+K10. The variation prompt (forces burstiness):
+
+```
+Write with a high degree of perplexity and burstiness. Mix short, punchy sentences with longer, complex ones. Avoid a uniform rhythm.
+```
+
+K11. The Reddit-user roleplay (high burstiness):
+
+```
+Rewrite this text in the style of a casual Reddit user. Keep the tone loose, opinionated, and slightly messy. Start some sentences with 'And' or 'But' to maintain conversational flow. Use contractions. Don't over-explain.
+```
+
+K12. The ban-list prompt:
+
+```
+Write [task]. Strict constraints:
+- Do not use: delve, landscape (figurative), tapestry, moreover, however (as opener), additionally, furthermore, in conclusion, it's worth noting, in today's, navigate (figurative).
+- Use active voice.
+- Maximum one em dash. Maximum one exclamation point.
+- No "Bold term: explanation" lists.
+- No three-item adjective stacks.
+- No restating the prompt.
+```
+
+K13. The CV-specific humaniser:
+
+```
+Rewrite these CV bullets so they sound like the person actually wrote them, not a results-driven professional template:
+- Cut every adjective that isn't load-bearing.
+- Use specific tools, scope, constraint, and outcome.
+- Vary opening verbs across bullets.
+- One idea per bullet.
+- No spearheaded, orchestrated, leveraged, championed.
+- No "passionate about", "results-driven", "proven track record".
+- If the original had a number, keep it. Don't invent new numbers.
+
+[PASTE BULLETS]
+```
+
+K14. The cover letter humaniser (story-led):
+
+```
+Write a cover letter for [role] at [company]. Constraints:
+- Start with a specific moment, problem, or observation. Not "I am writing to express my interest."
+- One concrete reason for interest in this company (not the homepage tagline).
+- One evidence story tied to a JD must-have.
+- One sentence on why now.
+- Calm next step.
+- No "valuable asset", "proven track record", "results-driven".
+- Maximum 250 words.
+- Use British English.
+- Use the writing style of someone who is tired of bad cover letters and has decided to write one good one.
+```
+
+K15. The two-pass humaniser (most effective per Reddit consensus):
+
+Pass 1: Generate.
+Pass 2: Paste output into a fresh window with the prompt: "Identify every phrase in this text that sounds AI-generated. Rewrite each one in plain human English. Return the rewritten version."
+
+K16. The "stop trying so hard" prompt:
+
+```
+Write [task]. Be boring. Do not try to make it interesting. Do not add hooks. Do not add takeaways. Do not summarise. Just answer the question and stop.
+```
+
+K17. The chain-of-edit prompt:
+
+```
+Step 1: Draft the response.
+Step 2: Re-read it. Mark every sentence that could be cut without losing meaning.
+Step 3: Cut those sentences. Return the shorter version.
+```
+
+K18. The voice-rules prompt for Claude Custom Instructions:
+
+```
+I write in a [TONE] tone. I'm [KNOWLEDGE LEVEL] without being showy. I use [British/Australian/US] English. I prefer short sentences and plain language over jargon. I never use em dashes. I never write "in today's" anything. I never start a response with "Great question" or end with "Let me know if you have any other questions". When I'm being asked for content (post, email, article), match my voice. When I'm being asked for analysis, be direct and stake claims.
+```
+
+K19. The "no preamble, no postamble" rule:
+
+```
+Answer immediately. No preamble. No postamble. No summary. No "here's what I've done". Just the requested output.
+```
+
+K20. The contrarian prompt:
+
+```
+Most writing on [topic] takes [position]. Write a piece that disagrees, in specific terms, with one concrete example. Don't both-sides it. Don't soften it at the end. Stake the claim.
+```
+
+K21. The boring-loading-message prompt for serious topics:
+
+```
+For [serious topic], write plainly. No metaphors. No vivid language. No persuasion. State what is, with sources where needed.
+```
+
+K22. The "fix only" pass:
+
+```
+Don't rewrite. Only remove. Read this draft and delete every sentence, phrase, and word that is filler, AI cliché, or restatement. Return the leaner version with nothing added.
+```
+
+K23. The negative-instruction stacking:
+
+```
+Write [task] without using any of these patterns:
+- Sentences that start with a transition word.
+- Sentences that contain "important", "crucial", "significant", "key".
+- Sentences that contain "it's not just X, it's Y".
+- Paragraphs that end with a wrap-up sentence.
+- Lists of exactly three items.
+- The word "comprehensive".
+```
+
+K24. The "evidence first" prompt:
+
+```
+Before generating, give me a 5-line evidence block: claim, source, specifics, constraint, outcome. Only generate the prose after I confirm the evidence is right.
+```
+
+K25. The Justin Fineberg / popularised one-liner:
+
+```
+Write this like you're texting a smart friend who's busy. No fluff.
+```
+
+---
+
+## L. Workflow fixes
+
+L1. Use AI for the draft, never the final pass.
+
+L2. Read every output out loud. Anything that sounds like a press release gets rewritten.
+
+L3. Two-pass minimum. Generate then human-edit, or generate then humanise-prompt then human-edit.
+
+L4. Save a personal banned-words list and add to it whenever you spot a new AI tell.
+
+L5. Save a personal voice description (3 sentences) and reuse across tools.
+
+L6. Build a master CV / wins file with provenance. AI can sharpen what you wrote; it should never originate facts.
+
+L7. For high-stakes content (CVs, cover letters, public posts), run output through an AI detector before submitting. Not because detectors are gospel, but because they catch the most obvious markers.
+
+L8. Use Claude over ChatGPT when voice matters. Per multiple 2025-2026 comparisons, Claude tends to produce less obviously formulaic output by default.
+
+L9. Use GPT-5 over older OpenAI models if you must use ChatGPT for voice work.
+
+L10. Avoid "polish this" or "make it better" prompts. They produce slop.
+
+L11. Use specific verbs in prompts: tighten, cut, sharpen, ground, specify, replace, rewrite the third paragraph only.
+
+L12. For CVs specifically, don't ask AI to rewrite the whole CV. Ask it to flag every sentence that doesn't have a metric, scope, or specific claim. You decide what to cut.
+
+L13. Use the human-AI-human sandwich: human writes raw bullets, AI tightens, human reviews and replaces any line that sounds borrowed.
+
+L14. Test by giving the AI your draft and asking "What sounds like AI here?". Models are surprisingly good at spotting their own patterns.
+
+L15. Always paste a writing sample into Claude Projects or ChatGPT Custom Instructions. Adapt to a described style means the style needs to exist somewhere.
+
+L16. Strip metadata. Save documents as plain DOCX or plain PDF. Remove "generated by" template fingerprints.
+
+L17. Avoid the "humanise this" tools (QuillBot, Undetectable AI, Humbot). They strip AI patterns but introduce their own paraphrase fingerprints. Detectors trained on paraphrased text catch them.
+
+L18. The accumulation rule: a handful of small specifics across a document (named projects, real constraints, real tradeoffs, defensible numbers, named tools, verifiable links) shifts the trust default more than one polished paragraph.
+
+L19. For technical writing, include code snippets, commands, or version numbers. AI tends to be vague about specific versions.
+
+L20. Don't run AI output through paraphrase tools more than once. Each pass introduces detectable artefacts.
+
+L21. The "what would I delete" test: skim your own output, mark anything that adds no information. Delete it.
+
+L22. The "would I say this aloud" test: read it out. If you would never speak these words, rewrite.
+
+L23. Time-box AI editing. The marginal return drops fast after the second pass.
+
+L24. Keep a "voice file" of your own past writing. Feed it into the prompt as context whenever voice matters.
+
+L25. For job applications, the gold-standard process is: human bullet notes with provenance, AI tightening (single pass), human voice review, plain-text test, submit.
+
+---
+
+## M. Detector behaviour and false positives
+
+M1. Detectors are noisy. False positive rates are significant, especially for:
+
+- Non-native English writers.
+- Regulated-industry writing (legal, medical, scientific).
+- Short documents (under 500 words).
+- Formal styles.
+- Heavily edited or templated content (CVs!).
+
+M2. Detectors flag non-native English authors more than native speakers, even before AI existed. This is a known fairness issue (J Dermatol 2025).
+
+M3. Pangram, GPTZero, Originality, Copyleaks, Turnitin all have different signatures. Passing one does not mean passing another.
+
+M4. Humanised AI text often still gets flagged when:
+
+- It still uses AI sentence shapes.
+- It still has uniform sentence length (low burstiness).
+- It still has perfect grammar with zero typos.
+
+M5. Detection is more accurate at paragraph level than sentence level.
+
+M6. Detectors lose accuracy with every new model release.
+
+M7. The Carnegie Mellon 2025 study and arXiv 2501.15654 paper found that experienced human ChatGPT users are better than every detector at spotting AI text.
+
+M8. Recruiters use pattern matching (vocabulary, structure, cliché phrases), not detection tools, in 2026. They're often more accurate than the tools.
+
+M9. Detection tools can be gamed but recruiters cannot. Optimise for the recruiter not the tool.
+
+M10. Some detectors specifically train on humaniser outputs. Running through QuillBot or Undetectable AI can flag your text as having been through a humaniser, which itself is a signal.
+
+M11. The Wikipedia editor approach (manual pattern recognition) outperforms automated tools across thousands of real cases.
+
+M12. The single highest-signal tells per Pangram and GPTZero corpus research:
+
+- Em dash overuse.
+- "Bold term: explanation" list format.
+- Negative parallelism ("It's not X, it's Y").
+- Vocabulary cluster (delve, landscape, tapestry, intricate, pivotal in the same paragraph).
+- Sentence-length uniformity (low burstiness).
+
+M13. Privacy warning: do not upload unredacted CVs to public detectors. Use redacted copies if testing is essential.
+
+M14. The "AI detector probability score" is misleading. A 35% AI score on one detector might be 89% on another. Treat scores as directional, not absolute.
+
+M15. False positive risk: do not assume silence from a recruiter means an AI rejection. Most rejections are about fit, role-match, or simple volume.
+
+---
+
+## Cross-reference notes for the CV checklist file
+
+The CV checklist consolidated v1 already covers many of these at a higher level in rules 49 to 60. This document expands those rules into actionable specifics. Suggested integration:
+
+- Rule 54 (strip AI vocabulary) -> use section A above as the source list.
+- Rule 55 (remove generic AI phrases) -> use section B above.
+- Rule 56 (avoid AI sentence shapes) -> use section C above.
+- Rule 57 (avoid AI cover letter scaffolding) -> use section J above.
+- Rule 58 (clean punctuation) -> use section F above.
+- Rule 59 (avoid over-designed AI format) -> use section E above.
+- Rule 60 (keep tone human and direct) -> use section H above.
+
+Add new candidate rules to the consolidated CV checklist:
+
+- N1. Test for vocabulary clusters: paragraphs with 3 or more banned-vocabulary words from section A trigger rewrite, not just edit.
+- N2. Test for sentence-length variance: if the standard deviation of sentence word count across a paragraph is under 3, vary lengths.
+- N3. Test for negative-parallelism: search for "not just" and "not only…but also" and rewrite each instance.
+- N4. Test for "Bold term: explanation" formatting in any skills or experience section and remove it.
+- N5. Test for em dashes; in Chris's case, target zero per his existing rule 100.
+- N6. Test for false ranges ("from X to Y"); rewrite as plain claims.
+- N7. Test for compulsive summaries at the end of any section; delete them.
+- N8. Personal-voice test: every paragraph should have something only the candidate would write. If a paragraph could appear on 50 other CVs, rewrite or cut.
+
+---
+
+## Sources
+
+- Wikipedia: Signs of AI Writing (WikiProject AI Cleanup, ongoing).
+- Will Francis, "How to Stop Claude Writing Like an AI", March 2026.
+- William Beutler, Beutler Ink, "How to Spot AI Writing, According to Wikipedia", January 2026.
+- Sabrina Ramonov, "Best AI Prompt to Humanize AI Writing", July 2025.
+- Edward Sturm, "How to Humanize ChatGPT Content", February 2026.
+- The Prompt Warrior, "The Content Humanizer Prompt", April 2025.
+- Dan Cleary, "I built a benchmark to measure AI Slop", April 2026.
+- Jalaaldeen, anti-ai-slop-writing GitHub skill, March 2026.
+- Reuters Institute, "How AI-generated prose diverges from human writing", December 2025.
+- Max Planck Institute, vocabulary studies, 2024-2025.
+- GPTZero corpus research (3.3 million documents).
+- Carnegie Mellon University, AI detection by human experts study, 2025.
+- arXiv 2501.15654 (humans outperform detectors on humanised AI text).
+- arXiv 2509.19163 (Measuring AI Slop in Text taxonomy).
+- BridgeView IT, recruiter AI detection guide, February 2026.
+- TopResume 2026 hiring manager survey (800+ respondents).
+- AiApply Blog, "Can Employers Tell If You Use AI for a Cover Letter?", January 2026.
+- T-AI-LOR, "AI Resume Detection in 2026", March 2026.
+- Cherryleaf, "Indicators that suggest something was written by AI", February 2026.
+- Embryo, "A list of words that AI over-uses", May 2025.
+- HumanizeThisAI, "50 Words AI Overuses", March 2026.
+- CBS Top 25 AI Tells, September 2024.
+- Intellectual Lead, "Make ChatGPT write like a human in 10 prompts", November 2025.
+- Wikipedia: Claude (language model), May 2026.
+- Claude personal observation (this output, May 2026).

--- a/apps/jobsmith/docs/copyroom/anti-ai-slop/anti-ai-slop_2_2.md
+++ b/apps/jobsmith/docs/copyroom/anti-ai-slop/anti-ai-slop_2_2.md
@@ -1,0 +1,1068 @@
+# Anti-AI Detection, Anti-AI Slop, and Humanizer Prompt Megalist
+
+Generated: 2026-05-19
+
+Scope: CVs, cover letters, LinkedIn, outreach, professional bios, work samples, web copy, reports, essays, and general written content.
+
+Important boundary: this is not a bypass-cheating playbook. AI detectors are probabilistic and can be wrong. The durable fix is genuine authorship, source grounding, human review, specific evidence, and a voice the author can explain. Prompts below are written for legitimate editing, quality control, and provenance, not for misrepresenting authorship or violating an employer, school, client, or platform policy.
+
+## Current Research Signals
+
+- Turnitin's 2026 guidance says its AI report may misidentify human, AI-generated, and AI-paraphrased text, and should not be the sole basis for adverse action.
+- Turnitin now distinguishes likely AI-generated text from likely AI-generated text that has been AI-paraphrased, but this is only in its English detector at the time of the guide checked.
+- Turnitin suppresses or marks low scores under 20 percent because low-score results are less reliable and more prone to false positives.
+- Turnitin requires long-form prose and at least 300 words, so bullets, tables, code, scripts, annotated bibliographies, and unconventional formats are weak detector targets.
+- OpenAI discontinued its original AI text classifier in July 2023 because of low accuracy, which remains an important cautionary precedent.
+- Stanford HAI found major bias risk for non-native English writers, with many TOEFL essays misclassified as AI by detectors tested in that study.
+- NBER 2025 research is more nuanced: some commercial detectors performed far better than open-source baselines in their tests, but the study still frames detector use around false positives, false negatives, thresholds, and policy tolerance.
+- ACL 2025 DAMAGE research treats AI humanizers as adversarial modification tools and studies how they change AI-generated text.
+- Recent detector research increasingly treats paraphrasing and "humanizing" as a cat-and-mouse attack surface, not a stable solution.
+- Google Search guidance does not ban AI-assisted content just because AI was used.
+- Google Search guidance does target scaled, low-value, unoriginal content created mainly to manipulate search rankings.
+- Google's helpful-content guidance repeatedly asks whether content has original information, analysis, sourcing, expertise, trust, and value beyond obvious summaries.
+- Wikipedia's "Signs of AI writing" is a community field guide, not a policy or universal detector.
+- Wikipedia's guide is useful because it catalogs surface tells: inflated significance, vague analysis, AI vocabulary clusters, rule-of-three phrasing, over-formatted lists, markup leftovers, broken citations, and false source confidence.
+- Merriam-Webster made "slop" its 2025 word of the year, reflecting the cultural shift from "AI detection" to "quality and trust detection."
+- AI slop is increasingly discussed as low-effort, generic, mass-producible content with superficial competence but weak substance.
+- Reddit and forum humanizer advice is noisy, often promotional, and often aimed at bypassing detectors. Treat it as market signal, not evidence that a method is safe, ethical, or reliable.
+- Humanizer websites commonly market "perplexity" and "burstiness" because many detector explanations mention predictability and sentence-variation patterns.
+- Chasing perplexity and burstiness can make writing worse: weird synonyms, forced sentence variety, awkward tone shifts, and meaning drift are themselves humanizer-tool residue.
+- Human reviewers increasingly look for proof, lived detail, factual consistency, and whether the writer can explain choices, not only for surface style.
+
+## Detector-Risk Rules That Are Ethical
+
+- Do not optimise for a detector score as the primary target.
+- Optimise for evidence, specificity, reader trust, and policy compliance.
+- Keep a master source file of facts, metrics, dates, role titles, projects, links, and proof.
+- Keep version history where possible.
+- Keep notes showing which parts were drafted by the author, which parts were edited with tools, and which facts came from source material.
+- Follow the target organisation's AI-use policy.
+- If disclosure is requested, disclose AI assistance accurately.
+- If AI assistance is forbidden, do not use it.
+- If AI is allowed for editing only, use it only for editing and keep the original authorial work.
+- Never submit generated claims that the author cannot explain in an interview.
+- Never submit a CV bullet that the candidate cannot defend with a two-minute story.
+- Never submit a cover letter paragraph that could be sent to fifty employers unchanged.
+- Do not upload private CVs, names, addresses, phone numbers, salary notes, client names, internal projects, or confidential metrics to random detector or humanizer sites.
+- If testing a detector is unavoidable, use a redacted copy.
+- Do not assume "0 percent AI" means safe.
+- Do not assume "AI detected" means misconduct.
+- Treat detector output as one weak signal, not truth.
+- Use human review from someone who knows the author or the subject.
+- Use a read-aloud pass to catch robotic rhythm.
+- Use a source-trace pass to catch unsupported claims.
+- Use a policy pass to catch prohibited assistance.
+- Use a privacy pass before uploading anything externally.
+- Keep all drafts and prompts for high-stakes documents.
+- Preserve comments and tracked changes until final export if process evidence may matter.
+- Use Google Docs, Word version history, Git commits, or dated local versions for provenance.
+- Keep handwritten notes, research notes, outline versions, and source links where relevant.
+- In education settings, keep assignment instructions, allowed-tool policy, outline, drafts, feedback, and revision history.
+- In hiring settings, keep job ad, tailoring notes, proof map, CV version, cover letter version, and submission date.
+- In publishing settings, keep source interviews, transcripts, original analysis, data files, and editorial notes.
+- If accused, respond with process evidence, not detector counter-scores.
+- Do not use hidden text, white text, zero-width characters, Unicode homoglyphs, deliberate OCR corruption, invisible prompt injections, metadata tricks, or random misspellings.
+- Do not translate text through multiple languages to launder style.
+- Do not use synonym spinners as a final pass.
+- Do not use a humanizer without manually checking meaning, tone, and policy.
+
+## Core Anti-Slop Principle
+
+- Every sentence should earn its place.
+- Every major claim should be source-traceable.
+- Every paragraph should add something non-obvious.
+- Every bullet should contain a real action, object, context, and result where possible.
+- Every adjective should either be proved or removed.
+- Every metric should be defensible.
+- Every rewrite should preserve meaning.
+- Every final document should sound like a real person with real constraints wrote it.
+
+## Evidence and Provenance Fixes
+
+- Add the source of each claim in private notes.
+- Map every CV claim to a role, project, artefact, metric, or witness.
+- Add role context: company type, team size, user group, budget, region, customer segment, system, or workflow.
+- Add time context: month, quarter, release cycle, campaign period, audit period, sprint, or deadline.
+- Add scale: users, volume, revenue, cost, tickets, cases, leads, accounts, locations, staff, assets, integrations, pages, datasets, incidents, or calls.
+- Add constraint: deadline, legacy system, compliance rule, budget limit, staffing shortage, migration risk, stakeholder conflict, data quality issue, or customer pressure.
+- Add method: tool, process, framework, analysis method, test method, governance method, design method, or communication method.
+- Add result: time saved, cost avoided, revenue influenced, error reduced, quality improved, adoption, retention, approval, incident avoided, audit passed, launch completed, or decision enabled.
+- Add proof route: portfolio link, GitHub link, public case study, talk, certificate, publication, screenshot, shipped product, testimonial, or reference.
+- Add claim boundary: led, co-led, owned, supported, contributed, assisted, exposed to, trained on, or observed.
+- Add who used the work.
+- Add who benefited from the work.
+- Add what changed after the work.
+- Add what would have happened if the work was not done.
+- Add what the author personally did.
+- Add what the team did.
+- Add what was inherited.
+- Add what was improved.
+- Add what was shipped.
+- Add what was measured.
+- Add what was learned.
+- Add what was deliberately not done.
+- Add what tradeoff was made.
+- Add what failure or setback was recovered from.
+- Add what decision was influenced.
+- Add what risk was reduced.
+- Add what manual work disappeared.
+- Add what customer or stakeholder friction improved.
+- Add what compliance or audit requirement was met.
+
+## Specificity Fixes
+
+- Replace "projects" with named or described projects.
+- Replace "stakeholders" with actual stakeholder groups.
+- Replace "systems" with system names or system types.
+- Replace "data" with source, field, dataset, dashboard, report, pipeline, or metric.
+- Replace "processes" with workflow names and before-after states.
+- Replace "content" with content type, audience, channel, cadence, and result.
+- Replace "campaigns" with channel, audience, spend, objective, and outcome.
+- Replace "customers" with segment, volume, region, or account type.
+- Replace "teams" with team size, function, seniority mix, or cross-functional partners.
+- Replace "tools" with exact tools and what they were used for.
+- Replace "automation" with trigger, input, output, control, and result.
+- Replace "AI" with model, feature, workflow, task, human review process, and risk control.
+- Replace "prompt engineering" with "prompt composition" if that is the preferred brand wording.
+- Replace "improved performance" with the metric that moved.
+- Replace "streamlined" with the bottleneck removed.
+- Replace "enhanced" with what became easier, faster, safer, cheaper, clearer, or more reliable.
+- Replace "optimised" with the method and result.
+- Replace "transformed" with before and after.
+- Replace "supported" with the task performed.
+- Replace "collaborated" with the contribution and handoff.
+- Replace "responsible for" with owned, ran, scheduled, reviewed, reconciled, configured, migrated, resolved, trained, wrote, tested, or reported.
+- Replace "leveraged" with used, analysed, built, negotiated, queried, configured, implemented, trained, audited, or reconciled.
+- Replace "utilised" with used.
+- Replace "facilitated" with ran, coordinated, hosted, scheduled, mediated, or documented.
+- Replace "spearheaded" only when the author truly initiated and led the work.
+- Replace "played a key role" with the exact role.
+- Replace "various" with the actual number or category.
+- Replace "multiple" with the number if known.
+- Replace "several" with the number if known.
+- Replace "significant" with measured size.
+- Replace "robust" with the failure mode handled.
+- Replace "scalable" with the scale tested.
+- Replace "seamless" with the friction removed.
+- Replace "innovative" with what was new, compared with what, and why it mattered.
+- Replace "cutting-edge" with the actual technology or method.
+- Replace "world-class" with evidence or delete it.
+
+## Voice and Human Specificity Fixes
+
+- Compare the final piece with three real writing samples from the author.
+- Preserve the author's natural level of formality.
+- Preserve the author's usual directness.
+- Preserve the author's usual punctuation habits unless the target format requires otherwise.
+- Preserve regional spelling: Australian, UK, US, or Canadian as appropriate.
+- Preserve the author's real domain language.
+- Preserve the author's real confidence level.
+- Preserve the author's real vocabulary level.
+- Preserve a few natural asymmetries in paragraph length.
+- Preserve occasional plain sentences.
+- Preserve honest uncertainty where the facts are uncertain.
+- Preserve opinion where opinion is expected.
+- Preserve humility without self-erasure.
+- Preserve specificity even when compressing.
+- Avoid making every sentence smooth.
+- Avoid making every paragraph the same size.
+- Avoid making every point equally important.
+- Avoid making every claim positive.
+- Avoid making the writer sound like a brand account.
+- Avoid overwriting a practical person into a corporate motivational poster.
+- Avoid turning technical writing into a TED Talk.
+- Avoid turning a CV into a sales page.
+- Avoid turning a cover letter into a love letter to the company.
+- Avoid fake casualness.
+- Avoid fake vulnerability.
+- Avoid forced contractions.
+- Avoid slang unless the author uses it naturally.
+- Avoid adding jokes to serious documents.
+- Avoid adding typos as a humanizer trick.
+- Avoid "messy" edits that reduce clarity.
+- Avoid adopting a Reddit voice outside Reddit.
+- Avoid copying another person's style so closely it becomes mimicry or misrepresentation.
+
+## Structure Fixes
+
+- Break the default intro-body-conclusion shape when it does not serve the content.
+- Start with the strongest evidence, not throat-clearing.
+- Use a summary only when the reader needs orientation.
+- Put the main answer in the first screen.
+- Avoid "In today's fast-paced world" openings.
+- Avoid "In an ever-evolving landscape" openings.
+- Avoid "Have you ever wondered" openings unless the author actually writes that way.
+- Avoid "This article explores" openings.
+- Avoid "In this guide, we will delve" openings.
+- Avoid ending with a generic recap.
+- End on the actual implication, next step, decision, or strongest detail.
+- Do not add "Overall" just to close.
+- Do not add "In conclusion" unless the genre expects it.
+- Do not use a list when a short paragraph is clearer.
+- Do not use a paragraph when bullets are more scannable.
+- Avoid exact three-part structures unless the content really has three parts.
+- Avoid exactly five or seven takeaways by default.
+- Avoid "not only X, but also Y" unless the contrast matters.
+- Avoid "not X, but Y" as a reflex.
+- Avoid "from X to Y" false-range phrasing.
+- Avoid over-balanced paragraphs where every sentence mirrors the previous one.
+- Vary bullet openings.
+- Vary paragraph length naturally.
+- Keep dense professional content scannable.
+- Keep one idea per CV bullet where possible.
+- Keep cover-letter paragraphs short.
+- Keep LinkedIn About sections tighter than a blog bio.
+- Keep outreach messages short enough to read on mobile.
+
+## Sentence-Level Fixes
+
+- Search for sentences over 35 words.
+- Split long sentences that carry two claims.
+- Cut opening prepositional padding.
+- Cut duplicate transitions.
+- Cut throat-clearing phrases.
+- Move the verb earlier.
+- Use concrete nouns.
+- Use active verbs when they clarify ownership.
+- Use passive voice only when the actor is unknown, irrelevant, or tactically omitted.
+- Use one strong verb instead of verb plus adverb.
+- Turn nominalisations back into verbs where possible.
+- Replace "the implementation of" with "implemented" or the exact action.
+- Replace "the creation of" with "created", "built", "wrote", "launched", or "designed".
+- Replace "the utilisation of" with "used".
+- Replace "was able to" with the action.
+- Replace "helped to" with helped plus exact object, or delete helped if the author owned it.
+- Delete "that" where it adds no clarity.
+- Delete "very", "really", "highly", "extremely", and "incredibly" unless needed.
+- Delete "various", "numerous", and "many" when specifics are possible.
+- Delete "clearly" if the sentence is clear.
+- Delete "simply" if the task was not simple.
+- Delete "effectively" unless the effectiveness is measured.
+- Delete "successfully" unless failure was likely and success matters.
+- Delete "comprehensive" unless scope is listed.
+- Delete "strategic" unless a strategy is visible.
+- Delete "impactful" unless impact is visible.
+- Delete "meaningful" unless meaning is visible.
+- Delete "valuable" unless value is visible.
+- Delete "key" unless the item is genuinely key.
+- Delete "crucial" unless stakes justify it.
+- Delete "pivotal" almost always.
+- Delete "testament to" almost always.
+- Delete "underscores" unless it is natural in the author voice.
+- Delete "showcases" unless it describes an actual showcase.
+- Delete "fosters" unless there is a real fostered behaviour.
+- Delete "cultivates" unless there is a real cultivation process.
+- Delete "navigates" unless the navigation metaphor helps.
+- Delete "realm" unless discussing an actual realm in a relevant genre.
+- Delete "landscape" unless the landscape is literal or industry-analysis standard.
+- Delete "tapestry" almost always.
+- Delete "delve" unless the author truly uses it.
+- Delete "meticulous" unless evidence supports it.
+- Delete "holistic" unless the scope is genuinely whole-system.
+- Delete "multifaceted" unless the facets are named.
+- Delete "robust" unless the failure modes are named.
+- Delete "seamless" unless the handoff or user flow is demonstrably seamless.
+- Delete "unlock" unless there is an actual lock, blocker, or capability.
+- Delete "elevate" unless the thing is literally raised or a brand voice expects it.
+- Delete "drive" when "increase", "reduce", "ship", "sell", "launch", or "resolve" is clearer.
+- Delete "empower" unless the audience gained a real capability.
+- Delete "harness" unless the source of power matters.
+- Delete "leverage" unless it is finance or physics.
+
+## AI Vocabulary Watchlist
+
+- actionable insights
+- at scale
+- at the forefront
+- battle-tested
+- best-in-class
+- bolster
+- comprehensive
+- craft
+- crucial
+- curated
+- cutting-edge
+- deep dive
+- delve
+- digital age
+- dynamic
+- elevate
+- empower
+- end-to-end
+- enduring
+- enhance
+- enterprise-grade
+- ever-evolving
+- facilitate
+- force multiplier
+- foster
+- game-changing
+- holistic
+- in today's world
+- innovative
+- intentional
+- intricate
+- journey
+- key
+- landscape
+- leverage
+- meticulous
+- multifaceted
+- navigate
+- nuanced
+- orchestration
+- paradigm
+- pivotal
+- production-grade
+- proven track record
+- purpose-built
+- realm
+- reimagine
+- robust
+- seamless
+- showcase
+- single source of truth
+- spearhead
+- state-of-the-art
+- streamline
+- synergy
+- tapestry
+- testament
+- thoughtful
+- transformative
+- unlock
+- underscore
+- unique blend
+- valuable insights
+- vibrant
+- white-glove
+- world-class
+- worth noting
+
+## Newer 2025-2026 AI Tells
+
+- Too many "quiet" adjectives: quiet confidence, quiet clarity, quiet power, quiet luxury, quiet discipline.
+- Too many "small but meaningful" phrasings.
+- Too many "the real unlock" phrasings.
+- Too many "the signal is" phrasings.
+- Too many "what matters is" phrasings.
+- Too many "the shape of" phrasings.
+- Too many "the throughline" phrasings.
+- Too many "the loop" phrasings.
+- Too many "this is where" transitions.
+- Too many "it is less about X and more about Y" structures.
+- Too many "not because X, but because Y" structures.
+- Too many "the answer is not X. It is Y" structures.
+- Too many "in practice, this means" pivots.
+- Too many "the catch is" pivots.
+- Too many "to be clear" hedges.
+- Too many "worth noting" hedges.
+- Too many "one useful way to think about it" prefaces.
+- Too many "there are two things going on" prefaces.
+- Too many "small, focused, and defensible" tricolons.
+- Too many "fast, practical, and reliable" tricolons.
+- Too many "clean, simple, and effective" tricolons.
+- Too many "this gives you X without Y" patterns.
+- Too many "strong opinions, loosely held" derivatives.
+- Too many "it depends, but" openings.
+- Too many "the durable fix" phrases.
+- Too many tidy mini-frameworks.
+- Too many headline-style labels inside bullets.
+- Too many confident category names invented for the moment.
+- Too many polished disclaimers.
+- Too many helpful caveats in low-stakes contexts.
+- Too many "calm" or "clean" style adjectives.
+- Too many motivational closing lines.
+- Too much perfect fairness to all sides.
+- Too much assistant-like helpfulness in a human document.
+
+## Punctuation and Formatting Fixes
+
+- Remove em dashes if the author does not naturally use them or the brand bans them.
+- Replace em dashes with commas, colons, parentheses, or sentence breaks where cleaner.
+- Do not overuse semicolons as sophistication theatre.
+- Do not overuse colons after bold list labels.
+- Do not mix smart quotes and straight quotes.
+- Do not mix hyphen, en dash, and em dash styles.
+- Do not leave Markdown headings in a final business document unless Markdown is the format.
+- Do not leave bold syntax like **this** in a Word or email document.
+- Do not leave code fences around prose.
+- Do not leave blockquote markers in non-quoted content.
+- Do not leave "Here is a revised version" in the document.
+- Do not leave "Certainly" or "Absolutely" from the AI response.
+- Do not leave prompt text, refusal text, or assistant notes.
+- Do not leave source markers like turn0search0, oai_citation, contentReference, attributionIndex, or citation-card fragments.
+- Do not leave placeholder tags like [insert example].
+- Do not leave template notes.
+- Do not leave "as of my last update" disclaimers.
+- Do not leave AI tool metadata in PDF properties.
+- Remove tracked changes before submission unless requested.
+- Remove private comments before submission.
+- Remove hidden text.
+- Remove unused styles.
+- Remove old file titles.
+- Check PDF author, title, subject, keywords, creator, and producer fields.
+- Check links after export.
+- Check copy-paste output into plain text.
+- Check mobile preview for emails and LinkedIn.
+- Check black-and-white readability for PDFs.
+- Check ATS-safe selectable text for CVs.
+
+## Citation and Source Fixes
+
+- Verify every URL.
+- Verify every DOI.
+- Verify every ISBN.
+- Verify every author name.
+- Verify every publication date.
+- Verify every statistic.
+- Verify every quote.
+- Verify that the cited source actually supports the sentence.
+- Replace vague "studies show" with a named study or delete it.
+- Replace "experts agree" with named experts or delete it.
+- Replace "research suggests" with source, method, and scope.
+- Do not cite a source you have not opened.
+- Do not cite search result snippets as if they were articles.
+- Do not cite AI-generated summaries as primary evidence.
+- Do not cite another article's citation without checking the original when accuracy matters.
+- Do not use broken links.
+- Do not use irrelevant citations to launder a claim.
+- Do not over-cite obvious facts in a promotional way.
+- Do not under-cite surprising claims.
+- Add dates for unstable facts.
+- Add jurisdiction for legal, education, hiring, medical, and financial guidance.
+- Add sample size for studies when it matters.
+- Add uncertainty when evidence is preliminary.
+- Separate evidence from inference.
+- Label your own inference.
+
+## CV Anti-Slop Fixes
+
+- Treat the CV as an evidence packet.
+- Put the strongest role-fit proof in the top third.
+- Replace generic summaries with proof-led summaries.
+- Remove "highly motivated", "results-driven", "passionate", "detail-oriented", and "team player" unless backed immediately by evidence.
+- Avoid an objective section unless the market expects it.
+- Use a factual headline, not a personality slogan.
+- Keep role titles, dates, employers, education, and LinkedIn consistent.
+- Use standard headings.
+- Use clean one-column structure for ATS versions.
+- Use real selectable text.
+- Avoid sidebars, text boxes, icons, tables, graphics, and progress bars in ATS versions.
+- Use canonical skill names.
+- Put critical skills in work context, not only in a skill cloud.
+- Expand acronyms once where useful.
+- Do not stuff synonyms.
+- Do not add tools not used.
+- Do not mirror the job ad so perfectly it smells copied.
+- Tailor by reordering proof, not inventing fit.
+- Build a proof map before editing.
+- Mark each claim as strong, medium, weak, assisted, exposure, training, or aspiration.
+- Label shared achievements honestly.
+- Do not borrow team results as solo wins.
+- Avoid fake-looking exact metrics.
+- Avoid clusters of round numbers if unsupported.
+- Use sensible precision.
+- Use ranges where exact numbers are confidential.
+- Use "approx." only when the estimate method is defensible.
+- Add scope when a metric is unavailable.
+- Add before-and-after when possible.
+- Add customer or stakeholder impact.
+- Add tools only where they matter.
+- Avoid "owned end-to-end" unless true.
+- Avoid "led" unless the author led people, workstream, decision, or delivery.
+- Avoid "architected" unless architecture decisions were actually made.
+- Avoid "strategic" unless strategy is visible.
+- Avoid "senior" language with junior evidence.
+- Avoid "hands-on" language with no hands-on evidence.
+- Avoid "AI product" claims when the work was prompting only.
+- Separate prototype from production.
+- Separate internal tool from customer-facing product.
+- Separate automation from autonomous agent.
+- Separate model integration from model training.
+- Separate evaluation from vibe checks.
+- Separate prompt use from product ownership.
+- Prepare interview stories for every major bullet.
+- Ask: what happened before, what did I do, what did others do, what changed, how do I know, what would I do differently?
+- Remove bullets that cannot survive interview probing.
+- Use a final "AI residue" search before sending.
+
+## CV Bullet Surgery
+
+- Weak: "Responsible for improving reporting processes."
+- Fix direction: name report, user, tool, cadence, before-after, and decision enabled.
+- Weak: "Worked with stakeholders to deliver projects."
+- Fix direction: name stakeholder groups, project type, delivery constraint, and result.
+- Weak: "Used data to generate insights."
+- Fix direction: name data source, analysis, output, decision, and measured effect.
+- Weak: "Streamlined operations."
+- Fix direction: name bottleneck, old process, new process, volume, and time saved.
+- Weak: "Supported marketing campaigns."
+- Fix direction: name channel, audience, asset, spend or reach, and outcome.
+- Weak: "Improved customer experience."
+- Fix direction: name friction, customer group, fix, metric, and feedback.
+- Weak: "Managed social media."
+- Fix direction: name channels, cadence, content type, audience, growth, engagement, or conversion.
+- Weak: "Implemented new system."
+- Fix direction: name system, migration scope, users, training, risk, and adoption.
+- Weak: "Helped with compliance."
+- Fix direction: name standard, audit, control, evidence, finding, and outcome.
+- Weak: "Built dashboards."
+- Fix direction: name audience, source systems, metrics, refresh cadence, and decisions.
+- Weak: "Automated tasks."
+- Fix direction: name trigger, input, output, error handling, human review, and hours saved.
+- Weak: "Provided leadership."
+- Fix direction: name team, decision, conflict, coaching, delivery, or outcome.
+- Weak: "Solved complex problems."
+- Fix direction: name the problem and why it was hard.
+- Weak: "Created content."
+- Fix direction: name content type, brief, audience, distribution, and performance.
+
+## Cover Letter Anti-Slop Fixes
+
+- Remove "I am writing to express my interest."
+- Remove "I was excited to see."
+- Remove "I believe my skills make me an ideal candidate."
+- Remove "I would be a valuable asset."
+- Remove generic company praise from the homepage.
+- Remove "your commitment to excellence" unless evidenced.
+- Start with the role and a concrete fit hook.
+- Use one proof story, not a CV summary.
+- Connect one company-specific reason to one candidate-specific proof point.
+- Keep the tone calm.
+- Avoid over-eagerness.
+- Avoid begging language.
+- Avoid repeating every requirement.
+- Avoid pretending deep personal connection to a company just discovered.
+- Use the employer's language only where true.
+- Mention AI assistance only if policy asks or if transparency is strategically appropriate.
+- Do not over-polish the letter into generic warmth.
+- Make the closing specific and brief.
+- Keep it under one page unless a formal selection-criteria response is required.
+
+## LinkedIn and Outreach Anti-Slop Fixes
+
+- Use first person in LinkedIn About unless the market expects third person.
+- Keep LinkedIn About shorter than a biography.
+- Make the first two lines useful before "see more."
+- Remove generic "passionate about innovation" lines.
+- Put proof in Featured.
+- Pin current, relevant work.
+- Remove stale or contradictory skills.
+- Keep role dates aligned with the CV.
+- Keep titles aligned with the CV.
+- Use recommendations that support the target role.
+- Avoid AI-generated comments that flatter without substance.
+- Avoid "Great insights!" comments.
+- Avoid "This really resonated" without a specific reason.
+- In cold outreach, mention the role, one relevant proof point, and one specific reason for contact.
+- Do not send a six-paragraph AI email to a busy hiring manager.
+- Do not over-personalise from scraped details.
+- Do not use fake familiarity.
+- Do not use "hope this finds you well" if the author never says it.
+- Do not use "circling back" unless it matches the relationship.
+
+## Web and SEO Anti-Slop Fixes
+
+- Add original research.
+- Add first-hand experience.
+- Add named examples.
+- Add screenshots where useful and allowed.
+- Add test methodology.
+- Add dates to tests.
+- Add what changed since the old advice.
+- Add what the author tried and what failed.
+- Add limitations.
+- Add tradeoffs.
+- Add comparison tables only where they help.
+- Add expert review when claims are specialised.
+- Add author expertise.
+- Add source transparency.
+- Add internal links only where useful.
+- Avoid scaled pages with thin variable swaps.
+- Avoid city-page boilerplate.
+- Avoid "best X" pages with no testing.
+- Avoid fake review data.
+- Avoid affiliate-driven praise with no method.
+- Avoid scraping and paraphrasing top results.
+- Avoid keyword-stuffed FAQ blocks.
+- Avoid "ultimate guide" unless it is actually deep.
+- Avoid "comprehensive" unless it is comprehensive.
+- Avoid content that says what every competitor says.
+- Ask: what is here that was not obvious before?
+- Ask: would anyone bookmark this?
+- Ask: would a practitioner trust this?
+- Ask: is the page useful without search traffic?
+
+## Academic and Report Anti-Slop Fixes
+
+- Follow the institution's AI policy exactly.
+- Use AI only in permitted ways.
+- Keep original notes and drafts.
+- Keep source PDFs and annotations.
+- Keep your thesis, argument, and analysis your own.
+- Do not outsource interpretation.
+- Do not submit generated paragraphs as your own where prohibited.
+- Avoid summary without argument.
+- Avoid sources that are not read.
+- Avoid fake citations.
+- Avoid vague "scholars argue" wording.
+- Define terms precisely.
+- Use discipline-specific conventions.
+- Include counterarguments where relevant, not as an automatic balance ritual.
+- Use evidence to support claims.
+- Distinguish paraphrase from analysis.
+- Distinguish common knowledge from cited claims.
+- Keep quotations accurate and brief.
+- Use citation style consistently.
+- Make the reasoning visible.
+- Make limitations visible.
+- Do not add "moreover" every second paragraph.
+- Do not add "furthermore" as a transition crutch.
+- Do not add elevated vocabulary to sound academic.
+- Do not make non-native English writing artificially "native" if it erases the author's real voice.
+- Use writing support ethically: grammar, clarity, structure, source management, and feedback.
+
+## Humanizer-Tool Residue to Remove
+
+- Weird synonyms that technically fit but feel wrong.
+- Randomly casual phrases inside formal prose.
+- Meaning drift.
+- Tone drift.
+- Mixed register.
+- Inconsistent author voice.
+- Inconsistent regional spelling.
+- Sudden contractions.
+- Sudden slang.
+- Unnatural idioms.
+- Choppy sentence variety inserted for detector metrics.
+- Run-on sentences inserted for detector metrics.
+- Over-correction into awkwardness.
+- Extra examples that were not in the source.
+- Added opinions the author does not hold.
+- Added anecdotes that did not happen.
+- Generic "personal" lines.
+- Fake sensory detail.
+- Artificial imperfections.
+- Broken transitions.
+- Lost technical precision.
+- Lost legal precision.
+- Lost metric precision.
+- Lost source support.
+- Rewritten quotes.
+- Changed names, dates, or numbers.
+- Changed modality: "may" becoming "will."
+- Changed ownership: "team" becoming "I."
+- Changed certainty: "estimated" becoming "proved."
+- Changed scope: "pilot" becoming "rollout."
+- Changed status: "prototype" becoming "production."
+- Detector-passing but reader-failing prose.
+
+## AI Trends I Commonly See In My Own Output
+
+- I over-structure answers into neat sections.
+- I default to short title-case headings.
+- I create tidy frameworks too quickly.
+- I make lists too balanced.
+- I make every bullet grammatically parallel.
+- I use "specific, practical, and..." style tricolons.
+- I use "the main thing is" or similar pivots.
+- I use "the durable fix" phrasing.
+- I overuse "signal" as a noun.
+- I overuse "shape" as a metaphor.
+- I overuse "loop" as a process metaphor.
+- I overuse "spine" as a structure metaphor.
+- I overuse "surface" as a product metaphor.
+- I sometimes say "not X, but Y" because it feels clarifying.
+- I sometimes make a caveat sound too polished.
+- I can be too even-handed when a stronger stance would be more human.
+- I can use warm, polished reassurance that sounds assistant-like.
+- I can produce "clean" prose that lacks a scar from real experience.
+- I can over-explain obvious context.
+- I can add final summary lines the reader does not need.
+- I can default to "Here is" openings.
+- I can write in a calm editorial voice that is too smooth for some authors.
+- I can unconsciously compress disagreement or frustration out of a person's voice.
+- I can replace rough but authentic phrasing with generic professional phrasing.
+- I can make a messy, true story sound like a case study.
+- I can overuse "clear" and "useful."
+- I can invent labels for patterns rather than just naming the plain issue.
+- I can sound more confident than the evidence deserves if not forced to cite sources.
+- I can flatten a user's idiosyncratic voice if told only to "polish."
+
+## Popular Humanizer Prompt Families Seen Online
+
+- "Make this sound more human."
+- "Humanize this text."
+- "Rewrite this in a natural voice."
+- "Rewrite this so it sounds like me."
+- "Make this less robotic."
+- "Make this less AI-sounding."
+- "Remove AI tone."
+- "Remove ChatGPT tone."
+- "Avoid AI words."
+- "Avoid em dashes."
+- "Avoid corporate jargon."
+- "Avoid fluff."
+- "Use simple language."
+- "Use short, direct sentences."
+- "Use active voice."
+- "Vary sentence length."
+- "Increase burstiness."
+- "Increase perplexity."
+- "Make word choices less predictable."
+- "Write with more personality."
+- "Add personal voice."
+- "Add opinion."
+- "Add warmth."
+- "Make it conversational."
+- "Make it casual professional."
+- "Make it sound like a Reddit comment."
+- "Make it sound like a human blog post."
+- "Make it sound like a student."
+- "Make it sound like a senior professional."
+- "Make it sound like a founder."
+- "Make it sound like a subject-matter expert."
+- "Write at an eighth-grade reading level."
+- "Write in plain English."
+- "Use contractions."
+- "Do not use contractions."
+- "Add small imperfections."
+- "Keep meaning unchanged."
+- "Preserve my tone."
+- "Use my writing sample as the style guide."
+- "Rewrite with my vocabulary."
+- "Make it less polished."
+- "Make it less formal."
+- "Make it more direct."
+- "Make it more specific."
+- "Add concrete examples."
+- "Add lived experience."
+- "Add current references."
+- "Add human anecdotes."
+- "Do not sound like marketing copy."
+- "Do not sound like an essay bot."
+- "Do not sound like a press release."
+- "No listicle structure."
+- "No rule of three."
+- "No 'not only, but also.'"
+- "No 'in conclusion.'"
+- "No 'overall.'"
+- "No 'delve'."
+- "No 'tapestry'."
+- "No 'ever-evolving landscape'."
+- "No 'testament'."
+- "No 'underscore'."
+- "No 'pivotal'."
+- "No 'foster'."
+- "No 'meticulous'."
+- "No "as an AI" disclaimers."
+- "Remove generic transitions."
+- "Use natural paragraph breaks."
+- "Rewrite with higher rhythm variation."
+- "Rewrite for readability, not detection."
+- "Line edit only."
+- "Do not invent facts."
+- "Ask questions before rewriting."
+- "Show what changed."
+- "Flag unsupported claims."
+- "Do a human editor pass."
+- "Do a voice-preservation pass."
+- "Do an anti-slop pass."
+- "Do a source-grounding pass."
+- "Do a final proofread."
+
+## Safer Humanizer Prompts You Can Actually Use
+
+- "Line edit this for clarity and natural rhythm. Do not change facts, add facts, or make it more impressive."
+- "Rewrite this in my voice using the sample below. Preserve my level of formality, punctuation habits, and vocabulary."
+- "Make this more specific by asking me for missing facts before you rewrite it."
+- "Highlight every vague phrase and suggest the exact type of detail needed to fix it."
+- "Find sentences that sound generic enough to belong to another person. Explain why and propose a more specific version."
+- "Replace inflated adjectives with evidence. If no evidence exists, delete the adjective."
+- "Turn this from polished generic writing into direct professional writing. Keep it credible and plain."
+- "Remove corporate jargon and replace it with concrete actions."
+- "Remove AI-cliche wording. Do not add slang, typos, or fake casualness."
+- "Make this sound like a real person wrote it, but do that by improving specificity and flow, not by adding errors."
+- "Vary sentence length only where it improves readability."
+- "Break up repetitive sentence structures, but preserve the meaning exactly."
+- "Find where the logic feels too tidy or over-balanced. Suggest a more natural structure."
+- "Cut any sentence that repeats a previous point."
+- "Cut any sentence that only announces importance without proving it."
+- "Rewrite the opening so it starts with the concrete point, not a broad setup."
+- "Rewrite the ending so it lands on the implication, not a recap."
+- "Flag all unsupported claims in this draft."
+- "For each claim, tell me what source or evidence I need."
+- "Create a private proof map from this CV bullet list."
+- "For each CV bullet, ask what changed, who used it, how often, and how we know."
+- "Rewrite these CV bullets using only the facts I provide. If a metric is missing, use scope instead of inventing one."
+- "Find all places where the author sounds more senior than the evidence supports."
+- "Find all places where the author sounds less senior than the evidence supports."
+- "Find every verb that overclaims ownership."
+- "Replace weak verbs with accurate verbs, not inflated verbs."
+- "Mark each claim as led, co-led, owned, supported, assisted, trained, exposed, or aspirational."
+- "Compress this without losing the evidence."
+- "Make this more scannable for a recruiter without adding hype."
+- "Make this cover letter less template-like. Keep one proof story and one company-specific reason."
+- "Remove all praise that could fit any company."
+- "Make this outreach message shorter, more specific, and less salesy."
+- "Rewrite this LinkedIn About section in first person with proof, not personality slogans."
+- "Remove all text that sounds like a motivational poster."
+- "Read this as a skeptical hiring manager and flag distrust triggers."
+- "Read this as a busy recruiter and flag what is unclear in six seconds."
+- "Read this as an interviewer and list the claims you would probe."
+- "Read this as a privacy reviewer and flag what should not be uploaded or shared."
+- "Read this as an ATS parser risk reviewer and flag formatting issues."
+- "Audit this for AI residue: vocabulary, structure, punctuation, template leftovers, and unsupported claims."
+- "Search this draft for repeated words, repeated sentence shapes, and repeated transitions."
+- "Suggest replacements for 'leverage', 'streamline', 'enhance', and 'impactful' based on the actual action."
+- "Replace 'worked with stakeholders' with clearer wording. Ask me which stakeholders if needed."
+- "Replace 'improved processes' with clearer wording. Ask me what process changed if needed."
+- "Replace 'used data' with clearer wording. Ask me what data and decision if needed."
+- "Rewrite in Australian English and keep spelling consistent."
+- "Proofread for punctuation consistency without changing voice."
+- "Check whether this sounds like my writing sample. List mismatches before editing."
+- "Edit for one target audience: [audience]. Remove anything that audience does not need."
+- "Edit for one outcome: [outcome]. Remove anything that does not support it."
+- "Give me three rewrite options: plainer, warmer, and more technical. Do not invent facts."
+- "Give me a minimal edit, a medium edit, and a strong edit so I can choose."
+- "Do not rewrite yet. Diagnose the top ten slop problems first."
+- "Do not rewrite yet. Ask me the five missing questions that would make this specific."
+- "Do not rewrite yet. Build a checklist for improving this draft."
+- "After editing, show a change log of any meaning changes."
+- "After editing, list every claim that still needs verification."
+
+## Prompts To Avoid Or Rewrite
+
+- Avoid: "Make this undetectable by AI detectors."
+- Safer: "Make this clearer, more specific, and closer to my real voice without changing facts."
+- Avoid: "Bypass Turnitin."
+- Safer: "Help me comply with my institution's AI policy and preserve process evidence."
+- Avoid: "Add human mistakes."
+- Safer: "Preserve natural rhythm without reducing correctness."
+- Avoid: "Increase perplexity as much as possible."
+- Safer: "Vary wording only where it improves readability and preserves meaning."
+- Avoid: "Make this sound like a native speaker."
+- Safer: "Improve clarity while preserving the author's voice and not erasing non-native style."
+- Avoid: "Rewrite my essay so it passes."
+- Safer: "Give feedback on my draft and ask questions that help me revise it myself."
+- Avoid: "Write my CV from this job ad."
+- Safer: "Compare my existing evidence to this job ad and suggest truthful tailoring."
+- Avoid: "Make me sound senior."
+- Safer: "Identify seniority signals I can support with evidence."
+- Avoid: "Make it impressive."
+- Safer: "Make the evidence easier to see."
+- Avoid: "Make it professional."
+- Safer: "Make it direct, specific, and appropriate for [audience]."
+- Avoid: "Polish this."
+- Safer: "Line edit for clarity and remove generic phrasing."
+- Avoid: "Use fancy vocabulary."
+- Safer: "Use precise vocabulary."
+- Avoid: "Rewrite the whole thing."
+- Safer: "Diagnose first, then edit the smallest amount needed."
+
+## Human Review Checklist
+
+- Can the author explain every sentence?
+- Can the author defend every metric?
+- Can the author name the source of every claim?
+- Can the author tell the story behind every CV bullet?
+- Can the author identify what they personally contributed?
+- Does the text include details only this author would know?
+- Does the text preserve the author's real voice?
+- Does the text avoid generic AI vocabulary clusters?
+- Does the text avoid detector-chasing weirdness?
+- Does the text avoid false polish?
+- Does the text avoid fake casualness?
+- Does the text avoid invented examples?
+- Does the text avoid unsupported certainty?
+- Does the text avoid generic praise?
+- Does the text avoid mass-application smell?
+- Does the text avoid hidden or unethical tricks?
+- Does the text comply with the relevant AI policy?
+- Does the text protect private and confidential information?
+- Does the document metadata need cleaning?
+- Does the final exported file match the draft?
+
+## Do-Not-Use Fixes
+
+- Do not hide keywords in white text.
+- Do not add invisible Unicode characters.
+- Do not use homoglyph substitutions.
+- Do not insert random spaces inside words.
+- Do not use OCR degradation.
+- Do not screenshot text to avoid parsing.
+- Do not submit rasterised CVs.
+- Do not add fake citations.
+- Do not add fake links.
+- Do not add fake interview stories.
+- Do not add fake metrics.
+- Do not invent employers.
+- Do not invent credentials.
+- Do not invent work rights.
+- Do not invent security clearance.
+- Do not invent publications.
+- Do not use a paid humanizer as ethical cover.
+- Do not use detector scores as proof of authorship.
+- Do not claim "written entirely by me" if that is false under the policy.
+- Do not disclose private client material to a tool.
+- Do not use one-click rewriting for high-stakes work without line-by-line review.
+
+## Humanizer Websites And Tools Mentioned In Current Web/Forum Chatter
+
+Not endorsed. Many are explicitly marketed for detector evasion, and many lists are promotional or affiliate-driven.
+
+- Undetectable.ai
+- WriteHuman
+- StealthWriter
+- StealthGPT
+- HIX Bypass
+- Humbot
+- BypassGPT
+- HumanizeAI
+- Humanize AI Text
+- Humanizer Pro
+- HumanizeThisAI
+- Clever AI Humanizer
+- Rephrasy
+- Walter Writes AI
+- GPTHuman AI
+- AuraWrite AI
+- UnAIMyText
+- Ryne AI
+- RealTouch AI
+- TwainGPT
+- ProseShift
+- HumanLike
+- MaxAI Human Style Rewriter
+- Phrasly
+- Netus AI
+- QuillBot
+- Smodin
+- WordAI
+- SpinRewriter
+- Grubby.ai
+- Originality.ai humanizer-adjacent workflows
+- Copyleaks humanizer-adjacent workflows
+- AIDetectPlus
+- Miniloop AI humanizer lists
+- AIHumanizer.tools directories
+
+## Forums And Communities Sampled For Patterns
+
+- r/ChatGPTPromptGenius
+- r/PromptEngineering
+- r/ChatGPT
+- r/humanizeAIwriting
+- r/BypassAiDetect
+- r/bestaihumanizers
+- r/BestAIHumanizer_
+- r/PassOrFlagged
+- r/AIDetectorHelp
+- r/WritingWithAI
+- r/SEO
+- r/content_marketing
+- r/college and adjacent student-writing discussions surfaced in search
+- Hacker News and developer discourse reflected indirectly in local SlopPass research
+- Wikipedia editor discussions reflected through the "Signs of AI writing" guide
+
+## Fast Anti-Slop Search Terms
+
+- delve
+- tapestry
+- landscape
+- realm
+- testament
+- underscore
+- pivotal
+- crucial
+- foster
+- cultivate
+- meticulous
+- nuanced
+- robust
+- seamless
+- leverage
+- streamline
+- enhance
+- elevate
+- empower
+- unlock
+- journey
+- navigate
+- ever-evolving
+- in today's world
+- it is worth noting
+- moreover
+- furthermore
+- in conclusion
+- overall
+- not only
+- but also
+- not X, but Y
+- as of my last
+- based on available information
+- provided sources
+- valuable insights
+- actionable insights
+- deep dive
+- best-in-class
+- cutting-edge
+- game-changing
+- dynamic
+- strategic
+- comprehensive
+- passionate
+- results-driven
+- proven track record
+- detail-oriented
+- team player
+- self-starter
+- fast-paced
+- hit the ground running
+- wear many hats
+- unique blend
+
+## Fast Anti-Slop Workflow
+
+- Step 1: Identify the document purpose.
+- Step 2: Identify the target reader.
+- Step 3: Identify the policy constraints.
+- Step 4: Build a source/proof map.
+- Step 5: Search for AI vocabulary and generic phrases.
+- Step 6: Search for unsupported claims.
+- Step 7: Replace vague nouns with specific nouns.
+- Step 8: Replace inflated verbs with accurate verbs.
+- Step 9: Add scale, method, constraint, and result where true.
+- Step 10: Remove fake polish.
+- Step 11: Compare to the author's real writing.
+- Step 12: Check privacy and metadata.
+- Step 13: Export and inspect the final format.
+- Step 14: Keep the submitted version and proof notes.
+
+## Key Sources Checked
+
+- Local source: `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\cv-checklist-consolidated-v1.md`
+- Local source: `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\SlopPass.md`
+- Local source: `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\SlopPass0.md`
+- Local source: `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\Skills_1_2.md`
+- Local source: `C:\G\MalamuteMayhem\Jobs\UnClick\Context\Deep Researches\Skills_2_2.md`
+- Turnitin AI Writing Report guide: https://guides.turnitin.com/hc/en-us/articles/22774058814093-Using-the-AI-Writing-Report
+- Turnitin AI writing detection model updates: https://guides.turnitin.com/hc/en-us/articles/28294949544717-AI-writing-detection-model
+- Turnitin product updates: https://guides.turnitin.com/hc/en-us/articles/29645383597965-Turnitin-product-updates
+- Stanford HAI on detector bias: https://hai.stanford.edu/news/ai-detectors-biased-against-non-native-english-writers
+- Stanford SCALE paper page: https://scale.stanford.edu/publications/gpt-detectors-are-biased-against-non-native-english-writers
+- NBER 2025 detector benchmark: https://www.nber.org/papers/w34223
+- OpenAI classifier retirement coverage: https://arstechnica.com/gadgets/2023/07/openai-discontinues-its-ai-writing-detector-due-to-low-rate-of-accuracy/
+- ACL DAMAGE paper page: https://aclanthology.org/2025.genaidetect-1.9/
+- Google helpful content guidance: https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+- Google generative AI content guidance: https://developers.google.com/search/docs/fundamentals/using-gen-ai-content
+- Google spam/scaled content policy: https://developers.google.com/search/docs/advanced/guidelines/auto-gen-content
+- Wikipedia Signs of AI writing: https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
+- Wikipedia AI slop: https://en.wikipedia.org/wiki/AI_slop
+- Merriam-Webster 2025 word of the year announcement: https://www.globenewswire.com/news-release/2025/12/15/3205236/0/en/Merriam-Webster-Announces-Slop-as-the-2025-Word-of-the-Year.html
+- Tech & Learning on AI humanizers: https://www.techlearning.com/how-to/ai-humanizers-everything-teachers-need-to-know
+- How-To Geek on humanizing ChatGPT text: https://www.howtogeek.com/how-to-humanize-chatgpt-text/
+- AiTwo humanizer prompt list, used only for pattern categories, not copied: https://www.aitwo.co/blog/prompts-to-humanize-ai-content
+- Tom's Guide AI writing signs: https://www.tomsguide.com/ai/how-to-spot-ai-writing-5-telltale-signs-to-look-for
+- Reddit/forum examples surfaced through web search for current humanizer-prompt and tool discourse, treated as noisy anecdotal market signal rather than reliable evidence.


### PR DESCRIPTION
Archived PR notes. Public planning details have been removed.