### PR TITLE
[codex] hydrate stale PR merge states for automerge

### DIFF
--- a/.github/workflows/tier2-auto-merge-queue-check.yml
+++ b/.github/workflows/tier2-auto-merge-queue-check.yml
@@ -27,4 +27,5 @@ jobs:
           TIER2_AUTOMERGE_ALLOW_UNREVIEWED_LOW_RISK: "true"
           TIER2_AUTOMERGE_MAX_MERGES: "1"
           TIER2_AUTOMERGE_OPTIONAL_PENDING_CHECKS: "Cursor Bugbot"
+          TIER2_AUTOMERGE_HYDRATE_POTENTIAL_CANDIDATES: "true"
         run: node scripts/tier2-auto-merge-queue-check.mjs

--- a/scripts/tier2-auto-merge-queue-check.mjs
+++ b/scripts/tier2-auto-merge-queue-check.mjs
@@ -48,6 +48,15 @@ function prNumber(pr = {}) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function isSensitiveHeadRefName(value) {
+  const headRefName = String(value || "").trim();
+  return /\b(auth|billing|payment|stripe|secret|credential|migration|schema|rls|tenant)\b/i.test(headRefName);
+}
+
+function isDependencyHeadRefName(value) {
+  return /^dependabot\//i.test(String(value || "").trim());
+}
+
 export function scoreTier2PullRequestRisk(pr = {}) {
   const reasons = [];
   let score = 0;
@@ -82,12 +91,12 @@ export function scoreTier2PullRequestRisk(pr = {}) {
     reasons.push("medium_diff");
   }
 
-  if (/\b(auth|billing|payment|stripe|secret|credential|migration|schema|rls|tenant)\b/i.test(headRefName)) {
+  if (isSensitiveHeadRefName(headRefName)) {
     score += 25;
     reasons.push("sensitive_branch_name");
   }
 
-  if (/^dependabot\//i.test(headRefName)) {
+  if (isDependencyHeadRefName(headRefName)) {
     score += 25;
     reasons.push("dependency_update_requires_review");
   }
@@ -337,6 +346,7 @@ export async function fetchOpenPullRequests({
   limit = parseBoundedInt(process.env.TIER2_AUTOMERGE_PR_LIMIT, 30, 1, 100),
   cwd = process.cwd(),
   runJson = runCommandJson,
+  hydratePotentialCandidates = parseBoolean(process.env.TIER2_AUTOMERGE_HYDRATE_POTENTIAL_CANDIDATES, true),
 } = {}) {
   const result = await runJson(
     "gh",
@@ -355,7 +365,62 @@ export async function fetchOpenPullRequests({
     { cwd },
   );
   if (!result.ok) return result;
-  return { ok: true, prs: Array.isArray(result.value) ? result.value : [] };
+  const listedPrs = Array.isArray(result.value) ? result.value : [];
+  if (!hydratePotentialCandidates) return { ok: true, prs: listedPrs };
+
+  const prs = [];
+  for (const pr of listedPrs) {
+    if (!shouldHydratePullRequestDetail(pr)) {
+      prs.push(pr);
+      continue;
+    }
+
+    const number = prNumber(pr);
+    const detail = await fetchPullRequestDetail({ repo, number, cwd, runJson });
+    prs.push(detail.ok ? detail.pr : pr);
+  }
+
+  return { ok: true, prs };
+}
+
+function shouldHydratePullRequestDetail(pr = {}) {
+  if (Boolean(pr.isDraft ?? pr.draft)) return false;
+  if (normalizeMergeState(pr.mergeStateStatus ?? pr.merge_state_status) === "CLEAN") return false;
+
+  const changedFiles = boundedNumber(pr.changedFiles ?? pr.changed_files);
+  const changedLines = boundedNumber(pr.additions) + boundedNumber(pr.deletions);
+  const headRefName = String(pr.headRefName || pr.head?.ref || "").trim();
+
+  if (changedFiles > 12 || changedLines > 500) return false;
+  if (isSensitiveHeadRefName(headRefName) || isDependencyHeadRefName(headRefName)) return false;
+  return Number.isFinite(prNumber(pr));
+}
+
+export async function fetchPullRequestDetail({
+  repo = process.env.GITHUB_REPOSITORY || "malamutemayhem/unclick",
+  number,
+  cwd = process.cwd(),
+  runJson = runCommandJson,
+} = {}) {
+  if (!Number.isFinite(number)) {
+    return { ok: false, reason: "missing_pr_number" };
+  }
+
+  const result = await runJson(
+    "gh",
+    [
+      "pr",
+      "view",
+      String(number),
+      "--repo",
+      repo,
+      "--json",
+      "number,isDraft,mergeStateStatus,url,headRefName,changedFiles,additions,deletions,reviewDecision,latestReviews,statusCheckRollup",
+    ],
+    { cwd },
+  );
+  if (!result.ok) return result;
+  return { ok: true, pr: result.value && typeof result.value === "object" ? result.value : {} };
 }
 
 export async function runCommandText(command, args, { cwd = process.cwd(), env = process.env } = {}) {

--- a/scripts/tier2-auto-merge-queue-check.test.mjs
+++ b/scripts/tier2-auto-merge-queue-check.test.mjs
@@ -242,6 +242,51 @@ describe("Tier-2 auto-merge queue check", () => {
     assert.equal(Object.hasOwn(calls[0].options, "env"), false);
   });
 
+  it("hydrates likely-safe PRs when list merge state is stale or unknown", async () => {
+    const calls = [];
+    const result = await fetchOpenPullRequests({
+      repo: "owner/repo",
+      limit: 5,
+      runJson: async (command, args, options) => {
+        calls.push({ command, args, options });
+        if (args[1] === "list") {
+          return {
+            ok: true,
+            value: [
+              {
+                number: 42,
+                isDraft: false,
+                mergeStateStatus: "UNKNOWN",
+                headRefName: "codex/small-safe-change",
+                changedFiles: 2,
+                additions: 10,
+                deletions: 3,
+              },
+            ],
+          };
+        }
+        return {
+          ok: true,
+          value: {
+            number: 42,
+            isDraft: false,
+            mergeStateStatus: "CLEAN",
+            headRefName: "codex/small-safe-change",
+            changedFiles: 2,
+            additions: 10,
+            deletions: 3,
+          },
+        };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.prs[0].mergeStateStatus, "CLEAN");
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls[1].args.slice(0, 5), ["pr", "view", "42", "--repo", "owner/repo"]);
+    assert.equal(Object.hasOwn(calls[1].options, "env"), false);
+  });
+
   it("executes a capped merge when the queue has approved safe candidates", async () => {
     const merged = [];
     const result = await runTier2AutoMergeQueueCheck({


### PR DESCRIPTION
## What changed
- Adds a hydration step for likely-safe PRs when `gh pr list` reports stale or UNKNOWN merge state.
- The workflow can now re-check those PRs with `gh pr view` before deciding whether a safe candidate exists.
- Keeps hydration narrow: non-draft, small diff, non-dependency, non-sensitive branches only.

## Why
After PR #978 merged, the first live workflow run succeeded but skipped PR #969 because the action runner saw stale `mergeStateStatus=UNKNOWN` from the list API. Local `gh pr view 969` showed CLEAN. This removes that false stopper.

## Validation
- node --test scripts/tier2-auto-merge-queue-check.test.mjs
- local dry-run with low-risk override and hydration found PR #969 as the only safe candidate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tier-2 auto-merge gate to optionally re-fetch PR details via `gh pr view`, which can alter which PRs are considered mergeable and increases reliance on GitHub CLI/API behavior.
> 
> **Overview**
> Reduces false negatives in the tier-2 auto-merge queue by **optionally hydrating PR details** when `gh pr list` reports a non-`CLEAN` (e.g. `UNKNOWN`) `mergeStateStatus` for otherwise small, low-risk PRs.
> 
> Adds a new `TIER2_AUTOMERGE_HYDRATE_POTENTIAL_CANDIDATES` toggle (enabled in the workflow) and implements narrow hydration criteria (non-draft, small diff, non-dependency, non-sensitive branch names), plus tests covering the new `gh pr view` fallback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977e443d92507e66b85611dbcb4f3b34f15c111a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->