### PR TITLE
fix(wakepass): register cleanup worker ignite route

### DIFF
--- a/packages/mcp-server/src/igniteonly-tool.test.ts
+++ b/packages/mcp-server/src/igniteonly-tool.test.ts
@@ -135,6 +135,45 @@ describe("IgniteOnlyAPI policy", () => {
     });
   });
 
+  it("routes verified duplicate WakePass cleanup requests to the registered cleanup worker", async () => {
+    await expect(igniteonlyReceiptConsumer({
+      nudge_bridge_result: {
+        bridge_id: "nudgebridge_duplicate_pr_981",
+        bridge_status: "escalation_request",
+        painpoint_detected: true,
+        painpoint_type: "duplicate_wake",
+        request: {
+          worker: "wakepass-cleanup-worker",
+          target: "PR #981 stale WakePass blocker",
+          expected_receipt: "Duplicate wake suppressed, resolved, or routed with superseding proof.",
+          verifier: "Compare source PR state, superseding PR proof, and WakePass dispatch timestamp.",
+        },
+        evidence: {
+          source_id: "wake-pull_request-pr-981-bbbaa2b37720",
+          source_url: "https://github.com/malamutemayhem/unclick/pull/981?token=secret-token",
+          nudge_trace_id: "nudgeonly_duplicate_pr_981",
+          verifier_required: true,
+        },
+      },
+      verifier_status: "proof_checked",
+    })).resolves.toMatchObject({
+      ignite_status: "escalation_wake_request",
+      painpoint_type: "duplicate_wake",
+      wake_packet: {
+        action: "wake_worker_and_escalate",
+        worker: "wakepass-cleanup-worker",
+        target: "PR #981 stale WakePass blocker",
+        painpoint_type: "duplicate_wake",
+        source_id: "wake-pull_request-pr-981-bbbaa2b37720",
+        source_url: "https://github.com/malamutemayhem/unclick/pull/981?token=<redacted>",
+        public_fields_only: true,
+      },
+      proof: {
+        receipt_line: expect.stringContaining("wakepass-cleanup-worker -> PR #981 stale WakePass blocker -> duplicate_wake"),
+      },
+    });
+  });
+
   it("escalates when the bridge is an escalation request", async () => {
     await expect(igniteonlyReceiptConsumer({
       bridge_id: "nudgebridge_stale",

--- a/packages/mcp-server/src/igniteonly-tool.ts
+++ b/packages/mcp-server/src/igniteonly-tool.ts
@@ -29,36 +29,43 @@ const WORKER_ROUTES = [
   {
     painpoint_type: "stale_ack",
     worker: "Reviewer",
+    worker_aliases: [],
     wake_reason: "A stale ACK needs a review receipt, blocker receipt, or WakePass escalation.",
   },
   {
     painpoint_type: "duplicate_wake",
     worker: "Job Manager",
+    worker_aliases: ["wakepass-cleanup-worker"],
     wake_reason: "Duplicate wakes need consolidation or a clear reason to keep both.",
   },
   {
     painpoint_type: "unclear_owner",
     worker: "Job Manager",
+    worker_aliases: [],
     wake_reason: "A visible blocker needs an owning job and next expected receipt.",
   },
   {
     painpoint_type: "queue_hydration_failure",
     worker: "pinballwake-jobs-worker",
+    worker_aliases: [],
     wake_reason: "Backlog exists while active jobs are zero, so the existing Jobs Worker needs to hydrate, scope, or route the queue.",
   },
   {
     painpoint_type: "missing_proof",
     worker: "Builder",
+    worker_aliases: [],
     wake_reason: "A claimed or expected build step needs a commit, PR, run ID, receipt, or blocker.",
   },
   {
     painpoint_type: "noisy_thread",
     worker: "Heartbeat Seat",
+    worker_aliases: [],
     wake_reason: "Repeated pulse noise needs a compact material state receipt.",
   },
   {
     painpoint_type: "dormant_worker",
     worker: "Job Manager",
+    worker_aliases: [],
     wake_reason: "A dormant worker lane needs a safe owner check before a specialist is woken.",
   },
 ] as const;
@@ -180,8 +187,9 @@ function workerFrom(request: Record<string, unknown>, painpointType: string): st
   const explicit = safeText(request.worker);
   const route = routeFor(painpointType);
   if (!route) return null;
-  if (explicit && explicit !== route.worker) return null;
-  return route.worker;
+  const knownWorkers: readonly string[] = [route.worker, ...route.worker_aliases];
+  if (explicit && !knownWorkers.includes(explicit)) return null;
+  return explicit ?? route.worker;
 }
 
 function targetFrom(args: Record<string, unknown>, bridge: Record<string, unknown>, request: Record<string, unknown>): string | null {


### PR DESCRIPTION
Summary:
- Registers `wakepass-cleanup-worker` as an allowed IgniteOnly lane for verified `duplicate_wake` requests while keeping `Job Manager` as the default duplicate-wake route.
- Adds regression coverage for the PR #981 stale WakePass blocker shape, including token redaction in the public wake packet.

Scope:
- Owned files: `packages/mcp-server/src/igniteonly-tool.ts`, `packages/mcp-server/src/igniteonly-tool.test.ts`.
- Lane: WakePass / IgniteOnly route validation.
- Linked Boardroom todo: `8b4af32b-1c1c-4f56-bac2-a87aafb64a64`.

Non-overlap:
- Does not mutate live dispatch data, close PR #981, mark the WakePass job DONE, or change NudgeOnly/PushOnly behavior.
- Does not broaden WakePass cleanup into general HarnessKit or AutoPilot queue work.

Verification:
- `npm --workspace @unclick/mcp-server exec vitest run src/igniteonly-tool.test.ts` passed, 10 tests.
- `npm --workspace @unclick/mcp-server exec vitest run src/nudgeonly-tool.test.ts src/igniteonly-tool.test.ts src/pushonly-tool.test.ts` passed, 36 tests.
- `npm --workspace @unclick/mcp-server run build` passed.
- `git diff --check` passed.

Risk:
- Low. This only allows one named cleanup worker alias for `duplicate_wake`; unknown worker overrides still block.
- No secrets, billing, DNS, production data, migrations, or auth changes.

Follow-up:
- After review and merge, rerun the PR #981 stale blocker through NudgeOnly/IgniteOnly and confirm the route no longer blocks on `known_worker`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly expands allowed worker routing for `duplicate_wake` to a single known alias and adds tests; no changes to verification gates or wake packet redaction beyond coverage.
> 
> **Overview**
> Enables verified `duplicate_wake` escalation requests to route to the dedicated `wakepass-cleanup-worker` lane while keeping `Job Manager` as the default route.
> 
> Updates IgniteOnly routing to support per-painpoint `worker_aliases` and validates explicit worker overrides against the route’s allowed set, and adds a regression test covering the PR #981 cleanup wake packet shape (including `source_url` token redaction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4ced27d2b984b93b861a29f756005c6af423b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->