### PR TITLE
feat(mcp): add FidelityCopy verifier tools

### DIFF
--- a/packages/mcp-server/src/__tests__/fidelitycopy-tool.test.ts
+++ b/packages/mcp-server/src/__tests__/fidelitycopy-tool.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { ADDITIONAL_HANDLERS, ADDITIONAL_TOOLS } from "../tool-wiring.js";
+import { fidelitycopyCopy, fidelitypassVerifyCopy } from "../fidelitycopy-tool.js";
+
+describe("FidelityCopy deterministic copy tools", () => {
+  it("registers fidelitycopy_copy and fidelitypass_verify_copy", () => {
+    const names = ADDITIONAL_TOOLS.map((tool) => tool.name);
+    expect(names).toContain("fidelitycopy_copy");
+    expect(names).toContain("fidelitypass_verify_copy");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("fidelitycopy_copy");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("fidelitypass_verify_copy");
+  });
+
+  it("creates a raw byte exact PASS receipt", async () => {
+    const source = Buffer.from("raw\0bytes\r\nsame", "utf8").toString("base64");
+    const result = (await fidelitycopyCopy({
+      source_ref: "copyroom://raw/source",
+      destination_ref: "copyroom://raw/output",
+      source_base64: source,
+      mode: "raw_bytes",
+    })) as { status?: string; verdict?: string; receipt?: { source_hash?: string; output_hash?: string; byte_count?: number } };
+
+    expect(result.status).toBe("pass");
+    expect(result.verdict).toBe("pass");
+    expect(result.receipt?.source_hash).toBe(result.receipt?.output_hash);
+    expect(result.receipt?.byte_count).toBe(Buffer.byteLength("raw\0bytes\r\nsame", "utf8"));
+  });
+
+  it("blocks newline drift in text_exact mode", async () => {
+    const result = (await fidelitycopyCopy({
+      source_ref: "copyroom://text/source",
+      destination_ref: "copyroom://text/output",
+      source_text: "Line 1\r\nLine 2",
+      output_text: "Line 1\nLine 2",
+      mode: "text_exact",
+    })) as { status?: string; verdict?: string; receipt?: { output_newline_style?: string; action_needed?: string[] } };
+
+    expect(result.status).toBe("blocked");
+    expect(result.verdict).toBe("blocker");
+    expect(result.receipt?.output_newline_style).toBe("lf");
+    expect(result.receipt?.action_needed?.[0]).toContain("FIDELITY_DRIFT_RISK");
+  });
+
+  it("blocks UTF-8 normalization drift", async () => {
+    const composed = "Cafe\u00e9";
+    const decomposed = "Cafe\u0065\u0301";
+    const result = (await fidelitypassVerifyCopy({
+      source_ref: "copyroom://unicode/source",
+      output_ref: "copyroom://unicode/output",
+      source_text: composed,
+      output_text: decomposed,
+      mode: "text_exact",
+    })) as { pass?: boolean; verdict?: string; receipt?: { source_hash?: string; output_hash?: string } };
+
+    expect(result.pass).toBe(false);
+    expect(result.verdict).toBe("blocker");
+    expect(result.receipt?.source_hash).not.toBe(result.receipt?.output_hash);
+  });
+
+  it("passes JSON canonical copies with different key order", async () => {
+    const result = (await fidelitypassVerifyCopy({
+      source_ref: "copyroom://json/source",
+      output_ref: "copyroom://json/output",
+      source_text: '{ "b": 2, "a": { "z": true, "m": [3, 2, 1] } }',
+      output_text: '{"a":{"m":[3,2,1],"z":true},"b":2}',
+      mode: "json_canonical",
+    })) as {
+      pass?: boolean;
+      receipt?: { canonicalization_mode?: string; source_canonical_hash?: string; output_canonical_hash?: string };
+    };
+
+    expect(result.pass).toBe(true);
+    expect(result.receipt?.canonicalization_mode).toBe("json_sort_keys");
+    expect(result.receipt?.source_canonical_hash).toBe(result.receipt?.output_canonical_hash);
+  });
+
+  it("passes approved transforms only with explicit transform proof", async () => {
+    const result = (await fidelitycopyCopy({
+      source_ref: "copyroom://transform/source",
+      destination_ref: "copyroom://transform/output",
+      source_text: "Name: Chris\n",
+      output_text: "Name: Chris",
+      mode: "approved_transform",
+      approved_transform_ref: "transform://trim-final-newline/v1",
+      allowed_changes: ["trim final newline"],
+    })) as { status?: string; verdict?: string; receipt?: { approved_transform_ref?: string; allowed_changes?: string[] } };
+
+    expect(result.status).toBe("pass");
+    expect(result.verdict).toBe("pass");
+    expect(result.receipt?.approved_transform_ref).toBe("transform://trim-final-newline/v1");
+    expect(result.receipt?.allowed_changes).toEqual(["trim final newline"]);
+  });
+
+  it("suppresses AI retype attempts even when text matches", async () => {
+    const result = (await fidelitycopyCopy({
+      source_ref: "copyroom://ai-retype/source",
+      destination_ref: "copyroom://ai-retype/output",
+      source_text: "Exact prompt text",
+      output_text: "Exact prompt text",
+      mode: "text_exact",
+      output_provenance: "ai_retype",
+    })) as { status?: string; verdict?: string; receipt?: { action_needed?: string[]; output_provenance?: string } };
+
+    expect(result.status).toBe("blocked");
+    expect(result.verdict).toBe("suppress");
+    expect(result.receipt?.output_provenance).toBe("ai_retype");
+    expect(result.receipt?.action_needed?.[0]).toContain("AI_RETYPE_SUPPRESS");
+  });
+
+  it("verifies stored receipts by receipt_id", async () => {
+    const copy = (await fidelitycopyCopy({
+      source_ref: "copyroom://stored/source",
+      destination_ref: "copyroom://stored/output",
+      source_text: "Stored receipt proof",
+      mode: "raw_bytes",
+    })) as { receipt_id?: string };
+
+    const verify = (await fidelitypassVerifyCopy({
+      receipt_id: copy.receipt_id,
+    })) as { pass?: boolean; verified_from?: string; receipt_id?: string };
+
+    expect(verify.pass).toBe(true);
+    expect(verify.verified_from).toBe("receipt");
+    expect(verify.receipt_id).toBe(copy.receipt_id);
+  });
+});

--- a/packages/mcp-server/src/fidelitycopy-tool.ts
+++ b/packages/mcp-server/src/fidelitycopy-tool.ts
@@ -1,0 +1,386 @@
+import { createHash, randomUUID } from "node:crypto";
+
+type FidelityCopyMode = "raw_bytes" | "text_exact" | "json_canonical" | "approved_transform";
+type FidelityCopyVerdict = "pass" | "blocker" | "suppress";
+type NewlineStyle = "none" | "lf" | "crlf" | "cr" | "mixed";
+type OutputProvenance = "deterministic_copy" | "tool" | "manual" | "ai_retype";
+
+interface Material {
+  bytes: Buffer;
+  text: string;
+  input_encoding: "utf8" | "base64";
+  sha256: string;
+  byte_count: number;
+  character_count: number;
+  line_count: number;
+  newline_style: NewlineStyle;
+}
+
+interface FidelityCopyReceipt {
+  kind: "fidelitycopy_receipt_v1";
+  receipt_id: string;
+  mode: FidelityCopyMode;
+  verdict: FidelityCopyVerdict;
+  status: "pass" | "blocked";
+  source_ref: string;
+  output_ref: string;
+  source_hash: string;
+  output_hash: string;
+  hash_algorithm: "sha256";
+  byte_count: number;
+  output_byte_count: number;
+  character_count: number;
+  output_character_count: number;
+  line_count: number;
+  output_line_count: number;
+  newline_style: NewlineStyle;
+  output_newline_style: NewlineStyle;
+  canonicalization_mode: "none" | "json_sort_keys";
+  source_canonical_hash?: string;
+  output_canonical_hash?: string;
+  approved_transform_ref?: string;
+  allowed_changes: string[];
+  output_provenance: OutputProvenance;
+  diff_summary: string;
+  invariants_checked: string[];
+  action_needed: string[];
+  validator: "fidelitycopy-tool";
+  validator_version: "v1";
+  timestamp: string;
+  provenance_pointer?: string;
+}
+
+interface StoredReceipt {
+  receipt: FidelityCopyReceipt;
+  output: Buffer;
+}
+
+const RECEIPTS = new Map<string, StoredReceipt>();
+
+export async function fidelitycopyCopy(args: Record<string, unknown>): Promise<unknown> {
+  const mode = parseMode(args.mode);
+  if (!mode) {
+    return { error: "mode must be one of: raw_bytes, text_exact, json_canonical, approved_transform" };
+  }
+
+  const sourceRef = readRequiredString(args.source_ref, "source_ref");
+  if ("error" in sourceRef) return sourceRef;
+  const outputRef = readOutputRef(args);
+  if ("error" in outputRef) return outputRef;
+
+  const source = parseMaterial(args, "source");
+  if ("error" in source) return source;
+  if ("missing" in source) return { error: "source_text or source_base64 is required" };
+
+  const output = deriveOutputMaterial(args, source.material, mode);
+  if ("error" in output) return output;
+
+  const receiptResult = createReceipt({
+    mode,
+    sourceRef: sourceRef.value,
+    outputRef: outputRef.value,
+    source: source.material,
+    output: output.material,
+    approvedTransformRef: readOptionalString(args.approved_transform_ref),
+    allowedChanges: readStringList(args.allowed_changes),
+    outputProvenance: parseOutputProvenance(args.output_provenance),
+    provenancePointer: readOptionalString(args.provenance_pointer),
+  });
+
+  if ("error" in receiptResult) return receiptResult;
+
+  RECEIPTS.set(receiptResult.receipt.receipt_id, {
+    receipt: receiptResult.receipt,
+    output: Buffer.from(output.material.bytes),
+  });
+
+  const response: Record<string, unknown> = {
+    receipt_id: receiptResult.receipt.receipt_id,
+    verdict: receiptResult.receipt.verdict,
+    status: receiptResult.receipt.status,
+    receipt: receiptResult.receipt,
+  };
+
+  if (args.include_output === true) {
+    response.output_text = output.material.text;
+    response.output_base64 = output.material.bytes.toString("base64");
+  }
+
+  return response;
+}
+
+export async function fidelitypassVerifyCopy(args: Record<string, unknown>): Promise<unknown> {
+  const receiptId = readOptionalString(args.receipt_id);
+  if (receiptId) {
+    const stored = RECEIPTS.get(receiptId);
+    if (!stored) {
+      return { error: `FidelityCopy receipt '${receiptId}' was not found in this MCP session` };
+    }
+    return verificationResponse(stored.receipt, "receipt");
+  }
+
+  const copyResult = await fidelitycopyCopy({
+    ...args,
+    destination_ref: args.output_ref ?? args.destination_ref ?? "fidelitypass://verify-output",
+    include_output: false,
+  });
+
+  if (!isRecord(copyResult) || !isRecord(copyResult.receipt)) return copyResult;
+  return verificationResponse(copyResult.receipt as unknown as FidelityCopyReceipt, "source_output");
+}
+
+function verificationResponse(receipt: FidelityCopyReceipt, verifiedFrom: "receipt" | "source_output"): Record<string, unknown> {
+  return {
+    verified_from: verifiedFrom,
+    receipt_id: receipt.receipt_id,
+    pass: receipt.verdict === "pass",
+    verdict: receipt.verdict,
+    status: receipt.status,
+    receipt,
+  };
+}
+
+function createReceipt(input: {
+  mode: FidelityCopyMode;
+  sourceRef: string;
+  outputRef: string;
+  source: Material;
+  output: Material;
+  approvedTransformRef?: string;
+  allowedChanges: string[];
+  outputProvenance: OutputProvenance;
+  provenancePointer?: string;
+}): { receipt: FidelityCopyReceipt } | { error: string } {
+  const timestamp = new Date().toISOString();
+  const invariants = [
+    "source_ref_present",
+    "output_ref_present",
+    "sha256_recorded",
+    "byte_count_recorded",
+    "character_count_recorded",
+    "newline_style_recorded",
+    "no_llm_copy_bytes",
+  ];
+
+  let verdict: FidelityCopyVerdict = "blocker";
+  let diffSummary = "Output differs from source.";
+  let sourceCanonicalHash: string | undefined;
+  let outputCanonicalHash: string | undefined;
+  let actionNeeded: string[] = [];
+
+  if (input.outputProvenance === "ai_retype") {
+    verdict = "suppress";
+    diffSummary = "AI retype attempt is not accepted for exact source-copy work.";
+    actionNeeded = ["AI_RETYPE_SUPPRESS: route exact source-copy work through FidelityCopy deterministic copy bytes."];
+  } else if (input.mode === "raw_bytes" || input.mode === "text_exact") {
+    const exact = input.source.bytes.equals(input.output.bytes);
+    verdict = exact ? "pass" : "blocker";
+    diffSummary = exact
+      ? "Raw source and output bytes match exactly."
+      : "Raw source and output bytes differ.";
+    if (!exact) actionNeeded = ["FIDELITY_DRIFT_RISK: output hash or bytes differ from source."];
+    invariants.push(input.mode === "text_exact" ? "text_exact_match" : "raw_byte_match");
+  } else if (input.mode === "json_canonical") {
+    const sourceCanonical = canonicalJson(input.source.text);
+    const outputCanonical = canonicalJson(input.output.text);
+    if ("error" in sourceCanonical) return { error: `source JSON invalid: ${sourceCanonical.error}` };
+    if ("error" in outputCanonical) return { error: `output JSON invalid: ${outputCanonical.error}` };
+    sourceCanonicalHash = sha256Utf8(sourceCanonical.value);
+    outputCanonicalHash = sha256Utf8(outputCanonical.value);
+    const exact = sourceCanonicalHash === outputCanonicalHash;
+    verdict = exact ? "pass" : "blocker";
+    diffSummary = exact
+      ? "JSON canonical hashes match under sorted-key canonicalization."
+      : "JSON canonical hashes differ under sorted-key canonicalization.";
+    if (!exact) actionNeeded = ["FIDELITY_DRIFT_RISK: canonical JSON output differs from source."];
+    invariants.push("json_canonical_hash_match");
+  } else {
+    const hasApproval = Boolean(input.approvedTransformRef) && input.allowedChanges.length > 0;
+    verdict = hasApproval ? "pass" : "blocker";
+    diffSummary = hasApproval
+      ? "Output differs under an approved transform receipt."
+      : "Approved transform mode requires approved_transform_ref and allowed_changes.";
+    if (!hasApproval) {
+      actionNeeded = ["APPROVED_TRANSFORM_MISSING: provide approved_transform_ref and allowed_changes."];
+    }
+    invariants.push("approved_transform_receipt");
+  }
+
+  const receipt: FidelityCopyReceipt = {
+    kind: "fidelitycopy_receipt_v1",
+    receipt_id: randomUUID(),
+    mode: input.mode,
+    verdict,
+    status: verdict === "pass" ? "pass" : "blocked",
+    source_ref: input.sourceRef,
+    output_ref: input.outputRef,
+    source_hash: input.source.sha256,
+    output_hash: input.output.sha256,
+    hash_algorithm: "sha256",
+    byte_count: input.source.byte_count,
+    output_byte_count: input.output.byte_count,
+    character_count: input.source.character_count,
+    output_character_count: input.output.character_count,
+    line_count: input.source.line_count,
+    output_line_count: input.output.line_count,
+    newline_style: input.source.newline_style,
+    output_newline_style: input.output.newline_style,
+    canonicalization_mode: input.mode === "json_canonical" ? "json_sort_keys" : "none",
+    source_canonical_hash: sourceCanonicalHash,
+    output_canonical_hash: outputCanonicalHash,
+    approved_transform_ref: input.approvedTransformRef,
+    allowed_changes: input.allowedChanges,
+    output_provenance: input.outputProvenance,
+    diff_summary: diffSummary,
+    invariants_checked: invariants,
+    action_needed: actionNeeded,
+    validator: "fidelitycopy-tool",
+    validator_version: "v1",
+    timestamp,
+    provenance_pointer: input.provenancePointer,
+  };
+
+  return { receipt };
+}
+
+function deriveOutputMaterial(
+  args: Record<string, unknown>,
+  source: Material,
+  mode: FidelityCopyMode,
+): { material: Material } | { error: string } {
+  const providedOutput = parseMaterial(args, "output", true);
+  if ("material" in providedOutput) return providedOutput;
+  if ("error" in providedOutput) return providedOutput;
+
+  if (mode === "json_canonical") {
+    const canonical = canonicalJson(source.text);
+    if ("error" in canonical) return { error: `source JSON invalid: ${canonical.error}` };
+    return { material: materialFromText(canonical.value, "utf8") };
+  }
+
+  return { material: materialFromBuffer(source.bytes, source.input_encoding) };
+}
+
+function parseMaterial(
+  args: Record<string, unknown>,
+  prefix: "source" | "output",
+  optional = false,
+): { material: Material } | { missing: true } | { error: string } {
+  const textKey = `${prefix}_text`;
+  const base64Key = `${prefix}_base64`;
+  const text = args[textKey];
+  const base64 = args[base64Key];
+
+  if (typeof text === "string") {
+    return { material: materialFromText(text, "utf8") };
+  }
+
+  if (typeof base64 === "string") {
+    try {
+      return { material: materialFromBuffer(Buffer.from(base64, "base64"), "base64") };
+    } catch {
+      return { error: `${base64Key} must be valid base64` };
+    }
+  }
+
+  if (optional) return { missing: true };
+  return { error: `${textKey} or ${base64Key} is required` };
+}
+
+function materialFromText(text: string, inputEncoding: "utf8" | "base64"): Material {
+  return materialFromBuffer(Buffer.from(text, "utf8"), inputEncoding);
+}
+
+function materialFromBuffer(bytes: Buffer, inputEncoding: "utf8" | "base64"): Material {
+  const text = bytes.toString("utf8");
+  return {
+    bytes,
+    text,
+    input_encoding: inputEncoding,
+    sha256: sha256Bytes(bytes),
+    byte_count: bytes.length,
+    character_count: Array.from(text).length,
+    line_count: lineCount(text),
+    newline_style: detectNewlineStyle(text),
+  };
+}
+
+function parseMode(value: unknown): FidelityCopyMode | null {
+  if (value === undefined || value === null || value === "") return "raw_bytes";
+  return value === "raw_bytes" || value === "text_exact" || value === "json_canonical" || value === "approved_transform"
+    ? value
+    : null;
+}
+
+function parseOutputProvenance(value: unknown): OutputProvenance {
+  return value === "tool" || value === "manual" || value === "ai_retype" ? value : "deterministic_copy";
+}
+
+function readRequiredString(value: unknown, label: string): { value: string } | { error: string } {
+  if (typeof value !== "string" || !value.trim()) return { error: `${label} is required` };
+  return { value: value.trim() };
+}
+
+function readOutputRef(args: Record<string, unknown>): { value: string } | { error: string } {
+  const raw = args.destination_ref ?? args.output_ref;
+  return readRequiredString(raw, "destination_ref or output_ref");
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).map((item) => item.trim());
+}
+
+function canonicalJson(text: string): { value: string } | { error: string } {
+  try {
+    return { value: JSON.stringify(sortJson(JSON.parse(text))) };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : "could not parse JSON" };
+  }
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!isRecord(value)) return value;
+  return Object.keys(value)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = sortJson(value[key]);
+      return acc;
+    }, {});
+}
+
+function sha256Utf8(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function sha256Bytes(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function lineCount(value: string): number {
+  if (value.length === 0) return 0;
+  return value.split(/\r\n|\r|\n/).length;
+}
+
+function detectNewlineStyle(value: string): NewlineStyle {
+  const crlf = /\r\n/.test(value);
+  const withoutCrlf = value.replace(/\r\n/g, "");
+  const lf = /\n/.test(withoutCrlf);
+  const cr = /\r/.test(withoutCrlf);
+  const count = [crlf, lf, cr].filter(Boolean).length;
+
+  if (count === 0) return "none";
+  if (count > 1) return "mixed";
+  if (crlf) return "crlf";
+  if (lf) return "lf";
+  return "cr";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -776,6 +776,12 @@ import {
   legalpassVerdict,
 } from "./legalpass-tool.js";
 
+// FidelityCopy deterministic copy and verifier tools
+import {
+  fidelitycopyCopy,
+  fidelitypassVerifyCopy,
+} from "./fidelitycopy-tool.js";
+
 // ─── UXPass (sister to TestPass, UI/UX QC) ───────────────────────────────────
 import {
   uxpassRun,
@@ -12176,6 +12182,70 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // fidelitycopy-tool.ts
+  {
+    name: "fidelitycopy_copy",
+    description: "Create a deterministic FidelityCopy receipt for exact source-copy work. Use this for raw bytes, exact text, canonical JSON, or approved transforms instead of AI retyping.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        source_ref: { type: "string", description: "Stable source pointer, CopyRoom packet id, path, or provenance ref." },
+        destination_ref: { type: "string", description: "Destination pointer for the copied output. output_ref is accepted by the verifier path." },
+        mode: {
+          type: "string",
+          enum: ["raw_bytes", "text_exact", "json_canonical", "approved_transform"],
+          description: "Copy mode. Defaults to raw_bytes.",
+        },
+        source_text: { type: "string", description: "Exact UTF-8 source text. Use source_base64 for binary or byte-focused fixtures." },
+        source_base64: { type: "string", description: "Exact source bytes encoded as base64." },
+        output_text: { type: "string", description: "Optional output text to verify. If omitted, FidelityCopy outputs a deterministic copy of source." },
+        output_base64: { type: "string", description: "Optional output bytes encoded as base64." },
+        approved_transform_ref: { type: "string", description: "Required for approved_transform mode." },
+        allowed_changes: { type: "array", items: { type: "string" }, description: "Required allowed changes for approved_transform mode." },
+        output_provenance: {
+          type: "string",
+          enum: ["deterministic_copy", "tool", "manual", "ai_retype"],
+          description: "Marks how output was produced. ai_retype is suppressed for fidelity work.",
+        },
+        provenance_pointer: { type: "string", description: "Optional upstream proof pointer." },
+        include_output: { type: "boolean", description: "When true, include copied output_text and output_base64 in the response." },
+      },
+      required: ["source_ref", "destination_ref"],
+    },
+  },
+  {
+    name: "fidelitypass_verify_copy",
+    description: "Verify a FidelityCopy receipt, or verify source and output bytes directly, returning PASS or BLOCKER proof for FidelityPass.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        receipt_id: { type: "string", description: "Receipt id returned by fidelitycopy_copy." },
+        source_ref: { type: "string", description: "Stable source pointer when verifying source/output directly." },
+        output_ref: { type: "string", description: "Output pointer when verifying source/output directly." },
+        destination_ref: { type: "string", description: "Alias for output_ref." },
+        mode: {
+          type: "string",
+          enum: ["raw_bytes", "text_exact", "json_canonical", "approved_transform"],
+          description: "Verification mode. Defaults to raw_bytes.",
+        },
+        source_text: { type: "string", description: "Exact UTF-8 source text." },
+        source_base64: { type: "string", description: "Exact source bytes encoded as base64." },
+        output_text: { type: "string", description: "Exact output text to verify." },
+        output_base64: { type: "string", description: "Exact output bytes encoded as base64." },
+        approved_transform_ref: { type: "string", description: "Required for approved_transform mode." },
+        allowed_changes: { type: "array", items: { type: "string" }, description: "Required allowed changes for approved_transform mode." },
+        output_provenance: {
+          type: "string",
+          enum: ["deterministic_copy", "tool", "manual", "ai_retype"],
+          description: "Marks how output was produced. ai_retype is suppressed for fidelity work.",
+        },
+        provenance_pointer: { type: "string", description: "Optional upstream proof pointer." },
+      },
+    },
+  },
+
   // ── uxpass-tool.ts (UI/UX QC, sister to TestPass) ──────────────────────────
   {
     name: "uxpass_run",
@@ -13538,6 +13608,10 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   // legalpass-tool.ts
   legalpass_run:     (args) => legalpassRun(args),
   legalpass_verdict: (args) => legalpassVerdict(args),
+
+  // fidelitycopy-tool.ts
+  fidelitycopy_copy:        (args) => fidelitycopyCopy(args),
+  fidelitypass_verify_copy: (args) => fidelitypassVerifyCopy(args),
 
   // uxpass-tool.ts
   uxpass_run:           (args) => uxpassRun(args),


### PR DESCRIPTION
## Summary
- Adds FidelityCopy deterministic copy and verifier MCP tools: `fidelitycopy_copy` and `fidelitypass_verify_copy`.
- Emits receipt fields for source/output refs, SHA-256 hashes, byte and character counts, line counts, newline styles, canonicalization mode, invariants, timestamp, verdict, and action-needed blocker text.
- Covers raw byte PASS, newline drift BLOCKER, UTF-8 normalization BLOCKER, JSON canonical PASS, approved transform PASS, AI retype SUPPRESS, and stored receipt verification.

## Scope
- `packages/mcp-server/src/fidelitycopy-tool.ts`
- `packages/mcp-server/src/__tests__/fidelitycopy-tool.test.ts`
- `packages/mcp-server/src/tool-wiring.ts`

## Proof
- `npm run test --workspace=@unclick/mcp-server -- src/__tests__/fidelitycopy-tool.test.ts` passed.
- `npm run build --workspace=@unclick/mcp-server` passed.

## Boardroom
- Supports todo `656728ef` FidelityCopy proof-missing lane.
- Does not mark the Boardroom job DONE. This PR supplies implementation proof for review.