### PR TITLE
fix(seatrelay): protect manual jobs from stale reclaim

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -465,6 +465,61 @@ describe("worker self-healing decision plan", () => {
     });
   });
 
+  it("does not reclaim protected manual or human-owned todo leases", () => {
+    const manualDecision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-manual-only",
+        title: "Manual only customer decision",
+        status: "in_progress",
+        assigned_to_agent_id: "worker-1",
+        lease_token: "lease-old",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-manual",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(manualDecision).toMatchObject({
+      action: "no_action",
+      todo_id: "todo-manual-only",
+      assigned_to_agent_id: "worker-1",
+      lease_token: "lease-old",
+      reclaim_count: 2,
+      next_reclaim_count: 2,
+      latest_handoff_receipt_id: "handoff-latest-manual",
+      reason: "protected_manual_or_human_owned",
+    });
+    expect(buildWorkerSelfHealingSignal(manualDecision)).toBeNull();
+
+    const humanDecision = planWorkerSelfHealingDecision({
+      todo: {
+        id: "todo-human-owned",
+        status: "in_progress",
+        assigned_to_agent_id: "human-123",
+        lease_token: "lease-old",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 1,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-human",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(humanDecision).toMatchObject({
+      action: "no_action",
+      todo_id: "todo-human-owned",
+      assigned_to_agent_id: "human-123",
+      lease_token: "lease-old",
+      reclaim_count: 1,
+      next_reclaim_count: 1,
+      latest_handoff_receipt_id: "handoff-latest-human",
+      reason: "protected_manual_or_human_owned",
+    });
+    expect(buildWorkerSelfHealingSignal(humanDecision)).toBeNull();
+  });
+
   it("flags a stale worker for action when no active todo lease exists", () => {
     const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
 

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -107,6 +107,7 @@ export interface WakepassReroutePlan {
 export interface WorkerSelfHealingTodoState {
   id: string;
   status: string;
+  title?: string | null;
   assigned_to_agent_id?: string | null;
   lease_token?: string | null;
   lease_expires_at?: string | null;
@@ -297,6 +298,15 @@ export function planWorkerSelfHealingDecision(params: {
     reclaim_count: reclaimCount,
     latest_handoff_receipt_id: latestHandoffReceiptId,
   };
+
+  if (isProtectedWorkerSelfHealingTodo(todo, assignedToAgentId)) {
+    return {
+      ...base,
+      action: "no_action",
+      next_reclaim_count: reclaimCount,
+      reason: "protected_manual_or_human_owned",
+    };
+  }
 
   if (leaseToken && leaseExpiresAt) {
     const staleDecision = decideStaleLease(
@@ -624,6 +634,31 @@ function nonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
+}
+
+const PROTECTED_WORKER_SELF_HEALING_MARKERS = [
+  "human_blocker",
+  "manual_only",
+  "blocked_chris_only",
+  "chris_only",
+  "human decision",
+  "manual only",
+];
+
+function isProtectedWorkerSelfHealingTodo(
+  todo: WorkerSelfHealingTodoState,
+  assignedToAgentId: string | null,
+) {
+  if (assignedToAgentId?.startsWith("human-")) return true;
+
+  const searchable = [todo.status, todo.title, assignedToAgentId]
+    .map((value) => nonEmptyString(value)?.toLowerCase())
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+
+  return PROTECTED_WORKER_SELF_HEALING_MARKERS.some((marker) =>
+    searchable.includes(marker),
+  );
 }
 
 function workerMovementBlockedReason(title: unknown): string | null {
@@ -1312,7 +1347,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // 3. Worker self-healing todo lease signal sweep.
   const { data: staleTodoLeaseRows, error: staleTodoLeaseErr } = await supabase
     .from("mc_fishbowl_todos")
-    .select("id, api_key_hash, status, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count")
+    .select("id, api_key_hash, title, status, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count")
     .in("status", ["open", "in_progress"])
     .not("lease_expires_at", "is", null)
     .lt("lease_expires_at", nowIso)


### PR DESCRIPTION
## Summary
- Adds a SeatRelay guard so expired worker leases on protected manual or human-owned jobs do not become reclaimable.
- Carries todo `title` into the watcher sweep so `manual_only`, `human_blocker`, `blocked_chris_only`, `chris_only`, `human decision`, and `manual only` cards can be recognized before any reclaim signal is emitted.
- Adds focused tests proving protected manual and `human-*` owned cards return `no_action` and emit no worker self-healing reclaim signal.

## Scope
- Lane: SeatRelay / Boardroom todo `4f0c0ef4-c0dd-4b7b-9e5a-f007575b7585`.
- Owned files: `api/fishbowl-watcher.ts`, `api/fishbowl-watcher.test.ts`.

## Non-overlap
- Does not implement broad auto-reassignment, learned thresholds, UI changes, JobSmith, DraftRoom, HarnessKit, merge/deploy automation, or DONE closeout.
- Does not touch secrets, billing, DNS, production data, force-push flows, or live todo data.

## Verification
- `npm run test -- api/fishbowl-watcher.test.ts` passed: 1 file, 31 tests.
- `git diff --check` passed with LF-to-CRLF warnings only.

## Risk
- Low runtime risk: the change narrows reclaim eligibility for protected work and leaves existing token redaction behavior intact.
- No schema migration or production mutation.

## Follow-up
- Next SeatRelay slice should add verified release/reassign mutation and bonded handoff proof after this safety gate is reviewed.