### PR TITLE
fix(heartbeat): point admin shortcut at action master

### DIFF
--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import { describe, expect, it } from "vitest";
 import AdminSeatHeartbeatPage, {
   buildHeartbeatSchedulePrompt,
-  HEARTBEAT_CONNECTION_PROMPT,
+  HEARTBEAT_MASTER_PROMPT,
+  HEARTBEAT_SHORTCUT_PROMPT,
   HEARTBEAT_SOURCE_OF_TRUTH,
 } from "./AdminSeatHeartbeat";
 
@@ -13,21 +14,23 @@ describe("AdminSeatHeartbeatPage", () => {
 
     expect(screen.getByRole("heading", { name: "Heartbeat Master" })).toBeInTheDocument();
     expect(screen.getByText("❤️ UnClick Heartbeat")).toBeInTheDocument();
-    expect(screen.getByText("Policy transparency")).toBeInTheDocument();
-    expect(screen.getByText("This is not copy-paste text. It explains why the small scheduler copy above is enough.")).toBeInTheDocument();
+    expect(screen.getByText("MASTER induction")).toBeInTheDocument();
+    expect(screen.getByText("This is the runtime policy an AI seat reads after the shortcut opens the door.")).toBeInTheDocument();
     expect(screen.queryByLabelText("Public default heartbeat policy")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Base schedule message")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Heartbeat cadence")).toHaveValue("7");
+    expect(screen.getByLabelText("Heartbeat cadence")).toHaveValue("10");
     expect(screen.getByLabelText("Heartbeat schedule message preview")).toHaveValue(
-      buildHeartbeatSchedulePrompt("7"),
+      buildHeartbeatSchedulePrompt("10"),
     );
+    expect(screen.getByLabelText("Heartbeat MASTER induction")).toHaveValue(HEARTBEAT_MASTER_PROMPT);
     expect(HEARTBEAT_SOURCE_OF_TRUTH).toHaveLength(4);
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("scheduled heartbeat seat");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("heartbeat_protocol first");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("commonsensepass_protocol");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("unclick-heartbeat-seat");
-    expect(HEARTBEAT_CONNECTION_PROMPT).toContain("stay quiet for routine healthy checks");
-    expect(HEARTBEAT_CONNECTION_PROMPT.length).toBeLessThan(700);
+    expect(HEARTBEAT_SHORTCUT_PROMPT).toContain("https://unclick.world/admin/agents/heartbeat");
+    expect(HEARTBEAT_SHORTCUT_PROMPT).toContain("unclick-builder-tether-seat");
+    expect(HEARTBEAT_SHORTCUT_PROMPT).not.toContain("Do not build");
+    expect(HEARTBEAT_SHORTCUT_PROMPT.length).toBeLessThan(220);
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("builder-capable tether");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("Boardroom Jobs are the work source");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("JobSmith is a separate CV and cover-letter tool");
   });
 
   it("updates the schedule message when cadence changes", () => {
@@ -43,9 +46,12 @@ describe("AdminSeatHeartbeatPage", () => {
   });
 
   it("keeps copied schedule text free of secret-shaped values and role override phrasing", () => {
-    const prompt = buildHeartbeatSchedulePrompt("7");
+    const prompt = buildHeartbeatSchedulePrompt("10");
 
-    expect(prompt).toContain("Schedule ❤️ UnClick Heartbeat every 7 min");
+    expect(prompt).toContain("Schedule ❤️ UnClick Action Heartbeat every 10 min");
+    expect(prompt).toContain("Load MASTER from https://unclick.world/admin/agents/heartbeat");
+    expect(prompt).not.toContain("Do not build");
+    expect(prompt).not.toContain("unclick-heartbeat-seat");
     expect(prompt).not.toMatch(/Bearer\s+[A-Za-z0-9._-]+/i);
     expect(prompt).not.toMatch(/sk-[A-Za-z0-9]{20,}/i);
     expect(prompt).not.toMatch(/[A-Za-z0-9+/]{32,}={0,2}/);

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -4,8 +4,8 @@ import { Check, Copy, HeartPulse } from "lucide-react";
 export const HEARTBEAT_CADENCE_OPTIONS = [
   { value: "1", label: "1 min", note: "High signal" },
   { value: "5", label: "5 min", note: "Fast loop" },
-  { value: "7", label: "7 min", note: "Current" },
-  { value: "10", label: "10 min", note: "Tight loop" },
+  { value: "7", label: "7 min", note: "Legacy" },
+  { value: "10", label: "10 min", note: "Current" },
   { value: "15", label: "15 min", note: "Balanced" },
   { value: "30", label: "30 min", note: "Balanced" },
   { value: "60", label: "1 hour", note: "Light" },
@@ -19,27 +19,52 @@ export const HEARTBEAT_CADENCE_OPTIONS = [
 
 export type HeartbeatCadenceValue = (typeof HEARTBEAT_CADENCE_OPTIONS)[number]["value"];
 
-export const DEFAULT_HEARTBEAT_CADENCE: HeartbeatCadenceValue = "7";
+export const DEFAULT_HEARTBEAT_CADENCE: HeartbeatCadenceValue = "10";
 
-export const HEARTBEAT_CONNECTION_PROMPT =
-  "Run UnClick Heartbeat as the scheduled heartbeat seat. Call heartbeat_protocol first. If commonsensepass_protocol is available, call it before any healthy, no_work, done, merge_ready, or PASS claim. Use session_id='unclick-heartbeat-seat'. Read Orchestrator, Boardroom, Jobs, dispatches, and signals before deciding. Do one safe useful heartbeat step only. Do not build, merge, edit code, assign ownership, or mark done outside the heartbeat policy. Use simple control-tower language. Reply only with PASS/BLOCKER when Chris needs to know; stay quiet for routine healthy checks.";
+export const HEARTBEAT_MASTER_URL = "https://unclick.world/admin/agents/heartbeat";
+
+export const HEARTBEAT_SHORTCUT_PROMPT =
+  `Load MASTER from ${HEARTBEAT_MASTER_URL}, then run one safe Fleet Action Runner step with proof. Use session_id='unclick-builder-tether-seat'.`;
+
+export const HEARTBEAT_MASTER_PROMPT = `MASTER: UnClick Action Heartbeat
+
+Role:
+Run as the UnClick Action Heartbeat builder-capable tether. This is not the old read-only watcher. Each wake should move one highest-value safe step with proof.
+
+Induction:
+You are entering the UnClick Bubble. Fresh state beats pasted chat. Save or confirm the wake turn, load Memory, then read Orchestrator, Boardroom, Jobs, dispatches, and signals before deciding. Boardroom Jobs are the work source. Orchestrator is context, not queue authority.
+
+One safe step:
+Pick one bounded step only. Allowed step types include build, patch, test, proof refresh, route, narrow ScopePack, CI fix, false-DONE repair, or blocker proof. Check the last 30 minutes for a fresh ACK, claim, HOLD, blocker, or proof on the exact slice before editing or waking anyone.
+
+Proof:
+Do not claim DONE, healthy, no_work, merge_ready, or PASS without current proof. Code work needs PR, commit, test, or explicit NO_CODE_NEEDED proof. UI work needs screenshot proof. Final receipts must say what moved, proof id/link/test/screenshot, and the next step.
+
+Safety:
+Protected surfaces are secrets, billing, DNS, production deploy, destructive data actions, force push, hard reset, and overriding another worker. Stop for a human decision when those appear.
+
+Lane rule:
+JobSmith is a separate CV and cover-letter tool. Do not couple JobSmith product work into AutoPilot or heartbeat automation.
+
+Chris updates:
+Use simple control-tower language. Notify Chris only for a real decision, access need, safety risk, or meaningful blocker. Stay quiet for routine safe progress.`;
 
 export const HEARTBEAT_SOURCE_OF_TRUTH = [
   {
-    title: "1. Scheduler copy",
-    body: "Copy the schedule text above into Codex or another AI platform. The cadence belongs in the scheduler.",
+    title: "1. Shortcut prompt",
+    body: "Copy only the short launcher above into Codex or another AI platform. It points seats back to this page.",
   },
   {
-    title: "2. Live policy",
-    body: "The full heartbeat playbook lives inside UnClick. The seat must fetch heartbeat_protocol every run.",
+    title: "2. MASTER induction",
+    body: "The longer seat induction lives below. Update it here once and every shortcut seat reads the new policy.",
   },
   {
-    title: "3. Green-claim guard",
-    body: "CommonSensePass is the check before any healthy, no_work, done, merge_ready, quiet, or PASS claim.",
+    title: "3. Action runner",
+    body: "The heartbeat is builder-capable. Each wake should do one safe useful step with proof.",
   },
   {
-    title: "Keep only one local schedule",
-    body: "Use the current 7 minute UnClick Heartbeat schedule. Old computer prompts should be replaced with the scheduler copy above.",
+    title: "4. Proof guard",
+    body: "No DONE, healthy, no_work, merge_ready, or PASS claim without fresh proof.",
   },
 ] as const;
 
@@ -48,7 +73,7 @@ export function getHeartbeatCadenceLabel(value: HeartbeatCadenceValue): string {
 }
 
 export function buildHeartbeatSchedulePrompt(cadence: HeartbeatCadenceValue): string {
-  return `Schedule ❤️ UnClick Heartbeat every ${getHeartbeatCadenceLabel(cadence)}. ${HEARTBEAT_CONNECTION_PROMPT}`;
+  return `Schedule ❤️ UnClick Action Heartbeat every ${getHeartbeatCadenceLabel(cadence)}. ${HEARTBEAT_SHORTCUT_PROMPT}`;
 }
 
 export default function AdminSeatHeartbeatPage() {
@@ -75,7 +100,7 @@ export default function AdminSeatHeartbeatPage() {
           </div>
           <h1 className="text-2xl font-semibold tracking-tight text-heading">Heartbeat Master</h1>
           <p className="mt-1 max-w-2xl text-sm text-body">
-            The clean copy source for the one scheduled UnClick Heartbeat.
+            Short launcher up top. Full seat induction below.
           </p>
         </div>
       </header>
@@ -89,7 +114,7 @@ export default function AdminSeatHeartbeatPage() {
             </div>
             <h2 className="mt-3 text-lg font-semibold text-heading">Schedule copy</h2>
             <p className="mt-1 max-w-2xl text-sm text-body">
-              Paste this into the scheduler. It is only a launcher; UnClick provides the full policy at runtime.
+              Paste this into the scheduler. It stays short because the MASTER lives on this page.
             </p>
           </div>
           <div className="grid gap-2 sm:grid-cols-[minmax(160px,220px)_auto] sm:items-end">
@@ -150,11 +175,18 @@ export default function AdminSeatHeartbeatPage() {
 
       <section className="space-y-3 rounded-md border border-border/30 bg-card/10 p-3">
         <div>
-          <h2 className="text-sm font-semibold text-heading">Policy transparency</h2>
+          <h2 className="text-sm font-semibold text-heading">MASTER induction</h2>
           <p className="mt-1 max-w-2xl text-xs leading-5 text-muted-foreground">
-            This is not copy-paste text. It explains why the small scheduler copy above is enough.
+            This is the runtime policy an AI seat reads after the shortcut opens the door.
           </p>
         </div>
+        <textarea
+          aria-label="Heartbeat MASTER induction"
+          readOnly
+          value={HEARTBEAT_MASTER_PROMPT}
+          rows={10}
+          className="w-full resize-none rounded-md border border-border/30 bg-black/20 px-3 py-2 font-mono text-xs leading-5 text-body outline-none focus:border-primary/40"
+        />
         <div className="grid gap-3 md:grid-cols-2">
           {HEARTBEAT_SOURCE_OF_TRUTH.map((item) => (
             <div key={item.title} className="rounded-md border border-border/30 bg-background/30 p-3">


### PR DESCRIPTION
Fixes the live /admin/agents/heartbeat page still showing the old read-only heartbeat prompt.\n\nWhat changed:\n- Default cadence is now 10 min and marked Current.\n- Scheduler copy now says Action Heartbeat and loads MASTER from https://unclick.world/admin/agents/heartbeat.\n- Removed old read-only wording from the shortcut, including Do not build and unclick-heartbeat-seat.\n- Added the lower MASTER induction block as the seat policy source.\n- Added tests for shortcut, master induction, no stale watcher copy, and no secret-shaped values.\n\nProof run locally:\n- npx vitest run src/pages/admin/AdminSeatHeartbeat.test.tsx\n- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to an admin UI copy/prompt page and its tests, with no backend/auth/data-flow modifications. Main risk is behavioral/operational—scheduled seats will follow the new builder-capable MASTER and 10-minute default cadence.
> 
> **Overview**
> Updates the admin `Heartbeat Master` page to publish a **short scheduler launcher** (`HEARTBEAT_SHORTCUT_PROMPT`) that points to a new on-page **MASTER induction** (`HEARTBEAT_MASTER_PROMPT`) for the *Action Heartbeat* (builder-capable) flow, replacing the old read-only connection prompt.
> 
> Switches the default cadence from `7` to `10` minutes (marking `7` as legacy) and updates the schedule prompt text accordingly, plus adds UI to display the MASTER prompt and refreshes `HEARTBEAT_SOURCE_OF_TRUTH` copy. Tests are updated/expanded to assert the new default cadence, presence of the MASTER textarea, shortcut/master content, and removal of stale watcher phrasing and secret-shaped strings from copied prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c65b4e58834b630868d87e38fe8146811539d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->