### PR TITLE
fix(memory): widen Top-of-Mind recall candidates

### DIFF
--- a/api/lib/memory-recall-sections.test.ts
+++ b/api/lib/memory-recall-sections.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRecallFactSections } from "./memory-recall-sections";
+
+function fact(
+  id: string,
+  overrides: Partial<{
+    fact: string;
+    category: string;
+    access_count: number;
+    decay_tier: string;
+  }> = {},
+) {
+  return {
+    id,
+    fact: overrides.fact ?? `fact ${id}`,
+    category: overrides.category ?? "technical",
+    access_count: overrides.access_count ?? 1,
+    decay_tier: overrides.decay_tier ?? "hot",
+  };
+}
+
+describe("memory recall sections", () => {
+  it("uses a broader candidate pool for Top of Mind than raw Most Accessed", () => {
+    const rawMostAccessed = Array.from({ length: 10 }, (_, index) =>
+      fact(`static-${index + 1}`, {
+        fact: `Chris profile preference ${index + 1}`,
+        category: "preference",
+        access_count: 2080 - index,
+      }),
+    );
+    const activeProjectFact = fact("active-project", {
+      fact: "PR #997 made FidelityCopy receipts green",
+      category: "technical",
+      access_count: 42,
+    });
+
+    const sections = buildRecallFactSections(rawMostAccessed, [...rawMostAccessed, activeProjectFact]);
+
+    expect(sections.top_facts).toHaveLength(10);
+    expect(sections.top_facts.every((row) => row.recall_signal === "background-heavy")).toBe(true);
+    expect(sections.top_of_mind_facts.map((row) => row.id)).toContain("active-project");
+    expect(sections.top_of_mind_facts.map((row) => row.id)).not.toContain("static-1");
+    expect(sections.recall_diagnostics).toMatchObject({
+      inspected_top_facts: 10,
+      inspected_top_of_mind_candidates: 11,
+      background_heavy_count: 10,
+      background_heavy_candidate_count: 10,
+    });
+  });
+});

--- a/api/lib/memory-recall-sections.ts
+++ b/api/lib/memory-recall-sections.ts
@@ -1,0 +1,53 @@
+const BACKGROUND_RECALL_CATEGORIES = new Set(["identity", "preference", "standing_rule"]);
+const BACKGROUND_RECALL_PATTERNS = [
+  /^chris('s)?\s/i,
+  /^user\s/i,
+  /should always/i,
+  /never use/i,
+  /operator timezone/i,
+  /standing rule/i,
+  /profile/i,
+  /preference/i,
+];
+
+function annotateRecallFact<
+  T extends { category?: string | null; fact?: string | null; access_count?: number | null },
+>(fact: T) {
+  const category = String(fact.category ?? "").toLowerCase();
+  const text = String(fact.fact ?? "");
+  const accessCount = Number(fact.access_count ?? 0);
+  const looksStatic =
+    BACKGROUND_RECALL_CATEGORIES.has(category) || BACKGROUND_RECALL_PATTERNS.some((pattern) => pattern.test(text));
+  const isBackgroundHeavy = accessCount >= 100 && looksStatic;
+
+  return {
+    ...fact,
+    recall_signal: isBackgroundHeavy ? "background-heavy" : "top-of-mind",
+    recall_note: isBackgroundHeavy ? "Startup or heartbeat reads" : "Human-facing recall",
+  };
+}
+
+export function buildRecallFactSections<
+  T extends { category?: string | null; fact?: string | null; access_count?: number | null },
+>(topFacts: T[], topOfMindCandidates: T[] = topFacts) {
+  const annotatedTopFacts = topFacts.map(annotateRecallFact);
+  const annotatedTopOfMindCandidates = topOfMindCandidates.map(annotateRecallFact);
+  const topOfMindFacts = annotatedTopOfMindCandidates
+    .filter((fact) => fact.recall_signal === "top-of-mind")
+    .slice(0, 10);
+  const backgroundHeavyCount = annotatedTopFacts.filter((fact) => fact.recall_signal === "background-heavy").length;
+  const backgroundHeavyCandidateCount = annotatedTopOfMindCandidates.filter(
+    (fact) => fact.recall_signal === "background-heavy",
+  ).length;
+
+  return {
+    top_facts: annotatedTopFacts,
+    top_of_mind_facts: topOfMindFacts,
+    recall_diagnostics: {
+      inspected_top_facts: annotatedTopFacts.length,
+      inspected_top_of_mind_candidates: annotatedTopOfMindCandidates.length,
+      background_heavy_count: backgroundHeavyCount,
+      background_heavy_candidate_count: backgroundHeavyCandidateCount,
+    },
+  };
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -106,6 +106,7 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { evaluateFishbowlCompletionPolicy } from "./lib/fishbowl-completion-policy.js";
 import { inferFishbowlJobPipeline } from "./lib/fishbowl-job-pipeline.js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
+import { buildRecallFactSections } from "./lib/memory-recall-sections.js";
 import {
   buildOrchestratorContext,
   mergeOrchestratorTodoRows,
@@ -549,31 +550,7 @@ async function upsertAdminLibraryDoc(
   return `Library doc created: "${data.title}" (v1)`;
 }
 
-const BACKGROUND_RECALL_CATEGORIES = new Set(["identity", "preference", "standing_rule"]);
-const BACKGROUND_RECALL_PATTERNS = [
-  /^chris('s)?\s/i,
-  /^user\s/i,
-  /should always/i,
-  /never use/i,
-  /operator timezone/i,
-  /standing rule/i,
-  /profile/i,
-  /preference/i,
-];
-
-function annotateRecallFact<T extends { category?: string | null; fact?: string | null; access_count?: number | null }>(fact: T) {
-  const category = String(fact.category ?? "").toLowerCase();
-  const text = String(fact.fact ?? "");
-  const accessCount = Number(fact.access_count ?? 0);
-  const looksStatic = BACKGROUND_RECALL_CATEGORIES.has(category) || BACKGROUND_RECALL_PATTERNS.some((pattern) => pattern.test(text));
-  const isBackgroundHeavy = accessCount >= 100 && looksStatic;
-
-  return {
-    ...fact,
-    recall_signal: isBackgroundHeavy ? "background-heavy" : "top-of-mind",
-    recall_note: isBackgroundHeavy ? "Startup or heartbeat reads" : "Human-facing recall",
-  };
-}
+const TOP_OF_MIND_CANDIDATE_LIMIT = 110;
 
 function getRequestBaseUrl(req: VercelRequest): string | null {
   const explicit = process.env.EMBED_API_URL?.replace(/\/$/, "");
@@ -4116,19 +4093,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const topFactsLimit = getClampedLimit(req.query.top_facts_limit, 10, 110);
 
-        // Most accessed facts
-        const { data: topFacts } = await supabase
-          .from("mc_extracted_facts")
-          .select("id, fact, category, access_count, decay_tier")
-          .eq("api_key_hash", apiKeyHash)
-          .eq("status", "active")
-          .order("access_count", { ascending: false })
-          .limit(topFactsLimit);
-        const annotatedTopFacts = (topFacts ?? []).map(annotateRecallFact);
-        const topOfMindFacts = annotatedTopFacts
-          .filter((fact) => fact.recall_signal === "top-of-mind")
-          .slice(0, 10);
-        const backgroundHeavyCount = annotatedTopFacts.filter((fact) => fact.recall_signal === "background-heavy").length;
+        // Most Accessed remains the raw inspectable debug list. Top of Mind
+        // uses a broader candidate pool so static startup facts cannot crowd
+        // out the human-facing recall surface before filtering runs.
+        const topOfMindCandidateLimit = Math.max(topFactsLimit, TOP_OF_MIND_CANDIDATE_LIMIT);
+        const [topFactsResult, topOfMindCandidateResult] = await Promise.all([
+          supabase
+            .from("mc_extracted_facts")
+            .select("id, fact, category, access_count, decay_tier")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "active")
+            .order("access_count", { ascending: false })
+            .limit(topFactsLimit),
+          supabase
+            .from("mc_extracted_facts")
+            .select("id, fact, category, access_count, decay_tier")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "active")
+            .order("access_count", { ascending: false })
+            .limit(topOfMindCandidateLimit),
+        ]);
+        if (topFactsResult.error) throw topFactsResult.error;
+        if (topOfMindCandidateResult.error) throw topOfMindCandidateResult.error;
+
+        const recallSections = buildRecallFactSections(topFactsResult.data ?? [], topOfMindCandidateResult.data ?? []);
 
         return res.status(200).json({
           facts_by_day: factsByDay,
@@ -4143,13 +4131,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                    (facts.count ?? 0) + (convos.count ?? 0) + (code.count ?? 0),
           },
           top_facts_limit: topFactsLimit,
-          recall_diagnostics: {
-            inspected_top_facts: annotatedTopFacts.length,
-            background_heavy_count: backgroundHeavyCount,
-          },
+          recall_diagnostics: recallSections.recall_diagnostics,
           recent_decay: recentDecay ?? [],
-          top_of_mind_facts: topOfMindFacts,
-          top_facts: annotatedTopFacts,
+          top_of_mind_facts: recallSections.top_of_mind_facts,
+          top_facts: recallSections.top_facts,
         });
       }
 

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 471,
+    "inventory": 472,
     "source_manifest": 93,
     "pages": 94,
     "tools": 182,
@@ -75,7 +75,7 @@
       "id": "source-of-truth",
       "name": "Source of truth",
       "meaning": "Canonical state, queue, memory, and context surfaces.",
-      "count": 9
+      "count": 10
     },
     {
       "id": "modules-and-apps",
@@ -2808,6 +2808,16 @@
       "kind": "state module",
       "meaning": "memory Data Island shared frontend logic.",
       "source": "src/lib/memoryDataIsland.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-memory-recall-sections-api-lib-memory-recall-sections-ts",
+      "division": "Source of truth",
+      "name": "memory recall sections",
+      "kind": "state module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/memory-recall-sections.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -120,7 +120,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 108 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
-| Source of truth | Canonical state, queue, memory, and context surfaces. | 9 |
+| Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 19 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 4 |
 
@@ -695,6 +695,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Source of truth | state module | embed | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory/embed.ts |
 | Source of truth | state module | memory admin | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory-admin.ts |
 | Source of truth | state module | memory Data Island | memory Data Island shared frontend logic. | - | src/lib/memoryDataIsland.ts |
+| Source of truth | state module | memory recall sections | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/memory-recall-sections.ts |
 | Source of truth | state module | memory retrieval eval | memory retrieval eval UnClick module. | - | scripts/memory-retrieval-eval.mjs |
 | Source of truth | state module | memory Taxonomy | memory Taxonomy shared frontend logic. | - | src/lib/memoryTaxonomy.ts |
 | Source of truth | state module | orchestrator context | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/orchestrator-context.ts |

--- a/docs/memory/active_facts-contract-v1.md
+++ b/docs/memory/active_facts-contract-v1.md
@@ -1,7 +1,7 @@
 # Active Facts Contract V1
 
 **Status**: Draft  
-**Last updated**: 2026-04-29  
+**Last updated**: 2026-05-22
 **Owner**: `🦾`  
 **Purpose**: Pre-work contract draft for Cluster A before Chris's design call
 
@@ -291,6 +291,25 @@ If any local path cannot bump metrics yet, it MUST still:
 - return the same surfaced set it would have returned under parity
 - avoid bumping hidden facts
 - document the temporary gap as an implementation limitation rather than a different contract
+
+## Recall Check presentation contract
+
+Recall Check has two separate jobs:
+
+1. preserve a raw, inspectable Most Accessed list
+2. present a human-facing Top of Mind list that remains useful when raw access counts are dominated by startup or heartbeat reads
+
+The Top of Mind list MUST NOT be derived only from the first visible page of raw Most Accessed rows. It should inspect a broader candidate pool, label or demote background-heavy static profile facts, and then choose the top user-facing facts from the remaining candidates.
+
+Raw Most Accessed may still show background-heavy facts for debugging and inspection, but those rows should carry a signal such as `background-heavy` so the UI and API response make the separation observable.
+
+The Recall Check response SHOULD include diagnostics that distinguish:
+
+- how many raw Most Accessed rows were returned
+- how many Top of Mind candidates were inspected
+- how many background-heavy rows were found in each set
+
+This preserves the debugging value of access counts without letting background loads become the main human-facing recall answer.
 
 ## Recommended V1 rule summary
 

--- a/src/pages/admin/memory/MemoryActivityTab.test.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.test.tsx
@@ -120,4 +120,46 @@ describe("MemoryActivityTab", () => {
     expect(screen.getByText("Background-heavy")).toBeInTheDocument();
     expect(screen.getByText("Startup or heartbeat reads")).toBeInTheDocument();
   });
+
+  it("keeps Top of Mind useful when raw Most Accessed is all background-heavy", async () => {
+    activityFactory = () => {
+      const backgroundFacts = Array.from({ length: 10 }, (_, index) => ({
+        id: `static-profile-${index + 1}`,
+        fact: `Chris profile preference ${index + 1}`,
+        category: "preference",
+        access_count: 2080 - index,
+        decay_tier: "hot",
+        recall_signal: "background-heavy" as const,
+        recall_note: "Startup or heartbeat reads",
+      }));
+      const activeFact = {
+        id: "active-project",
+        fact: "PR #997 made FidelityCopy receipts green",
+        category: "technical",
+        access_count: 42,
+        decay_tier: "hot",
+        recall_signal: "top-of-mind" as const,
+        recall_note: "Human-facing recall",
+      };
+
+      return {
+        ...makeActivity(10),
+        recall_diagnostics: {
+          inspected_top_facts: 10,
+          inspected_top_of_mind_candidates: 11,
+          background_heavy_count: 10,
+          background_heavy_candidate_count: 10,
+        },
+        top_of_mind_facts: [activeFact],
+        top_facts: backgroundFacts,
+      };
+    };
+
+    render(<MemoryActivityTab apiKey="test-token" />);
+
+    await screen.findByText("Top of Mind");
+
+    expect(screen.getByText("PR #997 made FidelityCopy receipts green")).toBeInTheDocument();
+    expect(screen.getAllByText("Background-heavy")).toHaveLength(10);
+  });
 });

--- a/src/pages/admin/memory/MemoryActivityTab.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.tsx
@@ -36,7 +36,9 @@ interface ActivityData {
   top_facts: RecallFact[];
   recall_diagnostics?: {
     inspected_top_facts: number;
+    inspected_top_of_mind_candidates?: number;
     background_heavy_count: number;
+    background_heavy_candidate_count?: number;
   };
 }
 


### PR DESCRIPTION
## Summary
- Widened Memory Recall Top of Mind selection so it filters from a broader candidate pool instead of only the first raw Most Accessed page.
- Kept raw Most Accessed as the inspectable debug list, with background-heavy signals preserved for static startup/profile facts.
- Added a small recall-section helper, focused helper test, UI test coverage, contract docs, and refreshed Brainmap inventory.

## Scope
- Todo: eb430faa Memory Recall Check pollution fix and useful Top-of-Mind proof
- ScopePack: 7740948e
- Owned lane: Memory Recall / Top of Mind
- Files touched: api/memory-admin.ts, api/lib/memory-recall-sections.ts, api/lib/memory-recall-sections.test.ts, src/pages/admin/memory/MemoryActivityTab.tsx, src/pages/admin/memory/MemoryActivityTab.test.tsx, docs/memory/active_facts-contract-v1.md, docs/UnClick-brainmap.generated.md, docs/UnClick-brainmap.generated.json

## Non-overlap
- Did not touch Orchestrator Log-Read-Decide PR #996 or FidelityCopy PR #997.
- Did not mark eb430faa DONE.
- Did not change memory storage, decay writes, or ingestion behavior.
- Did not merge, deploy, or mutate production data.

## Verification
- PASS: git diff --check
- PASS: direct helper proof via tsx confirmed 10 background-heavy raw rows, 11 Top of Mind candidates inspected, and active-project retained in Top of Mind.
- PASS: npm run brainmap:check
- PASS: npm run test:brainmap, 6/6
- PASS CI: Website root package, MCP server package, TestPass smoke run, Review dry-run warning, Vercel, and Vercel Preview Comments.
- Local limitation: the isolated cloud-backed worktree could not run full Vitest/build locally because node_modules linking failed and npm ci timed out. CI provided the package proof.

## Risk
- Low runtime risk: this adds one extra bounded query capped at 110 active facts for the Recall Check activity endpoint.
- User-facing risk: Top of Mind changes which facts are highlighted, but raw Most Accessed remains visible for debugging.

## Follow-up
- Keep this PR draft until reviewer or owner lift.
- Do not close eb430faa until live /admin/memory?tab=recall-check screenshot or API proof shows useful Top of Mind behavior in the product.