### PR TITLE
SeatRelay v1: protect human/manual jobs from stale reclaim

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -910,6 +910,61 @@ describe("Vercel worker movement workflow pilot plan", () => {
     expect(JSON.stringify(plan)).not.toContain("lease-secret");
   });
 
+  it("posts refusal proof for pure human-owned protected work", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "ordinary stale lease",
+      todo: {
+        id: "todo-human-owned-only",
+        status: "in_progress",
+        assigned_to_agent_id: "human-chris",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 1,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-human-owned",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+    const proof = planWorkerMovementWorkflowPilotProofSignal({
+      apiKeyHash: "hash_123",
+      plan,
+      emittedAt: "2026-05-01T01:22:00.000Z",
+    });
+
+    expect(plan).toMatchObject({
+      mode: "dry_run",
+      action: "post_refusal_proof",
+      candidate_id: "todo-human-owned-only",
+      safety: {
+        allowed: false,
+        reason: "human_owned_work_protected",
+      },
+      signal: null,
+      decision: {
+        action: "no_action",
+        has_lease_token: true,
+        reason: "human_owned_work_protected",
+      },
+      proof: {
+        next_safe_step:
+          "post refusal proof and leave the job with its owner (human_owned_work_protected)",
+        payload: {
+          action: "post_refusal_proof",
+          planned_signal_action: null,
+        },
+      },
+    });
+    expect(proof?.signal).toMatchObject({
+      action: "worker_movement_workflow_pilot_blocker",
+      severity: "action_needed",
+      payload: {
+        proof_status: "BLOCKER",
+        safety_reason: "human_owned_work_protected",
+      },
+    });
+    expect(JSON.stringify({ plan, proof })).not.toContain("lease-secret");
+  });
+
   it("skips workflow start when existing planner finds no movement needed", () => {
     const plan = planWorkerMovementWorkflowPilot({
       title: "Worker self-healing: heartbeat timeout, reclaim, and resume-safe queue behavior",

--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -465,6 +465,65 @@ describe("worker self-healing decision plan", () => {
     });
   });
 
+  it("protects human and manual-only work from stale lease reclaim", () => {
+    const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
+    const protectedCases = [
+      {
+        todo: {
+          id: "todo-human-owned",
+          status: "in_progress",
+          assigned_to_agent_id: "human-chris",
+          lease_token: "lease-old",
+          lease_expires_at: "2026-05-01T01:10:00.000Z",
+          reclaim_count: 2,
+        },
+        reason: "human_owned_work_protected",
+      },
+      {
+        todo: {
+          id: "todo-manual-only",
+          title: "manual_only operator handoff",
+          status: "in_progress",
+          assigned_to_agent_id: "worker-1",
+          lease_token: "lease-old",
+          lease_expires_at: "2026-05-01T01:10:00.000Z",
+          reclaim_count: 1,
+        },
+        reason: "manual_only_protected",
+      },
+      {
+        todo: {
+          id: "todo-human-blocker",
+          description: "human blocker: needs operator merge approval",
+          status: "in_progress",
+          assigned_to_agent_id: "worker-1",
+          lease_token: "lease-old",
+          lease_expires_at: "2026-05-01T01:10:00.000Z",
+          reclaim_count: 0,
+        },
+        reason: "human_blocker_protected",
+      },
+    ];
+
+    for (const testCase of protectedCases) {
+      const decision = planWorkerSelfHealingDecision({
+        todo: testCase.todo,
+        profile: null,
+        latestHandoffReceiptId: "handoff-protected",
+        nowMs,
+      });
+
+      expect(decision).toMatchObject({
+        action: "no_action",
+        todo_id: testCase.todo.id,
+        next_reclaim_count: testCase.todo.reclaim_count,
+        latest_handoff_receipt_id: "handoff-protected",
+        reason: testCase.reason,
+      });
+      expect(buildWorkerSelfHealingSignal(decision)).toBeNull();
+    }
+  });
+
   it("flags a stale worker for action when no active todo lease exists", () => {
     const nowMs = Date.parse("2026-05-01T01:22:00.000Z");
 
@@ -802,6 +861,49 @@ describe("Vercel worker movement workflow pilot plan", () => {
         payload: {
           action: "post_refusal_proof",
           planned_signal_action: "worker_self_healing_reclaimable_lease",
+        },
+      },
+    });
+    expect(JSON.stringify(plan)).not.toContain("lease-secret");
+  });
+
+  it("posts refusal proof instead of starting workflow for protected human/manual work", () => {
+    const plan = planWorkerMovementWorkflowPilot({
+      title: "SeatRelay manual-only operator blocker",
+      todo: {
+        id: "todo-manual-only",
+        title: "manual_only operator handoff",
+        status: "in_progress",
+        assigned_to_agent_id: "human-chris",
+        lease_token: "lease-secret",
+        lease_expires_at: "2026-05-01T01:10:00.000Z",
+        reclaim_count: 2,
+      },
+      profile: null,
+      latestHandoffReceiptId: "handoff-latest-protected",
+      nowMs: Date.parse("2026-05-01T01:22:00.000Z"),
+    });
+
+    expect(plan).toMatchObject({
+      mode: "dry_run",
+      action: "post_refusal_proof",
+      candidate_id: "todo-manual-only",
+      safety: {
+        allowed: false,
+        reason: "manual_only_protected",
+      },
+      signal: null,
+      decision: {
+        action: "no_action",
+        has_lease_token: true,
+        reason: "human_owned_work_protected",
+      },
+      proof: {
+        next_safe_step:
+          "post refusal proof and leave the job with its owner (manual_only_protected)",
+        payload: {
+          action: "post_refusal_proof",
+          planned_signal_action: null,
         },
       },
     });

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -106,7 +106,11 @@ export interface WakepassReroutePlan {
 
 export interface WorkerSelfHealingTodoState {
   id: string;
+  title?: string | null;
+  description?: string | null;
   status: string;
+  priority?: string | null;
+  created_by_agent_id?: string | null;
   assigned_to_agent_id?: string | null;
   lease_token?: string | null;
   lease_expires_at?: string | null;
@@ -297,6 +301,15 @@ export function planWorkerSelfHealingDecision(params: {
     reclaim_count: reclaimCount,
     latest_handoff_receipt_id: latestHandoffReceiptId,
   };
+  const protectedReason = workerSelfHealingProtectedReason(todo);
+  if (protectedReason) {
+    return {
+      ...base,
+      action: "no_action",
+      next_reclaim_count: reclaimCount,
+      reason: protectedReason,
+    };
+  }
 
   if (leaseToken && leaseExpiresAt) {
     const staleDecision = decideStaleLease(
@@ -463,7 +476,13 @@ export function planWorkerMovementWorkflowPilot(params: {
   });
   const decision = sanitizeWorkerMovementDecision(rawDecision);
   const plannedSignal = buildWorkerSelfHealingSignal(rawDecision);
-  const blockedReason = workerMovementBlockedReason(params.title);
+  const blockedReason = workerMovementBlockedReason([
+    params.title,
+    params.todo.title,
+    params.todo.description,
+    params.todo.priority,
+    rawDecision.reason,
+  ].join("\n"));
   const hasActionableSignal = plannedSignal?.severity === "action_needed";
   const action: WorkerMovementWorkflowPilotAction = blockedReason
     ? "post_refusal_proof"
@@ -626,9 +645,32 @@ function nonEmptyString(value: unknown): string | null {
   return trimmed ? trimmed : null;
 }
 
+function workerSelfHealingProtectedReason(todo: WorkerSelfHealingTodoState): string | null {
+  const status = normalizeToken(todo.status);
+  if (status === "human_blocker") return "human_blocker_protected";
+  if (status === "manual_only") return "manual_only_protected";
+
+  const owner = nonEmptyString(todo.assigned_to_agent_id) ?? nonEmptyString(todo.created_by_agent_id);
+  if (owner?.startsWith("human-")) return "human_owned_work_protected";
+
+  const text = [
+    todo.title,
+    todo.description,
+    todo.priority,
+  ].map((value) => String(value ?? "").toLowerCase()).join("\n");
+  if (/\bhuman[_ -]?blocker\b/.test(text)) return "human_blocker_protected";
+  if (/\bmanual[_ -]?only\b/.test(text)) return "manual_only_protected";
+  if (/\bhuman[_ -]?owned\b/.test(text)) return "human_owned_work_protected";
+
+  return null;
+}
+
 function workerMovementBlockedReason(title: unknown): string | null {
   const text = String(title ?? "").toLowerCase();
   if (!text) return null;
+  if (/\bhuman[_ -]?blocker\b/.test(text)) return "human_blocker_protected";
+  if (/\bmanual[_ -]?only\b/.test(text)) return "manual_only_protected";
+  if (/\bhuman[_ -]?owned\b/.test(text)) return "human_owned_work_protected";
   if (/\bsecurity\b|owner auth|owner-auth/.test(text)) {
     return "owner_or_security_gated_job";
   }
@@ -1312,7 +1354,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // 3. Worker self-healing todo lease signal sweep.
   const { data: staleTodoLeaseRows, error: staleTodoLeaseErr } = await supabase
     .from("mc_fishbowl_todos")
-    .select("id, api_key_hash, status, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count")
+    .select("id, api_key_hash, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count")
     .in("status", ["open", "in_progress"])
     .not("lease_expires_at", "is", null)
     .lt("lease_expires_at", nowIso)

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -481,8 +481,7 @@ export function planWorkerMovementWorkflowPilot(params: {
     params.todo.title,
     params.todo.description,
     params.todo.priority,
-    rawDecision.reason,
-  ].join("\n"));
+  ].join("\n")) ?? workerMovementProtectedDecisionReason(rawDecision.reason);
   const hasActionableSignal = plannedSignal?.severity === "action_needed";
   const action: WorkerMovementWorkflowPilotAction = blockedReason
     ? "post_refusal_proof"
@@ -662,6 +661,18 @@ function workerSelfHealingProtectedReason(todo: WorkerSelfHealingTodoState): str
   if (/\bmanual[_ -]?only\b/.test(text)) return "manual_only_protected";
   if (/\bhuman[_ -]?owned\b/.test(text)) return "human_owned_work_protected";
 
+  return null;
+}
+
+function workerMovementProtectedDecisionReason(reason: unknown): string | null {
+  const normalized = normalizeToken(reason);
+  if (
+    normalized === "human_blocker_protected" ||
+    normalized === "manual_only_protected" ||
+    normalized === "human_owned_work_protected"
+  ) {
+    return normalized;
+  }
   return null;
 }
 

--- a/api/worker-movement-pilot.test.ts
+++ b/api/worker-movement-pilot.test.ts
@@ -370,6 +370,41 @@ describe("worker movement pilot API dry-run", () => {
     expect(JSON.stringify(inserted[0])).not.toContain("lease-secret");
   });
 
+  it("inserts BLOCKER proof for protected human-owned or manual-only candidates", async () => {
+    const { store, inserted } = buildStore({
+      candidate: expiredLeaseCandidate({
+        id: "todo-human-manual",
+        title: "manual_only operator handoff",
+        assigned_to_agent_id: "human-chris",
+      }),
+    });
+
+    const result = await runWorkerMovementPilotDryRun({ store, nowMs });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "proof_inserted",
+      candidate_id: "todo-human-manual",
+      action: "post_refusal_proof",
+      proof_signal_action: "worker_movement_workflow_pilot_blocker",
+      proof_status: "BLOCKER",
+      next_safe_step:
+        "post refusal proof and leave the job with its owner (manual_only_protected)",
+    });
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      action: "worker_movement_workflow_pilot_blocker",
+      severity: "action_needed",
+      payload: {
+        proof_status: "BLOCKER",
+        candidate_id: "todo-human-manual",
+        decision_action: "no_action",
+        safety_reason: "manual_only_protected",
+      },
+    });
+    expect(JSON.stringify(inserted[0])).not.toContain("lease-secret");
+  });
+
   it("dedupes proof when the same candidate was recently emitted", async () => {
     const { store, inserted } = buildStore({
       candidate: expiredLeaseCandidate(),

--- a/api/worker-movement-pilot.ts
+++ b/api/worker-movement-pilot.ts
@@ -71,7 +71,7 @@ export function createWorkerMovementPilotStore(
     async fetchCandidate(nowIso) {
       const { data, error } = await supabase
         .from("mc_fishbowl_todos")
-        .select("id, api_key_hash, title, status, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count")
+        .select("id, api_key_hash, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count")
         .in("status", ["open", "in_progress"])
         .not("lease_expires_at", "is", null)
         .lt("lease_expires_at", nowIso)


### PR DESCRIPTION
## Summary
- Protect SeatRelay worker self-healing from reclaiming human-owned, human_blocker, or manual_only jobs.
- Carry title/description/priority/creator fields into stale lease scans so protected work can be recognized before any movement plan.
- Emit refusal proof instead of starting movement dry-runs for protected candidates, while still redacting lease tokens.

## Tests
- npm test -- api/fishbowl-watcher.test.ts api/worker-movement-pilot.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts automated stale-lease reclaim and workflow-start decisions; misclassification could cause missed self-healing actions or unnecessary blockers for legitimate worker-owned jobs. Scope is limited and covered by new unit tests, with no credential exposure (lease token redaction preserved).
> 
> **Overview**
> Prevents SeatRelay worker self-healing from reclaiming or acting on **protected** work: jobs that are `human_owned`, `human_blocker`, or `manual_only` now short-circuit to `no_action` and emit no reclaim signal.
> 
> To support earlier detection, stale-lease scans now fetch `title`/`description`/`priority`/`created_by_agent_id`, and the movement-workflow pilot uses both todo metadata and protected decision reasons to **refuse** these candidates by posting BLOCKER refusal proof (still redacting `lease_token`).
> 
> Adds targeted test coverage for protected-case decisions and proof emission in both `fishbowl-watcher` and `worker-movement-pilot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 188a37c4675ffeb38d6adb805ca8349d354159ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->