### PR TITLE
feat(proof-ledger): surface structured proof states

### DIFF
--- a/api/fishbowl-job-pipeline.test.ts
+++ b/api/fishbowl-job-pipeline.test.ts
@@ -16,6 +16,23 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_progress: 100,
       pipeline_source: "receipt: ship",
       pipeline_evidence: ["build", "proof", "ship"],
+      proof_state: "close_eligible",
+    });
+  });
+
+  it("labels completed jobs without receipts as missing proof", () => {
+    expect(
+      inferFishbowlJobPipeline({
+        title: "Completed without linked proof",
+        status: "done",
+      }),
+    ).toMatchObject({
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_source: "status: done",
+      pipeline_evidence: [],
+      proof_state: "missing",
+      proof_state_reason: "Completed job needs observable proof.",
     });
   });
 
@@ -33,6 +50,8 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_progress: 10,
       pipeline_source: "reopened: proof reset",
       pipeline_evidence: ["reopened", "proof_missing"],
+      proof_state: "stale",
+      proof_state_reason: "The latest receipt is stale or reset.",
     });
   });
 
@@ -50,6 +69,8 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_progress: 10,
       pipeline_source: "proof: missing",
       pipeline_evidence: ["proof_missing"],
+      proof_state: "missing",
+      proof_state_reason: "Proof is recorded as missing.",
     });
   });
 
@@ -80,6 +101,64 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_progress: 85,
       pipeline_source: "receipt: review",
       pipeline_evidence: ["build", "proof", "review"],
+      proof_state: "live",
+    });
+  });
+
+  it("surfaces missing UI proof as a structured proof state", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "Memory Recall Check proof",
+          status: "done",
+        },
+        ["PR #999 checks green.", "BLOCKER: missing authenticated screenshot proof for /admin/memory?tab=recall-check."],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_source: "receipt: proof",
+      pipeline_evidence: ["build", "proof"],
+      proof_state: "missing_ui_proof",
+      proof_state_reason: "UI or browser proof is still missing.",
+    });
+  });
+
+  it("keeps a blocker warning newer than old ship receipts", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "Proof Ledger v2",
+          status: "done",
+        },
+        ["Old receipt: PR #700 merged into main. Tests passed.", "BLOCKER: proof ledger hold, do not lift without real proof."],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["build", "proof", "ship"],
+      proof_state: "blocked",
+      proof_state_reason: "A blocker or hold is recorded after the latest proof.",
+    });
+  });
+
+  it("labels parked jobs without treating them as done", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "StepBack cleanup",
+          status: "open",
+        },
+        ["PARKED: missing ScopePack before any build work."],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 1,
+      pipeline_progress: 10,
+      pipeline_source: "status: open",
+      pipeline_evidence: [],
+      proof_state: "parked",
+      proof_state_reason: "The job is parked or waiting for scope.",
     });
   });
 });

--- a/api/lib/fishbowl-job-pipeline.ts
+++ b/api/lib/fishbowl-job-pipeline.ts
@@ -4,11 +4,24 @@ export interface FishbowlJobPipelineTodo {
   status?: unknown;
 }
 
+export type FishbowlJobProofState =
+  | "live"
+  | "close_eligible"
+  | "partial"
+  | "blocked"
+  | "missing"
+  | "missing_ui_proof"
+  | "parked"
+  | "stale"
+  | "wrong_scope";
+
 export interface FishbowlJobPipelineState {
   pipeline_stage_count: number;
   pipeline_progress: number;
   pipeline_source: string;
   pipeline_evidence: string[];
+  proof_state: FishbowlJobProofState;
+  proof_state_reason: string;
 }
 
 export type FishbowlJobPipelineComment =
@@ -37,6 +50,13 @@ const stageProgress: Record<number, number> = {
 const PROOF_RESET_RE = /\b(reopened|re-opened|proof\s+reset|false\s+completion|partial\s+completion)\b/i;
 const PROOF_MISSING_RE =
   /\b(no|missing|needs?|needed|waiting for|without|incomplete|stale)\s+(?:live\s+)?proof\b|\bproof\s+(?:missing|needed|incomplete|stale|not available)\b/i;
+const PROOF_UI_MISSING_RE =
+  /\b(no|missing|needs?|needed|waiting for|without|incomplete)\s+(?:authenticated\s+)?(?:ui|screenshot|browser|live page|live product)\s+proof\b|\b(?:ui|screenshot|browser|live page|live product)\s+proof\s+(?:missing|needed|incomplete|not available)\b/i;
+const PROOF_BLOCKED_RE = /\b(blocker|blocked|hold|do not merge|do not lift|cannot close|not closable)\b/i;
+const PROOF_PARTIAL_RE = /\b(partial|partial\/blocker|proof ceiling|follow-?up needed|not enough to close)\b/i;
+const PROOF_PARKED_RE = /\b(parked|parking|deferred|not next|scopepack needed|missing scopepack)\b/i;
+const PROOF_STALE_RE = /\b(stale|old|outdated)\s+(?:receipt|proof|green chip|claim)|\bfalse[- ]done\b|\bfalse green\b/i;
+const PROOF_WRONG_SCOPE_RE = /\b(wrong scope|scope mismatch|wrong surface|different scope|wrong job|not the requested surface)\b/i;
 
 function positiveStageHit(text: string, positive: RegExp, negative?: RegExp): boolean {
   if (!positive.test(text)) return false;
@@ -61,6 +81,72 @@ function buildSegments(todo: FishbowlJobPipelineTodo, comments: FishbowlJobPipel
     .map((value) => value.toLowerCase());
 }
 
+function proofWarningForText(text: string): Pick<FishbowlJobPipelineState, "proof_state" | "proof_state_reason"> | null {
+  if (PROOF_WRONG_SCOPE_RE.test(text)) {
+    return {
+      proof_state: "wrong_scope",
+      proof_state_reason: "Proof is attached to the wrong scope.",
+    };
+  }
+  if (PROOF_UI_MISSING_RE.test(text)) {
+    return {
+      proof_state: "missing_ui_proof",
+      proof_state_reason: "UI or browser proof is still missing.",
+    };
+  }
+  if (PROOF_STALE_RE.test(text) || PROOF_RESET_RE.test(text)) {
+    return {
+      proof_state: "stale",
+      proof_state_reason: "The latest receipt is stale or reset.",
+    };
+  }
+  if (PROOF_MISSING_RE.test(text)) {
+    return {
+      proof_state: "missing",
+      proof_state_reason: "Proof is recorded as missing.",
+    };
+  }
+  if (PROOF_PARKED_RE.test(text)) {
+    return {
+      proof_state: "parked",
+      proof_state_reason: "The job is parked or waiting for scope.",
+    };
+  }
+  if (PROOF_PARTIAL_RE.test(text)) {
+    return {
+      proof_state: "partial",
+      proof_state_reason: "Only partial proof is recorded.",
+    };
+  }
+  if (PROOF_BLOCKED_RE.test(text)) {
+    return {
+      proof_state: "blocked",
+      proof_state_reason: "A blocker or hold is recorded after the latest proof.",
+    };
+  }
+  return null;
+}
+
+function proofStateFromWarning(
+  activeSegments: string[],
+  latestProgressIndex: number,
+  fallback: Pick<FishbowlJobPipelineState, "proof_state" | "proof_state_reason">,
+): Pick<FishbowlJobPipelineState, "proof_state" | "proof_state_reason"> {
+  const latestWarning = activeSegments.reduce<
+    (Pick<FishbowlJobPipelineState, "proof_state" | "proof_state_reason"> & { index: number }) | null
+  >((latest, segment, index) => {
+    const warning = proofWarningForText(segment);
+    return warning ? { ...warning, index } : latest;
+  }, null);
+
+  if (latestWarning && latestWarning.index >= latestProgressIndex) {
+    const { index: _index, ...warning } = latestWarning;
+    return warning;
+  }
+
+  return fallback;
+}
+
 export function inferFishbowlJobPipeline(
   todo: FishbowlJobPipelineTodo,
   comments: FishbowlJobPipelineComment[] = [],
@@ -83,16 +169,30 @@ export function inferFishbowlJobPipeline(
   if (latestResetIndex >= 0 && latestResetIndex > latestProgressIndex) {
     const latestResetText = segments[latestResetIndex] ?? "";
     const resetHit = PROOF_RESET_RE.test(latestResetText);
+    const warning = proofWarningForText(latestResetText) ?? {
+      proof_state: resetHit ? "stale" : "missing",
+      proof_state_reason: resetHit ? "The latest receipt is stale or reset." : "Proof is recorded as missing.",
+    };
     return {
       pipeline_stage_count: stageRank.brief,
       pipeline_progress: stageProgress[stageRank.brief],
       pipeline_source: resetHit ? "reopened: proof reset" : "proof: missing",
       pipeline_evidence: resetHit ? ["reopened", "proof_missing"] : ["proof_missing"],
+      ...warning,
     };
   }
 
   const activeSegments = latestResetIndex >= 0 ? segments.slice(latestResetIndex + 1) : segments;
   const corpus = activeSegments.join("\n");
+  const latestActiveProgressIndex = activeSegments.reduce((latest, segment, index) => {
+    return positiveStageHit(
+      segment,
+      /\b(implemented|built|build complete|patch applied|changes applied|pr\s*#?\d+|branch ready|commit(?:ted)?|ready for proof|build passed|checks? (?:passed|green)|tests? passed|proof (?:passed|complete|attached|submitted|recorded|current|clean)|verification (?:passed|complete)|ci passed|npm run build passed|qc pass|review(?:ed)?|reviewer pass|gatekeeper pass|safety pass|approved|ack:\s*pass|pass on #\d+|ready for review|pr\s*#?\d+\s+merged|merged\s+#?\d+|merged into main|deployed|published|shipped|live on production|production live)\b/i,
+      /\b(blocker|hold|do not merge|do not lift)\b/i,
+    )
+      ? index
+      : latest;
+  }, -1);
   let activeCount = status === "done" ? stageRank.ship : status === "in_progress" ? stageRank.build : stageRank.brief;
   let source = status === "done" ? "status: done" : status === "in_progress" ? "status: active" : "status: open";
   const evidence: string[] = [];
@@ -149,5 +249,15 @@ export function inferFishbowlJobPipeline(
     pipeline_progress: stageProgress[activeCount] ?? stageProgress[stageRank.brief],
     pipeline_source: source,
     pipeline_evidence: evidence,
+    ...proofStateFromWarning(activeSegments, latestActiveProgressIndex, {
+      proof_state:
+        activeCount >= stageRank.ship && evidence.length > 0 ? "close_eligible" : status === "done" ? "missing" : "live",
+      proof_state_reason:
+        activeCount >= stageRank.ship && evidence.length > 0
+          ? "Ship proof is linked with no newer proof warning."
+          : status === "done"
+            ? "Completed job needs observable proof."
+          : "No newer proof warning is recorded.",
+    }),
   };
 }

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -9480,6 +9480,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             pipeline_progress: t.pipeline_progress,
             pipeline_source: t.pipeline_source,
             pipeline_evidence: t.pipeline_evidence,
+            proof_state: t.proof_state,
+            proof_state_reason: t.proof_state_reason,
           }));
           return res.status(200).json({
             todos: includeDescription ? decorated : compactTodos,

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -133,4 +133,33 @@ describe("AdminJobs", () => {
     expect(alertsCard).not.toBeNull();
     expect(within(alertsCard as HTMLElement).getByText("1")).toBeInTheDocument();
   });
+
+  it("shows a proof-state warning even when progress says shipped", async () => {
+    currentJobs = [
+      {
+        id: "false-green-job",
+        title: "False green proof job",
+        description: "Old PR merged, but missing authenticated screenshot proof.",
+        status: "done",
+        priority: "urgent",
+        created_by_agent_id: "tester",
+        assigned_to_agent_id: "chatgpt-codex-desktop",
+        created_at: "2026-05-14T12:00:00.000Z",
+        completed_at: "2026-05-14T12:30:00.000Z",
+        updated_at: "2026-05-14T12:55:00.000Z",
+        comment_count: 3,
+        pipeline_stage_count: 5,
+        pipeline_progress: 100,
+        pipeline_evidence: ["build", "proof", "ship"],
+        proof_state: "missing_ui_proof",
+        proof_state_reason: "UI or browser proof is still missing.",
+      },
+    ];
+
+    render(React.createElement(AdminJobs));
+
+    expect(await screen.findByText("False green proof job")).toBeInTheDocument();
+    expect(screen.getByText("UI proof")).toBeInTheDocument();
+    expect(screen.getByTitle("UI or browser proof is still missing.")).toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import Comments from "./fishbowl/Comments";
-import { buildJobGithubSyncSignal, type JobGithubSyncSignal } from "./jobsGithubSync";
+import { buildJobGithubSyncSignal, type JobGithubSyncSignal, type JobProofState } from "./jobsGithubSync";
 import { highlightSearchText } from "./searchHighlight";
 
 interface FishbowlProfile {
@@ -51,6 +51,8 @@ interface JobTodo {
   pipeline_progress?: number;
   pipeline_source?: string;
   pipeline_evidence?: string[];
+  proof_state?: JobProofState;
+  proof_state_reason?: string;
 }
 
 type JobSectionKey = "active" | "next" | "inline" | "done";
@@ -322,7 +324,7 @@ function SyncSignalPill({ signal }: { signal: JobGithubSyncSignal }) {
       {signal.href && <ExternalLink className="h-2.5 w-2.5 shrink-0 opacity-70" aria-hidden="true" />}
     </>
   );
-  const className = `inline-flex max-w-[78px] items-center gap-1 rounded-[4px] border px-1 py-px text-[9px] font-semibold ${SYNC_SIGNAL_STYLE[signal.tone]}`;
+  const className = `inline-flex max-w-[78px] shrink-0 items-center gap-1 whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold ${SYNC_SIGNAL_STYLE[signal.tone]}`;
 
   if (signal.href) {
     return (

--- a/src/pages/admin/jobsGithubSync.test.ts
+++ b/src/pages/admin/jobsGithubSync.test.ts
@@ -99,6 +99,24 @@ describe("Jobs and GitHub sync helpers", () => {
     });
   });
 
+  it("lets structured proof state override stale green links", () => {
+    const blockedJob = {
+      ...baseJob,
+      status: "done" as const,
+      description: "Old PR #699 merged and checks passed.",
+      pipeline_evidence: ["build", "proof", "ship"],
+      proof_state: "missing_ui_proof" as const,
+      proof_state_reason: "UI or browser proof is still missing.",
+    };
+
+    expect(jobHasProofReset(blockedJob)).toBe(true);
+    expect(buildJobGithubSyncSignal(blockedJob)).toEqual({
+      label: "UI proof",
+      detail: "UI or browser proof is still missing.",
+      tone: "alert",
+    });
+  });
+
   it("lets current pipeline proof clear old reopened wording", () => {
     const recoveredJob = {
       ...baseJob,

--- a/src/pages/admin/jobsGithubSync.ts
+++ b/src/pages/admin/jobsGithubSync.ts
@@ -1,4 +1,14 @@
 export type JobSyncStatus = "open" | "in_progress" | "done" | "dropped";
+export type JobProofState =
+  | "live"
+  | "close_eligible"
+  | "partial"
+  | "blocked"
+  | "missing"
+  | "missing_ui_proof"
+  | "parked"
+  | "stale"
+  | "wrong_scope";
 
 export interface JobGithubSyncInput {
   id: string;
@@ -6,6 +16,8 @@ export interface JobGithubSyncInput {
   description?: string | null;
   status: JobSyncStatus;
   pipeline_evidence?: string[];
+  proof_state?: JobProofState;
+  proof_state_reason?: string;
 }
 
 export interface JobGithubReference {
@@ -29,6 +41,43 @@ const FAILED_DEPLOY_RE = /\b(failed preview deployment|deployment failed|failed 
 const PROOF_RESET_RE = /\b(reopened|re-opened|proof\s+reset|false\s+completion|partial\s+completion|proof_missing)\b/i;
 const PROOF_MISSING_RE =
   /\b(no|missing|needs?|needed|waiting for|without|incomplete|stale)\s+(?:live\s+)?proof\b|\bproof\s+(?:missing|needed|incomplete|stale|not available)\b/i;
+const PROOF_WARNING_SIGNAL: Partial<Record<JobProofState, Omit<JobGithubSyncSignal, "href">>> = {
+  partial: {
+    label: "Partial proof",
+    detail: "This job has only partial proof recorded.",
+    tone: "alert",
+  },
+  blocked: {
+    label: "Proof blocked",
+    detail: "This job has a proof blocker or hold.",
+    tone: "alert",
+  },
+  missing: {
+    label: "Proof missing",
+    detail: "This job still needs observable proof.",
+    tone: "alert",
+  },
+  missing_ui_proof: {
+    label: "UI proof",
+    detail: "This job still needs UI, browser, or screenshot proof.",
+    tone: "alert",
+  },
+  parked: {
+    label: "Parked",
+    detail: "This job is parked or waiting for scope.",
+    tone: "quiet",
+  },
+  stale: {
+    label: "Proof stale",
+    detail: "This job has stale or reset proof.",
+    tone: "alert",
+  },
+  wrong_scope: {
+    label: "Wrong proof",
+    detail: "This job has proof attached to the wrong scope.",
+    tone: "alert",
+  },
+};
 
 function uniqueByLabel(refs: JobGithubReference[]): JobGithubReference[] {
   const seen = new Set<string>();
@@ -92,6 +141,7 @@ export function jobHasDeploymentFailure(job: JobGithubSyncInput): boolean {
 }
 
 export function jobHasProofReset(job: JobGithubSyncInput): boolean {
+  if (job.proof_state && PROOF_WARNING_SIGNAL[job.proof_state]?.tone === "alert") return true;
   const evidence = job.pipeline_evidence ?? [];
   const hasCurrentProgressEvidence = evidence.some((item) => /\b(build|proof|review|ship)\b/i.test(item));
   const hasResetEvidence = evidence.some((item) => PROOF_RESET_RE.test(item) || PROOF_MISSING_RE.test(item));
@@ -100,6 +150,16 @@ export function jobHasProofReset(job: JobGithubSyncInput): boolean {
 
   const text = jobSyncText(job);
   return PROOF_RESET_RE.test(text) || PROOF_MISSING_RE.test(text);
+}
+
+function buildProofStateSignal(job: JobGithubSyncInput): JobGithubSyncSignal | null {
+  if (!job.proof_state) return null;
+  const signal = PROOF_WARNING_SIGNAL[job.proof_state];
+  if (!signal) return null;
+  return {
+    ...signal,
+    detail: job.proof_state_reason?.trim() || signal.detail,
+  };
 }
 
 export function buildJobGithubSyncSignal(job: JobGithubSyncInput): JobGithubSyncSignal {
@@ -117,6 +177,9 @@ export function buildJobGithubSyncSignal(job: JobGithubSyncInput): JobGithubSync
       href: firstLink?.url,
     };
   }
+
+  const proofStateSignal = buildProofStateSignal(job);
+  if (proofStateSignal) return proofStateSignal;
 
   if (jobHasProofReset(job)) {
     return {


### PR DESCRIPTION
## Summary
- Adds structured `proof_state` and `proof_state_reason` to Fishbowl job pipeline inference.
- Returns proof state in the jobs API compact payload.
- Shows proof-state warnings in the jobs proof pill so stale green links, 100% progress, or old ship receipts do not hide missing UI proof, stale proof, blockers, parked scope, or wrong-scope proof.

## Proof
- `npm test -- api/fishbowl-job-pipeline.test.ts src/pages/admin/jobsGithubSync.test.ts src/pages/admin/AdminJobs.test.tsx` passed: 3 files, 20 tests.
- `npm run build` passed.
- UI screenshot proof captured locally: `C:\Users\Malamutemayhem\Documents\Codex\2026-05-22\hey-please-gain-context-via-unclick\proof-ledger-ui-proof-state.png`.

## Notes
- Branch name `codex/proof-ledger-state-warning` already existed remotely, so this PR uses `codex/proof-ledger-state-warning-397675b`.
- Existing unrelated working-tree status remains outside this PR: `packages/channel-plugin/index.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `proof_state` parsing and propagates it through the jobs API and admin UI, changing how “done/shipped” jobs are interpreted and flagged. Risk is moderate due to regex-based inference and UI signaling changes that could misclassify proof warnings.
> 
> **Overview**
> Adds structured `proof_state`/`proof_state_reason` to Fishbowl pipeline inference so jobs can be explicitly labeled as *close-eligible*, *missing proof*, *missing UI proof*, *blocked*, *parked*, *stale*, *partial*, or *wrong-scope* based on newer warning text.
> 
> Propagates these fields through the jobs API payload and updates the admin jobs UI proof pill to prefer structured proof warnings over “green” progress/ship receipts, with tests covering the new states and precedence rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 397675b8916cb20e369368e8d3917e92c7c9b982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->