### PR TITLE
fix(harnesskit): label queued work as needing claim

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -505,6 +505,8 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     nowMs,
     newestActivityAt,
     activeTodos,
+    activeJobsCount,
+    queuedTodoCount,
     continuityEvents,
     blockers,
     profileLastSeenByAgent,
@@ -674,11 +676,12 @@ function buildSeatHandshake({
   const recentProof = usefulEvents.find((event) => event.kind === "proof") ?? null;
   const decision = rollingSnapshot.promoted_decisions[0] ?? null;
   const job = rollingSnapshot.active_jobs[0] ?? null;
+  const jobIsQueued = job?.tags?.includes("open") ?? false;
   const blocker = rollingSnapshot.active_blockers[0] ?? null;
   const activeDecision =
     decision?.summary ??
     (job
-      ? `Continue current priority job: ${job.summary}`
+      ? `${jobIsQueued ? "Claim current priority queued job" : "Continue current active job"}: ${job.summary}`
       : recentProof
         ? `Continue from latest proof: ${recentProof.summary}`
         : blocker
@@ -712,7 +715,7 @@ function buildSeatHandshake({
       320,
     ),
     active_decision: activeDecision,
-    active_job: job?.summary ?? null,
+    active_job: job ? `${jobIsQueued ? "Queued job needs claim: " : ""}${job.summary}` : null,
     recent_proof: recentProof?.summary ?? null,
     active_blocker: blocker?.summary ?? null,
     seat_freshness: seatFreshness,
@@ -768,6 +771,8 @@ function buildRollingSnapshot({
   nowMs,
   newestActivityAt,
   activeTodos,
+  activeJobsCount,
+  queuedTodoCount,
   continuityEvents,
   blockers,
   profileLastSeenByAgent,
@@ -776,6 +781,8 @@ function buildRollingSnapshot({
   nowMs: number;
   newestActivityAt: string | null;
   activeTodos: OrchestratorTodoRow[];
+  activeJobsCount: number;
+  queuedTodoCount: number;
   continuityEvents: OrchestratorContinuityEvent[];
   blockers: string[];
   profileLastSeenByAgent: Map<string, string | null>;
@@ -814,7 +821,11 @@ function buildRollingSnapshot({
     mode: "read-plan",
     summary: compactText(
       [
-        `${activeJobs.length} active job${activeJobs.length === 1 ? "" : "s"}`,
+        activeJobsCount > 0
+          ? `${activeJobsCount} fresh active job${activeJobsCount === 1 ? "" : "s"}`
+          : queuedTodoCount > 0
+            ? `0 fresh active jobs, ${queuedTodoCount} queued job${queuedTodoCount === 1 ? "" : "s"} needing claim`
+            : "0 fresh active jobs, 0 queued jobs",
         `${promotedDecisions.length} promoted decision${promotedDecisions.length === 1 ? "" : "s"}`,
         `${activeBlockers.length || blockers.length} blocker signal${(activeBlockers.length || blockers.length) === 1 ? "" : "s"}`,
       ].join(", "),
@@ -825,7 +836,7 @@ function buildRollingSnapshot({
     persistence_plan: {
       recommended_key: "orchestrator:rolling-current-state:v1",
       retention: "Keep compact rolling snapshots and source pointers; refresh from live sources instead of storing duplicate raw rows.",
-      compaction: "Promote decisions, blockers, active jobs, and recent non-noise continuity only.",
+      compaction: "Promote decisions, blockers, queued or active job pointers, and recent non-noise continuity only.",
       raw_transcript_policy: "Do not persist raw transcripts, heartbeat noise, secret-shaped text, or bulk pasted content in the snapshot.",
     },
     promoted_decisions: promotedDecisions,

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -194,6 +194,8 @@ describe("orchestrator context", () => {
 
     expect(context.current_state_card.active_jobs).toBe(0);
     expect(context.current_state_card.queued_todo_count).toBe(1);
+    expect(context.current_state_card.health_verdict.verdict).toBe("BLOCKER");
+    expect(context.current_state_card.health_verdict.reason).toContain("queued");
     expect(context.current_state_card.harness_card.queue_state).toBe("needs_claim");
     expect(context.current_state_card.harness_card.gate_status).toBe("red");
     expect(context.current_state_card.harness_card.gate_reason).toContain("no fresh active owner");

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -200,6 +200,10 @@ describe("orchestrator context", () => {
     expect(context.current_state_card.harness_card.gate_status).toBe("red");
     expect(context.current_state_card.harness_card.gate_reason).toContain("no fresh active owner");
     expect(context.current_state_card.harness_card.queue_truth).toContain("red, not healthy");
+    expect(context.rolling_snapshot.summary).toContain("0 fresh active jobs, 1 queued job needing claim");
+    expect(context.rolling_snapshot.summary).not.toContain("1 active job");
+    expect(context.seat_handshake.active_decision).toContain("Claim current priority queued job");
+    expect(context.seat_handshake.active_job).toContain("Queued job needs claim");
     expect(context.current_state_card.harness_card.required_proof).toContain(
       "DONE, 100%, green chips, and proof badges are hints only until proof is observable",
     );
@@ -990,8 +994,9 @@ describe("orchestrator context", () => {
     });
 
     expect(context.rolling_snapshot.promoted_decisions).toHaveLength(0);
-    expect(context.seat_handshake.active_decision).toContain("Continue current priority job");
+    expect(context.seat_handshake.active_decision).toContain("Claim current priority queued job");
     expect(context.seat_handshake.active_decision).toContain("Orchestrator finish line proof");
+    expect(context.seat_handshake.active_job).toContain("Queued job needs claim");
     expect(context.seat_handshake.active_job).toContain("Orchestrator finish line proof");
     expect(context.seat_handshake.recent_proof).toContain("trusted fallback gate shipped");
     expect(context.seat_handshake.source_pointers.map((pointer) => pointer.source_id)).toEqual(


### PR DESCRIPTION
Summary:
- Fixes HarnessKit rolling snapshot wording so queued Boardroom work with active_jobs=0 says it needs claim, not active work.
- Fixes fresh-seat handoff wording so an open queued job says "Claim current priority queued job" and "Queued job needs claim".
- Keeps the existing BLOCKER verdict regression for open backlog with no fresh active owner.

Scope:
- Lane: HarnessKit / AutoPilot queue truth.
- Boardroom todo: 442f8f25-7507-4375-a71f-5c0044ffad24.
- Files touched: api/lib/orchestrator-context.ts, api/orchestrator-context.test.ts.

Non-overlap:
- No CopyRoom, WakePass, SeatRelay, Memory Library, auth, schema, billing, DNS, production data, or broad HarnessKit rewrite.
- Does not close the parent HarnessKit job.

Verification:
- npm run test -- api/orchestrator-context.test.ts: 32/32 passed.
- npm run test -- api/fishbowl-completion-policy.test.ts api/fishbowl-job-pipeline.test.ts api/orchestrator-context.test.ts: 45/45 passed.
- node --test scripts/pinballwake-autonomous-runner.test.mjs: 54/54 passed.
- npm run build: passed.
- git diff --check: passed with line-ending warnings only.

Risk:
- Narrow Orchestrator wording/queue-truth fix plus tests. No migration, auth, secrets, cron, API, or user-facing UI risk.

Follow-up:
- After review/merge, continue product-facing HarnessKit proof gates and compact harness-card consumption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to wording/summary generation for queued vs active work in orchestrator rolling snapshot and seat handoff, with updated tests covering the new behavior.
> 
> **Overview**
> Improves Orchestrator/HarnessKit queue-truth messaging so when `active_jobs=0` but there is queued Boardroom work, the rolling snapshot summary and persistence-plan wording explicitly call out **queued jobs needing claim** rather than implying active work.
> 
> Updates the fresh-seat handshake to detect queued jobs (via `open` tag) and change the decision/job strings to **“Claim current priority queued job”** / **“Queued job needs claim”**, with tests updated to assert the new snapshot and handshake text plus the existing `BLOCKER` health verdict behavior for unclaimed backlog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224142ee78cb40d80d0c9ee30a2b4b946068d830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->