### PR TITLE
feat(copyroom): add exact-copy receipts

### DIFF
--- a/packages/copypass/package.json
+++ b/packages/copypass/package.json
@@ -8,6 +8,7 @@
     ".": "./dist/index.js",
     "./copy-library": "./dist/copy-library.js",
     "./schema": "./dist/schema.js",
+    "./source-copy": "./dist/source-copy.js",
     "./verdict-pack": "./dist/verdict-pack.js"
   },
   "scripts": {

--- a/packages/copypass/src/__tests__/source-copy.test.ts
+++ b/packages/copypass/src/__tests__/source-copy.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  CopyRoomCopyError,
+  copyFromCopyRoomSourcePacket,
+  createCopyRoomSourcePacket,
+  verifyCopyRoomExactCopy,
+} from "../source-copy.js";
+
+describe("CopyRoom exact source copy", () => {
+  it("copies source text without byte or character drift and emits a receipt", () => {
+    const sourceText = "Prompt: keep this line exactly\r\nLabel: cafe\r\nCode: const value = 1;\r\n";
+    const source = createCopyRoomSourcePacket({
+      source_pointer: "copyroom://jobsmith/source.md",
+      text: sourceText,
+    });
+    const result = copyFromCopyRoomSourcePacket({
+      source,
+      output_pointer: "boardroom://todo/59955cb6/receipt.md",
+    });
+
+    expect(result.output.text).toBe(sourceText);
+    expect(result.output.bytes_base64).toBe(source.bytes_base64);
+    expect(result.receipt.source_pointer).toBe("copyroom://jobsmith/source.md");
+    expect(result.receipt.output_pointer).toBe("boardroom://todo/59955cb6/receipt.md");
+    expect(result.receipt.source_hash).toBe(result.receipt.output_hash);
+    expect(result.receipt.source_byte_count).toBe(Buffer.byteLength(sourceText, "utf8"));
+    expect(result.receipt.output_byte_count).toBe(Buffer.byteLength(sourceText, "utf8"));
+    expect(result.receipt.source_character_count).toBe(Array.from(sourceText).length);
+    expect(result.receipt.output_character_count).toBe(Array.from(sourceText).length);
+    expect(result.receipt.diff).toEqual({
+      status: "pass",
+      hash_match: true,
+      byte_count_delta: 0,
+      character_count_delta: 0,
+    });
+  });
+
+  it("keeps receipts stable across many programmatic copies", () => {
+    const source = createCopyRoomSourcePacket({
+      source_pointer: "copyroom://docs/table.tsv",
+      text: "label\tvalue\r\nAlpha\t1\r\nBeta\t2\r\n",
+    });
+    const receiptIds = new Set<string>();
+    const hashes = new Set<string>();
+
+    for (let index = 0; index < 10_000; index += 1) {
+      const { receipt } = copyFromCopyRoomSourcePacket({
+        source,
+        output_pointer: "boardroom://todo/59955cb6/table.tsv",
+      });
+
+      receiptIds.add(receipt.receipt_id);
+      hashes.add(receipt.output_hash);
+      expect(receipt.diff.status).toBe("pass");
+      expect(receipt.source_byte_count).toBe(receipt.output_byte_count);
+      expect(receipt.source_character_count).toBe(receipt.output_character_count);
+    }
+
+    expect(receiptIds.size).toBe(1);
+    expect(hashes.size).toBe(1);
+  });
+
+  it("fails closed when source packets are missing or drift is detected", () => {
+    expectCopyRoomError(
+      () =>
+        createCopyRoomSourcePacket({
+          source_pointer: "copyroom://missing",
+        }),
+      "COPYROOM_MISSING",
+    );
+
+    expectCopyRoomError(
+      () =>
+        createCopyRoomSourcePacket({
+          source_pointer: "copyroom://mismatch",
+          text: "source text",
+          bytes_base64: Buffer.from("changed text", "utf8").toString("base64"),
+        }),
+      "FIDELITY_DRIFT_RISK",
+    );
+
+    const source = createCopyRoomSourcePacket({
+      source_pointer: "copyroom://prompt",
+      text: "Keep exactly this prompt.",
+    });
+
+    expectCopyRoomError(
+      () =>
+        verifyCopyRoomExactCopy({
+          source,
+          output: {
+            output_pointer: "boardroom://todo/59955cb6/prompt",
+            text: "Keep almost exactly this prompt.",
+          },
+        }),
+      "FIDELITY_DRIFT_RISK",
+    );
+  });
+});
+
+function expectCopyRoomError(action: () => unknown, code: CopyRoomCopyError["code"]): void {
+  try {
+    action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(CopyRoomCopyError);
+    expect((error as CopyRoomCopyError).code).toBe(code);
+    return;
+  }
+
+  throw new Error(`Expected CopyRoomCopyError ${code}`);
+}

--- a/packages/copypass/src/index.ts
+++ b/packages/copypass/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./copy-library.js";
 export * from "./schema.js";
+export * from "./source-copy.js";
 export * from "./verdict-pack.js";

--- a/packages/copypass/src/source-copy.ts
+++ b/packages/copypass/src/source-copy.ts
@@ -1,0 +1,314 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+export const CopyRoomCopyBlockerCodeSchema = z.enum([
+  "COPYROOM_MISSING",
+  "FIDELITY_DRIFT_RISK",
+]);
+
+export const CopyRoomEncodingSchema = z.enum(["utf8", "binary"]);
+
+export const CopyRoomSourcePacketSchema = z.object({
+  source_pointer: z.string().min(1),
+  text: z.string().optional(),
+  bytes_base64: z.string().optional(),
+  expected_sha256: z.string().regex(/^[a-f0-9]{64}$/i).optional(),
+  encoding: CopyRoomEncodingSchema.default("utf8"),
+  newline_policy: z.literal("preserve").default("preserve"),
+});
+
+export const CopyRoomCopiedOutputSchema = z.object({
+  output_pointer: z.string().min(1),
+  text: z.string().optional(),
+  bytes_base64: z.string(),
+  encoding: CopyRoomEncodingSchema,
+  byte_count: z.number().int().nonnegative(),
+  character_count: z.number().int().nonnegative().nullable(),
+});
+
+export const CopyRoomExactCopyReceiptSchema = z.object({
+  receipt_id: z.string().min(1),
+  source_pointer: z.string().min(1),
+  output_pointer: z.string().min(1),
+  status: z.literal("copied_exactly"),
+  source_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  output_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  source_byte_count: z.number().int().nonnegative(),
+  output_byte_count: z.number().int().nonnegative(),
+  source_character_count: z.number().int().nonnegative().nullable(),
+  output_character_count: z.number().int().nonnegative().nullable(),
+  encoding: CopyRoomEncodingSchema,
+  newline_policy: z.literal("preserve"),
+  diff: z.object({
+    status: z.literal("pass"),
+    hash_match: z.literal(true),
+    byte_count_delta: z.literal(0),
+    character_count_delta: z.literal(0).nullable(),
+  }),
+});
+
+export type CopyRoomCopyBlockerCode = z.output<typeof CopyRoomCopyBlockerCodeSchema>;
+export type CopyRoomEncoding = z.output<typeof CopyRoomEncodingSchema>;
+export type CopyRoomSourcePacket = z.output<typeof CopyRoomSourcePacketSchema>;
+export type CopyRoomSourcePacketInput = z.input<typeof CopyRoomSourcePacketSchema>;
+export type CopyRoomCopiedOutput = z.output<typeof CopyRoomCopiedOutputSchema>;
+export type CopyRoomCopiedOutputInput = z.input<typeof CopyRoomCopiedOutputSchema>;
+export type CopyRoomExactCopyReceipt = z.output<typeof CopyRoomExactCopyReceiptSchema>;
+
+export interface CopyRoomExactCopyInput {
+  source: CopyRoomSourcePacketInput;
+  output_pointer: string;
+}
+
+export interface CopyRoomExactCopyResult {
+  output: CopyRoomCopiedOutput;
+  receipt: CopyRoomExactCopyReceipt;
+}
+
+export interface VerifyCopyRoomExactCopyInput {
+  source: CopyRoomSourcePacketInput;
+  output: {
+    output_pointer: string;
+    text?: string;
+    bytes_base64?: string;
+    encoding?: CopyRoomEncoding;
+  };
+}
+
+export class CopyRoomCopyError extends Error {
+  readonly code: CopyRoomCopyBlockerCode;
+
+  constructor(code: CopyRoomCopyBlockerCode, message: string) {
+    super(`${code}: ${message}`);
+    this.name = "CopyRoomCopyError";
+    this.code = code;
+  }
+}
+
+export function createCopyRoomSourcePacket(
+  input: CopyRoomSourcePacketInput,
+): CopyRoomSourcePacket {
+  const parsed = CopyRoomSourcePacketSchema.parse(input);
+  const source = readSourcePacket(parsed);
+
+  return CopyRoomSourcePacketSchema.parse({
+    ...parsed,
+    bytes_base64: parsed.bytes_base64 ?? source.bytes.toString("base64"),
+    expected_sha256: parsed.expected_sha256 ?? source.hash,
+  });
+}
+
+export function copyFromCopyRoomSourcePacket(
+  input: CopyRoomExactCopyInput,
+): CopyRoomExactCopyResult {
+  const sourcePacket = CopyRoomSourcePacketSchema.parse(input.source);
+  const source = readSourcePacket(sourcePacket);
+  const output = CopyRoomCopiedOutputSchema.parse({
+    output_pointer: input.output_pointer,
+    text: sourcePacket.text,
+    bytes_base64: source.bytes.toString("base64"),
+    encoding: sourcePacket.encoding,
+    byte_count: source.bytes.length,
+    character_count: source.characterCount,
+  });
+
+  return {
+    output,
+    receipt: buildReceipt({
+      sourcePacket,
+      source,
+      outputPointer: output.output_pointer,
+      outputBytes: source.bytes,
+      outputCharacterCount: output.character_count,
+    }),
+  };
+}
+
+export function verifyCopyRoomExactCopy(
+  input: VerifyCopyRoomExactCopyInput,
+): CopyRoomExactCopyReceipt {
+  const sourcePacket = CopyRoomSourcePacketSchema.parse(input.source);
+  const outputPacket = {
+    ...input.output,
+    encoding: input.output.encoding ?? sourcePacket.encoding,
+  };
+  const source = readSourcePacket(sourcePacket);
+  const output = readOutputBytes(outputPacket);
+
+  if (!source.bytes.equals(output.bytes)) {
+    throw new CopyRoomCopyError(
+      "FIDELITY_DRIFT_RISK",
+      "Copied output bytes do not match the CopyRoom source packet.",
+    );
+  }
+
+  return buildReceipt({
+    sourcePacket,
+    source,
+    outputPointer: input.output.output_pointer,
+    outputBytes: output.bytes,
+    outputCharacterCount: output.characterCount,
+  });
+}
+
+function readSourcePacket(packet: CopyRoomSourcePacket): {
+  bytes: Buffer;
+  hash: string;
+  characterCount: number | null;
+} {
+  const textBytes = packet.text === undefined ? null : Buffer.from(packet.text, "utf8");
+  const rawBytes =
+    packet.bytes_base64 === undefined ? null : decodeBase64(packet.bytes_base64);
+
+  if (!textBytes && !rawBytes) {
+    throw new CopyRoomCopyError(
+      "COPYROOM_MISSING",
+      "CopyRoom source packet must include text or bytes_base64.",
+    );
+  }
+
+  if (textBytes && rawBytes && !textBytes.equals(rawBytes)) {
+    throw new CopyRoomCopyError(
+      "FIDELITY_DRIFT_RISK",
+      "CopyRoom source text and bytes_base64 describe different bytes.",
+    );
+  }
+
+  const bytes = rawBytes ?? textBytes;
+  if (!bytes) {
+    throw new CopyRoomCopyError("COPYROOM_MISSING", "CopyRoom source bytes missing.");
+  }
+
+  const hash = sha256(bytes);
+  if (packet.expected_sha256 && packet.expected_sha256.toLowerCase() !== hash) {
+    throw new CopyRoomCopyError(
+      "FIDELITY_DRIFT_RISK",
+      "CopyRoom source packet hash does not match its bytes.",
+    );
+  }
+
+  return {
+    bytes,
+    hash,
+    characterCount: packet.text === undefined ? null : countCharacters(packet.text),
+  };
+}
+
+function readOutputBytes(output: {
+  text?: string;
+  bytes_base64?: string;
+}): { bytes: Buffer; characterCount: number | null } {
+  const textBytes = output.text === undefined ? null : Buffer.from(output.text, "utf8");
+  const rawBytes =
+    output.bytes_base64 === undefined ? null : decodeBase64(output.bytes_base64);
+
+  if (!textBytes && !rawBytes) {
+    throw new CopyRoomCopyError(
+      "COPYROOM_MISSING",
+      "Copied output must include text or bytes_base64.",
+    );
+  }
+
+  if (textBytes && rawBytes && !textBytes.equals(rawBytes)) {
+    throw new CopyRoomCopyError(
+      "FIDELITY_DRIFT_RISK",
+      "Copied output text and bytes_base64 describe different bytes.",
+    );
+  }
+
+  const bytes = rawBytes ?? textBytes;
+  if (!bytes) {
+    throw new CopyRoomCopyError("COPYROOM_MISSING", "Copied output bytes missing.");
+  }
+
+  return {
+    bytes,
+    characterCount: output.text === undefined ? null : countCharacters(output.text),
+  };
+}
+
+function buildReceipt(input: {
+  sourcePacket: CopyRoomSourcePacket;
+  source: { bytes: Buffer; hash: string; characterCount: number | null };
+  outputPointer: string;
+  outputBytes: Buffer;
+  outputCharacterCount: number | null;
+}): CopyRoomExactCopyReceipt {
+  const outputHash = sha256(input.outputBytes);
+
+  if (input.source.hash !== outputHash || input.source.bytes.length !== input.outputBytes.length) {
+    throw new CopyRoomCopyError(
+      "FIDELITY_DRIFT_RISK",
+      "CopyRoom receipt cannot pass because output differs from source.",
+    );
+  }
+
+  const characterDelta =
+    input.source.characterCount === null || input.outputCharacterCount === null
+      ? null
+      : input.outputCharacterCount - input.source.characterCount;
+
+  if (characterDelta !== null && characterDelta !== 0) {
+    throw new CopyRoomCopyError(
+      "FIDELITY_DRIFT_RISK",
+      "CopyRoom receipt cannot pass because character counts differ.",
+    );
+  }
+
+  return CopyRoomExactCopyReceiptSchema.parse({
+    receipt_id: createReceiptId(
+      input.sourcePacket.source_pointer,
+      input.outputPointer,
+      input.source.hash,
+    ),
+    source_pointer: input.sourcePacket.source_pointer,
+    output_pointer: input.outputPointer,
+    status: "copied_exactly",
+    source_hash: input.source.hash,
+    output_hash: outputHash,
+    source_byte_count: input.source.bytes.length,
+    output_byte_count: input.outputBytes.length,
+    source_character_count: input.source.characterCount,
+    output_character_count: input.outputCharacterCount,
+    encoding: input.sourcePacket.encoding,
+    newline_policy: input.sourcePacket.newline_policy,
+    diff: {
+      status: "pass",
+      hash_match: true,
+      byte_count_delta: 0,
+      character_count_delta: characterDelta,
+    },
+  });
+}
+
+function decodeBase64(value: string): Buffer {
+  const normalized = value.replace(/\s+/g, "");
+  const bytes = Buffer.from(normalized, "base64");
+  const roundTrip = bytes.toString("base64").replace(/=+$/, "");
+
+  if (roundTrip !== normalized.replace(/=+$/, "")) {
+    throw new CopyRoomCopyError(
+      "FIDELITY_DRIFT_RISK",
+      "Invalid base64 bytes in CopyRoom source-copy packet.",
+    );
+  }
+
+  return bytes;
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function countCharacters(text: string): number {
+  return Array.from(text).length;
+}
+
+function createReceiptId(
+  sourcePointer: string,
+  outputPointer: string,
+  sourceHash: string,
+): string {
+  const idHash = sha256(Buffer.from(`${sourcePointer}\0${outputPointer}\0${sourceHash}`));
+  return `copyroom:${idHash.slice(0, 16)}`;
+}


### PR DESCRIPTION
## Summary
- Adds a CopyRoom exact-copy helper inside `@unclick/copypass` for source packets, copied outputs, and receipts.
- Receipts include source/output pointers, SHA-256 hashes, byte counts, character counts, newline policy, and diff-pass proof.
- Fails closed with `COPYROOM_MISSING` or `FIDELITY_DRIFT_RISK` when source material is absent or bytes drift.

## Scope
- Lane: CopyRoom v1 exact-copy engine and receipt proof.
- Boardroom todo: `59955cb6-cbd6-42f6-a175-17edccb4e2da`.
- Owned files: `packages/copypass/src/source-copy.ts`, `packages/copypass/src/__tests__/source-copy.test.ts`, `packages/copypass/src/index.ts`, `packages/copypass/package.json`.

## Non-overlap
- Does not change HarnessKit/AutoPilot rules from PR #987.
- Does not add persistence, UI, MCP wiring, migrations, deploy behavior, or production data access.
- Does not touch DraftRoom, SeatRelay, JobSmith, or unrelated queue jobs.

## Verification
- `npm run test --workspace=@unclick/copypass`: 4 files passed, 10 tests passed.
- `npm run build --workspace=@unclick/copypass`: passed.
- `git diff --check`: passed.

## Risk
- Low. Pure TypeScript utility and tests in the CopyPass package.
- No auth, secrets, billing, DNS, cron, API, migration, or user-facing UI changes.

## Follow-up
- After review, wire CopyRoom receipts into the Boardroom/HarnessKit source-copy flow so source-copy jobs can attach receipts instead of only requiring them.