### PR TITLE
feat(memory): add library snapshot refresh gate

### DIFF
--- a/api/memory-admin-refresh.test.ts
+++ b/api/memory-admin-refresh.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAdminLibraryRefreshPayload,
+  parseAdminLibraryRefreshOptions,
+} from "./memory-admin";
+
+describe("admin library taxonomy refresh safety", () => {
+  it("defaults refresh requests to dry-run mode", () => {
+    const parsed = parseAdminLibraryRefreshOptions({}, {});
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.commit).toBe(false);
+    expect(parsed.options).toMatchObject({
+      dry_run: true,
+      max_sources: 80,
+      max_snapshots: 12,
+      max_sources_per_snapshot: 8,
+    });
+  });
+
+  it("requires explicit commit before writes", () => {
+    const parsed = parseAdminLibraryRefreshOptions({ dry_run: false }, {});
+
+    expect(parsed.error).toBe("commit=true is required when dry_run=false");
+  });
+
+  it("treats commit=true as the explicit write path", () => {
+    const parsed = parseAdminLibraryRefreshOptions(
+      { commit: true, max_sources: 999, max_snapshots: 40, max_sources_per_snapshot: 100 },
+      {},
+    );
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.commit).toBe(true);
+    expect(parsed.options).toMatchObject({
+      dry_run: false,
+      max_sources: 250,
+      max_snapshots: 30,
+      max_sources_per_snapshot: 25,
+    });
+  });
+
+  it("rejects conflicting commit and dry-run inputs", () => {
+    const parsed = parseAdminLibraryRefreshOptions({ commit: "true", dry_run: "true" }, {});
+
+    expect(parsed.error).toBe("commit=true conflicts with dry_run=true");
+  });
+
+  it("adds receipt counts without exposing snapshot content", () => {
+    const payload = buildAdminLibraryRefreshPayload(
+      {
+        dry_run: false,
+        generated_at: "2026-05-21T15:00:00.000Z",
+        source_count: 5,
+        snapshot_count: 2,
+        written_count: 2,
+        snapshots: [
+          {
+            slug: "memory-taxonomy-15-data-and-memory",
+            title: "Data memory snapshot",
+            primary_category: "15 Data & Memory",
+            source_ids: ["fact-1"],
+            source_receipts: [
+              {
+                memory_id: "fact:fact-1",
+                source_kind: "fact",
+                source_uri: "/admin/memory?tab=facts",
+                redaction_state: "clean",
+              },
+            ],
+          },
+        ],
+        written: [
+          {
+            slug: "memory-taxonomy-15-data-and-memory",
+            title: "Data memory snapshot",
+            message: "Library doc updated",
+          },
+        ],
+      },
+      1,
+    );
+
+    expect(payload.planned_snapshot_count).toBe(2);
+    expect(payload.skipped_secret_count).toBe(1);
+    expect(JSON.stringify(payload)).not.toContain("content");
+  });
+});

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -188,6 +188,16 @@ import {
   effectiveMemoryTier,
   isMemoryQuotaExemptEmail,
 } from "../packages/mcp-server/src/memory/quota-policy.js";
+import {
+  isSensitiveMemorySnapshotText,
+  writeMemoryTaxonomySnapshotsToLibrary,
+} from "../packages/mcp-server/src/memory/supabase.js";
+import type {
+  LibraryDocInput,
+  MemoryTaxonomySnapshotSource,
+  MemoryTaxonomySnapshotWriteOptions,
+  MemoryTaxonomySnapshotWriteResult,
+} from "../packages/mcp-server/src/memory/types.js";
 import { streamText, tool, stepCountIs, convertToModelMessages, type UIMessage, type ModelMessage } from "ai";
 import { z } from "zod";
 import * as crypto from "crypto";
@@ -344,6 +354,199 @@ function getClampedLimit(value: unknown, fallback = 50, max = 200): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
   return Math.min(Math.floor(parsed), max);
+}
+
+function firstRequestValue(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseBooleanRequestValue(value: unknown, fallback: boolean): boolean {
+  const first = firstRequestValue(value);
+  if (typeof first === "boolean") return first;
+  if (typeof first === "number") return first !== 0;
+  if (typeof first !== "string") return fallback;
+  const normalized = first.trim().toLowerCase();
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+  return fallback;
+}
+
+export interface AdminLibraryRefreshParseResult {
+  commit: boolean;
+  options: MemoryTaxonomySnapshotWriteOptions;
+  error?: string;
+}
+
+export function parseAdminLibraryRefreshOptions(
+  body: Record<string, unknown> = {},
+  query: Record<string, unknown> = {},
+): AdminLibraryRefreshParseResult {
+  const rawCommit = body.commit ?? query.commit;
+  const rawDryRun = body.dry_run ?? query.dry_run;
+  const commit = parseBooleanRequestValue(rawCommit, false);
+  const dryRun = rawDryRun === undefined
+    ? !commit
+    : parseBooleanRequestValue(rawDryRun, true);
+
+  if (commit && dryRun) {
+    return {
+      commit,
+      options: { dry_run: dryRun },
+      error: "commit=true conflicts with dry_run=true",
+    };
+  }
+  if (!dryRun && !commit) {
+    return {
+      commit,
+      options: { dry_run: dryRun },
+      error: "commit=true is required when dry_run=false",
+    };
+  }
+
+  return {
+    commit,
+    options: {
+      dry_run: dryRun,
+      max_sources: getClampedLimit(body.max_sources ?? query.max_sources, 80, 250),
+      max_snapshots: getClampedLimit(body.max_snapshots ?? query.max_snapshots, 12, 30),
+      max_sources_per_snapshot: getClampedLimit(
+        body.max_sources_per_snapshot ?? query.max_sources_per_snapshot,
+        8,
+        25,
+      ),
+    },
+  };
+}
+
+type AdminLibraryRefreshPayload = MemoryTaxonomySnapshotWriteResult & {
+  planned_snapshot_count: number;
+  skipped_secret_count: number;
+};
+
+export function buildAdminLibraryRefreshPayload(
+  result: MemoryTaxonomySnapshotWriteResult,
+  skippedSecretCount: number,
+): AdminLibraryRefreshPayload {
+  return {
+    ...result,
+    planned_snapshot_count: result.snapshot_count,
+    skipped_secret_count: skippedSecretCount,
+  };
+}
+
+async function readAdminLibraryTaxonomySources(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+  maxSources: number,
+): Promise<MemoryTaxonomySnapshotSource[]> {
+  const factLimit = Math.max(1, Math.min(250, maxSources));
+  const sessionLimit = Math.max(1, Math.floor(factLimit / 2));
+  const [factsRes, sessionsRes] = await Promise.all([
+    supabase
+      .from("mc_extracted_facts")
+      .select("id, fact, category, confidence, created_at, updated_at, valid_from")
+      .eq("api_key_hash", apiKeyHash)
+      .eq("status", "active")
+      .is("invalidated_at", null)
+      .order("confidence", { ascending: false })
+      .order("updated_at", { ascending: false })
+      .limit(factLimit),
+    supabase
+      .from("mc_session_summaries")
+      .select("id, summary, topics, created_at")
+      .eq("api_key_hash", apiKeyHash)
+      .order("created_at", { ascending: false })
+      .limit(sessionLimit),
+  ]);
+  if (factsRes.error) throw factsRes.error;
+  if (sessionsRes.error) throw sessionsRes.error;
+
+  type FactRow = {
+    id: string;
+    fact: string;
+    category?: string | null;
+    confidence?: number | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    valid_from?: string | null;
+  };
+  type SessionRow = {
+    id: string;
+    summary: string;
+    topics?: string[] | null;
+    created_at?: string | null;
+  };
+
+  const factSources: MemoryTaxonomySnapshotSource[] = ((factsRes.data ?? []) as FactRow[]).map((row) => ({
+    id: row.id,
+    kind: "fact",
+    text: row.fact,
+    category: row.category ?? undefined,
+    confidence: row.confidence ?? null,
+    created_at: row.created_at ?? null,
+    updated_at: row.updated_at ?? null,
+    valid_from: row.valid_from ?? null,
+  }));
+  const sessionSources: MemoryTaxonomySnapshotSource[] = ((sessionsRes.data ?? []) as SessionRow[]).map((row) => ({
+    id: row.id,
+    kind: "session",
+    text: row.summary,
+    category: Array.isArray(row.topics) && row.topics.length > 0 ? row.topics.join(" ") : "session",
+    confidence: 0.75,
+    created_at: row.created_at ?? null,
+    updated_at: row.created_at ?? null,
+    valid_from: row.created_at ?? null,
+  }));
+
+  return [...factSources, ...sessionSources];
+}
+
+async function upsertAdminLibraryDoc(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+  data: LibraryDocInput,
+): Promise<string> {
+  const { data: existing, error: existingError } = await supabase
+    .from("mc_knowledge_library")
+    .select("id, version")
+    .eq("api_key_hash", apiKeyHash)
+    .eq("slug", data.slug)
+    .maybeSingle();
+  if (existingError) throw existingError;
+
+  if (existing) {
+    const nextVersion = Number(existing.version ?? 1) + 1;
+    const { error } = await supabase
+      .from("mc_knowledge_library")
+      .update({
+        title: data.title,
+        category: data.category,
+        content: data.content,
+        tags: data.tags,
+        last_accessed: new Date().toISOString(),
+        decay_tier: "hot",
+      })
+      .eq("api_key_hash", apiKeyHash)
+      .eq("id", existing.id);
+    if (error) throw error;
+    return `Library doc updated: "${data.title}" (v${nextVersion})`;
+  }
+
+  const { error } = await supabase
+    .from("mc_knowledge_library")
+    .insert({
+      api_key_hash: apiKeyHash,
+      slug: data.slug,
+      title: data.title,
+      category: data.category,
+      content: data.content,
+      tags: data.tags,
+      version: 1,
+      decay_tier: "hot",
+      last_accessed: new Date().toISOString(),
+    });
+  if (error) throw error;
+  return `Library doc created: "${data.title}" (v1)`;
 }
 
 const BACKGROUND_RECALL_CATEGORIES = new Set(["identity", "preference", "standing_rule"]);
@@ -3812,6 +4015,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
         if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
         const method = (req.body?.method ?? req.query.method ?? "list") as string;
+
+        if (method === "refresh" || method === "refresh_taxonomy_snapshots") {
+          if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+          const parsed = parseAdminLibraryRefreshOptions(req.body ?? {}, req.query as Record<string, unknown>);
+          if (parsed.error) return res.status(400).json({ error: parsed.error });
+
+          const sources = await readAdminLibraryTaxonomySources(
+            supabase,
+            apiKeyHash,
+            parsed.options.max_sources ?? 80,
+          );
+          const skippedSecretCount = sources.filter((source) =>
+            isSensitiveMemorySnapshotText(String(source.text ?? ""))
+          ).length;
+          const result = await writeMemoryTaxonomySnapshotsToLibrary({
+            sources,
+            options: parsed.options,
+            upsertLibraryDoc: (doc) => upsertAdminLibraryDoc(supabase, apiKeyHash, doc),
+          });
+
+          return res.status(200).json({
+            success: true,
+            data: buildAdminLibraryRefreshPayload(result, skippedSecretCount),
+          });
+        }
 
         if (method === "view") {
           const docId = req.body?.id ?? req.query.id;

--- a/src/pages/admin/memory/LibraryTab.test.tsx
+++ b/src/pages/admin/memory/LibraryTab.test.tsx
@@ -77,4 +77,58 @@ describe("LibraryTab", () => {
     });
     expect(screen.getByText("Data memory snapshot")).toBeInTheDocument();
   });
+
+  it("previews and commits taxonomy refresh with an explicit write request", async () => {
+    const refreshBodies: Array<Record<string, unknown>> = [];
+    let listCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("method=list")) {
+          listCalls += 1;
+          return jsonResponse({ data: listCalls === 1 ? [] : docs });
+        }
+        if (url.includes("action=admin_library") && init?.method === "POST") {
+          const body = JSON.parse(String(init.body ?? "{}"));
+          refreshBodies.push(body);
+          return jsonResponse({
+            data: {
+              dry_run: body.dry_run,
+              source_count: 7,
+              snapshot_count: 2,
+              planned_snapshot_count: 2,
+              written_count: body.commit ? 2 : 0,
+              skipped_secret_count: 1,
+            },
+          });
+        }
+        return jsonResponse({});
+      }),
+    );
+
+    render(React.createElement(LibraryTab, { apiKey: "test-key" }));
+
+    await screen.findByText("No Library Snapshots yet");
+
+    fireEvent.click(screen.getByRole("button", { name: /Preview Refresh/i }));
+    await waitFor(() => {
+      expect(refreshBodies[0]).toMatchObject({
+        method: "refresh_taxonomy_snapshots",
+        commit: false,
+        dry_run: true,
+      });
+    });
+    expect(screen.getByText(/Preview: 2 planned, 0 written, 7 sources, 1 skipped/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Write Snapshots/i }));
+    await waitFor(() => {
+      expect(refreshBodies[1]).toMatchObject({
+        method: "refresh_taxonomy_snapshots",
+        commit: true,
+        dry_run: false,
+      });
+    });
+    await screen.findByText("Projects memory snapshot");
+  });
 });

--- a/src/pages/admin/memory/LibraryTab.tsx
+++ b/src/pages/admin/memory/LibraryTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { ChevronDown, ChevronRight, BookOpen, History } from "lucide-react";
+import { ChevronDown, ChevronRight, BookOpen, History, RefreshCw } from "lucide-react";
 import { groupMemoryTaxonomyShelves } from "@/lib/memoryTaxonomy";
 import EmptyState from "./EmptyState";
 
@@ -24,6 +24,14 @@ interface HistoryEntry {
   created_at: string;
 }
 
+interface RefreshResult {
+  dry_run: boolean;
+  source_count: number;
+  planned_snapshot_count: number;
+  written_count: number;
+  skipped_secret_count?: number;
+}
+
 const DECAY_COLORS: Record<string, string> = {
   hot: "bg-red-500",
   warm: "bg-amber-500",
@@ -44,6 +52,9 @@ export default function LibraryTab({ apiKey }: { apiKey: string }) {
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [collapsedShelfIds, setCollapsedShelfIds] = useState<Set<string>>(() => new Set());
+  const [refreshing, setRefreshing] = useState<"preview" | "commit" | null>(null);
+  const [refreshResult, setRefreshResult] = useState<RefreshResult | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
   const shelves = useMemo(() => groupMemoryTaxonomyShelves(docs), [docs]);
 
   const load = useCallback(async () => {
@@ -61,6 +72,36 @@ export default function LibraryTab({ apiKey }: { apiKey: string }) {
   }, [apiKey]);
 
   useEffect(() => { load(); }, [load]);
+
+  const refreshTaxonomy = async (commit: boolean) => {
+    setRefreshing(commit ? "commit" : "preview");
+    setRefreshError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=admin_library", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          method: "refresh_taxonomy_snapshots",
+          commit,
+          dry_run: !commit,
+          max_sources: 80,
+          max_snapshots: 12,
+          max_sources_per_snapshot: 8,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Refresh failed");
+      setRefreshResult(body.data ?? null);
+      if (commit) await load();
+    } catch (error) {
+      setRefreshError(error instanceof Error ? error.message : "Refresh failed");
+    } finally {
+      setRefreshing(null);
+    }
+  };
 
   const viewDoc = async (doc: LibraryDoc) => {
     if (expandedId === doc.id) {
@@ -114,27 +155,69 @@ export default function LibraryTab({ apiKey }: { apiKey: string }) {
     });
   };
 
+  const refreshControls = (
+    <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+      <div className="min-h-5 text-xs text-white/40">
+        {refreshResult && (
+          <span>
+            {refreshResult.dry_run ? "Preview" : "Write"}: {refreshResult.planned_snapshot_count} planned,
+            {" "}{refreshResult.written_count} written,
+            {" "}{refreshResult.source_count} sources
+            {typeof refreshResult.skipped_secret_count === "number"
+              ? `, ${refreshResult.skipped_secret_count} skipped`
+              : ""}
+          </span>
+        )}
+        {refreshError && <span className="text-red-300">{refreshError}</span>}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => refreshTaxonomy(false)}
+          disabled={refreshing !== null}
+          className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] px-3 py-1.5 text-xs font-medium text-white/60 transition-colors hover:bg-white/[0.04] hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing === "preview" ? "animate-spin" : ""}`} />
+          Preview Refresh
+        </button>
+        <button
+          type="button"
+          onClick={() => refreshTaxonomy(true)}
+          disabled={refreshing !== null}
+          className="inline-flex items-center gap-1.5 rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <BookOpen className="h-3.5 w-3.5" />
+          Write Snapshots
+        </button>
+      </div>
+    </div>
+  );
+
   if (loading) {
     return <div className="space-y-3">{[1,2,3].map(i => <div key={i} className="h-20 animate-pulse rounded-lg bg-white/[0.03] border border-white/[0.06]" />)}</div>;
   }
 
   if (docs.length === 0) {
     return (
-      <EmptyState
-        icon={BookOpen}
-        heading="No Library Snapshots yet"
-        description="Automatic taxonomy snapshots appear here once durable facts and sessions are compacted into source-linked memory shelves."
-        steps={[
-          "Save durable facts, decisions, and project state through Memory",
-          "Snapshots group related facts by taxonomy and keep source pointers",
-          "AI seats read compact shelves first, then open raw sources only when needed",
-        ]}
-      />
+      <div className="space-y-3">
+        {refreshControls}
+        <EmptyState
+          icon={BookOpen}
+          heading="No Library Snapshots yet"
+          description="Automatic taxonomy snapshots appear here once durable facts and sessions are compacted into source-linked memory shelves."
+          steps={[
+            "Save durable facts, decisions, and project state through Memory",
+            "Snapshots group related facts by taxonomy and keep source pointers",
+            "AI seats read compact shelves first, then open raw sources only when needed",
+          ]}
+        />
+      </div>
     );
   }
 
   return (
     <div className="space-y-5">
+      {refreshControls}
       {shelves.map((shelf) => {
         const isCollapsed = collapsedShelfIds.has(shelf.id);
         return (


### PR DESCRIPTION
Summary:
- Adds an owner-authenticated `admin_library` refresh method for Memory taxonomy snapshots.
- Keeps refresh dry-run-first and requires `commit=true` before any snapshot write.
- Adds Library tab controls to preview and explicitly write source-linked snapshots.

Scope:
- Memory Library lane: `api/memory-admin.ts`, `api/memory-admin-refresh.test.ts`, `src/pages/admin/memory/LibraryTab.tsx`, `src/pages/admin/memory/LibraryTab.test.tsx`.
- Boardroom job: b4331f02 Memory Library live taxonomy snapshot writer/storage proof.

Non-overlap:
- No schema migration, scheduler, destructive cleanup, raw transcript storage, secrets, billing, DNS, or production data access.
- Does not close the Memory Library job as DONE; live authenticated API proof is still required after deploy.

Verification:
- `npm run test --workspace=@unclick/mcp-server -- --test-name-pattern="memory taxonomy snapshots"` passed; node test suite reported 53/53 passed.
- `npx vitest run api/memory-admin-refresh.test.ts src/pages/admin/memory/LibraryTab.test.tsx` passed 7/7.
- `npx tsc --noEmit --pretty false` passed.
- `npm run build` passed.
- `git diff --check` passed.

Risk:
- Write path is gated behind authenticated admin Library route and explicit `commit=true`; dry-run remains default.
- Response proof contains counts, slugs, source ids, and receipt states, not stored snapshot content.

Follow-up:
- After deploy, run authenticated `admin_library` dry-run, then explicit commit if safe, and attach live/API proof that Library returns source-linked snapshot rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new admin API path that can write/update knowledge library rows in Supabase; although writes are gated behind an explicit `commit=true` (dry-run default), mistakes could still impact stored library snapshots.
> 
> **Overview**
> Adds an owner-authenticated `admin_library` refresh endpoint (`POST /api/memory-admin?action=admin_library`) to generate Memory taxonomy snapshots from recent facts/sessions and optionally upsert them into the knowledge library.
> 
> Refresh is **dry-run by default** and requires an explicit `commit=true` to perform any writes, with request limits clamped and conflicts rejected; the response now returns only counts/receipts (plus skipped-sensitive counts) rather than snapshot content.
> 
> Updates the Admin Memory *Library* tab UI to provide **Preview Refresh** and **Write Snapshots** controls, and adds tests covering the gating/limits behavior and the UI’s preview→commit flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4455a1719bcc3e15e73990eed7aa7edb93d8eedc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->