### PR TITLE
Fix Memory Recall Top-of-Mind candidate selection

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -4115,6 +4115,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .limit(20);
 
         const topFactsLimit = getClampedLimit(req.query.top_facts_limit, 10, 110);
+        const topOfMindCandidateLimit = Math.max(topFactsLimit, 110);
 
         // Most accessed facts
         const { data: topFacts } = await supabase
@@ -4123,12 +4124,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("api_key_hash", apiKeyHash)
           .eq("status", "active")
           .order("access_count", { ascending: false })
-          .limit(topFactsLimit);
-        const annotatedTopFacts = (topFacts ?? []).map(annotateRecallFact);
-        const topOfMindFacts = annotatedTopFacts
+          .limit(topOfMindCandidateLimit);
+        const annotatedRecallCandidates = (topFacts ?? []).map(annotateRecallFact);
+        const topFactsForDisplay = annotatedRecallCandidates.slice(0, topFactsLimit);
+        const topOfMindFacts = annotatedRecallCandidates
           .filter((fact) => fact.recall_signal === "top-of-mind")
           .slice(0, 10);
-        const backgroundHeavyCount = annotatedTopFacts.filter((fact) => fact.recall_signal === "background-heavy").length;
+        const backgroundHeavyCount = topFactsForDisplay.filter((fact) => fact.recall_signal === "background-heavy").length;
 
         return res.status(200).json({
           facts_by_day: factsByDay,
@@ -4144,12 +4146,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           },
           top_facts_limit: topFactsLimit,
           recall_diagnostics: {
-            inspected_top_facts: annotatedTopFacts.length,
+            inspected_top_facts: topFactsForDisplay.length,
             background_heavy_count: backgroundHeavyCount,
           },
           recent_decay: recentDecay ?? [],
           top_of_mind_facts: topOfMindFacts,
-          top_facts: annotatedTopFacts,
+          top_facts: topFactsForDisplay,
         });
       }
 

--- a/src/pages/admin/memory/MemoryActivityTab.test.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.test.tsx
@@ -104,11 +104,11 @@ describe("MemoryActivityTab", () => {
       return {
         ...makeActivity(2),
         recall_diagnostics: {
-          inspected_top_facts: 2,
+          inspected_top_facts: 1,
           background_heavy_count: 1,
         },
         top_of_mind_facts: [activeFact],
-        top_facts: [backgroundFact, activeFact],
+        top_facts: [backgroundFact],
       };
     };
 


### PR DESCRIPTION
Boardroom todo: eb430faa Memory Recall Check pollution fix and useful Top-of-Mind proof.

What changed:
- Builds Top-of-Mind from a wider accessed-fact candidate pool so useful current facts can surface even when the visible raw Most Accessed list is dominated by background-heavy static facts.
- Keeps raw Most Accessed capped to the requested top_facts_limit for inspectable/debug UI.
- Preserves the +100 progressive reveal path.

Verification run locally:
- npm run test -- src/pages/admin/memory/MemoryActivityTab.test.tsx
- npm run build
- npm run brainmap:check
- npm run test:brainmap
- git diff --check origin/main...HEAD

Still required before DONE:
- Live /admin/memory?tab=recall-check screenshot or API response showing Top-of-Mind usefulness, raw/debug separation, and +100 still working.