### PR TITLE
Keep heartbeat master replies compact

### DIFF
--- a/.claude/agents/heartbeat.md
+++ b/.claude/agents/heartbeat.md
@@ -87,6 +87,10 @@ Call `post_message` only for one of these:
 
 Keep posts short. Prefer one post per real event.
 
+## Chat Output Budget
+
+Keep the user-facing thread tiny. Store exact proof in Boardroom comments, PR comments, session summaries, and conversation receipts. A heartbeat reply should be one short line: `PASS`, `BLOCKER`, or `HOLD` plus the plain reason and one proof pointer. Do not paste receipt lists, Orchestrator timestamps, check rollups, or full PR metadata into chat unless Chris asks.
+
 ## Confidence Tags
 
 Every material post should include exactly one intent tag in plain text or Fishbowl tags:

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -90,6 +90,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 - Launchpad is the control hub for Autopilot work.
 - Rooms are the operational stages that route work through research, planning, build, proof, review, safety, merge, publish, repair, and improvement.
 - Heartbeat Master at `/admin/agents/heartbeat` teaches scheduled AI seats how to pulse safely.
+- Heartbeat policy changes must update the `/admin/agents/heartbeat` source and verify the MASTER induction text. Memory and Brainmap entries are pointers, not the runtime MASTER.
 - Ecosystem Brainmap at `/admin/brainmap` teaches seats what the system is and what each surface means.
 
 ## Pages and Meaning

--- a/scripts/UnClick-brainmap.mjs
+++ b/scripts/UnClick-brainmap.mjs
@@ -243,6 +243,7 @@ export async function generateBrainmap({ root = process.cwd() } = {}) {
     "- Launchpad is the control hub for Autopilot work.",
     "- Rooms are the operational stages that route work through research, planning, build, proof, review, safety, merge, publish, repair, and improvement.",
     "- Heartbeat Master at `/admin/agents/heartbeat` teaches scheduled AI seats how to pulse safely.",
+    "- Heartbeat policy changes must update the `/admin/agents/heartbeat` source and verify the MASTER induction text. Memory and Brainmap entries are pointers, not the runtime MASTER.",
     "- Ecosystem Brainmap at `/admin/brainmap` teaches seats what the system is and what each surface means.",
     "",
     "## Pages and Meaning",

--- a/scripts/UnClick-brainmap.test.mjs
+++ b/scripts/UnClick-brainmap.test.mjs
@@ -40,6 +40,7 @@ describe("UnClick ecosystem Brainmap", () => {
     assert.match(generated, /\| Coordinator \| Routes work/);
     assert.match(generated, /Admin-only surfaces use `RequireAdmin`/);
     assert.match(generated, /IgniteOnly can request worker wake packets only/);
+    assert.match(generated, /Memory and Brainmap entries are pointers, not the runtime MASTER/);
   });
 
   it("records generated Brainmap guardrails for CI", async () => {

--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -33,6 +33,8 @@ describe("AdminSeatHeartbeatPage", () => {
     expect(HEARTBEAT_MASTER_PROMPT).toContain("NudgeOnly is not the executor");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("do not stop there");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("JobSmith is a separate CV and cover-letter tool");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("Chat output budget");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("Keep the thread tiny");
   });
 
   it("updates the schedule message when cadence changes", () => {

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -43,6 +43,9 @@ NudgeOnly is not the executor. If nudgeonly_receipt_bridge returns receipt_reque
 Proof:
 Do not claim DONE, healthy, no_work, merge_ready, or PASS without current proof. Code work needs PR, commit, test, or explicit NO_CODE_NEEDED proof. UI work needs screenshot proof. Final receipts must say what moved, proof id/link/test/screenshot, and the next step.
 
+Chat output budget:
+Keep the thread tiny. Save exact proof in Boardroom comments, PR comments, session summaries, and conversation receipts. In the heartbeat reply, use one short line only: PASS, BLOCKER, or HOLD plus the plain reason and one proof pointer. Do not paste receipt lists, Orchestrator timestamps, check rollups, or full PR metadata into chat unless Chris asks.
+
 Safety:
 Protected surfaces are secrets, billing, DNS, production deploy, destructive data actions, force push, hard reset, and overriding another worker. Stop for a human decision when those appear.
 


### PR DESCRIPTION
Updates the Heartbeat MASTER induction so routine heartbeat replies stay short and exact proof moves into Boardroom, PR comments, session summaries, and conversation receipts.

Changes:
- Adds a Chat output budget section to the admin Heartbeat MASTER prompt.
- Adds assertions so the MASTER prompt keeps the compact-output rule.
- Mirrors the compact-output rule into the Claude heartbeat agent instructions.
- Clarifies in BrainMap that memory and BrainMap are pointers, while /admin/agents/heartbeat is the runtime MASTER source.

Verification:
- node --test scripts/UnClick-brainmap.test.mjs
- npm run brainmap:check
- Fetched branch source and confirmed HEARTBEAT_MASTER_PROMPT contains Chat output budget and Keep the thread tiny.

Not run locally:
- Full Vitest suite, because this checkout does not have node_modules installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to prompt/policy text and accompanying tests/generated docs, with no runtime business logic changes beyond displayed admin copy.
> 
> **Overview**
> **Heartbeat policy now enforces compact replies.** Adds a new *Chat output budget* section to the Heartbeat MASTER induction and the Claude `heartbeat` agent template, directing seats to respond with a single `PASS`/`BLOCKER`/`HOLD` line and store detailed proof elsewhere.
> 
> **Guardrails updated to keep policy in sync.** Updates Brainmap generation/output to note that Memory/Brainmap are pointers (not the runtime MASTER), and extends tests (`AdminSeatHeartbeat.test.tsx`, `UnClick-brainmap.test.mjs`) to assert the new policy text is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d736cceeae34a12450633759db9ab576ca76fe0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->