### PR TITLE
fix(reliability): derive job rail from proof evidence

### DIFF
--- a/api/fishbowl-completion-policy.test.ts
+++ b/api/fishbowl-completion-policy.test.ts
@@ -60,6 +60,27 @@ describe("evaluateFishbowlCompletionPolicy", () => {
     expect(result).toMatchObject({ allowed: false, code: "missing_proof" });
   });
 
+  it("blocks completion when a newer proof reset invalidates older proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: baseTodo,
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text: "PASS: PR #997 merged and checks passed.",
+          created_at: "2026-05-22T06:40:00Z",
+        },
+        {
+          author_agent_id: "reviewer-seat",
+          text: "Proof reset after live package publish failed.",
+          created_at: "2026-05-22T06:43:00Z",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "missing_proof" });
+  });
+
   it("allows backend automation completion-gate work without screenshot proof", () => {
     const result = evaluateFishbowlCompletionPolicy({
       todo: {

--- a/api/fishbowl-job-pipeline.test.ts
+++ b/api/fishbowl-job-pipeline.test.ts
@@ -30,9 +30,9 @@ describe("Fishbowl job pipeline inference", () => {
         status: "done",
       }),
     ).toMatchObject({
-      pipeline_stage_count: 5,
-      pipeline_progress: 100,
-      pipeline_source: "status: done",
+      pipeline_stage_count: 1,
+      pipeline_progress: 10,
+      pipeline_source: "proof: missing",
       pipeline_evidence: [],
       proof_state: "missing",
       proof_state_reason: "Completed job needs observable proof.",
@@ -130,8 +130,8 @@ describe("Fishbowl job pipeline inference", () => {
         ["PR #999 checks green.", "BLOCKER: missing authenticated screenshot proof for /admin/memory?tab=recall-check."],
       ),
     ).toMatchObject({
-      pipeline_stage_count: 5,
-      pipeline_progress: 100,
+      pipeline_stage_count: 3,
+      pipeline_progress: 70,
       pipeline_source: "receipt: proof",
       pipeline_evidence: ["build", "proof"],
       proof_state: "missing_ui_proof",
@@ -139,6 +139,29 @@ describe("Fishbowl job pipeline inference", () => {
       effective_status: "needs_proof",
       release_blocked: true,
       release_block_reason: "UI or browser proof is still missing.",
+    });
+  });
+
+  it("does not let a raw done chip advance the rail after proof is reset", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "CopyRoom exact-copy engine",
+          status: "done",
+        },
+        [
+          "Old receipt: PR #997 merged into main. Tests passed.",
+          "BLOCKER: proof reset after npm publish failed.",
+        ],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 1,
+      pipeline_progress: 10,
+      pipeline_source: "reopened: proof reset",
+      pipeline_evidence: ["reopened", "proof_missing"],
+      proof_state: "stale",
+      effective_status: "needs_proof",
+      release_blocked: true,
     });
   });
 

--- a/api/lib/fishbowl-completion-policy.ts
+++ b/api/lib/fishbowl-completion-policy.ts
@@ -35,7 +35,7 @@ const proofPositivePattern =
   /\b(pr\s*#?\d+|pull request\s*#?\d+|commit\s+[a-f0-9]{7,40}|sha\s+[a-f0-9]{7,40}|branch\s+[\w./-]+|git\s+diff|tests?\s+passed|build\s+passed|checks?\s+(?:passed|green)|ci\s+(?:passed|green)|playwright|screenshot|screen\s?shot|actions\/runs\/\d+|deployed|deployment|live on production|production live|no[_\s-]?code[_\s-]?needed|no code needed|proof:\s*\S+|receipt\s+[0-9a-f-]{8,})\b/i;
 
 const proofNegativePattern =
-  /\b(blocker|blocked|hold|no\s+(?:proof|screenshot|test|pr|commit)|missing\s+(?:proof|screenshot|test|pr|commit)|proof\s+(?:is\s+)?(?:missing|needed|incomplete|stale|not available)|without\s+(?:proof|screenshot|test|pr|commit)|needs?\s+(?:proof|screenshot|test|pr|commit)|publish\s+failed|release\/live\s+proof)\b/i;
+  /\b(blocker|blocked|hold|no\s+(?:proof|screenshot|test|pr|commit)|missing\s+(?:proof|screenshot|test|pr|commit)|proof\s+(?:is\s+)?(?:missing|needed|incomplete|stale|not available|reset)|proof\s+reset|reopened|re-opened|false\s+completion|false[- ]done|false\s+green|stale\s+(?:proof|receipt|green chip|claim)|wrong\s+(?:scope|surface|job|proof)|scope\s+mismatch|without\s+(?:proof|screenshot|test|pr|commit)|needs?\s+(?:proof|screenshot|test|pr|commit)|publish\s+failed|release\/live\s+proof)\b/i;
 
 const screenshotPattern =
   /\b(screenshot|screen\s?shot|before\/after|before and after|playwright|visual proof)\b|https?:\/\/\S+\.(?:png|jpe?g|webp)\b|[A-Za-z]:\\[^\n]+\.(?:png|jpe?g|webp)\b/i;

--- a/api/lib/fishbowl-job-pipeline.ts
+++ b/api/lib/fishbowl-job-pipeline.ts
@@ -218,8 +218,10 @@ export function inferFishbowlJobPipeline(
       ? index
       : latest;
   }, -1);
-  let activeCount = status === "done" ? stageRank.ship : status === "in_progress" ? stageRank.build : stageRank.brief;
-  let source = status === "done" ? "status: done" : status === "in_progress" ? "status: active" : "status: open";
+  const baseStatus = canonicalStatus(status);
+  let activeCount = baseStatus === "in_progress" ? stageRank.build : stageRank.brief;
+  let source =
+    baseStatus === "done" ? "proof: missing" : baseStatus === "in_progress" ? "status: active" : "status: open";
   const evidence: string[] = [];
 
   if (


### PR DESCRIPTION
## Summary
- make the jobs rail evidence-derived instead of letting raw `done` force Ship/100
- keep raw completed jobs without proof at Brief/10 and `needs_proof`
- block completion when newer proof reset, false-DONE, stale proof, or wrong-scope proof invalidates older proof

## Proof
- `npx vitest run api/fishbowl-job-pipeline.test.ts`
- `npx vitest run api/fishbowl-completion-policy.test.ts`
- `npx vitest run src/pages/admin/AdminJobs.test.tsx`
- `npm run build`

## Notes
- This is the first priority-1 spine slice: raw status is now weaker than observable proof.
- Unrelated dirty file left untouched locally: `packages/channel-plugin/index.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job pipeline inference and completion gating to treat raw `done` as insufficient without current proof, which can impact how jobs are shown/release-blocked and when closures are rejected. Risk is moderate due to regex-driven behavior changes and edge cases around comment ordering/timestamps.
> 
> **Overview**
> **Makes job rail and completion gating proof-first instead of status-first.** `inferFishbowlJobPipeline` no longer lets a raw `done` status force Ship/100; completed jobs without valid receipts stay at Brief/10 with `needs_proof`, and newer “proof reset/missing proof” signals can reopen/rollback the pipeline even if the status is still `done`.
> 
> **Tightens invalidation signals.** `evaluateFishbowlCompletionPolicy` expands negative-proof detection (e.g. `proof reset`, `reopened`, `false done/green`, `scope mismatch`) and adds coverage to ensure newer reset comments invalidate older PASS proof; tests are updated/added to lock in these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79ec9ebab286392ef36acceb887ca1f2c7cd628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->