### PR TITLE
fix(reliability): surface proof ledger state warnings

### DIFF
--- a/api/fishbowl-job-pipeline.test.ts
+++ b/api/fishbowl-job-pipeline.test.ts
@@ -28,11 +28,13 @@ describe("Fishbowl job pipeline inference", () => {
         },
         ["Old receipt: PR #699 merged into main. Tests passed.", "BLOCKER: proof reset, live page still shows no snapshots."],
       ),
-    ).toEqual({
+    ).toMatchObject({
       pipeline_stage_count: 1,
       pipeline_progress: 10,
       pipeline_source: "reopened: proof reset",
       pipeline_evidence: ["reopened", "proof_missing"],
+      proof_state: "STALE",
+      proof_state_closable: false,
     });
   });
 
@@ -45,11 +47,13 @@ describe("Fishbowl job pipeline inference", () => {
         },
         ["BLOCKER: proof missing, live recall check still repeats static identity facts."],
       ),
-    ).toEqual({
+    ).toMatchObject({
       pipeline_stage_count: 1,
       pipeline_progress: 10,
       pipeline_source: "proof: missing",
       pipeline_evidence: ["proof_missing"],
+      proof_state: "MISSING",
+      proof_state_closable: false,
     });
   });
 
@@ -80,6 +84,65 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_progress: 85,
       pipeline_source: "receipt: review",
       pipeline_evidence: ["build", "proof", "review"],
+      proof_state: "LIVE",
+      proof_state_closable: true,
+    });
+  });
+
+  it("keeps missing UI proof separate from a shipped-looking pipeline", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "Brainmap v2: visual private admin and full tool-worker tree",
+          status: "open",
+        },
+        [
+          "PASS: PR #943 merged into main. Tests passed.",
+          "PARTIAL/BLOCKER: missing authenticated /admin/brainmap screenshot or browser proof.",
+        ],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["build", "proof", "ship"],
+      proof_state: "MISSING_UI_PROOF",
+      proof_state_label: "Missing UI proof",
+      proof_state_closable: false,
+    });
+  });
+
+  it("marks broad parent proof as wrong scope even when slice proof is real", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "Absorb gbrain patterns into UnClick parent",
+          status: "open",
+        },
+        [
+          "PASS: PR #891 merged into main. Tests passed.",
+          "PARTIAL: typed-link slices are real, but broad parent remains unfinished.",
+        ],
+      ),
+    ).toMatchObject({
+      proof_state: "WRONG_SCOPE",
+      proof_state_closable: false,
+    });
+  });
+
+  it("keeps parked scoping proof from acting like completion proof", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "PARKED: StepBack Research Update",
+          status: "open",
+        },
+        ["Keep this parked unless a Master Plan rewrite is actively requested."],
+      ),
+    ).toMatchObject({
+      proof_state: "PARKED",
+      proof_state_label: "Parked",
+      proof_state_closable: false,
     });
   });
 });

--- a/api/lib/fishbowl-job-pipeline.ts
+++ b/api/lib/fishbowl-job-pipeline.ts
@@ -9,6 +9,10 @@ export interface FishbowlJobPipelineState {
   pipeline_progress: number;
   pipeline_source: string;
   pipeline_evidence: string[];
+  proof_state: FishbowlProofState;
+  proof_state_label: string;
+  proof_state_detail: string;
+  proof_state_closable: boolean;
 }
 
 export type FishbowlJobPipelineComment =
@@ -34,9 +38,83 @@ const stageProgress: Record<number, number> = {
   5: 100,
 };
 
+export type FishbowlProofState =
+  | "LIVE"
+  | "PARTIAL"
+  | "BLOCKED"
+  | "MISSING_UI_PROOF"
+  | "PARKED"
+  | "STALE"
+  | "WRONG_SCOPE"
+  | "CLOSE_ELIGIBLE"
+  | "MISSING";
+
+const PROOF_STATE_COPY: Record<
+  FishbowlProofState,
+  {
+    label: string;
+    detail: string;
+    closable: boolean;
+  }
+> = {
+  LIVE: {
+    label: "Live proof",
+    detail: "Current proof is present for this job.",
+    closable: true,
+  },
+  CLOSE_ELIGIBLE: {
+    label: "Close eligible",
+    detail: "Current proof looks complete enough for a closer to review.",
+    closable: true,
+  },
+  PARTIAL: {
+    label: "Partial proof",
+    detail: "Some real proof exists, but it does not satisfy the full job scope.",
+    closable: false,
+  },
+  BLOCKED: {
+    label: "Proof blocked",
+    detail: "The latest proof says this job is blocked or waiting on required evidence.",
+    closable: false,
+  },
+  MISSING_UI_PROOF: {
+    label: "Missing UI proof",
+    detail: "This visual or admin-surface job needs screenshot or browser proof.",
+    closable: false,
+  },
+  PARKED: {
+    label: "Parked",
+    detail: "This job has a parking or scoping decision, not completion proof.",
+    closable: false,
+  },
+  STALE: {
+    label: "Stale proof",
+    detail: "Older proof is present, but later evidence says it is stale or reset.",
+    closable: false,
+  },
+  WRONG_SCOPE: {
+    label: "Wrong scope",
+    detail: "Linked proof appears to cover a narrower or different scope.",
+    closable: false,
+  },
+  MISSING: {
+    label: "Proof missing",
+    detail: "Required outcome proof is missing.",
+    closable: false,
+  },
+};
+
 const PROOF_RESET_RE = /\b(reopened|re-opened|proof\s+reset|false\s+completion|partial\s+completion)\b/i;
 const PROOF_MISSING_RE =
   /\b(no|missing|needs?|needed|waiting for|without|incomplete|stale)\s+(?:live\s+)?proof\b|\bproof\s+(?:missing|needed|incomplete|stale|not available)\b/i;
+const PROOF_UI_MISSING_RE =
+  /\b(missing|needs?|needed|without|lacks?)\b.{0,80}\b(authenticated\s+)?(screenshot|browser|ui|admin\s+screen|\/admin)\b|\b(screenshot|browser|ui)\b.{0,80}\b(missing|needed|required)\b/i;
+const PROOF_WRONG_SCOPE_RE =
+  /\bwrong[-_\s]?scope\b|\bbroad(?:er)?\s+(?:parent|scope)\b|\bnarrower\s+(?:slice|scope)\b|\bnot\s+(?:the\s+)?whole\b|\bfull\s+acceptance\b/i;
+const PROOF_BLOCKED_RE =
+  /\b(blocker|blocked|hold|do not merge|do not lift|waiting on|pending owner|owner lift|safe fail-fast|missing configured)\b/i;
+const PROOF_PARKED_RE = /\bparked\b|\bkeep\s+(?:it\s+)?parked\b|\bparking decision\b/i;
+const PROOF_PARTIAL_RE = /\bpartial\b|\bfirst[-\s]?slice\b|\breal\s+first\s+slice\b|\bnot\s+completion\s+proof\b/i;
 
 function positiveStageHit(text: string, positive: RegExp, negative?: RegExp): boolean {
   if (!positive.test(text)) return false;
@@ -59,6 +137,51 @@ function buildSegments(todo: FishbowlJobPipelineTodo, comments: FishbowlJobPipel
   return [todo.title, todo.description, ...commentSegments.map(commentText)]
     .filter((value) => typeof value === "string" && value.trim().length > 0)
     .map((value) => value.toLowerCase());
+}
+
+function proofStateFromText(text: string): FishbowlProofState | null {
+  if (PROOF_PARKED_RE.test(text)) return "PARKED";
+  if (PROOF_UI_MISSING_RE.test(text)) return "MISSING_UI_PROOF";
+  if (PROOF_WRONG_SCOPE_RE.test(text)) return "WRONG_SCOPE";
+  if (PROOF_BLOCKED_RE.test(text)) return "BLOCKED";
+  if (PROOF_RESET_RE.test(text) || /\bstale\s+proof\b/i.test(text)) return "STALE";
+  if (PROOF_PARTIAL_RE.test(text)) return "PARTIAL";
+  if (PROOF_MISSING_RE.test(text)) return "MISSING";
+  return null;
+}
+
+function proofStateFields(state: FishbowlProofState): Pick<
+  FishbowlJobPipelineState,
+  "proof_state" | "proof_state_label" | "proof_state_detail" | "proof_state_closable"
+> {
+  const copy = PROOF_STATE_COPY[state];
+  return {
+    proof_state: state,
+    proof_state_label: copy.label,
+    proof_state_detail: copy.detail,
+    proof_state_closable: copy.closable,
+  };
+}
+
+function inferProofState(
+  segments: string[],
+  latestProgressIndex: number,
+  status: string,
+  activeCount: number,
+  evidence: string[],
+): FishbowlProofState {
+  const latestIssue = segments.reduce<{ index: number; state: FishbowlProofState | null }>(
+    (latest, segment, index) => {
+      const state = proofStateFromText(segment);
+      return state ? { index, state } : latest;
+    },
+    { index: -1, state: null },
+  );
+  if (latestIssue.state && latestIssue.index >= latestProgressIndex) return latestIssue.state;
+  if (activeCount >= stageRank.ship && evidence.includes("proof")) return "CLOSE_ELIGIBLE";
+  if (evidence.includes("proof")) return "LIVE";
+  if (status === "done") return "MISSING";
+  return "MISSING";
 }
 
 export function inferFishbowlJobPipeline(
@@ -88,6 +211,7 @@ export function inferFishbowlJobPipeline(
       pipeline_progress: stageProgress[stageRank.brief],
       pipeline_source: resetHit ? "reopened: proof reset" : "proof: missing",
       pipeline_evidence: resetHit ? ["reopened", "proof_missing"] : ["proof_missing"],
+      ...proofStateFields(resetHit ? "STALE" : "MISSING"),
     };
   }
 
@@ -144,10 +268,13 @@ export function inferFishbowlJobPipeline(
     source = "receipt: ship";
   }
 
+  const proofState = inferProofState(segments, latestProgressIndex, status, activeCount, evidence);
+
   return {
     pipeline_stage_count: activeCount,
     pipeline_progress: stageProgress[activeCount] ?? stageProgress[stageRank.brief],
     pipeline_source: source,
     pipeline_evidence: evidence,
+    ...proofStateFields(proofState),
   };
 }

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -9480,6 +9480,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             pipeline_progress: t.pipeline_progress,
             pipeline_source: t.pipeline_source,
             pipeline_evidence: t.pipeline_evidence,
+            proof_state: t.proof_state,
+            proof_state_label: t.proof_state_label,
+            proof_state_detail: t.proof_state_detail,
+            proof_state_closable: t.proof_state_closable,
           }));
           return res.status(200).json({
             todos: includeDescription ? decorated : compactTodos,

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -133,4 +133,34 @@ describe("AdminJobs", () => {
     expect(alertsCard).not.toBeNull();
     expect(within(alertsCard as HTMLElement).getByText("1")).toBeInTheDocument();
   });
+
+  it("surfaces current proof_state warnings on shipped-looking rows", async () => {
+    currentJobs = [
+      {
+        id: "visual-proof-job",
+        title: "Brainmap v2 visual admin proof",
+        description: "PR merged, but screenshot proof is missing.",
+        status: "open",
+        priority: "high",
+        created_by_agent_id: "tester",
+        assigned_to_agent_id: null,
+        created_at: "2026-05-14T12:00:00.000Z",
+        completed_at: null,
+        updated_at: "2026-05-14T12:00:00.000Z",
+        comment_count: 4,
+        pipeline_stage_count: 5,
+        pipeline_progress: 100,
+        pipeline_source: "receipt: ship",
+        pipeline_evidence: ["build", "proof", "ship"],
+        proof_state: "MISSING_UI_PROOF",
+        proof_state_label: "Missing UI proof",
+        proof_state_detail: "Needs authenticated /admin/jobs screenshot proof.",
+        proof_state_closable: false,
+      },
+    ];
+
+    render(React.createElement(AdminJobs));
+
+    expect(await screen.findByText("Missing UI proof")).toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -51,6 +51,10 @@ interface JobTodo {
   pipeline_progress?: number;
   pipeline_source?: string;
   pipeline_evidence?: string[];
+  proof_state?: string | null;
+  proof_state_label?: string | null;
+  proof_state_detail?: string | null;
+  proof_state_closable?: boolean | null;
 }
 
 type JobSectionKey = "active" | "next" | "inline" | "done";

--- a/src/pages/admin/jobsGithubSync.test.ts
+++ b/src/pages/admin/jobsGithubSync.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildJobGithubSyncSignal,
   extractJobGithubReferences,
+  jobHasCurrentProofWarning,
   jobHasDeploymentFailure,
   jobHasProofReset,
   type JobGithubSyncInput,
@@ -97,6 +98,75 @@ describe("Jobs and GitHub sync helpers", () => {
       detail: "This job was reopened or blocked because proof is stale or missing.",
       tone: "alert",
     });
+  });
+
+  it("lets current proof_state warnings override stale shipped-looking proof", () => {
+    const warningJob = {
+      ...baseJob,
+      description: "Proof: https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/943",
+      pipeline_evidence: ["build", "proof", "ship"],
+      proof_state: "MISSING_UI_PROOF",
+      proof_state_label: "Missing UI proof",
+      proof_state_detail: "Needs authenticated /admin/jobs screenshot proof.",
+      proof_state_closable: false,
+    };
+
+    expect(jobHasCurrentProofWarning(warningJob)).toBe(true);
+    expect(buildJobGithubSyncSignal(warningJob)).toEqual({
+      label: "Missing UI proof",
+      detail: "Needs authenticated /admin/jobs screenshot proof.",
+      tone: "alert",
+      href: "https://github.com/malamutemayhem/unclick-agent-native-endpoints/pull/943",
+    });
+  });
+
+  it("does not warn when proof_state is close eligible", () => {
+    expect(
+      jobHasCurrentProofWarning({
+        ...baseJob,
+        proof_state: "CLOSE_ELIGIBLE",
+        proof_state_closable: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not turn ordinary open missing proof state into a proof warning", () => {
+    expect(
+      jobHasCurrentProofWarning({
+        ...baseJob,
+        pipeline_progress: 10,
+        pipeline_source: "status: open",
+        proof_state: "MISSING",
+        proof_state_closable: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      buildJobGithubSyncSignal({
+        ...baseJob,
+        pipeline_progress: 10,
+        pipeline_source: "status: open",
+        proof_state: "MISSING",
+        proof_state_closable: false,
+      }),
+    ).toEqual({
+      label: "Job first",
+      detail: "Work starts here. Add a PR, run, or deployment link when code ships.",
+      tone: "quiet",
+    });
+  });
+
+  it("does flag missing proof state on shipped-looking rows", () => {
+    expect(
+      jobHasCurrentProofWarning({
+        ...baseJob,
+        pipeline_progress: 100,
+        pipeline_source: "receipt: ship",
+        pipeline_evidence: ["build", "proof", "ship"],
+        proof_state: "MISSING",
+        proof_state_closable: false,
+      }),
+    ).toBe(true);
   });
 
   it("lets current pipeline proof clear old reopened wording", () => {

--- a/src/pages/admin/jobsGithubSync.ts
+++ b/src/pages/admin/jobsGithubSync.ts
@@ -5,7 +5,13 @@ export interface JobGithubSyncInput {
   title: string;
   description?: string | null;
   status: JobSyncStatus;
+  pipeline_progress?: number | null;
+  pipeline_source?: string | null;
   pipeline_evidence?: string[];
+  proof_state?: string | null;
+  proof_state_label?: string | null;
+  proof_state_detail?: string | null;
+  proof_state_closable?: boolean | null;
 }
 
 export interface JobGithubReference {
@@ -102,6 +108,25 @@ export function jobHasProofReset(job: JobGithubSyncInput): boolean {
   return PROOF_RESET_RE.test(text) || PROOF_MISSING_RE.test(text);
 }
 
+export function jobHasCurrentProofWarning(job: JobGithubSyncInput): boolean {
+  const state = String(job.proof_state ?? "").trim().toUpperCase();
+  if (!state) return false;
+  if (job.proof_state_closable === true) return false;
+  if (["LIVE", "CLOSE_ELIGIBLE"].includes(state)) return false;
+  if (state !== "MISSING") return true;
+
+  const evidence = job.pipeline_evidence ?? [];
+  const source = String(job.pipeline_source ?? "");
+  const progress = typeof job.pipeline_progress === "number" ? job.pipeline_progress : 0;
+
+  return (
+    job.status === "done" ||
+    progress >= 100 ||
+    /\b(receipt:\s*(ship|proof|review)|status:\s*done|reopened|proof:\s*missing)\b/i.test(source) ||
+    evidence.some((item) => /\b(proof_missing|reopened|ship)\b/i.test(item))
+  );
+}
+
 export function buildJobGithubSyncSignal(job: JobGithubSyncInput): JobGithubSyncSignal {
   const refs = extractJobGithubReferences(job);
   const firstPr = refs.find((ref) => ref.kind === "pull_request");
@@ -113,6 +138,15 @@ export function buildJobGithubSyncSignal(job: JobGithubSyncInput): JobGithubSync
     return {
       label: "Deploy issue",
       detail: "A linked deployment needs attention.",
+      tone: "alert",
+      href: firstLink?.url,
+    };
+  }
+
+  if (jobHasCurrentProofWarning(job)) {
+    return {
+      label: job.proof_state_label?.trim() || "Proof warning",
+      detail: job.proof_state_detail?.trim() || "Current proof state is not close-ready.",
       tone: "alert",
       href: firstLink?.url,
     };


### PR DESCRIPTION
Summary:
- Adds typed proof_state metadata to Fishbowl job pipeline inference so shipped-looking rows can still say stale, partial, parked, wrong-scope, blocked, or missing UI proof.
- Passes proof_state through fishbowl_list_todos and surfaces non-close-ready proof states in the Admin Jobs proof pill.
- Keeps ordinary open rows quiet when proof_state is MISSING but the row is not done or shipped-looking.

Scope:
- Owned Boardroom todo: a3e42947 Proof Ledger v2 warning slice.
- Files touched: api/lib/fishbowl-job-pipeline.ts, api/memory-admin.ts, Admin Jobs sync/UI helpers, and focused tests.

Non-overlap:
- Does not close a3e42947.
- Does not change Completion audit, Memory Recall, FidelityCopy, Orchestrator gate, CopyRoom, routing, or live Boardroom queue ownership.
- Does not change database schema or persistence tables.

Verification:
- PASS: vitest focused suite, 3 files / 22 tests: api/fishbowl-job-pipeline.test.ts, src/pages/admin/jobsGithubSync.test.ts, src/pages/admin/AdminJobs.test.tsx.
- PASS: Vite production build using the clean worktree and shared installed deps.
- PASS: UI screenshot proof captured with Playwright Edge against a bundled AdminJobs harness showing the Missing UI proof pill: C:\Users\creat\Documents\Codex\2026-05-22\please-context-to-unclick-to-get\proof-ledger-proof-state-warning.png

Risk:
- Low runtime risk: metadata is derived from existing title/description/comment text and exposed as additional response fields.
- UI risk is limited to proof pill labeling; existing linked PR/run/deploy signals remain the fallback when no current proof warning applies.

Follow-up:
- A closer should verify live /admin/jobs rows after merge before marking a3e42947 done.