### PR TITLE
[codex] Expose ExpressRoom draft tools to agents

### DIFF
--- a/api/lib/expressroom-draft-search.test.ts
+++ b/api/lib/expressroom-draft-search.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  findExpressRoomDraftsByMirror,
+  type ExpressRoomDraftQuery,
+  type ExpressRoomDraftQueryResult,
+  type ExpressRoomDraftRow,
+} from "./expressroom-draft-search.js";
+
+class FakeExpressRoomDraftQuery implements ExpressRoomDraftQuery {
+  constructor(
+    private readonly rows: ExpressRoomDraftRow[],
+    private readonly filters: Array<(row: ExpressRoomDraftRow) => boolean> = [],
+  ) {}
+
+  eq(column: string, value: string): ExpressRoomDraftQuery {
+    return new FakeExpressRoomDraftQuery(this.rows, [
+      ...this.filters,
+      (row) => String(row[column] ?? "") === value,
+    ]);
+  }
+
+  ilike(column: string, pattern: string): ExpressRoomDraftQuery {
+    const needle = pattern
+      .replace(/^%/, "")
+      .replace(/%$/, "")
+      .replace(/\\([%_\\])/g, "$1")
+      .toLowerCase();
+    return new FakeExpressRoomDraftQuery(this.rows, [
+      ...this.filters,
+      (row) => String(row[column] ?? "").toLowerCase().includes(needle),
+    ]);
+  }
+
+  order(): ExpressRoomDraftQuery {
+    return this;
+  }
+
+  async limit(count: number): Promise<ExpressRoomDraftQueryResult> {
+    return {
+      data: this.rows.filter((row) => this.filters.every((filter) => filter(row))).slice(0, count),
+      error: null,
+    };
+  }
+}
+
+describe("findExpressRoomDraftsByMirror", () => {
+  it("returns an older mirror match when unfiltered newest rows exceed the public limit", async () => {
+    const rows: ExpressRoomDraftRow[] = [
+      {
+        id: "newest-non-match",
+        job_name_mirror: "Another job",
+        brief_markdown: "No matching PR here.",
+        updated_at: "2026-05-20T10:00:00Z",
+      },
+      {
+        id: "older-match",
+        job_name_mirror: "DraftRoom PR #970 follow-up",
+        brief_markdown: "Relevant manual draft.",
+        updated_at: "2026-05-19T10:00:00Z",
+      },
+    ];
+
+    const drafts = await findExpressRoomDraftsByMirror({
+      createQuery: () => new FakeExpressRoomDraftQuery(rows),
+      expressStatus: null,
+      officialJobMirror: "PR #970",
+      officialTodoId: null,
+      limit: 1,
+    });
+
+    expect(drafts.map((draft) => draft.id)).toEqual(["older-match"]);
+  });
+
+  it("keeps status and official todo filters on mirror searches", async () => {
+    const todoId = "11111111-1111-4111-8111-111111111111";
+    const rows: ExpressRoomDraftRow[] = [
+      {
+        id: "wrong-status",
+        express_status: "inserted",
+        official_todo_id: todoId,
+        job_name_mirror: "HarnessKit PR #971",
+        updated_at: "2026-05-20T10:00:00Z",
+      },
+      {
+        id: "wrong-todo",
+        express_status: "draft",
+        official_todo_id: "22222222-2222-4222-8222-222222222222",
+        job_name_mirror: "HarnessKit PR #971",
+        updated_at: "2026-05-20T09:00:00Z",
+      },
+      {
+        id: "matching-draft",
+        express_status: "draft",
+        official_todo_id: todoId,
+        job_name_mirror: "HarnessKit PR #971",
+        updated_at: "2026-05-20T08:00:00Z",
+      },
+    ];
+
+    const drafts = await findExpressRoomDraftsByMirror({
+      createQuery: () => new FakeExpressRoomDraftQuery(rows),
+      expressStatus: "draft",
+      officialJobMirror: "PR #971",
+      officialTodoId: todoId,
+      limit: 10,
+    });
+
+    expect(drafts.map((draft) => draft.id)).toEqual(["matching-draft"]);
+  });
+});

--- a/api/lib/expressroom-draft-search.ts
+++ b/api/lib/expressroom-draft-search.ts
@@ -1,0 +1,99 @@
+export type ExpressRoomDraftRow = Record<string, unknown>;
+
+export type ExpressRoomDraftQueryResult = {
+  data: ExpressRoomDraftRow[] | null;
+  error: unknown;
+};
+
+export type ExpressRoomDraftQuery = {
+  eq(column: string, value: string): ExpressRoomDraftQuery;
+  ilike(column: string, pattern: string): ExpressRoomDraftQuery;
+  order(column: string, options: { ascending: boolean }): ExpressRoomDraftQuery;
+  limit(count: number): PromiseLike<ExpressRoomDraftQueryResult>;
+};
+
+export const EXPRESSROOM_MIRROR_SEARCH_COLUMNS = [
+  "job_name_mirror",
+  "short_description",
+  "brief_markdown",
+  "source_chat_session_id",
+] as const;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function escapeExpressRoomIlikePattern(value: string): string {
+  return value.replace(/[%_\\]/g, (char) => `\\${char}`);
+}
+
+function updatedAtTime(draft: ExpressRoomDraftRow): number {
+  const parsed = Date.parse(String(draft.updated_at ?? ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function mergeExpressRoomDraftRows(
+  draftGroups: Array<ExpressRoomDraftRow[] | null | undefined>,
+  limit: number,
+): ExpressRoomDraftRow[] {
+  const draftsById = new Map<string, ExpressRoomDraftRow>();
+
+  for (const group of draftGroups) {
+    for (const draft of group ?? []) {
+      const id = String(draft.id ?? "");
+      if (!id || draftsById.has(id)) continue;
+      draftsById.set(id, draft);
+    }
+  }
+
+  return Array.from(draftsById.values())
+    .sort((left, right) => updatedAtTime(right) - updatedAtTime(left))
+    .slice(0, limit);
+}
+
+export async function findExpressRoomDraftsByMirror(params: {
+  createQuery: () => ExpressRoomDraftQuery;
+  expressStatus: string | null;
+  officialJobMirror: string;
+  officialTodoId: string | null;
+  limit: number;
+}): Promise<ExpressRoomDraftRow[]> {
+  const mirrorNeedle = params.officialJobMirror.trim();
+  if (!mirrorNeedle) return [];
+
+  const mirrorPattern = `%${escapeExpressRoomIlikePattern(mirrorNeedle)}%`;
+
+  const applyCommonFilters = (query: ExpressRoomDraftQuery): ExpressRoomDraftQuery => {
+    let filtered = query;
+    if (params.expressStatus) {
+      filtered = filtered.eq("express_status", params.expressStatus);
+    }
+    if (params.officialTodoId) {
+      filtered = filtered.eq("official_todo_id", params.officialTodoId);
+    }
+    return filtered;
+  };
+
+  const queries = EXPRESSROOM_MIRROR_SEARCH_COLUMNS.map((column) =>
+    applyCommonFilters(params.createQuery())
+      .ilike(column, mirrorPattern)
+      .order("updated_at", { ascending: false })
+      .limit(params.limit),
+  );
+
+  if (!params.officialTodoId && UUID_RE.test(mirrorNeedle)) {
+    queries.push(
+      applyCommonFilters(params.createQuery())
+        .eq("official_todo_id", mirrorNeedle)
+        .order("updated_at", { ascending: false })
+        .limit(params.limit),
+    );
+  }
+
+  const results = await Promise.all(queries);
+  const failedResult = results.find((result) => result.error);
+  if (failedResult?.error) throw failedResult.error;
+
+  return mergeExpressRoomDraftRows(
+    results.map((result) => result.data),
+    params.limit,
+  );
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7564,6 +7564,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         if (action === "expressroom_list_drafts") {
           const statusRaw = typeof body.express_status === "string" ? body.express_status : "";
+          const officialTodoId = optionalUuid("official_todo_id");
+          if (officialTodoId && typeof officialTodoId === "object") return res.status(400).json(officialTodoId);
+          const officialJobMirror = textField("official_job_mirror", 500, false);
+          if (typeof officialJobMirror !== "string") return res.status(400).json(officialJobMirror);
           let query = supabase
             .from("mc_expressroom_drafts")
             .select("*")
@@ -7575,9 +7579,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             if (typeof status !== "string") return res.status(400).json(status);
             query = query.eq("express_status", status);
           }
+          if (officialTodoId) {
+            query = query.eq("official_todo_id", officialTodoId);
+          }
           const { data, error } = await query;
           if (error) throw error;
-          return res.status(200).json({ drafts: data ?? [] });
+          const mirrorNeedle = officialJobMirror.toLowerCase();
+          const drafts = mirrorNeedle
+            ? (data ?? []).filter((draft: Record<string, unknown>) =>
+                [
+                  draft.official_todo_id,
+                  draft.job_name_mirror,
+                  draft.short_description,
+                  draft.brief_markdown,
+                  draft.source_chat_session_id,
+                ].some((value) => String(value ?? "").toLowerCase().includes(mirrorNeedle)),
+              )
+            : (data ?? []);
+          return res.status(200).json({ drafts });
         }
 
         if (action === "expressroom_create_draft") {

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -140,6 +140,10 @@ import {
   planFishbowlIdeaCouncilHandoffs,
 } from "./lib/fishbowl-idea-council.js";
 import {
+  findExpressRoomDraftsByMirror,
+  type ExpressRoomDraftQuery,
+} from "./lib/expressroom-draft-search.js";
+import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
@@ -7568,35 +7572,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           if (officialTodoId && typeof officialTodoId === "object") return res.status(400).json(officialTodoId);
           const officialJobMirror = textField("official_job_mirror", 500, false);
           if (typeof officialJobMirror !== "string") return res.status(400).json(officialJobMirror);
-          let query = supabase
+          const publicLimit = Math.max(1, Math.min(Number(body.limit ?? 100), 200));
+          const expressStatus = statusRaw ? validExpressStatus(statusRaw) : null;
+          if (expressStatus && typeof expressStatus !== "string") return res.status(400).json(expressStatus);
+          const createDraftQuery = (): ExpressRoomDraftQuery => supabase
             .from("mc_expressroom_drafts")
             .select("*")
             .eq("api_key_hash", apiKeyHash)
-            .order("updated_at", { ascending: false })
-            .limit(Math.max(1, Math.min(Number(body.limit ?? 100), 200)));
-          if (statusRaw) {
-            const status = validExpressStatus(statusRaw);
-            if (typeof status !== "string") return res.status(400).json(status);
-            query = query.eq("express_status", status);
+            as unknown as ExpressRoomDraftQuery;
+          if (officialJobMirror.trim()) {
+            const drafts = await findExpressRoomDraftsByMirror({
+              createQuery: createDraftQuery,
+              expressStatus,
+              officialJobMirror,
+              officialTodoId,
+              limit: publicLimit,
+            });
+            return res.status(200).json({ drafts });
           }
+          let query = createDraftQuery()
+            .order("updated_at", { ascending: false });
+          if (expressStatus) query = query.eq("express_status", expressStatus);
           if (officialTodoId) {
             query = query.eq("official_todo_id", officialTodoId);
           }
-          const { data, error } = await query;
+          const { data, error } = await query.limit(publicLimit);
           if (error) throw error;
-          const mirrorNeedle = officialJobMirror.toLowerCase();
-          const drafts = mirrorNeedle
-            ? (data ?? []).filter((draft: Record<string, unknown>) =>
-                [
-                  draft.official_todo_id,
-                  draft.job_name_mirror,
-                  draft.short_description,
-                  draft.brief_markdown,
-                  draft.source_chat_session_id,
-                ].some((value) => String(value ?? "").toLowerCase().includes(mirrorNeedle)),
-              )
-            : (data ?? []);
-          return res.status(200).json({ drafts });
+          return res.status(200).json({ drafts: data ?? [] });
         }
 
         if (action === "expressroom_create_draft") {

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -7575,11 +7575,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           const publicLimit = Math.max(1, Math.min(Number(body.limit ?? 100), 200));
           const expressStatus = statusRaw ? validExpressStatus(statusRaw) : null;
           if (expressStatus && typeof expressStatus !== "string") return res.status(400).json(expressStatus);
-          const createDraftQuery = (): ExpressRoomDraftQuery => supabase
-            .from("mc_expressroom_drafts")
-            .select("*")
-            .eq("api_key_hash", apiKeyHash)
-            as unknown as ExpressRoomDraftQuery;
+          const createDraftQuery = (): ExpressRoomDraftQuery => (
+            supabase
+              .from("mc_expressroom_drafts")
+              .select("*")
+              .eq("api_key_hash", apiKeyHash) as unknown as ExpressRoomDraftQuery
+          );
           if (officialJobMirror.trim()) {
             const drafts = await findExpressRoomDraftsByMirror({
               createQuery: createDraftQuery,

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { ENDPOINT_MAP } from "../catalog.js";
-import { validateToolArgumentsForRuntime } from "../server.js";
+import {
+  ADVERTISED_TOOLS,
+  EXPRESSROOM_VISIBLE_TOOL_NAMES,
+  validateToolArgumentsForRuntime,
+} from "../server.js";
 
 describe("runtime tool schema validation", () => {
   const probes: Array<{ name: string; args: Record<string, unknown> }> = [
@@ -22,6 +26,7 @@ describe("runtime tool schema validation", () => {
     { name: "read_orchestrator_context", args: { q: "strict schema probe", bogus_field: "should reject" } },
     { name: "heartbeat_protocol", args: { bogus_field: "should reject" } },
     { name: "commonsensepass_protocol", args: { bogus_field: "should reject" } },
+    { name: "list_expressroom_drafts", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
     {
       name: "ack_handoff",
       args: {
@@ -89,6 +94,13 @@ describe("runtime tool schema validation", () => {
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("heartbeat_protocol", {})).toBeNull();
     expect(validateToolArgumentsForRuntime("commonsensepass_protocol", {})).toBeNull();
+    expect(validateToolArgumentsForRuntime("list_expressroom_drafts", {
+      agent_id: "strict-probe",
+      official_todo_id: "11111111-1111-4111-8111-111111111111",
+      official_job_mirror: "PR #970",
+      express_status: "draft",
+      limit: 10,
+    })).toBeNull();
     expect(validateToolArgumentsForRuntime("ack_handoff", {
       agent_id: "strict-probe",
       thread_id: "11111111-1111-4111-8111-111111111111",
@@ -127,5 +139,13 @@ describe("runtime tool schema validation", () => {
         max_sources_per_snapshot: { type: "number", minimum: 1, maximum: 12, default: 8 },
       },
     });
+  });
+
+  it("advertises ExpressRoom Manual draft bridge tools to connected agents", () => {
+    const advertisedNames = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
+
+    for (const toolName of EXPRESSROOM_VISIBLE_TOOL_NAMES) {
+      expect(advertisedNames.has(toolName), toolName).toBe(true);
+    }
   });
 });

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -846,13 +846,19 @@ export const VISIBLE_TOOLS = [
     name: "list_expressroom_drafts",
     title: "List ExpressRoom Manual drafts",
     description:
-      "Lists Manual ExpressBuild drafts stored in ExpressRoom. These are draft-only records until promoted into official Jobs.",
+      "Lists Manual ExpressBuild drafts stored in ExpressRoom. These are draft-only records until promoted into official Jobs. " +
+      "Use official_todo_id or official_job_mirror to find drafts linked to a Jobs Board card, PR number, PR URL, or mirrored job name.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
         agent_id: { type: "string", description: "Stable identifier for the calling agent." },
         express_status: { type: "string", enum: ["draft", "inserted", "archived"], description: "Optional status filter." },
+        official_todo_id: { type: "string", description: "Optional exact Jobs Board todo UUID mirror." },
+        official_job_mirror: {
+          type: "string",
+          description: "Optional fuzzy mirror search text, such as job name, PR number, PR URL, or todo id.",
+        },
         limit: { type: "number", minimum: 1, maximum: 200, default: 100 },
       },
       required: ["agent_id"],
@@ -1536,6 +1542,24 @@ for (const tool of [...INTERNAL_TOOLS, ...VISIBLE_TOOLS, ...DIRECT_TOOLS, ...ADD
   registerToolInputSchema(tool);
 }
 
+export const EXPRESSROOM_VISIBLE_TOOL_NAMES = [
+  "create_expressroom_draft",
+  "list_expressroom_drafts",
+  "promote_expressroom_draft",
+] as const;
+
+// ExpressRoom needs friendly connected-agent tools, while the rest of the
+// internal meta layer stays hidden from tools/list.
+const EXPRESSROOM_VISIBLE_TOOLS = INTERNAL_TOOLS.filter((tool) =>
+  (EXPRESSROOM_VISIBLE_TOOL_NAMES as readonly string[]).includes(tool.name),
+);
+
+export const ADVERTISED_TOOLS = [
+  ...VISIBLE_TOOLS,
+  ...EXPRESSROOM_VISIBLE_TOOLS,
+  ...ADDITIONAL_TOOLS,
+];
+
 // Backwards-compatible memory tool names still dispatch directly, so they need
 // the same runtime guard as the newer visible names.
 for (const [alias, canonical] of Object.entries(MEMORY_TOOL_ALIASES)) {
@@ -1693,15 +1717,14 @@ export function createServer(): Server {
     }
   );
 
-  // LIST TOOLS: advertise the core memory tools PLUS every product + marketplace
-  // tool registered in ADDITIONAL_TOOLS (TestPass, Crews, and all third-party
-  // integrations from tool-wiring.ts). Internal meta tools (unclick_search,
-  // unclick_browse, unclick_tool_info, unclick_call) and the small DIRECT_TOOLS
-  // utility set remain callable for backwards compatibility but stay hidden
-  // from tools/list to avoid duplicating what native chat clients already
-  // discover.
+  // LIST TOOLS: advertise the core memory tools, the friendly ExpressRoom
+  // bridge tools, plus every product + marketplace tool registered in
+  // ADDITIONAL_TOOLS (TestPass, Crews, and third-party integrations from
+  // tool-wiring.ts). Internal meta tools (unclick_search, unclick_browse,
+  // unclick_tool_info, unclick_call) and the small DIRECT_TOOLS utility set
+  // remain callable for backwards compatibility but stay hidden from tools/list.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: [...VISIBLE_TOOLS, ...ADDITIONAL_TOOLS] };
+    return { tools: ADVERTISED_TOOLS };
   });
 
   // CALL TOOL


### PR DESCRIPTION
## What changed

- Advertises the three friendly ExpressRoom Manual draft tools to connected agents:
  - create_expressroom_draft
  - list_expressroom_drafts
  - promote_expressroom_draft
- Keeps the rest of the internal meta tools hidden from tools/list.
- Adds list filters so agents can find drafts by official todo id or a fuzzy official job mirror such as job name, PR number, PR URL, or mirrored job text.
- Adds a focused regression test that proves the three ExpressRoom bridge tools are advertised.

## Why

ExpressRoom was live, but connected agents could not reliably discover the friendly draft tools. That kept the lane stuck as a manual workaround. This patch makes the bridge visible while keeping the guardrails intact.

## Guardrails

ExpressRoom remains Manual draft input only. It is not proof, not DONE, and not an AutoPilot bypass. Supplied code still needs normal fitting, tests, review, and proof before official job completion.

## Validation

- npm run build --workspace=@unclick/mcp-server
- npx vitest run src/__tests__/tool-schema-validation.test.ts from packages/mcp-server
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP tool discovery (tools/list) and draft listing query behavior, which could affect connected agent capabilities and returned data ordering/filters. New fuzzy search runs multiple queries and merges results, so edge cases around limits/deduping and Supabase query typing are the main risk.
> 
> **Overview**
> **Exposes the ExpressRoom Manual draft bridge to connected agents** by advertising `create_expressroom_draft`, `list_expressroom_drafts`, and `promote_expressroom_draft` in MCP `tools/list` (while keeping other internal meta tools hidden).
> 
> **Extends `list_expressroom_drafts`** to accept `official_todo_id` and a fuzzy `official_job_mirror` search; mirror searches now query across several columns (and UUID-shaped mirrors can also match `official_todo_id`), then dedupe + sort by `updated_at` before applying the public limit.
> 
> Adds tests covering the new mirror-search behavior/filters and asserting the ExpressRoom tools are included in the advertised tool set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08338ebbc9c778d068f8b30b1ed616b32d4bf8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->