### PR TITLE
fix(harnesskit): keep backlog gate red

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -597,19 +597,26 @@ function buildHarnessCard({
         ? "amber"
         : "green";
   const gateReason =
-    queueState === "needs_claim"
+    queuedTodoCount > 0 && activeJobsCount > 0
+      ? "Fresh active work exists, but open backlog is still waiting. Do not call the queue healthy; claim a non-overlapping queued slice or post the exact blocker."
+      : queueState === "needs_claim"
       ? "Open Boardroom work has no fresh active owner. Claim one scoped job or post the exact blocker."
       : queueState === "active_work"
         ? "Fresh active work exists. Support with proof, review, tests, or a non-overlapping scoped patch."
         : "No open Boardroom work is visible in this snapshot.";
+  const queueTruth =
+    queuedTodoCount > 0
+      ? `active_jobs=${activeJobsCount}; queued_todo_count=${queuedTodoCount}. Open backlog with active_jobs=${activeJobsCount} needs claim/proof work and is red, not healthy.`
+      : activeJobsCount > 0
+        ? `active_jobs=${activeJobsCount}; queued_todo_count=0. Fresh active work exists; support it with proof, review, tests, or a non-overlapping scoped patch.`
+        : "active_jobs=0; queued_todo_count=0. No open Boardroom work is visible in this snapshot.";
 
   return {
     source_of_truth: "Boardroom Jobs",
     queue_state: queueState,
     gate_status: gateStatus,
     gate_reason: gateReason,
-    queue_truth:
-      "active_jobs counts in_progress work with a fresh owner; queued_todo_count is open backlog. Open backlog with active_jobs=0 is red, not healthy.",
+    queue_truth: queueTruth,
     allowed_actions: [
       "claim one unowned scoped job",
       "verify proof on a completed-looking job",
@@ -622,6 +629,7 @@ function buildHarnessCard({
       "tests or CI must be named when code changed",
       "UI/UX jobs need screenshot proof",
       "DONE, 100%, green chips, and proof badges are hints only until proof is observable",
+      "healthy/no_work/PASS needs queued_todo_count=0 or a fresh claim/blocker proof",
       `health verdict is ${healthVerdict.verdict}`,
     ],
     test_runner_rule:

--- a/api/orchestrator-context-health-verdict.test.ts
+++ b/api/orchestrator-context-health-verdict.test.ts
@@ -67,9 +67,66 @@ describe("orchestrator-context / current_state_card.health_verdict (CommonSenseP
     expect(context.current_state_card.harness_card.required_proof).toContain(
       "UI/UX jobs need screenshot proof",
     );
+    expect(context.current_state_card.harness_card.required_proof).toContain(
+      "healthy/no_work/PASS needs queued_todo_count=0 or a fresh claim/blocker proof",
+    );
     // active_jobs should also be 0 (no in_progress todos), so the BLOCKER is
     // entirely driven by the actionable queue depth.
     expect(context.current_state_card.active_jobs).toBe(0);
+  });
+
+  it("keeps the harness gate red when fresh active work still has open backlog beside it", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: NOW,
+      profiles: [
+        {
+          agent_id: "builder-fresh",
+          last_seen_at: new Date(NOW_MS - 2 * HOUR_MS).toISOString(),
+        },
+      ],
+      messages: [],
+      todos: [
+        {
+          id: "todo-active",
+          title: "Active build",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: "builder-fresh",
+          created_at: NOW,
+        },
+        {
+          id: "todo-queued",
+          title: "Queued follow-up",
+          status: "open",
+          priority: "high",
+          created_by_agent_id: "watcher",
+          assigned_to_agent_id: null,
+          created_at: NOW,
+        },
+      ],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.current_state_card.active_jobs).toBe(1);
+    expect(context.current_state_card.queued_todo_count).toBe(1);
+    expect(context.current_state_card.health_verdict.verdict).toBe("BLOCKER");
+    expect(context.current_state_card.harness_card).toMatchObject({
+      queue_state: "active_work",
+      gate_status: "red",
+    });
+    expect(context.current_state_card.harness_card.gate_reason).toContain(
+      "open backlog is still waiting",
+    );
+    expect(context.current_state_card.harness_card.queue_truth).toContain(
+      "Open backlog with active_jobs=1 needs claim/proof work and is red, not healthy",
+    );
   });
 
   it("keeps live queue rows in the health verdict when the visible context is search-filtered", () => {


### PR DESCRIPTION
## Summary
- keep the HarnessKit gate red when fresh active work still has open backlog beside it
- make queue_truth include active_jobs and queued_todo_count explicitly
- add regression coverage so healthy/no_work/PASS claims require zero queued backlog or fresh claim/blocker proof

## Tests
- npm test -- api/fishbowl-completion-policy.test.ts api/fishbowl-job-pipeline.test.ts api/orchestrator-context-health-verdict.test.ts api/orchestrator-context.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HarnessKit gating logic and messaging around queue health, which can affect how operators/automation interpret PASS/BLOCKER when backlog exists alongside active jobs. Scope is small and covered by added regression tests.
> 
> **Overview**
> Updates `buildHarnessCard` so the gate stays **red** whenever any queued backlog exists (even if `active_jobs>0`), and expands `gate_reason`/`queue_truth` to explicitly include both `active_jobs` and `queued_todo_count`.
> 
> Adds regression coverage in `api/orchestrator-context-health-verdict.test.ts` for the “active work + queued backlog” case, and asserts a new required-proof rule that *PASS/healthy* claims require `queued_todo_count=0` (or explicit fresh claim/blocker proof).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a88e5f3be9b1afc0544728e64ceb1984f0f92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->