### PR TITLE
fix(orchestrator): enforce log-read gate

### DIFF
--- a/packages/channel-plugin/index.js
+++ b/packages/channel-plugin/index.js
@@ -36,6 +36,7 @@ import { apiFetchJson } from "./http.js";
 import { createHeartbeatGate } from "./heartbeat-gate.js";
 import { readTimingConfig } from "./config.js";
 import {
+  createLogReadDecideGate,
   getReceiptFirstTetherLadder,
   orchestratorContextReadTool,
   readOrchestratorContext,
@@ -55,6 +56,7 @@ const timingConfig = readTimingConfig();
 const POLL_INTERVAL = timingConfig.pollIntervalMs;
 const API_TIMEOUT_MS = timingConfig.apiTimeoutMs;
 const heartbeatGate = createHeartbeatGate();
+const logReadDecideGate = createLogReadDecideGate();
 
 function log(...args) {
   // Channel hosts use stdio for JSON-RPC, so keep human logs on stderr.
@@ -178,7 +180,7 @@ async function handleRpcLine(line) {
     }
     if (name === "unclick_save_conversation_turn") {
       try {
-        const result = await saveConversationTurn(apiFetch, args);
+        const result = await saveConversationTurn(apiFetch, args, { gate: logReadDecideGate });
         writeRpc({
           jsonrpc: "2.0",
           id: msg.id,
@@ -221,7 +223,7 @@ async function handleRpcLine(line) {
     }
     if (name === "unclick_orchestrator_context_read") {
       try {
-        const result = await readOrchestratorContext(apiFetch, args);
+        const result = await readOrchestratorContext(apiFetch, args, { gate: logReadDecideGate });
         writeRpc({
           jsonrpc: "2.0",
           id: msg.id,

--- a/packages/channel-plugin/orchestrator-turns.js
+++ b/packages/channel-plugin/orchestrator-turns.js
@@ -2,6 +2,7 @@ const ALLOWED_ROLES = new Set(["user", "assistant", "system"]);
 const DEFAULT_SOURCE_APP = "claude-code-channel";
 const MAX_CONTENT_LENGTH = 12_000;
 const DEFAULT_SELF_CHECK_SESSION = "orchestrator-tether-self-check";
+const LOG_READ_DECIDE_RECEIPT_WINDOW_MS = 30 * 60 * 1000;
 
 export const RECEIPT_FIRST_TETHER_LADDER = [
   "1. Live chat wake: save the accepted human turn immediately and keep the receipt id.",
@@ -57,13 +58,17 @@ export const orchestratorContextReadTool = {
   name: "unclick_orchestrator_context_read",
   description:
     "Read UnClick Orchestrator continuity after saving an accepted human turn and before interpreting or acting. " +
-    "This is the mandatory Log -> Read -> Decide gate: save the turn, read nearby context, then decide whether the text is a test cue, real request, blocker, proof, or status. " +
+    "This is the mandatory Log -> Read -> Decide gate: save the turn in this same process/session, read nearby context, then decide whether the text is a test cue, real request, blocker, proof, or status. " +
     "Use q to narrow around words from the saved turn, or omit q for recent context. " +
     "If context cannot be read, say CONTEXT_UNREAD or UNTETHERED instead of guessing what the user meant.",
   inputSchema: {
     type: "object",
     additionalProperties: false,
     properties: {
+      session_id: {
+        type: "string",
+        description: "Optional stable session id. When provided, a recent saved turn for the same session is required before this read.",
+      },
       q: {
         type: "string",
         description: "Optional search text from the saved turn. Do not use secrets.",
@@ -149,12 +154,58 @@ export function buildConversationTurnPayload(args, options = {}) {
   };
 }
 
-export async function saveConversationTurn(apiFetch, args) {
+function normalizeSessionId(value) {
+  return String(value ?? "").trim();
+}
+
+function findFreshSavedTurn(savedTurnsBySession, sessionId, nowMs, windowMs) {
+  if (sessionId) {
+    const record = savedTurnsBySession.get(sessionId);
+    if (record && nowMs - record.savedAtMs <= windowMs) return record;
+    return null;
+  }
+
+  for (const record of savedTurnsBySession.values()) {
+    if (nowMs - record.savedAtMs <= windowMs) return record;
+  }
+  return null;
+}
+
+export function createLogReadDecideGate({ now = () => Date.now(), windowMs = LOG_READ_DECIDE_RECEIPT_WINDOW_MS } = {}) {
+  const savedTurnsBySession = new Map();
+
+  return {
+    recordSavedTurn(args = {}, receipt = {}) {
+      const sessionId = normalizeSessionId(receipt?.session_id) || normalizeSessionId(args?.session_id);
+      if (!sessionId) return;
+      const turnId = String(receipt?.turn_id ?? receipt?.receipt_id ?? "").trim() || null;
+      savedTurnsBySession.set(sessionId, {
+        sessionId,
+        turnId,
+        savedAtMs: now(),
+      });
+    },
+    requireSavedTurn(args = {}) {
+      const sessionId = normalizeSessionId(args?.session_id);
+      const record = findFreshSavedTurn(savedTurnsBySession, sessionId, now(), windowMs);
+      if (record) return record;
+
+      const scope = sessionId ? ` for session_id=${sessionId}` : " in this process";
+      throw new Error(
+        `Log-Read-Decide gate requires a prior save_conversation_turn receipt${scope} before reading Orchestrator context`
+      );
+    },
+  };
+}
+
+export async function saveConversationTurn(apiFetch, args, options = {}) {
   const payload = buildConversationTurnPayload(args);
-  return apiFetch("admin_conversation_turn_ingest", {
+  const receipt = await apiFetch("admin_conversation_turn_ingest", {
     method: "POST",
     body: payload,
   });
+  options?.gate?.recordSavedTurn?.(payload, receipt);
+  return receipt;
 }
 
 export function buildOrchestratorContextReadQuery(args = {}) {
@@ -182,7 +233,8 @@ export function buildOrchestratorContextReadQuery(args = {}) {
   return query;
 }
 
-export async function readOrchestratorContext(apiFetch, args = {}) {
+export async function readOrchestratorContext(apiFetch, args = {}, options = {}) {
+  options?.gate?.requireSavedTurn?.(args);
   return apiFetch("orchestrator_context_read", {
     method: "GET",
     query: buildOrchestratorContextReadQuery(args),
@@ -222,16 +274,18 @@ export function orchestratorContextContainsReceipt(contextReadResult, { marker, 
 
 export async function runTetherSelfCheck(apiFetch, args = {}) {
   const payload = buildTetherSelfCheckPayload(args);
-  const receipt = await saveConversationTurn(apiFetch, payload.turn);
+  const gate = createLogReadDecideGate();
+  const receipt = await saveConversationTurn(apiFetch, payload.turn, { gate });
   const turnId = receipt?.turn_id ? String(receipt.turn_id) : "";
   if (!turnId) {
     throw new Error("admin_conversation_turn_ingest returned no receipt turn_id");
   }
 
   const contextRead = await readOrchestratorContext(apiFetch, {
+    session_id: payload.turn.session_id,
     q: payload.marker,
     limit: 20,
-  });
+  }, { gate });
 
   if (!orchestratorContextContainsReceipt(contextRead, { marker: payload.marker, turnId })) {
     throw new Error("saved self-check turn was not found by Orchestrator search");

--- a/packages/channel-plugin/orchestrator-turns.test.js
+++ b/packages/channel-plugin/orchestrator-turns.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildOrchestratorContextReadQuery,
   buildTetherSelfCheckPayload,
+  createLogReadDecideGate,
   getReceiptFirstTetherLadder,
   orchestratorContextContainsReceipt,
   orchestratorContextReadTool,
@@ -119,6 +120,71 @@ test("saveConversationTurn calls the existing admin ingest endpoint", async () =
       },
     },
   ]);
+});
+
+test("Log-Read-Decide gate blocks reads before a same-session save", async () => {
+  const gate = createLogReadDecideGate();
+
+  await assert.rejects(
+    () => readOrchestratorContext(async () => ({ context: {} }), {
+      session_id: "thread-1",
+      q: "proof",
+    }, { gate }),
+    /prior save_conversation_turn receipt for session_id=thread-1/
+  );
+});
+
+test("Log-Read-Decide gate allows read after a saved turn in the same session", async () => {
+  const gate = createLogReadDecideGate();
+  const calls = [];
+
+  await saveConversationTurn(async (action, options) => {
+    calls.push({ action, options });
+    return {
+      turn_id: "turn-1",
+      session_id: options.body.session_id,
+      role: options.body.role,
+    };
+  }, {
+    session_id: "thread-1",
+    role: "user",
+    content: "fresh wake",
+  }, { gate });
+
+  const result = await readOrchestratorContext(async (action, options) => {
+    calls.push({ action, options });
+    return { context: { continuity_events: [{ source_id: "turn-1" }] } };
+  }, {
+    session_id: "thread-1",
+    q: "fresh wake",
+  }, { gate });
+
+  assert.deepEqual(result, { context: { continuity_events: [{ source_id: "turn-1" }] } });
+  assert.deepEqual(calls.map((call) => call.action), [
+    "admin_conversation_turn_ingest",
+    "orchestrator_context_read",
+  ]);
+});
+
+test("Log-Read-Decide gate rejects a mismatched saved session", async () => {
+  const gate = createLogReadDecideGate();
+
+  await saveConversationTurn(async (_action, options) => ({
+    turn_id: "turn-1",
+    session_id: options.body.session_id,
+  }), {
+    session_id: "thread-1",
+    role: "user",
+    content: "fresh wake",
+  }, { gate });
+
+  await assert.rejects(
+    () => readOrchestratorContext(async () => ({ context: {} }), {
+      session_id: "thread-2",
+      q: "fresh wake",
+    }, { gate }),
+    /prior save_conversation_turn receipt for session_id=thread-2/
+  );
 });
 
 test("buildOrchestratorContextReadQuery normalizes search and clamps limits", () => {

--- a/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
@@ -38,6 +38,7 @@ describe("heartbeat_protocol payload", () => {
     expect(protocol.procedure[1]).toContain("continuity receipts");
     expect(protocol.procedure[2]).toContain("unclick-builder-tether-seat");
     expect(protocol.procedure[3]).toContain("job hunt");
+    expect(protocol.procedure[3]).toContain("First call save_conversation_turn");
     expect(protocol.procedure[4]).toContain("0 active jobs");
     expect(protocol.procedure[4]).toContain("queue hydration failure");
     // active_jobs definition is pinned in step 5 (procedure[4]) so the
@@ -52,7 +53,7 @@ describe("heartbeat_protocol payload", () => {
     expect(protocol.procedure[5]).toContain("free API classifiers may only classify or nudge");
     expect(protocol.procedure[5]).toContain("PushOnly");
     expect(protocol.procedure[5]).toContain("must not create duplicate jobs");
-    expect(protocol.procedure[6]).toContain("After check_signals");
+    expect(protocol.procedure[6]).toContain("After the action step");
     expect(protocol.procedure[7]).toContain("compact public fields");
     expect(protocol.procedure[8]).toContain("smallest safe source text");
     expect(protocol.procedure[9]).toContain("receipt_line");
@@ -84,9 +85,9 @@ describe("heartbeat_protocol payload", () => {
       procedure: [...protocol.procedure, "new instruction"],
     };
 
-    expect(formatHeartbeatProtocolVersion(11)).toBe("2026-05-12.v11");
-    expect(protocol.version).toBe("2026-05-12.v11");
-    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("bde9cae82e8d455c");
+    expect(formatHeartbeatProtocolVersion(12)).toBe("2026-05-12.v12");
+    expect(protocol.version).toBe("2026-05-12.v12");
+    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("40e6cc443687b548");
     expect(heartbeatProtocolContentFingerprint(changed)).not.toBe(
       heartbeatProtocolContentFingerprint(protocol),
     );

--- a/packages/mcp-server/src/__tests__/orchestrator-tether-contract.test.ts
+++ b/packages/mcp-server/src/__tests__/orchestrator-tether-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { evaluateOrchestratorContextReadGate } from "../memory/session-state.js";
 import { MCP_SERVER_INSTRUCTIONS, VISIBLE_TOOLS } from "../server.js";
 
 describe("Orchestrator tether contract", () => {
@@ -29,6 +30,47 @@ describe("Orchestrator tether contract", () => {
     const readContextTool = VISIBLE_TOOLS.find((tool) => tool.name === "read_orchestrator_context");
 
     expect(readContextTool?.description).toContain("Log -> Read -> Decide");
+    expect(readContextTool?.description).toContain("blocks until a prior save_conversation_turn receipt");
     expect(readContextTool?.description).toContain("CONTEXT_UNREAD");
+  });
+
+  it("blocks context reads before a saved turn receipt exists", () => {
+    const result = evaluateOrchestratorContextReadGate([], {
+      session_id: "strict-session",
+      q: "fresh wake",
+    }, new Date("2026-05-22T01:00:00.000Z"));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe("CONTEXT_UNREAD");
+      expect(result.missing).toContain("session_id='strict-session'");
+      expect(result.guidance).toContain("save_conversation_turn");
+    }
+  });
+
+  it("allows context reads only after a fresh same-session receipt", () => {
+    const savedAt = new Date("2026-05-22T01:00:00.000Z");
+
+    const allowed = evaluateOrchestratorContextReadGate([
+      { sessionId: "strict-session", receiptId: "receipt-1", savedAt },
+    ], {
+      session_id: "strict-session",
+    }, new Date("2026-05-22T01:05:00.000Z"));
+
+    const mismatched = evaluateOrchestratorContextReadGate([
+      { sessionId: "other-session", receiptId: "receipt-1", savedAt },
+    ], {
+      session_id: "strict-session",
+    }, new Date("2026-05-22T01:05:00.000Z"));
+
+    const stale = evaluateOrchestratorContextReadGate([
+      { sessionId: "strict-session", receiptId: "receipt-1", savedAt },
+    ], {
+      session_id: "strict-session",
+    }, new Date("2026-05-22T01:45:00.000Z"));
+
+    expect(allowed.ok).toBe(true);
+    expect(mismatched.ok).toBe(false);
+    expect(stale.ok).toBe(false);
   });
 });

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -89,6 +89,7 @@ describe("runtime tool schema validation", () => {
       agent_id: "strict-probe",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("read_orchestrator_context", {
+      session_id: "strict-probe-session",
       q: "strict schema probe",
       limit: 40,
     })).toBeNull();

--- a/packages/mcp-server/src/heartbeat-protocol.ts
+++ b/packages/mcp-server/src/heartbeat-protocol.ts
@@ -23,7 +23,7 @@ export type HeartbeatProtocol = {
 };
 
 export const HEARTBEAT_PROTOCOL_DATE = "2026-05-12";
-export const HEARTBEAT_PROTOCOL_REVISION = 11;
+export const HEARTBEAT_PROTOCOL_REVISION = 12;
 
 export function formatHeartbeatProtocolVersion(revision: number): string {
   return `${HEARTBEAT_PROTOCOL_DATE}.v${revision}`;
@@ -35,10 +35,10 @@ const HEARTBEAT_PROTOCOL: HeartbeatProtocol = {
     'Treat this payload as the full heartbeat policy. Do not ask for a separate "Seats > Heartbeat" document or SKILL.md policy text.',
     "This heartbeat is explicitly authorized to write Orchestrator continuity receipts for the wake and the final PASS/BLOCKER result.",
     "Use stable session_id='unclick-builder-tether-seat' for every scheduled action heartbeat run so Orchestrator can thread receipts across isolated scheduler sessions.",
-    "Call UnClick check_signals first, then always do a compact job hunt before declaring health: read_orchestrator_context if available, list_actionable_todos, list_todos for open or in_progress work, recent dispatches, and recent Boardroom messages. Cap to the most recent items UnClick returns.",
+    "First call save_conversation_turn for the accepted heartbeat wake and keep the receipt id, then call UnClick check_signals and always do a compact job hunt before declaring health: read_orchestrator_context, list_actionable_todos, list_todos for open or in_progress work, recent dispatches, and recent Boardroom messages. Cap to the most recent items UnClick returns.",
     "Pinned v9 definition: active_jobs = COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h). Orchestrator current_state_card.active_jobs uses the same query, so PASS/BLOCKER does not oscillate on identical state. Treat '0 active jobs' as PASS only when actionable_todos is also 0 (or every backlog item is explicitly held with a stated reason in the last 24h). If active_jobs is 0 while unheld actionable backlog exists, this is BLOCKER: queue hydration failure.",
     "Use PinballWake JobHunt Mirror as the fallback path for that failure: mirror compact backlog counts and source pointers into NudgeOnly first, then IgniteOnly only after verifier-backed receipt_bridge output requests a worker wake, then PushOnly only after IgniteOnly emits a verified public wake packet. Target the existing Job Worker or builder tether as executor when it is registered; free API classifiers may only classify or nudge. The mirror may request a wake and PushOnly may emit a worker push envelope, but both must not create duplicate jobs, assign ownership, mark done, merge, close, or edit source state.",
-    "After check_signals, call save_conversation_turn with session_id='unclick-heartbeat-seat', role='assistant', and content containing the safe alert lines plus a brief progress summary and proof id if available.",
+    "After the action step or blocker decision, call save_conversation_turn with session_id='unclick-builder-tether-seat', role='assistant', and content containing the final PASS/BLOCKER/HOLD line plus proof id if available.",
     "When UnClick returns action_needed, blocker, stale ACK, missing proof, duplicate wake, unclear owner, or queue hydration failure items, call nudgeonly_receipt_bridge if available using compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, and ttl_minutes.",
     "Prefer deterministic painpoint labels from UnClick. Call nudgeonly_api only when no deterministic bucket exists, and only for the smallest safe source text needed to classify the painpoint.",
     "If nudgeonly_receipt_bridge returns receipt_request or escalation_request, save its bridge_id and receipt_line in the continuity receipt and alert line. If it returns quiet or advisory_only, do not notify.",

--- a/packages/mcp-server/src/memory/session-state.ts
+++ b/packages/mcp-server/src/memory/session-state.ts
@@ -15,6 +15,18 @@ export type AutoloadMethod =
   | "manual"
   | "none";
 
+export const LOG_READ_DECIDE_RECEIPT_WINDOW_MS = 30 * 60 * 1000;
+
+export interface OrchestratorSavedTurn {
+  sessionId: string;
+  receiptId: string | null;
+  savedAt: Date;
+}
+
+export type OrchestratorReadGateResult =
+  | { ok: true; savedTurn: OrchestratorSavedTurn }
+  | { ok: false; status: "CONTEXT_UNREAD"; missing: string; guidance: string };
+
 export interface SessionState {
   sessionId: string;
   clientInfo: { name: string; version: string } | null;
@@ -27,6 +39,7 @@ export interface SessionState {
   toolsCalledBeforeContext: number;
   sessionStart: Date;
   logged: boolean;
+  orchestratorSavedTurns: OrchestratorSavedTurn[];
 }
 
 function randomSessionId(): string {
@@ -45,7 +58,16 @@ export const sessionState: SessionState = {
   toolsCalledBeforeContext: 0,
   sessionStart: new Date(),
   logged: false,
+  orchestratorSavedTurns: [],
 };
+
+function normalizeSessionId(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeReceiptId(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
 
 export function setClientInfo(info: { name?: string; version?: string } | undefined): void {
   if (!info) return;
@@ -104,6 +126,64 @@ export function recordToolCall(name: string): void {
   }
 }
 
+export function evaluateOrchestratorContextReadGate(
+  savedTurns: OrchestratorSavedTurn[],
+  args: Record<string, unknown> = {},
+  now = new Date(),
+  windowMs = LOG_READ_DECIDE_RECEIPT_WINDOW_MS,
+): OrchestratorReadGateResult {
+  const requestedSessionId = normalizeSessionId(args.session_id);
+  const nowMs = now.getTime();
+  const savedTurn = savedTurns.find((turn) => {
+    if (requestedSessionId && turn.sessionId !== requestedSessionId) return false;
+    return nowMs - turn.savedAt.getTime() <= windowMs;
+  });
+
+  if (savedTurn) return { ok: true, savedTurn };
+
+  const missing = requestedSessionId
+    ? `No prior save_conversation_turn receipt for session_id='${requestedSessionId}' in this MCP server session.`
+    : "No prior save_conversation_turn receipt in this MCP server session.";
+
+  return {
+    ok: false,
+    status: "CONTEXT_UNREAD",
+    missing,
+    guidance:
+      "Save the accepted wake or turn first with save_conversation_turn, keep the receipt id, then call read_orchestrator_context before deciding or acting.",
+  };
+}
+
+export function markConversationTurnSaved(
+  args: Record<string, unknown>,
+  result: unknown,
+  savedAt = new Date(),
+): void {
+  const sessionId = normalizeSessionId(args.session_id);
+  if (!sessionId) return;
+  const record = result && typeof result === "object" ? result as Record<string, unknown> : {};
+  const receiptId =
+    normalizeReceiptId(record.receipt_id) ??
+    normalizeReceiptId(record.turn_id) ??
+    normalizeReceiptId(record.id);
+  const cutoffMs = savedAt.getTime() - LOG_READ_DECIDE_RECEIPT_WINDOW_MS;
+
+  sessionState.orchestratorSavedTurns = [
+    { sessionId, receiptId, savedAt },
+    ...sessionState.orchestratorSavedTurns.filter((turn) =>
+      turn.sessionId !== sessionId && turn.savedAt.getTime() >= cutoffMs
+    ),
+  ];
+}
+
+export function requireConversationTurnBeforeOrchestratorRead(args: Record<string, unknown>): OrchestratorReadGateResult {
+  return evaluateOrchestratorContextReadGate(sessionState.orchestratorSavedTurns, args);
+}
+
 export function snapshotSessionState(): SessionState {
-  return { ...sessionState, resourcesRead: [...sessionState.resourcesRead] };
+  return {
+    ...sessionState,
+    resourcesRead: [...sessionState.resourcesRead],
+    orchestratorSavedTurns: sessionState.orchestratorSavedTurns.map((turn) => ({ ...turn })),
+  };
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -11,7 +11,12 @@ import { createClient, type UnClickClient } from "./client.js";
 import { ADDITIONAL_TOOLS, ADDITIONAL_HANDLERS } from "./tool-wiring.js";
 import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
-import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
+import {
+  markContextLoaded,
+  markConversationTurnSaved,
+  recordToolCall,
+  requireConversationTurnBeforeOrchestratorRead,
+} from "./memory/session-state.js";
 import { emitSignal } from "./signals/emit.js";
 import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
 import { getCommonSensePassProtocol } from "./commonsensepass-protocol.js";
@@ -538,12 +543,16 @@ export const VISIBLE_TOOLS = [
     title: "Read Orchestrator context",
     description:
       "Reads current UnClick Orchestrator continuity so a seat can interpret a freshly saved turn before acting. " +
-      "Use immediately after save_conversation_turn in the required Log -> Read -> Decide -> Reply -> Log reply gate. " +
+      "Use immediately after save_conversation_turn in the required Log -> Read -> Decide -> Reply -> Log reply gate. This tool blocks until a prior save_conversation_turn receipt exists in this MCP server session. " +
       "If this read fails, say CONTEXT_UNREAD or UNTETHERED instead of guessing whether a phrase is a test cue, real request, blocker, proof, or status.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
+        session_id: {
+          type: "string",
+          description: "Optional stable session id. When provided, the saved turn receipt must be for this same session.",
+        },
         q: {
           type: "string",
           description: "Optional search text from the saved turn. Do not include secrets.",
@@ -1759,6 +1768,23 @@ export function createServer(): Server {
 
       // ── Orchestrator context: mandatory read step after turn capture ──
       if (name === "read_orchestrator_context") {
+        const gate = requireConversationTurnBeforeOrchestratorRead(args);
+        if (!gate.ok) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  ok: false,
+                  status: gate.status,
+                  missing: gate.missing,
+                  guidance: gate.guidance,
+                }, null, 2),
+              },
+            ],
+            isError: true,
+          };
+        }
         const apiKey = process.env.UNCLICK_API_KEY;
         const base =
           process.env.UNCLICK_MEMORY_BASE_URL ||
@@ -2035,6 +2061,9 @@ export function createServer(): Server {
       if (MEMORY_HANDLERS[memoryKey]) {
         recordToolCall(memoryKey);
         const result = await MEMORY_HANDLERS[memoryKey](args);
+        if (memoryKey === "log_conversation") {
+          markConversationTurnSaved(args, result);
+        }
         return {
           content: [{ type: "text", text: memoryToolText(memoryKey, result) }],
         };


### PR DESCRIPTION
## Summary
- Adds a process-local Log-Read-Decide receipt gate for the Channel plugin and MCP server.
- `read_orchestrator_context` and `unclick_orchestrator_context_read` now require a recent saved turn receipt before Orchestrator context can be read.
- Updates heartbeat protocol text so scheduled seats save the wake before reading Orchestrator context.

## Scope
- Lane: Orchestrator and queue truth, Boardroom todo 6e269eca.
- Touched `packages/channel-plugin` Orchestrator turn helpers and tests.
- Touched `packages/mcp-server` session state, tool schema, heartbeat protocol, and focused tests.

## Non-overlap
- No UI changes.
- No secrets, billing, DNS, production data, deployment config, or unrelated queue cleanup.
- Does not close Boardroom todo 6e269eca by itself. This PR provides the runtime gate and proof path.

## Verification
- `node --test packages\channel-plugin\orchestrator-turns.test.js` passed, 17 tests.
- `npx vitest run --root packages\mcp-server src\__tests__\orchestrator-tether-contract.test.ts src\__tests__\tool-schema-validation.test.ts src\__tests__\heartbeat-protocol.test.ts` passed, 13 tests.
- `npm run build --workspace=@unclick/mcp-server` passed.
- `npm run build` passed.
- `git diff --check` passed with line-ending warnings only.

## Risk
- Low to medium behavior risk: clients that try to read Orchestrator context before saving a turn now get a structured `CONTEXT_UNREAD` response.
- Intended safety effect: prevents false Log-Read-Decide compliance when no receipt exists.

## Follow-up
- After CI and review, use the merged PR plus test proof to update Boardroom todo 6e269eca. Close only if the Boardroom accepts runtime enforcement as the missing proof.