### PR TITLE
feat(agents): add worker performance monitor

### DIFF
--- a/src/pages/admin/AdminAgents.test.ts
+++ b/src/pages/admin/AdminAgents.test.ts
@@ -5,6 +5,7 @@ import AdminAgentsPage from "./AdminAgents";
 import {
   AI_SEAT_LOAD_OVERRIDE_STORAGE_KEY,
   buildSeatOverrideStoragePayload,
+  buildSeatPerformanceScores,
   latestProfileCheckInAt,
   loadSeatOverridesFromStorage,
   mapProfilesToSeats,
@@ -57,6 +58,7 @@ describe("AdminAgents seat check-ins", () => {
 
     expect(screen.getByRole("heading", { name: "Seats" })).toBeInTheDocument();
     expect(screen.getByText("AI Seats")).toBeInTheDocument();
+    expect(screen.getByText("Performance monitor")).toBeInTheDocument();
     expect(screen.getByText("Cycle share")).toBeInTheDocument();
     expect(screen.getByText("Fungible mode")).toBeInTheDocument();
     expect(screen.queryByText("UnClick Workers")).not.toBeInTheDocument();
@@ -170,5 +172,37 @@ describe("AdminAgents seat check-ins", () => {
     );
 
     expect(ranked.map((item) => item.id)).toEqual(["preferred", "busy"]);
+  });
+
+  it("scores seat performance from check-in freshness, missed tethers, load, and routing policy", () => {
+    const now = Date.parse("2026-05-09T04:10:00.000Z");
+    const scores = buildSeatPerformanceScores(
+      [
+        seat({ id: "live", name: "Live seat", load: 20, routingPolicy: "prefer" }),
+        seat({ id: "missed", name: "Missed seat", load: 90, routingPolicy: "auto" }),
+        seat({ id: "blocked", name: "Blocked seat", load: 10, routingPolicy: "blocked" }),
+      ],
+      [
+        profile({
+          agent_id: "live",
+          display_name: "Live seat",
+          last_seen_at: "2026-05-09T04:05:00.000Z",
+          current_status: "Building one safe slice.",
+        }),
+        profile({
+          agent_id: "missed",
+          display_name: "Missed seat",
+          last_seen_at: "2026-05-09T03:00:00.000Z",
+          next_checkin_at: "2026-05-09T03:20:00.000Z",
+        }),
+      ],
+      now,
+    );
+
+    expect(scores.map((item) => item.id)).toEqual(["live", "missed", "blocked"]);
+    expect(scores[0].score).toBeGreaterThan(scores[1].score);
+    expect(scores[1].reasons).toContain("missed check-in");
+    expect(scores[2].status).toBe("blocked");
+    expect(scores[2].reasons).toContain("blocked for routing");
   });
 });

--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -23,6 +23,7 @@ import {
   latestProfileCheckInAt,
   AI_SEAT_LOAD_OVERRIDE_STORAGE_KEY,
   buildSeatOverrideStoragePayload,
+  buildSeatPerformanceScores,
   loadSeatOverridesFromStorage,
   normalizeSeatRoutingPolicy,
   mapProfilesToSeats,
@@ -256,6 +257,10 @@ function AISeatsPanel() {
     () => unmatchedRecentProfiles(profiles, seatProfiles.values()),
     [profiles, seatProfiles],
   );
+  const performanceScores = useMemo(
+    () => buildSeatPerformanceScores(seats, profiles),
+    [profiles, seats],
+  );
   const matchedProfileCount = seatProfiles.size;
   const checkInSummary = profilesError
     ? profilesError
@@ -337,6 +342,8 @@ function AISeatsPanel() {
 
   return (
     <section className="space-y-4">
+      <PerformanceMonitorPanel scores={performanceScores} loading={profilesLoading || sessionLoading} />
+
       <div className="overflow-hidden rounded-xl border border-border/40 bg-card/20">
         <div className="flex flex-col gap-2 border-b border-border/40 px-4 py-3 md:flex-row md:items-center md:justify-between">
           <div>
@@ -601,6 +608,63 @@ function AISeatsPanel() {
           </ul>
         </div>
       )}
+    </section>
+  );
+}
+
+function PerformanceMonitorPanel({
+  scores,
+  loading,
+}: {
+  scores: ReturnType<typeof buildSeatPerformanceScores>;
+  loading: boolean;
+}) {
+  const topScores = scores.slice(0, 6);
+  const watchCount = scores.filter((score) => score.status !== "strong").length;
+  return (
+    <section className="overflow-hidden rounded-xl border border-border/40 bg-card/20">
+      <div className="flex flex-col gap-2 border-b border-border/40 px-4 py-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-heading">Performance monitor</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Live seat score from check-ins, missed tethers, load, and routing policy.
+          </p>
+        </div>
+        <span
+          className={`w-fit rounded-md border px-2 py-1 text-[11px] ${
+            watchCount > 0
+              ? "border-amber-400/30 bg-amber-400/10 text-amber-300"
+              : "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+          }`}
+        >
+          {loading ? "Refreshing..." : watchCount > 0 ? `${watchCount} need watch` : "All strong"}
+        </span>
+      </div>
+      <div className="grid gap-2 p-4 md:grid-cols-2 xl:grid-cols-3">
+        {topScores.map((score) => (
+          <div key={score.id} className="rounded-lg border border-border/30 bg-card/30 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-xs font-semibold text-heading">{score.label}</p>
+                <p className="mt-0.5 truncate text-[10px] text-muted-foreground">{score.reasons.join(", ")}</p>
+              </div>
+              <span
+                className={`rounded-md border px-2 py-1 text-xs font-semibold ${
+                  score.status === "strong"
+                    ? "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+                    : score.status === "watch"
+                      ? "border-sky-400/30 bg-sky-400/10 text-sky-300"
+                      : score.status === "stale"
+                        ? "border-amber-400/30 bg-amber-400/10 text-amber-300"
+                        : "border-rose-400/30 bg-rose-400/10 text-rose-300"
+                }`}
+              >
+                {score.score}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/pages/admin/AdminAgentsSeatUtils.ts
+++ b/src/pages/admin/AdminAgentsSeatUtils.ts
@@ -27,6 +27,18 @@ export interface AISeat {
   routingPolicy?: SeatRoutingPolicy;
 }
 
+export type SeatPerformanceStatus = "strong" | "watch" | "stale" | "blocked";
+
+export interface SeatPerformanceScore {
+  id: string;
+  label: string;
+  score: number;
+  status: SeatPerformanceStatus;
+  reasons: string[];
+  lastCheckInAt: string | null;
+  source: "matched-seat" | "live-profile" | "manual-seat";
+}
+
 export const AI_SEAT_LOAD_OVERRIDE_STORAGE_KEY = "unclick_ai_seat_load_overrides_v1";
 export const AI_SEAT_LEGACY_STORAGE_KEY = "unclick_ai_seat_manual_slots_v1";
 
@@ -188,4 +200,112 @@ export function rankSeatsForRouting(
       const rightScore = policyScore(rightPolicy) + liveScore(right) + capacityScore(right) - (right.isVirtual ? 25 : 0);
       return rightScore - leftScore || left.name.localeCompare(right.name);
     });
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function freshnessPenalty(checkedInAt: string | null, nowMs: number): { penalty: number; reason: string } {
+  if (!checkedInAt) return { penalty: 45, reason: "no live check-in" };
+  const checkedInMs = Date.parse(checkedInAt);
+  if (!Number.isFinite(checkedInMs)) return { penalty: 45, reason: "invalid check-in time" };
+  const ageMs = Math.max(0, nowMs - checkedInMs);
+  if (ageMs <= 15 * 60 * 1000) return { penalty: 0, reason: "live" };
+  if (ageMs <= 30 * 60 * 1000) return { penalty: 10, reason: "warming up" };
+  if (ageMs <= 4 * 60 * 60 * 1000) return { penalty: 25, reason: "quiet" };
+  if (ageMs <= 24 * 60 * 60 * 1000) return { penalty: 45, reason: "stale" };
+  return { penalty: 65, reason: "cold" };
+}
+
+function missedCheckInPenalty(profile: FishbowlProfile | null, nowMs: number): { penalty: number; reason: string | null } {
+  if (!profile?.next_checkin_at) return { penalty: 0, reason: null };
+  const nextMs = Date.parse(profile.next_checkin_at);
+  if (!Number.isFinite(nextMs) || nowMs <= nextMs) return { penalty: 0, reason: null };
+  return { penalty: 25, reason: "missed check-in" };
+}
+
+function scoreSeatPerformance({
+  id,
+  label,
+  seat = null,
+  profile = null,
+  nowMs,
+  source,
+}: {
+  id: string;
+  label: string;
+  seat?: AISeat | null;
+  profile?: FishbowlProfile | null;
+  nowMs: number;
+  source: SeatPerformanceScore["source"];
+}): SeatPerformanceScore {
+  const reasons: string[] = [];
+  const checkedInAt = profile ? latestProfileCheckInAt(profile) : null;
+  const freshness = freshnessPenalty(checkedInAt, nowMs);
+  if (freshness.reason !== "live") reasons.push(freshness.reason);
+
+  const missed = missedCheckInPenalty(profile, nowMs);
+  if (missed.reason) reasons.push(missed.reason);
+
+  const routingPolicy = seat ? normalizeSeatRoutingPolicy(seat.routingPolicy) : "auto";
+  const routingPenalty = routingPolicy === "blocked" ? 35 : routingPolicy === "avoid" ? 10 : 0;
+  if (routingPolicy === "blocked") reasons.push("blocked for routing");
+  if (routingPolicy === "avoid") reasons.push("avoid for routing");
+
+  const load = seat ? normalizeSeatLoadOverride(seat.load, 0) : 25;
+  const loadPenalty = load >= 90 ? 15 : load >= 75 ? 8 : 0;
+  if (loadPenalty) reasons.push("high load");
+
+  const issuePenalty = seat?.issue ? 20 : 0;
+  if (seat?.issue) reasons.push(seat.issue);
+  if (profile && !profile.current_status) reasons.push("no current status");
+
+  const preferBonus = routingPolicy === "prefer" ? 5 : 0;
+  const score = clampScore(100 - freshness.penalty - missed.penalty - routingPenalty - loadPenalty - issuePenalty + preferBonus);
+  const status: SeatPerformanceStatus =
+    score >= 80 ? "strong" : score >= 60 ? "watch" : score >= 35 ? "stale" : "blocked";
+
+  return {
+    id,
+    label,
+    score,
+    status,
+    reasons: reasons.length > 0 ? reasons : ["healthy"],
+    lastCheckInAt: checkedInAt,
+    source,
+  };
+}
+
+export function buildSeatPerformanceScores(
+  seats: AISeat[],
+  profiles: FishbowlProfile[] = [],
+  nowMs = Date.now(),
+): SeatPerformanceScore[] {
+  const seatProfiles = mapProfilesToSeats(seats, profiles);
+  const matchedProfiles = seatProfiles.values();
+  const scores = seats.map((seat) =>
+    scoreSeatPerformance({
+      id: seat.id,
+      label: seat.name,
+      seat,
+      profile: seatProfiles.get(seat.id) ?? null,
+      nowMs,
+      source: seatProfiles.has(seat.id) ? "matched-seat" : "manual-seat",
+    }),
+  );
+
+  for (const profile of unmatchedRecentProfiles(profiles, matchedProfiles, nowMs)) {
+    scores.push(
+      scoreSeatPerformance({
+        id: profile.agent_id,
+        label: profile.display_name?.trim() || profile.agent_id,
+        profile,
+        nowMs,
+        source: "live-profile",
+      }),
+    );
+  }
+
+  return scores.sort((left, right) => right.score - left.score || left.label.localeCompare(right.label));
 }


### PR DESCRIPTION
## Summary
- Adds a small Performance monitor panel to the Seats admin page.
- Scores seats from live check-in freshness, missed tether time, load, routing policy, and visible issues.
- Keeps this as read-only visibility first, not automatic promotion/demotion.

## Proof
- `npx vitest run src/pages/admin/AdminAgents.test.ts src/lib/workerHealthMonitor.test.ts`
- `npm run build`

## Notes
- Local browser reached the expected admin sign-in gate, so visual proof is deferred to authenticated preview/Vercel.
- This is the first Worker Registry / Performance Monitor slice for the weak AutoPilot layer below HarnessKit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds read-only scoring/visibility to the admin Seats page and new utility functions, without changing routing decisions or persistence behavior.
> 
> **Overview**
> Adds a **read-only “Performance monitor”** panel to the admin Seats page, showing the top seat health scores and an overall “need watch”/“all strong” indicator.
> 
> Introduces `buildSeatPerformanceScores` in `AdminAgentsSeatUtils` to score seats (and recent unmatched live profiles) based on check-in freshness, missed check-ins, load, routing policy, and seat issues, and adds tests covering the scoring and UI presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d89a481e06cae414e212991bef357ee97de8155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->