### PR TITLE
Add JobSmith decision card review state

### DIFF
--- a/apps/jobsmith/src/lib/applicationManager.ts
+++ b/apps/jobsmith/src/lib/applicationManager.ts
@@ -36,6 +36,7 @@ export interface WelcomePacket {
 
 export type DecisionCardOwner = "human" | "jobsmith" | "reviewer";
 export type DecisionCardStatus = "needs_decision" | "blocked" | "ready_for_review";
+export type DecisionCardResolution = "pass" | "blocker" | "not_applicable";
 
 export interface DecisionCard {
   id: string;
@@ -48,6 +49,24 @@ export interface DecisionCard {
   reason: string;
   proofNeeded: string;
   suggestedAction: string;
+  resolution?: DecisionCardResolution;
+  resolutionEvidence?: string;
+}
+
+export interface DecisionCardReview {
+  ruleId: string;
+  resolution: DecisionCardResolution;
+  evidence: string;
+}
+
+export interface DecisionCardSummary {
+  total: number;
+  blocked: number;
+  needsDecision: number;
+  readyForReview: number;
+  resolved: number;
+  unresolved: number;
+  submitReady: boolean;
 }
 
 export interface DecisionCardInput {
@@ -55,6 +74,7 @@ export interface DecisionCardInput {
   findings: RuleFinding[];
   missingInputs: string[];
   artifactsReady: boolean;
+  reviews?: DecisionCardReview[];
 }
 
 export type ManagedApplicationRunStatus = "blocked" | "review_needed" | "proof_needed" | "submit_ready";
@@ -254,7 +274,31 @@ export function buildDecisionCards(input: DecisionCardInput): DecisionCard[] {
     });
   }
 
+  for (const review of input.reviews ?? []) {
+    const card = cards.get(review.ruleId);
+    if (!card || !hasText(review.evidence)) continue;
+    cards.set(review.ruleId, applyDecisionCardReview(card, review));
+  }
+
   return Array.from(cards.values()).sort(decisionCardSort);
+}
+
+export function summarizeDecisionCards(cards: DecisionCard[], artifactsReady: boolean): DecisionCardSummary {
+  const blocked = cards.filter((card) => card.status === "blocked").length;
+  const needsDecision = cards.filter((card) => card.status === "needs_decision").length;
+  const readyForReview = cards.filter((card) => card.status === "ready_for_review").length;
+  const resolved = cards.filter((card) => Boolean(card.resolution && card.resolutionEvidence)).length;
+  const unresolved = Math.max(0, cards.length - resolved);
+
+  return {
+    total: cards.length,
+    blocked,
+    needsDecision,
+    readyForReview,
+    resolved,
+    unresolved,
+    submitReady: artifactsReady && blocked === 0 && needsDecision === 0 && unresolved === 0,
+  };
 }
 
 export function buildManagedApplicationRun(input: ManagedApplicationRunInput): ManagedApplicationRunReport {
@@ -383,6 +427,35 @@ function suggestedActionForRule(severity: RuleSeverity): string {
   if (severity === "ERROR") return "Block submit-ready until this is resolved or explicitly accepted.";
   if (severity === "WARN") return "Review and either revise the draft or record an accepted risk.";
   return "Review when time allows and keep the note with the final report.";
+}
+
+function applyDecisionCardReview(card: DecisionCard, review: DecisionCardReview): DecisionCard {
+  const evidence = review.evidence.trim();
+
+  if (review.resolution === "blocker") {
+    return {
+      ...card,
+      owner: "reviewer",
+      status: "blocked",
+      reason: `Reviewer marked BLOCKER: ${evidence}`,
+      proofNeeded: "Fix the blocker, then rerun checks and update the card evidence.",
+      suggestedAction: "Revise the application pack before submit-ready.",
+      resolution: review.resolution,
+      resolutionEvidence: evidence,
+    };
+  }
+
+  const label = review.resolution === "pass" ? "PASS" : "N/A";
+  return {
+    ...card,
+    owner: "reviewer",
+    status: "ready_for_review",
+    reason: `Reviewer marked ${label}: ${evidence}`,
+    proofNeeded: "Keep this evidence with the final report.",
+    suggestedAction: "Carry this decision into the final managed run report.",
+    resolution: review.resolution,
+    resolutionEvidence: evidence,
+  };
 }
 
 function decisionCardSort(a: DecisionCard, b: DecisionCard): number {

--- a/src/pages/Jobsmith.test.tsx
+++ b/src/pages/Jobsmith.test.tsx
@@ -44,7 +44,10 @@ describe("JobsmithPage", () => {
     expect(managedRunReport).toHaveTextContent("Blockers");
     expect(managedRunReport).toHaveTextContent("No run proof attached yet.");
     expect(managedRunReport).toHaveTextContent("Decision cards");
+    expect(managedRunReport).toHaveTextContent("Resolved");
+    expect(managedRunReport).toHaveTextContent("Unresolved");
     expect(managedRunReport).toHaveTextContent("Not submit-ready");
+    expect(managedRunReport).toHaveTextContent("Graduation-year review is still unresolved");
     expect(managedRunReport).toHaveTextContent("Missing application inputs");
 
     fireEvent.change(screen.getByLabelText("Source-backed claim"), {
@@ -91,8 +94,10 @@ describe("JobsmithPage", () => {
     expect(managedRunReport).toHaveTextContent("Browser-local starter packet: Ready");
     expect(managedRunReport).toHaveTextContent("Managed run report UI");
     expect(managedRunReport).toHaveTextContent("Run proof");
+    expect(managedRunReport).toHaveTextContent("1 resolved");
     expect(managedRunReport).toHaveTextContent("Not submit-ready");
     expect(managedRunReport).toHaveTextContent("Proof needed:");
+    expect(managedRunReport).toHaveTextContent("Evidence: Graduation-year review is still unresolved");
 
     const packet = screen.getByRole("region", { name: "Starter packet" });
     const packetText = within(packet).getByTestId("jobsmith-public-packet-copy");

--- a/src/pages/Jobsmith.tsx
+++ b/src/pages/Jobsmith.tsx
@@ -18,7 +18,9 @@ import {
   buildDecisionCards,
   buildManagedApplicationRun,
   buildWelcomePacket,
+  summarizeDecisionCards,
   type DecisionCard,
+  type DecisionCardReview,
   type ManagedApplicationRunReport,
   type WelcomePacket,
 } from "../../apps/jobsmith/src/lib/applicationManager";
@@ -104,6 +106,14 @@ const MANAGED_RUN_STATUS_LABELS: Record<ManagedApplicationRunReport["status"], s
   review_needed: "Review needed",
   submit_ready: "Submit-ready",
 };
+
+const SAMPLE_DECISION_REVIEWS: DecisionCardReview[] = [
+  {
+    ruleId: "JS-AGE-02",
+    resolution: "blocker",
+    evidence: "Graduation-year review is still unresolved in this browser-local starter run.",
+  },
+];
 
 function hasText(value: string): boolean {
   return value.trim().length > 0;
@@ -291,8 +301,10 @@ function ManagedRunReport({
   report: ManagedApplicationRunReport;
   decisionCards: DecisionCard[];
 }) {
-  const blockedCards = decisionCards.filter((card) => card.status === "blocked");
-  const needsDecisionCards = decisionCards.filter((card) => card.status === "needs_decision");
+  const decisionSummary = summarizeDecisionCards(
+    decisionCards,
+    report.artifacts.every((artifact) => artifact.ready),
+  );
   const visibleBlockers = report.blockers.slice(0, 4);
   const visibleFindings = report.deterministicFindings.slice(0, 3);
 
@@ -326,6 +338,8 @@ function ManagedRunReport({
         <RunMetric label="Review needed" value={report.reviewNeededCount} />
         <RunMetric label="Artifacts" value={report.artifacts.length} />
         <RunMetric label="Proof" value={report.proof.length} />
+        <RunMetric label="Resolved" value={decisionSummary.resolved} />
+        <RunMetric label="Unresolved" value={decisionSummary.unresolved} />
       </div>
 
       <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)]">
@@ -418,7 +432,7 @@ function ManagedRunReport({
           ) : (
             <p className="mt-3 text-xs leading-5 text-emerald-100">No deterministic findings in the current run.</p>
           )}
-      </div>
+        </div>
       </div>
 
       <div className="mt-5 rounded-lg border border-white/[0.06] bg-black/20 p-4">
@@ -430,7 +444,7 @@ function ManagedRunReport({
             </p>
           </div>
           <p className="text-xs font-semibold text-[#9EE4E6]">
-            {blockedCards.length} blocked, {needsDecisionCards.length} need decision
+            {decisionSummary.blocked} blocked, {decisionSummary.needsDecision} need decision, {decisionSummary.resolved} resolved
           </p>
         </div>
 
@@ -450,6 +464,9 @@ function ManagedRunReport({
               </div>
               <p className="mt-2 text-xs leading-5 text-white/55">{card.reason}</p>
               <p className="mt-2 text-xs leading-5 text-[#9EE4E6]">Proof needed: {card.proofNeeded}</p>
+              {card.resolutionEvidence ? (
+                <p className="mt-2 text-xs leading-5 text-emerald-100">Evidence: {card.resolutionEvidence}</p>
+              ) : null}
             </article>
           ))}
         </div>
@@ -610,6 +627,7 @@ export default function JobsmithPage() {
         findings: checkResult.findings,
         missingInputs: welcomePacket.missingInputs,
         artifactsReady: level !== "blocked",
+        reviews: SAMPLE_DECISION_REVIEWS,
       }),
     [checkResult.findings, checkResult.reviewNeeded, level, welcomePacket.missingInputs],
   );


### PR DESCRIPTION
## Summary
- Adds reviewer decision state for JobSmith decision cards.
- Carries decision evidence into the managed run report.
- Adds resolved and unresolved card counts so submit-ready cannot hide unresolved review work.

## Proof
- Local commit: 1ad902775f1e0bea3c6a0e5b5a86806b9333f417
- Test: `npm run test -- src/pages/Jobsmith.test.tsx` passed, 1 file, 2 tests.
- Screenshot proof saved locally: `proof/jobsmith-55766d56-20260519T1820Z/jobsmith-decision-card-resolver-v1.png`
- Boardroom proof comment: 6d364e7c-aa88-4644-b785-52765fe6cd24

## Job
- Parent todo: 55766d56-ac36-476b-a6e3-81202dc5f501
- Parent stays open. This is the first resolver slice, not full completion.

## Safety
- No submission flow added.
- No secrets, billing, DNS, deploy, or data deletion touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new decision-card resolution state that can change card ownership/status (including turning items into blockers) and updates the managed run report UI/tests; mistakes could misrepresent readiness or hide/show blockers incorrectly.
> 
> **Overview**
> Adds a reviewer resolution layer for JobSmith decision cards (`pass`/`blocker`/`not_applicable`), storing `resolution` + `resolutionEvidence` and applying incoming `reviews` to update card owner/status/reason.
> 
> Updates the managed run report UI to compute a `summarizeDecisionCards` summary and display **Resolved/Unresolved** metrics, include resolution evidence on cards, and adjusts tests to assert the new counts/evidence (with a sample review injected in the browser-local page).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdbc3f631acaae15ced204742ca9a18a74ed94d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->