### PR TITLE
feat(harnesskit): surface queue truth gate

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -295,9 +295,12 @@ export interface OrchestratorContext {
     harness_card: {
       source_of_truth: "Boardroom Jobs";
       queue_state: "active_work" | "needs_claim" | "quiet";
+      gate_status: "green" | "amber" | "red";
+      gate_reason: string;
       queue_truth: string;
       allowed_actions: string[];
       required_proof: string[];
+      test_runner_rule: string;
       cleanup_rule: string;
       recovery_path: string;
     };
@@ -587,24 +590,42 @@ function buildHarnessCard({
 }): OrchestratorContext["current_state_card"]["harness_card"] {
   const queueState =
     activeJobsCount > 0 ? "active_work" : queuedTodoCount > 0 ? "needs_claim" : "quiet";
+  const gateStatus =
+    healthVerdict.verdict === "BLOCKER" || queueState === "needs_claim"
+      ? "red"
+      : queueState === "active_work"
+        ? "amber"
+        : "green";
+  const gateReason =
+    queueState === "needs_claim"
+      ? "Open Boardroom work has no fresh active owner. Claim one scoped job or post the exact blocker."
+      : queueState === "active_work"
+        ? "Fresh active work exists. Support with proof, review, tests, or a non-overlapping scoped patch."
+        : "No open Boardroom work is visible in this snapshot.";
 
   return {
     source_of_truth: "Boardroom Jobs",
     queue_state: queueState,
+    gate_status: gateStatus,
+    gate_reason: gateReason,
     queue_truth:
-      "active_jobs counts in_progress work with a fresh owner; queued_todo_count is open backlog. Open backlog with active_jobs=0 needs claim/proof work and must not be treated as healthy.",
+      "active_jobs counts in_progress work with a fresh owner; queued_todo_count is open backlog. Open backlog with active_jobs=0 is red, not healthy.",
     allowed_actions: [
       "claim one unowned scoped job",
       "verify proof on a completed-looking job",
       "patch a narrow owned file slice",
+      "open a draft PR for one ScopePack slice",
       "post BLOCKER with exact missing proof",
     ],
     required_proof: [
       "coding jobs need PR, commit, deploy, or explicit NO_CODE_NEEDED proof",
       "tests or CI must be named when code changed",
       "UI/UX jobs need screenshot proof",
+      "DONE, 100%, green chips, and proof badges are hints only until proof is observable",
       `health verdict is ${healthVerdict.verdict}`,
     ],
+    test_runner_rule:
+      "Test-only runner packets do not create active work claims unless they include build proof and a Boardroom receipt.",
     cleanup_rule: "Do not mark DONE from green chips or stale receipts; close only after required proof is observable.",
     recovery_path:
       "If the queue is blocked or scope is unclear, add a narrow ScopePack or proof comment instead of posting a status-only wake.",

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -165,6 +165,45 @@ describe("orchestrator context", () => {
     expect(context.rolling_snapshot.source_pointers.some((pointer) => pointer.source_id === "todo-1")).toBe(true);
   });
 
+  it("makes the harness card red when open Boardroom work has no fresh owner", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-19T15:45:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [
+        {
+          id: "todo-open",
+          title: "HarnessKit queue truth",
+          description: "Build proof gates and queue truth.",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "orchestrator",
+          assigned_to_agent_id: null,
+          created_at: "2026-05-19T15:00:00.000Z",
+          updated_at: "2026-05-19T15:00:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.current_state_card.active_jobs).toBe(0);
+    expect(context.current_state_card.queued_todo_count).toBe(1);
+    expect(context.current_state_card.harness_card.queue_state).toBe("needs_claim");
+    expect(context.current_state_card.harness_card.gate_status).toBe("red");
+    expect(context.current_state_card.harness_card.gate_reason).toContain("no fresh active owner");
+    expect(context.current_state_card.harness_card.queue_truth).toContain("red, not healthy");
+    expect(context.current_state_card.harness_card.required_proof).toContain(
+      "DONE, 100%, green chips, and proof badges are hints only until proof is observable",
+    );
+    expect(context.current_state_card.harness_card.test_runner_rule).toContain("Test-only runner packets");
+  });
+
   it("adds human operator timezone context to compact handoffs", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-10T01:00:00.000Z",


### PR DESCRIPTION
## Summary
- Adds a visible HarnessKit gate status and reason to the Orchestrator state card.
- Makes open Boardroom work with `active_jobs=0` red, not healthy.
- Adds explicit proof language that DONE, 100%, green chips, and proof badges are hints until observable proof exists.
- Adds a test-only runner rule so test packets do not become active work claims without build proof and a Boardroom receipt.

## Proof
- Commit: `3caee0e`
- `npm run test -- api/fishbowl-completion-policy.test.ts api/fishbowl-job-pipeline.test.ts api/orchestrator-context.test.ts` passed, 43/43.
- `node --test scripts/pinballwake-autonomous-runner.test.mjs` passed, 54/54.
- `npm run build` passed locally in 4m 17s.
- `git diff --check` passed.
- GitHub checks on head `3caee0e` are green or neutral: Website, MCP server package, TestPass smoke, Review dry-run, Vercel, and Vercel Preview Comments passed; Dirty-branch hygiene skipped.

## Gate
- This PR is now ready for review after full build proof was added.
- Do not mark HarnessKit parent done from this slice alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new required fields to `current_state_card.harness_card`, which may break downstream consumers that assume the previous shape; logic change affects how “healthy/quiet” is interpreted when backlog exists without an active owner.
> 
> **Overview**
> **Surfaces a new HarnessKit “gate” on the Orchestrator state card.** The `harness_card` now includes `gate_status` (green/amber/red) and `gate_reason`, computed from `queue_state` plus `health_verdict`, to make the queue’s implied health explicit.
> 
> Tightens queue truth/proof messaging by treating *open backlog with `active_jobs=0`* as **red** (not healthy), adds an explicit note that “DONE/100%/green chips/proof badges” are only hints until observable proof exists, and documents a `test_runner_rule` stating test-only runner packets don’t count as active work claims without build proof + a Boardroom receipt.
> 
> Adds a unit test covering the red gate behavior when there is open work but no fresh active owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3caee0eaac59f4bf0742da7db7d24914573ceb01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->