### PR TITLE
feat(seatrelay): implement SeatRelay v1 - stale claim relay with safety guards

### DIFF
--- a/src/lib/seatRelay.test.ts
+++ b/src/lib/seatRelay.test.ts
@@ -1,0 +1,377 @@
+// src/lib/seatRelay.test.ts
+
+import { describe, test, expect } from "vitest";
+import {
+  evaluateSeatRelay,
+  redactSecrets,
+  __testing__,
+  type RelayableItem,
+  type RelayCandidate,
+} from "./seatRelay";
+import type { SeatSnapshot } from "./workerHealthMonitor";
+
+const { isProtected, isInCooldown, findBestCandidate, PROTECTED_TAGS_DEFAULT } = __testing__;
+
+const NOW = new Date("2026-05-21T04:00:00Z");
+
+function isoMinus(ms: number): string {
+  return new Date(NOW.getTime() - ms).toISOString();
+}
+
+function staleSeat(id: string, todoId: string): SeatSnapshot {
+  return {
+    id,
+    last_seen: isoMinus(6 * 60 * 60 * 1000), // 6h ago - stale
+    open_claims: [{ todo_id: todoId, claimed_at: isoMinus(8 * 60 * 60 * 1000), eta: null, resume_safe: true }],
+  };
+}
+
+function deadSeat(id: string, todoId: string): SeatSnapshot {
+  return {
+    id,
+    last_seen: isoMinus(48 * 60 * 60 * 1000), // 48h ago - dead
+    open_claims: [{ todo_id: todoId, claimed_at: isoMinus(50 * 60 * 60 * 1000), eta: null, resume_safe: true }],
+  };
+}
+
+function healthySeat(id: string): SeatSnapshot {
+  return {
+    id,
+    last_seen: isoMinus(5 * 60 * 1000), // 5 min ago - healthy
+    open_claims: [],
+  };
+}
+
+function makeItem(overrides: Partial<RelayableItem> & { todo_id: string }): RelayableItem {
+  return {
+    title: `Task ${overrides.todo_id}`,
+    assigned_to: null,
+    ...overrides,
+  };
+}
+
+function makeCandidate(overrides: Partial<RelayCandidate> & { seat_id: string }): RelayCandidate {
+  return {
+    active_claims: 0,
+    max_claims: 5,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: isProtected
+// ---------------------------------------------------------------------------
+
+describe("isProtected", () => {
+  test("returns true for human_blocker items", () => {
+    expect(isProtected(makeItem({ todo_id: "T1", human_blocker: true }), PROTECTED_TAGS_DEFAULT)).toBe(true);
+  });
+
+  test("returns true for manual_only items", () => {
+    expect(isProtected(makeItem({ todo_id: "T1", manual_only: true }), PROTECTED_TAGS_DEFAULT)).toBe(true);
+  });
+
+  test("returns true for human-owned items", () => {
+    expect(isProtected(makeItem({ todo_id: "T1", owner_type: "human" }), PROTECTED_TAGS_DEFAULT)).toBe(true);
+  });
+
+  test("returns true for items with protected tags", () => {
+    expect(isProtected(makeItem({ todo_id: "T1", tags: ["security"] }), PROTECTED_TAGS_DEFAULT)).toBe(true);
+    expect(isProtected(makeItem({ todo_id: "T1", tags: ["billing"] }), PROTECTED_TAGS_DEFAULT)).toBe(true);
+    expect(isProtected(makeItem({ todo_id: "T1", tags: ["gated"] }), PROTECTED_TAGS_DEFAULT)).toBe(true);
+  });
+
+  test("returns false for normal agent items", () => {
+    expect(isProtected(makeItem({ todo_id: "T1", owner_type: "agent", tags: ["build"] }), PROTECTED_TAGS_DEFAULT)).toBe(false);
+  });
+
+  test("returns false for untagged items", () => {
+    expect(isProtected(makeItem({ todo_id: "T1" }), PROTECTED_TAGS_DEFAULT)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: isInCooldown
+// ---------------------------------------------------------------------------
+
+describe("isInCooldown", () => {
+  test("returns true when last relay is within cooldown", () => {
+    const item = makeItem({ todo_id: "T1", last_relay_at: isoMinus(30 * 60 * 1000) }); // 30 min ago
+    expect(isInCooldown(item, 60 * 60 * 1000, NOW)).toBe(true);
+  });
+
+  test("returns false when last relay exceeds cooldown", () => {
+    const item = makeItem({ todo_id: "T1", last_relay_at: isoMinus(2 * 60 * 60 * 1000) }); // 2h ago
+    expect(isInCooldown(item, 60 * 60 * 1000, NOW)).toBe(false);
+  });
+
+  test("returns false when no last_relay_at", () => {
+    const item = makeItem({ todo_id: "T1", last_relay_at: null });
+    expect(isInCooldown(item, 60 * 60 * 1000, NOW)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: findBestCandidate
+// ---------------------------------------------------------------------------
+
+describe("findBestCandidate", () => {
+  test("selects candidate with lowest load", () => {
+    const candidates = [
+      makeCandidate({ seat_id: "A", active_claims: 3 }),
+      makeCandidate({ seat_id: "B", active_claims: 1 }),
+      makeCandidate({ seat_id: "C", active_claims: 2 }),
+    ];
+    const result = findBestCandidate(candidates, "T1");
+    expect(result?.seat_id).toBe("B");
+  });
+
+  test("excludes the current owner seat", () => {
+    const candidates = [
+      makeCandidate({ seat_id: "A", active_claims: 0 }),
+      makeCandidate({ seat_id: "B", active_claims: 1 }),
+    ];
+    const result = findBestCandidate(candidates, "T1", "A");
+    expect(result?.seat_id).toBe("B");
+  });
+
+  test("returns null when all candidates are at capacity", () => {
+    const candidates = [
+      makeCandidate({ seat_id: "A", active_claims: 5, max_claims: 5 }),
+      makeCandidate({ seat_id: "B", active_claims: 5, max_claims: 5 }),
+    ];
+    expect(findBestCandidate(candidates, "T1")).toBeNull();
+  });
+
+  test("returns null with empty candidates", () => {
+    expect(findBestCandidate([], "T1")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: redactSecrets
+// ---------------------------------------------------------------------------
+
+describe("redactSecrets", () => {
+  test("redacts Stripe-style keys", () => {
+    const input = "key is sk_test_abcdefghij1234567890";
+    const result = redactSecrets(input);
+    expect(result).toContain("[REDACTED]");
+    expect(result).not.toContain("abcdefghij1234567890");
+  });
+
+  test("redacts GitHub PAT tokens", () => {
+    const input = "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
+    const result = redactSecrets(input);
+    expect(result).toContain("[REDACTED]");
+  });
+
+  test("leaves short strings alone", () => {
+    const input = "seat hello-world is stale";
+    expect(redactSecrets(input)).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: evaluateSeatRelay
+// ---------------------------------------------------------------------------
+
+describe("evaluateSeatRelay", () => {
+  test("releases stale claims that are safe to release", () => {
+    const seats = [staleSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A" })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.released).toHaveLength(1);
+    expect(result.released[0].todo_id).toBe("T1");
+    expect(result.released[0].action).toBe("release");
+    expect(result.released[0].from_seat).toBe("worker-A");
+    expect(result.released[0].proof.release_verified).toBe(true);
+  });
+
+  test("reassigns when candidates are available", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A" })];
+    const candidates = [makeCandidate({ seat_id: "worker-B", active_claims: 0 })];
+
+    const result = evaluateSeatRelay({ seats, items, candidates, now: NOW });
+
+    expect(result.reassigned).toHaveLength(1);
+    expect(result.reassigned[0].to_seat).toBe("worker-B");
+    expect(result.reassigned[0].proof.handoff_bonded).toBe(true);
+    expect(result.reassigned[0].proof.release_verified).toBe(true);
+  });
+
+  test("skips protected items (human_blocker)", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A", human_blocker: true })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe("protected_item");
+  });
+
+  test("skips protected items (manual_only)", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A", manual_only: true })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe("protected_item");
+  });
+
+  test("skips protected items (human owner_type)", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A", owner_type: "human" })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe("protected_item");
+  });
+
+  test("holds when max relay attempts exceeded", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A", relay_attempt_count: 3 })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.held).toHaveLength(1);
+    expect(result.held[0].reason).toBe("max_attempts_exceeded");
+    expect(result.held[0].safe).toBe(false);
+  });
+
+  test("skips items in cooldown", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A", last_relay_at: isoMinus(30 * 60 * 1000) })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe("cooldown_active");
+  });
+
+  test("skips items not flagged for reclaim", () => {
+    const seats = [healthySeat("worker-A")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A" })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe("not_stale");
+  });
+
+  test("holds items that need coordinator review (non-resume-safe stale claims)", () => {
+    const seats: SeatSnapshot[] = [{
+      id: "worker-A",
+      last_seen: isoMinus(6 * 60 * 60 * 1000), // stale
+      open_claims: [{ todo_id: "T1", claimed_at: isoMinus(8 * 60 * 60 * 1000), eta: null, resume_safe: false }],
+    }];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A" })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    expect(result.held).toHaveLength(1);
+    expect(result.held[0].reason).toBe("needs_coordinator_review");
+  });
+
+  test("does not reassign to the same seat that owns it", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A" })];
+    const candidates = [makeCandidate({ seat_id: "worker-A", active_claims: 0 })];
+
+    const result = evaluateSeatRelay({ seats, items, candidates, now: NOW });
+
+    // Should release, not reassign (only candidate is the current owner)
+    expect(result.released).toHaveLength(1);
+    expect(result.reassigned).toHaveLength(0);
+  });
+
+  test("never marks anything false DONE", () => {
+    const seats = [deadSeat("worker-A", "T1"), staleSeat("worker-B", "T2")];
+    const items = [
+      makeItem({ todo_id: "T1", assigned_to: "worker-A" }),
+      makeItem({ todo_id: "T2", assigned_to: "worker-B" }),
+    ];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    for (const decision of result.decisions) {
+      expect(decision.action).not.toBe("done");
+      expect(decision.reason).not.toContain("DONE");
+    }
+  });
+
+  test("proof trail redacts secrets in reasons", () => {
+    const seats: SeatSnapshot[] = [{
+      id: "worker-A",
+      last_seen: isoMinus(48 * 60 * 60 * 1000),
+      open_claims: [{ todo_id: "T1", claimed_at: isoMinus(50 * 60 * 60 * 1000), eta: null, resume_safe: true }],
+    }];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A" })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    for (const entry of result.proof_trail) {
+      expect(entry).not.toMatch(/sk_test_[a-zA-Z0-9]{20}/);
+      expect(entry).not.toMatch(/ghp_[a-zA-Z0-9]{36}/);
+    }
+  });
+
+  test("handles multiple items with mixed states", () => {
+    const seats: SeatSnapshot[] = [
+      deadSeat("worker-dead", "T1"),
+      staleSeat("worker-stale", "T2"),
+      healthySeat("worker-healthy"),
+    ];
+    const items: RelayableItem[] = [
+      makeItem({ todo_id: "T1", assigned_to: "worker-dead" }),
+      makeItem({ todo_id: "T2", assigned_to: "worker-stale" }),
+      makeItem({ todo_id: "T3", assigned_to: "worker-healthy" }),
+      makeItem({ todo_id: "T4", assigned_to: "worker-dead", human_blocker: true }),
+    ];
+    const candidates = [makeCandidate({ seat_id: "worker-healthy", active_claims: 1 })];
+
+    const result = evaluateSeatRelay({ seats, items, candidates, now: NOW });
+
+    // T1: dead seat, safe to release, candidate available -> reassign
+    expect(result.reassigned.find((d) => d.todo_id === "T1")).toBeTruthy();
+    // T2: stale but resume_safe -> release (candidate excludes stale owner)
+    expect(result.released.find((d) => d.todo_id === "T2") || result.reassigned.find((d) => d.todo_id === "T2")).toBeTruthy();
+    // T3: healthy seat -> skip (not stale)
+    expect(result.skipped.find((d) => d.todo_id === "T3")).toBeTruthy();
+    // T4: human_blocker -> skip (protected)
+    expect(result.skipped.find((d) => d.todo_id === "T4")).toBeTruthy();
+  });
+
+  test("caps reassignment attempts with custom max", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A", relay_attempt_count: 1 })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW, options: { maxRelayAttempts: 1 } });
+
+    expect(result.held).toHaveLength(1);
+    expect(result.held[0].reason).toBe("max_attempts_exceeded");
+  });
+
+  test("each decision includes a relay_id proof", () => {
+    const seats = [deadSeat("worker-A", "T1")];
+    const items = [makeItem({ todo_id: "T1", assigned_to: "worker-A" })];
+
+    const result = evaluateSeatRelay({ seats, items, now: NOW });
+
+    for (const decision of result.decisions) {
+      expect(decision.proof.relay_id).toMatch(/^relay_/);
+      expect(decision.proof.timestamp).toBe(NOW.toISOString());
+      expect(decision.proof.trail.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("returns evaluated_at timestamp", () => {
+    const result = evaluateSeatRelay({ seats: [], items: [], now: NOW });
+    expect(result.evaluated_at).toBe(NOW.toISOString());
+  });
+});

--- a/src/lib/seatRelay.ts
+++ b/src/lib/seatRelay.ts
@@ -1,0 +1,395 @@
+// src/lib/seatRelay.ts
+//
+// SeatRelay v1: the smallest safe relay that reduces stale worker issues.
+//
+// Mission:
+// - Release stale claims only when clearly expired
+// - Protect human_blocker/manual_only/human-owned work
+// - Reassign stuck work only after verified release
+// - Require bonded handoff proof
+// - Cap reassignment attempts
+// - Leave visible proof trail
+// - Redact secrets/tokens
+// - No false DONE
+//
+// Integrates with workerHealthMonitor.ts for seat health evaluation.
+
+import {
+  evaluateFleetHealth,
+  safeReleaseTargets,
+  pendingCoordinatorReview,
+  type SeatSnapshot,
+  type FleetHealthReport,
+  type ReclaimRecommendation,
+  type HealthOptions,
+} from "./workerHealthMonitor";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RelayableItem {
+  todo_id: string;
+  title: string;
+  assigned_to?: string | null;
+  /** Tags that protect this item from auto-relay. */
+  tags?: string[];
+  /** If true, only a human can reassign this. */
+  human_blocker?: boolean;
+  /** If true, this item requires manual handling. */
+  manual_only?: boolean;
+  /** Owner type: "human" items are never auto-relayed. */
+  owner_type?: "human" | "agent" | "unassigned";
+  /** Number of times this item has already been reassigned by SeatRelay. */
+  relay_attempt_count?: number;
+  /** ISO timestamp of last relay attempt. */
+  last_relay_at?: string | null;
+}
+
+export interface RelayCandidate {
+  /** Agent/seat id that can accept work. */
+  seat_id: string;
+  /** Current load (number of active claims). */
+  active_claims: number;
+  /** Max claims this seat should hold. */
+  max_claims?: number;
+  /** Lanes this seat can work in. */
+  lanes?: string[];
+}
+
+export interface RelayDecision {
+  todo_id: string;
+  action: "release" | "reassign" | "hold" | "skip";
+  reason: string;
+  from_seat: string | null;
+  to_seat: string | null;
+  proof: RelayProof;
+  safe: boolean;
+}
+
+export interface RelayProof {
+  relay_id: string;
+  timestamp: string;
+  health_status?: string;
+  reclaim_reason?: string;
+  release_verified: boolean;
+  handoff_bonded: boolean;
+  attempt_number: number;
+  max_attempts: number;
+  trail: string[];
+}
+
+export interface RelayResult {
+  evaluated_at: string;
+  decisions: RelayDecision[];
+  released: RelayDecision[];
+  reassigned: RelayDecision[];
+  held: RelayDecision[];
+  skipped: RelayDecision[];
+  proof_trail: string[];
+}
+
+export interface SeatRelayOptions {
+  /** Max times an item can be relayed before requiring human intervention. Default 3. */
+  maxRelayAttempts?: number;
+  /** Tags that protect items from relay. Default includes common human-gating tags. */
+  protectedTags?: string[];
+  /** Minimum cooldown between relay attempts for the same item (ms). Default 1 hour. */
+  relayCooldownMs?: number;
+  /** Health evaluation options passed to workerHealthMonitor. */
+  healthOptions?: HealthOptions;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROTECTED_TAGS_DEFAULT = [
+  "human_blocker",
+  "manual_only",
+  "human_owned",
+  "needs_human",
+  "security",
+  "billing",
+  "secrets",
+  "gated",
+];
+
+const DEFAULT_OPTIONS: Required<SeatRelayOptions> = {
+  maxRelayAttempts: 3,
+  protectedTags: PROTECTED_TAGS_DEFAULT,
+  relayCooldownMs: 60 * 60 * 1000, // 1 hour
+  healthOptions: {},
+};
+
+const SECRET_PATTERNS = [
+  /sk_[a-zA-Z0-9_-]{20,}/g,
+  /pk_[a-zA-Z0-9_-]{20,}/g,
+  /whsec_[a-zA-Z0-9_-]{10,}/g,
+  /re_[a-zA-Z0-9_-]{20,}/g,
+  /ghp_[a-zA-Z0-9]{36,}/g,
+  /ghs_[a-zA-Z0-9]{36,}/g,
+  /xox[boaprs]-[a-zA-Z0-9-]{10,}/g,
+  /eyJ[a-zA-Z0-9_-]{20,}\.[a-zA-Z0-9_-]{20,}/g,
+  /AKIA[A-Z0-9]{16}/g,
+  /[a-zA-Z0-9+/]{40,}={0,2}/g,
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateRelayId(): string {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `relay_${ts}_${rand}`;
+}
+
+export function redactSecrets(text: string): string {
+  let redacted = text;
+  for (const pattern of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, (match) => {
+      if (match.length < 12) return match;
+      return `${match.slice(0, 4)}...[REDACTED]`;
+    });
+  }
+  return redacted;
+}
+
+function isProtected(item: RelayableItem, protectedTags: string[]): boolean {
+  if (item.human_blocker) return true;
+  if (item.manual_only) return true;
+  if (item.owner_type === "human") return true;
+  const tags = item.tags ?? [];
+  return tags.some((tag) => protectedTags.includes(tag.toLowerCase()));
+}
+
+function isInCooldown(item: RelayableItem, cooldownMs: number, now: Date): boolean {
+  if (!item.last_relay_at) return false;
+  const lastRelay = new Date(item.last_relay_at).getTime();
+  if (!Number.isFinite(lastRelay)) return false;
+  return now.getTime() - lastRelay < cooldownMs;
+}
+
+function findBestCandidate(
+  candidates: RelayCandidate[],
+  _todoId: string,
+  excludeSeat?: string | null,
+): RelayCandidate | null {
+  const eligible = candidates.filter((c) => {
+    if (c.seat_id === excludeSeat) return false;
+    const max = c.max_claims ?? 5;
+    return c.active_claims < max;
+  });
+
+  if (eligible.length === 0) return null;
+
+  // Prefer the seat with the lowest active load.
+  eligible.sort((a, b) => a.active_claims - b.active_claims);
+  return eligible[0];
+}
+
+// ---------------------------------------------------------------------------
+// Core: evaluateSeatRelay
+// ---------------------------------------------------------------------------
+
+export function evaluateSeatRelay({
+  seats,
+  items,
+  candidates = [],
+  now = new Date(),
+  options = {},
+}: {
+  seats: ReadonlyArray<SeatSnapshot>;
+  items: ReadonlyArray<RelayableItem>;
+  candidates?: ReadonlyArray<RelayCandidate>;
+  now?: Date;
+  options?: SeatRelayOptions;
+}): RelayResult {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const healthReport = evaluateFleetHealth(seats, now, opts.healthOptions);
+  const safeIds = new Set(safeReleaseTargets(healthReport));
+  const pendingReview = pendingCoordinatorReview(healthReport);
+
+  const reclaimMap = new Map<string, ReclaimRecommendation>();
+  for (const rec of healthReport.reclaim_recommendations) {
+    reclaimMap.set(rec.todo_id, rec);
+  }
+
+  const decisions: RelayDecision[] = [];
+  const proofTrail: string[] = [];
+
+  for (const item of items) {
+    const relayId = generateRelayId();
+    const attemptNumber = (item.relay_attempt_count ?? 0) + 1;
+    const reclaim = reclaimMap.get(item.todo_id);
+
+    const baseProof: RelayProof = {
+      relay_id: relayId,
+      timestamp: now.toISOString(),
+      health_status: reclaim ? reclaim.reason : "not_in_reclaim",
+      reclaim_reason: reclaim?.reason,
+      release_verified: false,
+      handoff_bonded: false,
+      attempt_number: attemptNumber,
+      max_attempts: opts.maxRelayAttempts,
+      trail: [],
+    };
+
+    // Guard 1: Protected items are never auto-relayed.
+    if (isProtected(item, opts.protectedTags)) {
+      const decision: RelayDecision = {
+        todo_id: item.todo_id,
+        action: "skip",
+        reason: "protected_item",
+        from_seat: item.assigned_to ?? null,
+        to_seat: null,
+        proof: { ...baseProof, trail: [`${relayId}: skipped - item is protected (human_blocker/manual_only/protected_tag)`] },
+        safe: true,
+      };
+      decisions.push(decision);
+      proofTrail.push(decision.proof.trail[0]);
+      continue;
+    }
+
+    // Guard 2: Max relay attempts exceeded.
+    if (attemptNumber > opts.maxRelayAttempts) {
+      const decision: RelayDecision = {
+        todo_id: item.todo_id,
+        action: "hold",
+        reason: "max_attempts_exceeded",
+        from_seat: item.assigned_to ?? null,
+        to_seat: null,
+        proof: {
+          ...baseProof,
+          trail: [`${relayId}: held - relay attempt ${attemptNumber} exceeds max ${opts.maxRelayAttempts}; needs human review`],
+        },
+        safe: false,
+      };
+      decisions.push(decision);
+      proofTrail.push(decision.proof.trail[0]);
+      continue;
+    }
+
+    // Guard 3: Cooldown not met.
+    if (isInCooldown(item, opts.relayCooldownMs, now)) {
+      const decision: RelayDecision = {
+        todo_id: item.todo_id,
+        action: "skip",
+        reason: "cooldown_active",
+        from_seat: item.assigned_to ?? null,
+        to_seat: null,
+        proof: { ...baseProof, trail: [`${relayId}: skipped - cooldown period active since ${item.last_relay_at}`] },
+        safe: true,
+      };
+      decisions.push(decision);
+      proofTrail.push(decision.proof.trail[0]);
+      continue;
+    }
+
+    // Guard 4: Not in reclaim set at all.
+    if (!reclaim) {
+      const decision: RelayDecision = {
+        todo_id: item.todo_id,
+        action: "skip",
+        reason: "not_stale",
+        from_seat: item.assigned_to ?? null,
+        to_seat: null,
+        proof: { ...baseProof, trail: [`${relayId}: skipped - item not flagged for reclaim by health monitor`] },
+        safe: true,
+      };
+      decisions.push(decision);
+      proofTrail.push(decision.proof.trail[0]);
+      continue;
+    }
+
+    // Guard 5: Not safe to release and not auto-releasable.
+    if (!safeIds.has(item.todo_id)) {
+      const decision: RelayDecision = {
+        todo_id: item.todo_id,
+        action: "hold",
+        reason: "needs_coordinator_review",
+        from_seat: item.assigned_to ?? null,
+        to_seat: null,
+        proof: {
+          ...baseProof,
+          trail: [`${relayId}: held - reclaim recommended but not safe_to_release; needs coordinator review`],
+        },
+        safe: false,
+      };
+      decisions.push(decision);
+      proofTrail.push(decision.proof.trail[0]);
+      continue;
+    }
+
+    // Safe to release. Attempt relay.
+    const releaseTrail = `${relayId}: releasing stale claim on ${item.todo_id} from seat ${item.assigned_to ?? "unassigned"} (reason: ${reclaim.reason})`;
+    baseProof.release_verified = true;
+    baseProof.trail.push(releaseTrail);
+
+    // Try to find a candidate for reassignment.
+    const candidate = findBestCandidate(
+      candidates as RelayCandidate[],
+      item.todo_id,
+      item.assigned_to,
+    );
+
+    if (candidate) {
+      const handoffTrail = `${relayId}: reassigning ${item.todo_id} to ${candidate.seat_id} (load: ${candidate.active_claims}/${candidate.max_claims ?? 5})`;
+      baseProof.handoff_bonded = true;
+      baseProof.trail.push(handoffTrail);
+
+      const decision: RelayDecision = {
+        todo_id: item.todo_id,
+        action: "reassign",
+        reason: redactSecrets(reclaim.detail),
+        from_seat: item.assigned_to ?? null,
+        to_seat: candidate.seat_id,
+        proof: baseProof,
+        safe: true,
+      };
+      decisions.push(decision);
+      proofTrail.push(releaseTrail, handoffTrail);
+    } else {
+      // Release only (no candidate available).
+      const noCandidate = `${relayId}: released ${item.todo_id} to pool (no eligible candidate found)`;
+      baseProof.trail.push(noCandidate);
+
+      const decision: RelayDecision = {
+        todo_id: item.todo_id,
+        action: "release",
+        reason: redactSecrets(reclaim.detail),
+        from_seat: item.assigned_to ?? null,
+        to_seat: null,
+        proof: baseProof,
+        safe: true,
+      };
+      decisions.push(decision);
+      proofTrail.push(releaseTrail, noCandidate);
+    }
+  }
+
+  return {
+    evaluated_at: now.toISOString(),
+    decisions,
+    released: decisions.filter((d) => d.action === "release"),
+    reassigned: decisions.filter((d) => d.action === "reassign"),
+    held: decisions.filter((d) => d.action === "hold"),
+    skipped: decisions.filter((d) => d.action === "skip"),
+    proof_trail: proofTrail.map(redactSecrets),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports for testing
+// ---------------------------------------------------------------------------
+
+export const __testing__ = {
+  DEFAULT_OPTIONS,
+  PROTECTED_TAGS_DEFAULT,
+  SECRET_PATTERNS,
+  isProtected,
+  isInCooldown,
+  findBestCandidate,
+  generateRelayId,
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Implements SeatRelay v1: the smallest safe relay module that reduces stale worker issues in the fleet.
- Integrates with existing `workerHealthMonitor.ts` for seat health evaluation.
- 32 passing tests covering all safety guards and execution flows.

## Changes
- `src/lib/seatRelay.ts` - Core SeatRelay module
- `src/lib/seatRelay.test.ts` - Comprehensive test suite (32 tests)

## SeatRelay v1 capabilities

| Guard | What it does |
|-------|-------------|
| Protected item skip | Never auto-relays human_blocker, manual_only, human-owned, or tagged (security/billing/gated) items |
| Max attempts cap | Holds items after N relay attempts (default 3) to prevent storms |
| Cooldown enforcement | Skips items relayed too recently (default 1h) |
| Coordinator review hold | Holds non-resume-safe stale claims for human review |
| Safe release verification | Only releases items the health monitor marks safe_to_release |
| Bonded handoff proof | Every reassignment includes a proof record with relay_id, timestamps, and trail |
| Secret redaction | Scrubs API keys, tokens, and credentials from all proof output |
| No false DONE | Never marks items as completed - only releases, reassigns, or holds |

## Owner and lift status
- Owner: 🎯 Cursor (SeatRelay lane, per broadcast priority)
- Non-overlap: New files only, no existing file modifications
- Status: Draft

## Review handoff
- Reviewer or lane: Chris
- Human decision pending: None
- Merge policy: draft

## Deletions

None

## Archaeology

N/A - new feature implementation

## Testing
- `vitest run src/lib/seatRelay.test.ts` - 32 tests PASS
- `vitest run src/lib/workerHealthMonitor.test.ts` - 17 tests PASS (no regression)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e873604-a195-4346-b61e-0784afafaabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e873604-a195-4346-b61e-0784afafaabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

