### PR TITLE
fix(harnesskit): require CopyRoom fidelity receipts

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -300,6 +300,7 @@ export interface OrchestratorContext {
       queue_truth: string;
       allowed_actions: string[];
       required_proof: string[];
+      copyroom_rule: string;
       test_runner_rule: string;
       cleanup_rule: string;
       recovery_path: string;
@@ -630,10 +631,13 @@ function buildHarnessCard({
       "coding jobs need PR, commit, deploy, or explicit NO_CODE_NEEDED proof",
       "tests or CI must be named when code changed",
       "UI/UX jobs need screenshot proof",
+      "CopyRoom/source-copy jobs need a copy receipt or COPYROOM_MISSING/FIDELITY_DRIFT_RISK blocker",
       "DONE, 100%, green chips, and proof badges are hints only until proof is observable",
       "healthy/no_work/PASS needs queued_todo_count=0 or a fresh claim/blocker proof",
       `health verdict is ${healthVerdict.verdict}`,
     ],
+    copyroom_rule:
+      "When exact source text, code, tables, prompts, labels, or data are provided, workers copy from CopyRoom/source packets and leave a copy receipt instead of retyping from memory.",
     test_runner_rule:
       "Test-only runner packets do not create active work claims unless they include build proof and a Boardroom receipt.",
     cleanup_rule: "Do not mark DONE from green chips or stale receipts; close only after required proof is observable.",

--- a/api/orchestrator-context-health-verdict.test.ts
+++ b/api/orchestrator-context-health-verdict.test.ts
@@ -70,6 +70,10 @@ describe("orchestrator-context / current_state_card.health_verdict (CommonSenseP
     expect(context.current_state_card.harness_card.required_proof).toContain(
       "healthy/no_work/PASS needs queued_todo_count=0 or a fresh claim/blocker proof",
     );
+    expect(context.current_state_card.harness_card.required_proof).toContain(
+      "CopyRoom/source-copy jobs need a copy receipt or COPYROOM_MISSING/FIDELITY_DRIFT_RISK blocker",
+    );
+    expect(context.current_state_card.harness_card.copyroom_rule).toContain("CopyRoom/source packets");
     // active_jobs should also be 0 (no in_progress todos), so the BLOCKER is
     // entirely driven by the actionable queue depth.
     expect(context.current_state_card.active_jobs).toBe(0);

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -201,6 +201,10 @@ describe("orchestrator context", () => {
     expect(context.current_state_card.harness_card.required_proof).toContain(
       "DONE, 100%, green chips, and proof badges are hints only until proof is observable",
     );
+    expect(context.current_state_card.harness_card.required_proof).toContain(
+      "CopyRoom/source-copy jobs need a copy receipt or COPYROOM_MISSING/FIDELITY_DRIFT_RISK blocker",
+    );
+    expect(context.current_state_card.harness_card.copyroom_rule).toContain("copy receipt");
     expect(context.current_state_card.harness_card.test_runner_rule).toContain("Test-only runner packets");
   });
 


### PR DESCRIPTION
## Summary
- adds CopyRoom/source-copy fidelity into the Orchestrator harness card
- requires copy receipts or explicit COPYROOM_MISSING/FIDELITY_DRIFT_RISK blockers when exact source material is involved
- adds regression coverage so queue-truth cards keep surfacing the CopyRoom rule

## Proof
- `npm test -- api/orchestrator-context.test.ts api/orchestrator-context-health-verdict.test.ts`
- `npm test -- api/fishbowl-completion-policy.test.ts api/fishbowl-job-pipeline.test.ts api/orchestrator-context.test.ts api/orchestrator-context-health-verdict.test.ts`
- `node --test scripts/pinballwake-autonomous-runner.test.mjs`

## Notes
- Boardroom todo: `442f8f25-7507-4375-a71f-5c0044ffad24`
- CopyRoom fidelity standing rule saved as `copyroom_fidelity_priority_v1`
- No secrets, billing, DNS, production data, schema changes, or broad rewrite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `OrchestratorContext` contract (`harness_card.copyroom_rule`) and tightens proof requirements, which may affect downstream consumers expecting the prior shape/strings.
> 
> **Overview**
> **Adds explicit CopyRoom fidelity requirements to the Orchestrator harness card.** The `current_state_card.harness_card` now includes a new `copyroom_rule` field and a new `required_proof` line requiring CopyRoom/source-copy jobs to provide a copy receipt or raise `COPYROOM_MISSING/FIDELITY_DRIFT_RISK`.
> 
> Updates orchestrator context tests to assert the new CopyRoom proof requirement and that the rule text is surfaced alongside existing queue-truth/health-verdict behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c7cf25fd1c678f9dd93f4f5aa7ca5f40f13ea94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->