### PR TITLE
[codex] fix CopyRoom required receipt guard

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6837,8 +6837,8 @@
     },
     {
       "source": "packages/mcp-server/src/copypass-tool.ts",
-      "hash": "0a26dc5c960d",
-      "bytes": 13895
+      "hash": "2a5f73ece606",
+      "bytes": 14259
     },
     {
       "source": "packages/mcp-server/src/crews-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -77,7 +77,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/coinmarketcap-tool.ts | b1c5fd280acb | 6892 |
 | packages/mcp-server/src/color-tool.ts | f9aa9c0fec6e | 13643 |
 | packages/mcp-server/src/convertkit-tool.ts | 2f77303a3441 | 8498 |
-| packages/mcp-server/src/copypass-tool.ts | 0a26dc5c960d | 13895 |
+| packages/mcp-server/src/copypass-tool.ts | 2a5f73ece606 | 14259 |
 | packages/mcp-server/src/crews-tool.ts | 18a489d3ab94 | 5750 |
 | packages/mcp-server/src/csuite-tool.ts | 0ab5af89bb49 | 70236 |
 | packages/mcp-server/src/datadog-tool.ts | 802b808614cd | 5556 |

--- a/packages/mcp-server/src/copypass-tool.test.ts
+++ b/packages/mcp-server/src/copypass-tool.test.ts
@@ -41,6 +41,7 @@ describe("copypass-tool", () => {
   it("attaches a CopyRoom exact-copy receipt from a source packet", async () => {
     const sourceText = "Line 1\r\nLine 2 with symbols: GBP, EUR, emoji ok";
     const run = (await copypassRun({
+      copyroom_required: true,
       copyroom_source_packet: {
         source_id: "jobsmith-checklist-source",
         source_pointer: "apps/jobsmith/docs/copyroom/cv-checklists/cv-checklists_1.md",
@@ -87,6 +88,28 @@ describe("copypass-tool", () => {
 
     expect(status.copyroom_receipt?.status).toBe("pass");
     expect(status.copyroom_receipt?.source_sha256).toBe(status.copyroom_receipt?.output_sha256);
+  });
+
+  it("blocks required CopyRoom receipt runs when the source packet is missing", async () => {
+    const result = (await copypassRun({
+      copy_text: "Exact source text needs a real CopyRoom packet.",
+      copyroom_required: true,
+      copyroom_output_pointer: "mcp://copypass/runs/missing-source",
+    })) as { error?: string; run_id?: string; copyroom_receipt?: unknown };
+
+    expect(result.run_id).toBeUndefined();
+    expect(result.error).toContain("COPYROOM_MISSING");
+    expect(result.copyroom_receipt).toBeNull();
+  });
+
+  it("still allows non-fidelity CopyPass runs without a CopyRoom packet", async () => {
+    const result = (await copypassRun({
+      copy_text: "A normal copy review can run without exact-copy proof.",
+      profile: "smoke",
+    })) as { status?: string; copyroom_receipt?: unknown };
+
+    expect(result.status).toBe("complete");
+    expect(result.copyroom_receipt).toBeNull();
   });
 
   it("blocks CopyRoom source-copy drift before creating a run", async () => {

--- a/packages/mcp-server/src/copypass-tool.ts
+++ b/packages/mcp-server/src/copypass-tool.ts
@@ -211,7 +211,7 @@ export async function copypassRun(args: Record<string, unknown>): Promise<unknow
   if (prepared.error) {
     return {
       error: prepared.error,
-      copyroom_receipt: prepared.copyroomReceipt,
+      copyroom_receipt: prepared.copyroomReceipt ?? null,
     };
   }
   const copyText = prepared.copyText;
@@ -268,6 +268,7 @@ export async function copypassStatus(args: Record<string, unknown>): Promise<unk
 
 function prepareCopyText(args: Record<string, unknown>): CopyRoomPreparedCopy {
   const rawSourcePacket = args.copyroom_source_packet;
+  const copyroomRequired = requiresCopyRoomReceipt(args.copyroom_required);
   if (rawSourcePacket !== undefined && rawSourcePacket !== null) {
     const packetInput = parseCopyRoomSourcePacketInput(rawSourcePacket);
     if (!packetInput) {
@@ -293,9 +294,20 @@ function prepareCopyText(args: Record<string, unknown>): CopyRoomPreparedCopy {
     return { copyText: outputText, copyroomReceipt: receipt };
   }
 
+  if (copyroomRequired) {
+    return {
+      copyText: "",
+      error: "COPYROOM_MISSING: copyroom_source_packet is required when copyroom_required is true.",
+    };
+  }
+
   return {
     copyText: typeof args.copy_text === "string" ? args.copy_text.trim() : "",
   };
+}
+
+function requiresCopyRoomReceipt(value: unknown): boolean {
+  return value === true || value === "true";
 }
 
 function parseCopyRoomSourcePacketInput(value: unknown): CopyRoomSourcePacketInput | null {

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12314,12 +12314,16 @@ export const ADDITIONAL_TOOLS = [
   // ── copypass-tool.ts (copy quality QC with CopyRoom receipt support) ─────
   {
     name: "copypass_run",
-    description: "Start a CopyPass run for AI-generated copy. When exact fidelity matters, pass copyroom_source_packet so the run attaches a CopyRoom receipt instead of relying on retyped source text.",
+    description: "Start a CopyPass run for AI-generated copy. When exact fidelity matters, set copyroom_required=true and pass copyroom_source_packet so the run attaches a CopyRoom receipt instead of relying on retyped source text.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
         copy_text: { type: "string", description: "The AI-generated copy to review. Optional when copyroom_source_packet is provided; exact-copy verification compares this text byte-for-byte against the packet." },
+        copyroom_required: {
+          type: "boolean",
+          description: "Set true when exact fidelity matters. Missing copyroom_source_packet returns COPYROOM_MISSING instead of a run with a null receipt.",
+        },
         copyroom_source_packet: {
           type: "object",
           additionalProperties: false,

--- a/src/pages/admin/copypass/CopyPassCatalog.tsx
+++ b/src/pages/admin/copypass/CopyPassCatalog.tsx
@@ -96,7 +96,8 @@ export default function CopyPassCatalog() {
               <h2 className="text-sm font-semibold text-white">Available now through MCP scaffold</h2>
               <p className="mt-1 text-sm text-[#888]">
                 `copypass_run` accepts `copy_text` plus optional `channel`, `audience`, and `goal` fields today.
-                `copypass_status` polls the in-session scaffold run record.
+                For exact-copy work, send `copyroom_required: true` with `copyroom_source_packet` so missing source proof blocks instead of returning a null receipt.
+                `copypass_status` polls the in-session scaffold run record and attached CopyRoom receipt.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## What changed
- Added `copyroom_required` to `copypass_run` so exact-fidelity work blocks with `COPYROOM_MISSING` when no source packet is supplied.
- Kept normal non-fidelity CopyPass runs working without a CopyRoom packet.
- Updated the MCP tool schema and admin CopyPass wording so workers know how to request a real CopyRoom receipt.

## Why
Live CopyPass probes could return `copyroom_receipt: null`, which made exact-copy work too easy to misread as proof. Exact-fidelity work should either attach a receipt or clearly block.

## Proof
- `npx vitest run src/copypass-tool.test.ts` from `packages/mcp-server`: 8 tests passed.
- `npm run test --workspace=packages/mcp-server`: 53 node tests and 116 Vitest tests passed.
- `npm run build --workspace=packages/mcp-server`: passed.
- `npm run build`: passed.

## Scope
Files touched are limited to CopyPass MCP logic/tests, tool schema, and CopyPass admin wording.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `copypass_run` behavior to block runs when `copyroom_required` is set but no `copyroom_source_packet` is provided, which can affect existing callers and workflows relying on null receipts.
> 
> **Overview**
> **CopyPass now has an explicit “exact-fidelity” mode.** `copypass_run` adds a `copyroom_required` flag; when true, the run fails fast with `COPYROOM_MISSING` unless a `copyroom_source_packet` is supplied, rather than creating a run with a null receipt.
> 
> Tool schema, admin CopyPass copy, and tests are updated to document/verify the new guardrail, while keeping normal (non-required) CopyPass runs working without CopyRoom input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70034ed660e14705229a3c8ff7fb5718b70d1922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->