### PR TITLE
Guard completed jobs with proof state

### DIFF
--- a/api/fishbowl-job-pipeline.test.ts
+++ b/api/fishbowl-job-pipeline.test.ts
@@ -17,6 +17,9 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_source: "receipt: ship",
       pipeline_evidence: ["build", "proof", "ship"],
       proof_state: "close_eligible",
+      effective_status: "done",
+      release_blocked: false,
+      release_block_reason: null,
     });
   });
 
@@ -33,6 +36,9 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_evidence: [],
       proof_state: "missing",
       proof_state_reason: "Completed job needs observable proof.",
+      effective_status: "needs_proof",
+      release_blocked: true,
+      release_block_reason: "Completed job needs observable proof.",
     });
   });
 
@@ -52,6 +58,9 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_evidence: ["reopened", "proof_missing"],
       proof_state: "stale",
       proof_state_reason: "The latest receipt is stale or reset.",
+      effective_status: "open",
+      release_blocked: false,
+      release_block_reason: null,
     });
   });
 
@@ -71,6 +80,9 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_evidence: ["proof_missing"],
       proof_state: "missing",
       proof_state_reason: "Proof is recorded as missing.",
+      effective_status: "needs_proof",
+      release_blocked: true,
+      release_block_reason: "Proof is recorded as missing.",
     });
   });
 
@@ -102,6 +114,9 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_source: "receipt: review",
       pipeline_evidence: ["build", "proof", "review"],
       proof_state: "live",
+      effective_status: "open",
+      release_blocked: false,
+      release_block_reason: null,
     });
   });
 
@@ -121,6 +136,9 @@ describe("Fishbowl job pipeline inference", () => {
       pipeline_evidence: ["build", "proof"],
       proof_state: "missing_ui_proof",
       proof_state_reason: "UI or browser proof is still missing.",
+      effective_status: "needs_proof",
+      release_blocked: true,
+      release_block_reason: "UI or browser proof is still missing.",
     });
   });
 

--- a/api/lib/fishbowl-job-pipeline.ts
+++ b/api/lib/fishbowl-job-pipeline.ts
@@ -15,6 +15,8 @@ export type FishbowlJobProofState =
   | "stale"
   | "wrong_scope";
 
+export type FishbowlJobEffectiveStatus = "open" | "in_progress" | "done" | "dropped" | "needs_proof";
+
 export interface FishbowlJobPipelineState {
   pipeline_stage_count: number;
   pipeline_progress: number;
@@ -22,6 +24,9 @@ export interface FishbowlJobPipelineState {
   pipeline_evidence: string[];
   proof_state: FishbowlJobProofState;
   proof_state_reason: string;
+  effective_status: FishbowlJobEffectiveStatus;
+  release_blocked: boolean;
+  release_block_reason: string | null;
 }
 
 export type FishbowlJobPipelineComment =
@@ -79,6 +84,26 @@ function buildSegments(todo: FishbowlJobPipelineTodo, comments: FishbowlJobPipel
   return [todo.title, todo.description, ...commentSegments.map(commentText)]
     .filter((value) => typeof value === "string" && value.trim().length > 0)
     .map((value) => value.toLowerCase());
+}
+
+function canonicalStatus(status: unknown): Exclude<FishbowlJobEffectiveStatus, "needs_proof"> {
+  return status === "in_progress" || status === "done" || status === "dropped" ? status : "open";
+}
+
+function withEffectiveStatus(
+  status: unknown,
+  state: Omit<FishbowlJobPipelineState, "effective_status" | "release_blocked" | "release_block_reason">,
+): FishbowlJobPipelineState {
+  const baseStatus = canonicalStatus(status);
+  const effectiveStatus =
+    baseStatus === "done" && state.proof_state !== "close_eligible" ? "needs_proof" : baseStatus;
+  const releaseBlocked = effectiveStatus === "needs_proof";
+  return {
+    ...state,
+    effective_status: effectiveStatus,
+    release_blocked: releaseBlocked,
+    release_block_reason: releaseBlocked ? state.proof_state_reason : null,
+  };
 }
 
 function proofWarningForText(text: string): Pick<FishbowlJobPipelineState, "proof_state" | "proof_state_reason"> | null {
@@ -173,13 +198,13 @@ export function inferFishbowlJobPipeline(
       proof_state: resetHit ? "stale" : "missing",
       proof_state_reason: resetHit ? "The latest receipt is stale or reset." : "Proof is recorded as missing.",
     };
-    return {
+    return withEffectiveStatus(status, {
       pipeline_stage_count: stageRank.brief,
       pipeline_progress: stageProgress[stageRank.brief],
       pipeline_source: resetHit ? "reopened: proof reset" : "proof: missing",
       pipeline_evidence: resetHit ? ["reopened", "proof_missing"] : ["proof_missing"],
       ...warning,
-    };
+    });
   }
 
   const activeSegments = latestResetIndex >= 0 ? segments.slice(latestResetIndex + 1) : segments;
@@ -244,7 +269,7 @@ export function inferFishbowlJobPipeline(
     source = "receipt: ship";
   }
 
-  return {
+  return withEffectiveStatus(status, {
     pipeline_stage_count: activeCount,
     pipeline_progress: stageProgress[activeCount] ?? stageProgress[stageRank.brief],
     pipeline_source: source,
@@ -259,5 +284,5 @@ export function inferFishbowlJobPipeline(
             ? "Completed job needs observable proof."
           : "No newer proof warning is recorded.",
     }),
-  };
+  });
 }

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -9465,10 +9465,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               ...inferFishbowlJobPipeline(t, textMap[id] ?? []),
             };
           });
+          const effectiveMetrics = decorated.reduce(
+            (acc, t) => {
+              const effective = String(t.effective_status ?? t.status);
+              if (effective === "needs_proof") acc.needs_proof += 1;
+              if (effective === "done") acc.done_clean += 1;
+              if (effective === "in_progress" || effective === "needs_proof") acc.active_effective += 1;
+              return acc;
+            },
+            { active_effective: 0, done_clean: 0, needs_proof: 0 },
+          );
           const compactTodos = decorated.map((t) => ({
             id: t.id,
             title: t.title,
             status: t.status,
+            effective_status: t.effective_status,
             priority: t.priority,
             assigned_to_agent_id: t.assigned_to_agent_id,
             created_by_agent_id: t.created_by_agent_id,
@@ -9482,16 +9493,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             pipeline_evidence: t.pipeline_evidence,
             proof_state: t.proof_state,
             proof_state_reason: t.proof_state_reason,
+            release_blocked: t.release_blocked,
+            release_block_reason: t.release_block_reason,
           }));
           return res.status(200).json({
             todos: includeDescription ? decorated : compactTodos,
             queue_metrics: {
               active: activeCount,
+              active_effective_returned: effectiveMetrics.active_effective,
               open_backlog: openBacklogCount,
               done: doneCount,
+              done_clean_returned: effectiveMetrics.done_clean,
+              needs_proof_returned: effectiveMetrics.needs_proof,
               dropped: droppedCount,
               legacy_queued_equals: "open_backlog",
-              note: "Open backlog is not the runnable queue; active is in_progress work.",
+              note: "Open backlog is not the runnable queue; active is in_progress work. active_effective_returned also includes returned done rows blocked by proof.",
             },
             response_bounds: {
               compact: !includeDescription,

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -141,6 +141,7 @@ describe("AdminJobs", () => {
         title: "False green proof job",
         description: "Old PR merged, but missing authenticated screenshot proof.",
         status: "done",
+        effective_status: "needs_proof",
         priority: "urgent",
         created_by_agent_id: "tester",
         assigned_to_agent_id: "chatgpt-codex-desktop",
@@ -153,13 +154,24 @@ describe("AdminJobs", () => {
         pipeline_evidence: ["build", "proof", "ship"],
         proof_state: "missing_ui_proof",
         proof_state_reason: "UI or browser proof is still missing.",
+        release_blocked: true,
+        release_block_reason: "UI or browser proof is still missing.",
       },
     ];
 
     render(React.createElement(AdminJobs));
 
     expect(await screen.findByText("False green proof job")).toBeInTheDocument();
+    expect(screen.getByText("needs proof")).toBeInTheDocument();
     expect(screen.getByText("UI proof")).toBeInTheDocument();
     expect(screen.getByTitle("UI or browser proof is still missing.")).toBeInTheDocument();
+    expect(screen.getByTestId("job-row-title")).not.toHaveClass("line-through");
+
+    const activeSection = screen.getByRole("button", { name: /Active/i }).closest("section");
+    const completedSection = screen.getByRole("button", { name: /Completed/i }).closest("section");
+    expect(activeSection).not.toBeNull();
+    expect(completedSection).not.toBeNull();
+    expect(within(activeSection as HTMLElement).getByText("False green proof job")).toBeInTheDocument();
+    expect(within(completedSection as HTMLElement).queryByText("False green proof job")).not.toBeInTheDocument();
   });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -19,7 +19,11 @@ import {
 } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import Comments from "./fishbowl/Comments";
-import { buildJobGithubSyncSignal, type JobGithubSyncSignal, type JobProofState } from "./jobsGithubSync";
+import {
+  buildJobGithubSyncSignal,
+  type JobGithubSyncSignal,
+  type JobProofState,
+} from "./jobsGithubSync";
 import { highlightSearchText } from "./searchHighlight";
 
 interface FishbowlProfile {
@@ -39,6 +43,7 @@ interface JobTodo {
   title: string;
   description?: string | null;
   status: "open" | "in_progress" | "done" | "dropped";
+  effective_status?: DisplayStatus;
   priority: "low" | "normal" | "high" | "urgent";
   created_by_agent_id: string;
   assigned_to_agent_id: string | null;
@@ -53,11 +58,14 @@ interface JobTodo {
   pipeline_evidence?: string[];
   proof_state?: JobProofState;
   proof_state_reason?: string;
+  release_blocked?: boolean;
+  release_block_reason?: string | null;
 }
 
 type JobSectionKey = "active" | "next" | "inline" | "done";
 type SortKey = "queue" | "title" | "status" | "priority" | "worker" | "live" | "progress" | "notes" | "updated";
 type SortDirection = "asc" | "desc";
+type DisplayStatus = JobTodo["status"] | "needs_proof";
 
 const SECTION_LABELS: Record<JobSectionKey, string> = {
   active: "Active",
@@ -105,11 +113,12 @@ const PRIORITY_STYLE: Record<JobTodo["priority"], string> = {
   low: "border-white/[0.06] bg-white/[0.02] text-white/40",
 };
 
-const STATUS_STYLE: Record<JobTodo["status"], string> = {
+const STATUS_STYLE: Record<DisplayStatus, string> = {
   open: "border-white/10 bg-white/[0.035] text-white/60",
   in_progress: "border-[#E2B93B]/35 bg-[#E2B93B]/10 text-[#E2B93B]",
   done: "border-green-400/25 bg-green-400/10 text-green-300",
   dropped: "border-white/[0.06] bg-white/[0.02] text-white/35",
+  needs_proof: "border-red-300/35 bg-red-500/10 text-red-200",
 };
 
 const ACTION_BUTTONS = {
@@ -256,9 +265,35 @@ function ownerLabel(todo: JobTodo): string {
     .replace(/\bAi\b/g, "AI");
 }
 
-function statusLabel(status: JobTodo["status"]): string {
+function statusLabel(status: DisplayStatus): string {
+  if (status === "needs_proof") return "needs proof";
   if (status === "in_progress") return "active";
   return status.replace("_", " ");
+}
+
+function syncSignalFor(todo: JobTodo): JobGithubSyncSignal {
+  return buildJobGithubSyncSignal(todo);
+}
+
+function backendDisplayStatusFor(todo: JobTodo): DisplayStatus | null {
+  const status = todo.effective_status;
+  return status === "open" ||
+    status === "in_progress" ||
+    status === "done" ||
+    status === "dropped" ||
+    status === "needs_proof"
+    ? status
+    : null;
+}
+
+function needsProofAfterDone(todo: JobTodo): boolean {
+  const backendStatus = backendDisplayStatusFor(todo);
+  if (backendStatus) return backendStatus === "needs_proof";
+  return todo.status === "done" && syncSignalFor(todo).tone === "alert";
+}
+
+function displayStatusFor(todo: JobTodo): DisplayStatus {
+  return backendDisplayStatusFor(todo) ?? (needsProofAfterDone(todo) ? "needs_proof" : todo.status);
 }
 
 function progressFor(todo: JobTodo): number {
@@ -283,6 +318,7 @@ function StageStrip({ todo }: { todo: JobTodo }) {
   const active = activeStageCount(todo);
   const progress = progressFor(todo);
   const source = todo.pipeline_source ?? "estimated from todo status";
+  const displayStatus = displayStatusFor(todo);
   return (
     <div className="flex min-w-[200px] items-center gap-1" aria-label="Assembly line progress" title={source}>
       <span className="w-7 shrink-0 text-right text-[10px] font-semibold text-white/55">
@@ -295,7 +331,9 @@ function StageStrip({ todo }: { todo: JobTodo }) {
             title={stage}
             className={`flex h-4 min-w-0 items-center justify-center text-[7px] font-semibold uppercase ${
               index < active
-                ? todo.status === "done"
+                ? displayStatus === "needs_proof"
+                  ? "bg-red-300/85 text-black/70"
+                  : todo.status === "done"
                   ? "bg-green-400/85 text-black/70"
                   : "bg-[#61C1C4]/90 text-black/70"
                 : "bg-white/[0.08] text-white/30"
@@ -481,7 +519,7 @@ function compareSortedJobs(
       result = compareText(a.title, b.title);
       break;
     case "status":
-      result = compareText(statusLabel(a.status), statusLabel(b.status));
+      result = compareText(statusLabel(displayStatusFor(a)), statusLabel(displayStatusFor(b)));
       break;
     case "priority":
       result = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
@@ -538,12 +576,12 @@ function SortHeader({
 }
 
 function groupJobs(todos: JobTodo[]): Record<JobSectionKey, JobTodo[]> {
-  const active = todos.filter((todo) => todo.status === "in_progress").sort(sortJobs);
+  const active = todos.filter((todo) => todo.status === "in_progress" || needsProofAfterDone(todo)).sort(sortJobs);
   const open = todos.filter((todo) => todo.status === "open").sort(sortJobs);
   const next = open.filter((todo) => todo.priority === "urgent" || todo.priority === "high");
   const inline = open.filter((todo) => todo.priority === "normal" || todo.priority === "low");
   const done = todos
-    .filter((todo) => todo.status === "done")
+    .filter((todo) => todo.status === "done" && !needsProofAfterDone(todo))
     .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
   return { active, next, inline, done };
 }
@@ -629,7 +667,8 @@ function JobRow({
   const alert = attention ? attentionCopy(todo) : null;
   const emoji = ownerEmoji(todo);
   const displayCopy = displayCopyFor(todo);
-  const syncSignal = buildJobGithubSyncSignal(todo);
+  const syncSignal = syncSignalFor(todo);
+  const displayStatus = displayStatusFor(todo);
 
   return (
     <li
@@ -693,7 +732,9 @@ function JobRow({
           title={todo.title}
         >
           <p
-            className={`truncate text-[11px] font-semibold leading-4 hover:text-white ${todo.status === "done" ? "text-white/35 line-through" : "text-white/85"}`}
+            className={`truncate text-[11px] font-semibold leading-4 hover:text-white ${
+              todo.status === "done" && displayStatus !== "needs_proof" ? "text-white/35 line-through" : "text-white/85"
+            }`}
             data-testid="job-row-title"
           >
             {highlightSearchText(displayCopy.title, searchQuery)}
@@ -705,9 +746,9 @@ function JobRow({
 
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 md:contents">
           <span
-            className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${STATUS_STYLE[todo.status]}`}
+            className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${STATUS_STYLE[displayStatus]}`}
           >
-            {statusLabel(todo.status)}
+            {statusLabel(displayStatus)}
           </span>
           <span
             className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${PRIORITY_STYLE[todo.priority]}`}
@@ -724,9 +765,11 @@ function JobRow({
           </span>
           <span className="flex items-center gap-1 text-[11px] text-white/45">
             <span
-              className={`h-1.5 w-1.5 rounded-full ${isStaleActive(todo) ? "bg-red-300" : todo.status === "done" ? "bg-green-300" : "bg-green-400"}`}
+              className={`h-1.5 w-1.5 rounded-full ${
+                displayStatus === "needs_proof" || isStaleActive(todo) ? "bg-red-300" : todo.status === "done" ? "bg-green-300" : "bg-green-400"
+              }`}
             />
-            {todo.status === "done" ? "ship" : isStaleActive(todo) ? "stale" : "live"}
+            {displayStatus === "needs_proof" ? "proof" : todo.status === "done" ? "ship" : isStaleActive(todo) ? "stale" : "live"}
           </span>
           <span className="text-[11px] font-medium text-white/55">
             <StageStrip todo={todo} />


### PR DESCRIPTION
## Summary
- Add backend proof-derived `effective_status`, `release_blocked`, and `release_block_reason` fields to Fishbowl/Boardroom job pipeline inference.
- Return effective proof metrics from `fishbowl_list_todos` so automation can see returned jobs blocked by proof instead of trusting raw DONE.
- Treat done jobs with an alerting proof sync signal as `needs proof` in the Jobs board, keep them in Active, and remove the crossed-out completed styling.

## Verification
- `npx vitest run api/fishbowl-job-pipeline.test.ts`
- `npx vitest run src/pages/admin/AdminJobs.test.tsx`
- `npm run build`

## Notes
This is the first execution-spine slice: job state starts following proof state. DONE plus missing, stale, blocked, or wrong-scope proof becomes machine-readable `needs_proof` instead of a clean completion signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates backend job-status inference and API metrics to treat some `done` jobs as `needs_proof`, which can change queue counts and automation behavior. UI grouping/styling is adjusted accordingly, so regressions would mainly impact operational visibility rather than data security.
> 
> **Overview**
> Adds proof-derived fields (`effective_status`, `release_blocked`, `release_block_reason`) to `inferFishbowlJobPipeline`, marking `done` jobs without *close-eligible* proof as `needs_proof` and exposing the block reason.
> 
> Extends `fishbowl_list_todos` to return these fields plus new queue metrics (`active_effective_returned`, `done_clean_returned`, `needs_proof_returned`) so consumers can distinguish clean completions from proof-blocked returns.
> 
> Updates the Admin Jobs board to display `needs proof` status (including styling/progress colors), keep proof-blocked done jobs in the Active section (not crossed out), and adjusts tests to assert the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c063085549812a5984daf2ab292ab833a29b46c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->