### PR TITLE
feat(copyroom): attach receipts to copypass runs

### DIFF
--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -70,7 +70,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/coinmarketcap-tool.ts | b1c5fd280acb | 6892 |
 | packages/mcp-server/src/color-tool.ts | f9aa9c0fec6e | 13643 |
 | packages/mcp-server/src/convertkit-tool.ts | 2f77303a3441 | 8498 |
-| packages/mcp-server/src/copypass-tool.ts | 58487357de03 | 5744 |
+| packages/mcp-server/src/copypass-tool.ts | 0a26dc5c960d | 13895 |
 | packages/mcp-server/src/crews-tool.ts | 18a489d3ab94 | 5750 |
 | packages/mcp-server/src/csuite-tool.ts | 0ab5af89bb49 | 70236 |
 | packages/mcp-server/src/datadog-tool.ts | 802b808614cd | 5556 |

--- a/packages/mcp-server/src/copypass-tool.test.ts
+++ b/packages/mcp-server/src/copypass-tool.test.ts
@@ -4,7 +4,7 @@ import { copypassRun, copypassStatus } from "./copypass-tool.js";
 describe("copypass-tool", () => {
   it("requires copy_text", async () => {
     const result = (await copypassRun({})) as { error?: string };
-    expect(result.error).toMatch(/copy_text is required/);
+    expect(result.error).toMatch(/copy_text or copyroom_source_packet is required/);
   });
 
   it("rejects invalid profiles", async () => {
@@ -36,6 +36,79 @@ describe("copypass-tool", () => {
     expect(status.run_id).toBe(run.run_id);
     expect(status.status).toBe("complete");
     expect(status.target?.channel).toBe("homepage_hero");
+  });
+
+  it("attaches a CopyRoom exact-copy receipt from a source packet", async () => {
+    const sourceText = "Line 1\r\nLine 2 with symbols: GBP, EUR, emoji ok";
+    const run = (await copypassRun({
+      copyroom_source_packet: {
+        source_id: "jobsmith-checklist-source",
+        source_pointer: "apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1.md",
+        text: sourceText,
+      },
+      copyroom_output_pointer: "mcp://copypass/runs/jobsmith-checklist-source",
+      channel: "jobsmith_rule_source",
+      profile: "smoke",
+    })) as {
+      run_id?: string;
+      status?: string;
+      copyroom_receipt?: {
+        status?: string;
+        exact_diff?: string;
+        source_pointer?: string;
+        output_pointer?: string;
+        source_sha256?: string;
+        output_sha256?: string;
+        byte_count?: number;
+        output_byte_count?: number;
+        character_count?: number;
+        output_character_count?: number;
+        newline_style?: string;
+      };
+    };
+
+    expect(run.status).toBe("complete");
+    expect(run.copyroom_receipt?.status).toBe("pass");
+    expect(run.copyroom_receipt?.exact_diff).toBe("pass");
+    expect(run.copyroom_receipt?.source_pointer).toBe(
+      "apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1.md",
+    );
+    expect(run.copyroom_receipt?.output_pointer).toBe("mcp://copypass/runs/jobsmith-checklist-source");
+    expect(run.copyroom_receipt?.source_sha256).toBe(run.copyroom_receipt?.output_sha256);
+    expect(run.copyroom_receipt?.byte_count).toBe(Buffer.byteLength(sourceText, "utf8"));
+    expect(run.copyroom_receipt?.output_byte_count).toBe(run.copyroom_receipt?.byte_count);
+    expect(run.copyroom_receipt?.character_count).toBe(Array.from(sourceText).length);
+    expect(run.copyroom_receipt?.output_character_count).toBe(run.copyroom_receipt?.character_count);
+    expect(run.copyroom_receipt?.newline_style).toBe("crlf");
+
+    const status = (await copypassStatus({
+      run_id: run.run_id,
+    })) as { copyroom_receipt?: { status?: string; source_sha256?: string; output_sha256?: string } };
+
+    expect(status.copyroom_receipt?.status).toBe("pass");
+    expect(status.copyroom_receipt?.source_sha256).toBe(status.copyroom_receipt?.output_sha256);
+  });
+
+  it("blocks CopyRoom source-copy drift before creating a run", async () => {
+    const result = (await copypassRun({
+      copy_text: "Exact source text must not draft.",
+      copyroom_source_packet: {
+        source_id: "prompt-source",
+        source_pointer: "copyroom://prompts/prompt-source",
+        text: "Exact source text must not drift.",
+      },
+      copyroom_output_pointer: "mcp://copypass/runs/prompt-source",
+    })) as {
+      error?: string;
+      run_id?: string;
+      copyroom_receipt?: { status?: string; exact_diff?: string; action_needed?: string[] };
+    };
+
+    expect(result.run_id).toBeUndefined();
+    expect(result.error).toContain("FIDELITY_DRIFT_RISK");
+    expect(result.copyroom_receipt?.status).toBe("blocked");
+    expect(result.copyroom_receipt?.exact_diff).toBe("fail");
+    expect(result.copyroom_receipt?.action_needed?.[0]).toContain("FIDELITY_DRIFT_RISK");
   });
 
   it("returns a clear error for missing run ids", async () => {

--- a/packages/mcp-server/src/copypass-tool.ts
+++ b/packages/mcp-server/src/copypass-tool.ts
@@ -1,9 +1,61 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 type Verdict = "check" | "na" | "fail" | "other" | "pending";
 type Severity = "critical" | "high" | "medium" | "low";
 type RunStatus = "queued" | "running" | "complete" | "failed";
 type RunProfile = "smoke" | "standard" | "deep";
+type CopyRoomEncoding = "utf8";
+type CopyRoomExactStatus = "pass" | "blocked";
+type CopyRoomDiffResult = "pass" | "fail";
+type CopyRoomNewlinePolicy = "preserve";
+type CopyRoomNewlineStyle = "none" | "lf" | "crlf" | "cr" | "mixed";
+
+interface CopyRoomSourcePacketInput {
+  source_id: string;
+  source_pointer: string;
+  text: string;
+  encoding?: CopyRoomEncoding;
+  newline_policy?: CopyRoomNewlinePolicy;
+}
+
+interface CopyRoomSourcePacket {
+  kind: "copyroom_source_packet";
+  source_id: string;
+  source_pointer: string;
+  text: string;
+  encoding: CopyRoomEncoding;
+  newline_policy: CopyRoomNewlinePolicy;
+  newline_style: CopyRoomNewlineStyle;
+  source_sha256: string;
+  byte_count: number;
+  character_count: number;
+}
+
+interface CopyRoomCopyReceipt {
+  kind: "copyroom_exact_copy_receipt";
+  status: CopyRoomExactStatus;
+  source_id: string;
+  source_pointer: string;
+  output_pointer: string;
+  source_sha256: string;
+  output_sha256: string;
+  byte_count: number;
+  output_byte_count: number;
+  character_count: number;
+  output_character_count: number;
+  encoding: CopyRoomEncoding;
+  newline_policy: CopyRoomNewlinePolicy;
+  newline_style: CopyRoomNewlineStyle;
+  output_newline_style: CopyRoomNewlineStyle;
+  exact_diff: CopyRoomDiffResult;
+  action_needed: string[];
+}
+
+interface CopyRoomPreparedCopy {
+  copyText: string;
+  copyroomReceipt?: CopyRoomCopyReceipt;
+  error?: string;
+}
 
 interface VerdictSummary {
   total: number;
@@ -44,6 +96,7 @@ interface CopyRunRecord {
   completed_at: string | null;
   findings: CopyFinding[];
   notes: string[];
+  copyroom_receipt?: CopyRoomCopyReceipt;
   error?: string;
 }
 
@@ -60,6 +113,9 @@ function parseProfile(raw: unknown): RunProfile | null {
 
 function previewCopy(text: string): string {
   const oneLine = text.replace(/\s+/g, " ").trim();
+  if (SENSITIVE_COPY_PATTERN.test(oneLine)) {
+    return "[redacted-sensitive-copy-fragment]";
+  }
   return oneLine.length > 160 ? `${oneLine.slice(0, 157)}...` : oneLine;
 }
 
@@ -74,7 +130,12 @@ function summarize(findings: CopyFinding[]): VerdictSummary {
   return summary;
 }
 
-function createRunRecord(copyText: string, profile: RunProfile, args: Record<string, unknown>): CopyRunRecord {
+function createRunRecord(
+  copyText: string,
+  profile: RunProfile,
+  args: Record<string, unknown>,
+  copyroomReceipt?: CopyRoomCopyReceipt,
+): CopyRunRecord {
   const record: CopyRunRecord = {
     id: randomUUID(),
     profile,
@@ -91,6 +152,7 @@ function createRunRecord(copyText: string, profile: RunProfile, args: Record<str
     completed_at: null,
     findings: [],
     notes: [],
+    copyroom_receipt: copyroomReceipt,
   };
   RUNS.set(record.id, record);
   return record;
@@ -116,6 +178,20 @@ function appendScaffoldFinding(runId: string, copyText: string): void {
       channel: current.target.channel ?? null,
       audience: current.target.audience ?? null,
       goal: current.target.goal ?? null,
+      copyroom_receipt: current.copyroom_receipt
+        ? {
+            status: current.copyroom_receipt.status,
+            source_pointer: current.copyroom_receipt.source_pointer,
+            output_pointer: current.copyroom_receipt.output_pointer,
+            source_sha256: current.copyroom_receipt.source_sha256,
+            output_sha256: current.copyroom_receipt.output_sha256,
+            byte_count: current.copyroom_receipt.byte_count,
+            output_byte_count: current.copyroom_receipt.output_byte_count,
+            character_count: current.copyroom_receipt.character_count,
+            output_character_count: current.copyroom_receipt.output_character_count,
+            exact_diff: current.copyroom_receipt.exact_diff,
+          }
+        : null,
     },
     created_at: new Date().toISOString(),
   });
@@ -131,16 +207,29 @@ function appendNote(runId: string, note: string): void {
 }
 
 export async function copypassRun(args: Record<string, unknown>): Promise<unknown> {
-  const copyText = typeof args.copy_text === "string" ? args.copy_text.trim() : "";
-  if (!copyText) return { error: "copy_text is required" };
+  const prepared = prepareCopyText(args);
+  if (prepared.error) {
+    return {
+      error: prepared.error,
+      copyroom_receipt: prepared.copyroomReceipt,
+    };
+  }
+  const copyText = prepared.copyText;
+  if (!copyText) return { error: "copy_text or copyroom_source_packet is required" };
   const profile = parseProfile(args.profile);
   if (!profile) return { error: "profile must be one of: smoke, standard, deep" };
 
-  const run = createRunRecord(copyText, profile, args);
+  const run = createRunRecord(copyText, profile, args, prepared.copyroomReceipt);
   RUNS.set(run.id, { ...run, status: "running" });
   appendScaffoldFinding(run.id, copyText);
   appendNote(run.id, "Chunk 1 scaffold only: CopyPass surface is live, but deterministic copy-quality checks land in a later chunk.");
   appendNote(run.id, "Use channel, audience, and goal fields now so later evaluator passes inherit realistic operator context.");
+  if (prepared.copyroomReceipt) {
+    appendNote(
+      run.id,
+      "CopyRoom exact-copy receipt attached: source/output hashes, byte counts, character counts, and diff status are included.",
+    );
+  }
 
   const completed = RUNS.get(run.id);
   if (!completed) return { error: "run disappeared before completion" };
@@ -155,6 +244,7 @@ export async function copypassRun(args: Record<string, unknown>): Promise<unknow
     verdict_summary: completed.verdict_summary,
     notes: completed.notes,
     preview: completed.target.copy_text_preview,
+    copyroom_receipt: completed.copyroom_receipt ?? null,
   };
 }
 
@@ -172,5 +262,155 @@ export async function copypassStatus(args: Record<string, unknown>): Promise<unk
     target: run.target,
     notes: run.notes,
     completed_at: run.completed_at,
+    copyroom_receipt: run.copyroom_receipt ?? null,
   };
 }
+
+function prepareCopyText(args: Record<string, unknown>): CopyRoomPreparedCopy {
+  const rawSourcePacket = args.copyroom_source_packet;
+  if (rawSourcePacket !== undefined && rawSourcePacket !== null) {
+    const packetInput = parseCopyRoomSourcePacketInput(rawSourcePacket);
+    if (!packetInput) {
+      return { copyText: "", error: "COPYROOM_MISSING: copyroom_source_packet must include source_id, source_pointer, and text." };
+    }
+
+    const packet = createCopyRoomSourcePacket(packetInput);
+    const outputText = typeof args.copy_text === "string" ? args.copy_text : packet.text;
+    const outputPointer =
+      typeof args.copyroom_output_pointer === "string" && args.copyroom_output_pointer.trim()
+        ? args.copyroom_output_pointer.trim()
+        : `copypass://copyroom-output/${packet.source_id}`;
+    const receipt = verifyCopyRoomExact(packet, outputText, outputPointer);
+
+    if (receipt.status !== "pass") {
+      return {
+        copyText: "",
+        copyroomReceipt: receipt,
+        error: "FIDELITY_DRIFT_RISK: copy_text differs from the CopyRoom source packet.",
+      };
+    }
+
+    return { copyText: outputText, copyroomReceipt: receipt };
+  }
+
+  return {
+    copyText: typeof args.copy_text === "string" ? args.copy_text.trim() : "",
+  };
+}
+
+function parseCopyRoomSourcePacketInput(value: unknown): CopyRoomSourcePacketInput | null {
+  if (!isRecord(value)) return null;
+
+  const sourceId = typeof value.source_id === "string" ? value.source_id : "";
+  const sourcePointer = typeof value.source_pointer === "string" ? value.source_pointer : "";
+  const text = typeof value.text === "string" ? value.text : "";
+  const encoding = value.encoding === undefined || value.encoding === "utf8" ? "utf8" : null;
+  const newlinePolicy =
+    value.newline_policy === undefined || value.newline_policy === "preserve" ? "preserve" : null;
+
+  if (!sourceId.trim() || !sourcePointer.trim() || text === "" || !encoding || !newlinePolicy) {
+    return null;
+  }
+
+  return {
+    source_id: sourceId,
+    source_pointer: sourcePointer,
+    text,
+    encoding,
+    newline_policy: newlinePolicy,
+  };
+}
+
+function createCopyRoomSourcePacket(input: CopyRoomSourcePacketInput): CopyRoomSourcePacket {
+  return {
+    kind: "copyroom_source_packet",
+    source_id: requireNonEmpty(input.source_id, "source_id"),
+    source_pointer: requireNonEmpty(input.source_pointer, "source_pointer"),
+    text: input.text,
+    encoding: input.encoding ?? "utf8",
+    newline_policy: input.newline_policy ?? "preserve",
+    newline_style: detectNewlineStyle(input.text),
+    source_sha256: sha256Utf8(input.text),
+    byte_count: byteCount(input.text),
+    character_count: characterCount(input.text),
+  };
+}
+
+function verifyCopyRoomExact(
+  packet: CopyRoomSourcePacket,
+  outputText: string,
+  outputPointer: string,
+): CopyRoomCopyReceipt {
+  const outputSha256 = sha256Utf8(outputText);
+  const outputByteCount = byteCount(outputText);
+  const outputCharacterCount = characterCount(outputText);
+  const outputNewlineStyle = detectNewlineStyle(outputText);
+  const exactMatch =
+    outputSha256 === packet.source_sha256 &&
+    outputByteCount === packet.byte_count &&
+    outputCharacterCount === packet.character_count &&
+    outputNewlineStyle === packet.newline_style &&
+    outputText === packet.text;
+
+  return {
+    kind: "copyroom_exact_copy_receipt",
+    status: exactMatch ? "pass" : "blocked",
+    source_id: packet.source_id,
+    source_pointer: packet.source_pointer,
+    output_pointer: requireNonEmpty(outputPointer, "output_pointer"),
+    source_sha256: packet.source_sha256,
+    output_sha256: outputSha256,
+    byte_count: packet.byte_count,
+    output_byte_count: outputByteCount,
+    character_count: packet.character_count,
+    output_character_count: outputCharacterCount,
+    encoding: packet.encoding,
+    newline_policy: packet.newline_policy,
+    newline_style: packet.newline_style,
+    output_newline_style: outputNewlineStyle,
+    exact_diff: exactMatch ? "pass" : "fail",
+    action_needed: exactMatch
+      ? []
+      : ["FIDELITY_DRIFT_RISK: output differs from CopyRoom source packet."],
+  };
+}
+
+function sha256Utf8(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function byteCount(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function characterCount(value: string): number {
+  return Array.from(value).length;
+}
+
+function detectNewlineStyle(value: string): CopyRoomNewlineStyle {
+  const crlf = /\r\n/.test(value);
+  const withoutCrlf = value.replace(/\r\n/g, "");
+  const lf = /\n/.test(withoutCrlf);
+  const cr = /\r/.test(withoutCrlf);
+  const count = [crlf, lf, cr].filter(Boolean).length;
+
+  if (count === 0) return "none";
+  if (count > 1) return "mixed";
+  if (crlf) return "crlf";
+  if (lf) return "lf";
+  return "cr";
+}
+
+function requireNonEmpty(value: string, label: string): string {
+  if (!value.trim()) {
+    throw new Error(`CopyRoom ${label} is required.`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const SENSITIVE_COPY_PATTERN =
+  /\b(api[_ -]?key|bearer|password|secret|sk-[a-z0-9_-]{8,}|token)\b/i;

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12311,21 +12311,35 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
-  // ── copypass-tool.ts (copy quality QC, scaffold-only for Chunk 1) ────────
+  // ── copypass-tool.ts (copy quality QC with CopyRoom receipt support) ─────
   {
     name: "copypass_run",
-    description: "Start a scaffold CopyPass run for AI-generated copy. Chunk 1 stores an in-session run record and echoes operator context so later evidence-led copy checks can plug into a stable shape.",
+    description: "Start a CopyPass run for AI-generated copy. When exact fidelity matters, pass copyroom_source_packet so the run attaches a CopyRoom receipt instead of relying on retyped source text.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        copy_text: { type: "string", description: "The AI-generated copy to review." },
+        copy_text: { type: "string", description: "The AI-generated copy to review. Optional when copyroom_source_packet is provided; exact-copy verification compares this text byte-for-byte against the packet." },
+        copyroom_source_packet: {
+          type: "object",
+          additionalProperties: false,
+          description: "Exact source packet for CopyRoom fidelity work. Use this instead of retyping source text when code, prompts, labels, tables, documents, or user-provided text must stay exact.",
+          properties: {
+            source_id: { type: "string", description: "Stable source identifier." },
+            source_pointer: { type: "string", description: "Pointer to the CopyRoom/source location." },
+            text: { type: "string", description: "Exact source text to copy or verify." },
+            encoding: { type: "string", enum: ["utf8"], description: "CopyRoom v1 encoding. Defaults to utf8." },
+            newline_policy: { type: "string", enum: ["preserve"], description: "CopyRoom v1 newline policy. Defaults to preserve." },
+          },
+          required: ["source_id", "source_pointer", "text"],
+        },
+        copyroom_output_pointer: { type: "string", description: "Pointer to the intended output artifact for the CopyRoom receipt." },
         channel: { type: "string", description: "Optional surface label such as homepage_hero, pricing_section, or onboarding_email." },
         audience: { type: "string", description: "Optional intended audience for the copy." },
         goal: { type: "string", description: "Optional goal for the copy, such as clarity, conversion, or trust." },
         profile: { type: "string", enum: ["smoke", "standard", "deep"], description: "Reserved for later evaluator depth. Defaults to smoke." },
       },
-      required: ["copy_text"],
+      required: [],
     },
   },
   {


### PR DESCRIPTION
Summary:
- Adds CopyRoom source-packet support to `copypass_run` so exact-copy work can attach a receipt with source/output pointers, hashes, byte counts, character counts, newline style, and diff status.
- Blocks drifted source-copy submissions with `FIDELITY_DRIFT_RISK` before creating a run.
- Redacts token-shaped text from CopyPass previews and exposes the receipt through `copypass_status`.

Scope:
- Lane: CopyRoom v1 product wiring and dogfood proof.
- Owned files: `packages/mcp-server/src/copypass-tool.ts`, `packages/mcp-server/src/copypass-tool.test.ts`, `packages/mcp-server/src/tool-wiring.ts`, `docs/UnClick-brainmap.generated.md`.

Non-overlap:
- Does not change CopyRoom engine internals from PR #988.
- Does not touch DraftRoom, SeatRelay, billing, DNS, secrets, or production data.
- Does not mark the broader CopyRoom rollout done.

Verification:
- `npx vitest run src/copypass-tool.test.ts --config vitest.config.ts` from `packages/mcp-server`: 6 tests passed.
- `npm run build --workspace=@unclick/mcp-server`: passed.
- `npm test --workspace=@unclick/mcp-server`: 53 node tests and 113 vitest tests passed.
- `npm run brainmap:check`: passed.
- `npm run test:brainmap`: 4 tests passed.
- `npm run build`: passed.
- `git diff --check`: passed with line-ending warnings only.

Risk:
- User-facing MCP schema expands `copypass_run` input; existing `copy_text` calls still work.
- CopyRoom source packets do not return source text, only preview plus receipt metadata; token-shaped previews are redacted.

Follow-up:
- Dogfood this via a live connected-agent `copypass_run` source packet after review/merge.