### PR TITLE
fix(harnesskit): suppress superseded check-in blockers

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -415,6 +415,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   const queuedTodoCount = input.todos.filter((todo) => todo.status === "open").length;
   const inProgressTodoCount = input.todos.filter((todo) => todo.status === "in_progress").length;
   const activeTodos = activeTodoRows.slice(0, 8);
+  const profileLastSeenByAgent = buildProfileLastSeenByAgent(input.profiles);
   // active_jobs (v9 definition pinned by todo a4cd5229): strict
   // in_progress + owner_last_seen <= 24h. Heartbeat step 5 uses the same
   // formula so state_card and PASS/BLOCKER never disagree on identical
@@ -463,7 +464,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     .map((event) => (compact ? compactContinuityEvent(event) : event));
 
   const blockers = continuityEvents
-    .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs))
+    .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs, profileLastSeenByAgent))
     .map((event) => event.summary)
     .slice(0, 5);
 
@@ -505,6 +506,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     activeTodos,
     continuityEvents,
     blockers,
+    profileLastSeenByAgent,
   });
   const seatHandshake = buildSeatHandshake({
     profiles,
@@ -764,6 +766,7 @@ function buildRollingSnapshot({
   activeTodos,
   continuityEvents,
   blockers,
+  profileLastSeenByAgent,
 }: {
   generatedAt: string;
   nowMs: number;
@@ -771,6 +774,7 @@ function buildRollingSnapshot({
   activeTodos: OrchestratorTodoRow[];
   continuityEvents: OrchestratorContinuityEvent[];
   blockers: string[];
+  profileLastSeenByAgent: Map<string, string | null>;
 }): OrchestratorRollingSnapshot {
   const snapshotEvents = continuityEvents.filter((event) => !isSnapshotNoise(event));
   const promotedDecisions = snapshotEvents
@@ -778,7 +782,7 @@ function buildRollingSnapshot({
     .slice(0, 5)
     .map((event) => eventToSnapshotItem(event, "decision"));
   const activeBlockers = snapshotEvents
-    .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs))
+    .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs, profileLastSeenByAgent))
     .slice(0, 5)
     .map((event) => eventToSnapshotItem(event, "blocker"));
   const activeJobs = activeTodos.slice(0, 6).map((todo) => ({
@@ -832,12 +836,47 @@ function isActiveBlockerEvent(
   event: OrchestratorContinuityEvent,
   activeTodos: OrchestratorTodoRow[],
   nowMs: number,
+  profileLastSeenByAgent: Map<string, string | null>,
 ): boolean {
   if (event.kind !== "blocker") return false;
   if (isWakeIssueCommentStale(event, activeTodos)) return false;
   if (isSuppressedWakePassStatusDispatch(event)) return false;
+  if (isSupersededMissedCheckinDispatch(event, profileLastSeenByAgent, nowMs)) return false;
   if (!isHistoricalWakeOrFishbowlStale(event, activeTodos, nowMs)) return true;
   return false;
+}
+
+function isSupersededMissedCheckinDispatch(
+  event: OrchestratorContinuityEvent,
+  profileLastSeenByAgent: Map<string, string | null>,
+  nowMs: number,
+): boolean {
+  if (event.source_kind !== "dispatch") return false;
+
+  const tags = (event.tags ?? []).map((tag) => tag.toLowerCase());
+  const summary = event.summary.toLowerCase();
+  const text = `${summary} ${tags.join(" ")}`;
+  const isStale = tags.includes("stale") || /\bstale\b/.test(text);
+  if (!isStale || !text.includes("fishbowl-checkin:")) return false;
+
+  const agentId = extractMissedCheckinAgentId(event);
+  if (!agentId) return false;
+
+  const lastSeenMs = Date.parse(profileLastSeenByAgent.get(agentId) ?? "");
+  const eventMs = Date.parse(event.created_at ?? "");
+  if (!Number.isFinite(lastSeenMs) || !Number.isFinite(eventMs) || !Number.isFinite(nowMs)) {
+    return false;
+  }
+
+  return lastSeenMs > eventMs && lastSeenMs <= nowMs + 60_000;
+}
+
+function extractMissedCheckinAgentId(event: OrchestratorContinuityEvent): string | null {
+  const match = event.summary.match(/\bfishbowl-checkin:([^:\s{]+):/i);
+  if (match?.[1]) return match[1];
+  return event.actor_agent_id && !/^\p{Emoji_Presentation}$/u.test(event.actor_agent_id)
+    ? event.actor_agent_id
+    : null;
 }
 
 function isWakeIssueCommentStale(
@@ -1407,6 +1446,15 @@ function isFresh(iso: string | null | undefined, nowMs: number): boolean {
   if (!iso) return false;
   const seenMs = Date.parse(iso);
   return Number.isFinite(seenMs) && Number.isFinite(nowMs) && nowMs - seenMs <= ACTIVE_WINDOW_MS;
+}
+
+function buildProfileLastSeenByAgent(profiles: OrchestratorProfileRow[]): Map<string, string | null> {
+  const lastSeen = new Map<string, string | null>();
+  for (const profile of profiles) {
+    if (!profile.agent_id) continue;
+    lastSeen.set(profile.agent_id, profile.last_seen_at ?? profile.created_at ?? null);
+  }
+  return lastSeen;
 }
 
 // Owner-freshness gate for current_state_card.active_jobs. Mirrors the

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -499,6 +499,61 @@ describe("orchestrator context", () => {
     expect(JSON.stringify(context.current_state_card.blockers)).not.toContain("superseded_status_comment");
   });
 
+  it("does not count missed-checkin dispatches after the same seat checked in again", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-21T12:50:00.000Z",
+      profiles: [
+        {
+          agent_id: "unclick-builder-tether-seat",
+          display_name: "Builder Tether",
+          last_seen_at: "2026-05-21T12:49:08.568Z",
+        },
+      ],
+      messages: [],
+      todos: [
+        {
+          id: "todo-open-backlog",
+          title: "Keep backlog visible",
+          description: "Open work still needs a claim.",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "codex",
+          created_at: "2026-05-21T06:00:00.000Z",
+          updated_at: "2026-05-21T06:00:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-old-checkin",
+          source: "wakepass",
+          target_agent_id: "unclick-builder-tether-seat",
+          task_ref: "fishbowl-checkin:unclick-builder-tether-seat:2026-05-21T06:32:08.227Z",
+          status: "stale",
+          payload: {
+            wake_reason: "missed_next_checkin",
+            agent_id: "unclick-builder-tether-seat",
+          },
+          created_at: "2026-05-21T07:15:31.265Z",
+          updated_at: "2026-05-21T07:15:31.265Z",
+        },
+      ],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.continuity_events.find((event) => event.source_id === "dispatch-old-checkin")?.kind).toBe(
+      "blocker",
+    );
+    expect(context.current_state_card.active_todo_count).toBe(1);
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.current_state_card.blockers).toHaveLength(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+  });
+
   it("hides merged PR WakePass leased dispatches after ACK proof exists", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-16T14:20:00.000Z",


### PR DESCRIPTION
## Summary
- stop old missed-check-in dispatches counting as live blockers after the same seat has checked in again
- keep the dispatch in continuity history so proof is still traceable
- add regression coverage with open backlog still visible

## Validation
- npm test -- api/orchestrator-context.test.ts api/orchestrator-context-health-verdict.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how orchestrator context computes active blockers, which can affect health/blocker signaling and downstream operational behavior; logic is scoped and covered by a new regression test but relies on timestamp parsing/tag detection.
> 
> **Overview**
> Suppresses *superseded* stale `fishbowl-checkin`/missed-checkin dispatches from counting as active blockers when the targeted seat has checked in again (based on profile `last_seen_at` vs dispatch `created_at`), while keeping the dispatch in `continuity_events` for traceability.
> 
> Threads a `profileLastSeenByAgent` map through blocker filtering in both `current_state_card.blockers` and `rolling_snapshot.active_blockers`, and adds a regression test ensuring open backlog remains visible with blocker count staying at 0 after a subsequent check-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae02a1e8beaad4a970e6bf2a1b8e34536968c0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->