### PR TITLE
Fix NudgeOnly handoff into executor chain

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -10,7 +10,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | FLEET_SYNC.md | 41ebcbca94b0 | 13200 |
 | docs/unclick-context-boot-packet.md | 7cf131cf22e0 | 4785 |
 | docs/agent-observability.md | bffd9f890c75 | 4629 |
-| docs/pinballwake-nudgeonly-api.md | 901e39017aa9 | 6910 |
+| docs/pinballwake-nudgeonly-api.md | 05c3d0e6f842 | 7262 |
 | docs/pinballwake-igniteonly-api.md | bea4d9c8fa21 | 7919 |
 | docs/fleet-worker-roles.md | ed620f347d4f | 4873 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |

--- a/docs/automation-trigger-playbook.md
+++ b/docs/automation-trigger-playbook.md
@@ -117,8 +117,11 @@ Use these lanes in sequence:
 1. NudgeOnly spots a painpoint or asks for a receipt.
 2. IgniteOnly turns verified evidence into a worker wake packet.
 3. PushOnly emits the worker-facing push envelope.
+4. The Action Heartbeat or builder tether does one safe runnable step, or posts the exact executor blocker.
 
 None of these lanes can build, merge, close, approve, assign ownership, mark done, or overwrite source-of-truth state.
+
+Important: a repeated NudgeOnly bridge without IgniteOnly, PushOnly, or executor proof is not progress. Treat it as a handoff gap and keep moving the chain.
 
 ### GitHub Actions
 

--- a/docs/pinballwake-nudgeonly-api.md
+++ b/docs/pinballwake-nudgeonly-api.md
@@ -70,6 +70,10 @@ Flow:
 4. WakePass or another deterministic verifier checks the ACK/proof.
 5. If ACK/proof is still missing after the TTL, the bridge emits an escalation request.
 
+Execution rule:
+
+NudgeOnly does not execute by itself. A `receipt_request` or `escalation_request` must be consumed by IgniteOnly, then PushOnly, then the Action Heartbeat or builder tether must either do one safe runnable step or post the exact executor blocker. A NudgeOnly bridge ID alone is evidence of a stuck handoff, not proof that work moved.
+
 Receipt line shape:
 
 `worker -> target -> painpoint -> expected receipt -> verifier`

--- a/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../heartbeat-protocol.js";
 
 describe("heartbeat_protocol payload", () => {
-  it("returns the same read-only playbook across cycles", () => {
+  it("returns the same builder-capable playbook across cycles", () => {
     const first = getHeartbeatProtocol();
     const second = getHeartbeatProtocol();
 
@@ -36,7 +36,7 @@ describe("heartbeat_protocol payload", () => {
     expect(protocol.procedure).toHaveLength(18);
     expect(protocol.procedure[0]).toContain("full heartbeat policy");
     expect(protocol.procedure[1]).toContain("continuity receipts");
-    expect(protocol.procedure[2]).toContain("unclick-heartbeat-seat");
+    expect(protocol.procedure[2]).toContain("unclick-builder-tether-seat");
     expect(protocol.procedure[3]).toContain("job hunt");
     expect(protocol.procedure[4]).toContain("0 active jobs");
     expect(protocol.procedure[4]).toContain("queue hydration failure");
@@ -48,6 +48,7 @@ describe("heartbeat_protocol payload", () => {
     expect(protocol.procedure[4]).toContain("current_state_card.active_jobs");
     expect(protocol.procedure[5]).toContain("PinballWake JobHunt Mirror");
     expect(protocol.procedure[5]).toContain("Job Worker");
+    expect(protocol.procedure[5]).toContain("builder tether");
     expect(protocol.procedure[5]).toContain("free API classifiers may only classify or nudge");
     expect(protocol.procedure[5]).toContain("PushOnly");
     expect(protocol.procedure[5]).toContain("must not create duplicate jobs");
@@ -57,6 +58,7 @@ describe("heartbeat_protocol payload", () => {
     expect(protocol.procedure[9]).toContain("receipt_line");
     expect(protocol.procedure[10]).toContain("ignite_id");
     expect(protocol.procedure[10]).toContain("push_id");
+    expect(protocol.procedure[10]).toContain("Do not stop at NudgeOnly alone");
     expect(protocol.procedure[11]).toContain("read UI");
     expect(protocol.procedure[16]).toContain("missing capability");
     expect(protocol.alert_format).toEqual({
@@ -82,9 +84,9 @@ describe("heartbeat_protocol payload", () => {
       procedure: [...protocol.procedure, "new instruction"],
     };
 
-    expect(formatHeartbeatProtocolVersion(10)).toBe("2026-05-12.v10");
-    expect(protocol.version).toBe("2026-05-12.v10");
-    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("a589b15dfc093012");
+    expect(formatHeartbeatProtocolVersion(11)).toBe("2026-05-12.v11");
+    expect(protocol.version).toBe("2026-05-12.v11");
+    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("bde9cae82e8d455c");
     expect(heartbeatProtocolContentFingerprint(changed)).not.toBe(
       heartbeatProtocolContentFingerprint(protocol),
     );

--- a/packages/mcp-server/src/heartbeat-protocol.ts
+++ b/packages/mcp-server/src/heartbeat-protocol.ts
@@ -23,7 +23,7 @@ export type HeartbeatProtocol = {
 };
 
 export const HEARTBEAT_PROTOCOL_DATE = "2026-05-12";
-export const HEARTBEAT_PROTOCOL_REVISION = 10;
+export const HEARTBEAT_PROTOCOL_REVISION = 11;
 
 export function formatHeartbeatProtocolVersion(revision: number): string {
   return `${HEARTBEAT_PROTOCOL_DATE}.v${revision}`;
@@ -34,22 +34,22 @@ const HEARTBEAT_PROTOCOL: HeartbeatProtocol = {
   procedure: [
     'Treat this payload as the full heartbeat policy. Do not ask for a separate "Seats > Heartbeat" document or SKILL.md policy text.',
     "This heartbeat is explicitly authorized to write Orchestrator continuity receipts for the wake and the final PASS/BLOCKER result.",
-    "Use stable session_id='unclick-heartbeat-seat' for every scheduled heartbeat run so Orchestrator can thread receipts across isolated scheduler sessions.",
+    "Use stable session_id='unclick-builder-tether-seat' for every scheduled action heartbeat run so Orchestrator can thread receipts across isolated scheduler sessions.",
     "Call UnClick check_signals first, then always do a compact job hunt before declaring health: read_orchestrator_context if available, list_actionable_todos, list_todos for open or in_progress work, recent dispatches, and recent Boardroom messages. Cap to the most recent items UnClick returns.",
     "Pinned v9 definition: active_jobs = COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h). Orchestrator current_state_card.active_jobs uses the same query, so PASS/BLOCKER does not oscillate on identical state. Treat '0 active jobs' as PASS only when actionable_todos is also 0 (or every backlog item is explicitly held with a stated reason in the last 24h). If active_jobs is 0 while unheld actionable backlog exists, this is BLOCKER: queue hydration failure.",
-    "Use PinballWake JobHunt Mirror as the fallback path for that failure: mirror compact backlog counts and source pointers into NudgeOnly first, then IgniteOnly only after verifier-backed receipt_bridge output requests a worker wake, then PushOnly only after IgniteOnly emits a verified public wake packet. Target the existing Job Worker as executor when it is registered; free API classifiers may only classify or nudge. The mirror may request a wake and PushOnly may emit a worker push envelope, but both must not create duplicate jobs, assign ownership, mark done, merge, close, or edit source state.",
+    "Use PinballWake JobHunt Mirror as the fallback path for that failure: mirror compact backlog counts and source pointers into NudgeOnly first, then IgniteOnly only after verifier-backed receipt_bridge output requests a worker wake, then PushOnly only after IgniteOnly emits a verified public wake packet. Target the existing Job Worker or builder tether as executor when it is registered; free API classifiers may only classify or nudge. The mirror may request a wake and PushOnly may emit a worker push envelope, but both must not create duplicate jobs, assign ownership, mark done, merge, close, or edit source state.",
     "After check_signals, call save_conversation_turn with session_id='unclick-heartbeat-seat', role='assistant', and content containing the safe alert lines plus a brief progress summary and proof id if available.",
     "When UnClick returns action_needed, blocker, stale ACK, missing proof, duplicate wake, unclear owner, or queue hydration failure items, call nudgeonly_receipt_bridge if available using compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, and ttl_minutes.",
     "Prefer deterministic painpoint labels from UnClick. Call nudgeonly_api only when no deterministic bucket exists, and only for the smallest safe source text needed to classify the painpoint.",
     "If nudgeonly_receipt_bridge returns receipt_request or escalation_request, save its bridge_id and receipt_line in the continuity receipt and alert line. If it returns quiet or advisory_only, do not notify.",
-    "If a verified bridge request needs a dormant worker, call igniteonly_receipt_consumer if available using the bridge result and compact public fields only. When it returns wake_request or escalation_wake_request, call pushonly_wake_pusher if available using the public wake_packet. Save ignite_id, push_id, and wake_packet.receipt_line or push_packet.receipt_line.",
+    "If a verified bridge request needs a dormant worker or executor action, call igniteonly_receipt_consumer if available using the bridge result and compact public fields only. When it returns wake_request or escalation_wake_request, call pushonly_wake_pusher if available using the public wake_packet. Save ignite_id, push_id, and wake_packet.receipt_line or push_packet.receipt_line. Do not stop at NudgeOnly alone.",
     "If save_conversation_turn is unavailable, use unclick_save_conversation_turn. If no UnClick connector exists but an UnClick API key is already available, POST the same turn to https://unclick.world/api/memory-admin?action=admin_conversation_turn_ingest. Never print the key. Do not POST to /admin/orchestrator because it is the read UI.",
     'For admin_conversation_turn_ingest, send Authorization: Bearer <redacted> and body { "session_id": "unclick-heartbeat-seat", "role": "assistant", "content": "<safe redacted heartbeat text>", "source_app": "scheduled-heartbeat", "client_session_id": "<local run id>" }.',
     "Compare against prior tether state from local automation state first, then heartbeat_last_state search_memory only if no transient state is available. The diff is the only thing worth surfacing.",
     'If no change, send nothing or exactly: "UnClick healthy." If UnClick surfaces action_needed, blocker, failed check, stale ACK, or approval-required items, send only the alert format.',
     "Keep healthy heartbeat state transient. Do not save recurring healthy or no-change heartbeats as Memory facts; use save_fact only for actionable diffs, tether errors, or explicit user-relevant state changes.",
     "If every UnClick write path, tool, and context path is missing, reply with a concise BLOCKER that names the missing capability and the next packaging fix.",
-    "Do not build, merge, edit code, assign ownership, mark done, or perform mutation actions outside this heartbeat procedure. NudgeOnly may request a receipt or escalation only. IgniteOnly may request a worker wake only. PushOnly may emit a worker push envelope only. Trusted lanes must verify before action.",
+    "The action heartbeat may perform one safe Fleet Action Runner step with proof when scope is clear and protected surfaces are absent. NudgeOnly may request a receipt or escalation only. IgniteOnly may request a worker wake only. PushOnly may emit a worker push envelope only. The builder tether or trusted executor lane does the actual build, patch, test, route, or proof refresh. Protected surfaces still require a BLOCKER or human decision.",
   ],
   alert_format: {
     heading: "UnClick alert",

--- a/packages/mcp-server/src/nudgeonly-tool.test.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.test.ts
@@ -436,6 +436,28 @@ describe("NudgeOnlyAPI policy", () => {
     });
   });
 
+  it("keeps ownerless stale ACK requests on the Reviewer route so IgniteOnly can consume them", async () => {
+    await expect(nudgeonlyReceiptBridge({
+      painpoint_detected: true,
+      painpoint_type: "stale_ack",
+      event_text: "WakePass stale ACK for issue #766, no ACK receipt yet.",
+      source_id: "todo:8b4af32b-1c1c-4f56-bac2-a87aafb64a64",
+      target: "WakePass ACK miss repair issues #766 and #767",
+      ack_status: "stale",
+      created_at: "2026-05-19T11:55:02.558Z",
+      now: "2026-05-20T04:17:30.000Z",
+      ttl_minutes: 60,
+    })).resolves.toMatchObject({
+      bridge_status: "escalation_request",
+      request: {
+        worker: "Reviewer",
+        owner: null,
+        target: "WakePass ACK miss repair issues #766 and #767",
+        painpoint_type: "stale_ack",
+      },
+    });
+  });
+
   it("suppresses ACK-only WakePass comments instead of creating duplicate stale wakes", async () => {
     await expect(nudgeonlyReceiptBridge({
       painpoint_detected: true,

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -541,7 +541,7 @@ function workerFrom(args: Record<string, unknown>, painpointType: string, routeW
   const explicitWorker = asOptionalString(args.worker);
   const owner = asOptionalString(args.owner);
   if (painpointType === "queue_hydration_failure") return "pinballwake-jobs-worker";
-  if (painpointType === "unclear_owner" || !owner) return "Job Manager";
+  if (painpointType === "unclear_owner") return "Job Manager";
   return explicitWorker ?? routeWorker;
 }
 

--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -30,6 +30,8 @@ describe("AdminSeatHeartbeatPage", () => {
     expect(HEARTBEAT_SHORTCUT_PROMPT.length).toBeLessThan(220);
     expect(HEARTBEAT_MASTER_PROMPT).toContain("builder-capable tether");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("Boardroom Jobs are the work source");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("NudgeOnly is not the executor");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("do not stop there");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("JobSmith is a separate CV and cover-letter tool");
   });
 

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -37,6 +37,9 @@ You are entering the UnClick Bubble. Fresh state beats pasted chat. Save or conf
 One safe step:
 Pick one bounded step only. Allowed step types include build, patch, test, proof refresh, route, narrow ScopePack, CI fix, false-DONE repair, or blocker proof. Check the last 30 minutes for a fresh ACK, claim, HOLD, blocker, or proof on the exact slice before editing or waking anyone.
 
+Nudge handoff:
+NudgeOnly is not the executor. If nudgeonly_receipt_bridge returns receipt_request or escalation_request, do not stop there. Continue through IgniteOnly for a verified wake packet, PushOnly for the worker envelope, then let the Action Heartbeat or builder tether do one safe runnable step, or post BLOCKER with the exact missing executor gate.
+
 Proof:
 Do not claim DONE, healthy, no_work, merge_ready, or PASS without current proof. Code work needs PR, commit, test, or explicit NO_CODE_NEEDED proof. UI work needs screenshot proof. Final receipts must say what moved, proof id/link/test/screenshot, and the next step.
 


### PR DESCRIPTION
## Summary
- keep ownerless stale ACK NudgeOnly requests on the Reviewer route so IgniteOnly accepts them
- update heartbeat MASTER/protocol wording so NudgeOnly cannot be mistaken for an executor
- document that verified NudgeOnly requests must continue through IgniteOnly, PushOnly, then builder tether or a precise executor blocker

## Proof
- npx vitest run src/nudgeonly-tool.test.ts src/igniteonly-tool.test.ts src/pushonly-tool.test.ts src/__tests__/heartbeat-protocol.test.ts (packages/mcp-server)
- npx vitest run src/pages/admin/AdminSeatHeartbeat.test.tsx
- local chain replay: NudgeOnly escalation_request -> IgniteOnly escalation_wake_request -> PushOnly escalation_push_request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes NudgeOnly receipt routing behavior (who gets escalations) and updates the published heartbeat protocol version, which can affect automation flows consuming these policies.
> 
> **Overview**
> Tightens the NudgeOnly→IgniteOnly→PushOnly→executor handoff by clarifying in docs and the heartbeat MASTER/protocol that **NudgeOnly is not execution** and verified bridge outputs must continue through the executor chain (or produce an explicit blocker).
> 
> Fixes a routing edge case in `nudgeonly_receipt_bridge` so ownerless `stale_ack` events stay on the `Reviewer` route (instead of defaulting to `Job Manager`), with a new test covering the scenario.
> 
> Updates the MCP `heartbeat-protocol` copy to reference the `unclick-builder-tether-seat`, allow targeting the builder tether as an executor, adds “do not stop at NudgeOnly alone”, and bumps the protocol revision/fingerprint; associated tests and generated brainmap manifest are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816b915d936e9a99c5409b4f93477b83dd73b18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->