### PR TITLE
fix(reliability): preflight mcp publish access

### DIFF
--- a/.github/workflows/publish-mcp-package.yml
+++ b/.github/workflows/publish-mcp-package.yml
@@ -74,6 +74,51 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Preflight npm publish access
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        working-directory: packages/mcp-server
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          pkg_name=$(node -p "require('./package.json').name")
+          scope="${pkg_name%%/*}"
+
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN is not configured; cannot publish ${pkg_name}."
+            exit 1
+          fi
+
+          if ! npm_user=$(npm whoami --registry=https://registry.npmjs.org/ 2>/dev/null); then
+            echo "::error::NPM_TOKEN is invalid or expired; npm whoami failed."
+            exit 1
+          fi
+          echo "NPM token authenticated as ${npm_user}."
+
+          if ! npm view "${pkg_name}" version --registry=https://registry.npmjs.org/ >/tmp/npm-current-version.txt 2>/dev/null; then
+            echo "::error::Unable to read ${pkg_name} from npm registry; check package name and scope."
+            exit 1
+          fi
+          echo "Current published ${pkg_name}@$(cat /tmp/npm-current-version.txt)."
+
+          if ! npm access ls-packages "${scope}" --json --registry=https://registry.npmjs.org/ >/tmp/npm-access.json 2>/dev/null; then
+            echo "::error::NPM_TOKEN cannot inspect ${scope} package access; grant publish/write access to ${pkg_name} or replace NPM_TOKEN."
+            exit 1
+          fi
+
+          node - "${pkg_name}" /tmp/npm-access.json <<'NODE'
+          const fs = require("fs");
+          const pkgName = process.argv[2];
+          const accessPath = process.argv[3];
+          const access = JSON.parse(fs.readFileSync(accessPath, "utf8"));
+          const permission = String(access[pkgName] ?? "");
+          if (!/(write|read-write|owner|admin)/i.test(permission)) {
+            console.error(`::error::NPM_TOKEN lacks write access for ${pkgName}; npm access shows '${permission || "none"}'.`);
+            process.exit(1);
+          }
+          console.log(`NPM publish access confirmed for ${pkgName}.`);
+          NODE
+
       - name: Install (workspace aware)
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
         run: npm ci --no-audit --no-fund

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6967,8 +6967,8 @@
     },
     {
       "source": ".github/workflows/publish-mcp-package.yml",
-      "hash": "592df08439d4",
-      "bytes": 6824
+      "hash": "a2412e1ef536",
+      "bytes": 8962
     },
     {
       "source": ".github/workflows/review-enforcement-warning.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -100,7 +100,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
 | .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |
 | .github/workflows/publish-channel-package.yml | 25c5e6a54858 | 6832 |
-| .github/workflows/publish-mcp-package.yml | 592df08439d4 | 6824 |
+| .github/workflows/publish-mcp-package.yml | a2412e1ef536 | 8962 |
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
 | .github/workflows/testpass-pr-check.yml | 398a44d83549 | 9548 |


### PR DESCRIPTION
## Summary
- Adds an npm publish-access preflight to the MCP server publish workflow before install, build, version bump, push, or publish.
- Fails early with an explicit `NPM_TOKEN`/scope-access error when the token cannot authenticate, read `@unclick/mcp-server`, inspect `@unclick` package access, or lacks write permission.
- Prevents the release workflow from creating another package version bump on main before proving the npm token can publish.
- Refreshes generated Brainmap inventory for the workflow hash change.

## Scope
- Owned files: `.github/workflows/publish-mcp-package.yml`, `docs/UnClick-brainmap.generated.md`, `docs/UnClick-brainmap.generated.json`.
- Lane: FidelityCopy release blocker / proof integrity.
- Related todo: `656728ef`.

## Non-overlap
- Does not change MCP server code, FidelityCopy behavior, package versions, npm secrets, or registry configuration.
- Does not trigger another publish attempt.
- Does not mark the FidelityCopy todo DONE.

## Verification
- `git diff --check` passed with Windows LF/CRLF warning only.
- Parsed `.github/workflows/publish-mcp-package.yml` with `js-yaml` from the known-good dependency tree: `workflow yaml ok`.
- `npm run brainmap:check` passed.
- `npm run test:brainmap` passed: 6/6.
- Confirmed live npm registry still shows `@unclick/mcp-server@0.3.99`; failed run 26272653064 failed at `npm publish --access public` for `@unclick/mcp-server@0.3.107` with npm E404 after pack/build succeeded.

## Risk
- Low product runtime risk: GitHub Actions workflow only plus generated docs.
- Release risk is intentionally stricter: future MCP publish runs will fail before version bump/push if the npm token cannot prove package write access.

## Follow-up
- After this merges, rerun `Publish MCP server` on `main`. If preflight fails, the exact missing access is `NPM_TOKEN` publish/write permission for `@unclick/mcp-server` under the `@unclick` npm scope. If preflight passes, publish can proceed and then FidelityCopy still needs live tool-discovery and receipt proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release GitHub Actions workflow to gate version bumps and publishes on npm auth/access checks, which could block future releases if the checks are too strict or npm responses differ. No product runtime code is affected.
> 
> **Overview**
> Adds a **preflight npm publish-access check** to `publish-mcp-package.yml` that validates `NPM_TOKEN` (via `npm whoami`), confirms the package is readable on the registry, and verifies the token has *write-level* access for the package scope before running install/build/version bump/push/publish.
> 
> Regenerates the Brainmap inventory files to reflect the updated workflow hash/size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03b78018481cfe8ea1932292eb47129f05e9c2bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->