### PR TITLE
fix(reliability): keep open backlog out of rolling active jobs

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -446,6 +446,9 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   // input. Computed over the full input.todos array, NOT the sliced
   // activeTodos, so the count is deterministic regardless of UI cap.
   const activeJobsCount = computeActiveJobsCount(input.todos, input.profiles, nowMs);
+  const activeJobTodos = input.todos
+    .filter((todo) => isFreshlyOwnedInProgressTodo(todo, profileLastSeenByAgent, nowMs))
+    .sort(compareTodoPriorityThenUpdated);
 
   // CommonSensePass R1 verdict (added by PR #746). The orchestrator
   // context publishes an implicit "healthy" / "quiet" claim whenever
@@ -528,6 +531,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     nowMs,
     newestActivityAt,
     activeTodos,
+    activeJobTodos,
     activeJobsCount,
     queuedTodoCount,
     continuityEvents,
@@ -830,8 +834,14 @@ function buildSeatHandshake({
   const usefulEvents = continuityEvents.filter((event) => !isSnapshotNoise(event));
   const recentProof = usefulEvents.find((event) => event.kind === "proof") ?? null;
   const decision = rollingSnapshot.promoted_decisions[0] ?? null;
-  const job = rollingSnapshot.active_jobs[0] ?? null;
-  const jobIsQueued = job?.tags?.includes("open") ?? false;
+  const activeJob = rollingSnapshot.active_jobs[0] ?? null;
+  const queuedJob = activeJob
+    ? null
+    : rollingSnapshot.recent_continuity.find(
+        (item) => item.source_kind === "todo" && (item.tags ?? []).includes("open"),
+      ) ?? null;
+  const job = activeJob ?? queuedJob;
+  const jobIsQueued = !activeJob && !!queuedJob;
   const blocker = rollingSnapshot.active_blockers[0] ?? null;
   const activeDecision =
     decision?.summary ??
@@ -926,6 +936,7 @@ function buildRollingSnapshot({
   nowMs,
   newestActivityAt,
   activeTodos,
+  activeJobTodos,
   activeJobsCount,
   queuedTodoCount,
   continuityEvents,
@@ -936,6 +947,7 @@ function buildRollingSnapshot({
   nowMs: number;
   newestActivityAt: string | null;
   activeTodos: OrchestratorTodoRow[];
+  activeJobTodos: OrchestratorTodoRow[];
   activeJobsCount: number;
   queuedTodoCount: number;
   continuityEvents: OrchestratorContinuityEvent[];
@@ -951,7 +963,7 @@ function buildRollingSnapshot({
     .filter((event) => isActiveBlockerEvent(event, activeTodos, nowMs, profileLastSeenByAgent))
     .slice(0, 5)
     .map((event) => eventToSnapshotItem(event, "blocker"));
-  const activeJobs = activeTodos.slice(0, 6).map((todo) => ({
+  const activeJobs = activeJobTodos.slice(0, 6).map((todo) => ({
     source_kind: "todo" as const,
     source_id: todo.id,
     deep_link: `/admin/jobs#todo-${todo.id}`,
@@ -1637,6 +1649,17 @@ function isOwnerFresh(iso: string | null | undefined, nowMs: number): boolean {
   return Number.isFinite(seenMs) && Number.isFinite(nowMs) && nowMs - seenMs <= OWNER_FRESH_WINDOW_MS;
 }
 
+function isFreshlyOwnedInProgressTodo(
+  todo: OrchestratorTodoRow,
+  ownerLastSeen: Map<string, string | null>,
+  nowMs: number,
+): boolean {
+  if (todo.status !== "in_progress") return false;
+  const owner = todo.assigned_to_agent_id;
+  if (!owner) return false;
+  return isOwnerFresh(ownerLastSeen.get(owner), nowMs);
+}
+
 export function computeActiveJobsCount(
   todos: OrchestratorTodoRow[],
   profiles: OrchestratorProfileRow[],
@@ -1649,10 +1672,7 @@ export function computeActiveJobsCount(
     }
   }
   return todos.filter((todo) => {
-    if (todo.status !== "in_progress") return false;
-    const owner = todo.assigned_to_agent_id;
-    if (!owner) return false;
-    return isOwnerFresh(ownerLastSeen.get(owner), nowMs);
+    return isFreshlyOwnedInProgressTodo(todo, ownerLastSeen, nowMs);
   }).length;
 }
 

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -237,6 +237,60 @@ describe("orchestrator context", () => {
     expect(context.current_state_card.harness_card.test_runner_rule).toContain("Test-only runner packets");
   });
 
+  it("keeps open backlog out of rolling snapshot active jobs", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-22T03:55:00.000Z",
+      profiles: [
+        {
+          agent_id: "fresh-builder",
+          display_name: "Fresh Builder",
+          user_agent_hint: "codex-desktop",
+          last_seen_at: "2026-05-22T03:54:00.000Z",
+        },
+      ],
+      messages: [],
+      todos: [
+        {
+          id: "todo-open",
+          title: "JobSmith application manager",
+          description: "Open urgent backlog that should stay in next actions, not active work.",
+          status: "open",
+          priority: "urgent",
+          created_by_agent_id: "stale-seat",
+          assigned_to_agent_id: null,
+          created_at: "2026-05-19T10:44:00.000Z",
+          updated_at: "2026-05-19T10:44:00.000Z",
+        },
+        {
+          id: "todo-active",
+          title: "Proof Ledger v2",
+          description: "Fresh in-progress active work.",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "router",
+          assigned_to_agent_id: "fresh-builder",
+          created_at: "2026-05-18T09:41:00.000Z",
+          updated_at: "2026-05-22T03:15:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.current_state_card.active_jobs).toBe(1);
+    expect(context.current_state_card.queued_todo_count).toBe(1);
+    expect(context.current_state_card.next_actions.join(" ")).toContain("JobSmith application manager");
+    expect(context.rolling_snapshot.active_jobs.map((job) => job.source_id)).toEqual(["todo-active"]);
+    expect(context.rolling_snapshot.active_jobs.map((job) => job.source_id)).not.toContain("todo-open");
+    expect(context.seat_handshake.active_job).toContain("Proof Ledger v2");
+    expect(context.seat_handshake.active_job).not.toContain("Queued job needs claim");
+  });
+
   it("adds human operator timezone context to compact handoffs", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-10T01:00:00.000Z",


### PR DESCRIPTION
Summary:
- Align rolling_snapshot.active_jobs with current_state_card active job truth.
- Keep open urgent backlog in next_actions/recent continuity instead of promoting it as active work.
- Preserve queued-job seat handoff behavior only when there is no fresh in-progress active job.

Scope:
- Owned files: api/lib/orchestrator-context.ts and api/orchestrator-context.test.ts.
- Lane: Orchestrator / queue truth.
- Linked Boardroom todo: 00337dd1.

Non-overlap:
- Does not touch Proof Ledger, Memory Recall, FidelityCopy, JobSmith product work, UI, database schema, or auth.
- Does not mark any Boardroom job DONE.

Verification:
- PASS: C:\G\UnClick\repos\unclick-agent-native-endpoints\node_modules\.bin\vitest.cmd run api/orchestrator-context.test.ts --config C:\Users\creat\Documents\Codex\2026-05-22\please-context-to-unclick-to-get\vitest.node.config.mjs (33 tests passed).
- PASS: targeted tsx assertion against buildOrchestratorContext proved open todo-open stays out of rolling_snapshot.active_jobs while fresh todo-active remains active.
- PASS: git diff --check.
- Note: npm ci in the isolated worktree timed out and left ignored node_modules partials; verification used the existing repository dependency install plus a minimal node Vitest config.

Risk:
- Low. This changes Orchestrator context classification only. The main user-facing effect is fewer stale/open backlog rows being presented as active jobs.
- No migrations, secrets, cron, billing, or production data changes.

Follow-up:
- After review/merge, confirm live Orchestrator context no longer includes open JobSmith 55766d56 in rolling_snapshot.active_jobs while still showing it as queued/next action.
- Draft until reviewer or owner lift approves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `rolling_snapshot.active_jobs` and `seat_handshake` select the “current job”, which can affect what operators/seats see and act on. Scoped to orchestrator context classification with no persistence/auth changes, but incorrect filtering could hide or misprioritize work in handoffs.
> 
> **Overview**
> **Rolling snapshots now only promote truly-active work.** `rolling_snapshot.active_jobs` is built from freshly-owned `in_progress` todos (owner seen within the freshness window) instead of the general `activeTodos` list, keeping `open` backlog items in `next_actions`/continuity rather than “active jobs.”
> 
> **Seat handoff preserves queued-job behavior only when needed.** `buildSeatHandshake` prefers the top active job, but if none exists it falls back to the most recent queued (`open`) todo from `recent_continuity`, maintaining “queued job needs claim” messaging only when there’s no fresh active job.
> 
> Adds a focused test asserting that an `open` urgent todo stays out of `rolling_snapshot.active_jobs` while a fresh `in_progress` todo is promoted and used in the handshake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a090995f44e61120ddc2d2e05894f4b2aa952fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->