### PR TITLE
Add Manual ExpressRoom draft lane

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7436,6 +7436,327 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       // ─── Fishbowl Phase 1: agent group chat ───────────────────────────────
 
+      case "expressroom_create_draft":
+      case "expressroom_list_drafts":
+      case "expressroom_update_draft":
+      case "expressroom_promote_to_todo": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Sign in to the admin UI or pass your UnClick API key as 'Authorization: Bearer <api_key>'.",
+          });
+        }
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const sessionUser = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        const actorAgentId = (() => {
+          const raw = String(body.agent_id ?? "").trim();
+          if (raw) return raw;
+          if (sessionUser?.id) return `human-${sessionUser.id}`;
+          return "";
+        })();
+        if (!actorAgentId) return res.status(400).json({ error: "agent_id required" });
+        if (actorAgentId.length > 128) return res.status(400).json({ error: "agent_id must be at most 128 characters" });
+        if (actorAgentId.startsWith("human-") && !sessionUser) {
+          return res.status(403).json({ error: "human-* agent_id is reserved for the admin UI" });
+        }
+
+        const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        const textField = (field: string, max: number, required = true): string | { error: string } => {
+          const value = typeof body[field] === "string" ? String(body[field]).trim() : "";
+          if (required && !value) return { error: `${field} required` };
+          if (value.length > max) return { error: `${field} must be at most ${max} characters` };
+          return value;
+        };
+        const optionalUuid = (field: string): string | null | { error: string } => {
+          const value = typeof body[field] === "string" ? String(body[field]).trim() : "";
+          if (!value) return null;
+          if (!UUID_RE.test(value)) return { error: `${field} must be a uuid` };
+          return value;
+        };
+        const draftId = (): string | { error: string } => {
+          const id = typeof body.draft_id === "string" ? body.draft_id.trim() : "";
+          if (!id) return { error: "draft_id required" };
+          if (!UUID_RE.test(id)) return { error: "draft_id must be a uuid" };
+          return id;
+        };
+        const validCodeStatus = (value: unknown): "not_supplied" | "partial" | "complete" | "unknown" | { error: string } => {
+          const status = String(value ?? "not_supplied");
+          if (!["not_supplied", "partial", "complete", "unknown"].includes(status)) {
+            return { error: "supplied_code_status must be not_supplied|partial|complete|unknown" };
+          }
+          return status as "not_supplied" | "partial" | "complete" | "unknown";
+        };
+        const validExpressStatus = (value: unknown): "draft" | "inserted" | "archived" | { error: string } => {
+          const status = String(value ?? "draft");
+          if (!["draft", "inserted", "archived"].includes(status)) {
+            return { error: "express_status must be draft|inserted|archived" };
+          }
+          return status as "draft" | "inserted" | "archived";
+        };
+        const codeStatusLabel = (status: string) => ({
+          not_supplied: "Not supplied",
+          partial: "Partial",
+          complete: "Complete",
+          unknown: "Unknown",
+        }[status] ?? "Unknown");
+        const draftStatusLabel = (status: string) => ({
+          draft: "Manual draft",
+          inserted: "Inserted into Jobs",
+          archived: "Archived",
+        }[status] ?? "Manual draft");
+        const buildOfficialDescription = (draft: Record<string, unknown>): string => {
+          const suppliedCode = String(draft.supplied_code ?? "").trim();
+          const codePreview = suppliedCode ? suppliedCode.slice(0, 1600) : "No code supplied yet.";
+          return [
+            "Manual ExpressBuild import from ExpressRoom.",
+            "",
+            `ExpressRoom draft: ${draft.id}`,
+            `Draft status: ${draftStatusLabel(String(draft.express_status ?? "draft"))}`,
+            `Supplied code status: ${codeStatusLabel(String(draft.supplied_code_status ?? "unknown"))}`,
+            "",
+            "Short description:",
+            String(draft.short_description ?? "").trim(),
+            "",
+            "Detailed brief MD:",
+            String(draft.brief_markdown ?? "").trim(),
+            "",
+            "Supplied code preview:",
+            codePreview,
+            "",
+            "Insertion rule:",
+            "This is a Manual draft, not finished work. Fit it into the repo, run checks, create PR or commit proof, then use the normal UnClick review and proof gates before any DONE claim.",
+            "",
+            "Alarm bells:",
+            "- Manual ExpressRoom code is untrusted until fitted into the repo.",
+            "- Do not mark this official job done from the draft alone.",
+            "- Require normal tests, PR or commit proof, review, and product proof where relevant.",
+          ].join("\n");
+        };
+        const verifyTodoMirror = async (todoId: string): Promise<boolean> => {
+          const { data } = await supabase
+            .from("mc_fishbowl_todos")
+            .select("id")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", todoId)
+            .maybeSingle();
+          return Boolean(data);
+        };
+        const postTodoMirrorComment = async (todoId: string, draft: Record<string, unknown>): Promise<void> => {
+          const text = [
+            "Manual ExpressRoom mirror attached.",
+            "",
+            `ExpressRoom draft: ${draft.id}`,
+            `Code state: ${codeStatusLabel(String(draft.supplied_code_status ?? "unknown"))}`,
+            "",
+            "Alarm bell: this is Manual draft material only. Do not mark the official job done from this draft. Fit it into the repo, test it, review it, and record proof first.",
+          ].join("\n");
+          await supabase.from("mc_fishbowl_comments").insert({
+            api_key_hash: apiKeyHash,
+            target_kind: "todo",
+            target_id: todoId,
+            author_agent_id: actorAgentId,
+            text,
+          });
+        };
+
+        if (action === "expressroom_list_drafts") {
+          const statusRaw = typeof body.express_status === "string" ? body.express_status : "";
+          let query = supabase
+            .from("mc_expressroom_drafts")
+            .select("*")
+            .eq("api_key_hash", apiKeyHash)
+            .order("updated_at", { ascending: false })
+            .limit(Math.max(1, Math.min(Number(body.limit ?? 100), 200)));
+          if (statusRaw) {
+            const status = validExpressStatus(statusRaw);
+            if (typeof status !== "string") return res.status(400).json(status);
+            query = query.eq("express_status", status);
+          }
+          const { data, error } = await query;
+          if (error) throw error;
+          return res.status(200).json({ drafts: data ?? [] });
+        }
+
+        if (action === "expressroom_create_draft") {
+          const jobName = textField("job_name_mirror", 200);
+          if (typeof jobName !== "string") return res.status(400).json(jobName);
+          const shortDescription = textField("short_description", 1000);
+          if (typeof shortDescription !== "string") return res.status(400).json(shortDescription);
+          const briefMarkdown = textField("brief_markdown", 30000);
+          if (typeof briefMarkdown !== "string") return res.status(400).json(briefMarkdown);
+          const suppliedCode = textField("supplied_code", 100000, false);
+          if (typeof suppliedCode !== "string") return res.status(400).json(suppliedCode);
+          const suppliedCodeStatus = validCodeStatus(body.supplied_code_status);
+          if (typeof suppliedCodeStatus !== "string") return res.status(400).json(suppliedCodeStatus);
+          const officialTodoId = optionalUuid("official_todo_id");
+          if (officialTodoId && typeof officialTodoId === "object") return res.status(400).json(officialTodoId);
+          if (officialTodoId && !(await verifyTodoMirror(officialTodoId))) {
+            return res.status(404).json({ error: "official_todo_id not found" });
+          }
+          const sourceChatSessionId = textField("source_chat_session_id", 200, false);
+          if (typeof sourceChatSessionId !== "string") return res.status(400).json(sourceChatSessionId);
+
+          const { data, error } = await supabase
+            .from("mc_expressroom_drafts")
+            .insert({
+              api_key_hash: apiKeyHash,
+              job_name_mirror: jobName,
+              official_todo_id: officialTodoId,
+              short_description: shortDescription,
+              brief_markdown: briefMarkdown,
+              supplied_code: suppliedCode,
+              supplied_code_status: suppliedCodeStatus,
+              express_status: "draft",
+              created_by_agent_id: actorAgentId,
+              source_chat_session_id: sourceChatSessionId || null,
+            })
+            .select("*")
+            .single();
+          if (error) throw error;
+
+          if (officialTodoId) {
+            await postTodoMirrorComment(officialTodoId, data);
+          }
+
+          void postFishbowlEvent(
+            supabase,
+            apiKeyHash,
+            actorAgentId,
+            "expressroom-created",
+            `Manual ExpressRoom draft created: ${jobName}`,
+          );
+
+          return res.status(200).json({ draft: data });
+        }
+
+        if (action === "expressroom_update_draft") {
+          const id = draftId();
+          if (typeof id !== "string") return res.status(400).json(id);
+          const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+          const fieldSpecs: Array<[string, number, boolean]> = [
+            ["job_name_mirror", 200, true],
+            ["short_description", 1000, true],
+            ["brief_markdown", 30000, true],
+            ["supplied_code", 100000, false],
+            ["source_chat_session_id", 200, false],
+          ];
+          for (const [field, max, required] of fieldSpecs) {
+            if (body[field] !== undefined) {
+              const value = textField(field, max, required);
+              if (typeof value !== "string") return res.status(400).json(value);
+              update[field] = field === "source_chat_session_id" && !value ? null : value;
+            }
+          }
+          if (body.official_todo_id !== undefined) {
+            const officialTodoId = optionalUuid("official_todo_id");
+            if (officialTodoId && typeof officialTodoId === "object") return res.status(400).json(officialTodoId);
+            if (officialTodoId && !(await verifyTodoMirror(officialTodoId))) {
+              return res.status(404).json({ error: "official_todo_id not found" });
+            }
+            update.official_todo_id = officialTodoId;
+          }
+          if (body.supplied_code_status !== undefined) {
+            const status = validCodeStatus(body.supplied_code_status);
+            if (typeof status !== "string") return res.status(400).json(status);
+            update.supplied_code_status = status;
+          }
+          if (body.express_status !== undefined) {
+            const status = validExpressStatus(body.express_status);
+            if (typeof status !== "string") return res.status(400).json(status);
+            update.express_status = status;
+          }
+
+          const { data, error } = await supabase
+            .from("mc_expressroom_drafts")
+            .update(update)
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", id)
+            .select("*")
+            .single();
+          if (error) throw error;
+          return res.status(200).json({ draft: data });
+        }
+
+        if (action === "expressroom_promote_to_todo") {
+          const id = draftId();
+          if (typeof id !== "string") return res.status(400).json(id);
+          const priority = String(body.priority ?? "normal");
+          if (!["low", "normal", "high", "urgent"].includes(priority)) {
+            return res.status(400).json({ error: "priority must be low|normal|high|urgent" });
+          }
+          const { data: draft, error: draftErr } = await supabase
+            .from("mc_expressroom_drafts")
+            .select("*")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", id)
+            .maybeSingle();
+          if (draftErr) throw draftErr;
+          if (!draft) return res.status(404).json({ error: "ExpressRoom draft not found" });
+          if (draft.official_todo_id && body.force_new !== true) {
+            await postTodoMirrorComment(String(draft.official_todo_id), draft);
+            return res.status(200).json({ draft, todo: null, reused: true });
+          }
+
+          const title = `Manual ExpressBuild integration: ${String(draft.job_name_mirror).trim()}`.slice(0, 200);
+          const description = buildOfficialDescription(draft);
+          const { data: todo, error: todoErr } = await supabase
+            .from("mc_fishbowl_todos")
+            .insert({
+              api_key_hash: apiKeyHash,
+              title,
+              description,
+              priority,
+              status: "open",
+              created_by_agent_id: actorAgentId,
+              assigned_to_agent_id: null,
+            })
+            .select("*")
+            .single();
+          if (todoErr) throw todoErr;
+
+          await recordAutopilotEvents(
+            supabase,
+            apiKeyHash,
+            planTodoLedgerEvents({
+              todoId: todo.id,
+              actorAgentId,
+              before: null,
+              after: todo,
+            }),
+          );
+
+          const { data: updatedDraft, error: updateErr } = await supabase
+            .from("mc_expressroom_drafts")
+            .update({
+              official_todo_id: todo.id,
+              express_status: "inserted",
+              updated_at: new Date().toISOString(),
+            })
+            .eq("api_key_hash", apiKeyHash)
+            .eq("id", id)
+            .select("*")
+            .single();
+          if (updateErr) throw updateErr;
+
+          await postTodoMirrorComment(todo.id, updatedDraft);
+
+          void postFishbowlEvent(
+            supabase,
+            apiKeyHash,
+            actorAgentId,
+            "expressroom-inserted",
+            `Manual ExpressRoom draft inserted into official Jobs: ${title}`,
+          );
+
+          return res.status(200).json({ draft: updatedDraft, todo, reused: false });
+        }
+
+        return res.status(400).json({ error: `Unhandled ExpressRoom action: ${action}` });
+      }
+
       case "fishbowl_admin_claim": {
         // Web-UI-only action. Auto-creates (or refreshes) a profile for the
         // signed-in human admin so they can post into the Fishbowl as

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -15,8 +15,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | ed620f347d4f | 4873 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | b02c3916f083 | 13089 |
-| src/pages/admin/AdminShell.tsx | fcbb1fa44f40 | 19018 |
+| src/App.tsx | fd2479b601d8 | 13242 |
+| src/pages/admin/AdminShell.tsx | 85f51159bb4c | 19116 |
 | .github/workflows/ci.yml | 79e43dd8e26c | 1608 |
 | .github/workflows/brainmap-auto-update.yml | 7e8b08eb16aa | 1137 |
 | package.json | 9f761ff407b1 | 4232 |
@@ -104,6 +104,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | /admin/codebase | Admin Codebase | Internal source and architecture orientation surface. | src/pages/admin/AdminCodebase.tsx |
 | /admin/dashboard | Admin Dashboard | Front door for current operator state. | src/pages/admin/AdminDashboard.tsx |
 | /admin/ecosystem-pages | Admin Ecosystem Pages | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
+| /admin/express-build | Admin Express Build | Admin surface for Admin Express Build. | src/pages/admin/AdminExpressBuild.tsx |
 | /admin/jobs | Admin Jobs | Operational job and task queue. | src/pages/admin/AdminJobs.tsx |
 | /admin/jobsmith | Admin Jobsmith | Admin surface for Admin Jobsmith. | src/pages/admin/AdminJobsmith.tsx |
 | /admin/keychain | Admin Keychain | Passport and credential connection health. | src/pages/admin/AdminKeychain.tsx |

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -821,6 +821,61 @@ export const VISIBLE_TOOLS = [
     },
   },
   {
+    name: "create_expressroom_draft",
+    title: "Create an ExpressRoom Manual draft",
+    description:
+      "Creates a Manual ExpressBuild draft in ExpressRoom. Use this when a chat seat has a detailed brief, a job name mirror, a short description, and supplied draft code. " +
+      "Alarm bell: this does not mark official work done. It stores untrusted draft material so it can later be inserted into the official Jobs Board, then tested, reviewed, and proved.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for the calling agent." },
+        job_name_mirror: { type: "string", description: "The official job name or intended official job name." },
+        official_todo_id: { type: "string", description: "Optional existing Jobs Board todo id to mirror." },
+        short_description: { type: "string", description: "Quick read of the draft job." },
+        brief_markdown: { type: "string", description: "Detailed intake brief from the chat." },
+        supplied_code: { type: "string", description: "Draft code, patch notes, or file contents supplied by the express builder." },
+        supplied_code_status: { type: "string", enum: ["not_supplied", "partial", "complete", "unknown"], default: "not_supplied" },
+        source_chat_session_id: { type: "string", description: "Optional source chat/session id." },
+      },
+      required: ["agent_id", "job_name_mirror", "short_description", "brief_markdown", "supplied_code", "supplied_code_status"],
+    },
+  },
+  {
+    name: "list_expressroom_drafts",
+    title: "List ExpressRoom Manual drafts",
+    description:
+      "Lists Manual ExpressBuild drafts stored in ExpressRoom. These are draft-only records until promoted into official Jobs.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for the calling agent." },
+        express_status: { type: "string", enum: ["draft", "inserted", "archived"], description: "Optional status filter." },
+        limit: { type: "number", minimum: 1, maximum: 200, default: 100 },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "promote_expressroom_draft",
+    title: "Insert ExpressRoom draft into Jobs",
+    description:
+      "Creates an official Boardroom job from a Manual ExpressRoom draft and links the two records. The new job still needs normal UnClick integration, tests, PR or commit proof, and review.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        agent_id: { type: "string", description: "Stable identifier for the calling agent." },
+        draft_id: { type: "string", description: "ExpressRoom draft id." },
+        priority: { type: "string", enum: ["low", "normal", "high", "urgent"], default: "normal" },
+        force_new: { type: "boolean", description: "Create a new job even if this draft already has a linked official job." },
+      },
+      required: ["agent_id", "draft_id"],
+    },
+  },
+  {
     name: "update_todo",
     title: "Update a Boardroom todo",
     description:
@@ -1860,6 +1915,9 @@ export function createServer(): Server {
         post_message: "fishbowl_post",
         read_messages: "fishbowl_read",
         set_my_status: "fishbowl_set_status",
+        create_expressroom_draft: "expressroom_create_draft",
+        list_expressroom_drafts: "expressroom_list_drafts",
+        promote_expressroom_draft: "expressroom_promote_to_todo",
         create_todo: "fishbowl_create_todo",
         update_todo: "fishbowl_update_todo",
         complete_todo: "fishbowl_complete_todo",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ import AdminAuditLog from "./pages/admin/AdminAuditLog.tsx";
 import AdminBrainmap from "./pages/admin/AdminBrainmap.tsx";
 import AdminJobs from "./pages/admin/AdminJobs.tsx";
 import AdminJobsmith from "./pages/admin/AdminJobsmith.tsx";
+import AdminExpressBuild from "./pages/admin/AdminExpressBuild.tsx";
 import {
   AdminAutopilot,
   AdminBilling,
@@ -165,6 +166,7 @@ const App = () => (
             <Route path="settings" element={<AdminSettings />} />
             <Route path="projects" element={<AdminProjects />} />
             <Route path="autopilot" element={<AdminAutopilot />} />
+            <Route path="autopilot/expressbuild" element={<AdminExpressBuild />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
             <Route path="agents/heartbeat" element={<AdminSeatHeartbeatPage />} />
             <Route path="workers" element={<AdminWorkers />} />

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -123,6 +123,7 @@ export function AdminAutopilot() {
         items={[
           { title: "Boardroom", body: "Shared room for decisions, handoffs, and short updates from people and AI workers.", icon: MessagesSquare, href: "/admin/boardroom" },
           { title: "Orchestrator", body: "Compact cross-seat context with profile cards, continuity, and memory snapshots.", icon: Brain, href: "/admin/orchestrator" },
+          { title: "ExpressBuild", body: "Manual draft room for fast outside builds before they are inserted into official Jobs.", icon: Code2, href: "/admin/autopilot/expressbuild" },
           { title: "Jobs", body: "The live work queue. Pick, assign, complete, and prove the next safe step.", icon: ListTodo, href: "/admin/jobs" },
           { title: "XPass", body: "Proof and quality checks for work before it ships.", icon: ClipboardCheck, href: "/admin/checks" },
           { title: "Projects", body: "Containers for company, team, client, or personal work areas.", icon: FolderKanban, href: "/admin/projects" },

--- a/src/pages/admin/AdminExpressBuild.test.tsx
+++ b/src/pages/admin/AdminExpressBuild.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdminExpressBuild from "./AdminExpressBuild";
+
+vi.mock("@/lib/auth", () => ({
+  useSession: () => ({
+    session: { access_token: "test-session-token" },
+    user: { email: "admin@example.com" },
+    loading: false,
+  }),
+}));
+
+const draft = {
+  id: "11111111-1111-4111-8111-111111111111",
+  job_name_mirror: "Proof Ledger v2",
+  official_todo_id: null,
+  short_description: "Manual draft for structured evidence.",
+  brief_markdown: "# Intake\nChris wants proof types.",
+  supplied_code: "export const proof = true;",
+  supplied_code_status: "partial",
+  express_status: "draft",
+  created_by_agent_id: "chat-seat",
+  source_chat_session_id: "session-1",
+  created_at: "2026-05-20T00:00:00Z",
+  updated_at: "2026-05-20T00:00:00Z",
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/admin/autopilot/expressbuild"]}>
+      <AdminExpressBuild />
+    </MemoryRouter>,
+  );
+}
+
+describe("AdminExpressBuild", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("expressroom_list_drafts")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ drafts: [draft] }),
+          });
+        }
+        if (url.includes("expressroom_create_draft")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ draft }),
+          });
+        }
+        if (url.includes("expressroom_promote_to_todo")) {
+          const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                draft: { ...draft, official_todo_id: "22222222-2222-4222-8222-222222222222", express_status: "inserted" },
+                todo: { id: "22222222-2222-4222-8222-222222222222", title: "Manual ExpressBuild integration: Proof Ledger v2" },
+                request: body,
+              }),
+          });
+        }
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({ error: "unexpected fetch" }) });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("explains that ExpressRoom is a Manual draft lane under AutoPilot", async () => {
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: "ExpressBuild" })).toBeInTheDocument();
+    expect(screen.getByText("Manual ExpressBuild")).toBeInTheDocument();
+    expect(screen.getByText(/disconnected from the usual assembly line/i)).toBeInTheDocument();
+    expect(screen.getByText(/Do not claim DONE from ExpressRoom/i)).toBeInTheDocument();
+    expect(screen.getByText("Manual draft alarm bells")).toBeInTheDocument();
+    expect(screen.getAllByText(/Supplied code is untrusted/i).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Proof Ledger v2")).toBeInTheDocument();
+  });
+
+  it("captures the required Manual draft fields", async () => {
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText("Job name mirror"), { target: { value: "Worker Registry score panel" } });
+    fireEvent.change(screen.getByLabelText("Short description"), { target: { value: "Build a small score panel." } });
+    fireEvent.change(screen.getByLabelText("Detailed intake brief"), { target: { value: "Chris asked for a ranked worker score table." } });
+    fireEvent.change(screen.getByLabelText("Supplied code"), { target: { value: "export const score = 88;" } });
+    fireEvent.change(screen.getByLabelText("Code state"), { target: { value: "complete" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Save Manual draft/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/memory-admin?action=expressroom_create_draft",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("Worker Registry score panel"),
+        }),
+      );
+    });
+  });
+
+  it("inserts a Manual draft into the official Jobs Board", async () => {
+    renderPage();
+
+    const row = await screen.findByText("Proof Ledger v2");
+    const tableRow = row.closest("tr");
+    expect(tableRow).not.toBeNull();
+
+    fireEvent.click(within(tableRow as HTMLTableRowElement).getByRole("button", { name: /Insert to Jobs/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/memory-admin?action=expressroom_promote_to_todo",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("11111111-1111-4111-8111-111111111111"),
+        }),
+      );
+    });
+  });
+});

--- a/src/pages/admin/AdminExpressBuild.tsx
+++ b/src/pages/admin/AdminExpressBuild.tsx
@@ -1,0 +1,492 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowUpRight,
+  FileCode2,
+  FileText,
+  Loader2,
+  NotebookTabs,
+  Plus,
+  Rocket,
+  Save,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+import { useSession } from "@/lib/auth";
+import {
+  DEFAULT_EXPRESSROOM_DRAFT_INPUT,
+  EXPRESSROOM_CODE_STATUS_LABELS,
+  EXPRESSROOM_DRAFT_STATUS_LABELS,
+  EXPRESSROOM_GUARDRAILS,
+  EXPRESSROOM_INDUCTION_TEXT,
+  EXPRESSROOM_REQUIRED_FIELDS,
+  buildExpressRoomOfficialJobDescription,
+  countReadyExpressRoomFields,
+  type ExpressRoomCodeStatus,
+  type ExpressRoomDraft,
+  type ExpressRoomDraftInput,
+} from "./expressroom";
+
+type Priority = "low" | "normal" | "high" | "urgent";
+
+interface DraftListResponse {
+  drafts?: ExpressRoomDraft[];
+  error?: string;
+}
+
+interface DraftCreateResponse {
+  draft?: ExpressRoomDraft;
+  error?: string;
+}
+
+interface DraftPromoteResponse {
+  draft?: ExpressRoomDraft;
+  todo?: { id: string; title: string };
+  reused?: boolean;
+  error?: string;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function clip(value: string, max = 180): string {
+  const clean = value.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  return `${clean.slice(0, max - 3).trimEnd()}...`;
+}
+
+function makeMarkdownBrief(input: ExpressRoomDraftInput): string {
+  return [
+    `# ${input.job_name_mirror.trim() || "Manual ExpressBuild draft"}`,
+    "",
+    "## What Chris told the chat agent",
+    input.brief_markdown.trim() || "- Not captured yet.",
+    "",
+    "## Short description",
+    input.short_description.trim() || "- Not captured yet.",
+    "",
+    "## Supplied code status",
+    EXPRESSROOM_CODE_STATUS_LABELS[input.supplied_code_status ?? "not_supplied"],
+  ].join("\n");
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <span className="text-xs font-semibold uppercase tracking-wide text-white/45">{children}</span>;
+}
+
+function ManualPill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-full border border-[#E2B93B]/35 bg-[#E2B93B]/10 px-2.5 py-1 text-xs font-semibold text-[#E2B93B]">
+      {children}
+    </span>
+  );
+}
+
+export default function AdminExpressBuild() {
+  const { session } = useSession();
+  const token = session?.access_token;
+  const authHeader = useMemo(
+    () => (token ? { Authorization: `Bearer ${token}` } : {}),
+    [token],
+  );
+  const [drafts, setDrafts] = useState<ExpressRoomDraft[]>([]);
+  const [form, setForm] = useState<ExpressRoomDraftInput>(DEFAULT_EXPRESSROOM_DRAFT_INPUT);
+  const [priority, setPriority] = useState<Priority>("normal");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [promotingId, setPromotingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const readyFields = countReadyExpressRoomFields(form);
+  const canCreate = readyFields === EXPRESSROOM_REQUIRED_FIELDS.length && Boolean(token);
+  const generatedBrief = makeMarkdownBrief(form);
+
+  const fetchDrafts = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=expressroom_list_drafts", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ limit: 100 }),
+      });
+      const body = (await res.json().catch(() => ({}))) as DraftListResponse;
+      if (!res.ok) throw new Error(body.error ?? "Failed to load ExpressRoom");
+      setDrafts(body.drafts ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load ExpressRoom");
+    } finally {
+      setLoading(false);
+    }
+  }, [authHeader, token]);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      void fetchDrafts();
+    }, 0);
+    return () => window.clearTimeout(handle);
+  }, [fetchDrafts]);
+
+  async function createDraft() {
+    if (!canCreate) return;
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=expressroom_create_draft", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          brief_markdown: generatedBrief,
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as DraftCreateResponse;
+      if (!res.ok) throw new Error(body.error ?? "Failed to create Manual draft");
+      setForm(DEFAULT_EXPRESSROOM_DRAFT_INPUT);
+      setNotice("Manual ExpressRoom draft saved.");
+      await fetchDrafts();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create Manual draft");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function promoteDraft(draft: ExpressRoomDraft) {
+    if (!token) return;
+    setPromotingId(draft.id);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=expressroom_promote_to_todo", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ draft_id: draft.id, priority }),
+      });
+      const body = (await res.json().catch(() => ({}))) as DraftPromoteResponse;
+      if (!res.ok) throw new Error(body.error ?? "Failed to insert into Jobs");
+      const todoId = body.todo?.id ?? body.draft?.official_todo_id;
+      setNotice(todoId ? `Inserted into official Jobs Board: ${todoId}` : "Draft already has an official job mirror.");
+      await fetchDrafts();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to insert into Jobs");
+    } finally {
+      setPromotingId(null);
+    }
+  }
+
+  function updateForm<Key extends keyof ExpressRoomDraftInput>(key: Key, value: ExpressRoomDraftInput[Key]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-xl border border-[#61C1C4]/20 bg-[#0f1717] p-5">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <ManualPill>Manual ExpressBuild</ManualPill>
+              <span className="rounded-full border border-white/[0.08] px-2.5 py-1 text-xs text-white/45">
+                ExpressRoom
+              </span>
+            </div>
+            <h1 className="text-2xl font-semibold tracking-tight text-white">ExpressBuild</h1>
+            <p className="mt-2 text-sm leading-6 text-white/60">
+              ExpressRoom stores Manual draft builds from outside chat seats. It is disconnected
+              from the usual assembly line until you insert a draft into the official Jobs Board.
+            </p>
+          </div>
+          <div className="grid gap-2 text-sm sm:grid-cols-3 lg:min-w-[420px]">
+            <div className="rounded-lg border border-white/[0.06] bg-black/20 p-3">
+              <p className="text-xs uppercase tracking-wide text-white/35">Room</p>
+              <p className="mt-1 font-semibold text-white">Drafts only</p>
+            </div>
+            <div className="rounded-lg border border-white/[0.06] bg-black/20 p-3">
+              <p className="text-xs uppercase tracking-wide text-white/35">Insert path</p>
+              <p className="mt-1 font-semibold text-white">Jobs Board</p>
+            </div>
+            <div className="rounded-lg border border-white/[0.06] bg-black/20 p-3">
+              <p className="text-xs uppercase tracking-wide text-white/35">Done claims</p>
+              <p className="mt-1 font-semibold text-white">Not here</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[1fr_0.85fr]">
+        <div className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <div className="mb-4 flex items-center gap-2">
+            <NotebookTabs className="h-4 w-4 text-[#61C1C4]" />
+            <h2 className="text-sm font-semibold text-white">Builder induction</h2>
+          </div>
+          <p className="text-sm leading-6 text-white/60">{EXPRESSROOM_INDUCTION_TEXT}</p>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            {EXPRESSROOM_REQUIRED_FIELDS.map((field) => (
+              <div key={field} className="rounded-lg border border-white/[0.06] bg-black/20 p-3">
+                <p className="text-xs uppercase tracking-wide text-white/35">Required</p>
+                <p className="mt-1 text-sm font-semibold text-white">{field}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+          <div className="mb-4 flex items-center gap-2">
+            <Rocket className="h-4 w-4 text-[#E2B93B]" />
+            <h2 className="text-sm font-semibold text-white">Clean insertion path</h2>
+          </div>
+          <ol className="list-decimal space-y-2 pl-5 text-sm leading-6 text-white/60">
+            <li>Capture the Manual brief and supplied code in ExpressRoom.</li>
+            <li>Mirror or create the official job name so both places make sense.</li>
+            <li>Insert into the Jobs Board when the draft needs real UnClick integration.</li>
+            <li>Use normal repo fit, tests, PR, review, and proof before any DONE claim.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-red-400/20 bg-red-500/[0.04] p-5">
+        <div className="mb-4 flex items-center gap-2">
+          <FileCode2 className="h-4 w-4 text-red-200" />
+          <h2 className="text-sm font-semibold text-red-100">Manual draft alarm bells</h2>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {EXPRESSROOM_GUARDRAILS.map((guardrail) => (
+            <div key={guardrail} className="rounded-lg border border-red-300/15 bg-black/20 p-3 text-sm leading-6 text-red-100/75">
+              {guardrail}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Add Manual ExpressRoom job</h2>
+            <p className="mt-1 text-sm text-white/50">
+              Use this when a chat seat or you want to dump the intake, draft code, and mirror name directly.
+            </p>
+          </div>
+          <ManualPill>{readyFields}/{EXPRESSROOM_REQUIRED_FIELDS.length} ready</ManualPill>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <label className="space-y-2">
+            <FieldLabel>Job name mirror</FieldLabel>
+            <input
+              value={form.job_name_mirror}
+              onChange={(event) => updateForm("job_name_mirror", event.target.value)}
+              maxLength={200}
+              placeholder="Same name as the official job, or the intended official name"
+              className="w-full rounded-lg border border-white/[0.08] bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-[#61C1C4]/50"
+            />
+          </label>
+          <label className="space-y-2">
+            <FieldLabel>Official job id mirror</FieldLabel>
+            <input
+              value={form.official_todo_id ?? ""}
+              onChange={(event) => updateForm("official_todo_id", event.target.value || null)}
+              placeholder="Optional existing Jobs Board id"
+              className="w-full rounded-lg border border-white/[0.08] bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-[#61C1C4]/50"
+            />
+          </label>
+          <label className="space-y-2 lg:col-span-2">
+            <FieldLabel>Short description</FieldLabel>
+            <input
+              value={form.short_description}
+              onChange={(event) => updateForm("short_description", event.target.value)}
+              maxLength={1000}
+              placeholder="Quick read of what this Manual draft is trying to build"
+              className="w-full rounded-lg border border-white/[0.08] bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-[#61C1C4]/50"
+            />
+          </label>
+          <label className="space-y-2">
+            <FieldLabel>Detailed intake brief</FieldLabel>
+            <textarea
+              value={form.brief_markdown}
+              onChange={(event) => updateForm("brief_markdown", event.target.value)}
+              rows={10}
+              placeholder="Paste the full chat intake here. This becomes the Brief MD."
+              className="w-full resize-y rounded-lg border border-white/[0.08] bg-black/25 px-3 py-2 font-mono text-xs text-white outline-none focus:border-[#61C1C4]/50"
+            />
+          </label>
+          <label className="space-y-2">
+            <FieldLabel>Supplied code</FieldLabel>
+            <textarea
+              value={form.supplied_code ?? ""}
+              onChange={(event) => updateForm("supplied_code", event.target.value)}
+              rows={10}
+              placeholder="Paste draft code, patch notes, file contents, or say what was not supplied."
+              className="w-full resize-y rounded-lg border border-white/[0.08] bg-black/25 px-3 py-2 font-mono text-xs text-white outline-none focus:border-[#61C1C4]/50"
+            />
+          </label>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <label className="space-y-2">
+              <FieldLabel>Code state</FieldLabel>
+              <select
+                value={form.supplied_code_status ?? "not_supplied"}
+                onChange={(event) => updateForm("supplied_code_status", event.target.value as ExpressRoomCodeStatus)}
+                className="w-full rounded-lg border border-white/[0.08] bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-[#61C1C4]/50"
+              >
+                {Object.entries(EXPRESSROOM_CODE_STATUS_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-2">
+              <FieldLabel>Jobs priority when inserted</FieldLabel>
+              <select
+                value={priority}
+                onChange={(event) => setPriority(event.target.value as Priority)}
+                className="w-full rounded-lg border border-white/[0.08] bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-[#61C1C4]/50"
+              >
+                <option value="low">low</option>
+                <option value="normal">normal</option>
+                <option value="high">high</option>
+                <option value="urgent">urgent</option>
+              </select>
+            </label>
+          </div>
+          <div className="rounded-lg border border-white/[0.06] bg-black/20 p-3">
+            <div className="mb-2 flex items-center gap-2">
+              <FileText className="h-4 w-4 text-[#61C1C4]" />
+              <FieldLabel>Brief MD preview</FieldLabel>
+            </div>
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-md bg-black/30 p-3 text-xs leading-5 text-white/60">
+              {generatedBrief}
+            </pre>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={createDraft}
+            disabled={!canCreate || saving}
+            className="inline-flex items-center gap-2 rounded-lg border border-[#61C1C4]/35 bg-[#61C1C4]/15 px-4 py-2 text-sm font-semibold text-[#61C1C4] hover:bg-[#61C1C4]/25 disabled:opacity-40"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            Save Manual draft
+          </button>
+          <button
+            type="button"
+            onClick={() => setForm(DEFAULT_EXPRESSROOM_DRAFT_INPUT)}
+            className="rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-white/55 hover:bg-white/[0.04]"
+          >
+            Clear
+          </button>
+          {error && <p className="text-sm text-red-300">{error}</p>}
+          {notice && <p className="text-sm text-green-300">{notice}</p>}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-white">ExpressRoom table</h2>
+            <p className="mt-1 text-sm text-white/50">
+              Manual drafts live here until they are inserted into official Jobs.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void fetchDrafts()}
+            className="inline-flex items-center gap-2 rounded-lg border border-white/[0.08] px-3 py-2 text-sm text-white/60 hover:bg-white/[0.04]"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+            Refresh
+          </button>
+        </div>
+
+        {drafts.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-white/[0.12] p-8 text-center">
+            <FileCode2 className="mx-auto h-8 w-8 text-white/35" />
+            <p className="mt-3 text-sm font-semibold text-white">No Manual ExpressRoom drafts yet</p>
+            <p className="mt-1 text-sm text-white/45">
+              Add the first brief and supplied code above, or let a connected chat seat create one directly.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-[980px] w-full border-separate border-spacing-y-2 text-left text-sm">
+              <thead>
+                <tr className="text-xs uppercase tracking-wide text-white/35">
+                  <th className="px-3 py-2">Job name mirror</th>
+                  <th className="px-3 py-2">Short description</th>
+                  <th className="px-3 py-2">Brief MD</th>
+                  <th className="px-3 py-2">Supplied code</th>
+                  <th className="px-3 py-2">Official job</th>
+                  <th className="px-3 py-2">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {drafts.map((draft) => {
+                  const description = buildExpressRoomOfficialJobDescription(draft);
+                  return (
+                    <tr key={draft.id} className="align-top">
+                      <td className="rounded-l-lg border-y border-l border-white/[0.06] bg-black/20 px-3 py-3">
+                        <p className="font-semibold text-white">{draft.job_name_mirror}</p>
+                        <p className="mt-1 text-xs text-white/35">{formatDate(draft.updated_at)}</p>
+                        <p className="mt-2 text-xs text-[#E2B93B]">
+                          {EXPRESSROOM_DRAFT_STATUS_LABELS[draft.express_status]}
+                        </p>
+                      </td>
+                      <td className="border-y border-white/[0.06] bg-black/20 px-3 py-3 text-white/60">
+                        {clip(draft.short_description, 220)}
+                      </td>
+                      <td className="border-y border-white/[0.06] bg-black/20 px-3 py-3">
+                        <pre className="max-h-28 max-w-[260px] overflow-auto whitespace-pre-wrap text-xs leading-5 text-white/50">
+                          {clip(draft.brief_markdown, 420)}
+                        </pre>
+                      </td>
+                      <td className="border-y border-white/[0.06] bg-black/20 px-3 py-3">
+                        <div className="mb-2 inline-flex rounded-full border border-white/[0.08] px-2 py-1 text-xs text-white/45">
+                          {EXPRESSROOM_CODE_STATUS_LABELS[draft.supplied_code_status]}
+                        </div>
+                        <pre className="max-h-28 max-w-[260px] overflow-auto whitespace-pre-wrap text-xs leading-5 text-white/50">
+                          {draft.supplied_code.trim() ? clip(draft.supplied_code, 420) : "No code supplied."}
+                        </pre>
+                      </td>
+                      <td className="border-y border-white/[0.06] bg-black/20 px-3 py-3">
+                        {draft.official_todo_id ? (
+                          <Link
+                            to={`/admin/jobs#todo-${draft.official_todo_id}`}
+                            className="inline-flex items-center gap-1 text-[#61C1C4] hover:text-[#8be4e6]"
+                          >
+                            Jobs mirror <ArrowUpRight className="h-3 w-3" />
+                          </Link>
+                        ) : (
+                          <span className="text-white/35">Not inserted</span>
+                        )}
+                      </td>
+                      <td className="rounded-r-lg border-y border-r border-white/[0.06] bg-black/20 px-3 py-3">
+                        <button
+                          type="button"
+                          onClick={() => void promoteDraft(draft)}
+                          disabled={Boolean(draft.official_todo_id) || promotingId === draft.id}
+                          title={description}
+                          className="inline-flex items-center gap-2 rounded-lg border border-[#E2B93B]/35 bg-[#E2B93B]/10 px-3 py-2 text-xs font-semibold text-[#E2B93B] hover:bg-[#E2B93B]/20 disabled:opacity-40"
+                        >
+                          {promotingId === draft.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Rocket className="h-3.5 w-3.5" />}
+                          Insert to Jobs
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -57,6 +57,7 @@ import {
   LockKeyhole,
   Tags,
   FileStack,
+  FileCode2,
   SlidersHorizontal,
 } from "lucide-react";
 
@@ -116,6 +117,7 @@ function SeatsCascadeIcon(props: SVGProps<SVGSVGElement>) {
 }
 
 const AUTOPILOT_LINKS = [
+  { path: "/admin/autopilot/expressbuild", label: "ExpressBuild", icon: FileCode2 },
   { path: "/admin/boardroom", label: "Boardroom", icon: MessagesSquare },
   { path: "/admin/jobs", label: "Jobs", icon: ListTodo },
   { path: "/admin/checks", label: "XPass", icon: ClipboardCheck },

--- a/src/pages/admin/expressroom.test.ts
+++ b/src/pages/admin/expressroom.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXPRESSROOM_INDUCTION_TEXT,
+  EXPRESSROOM_GUARDRAILS,
+  buildExpressRoomOfficialJobDescription,
+  countReadyExpressRoomFields,
+  type ExpressRoomDraft,
+} from "./expressroom";
+
+describe("ExpressRoom model", () => {
+  it("keeps the Manual draft lane clearly separated from official done work", () => {
+    expect(EXPRESSROOM_INDUCTION_TEXT).toContain("Manual ExpressBuild");
+    expect(EXPRESSROOM_INDUCTION_TEXT).toContain("draft-only");
+    expect(EXPRESSROOM_INDUCTION_TEXT).toContain("official Jobs Board");
+    expect(EXPRESSROOM_INDUCTION_TEXT).toContain("Do not claim DONE from ExpressRoom");
+    expect(EXPRESSROOM_GUARDRAILS.join(" ")).toContain("untrusted");
+  });
+
+  it("counts the required fields for a direct chat capture", () => {
+    expect(
+      countReadyExpressRoomFields({
+        job_name_mirror: "Proof Ledger v2",
+        short_description: "Build the evidence model.",
+        brief_markdown: "Chris asked for structured proof.",
+        supplied_code: "",
+        supplied_code_status: "not_supplied",
+      }),
+    ).toBe(4);
+  });
+
+  it("builds a Jobs Board insertion brief from a Manual draft", () => {
+    const draft: ExpressRoomDraft = {
+      id: "11111111-1111-4111-8111-111111111111",
+      job_name_mirror: "HarnessKit worker packet",
+      official_todo_id: null,
+      short_description: "Manual draft for worker induction.",
+      brief_markdown: "# Intake\nChris wants a faster builder path.",
+      supplied_code: "export const draft = true;",
+      supplied_code_status: "partial",
+      express_status: "draft",
+      created_by_agent_id: "chat-seat",
+      source_chat_session_id: "session-1",
+      created_at: "2026-05-20T00:00:00Z",
+      updated_at: "2026-05-20T00:00:00Z",
+    };
+
+    const description = buildExpressRoomOfficialJobDescription(draft);
+
+    expect(description).toContain("Manual ExpressBuild import from ExpressRoom.");
+    expect(description).toContain("This is a Manual draft, not finished work.");
+    expect(description).toContain("export const draft = true;");
+    expect(description).toContain("normal UnClick review and proof gates");
+    expect(description).toContain("Alarm bells");
+    expect(description).toContain("Do not mark this official job done from the draft alone");
+  });
+});

--- a/src/pages/admin/expressroom.ts
+++ b/src/pages/admin/expressroom.ts
@@ -1,0 +1,123 @@
+export type ExpressRoomDraftStatus = "draft" | "inserted" | "archived";
+export type ExpressRoomCodeStatus = "not_supplied" | "partial" | "complete" | "unknown";
+
+export interface ExpressRoomDraft {
+  id: string;
+  job_name_mirror: string;
+  official_todo_id: string | null;
+  short_description: string;
+  brief_markdown: string;
+  supplied_code: string;
+  supplied_code_status: ExpressRoomCodeStatus;
+  express_status: ExpressRoomDraftStatus;
+  created_by_agent_id: string;
+  source_chat_session_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ExpressRoomDraftInput {
+  job_name_mirror: string;
+  official_todo_id?: string | null;
+  short_description: string;
+  brief_markdown: string;
+  supplied_code?: string;
+  supplied_code_status?: ExpressRoomCodeStatus;
+  source_chat_session_id?: string | null;
+}
+
+export const EXPRESSROOM_INDUCTION_TEXT = [
+  "ExpressRoom is the Manual ExpressBuild room.",
+  "It is for fast draft builds from chat seats, not official completion.",
+  "Store the detailed brief, the job name mirror, the short description, and any supplied code here.",
+  "Treat every item as draft-only until it is inserted into the official Jobs Board and checked through the normal UnClick line.",
+  "Do not claim DONE from ExpressRoom. Use it to move fast, then hand the draft to the proper integration, test, review, and proof path.",
+  "Alarm bell: supplied code is untrusted draft material until a normal UnClick worker fits it, tests it, reviews it, and records proof.",
+].join(" ");
+
+export const EXPRESSROOM_GUARDRAILS = [
+  "Manual draft only. Never treat ExpressRoom as source-of-truth completion.",
+  "Supplied code is untrusted until integrated through repo tests and review.",
+  "Inserted Jobs Board cards must say Manual ExpressBuild import and must not be marked done from draft code alone.",
+  "Official completion still requires PR, commit, test, deploy, screenshot, or explicit no-code proof.",
+  "If the mirror job name is unclear, stop and ask for a smaller official job before promotion.",
+] as const;
+
+export const EXPRESSROOM_REQUIRED_FIELDS = [
+  "Brief MD",
+  "Job name mirror",
+  "Short description",
+  "Supplied code field and code state",
+] as const;
+
+export const EXPRESSROOM_CODE_STATUS_LABELS: Record<ExpressRoomCodeStatus, string> = {
+  not_supplied: "Not supplied",
+  partial: "Partial",
+  complete: "Complete",
+  unknown: "Unknown",
+};
+
+export const EXPRESSROOM_DRAFT_STATUS_LABELS: Record<ExpressRoomDraftStatus, string> = {
+  draft: "Manual draft",
+  inserted: "Inserted into Jobs",
+  archived: "Archived",
+};
+
+export const DEFAULT_EXPRESSROOM_DRAFT_INPUT: ExpressRoomDraftInput = {
+  job_name_mirror: "",
+  official_todo_id: null,
+  short_description: "",
+  brief_markdown: "",
+  supplied_code: "",
+  supplied_code_status: "not_supplied",
+  source_chat_session_id: null,
+};
+
+export function isExpressRoomCodeStatus(value: string): value is ExpressRoomCodeStatus {
+  return ["not_supplied", "partial", "complete", "unknown"].includes(value);
+}
+
+export function isExpressRoomDraftStatus(value: string): value is ExpressRoomDraftStatus {
+  return ["draft", "inserted", "archived"].includes(value);
+}
+
+export function countReadyExpressRoomFields(input: ExpressRoomDraftInput): number {
+  const checks = [
+    input.brief_markdown.trim().length > 0,
+    input.job_name_mirror.trim().length > 0,
+    input.short_description.trim().length > 0,
+    Boolean(input.supplied_code?.trim()) || input.supplied_code_status === "not_supplied",
+  ];
+  return checks.filter(Boolean).length;
+}
+
+export function buildExpressRoomOfficialJobDescription(draft: ExpressRoomDraft): string {
+  const codePreview = draft.supplied_code.trim()
+    ? draft.supplied_code.trim().slice(0, 1600)
+    : "No code supplied yet.";
+
+  return [
+    "Manual ExpressBuild import from ExpressRoom.",
+    "",
+    `ExpressRoom draft: ${draft.id}`,
+    `Draft status: ${EXPRESSROOM_DRAFT_STATUS_LABELS[draft.express_status]}`,
+    `Supplied code status: ${EXPRESSROOM_CODE_STATUS_LABELS[draft.supplied_code_status]}`,
+    "",
+    "Short description:",
+    draft.short_description.trim(),
+    "",
+    "Detailed brief MD:",
+    draft.brief_markdown.trim(),
+    "",
+    "Supplied code preview:",
+    codePreview,
+    "",
+    "Insertion rule:",
+    "This is a Manual draft, not finished work. Fit it into the repo, run checks, create PR or commit proof, then use the normal UnClick review and proof gates before any DONE claim.",
+    "",
+    "Alarm bells:",
+    "- Manual ExpressRoom code is untrusted until fitted into the repo.",
+    "- Do not mark this official job done from the draft alone.",
+    "- Require normal tests, PR or commit proof, review, and product proof where relevant.",
+  ].join("\n");
+}

--- a/supabase/migrations/20260520050000_expressroom_manual_builds.sql
+++ b/supabase/migrations/20260520050000_expressroom_manual_builds.sql
@@ -1,0 +1,44 @@
+-- ExpressRoom Manual ExpressBuild drafts.
+--
+-- This is a draft-only lane. Rows here are not official Jobs Board work until
+-- they are promoted into mc_fishbowl_todos by the admin API.
+
+CREATE TABLE IF NOT EXISTS mc_expressroom_drafts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  job_name_mirror text NOT NULL,
+  official_todo_id uuid,
+  short_description text NOT NULL,
+  brief_markdown text NOT NULL,
+  supplied_code text NOT NULL DEFAULT '',
+  supplied_code_status text NOT NULL DEFAULT 'not_supplied'
+    CHECK (supplied_code_status IN ('not_supplied', 'partial', 'complete', 'unknown')),
+  express_status text NOT NULL DEFAULT 'draft'
+    CHECK (express_status IN ('draft', 'inserted', 'archived')),
+  created_by_agent_id text NOT NULL,
+  source_chat_session_id text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_expressroom_drafts_tenant_status
+  ON mc_expressroom_drafts(api_key_hash, express_status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_expressroom_drafts_official_todo
+  ON mc_expressroom_drafts(api_key_hash, official_todo_id)
+  WHERE official_todo_id IS NOT NULL;
+
+ALTER TABLE mc_expressroom_drafts ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'mc_expressroom_drafts'
+      AND policyname = 'mc_expressroom_drafts_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_expressroom_drafts_service_role_all"
+      ON mc_expressroom_drafts FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Adds ExpressRoom under AutoPilot as a Manual ExpressBuild draft room.
- Stores detailed brief MD, job name mirror, short description, supplied code, code state, and official job mirror.
- Adds direct connected-agent tools to create/list/promote ExpressRoom drafts.
- Promoting a draft creates an official Jobs Board card with alarm-bell wording and proof requirements.
- If a draft mirrors an existing official job, the official job receives a visible Manual draft warning comment.

## Guardrails
- ExpressRoom is draft-only and disconnected from official completion.
- Supplied code is treated as untrusted until normal repo fit, tests, PR/commit proof, review, and product proof.
- Official DONE cannot come from an ExpressRoom draft alone.

## Proof
- `npx vitest run src/pages/admin/expressroom.test.ts src/pages/admin/AdminExpressBuild.test.tsx src/pages/admin/AdminShell.test.tsx`
- `npx tsc --noEmit --pretty false`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted draft workflow (DB table + admin API + MCP tools) that can create/attach Jobs Board todos, so bugs could affect job creation/linking or tenant scoping despite guardrails and validation.
> 
> **Overview**
> Introduces **ExpressRoom** as a *Manual ExpressBuild draft* lane: admins (and connected agents) can create, list, update, and promote draft records containing brief markdown, job-name mirror, short description, and supplied code/code-state.
> 
> Promotion inserts a new Jobs Board todo (or reuses an existing mirrored one) with explicit alarm-bell wording, records ledger/events, and optionally posts a warning comment to the official todo. The admin UI adds a new `AutoPilot → ExpressBuild` page/route/nav entry with tests, and Supabase adds `mc_expressroom_drafts` with RLS/indexes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1624b9f544ea68b7bd3cfb0e7a7e5f6384215bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->