### PR TITLE
Update heartbeat MASTER for live chat capture

### DIFF
--- a/.claude/agents/heartbeat.md
+++ b/.claude/agents/heartbeat.md
@@ -73,6 +73,20 @@ tag: act
 Then set your status to the same chip and a short next check-in. If the status
 tool is unavailable, make the first line of the material post the status line.
 
+## Active Chat Build Capture
+
+When Chris is already in a live Chat/subscription LLM seat and the build context
+is fresh, prefer getting that active seat to code or fit the change immediately.
+Capture the build into repo code, a draft PR, or a scoped handoff quickly. Do not
+leave fresh build context for later heartbeat recovery if the active seat can
+safely act now.
+
+## SeatRelay Priority
+
+Treat SeatRelay as high priority when choosing between safe queue slices because
+stale worker issues are recurring. Favor fixes that reduce stale owners, stale
+HOLD loops, unclear reassignment, and weak handoff.
+
 ## Material Post Rules
 
 Call `post_message` only for one of these:

--- a/src/pages/admin/AdminSeatHeartbeat.test.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.test.tsx
@@ -33,6 +33,9 @@ describe("AdminSeatHeartbeatPage", () => {
     expect(HEARTBEAT_MASTER_PROMPT).toContain("NudgeOnly is not the executor");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("do not stop there");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("JobSmith is a separate CV and cover-letter tool");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("live Chat/subscription LLM seat");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("active seat can safely act now");
+    expect(HEARTBEAT_MASTER_PROMPT).toContain("SeatRelay as high priority");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("Chat output budget");
     expect(HEARTBEAT_MASTER_PROMPT).toContain("Keep the thread tiny");
   });

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -40,6 +40,12 @@ Pick one bounded step only. Allowed step types include build, patch, test, proof
 Nudge handoff:
 NudgeOnly is not the executor. If nudgeonly_receipt_bridge returns receipt_request or escalation_request, do not stop there. Continue through IgniteOnly for a verified wake packet, PushOnly for the worker envelope, then let the Action Heartbeat or builder tether do one safe runnable step, or post BLOCKER with the exact missing executor gate.
 
+Active chat build capture:
+When Chris is already in a live Chat/subscription LLM seat and the build context is fresh, prefer getting that active seat to code or fit the change immediately. Capture the build into repo code, a draft PR, or a scoped handoff quickly. Do not leave fresh build context for later heartbeat recovery if the active seat can safely act now.
+
+SeatRelay priority:
+Treat SeatRelay as high priority when choosing between safe queue slices because stale worker issues are recurring. Favor fixes that reduce stale owners, stale HOLD loops, unclear reassignment, and weak handoff.
+
 Proof:
 Do not claim DONE, healthy, no_work, merge_ready, or PASS without current proof. Code work needs PR, commit, test, or explicit NO_CODE_NEEDED proof. UI work needs screenshot proof. Final receipts must say what moved, proof id/link/test/screenshot, and the next step.
 


### PR DESCRIPTION
## Summary
- Add active Chat/subscription LLM build-capture guidance to the heartbeat MASTER induction.
- Add SeatRelay priority guidance for recurring stale-worker issues.
- Mirror the policy in the canonical heartbeat agent template.

## Tests
- npm test -- --run src/pages/admin/AdminSeatHeartbeat.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to prompt/policy text and corresponding UI test assertions, with no functional runtime logic changes.
> 
> **Overview**
> Updates the heartbeat MASTER induction and the canonical `.claude/agents/heartbeat.md` template to **push immediate capture of fresh live Chat/subscription build context** (into code/PR/handoff) and to **prioritize SeatRelay work** to reduce recurring stale-worker issues.
> 
> Adjusts `AdminSeatHeartbeat` page tests to assert the new policy text is present in `HEARTBEAT_MASTER_PROMPT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 168220ebf4f59d4439bfae91f5388bdaea11768c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->