### PR TITLE
fix(reliability): guard todo close on live proof

### DIFF
--- a/api/fishbowl-completion-policy.test.ts
+++ b/api/fishbowl-completion-policy.test.ts
@@ -39,6 +39,27 @@ describe("evaluateFishbowlCompletionPolicy", () => {
     expect(result).toMatchObject({ allowed: true, code: "allowed" });
   });
 
+  it("blocks completion when a newer blocker invalidates older proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: baseTodo,
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text: "PASS: PR #997 merged and checks passed.",
+          created_at: "2026-05-22T06:40:00Z",
+        },
+        {
+          author_agent_id: "reviewer-seat",
+          text: "BLOCKED: release/live proof is missing after publish failed.",
+          created_at: "2026-05-22T06:43:00Z",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "missing_proof" });
+  });
+
   it("allows backend automation completion-gate work without screenshot proof", () => {
     const result = evaluateFishbowlCompletionPolicy({
       todo: {
@@ -51,6 +72,47 @@ describe("evaluateFishbowlCompletionPolicy", () => {
         {
           author_agent_id: "reviewer-seat",
           text: "PASS: PR #977 merged and tests passed; proof: commit d32673c.",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: true, code: "allowed" });
+  });
+
+  it("blocks runtime tool work when PR proof lacks release or live availability proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "FidelityCopy: deterministic non-AI copy engine for FidelityPass",
+        description:
+          "Build the official non-AI Copy Machine under FidelityPass. AI workers may request exact copy/import/export/restore operations.",
+      },
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text: "PASS: PR #997 merged and CI passed; proof: actions/runs/26272653066.",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "release_or_live_proof_required" });
+  });
+
+  it("allows runtime tool work with registry and discovery proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "FidelityCopy: deterministic non-AI copy engine for FidelityPass",
+        description:
+          "Build the official non-AI Copy Machine under FidelityPass. AI workers may request exact copy/import/export/restore operations.",
+      },
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text:
+            "PASS: PR #997 merged, npm view confirms registry latest 0.3.107, and fidelitycopy_copy tool discovery is available.",
         },
       ],
       closerAgentId: "builder-seat",

--- a/api/lib/fishbowl-completion-policy.ts
+++ b/api/lib/fishbowl-completion-policy.ts
@@ -8,6 +8,7 @@ export interface FishbowlCompletionTodo {
 export interface FishbowlCompletionComment {
   author_agent_id: string | null;
   text: string | null;
+  created_at?: string | null;
 }
 
 export interface FishbowlCompletionPolicyInput {
@@ -23,6 +24,7 @@ export interface FishbowlCompletionPolicyResult {
     | "allowed"
     | "missing_proof"
     | "git_proof_required"
+    | "release_or_live_proof_required"
     | "ui_screenshot_required"
     | "independent_verifier_required";
   reason: string;
@@ -33,7 +35,7 @@ const proofPositivePattern =
   /\b(pr\s*#?\d+|pull request\s*#?\d+|commit\s+[a-f0-9]{7,40}|sha\s+[a-f0-9]{7,40}|branch\s+[\w./-]+|git\s+diff|tests?\s+passed|build\s+passed|checks?\s+(?:passed|green)|ci\s+(?:passed|green)|playwright|screenshot|screen\s?shot|actions\/runs\/\d+|deployed|deployment|live on production|production live|no[_\s-]?code[_\s-]?needed|no code needed|proof:\s*\S+|receipt\s+[0-9a-f-]{8,})\b/i;
 
 const proofNegativePattern =
-  /\b(blocker|hold|no\s+(?:proof|screenshot|test|pr|commit)|missing\s+(?:proof|screenshot|test|pr|commit)|proof\s+(?:missing|needed|incomplete|stale|not available)|without\s+(?:proof|screenshot|test|pr|commit)|needs?\s+(?:proof|screenshot|test|pr|commit))\b/i;
+  /\b(blocker|blocked|hold|no\s+(?:proof|screenshot|test|pr|commit)|missing\s+(?:proof|screenshot|test|pr|commit)|proof\s+(?:is\s+)?(?:missing|needed|incomplete|stale|not available)|without\s+(?:proof|screenshot|test|pr|commit)|needs?\s+(?:proof|screenshot|test|pr|commit)|publish\s+failed|release\/live\s+proof)\b/i;
 
 const screenshotPattern =
   /\b(screenshot|screen\s?shot|before\/after|before and after|playwright|visual proof)\b|https?:\/\/\S+\.(?:png|jpe?g|webp)\b|[A-Za-z]:\\[^\n]+\.(?:png|jpe?g|webp)\b/i;
@@ -56,15 +58,28 @@ const gitProofPattern =
 const noCodeNeededPattern =
   /\b(no[_\s-]?code[_\s-]?needed|no code needed|non-code|no code change|policy only|comment only|routing only|docs only)\b/i;
 
+const runtimeDeliveryTodoPattern =
+  /\b(mcp\s+(?:server|tool)|publish(?:ed|ing)?|registry|npm|release|deploy(?:ed|ment)?|production|live\s+(?:tool|receipt|api|proof)|expos(?:e|ed|ing)|workers?\s+may\s+request|worker(?:s)?\s+tool)\b/i;
+
+const runtimeDeliveryProofPattern =
+  /\b(published|npm\s+(?:view|latest|dist-tag)|registry\s+(?:confirms|shows|latest)|deployed|deployment|live\s+on\s+production|production\s+live|vercel\.app|tool(?:s)?\s+(?:discoverable|available|exposed)|(?:mcp|tool)\s+discovery|live\s+(?:receipt|api|tool)|fidelitycopy_(?:copy|verify)|fidelitypass_verify_copy)\b/i;
+
 function isUiCompletionTodo(corpus: string): boolean {
   if (!uiTodoPattern.test(corpus)) return false;
   if (nonVisualCompletionGatePattern.test(corpus) && !uiDeliveryPattern.test(corpus)) return false;
   return true;
 }
 
+function commentTime(comment: FishbowlCompletionComment): number {
+  if (!comment.created_at) return 0;
+  const parsed = Date.parse(comment.created_at);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
 export function evaluateFishbowlCompletionPolicy(input: FishbowlCompletionPolicyInput): FishbowlCompletionPolicyResult {
   const closer = input.closerAgentId.trim();
   const corpus = [input.todo.title, input.todo.description].filter(Boolean).join("\n");
+  const negativeProofComments = input.comments.filter((comment) => proofNegativePattern.test(comment.text ?? ""));
   const positiveProofComments = input.comments.filter((comment) => {
     const text = comment.text ?? "";
     return proofPositivePattern.test(text) && !proofNegativePattern.test(text);
@@ -76,6 +91,17 @@ export function evaluateFishbowlCompletionPolicy(input: FishbowlCompletionPolicy
       code: "missing_proof",
       reason: "Done is blocked until the job has a real proof comment.",
       how_to_fix: "Add a proof comment with a PR, commit, test/build result, run link, receipt, or screenshot, then close the job.",
+    };
+  }
+
+  const latestPositiveProofAt = Math.max(...positiveProofComments.map(commentTime));
+  const latestNegativeProofAt = Math.max(0, ...negativeProofComments.map(commentTime));
+  if (latestNegativeProofAt > latestPositiveProofAt) {
+    return {
+      allowed: false,
+      code: "missing_proof",
+      reason: "Done is blocked because a newer blocker or missing-proof comment exists after the latest proof.",
+      how_to_fix: "Resolve the blocker with newer observable PASS proof, then close the job.",
     };
   }
 
@@ -124,6 +150,21 @@ export function evaluateFishbowlCompletionPolicy(input: FishbowlCompletionPolicy
         reason: "Coding jobs need Git, deploy, or no-code proof before they can be marked done.",
         how_to_fix:
           "Add proof with a PR, commit SHA, branch diff, deployed URL, or explicit NO_CODE_NEEDED reason, then close the job.",
+      };
+    }
+  }
+
+  if (runtimeDeliveryTodoPattern.test(corpus)) {
+    const hasRuntimeDeliveryProof = positiveProofComments.some((comment) =>
+      runtimeDeliveryProofPattern.test(comment.text ?? ""),
+    );
+    if (!hasRuntimeDeliveryProof) {
+      return {
+        allowed: false,
+        code: "release_or_live_proof_required",
+        reason: "Runtime, package, or tool jobs need release/live availability proof before they can be marked done.",
+        how_to_fix:
+          "Add proof that the package, deployment, live API, or tool discovery is available, then close the job.",
       };
     }
   }

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -9129,7 +9129,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           if (update.status === "done" && beforeTodo) {
             const { data: proofComments, error: proofErr } = await supabase
               .from("mc_fishbowl_comments")
-              .select("author_agent_id,text")
+              .select("author_agent_id,text,created_at")
               .eq("api_key_hash", apiKeyHash)
               .eq("target_kind", "todo")
               .eq("target_id", idRes);
@@ -9152,6 +9152,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 author_agent_id:
                   typeof comment.author_agent_id === "string" ? comment.author_agent_id : null,
                 text: typeof comment.text === "string" ? comment.text : null,
+                created_at: typeof comment.created_at === "string" ? comment.created_at : null,
               })),
               closerAgentId: agentId,
             });
@@ -9267,7 +9268,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           if (beforeTodo) {
             const { data: proofComments, error: proofErr } = await supabase
               .from("mc_fishbowl_comments")
-              .select("author_agent_id,text")
+              .select("author_agent_id,text,created_at")
               .eq("api_key_hash", apiKeyHash)
               .eq("target_kind", "todo")
               .eq("target_id", idRes);
@@ -9285,6 +9286,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 author_agent_id:
                   typeof comment.author_agent_id === "string" ? comment.author_agent_id : null,
                 text: typeof comment.text === "string" ? comment.text : null,
+                created_at: typeof comment.created_at === "string" ? comment.created_at : null,
               })),
               closerAgentId: agentId,
             });


### PR DESCRIPTION
## Summary
- Tightens the Fishbowl todo completion gate so runtime/package/tool jobs cannot be marked done from PR-only proof.
- Blocks a close when a newer blocker or missing-proof comment exists after the latest positive proof.
- Includes comment timestamps in the completion policy inputs so stale positive proof cannot outrank newer release-proof failures.

## Scope
- Owned files: `api/lib/fishbowl-completion-policy.ts`, `api/fishbowl-completion-policy.test.ts`, `api/memory-admin.ts`.
- Lane: reliability / proof integrity.
- Related Boardroom todos, no close marker: `656728ef`, `1b12d10a`, `ef8f5242`, `6819cb82`.

## Non-overlap
- Does not publish `@unclick/mcp-server` or change npm credentials.
- Does not mark any Boardroom todo done.
- Does not change the GitHub auto-close workflow marker parser.
- Does not touch UI surfaces or screenshot proof flows.

## Verification
- PASS: `vitest run --root C:\G\UnClick\worktrees\autoclose-proof-guard --config C:\Users\creat\Documents\Codex\2026-05-22\please-context-to-unclick-to-get\vitest.policy.config.mjs`: 12/12 tests passed.
- PASS: `git diff --check` exited 0 with existing Windows LF to CRLF warnings only.
- Release proof inspected: Publish MCP server run `26272653064` failed on `npm publish --access public` with npm E404 for `@unclick/mcp-server@0.3.107`; public latest is still `0.3.99`.

## Risk
- Medium: this makes completion stricter for runtime/package/tool jobs and may hold some jobs until release or live availability proof is added.
- Low data risk: no schema, credential, billing, DNS, or production data changes.

## Follow-up
- Fix the npm publish permission/path for `@unclick/mcp-server`, then capture live FidelityCopy tool-discovery or receipt proof before closing `656728ef`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens the server-side completion gate for marking Fishbowl todos `done`, which may newly block closures until additional proof is provided. Logic changes depend on comment timestamps and new runtime/release proof heuristics, so misclassification could impact workflow.
> 
> **Overview**
> **Fishbowl todo completion is now stricter and time-aware.** The completion policy accepts `created_at` on comments and blocks closing a todo if a *newer* blocker/missing-proof comment appears after the latest positive proof.
> 
> It also adds a new `release_or_live_proof_required` outcome for runtime/package/tool delivery work, requiring evidence of publish/deploy/tool-discovery (not just PR/CI proof). The admin todo-close path now fetches and passes `created_at` from `mc_fishbowl_comments`, and tests cover the new timestamp and runtime-proof gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17ae888436d5c3bdc2465c9d08156212291e908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->