### PR TITLE
fix(release): move package distribution to GitHub releases

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -12,7 +12,7 @@ What's automated, what secrets are required, and what to do when something goes 
 | `dogfood-report.yml` | Nightly schedule + manual dispatch | Rebuilds `public/dogfood/latest.json` with honest passing / blocked / pending proof status |
 | `event-wake-router.yml` | `issue_comment` + workflow fan-in | Routes ready-work wake events without waking healthy quiet cycles |
 | `auto-close-fishbowl-todo.yml` | PR merge hooks | Closes linked Fishbowl todos when a merged PR satisfies them |
-| `publish-mcp-package.yml` | Push to main touching `packages/mcp-server/**` | Bumps patch version, publishes `@unclick/mcp-server` to npm, tags the commit |
+| `publish-mcp-package.yml` | Push to main touching `packages/mcp-server/**` | Bumps patch version and publishes the MCP server GitHub Release tarball |
 | `apply-migrations.yml` | Push to main touching `supabase/migrations/**` | Runs `supabase db push` against production |
 | `dependabot.yml` | Weekly schedule | Opens PRs for npm + GH Actions updates, grouped sensibly |
 
@@ -28,7 +28,6 @@ Set these at **Settings → Secrets and variables → Actions → Repository sec
 | `TESTPASS_CRON_SECRET` | `testpass-scheduled-smoke.yml` first-choice token | Optional dedicated scheduled-smoke bearer for `/api/testpass-run` |
 | `UXPASS_TOKEN` | `dogfood-report.yml` UXPass proof | Active UXPass bearer for `/api/uxpass-run` |
 | `CRON_SECRET` | `testpass-scheduled-smoke.yml` fallback, `dogfood-report.yml` UXPass fallback | Shared cron bearer when a dedicated pass token is not set |
-| `NPM_TOKEN` | `publish-mcp-package.yml` | npm → Account → Access Tokens → Create Automation token (Bypass 2FA) |
 | `SUPABASE_ACCESS_TOKEN` | `apply-migrations.yml` | https://supabase.com/dashboard/account/tokens |
 | `SUPABASE_PROJECT_REF` | `apply-migrations.yml` | The subdomain from `xxxxx.supabase.co` |
 | `SUPABASE_DB_PASSWORD` | `apply-migrations.yml` | Supabase dashboard → Settings → Database |
@@ -105,13 +104,19 @@ workflow:
 2. Runs `npm pack --dry-run` so `files:` errors surface before publish.
 3. Bumps patch (`0.3.0 → 0.3.1`), pushes the bump commit + tag with
    `[skip ci]` so it doesn't loop.
-4. `npm publish --access public`.
-5. Polls `npm view` to confirm propagation.
+4. Packs `unclick-mcp-server.tgz`.
+5. Creates a GitHub Release tagged `mcp-server-v<version>` and uploads the tarball.
+6. Confirms the release asset exists.
 
 To cut a minor or major release, bump manually in `packages/mcp-server/package.json`
-and push, the workflow will still publish (its `npm version patch` becomes a
-no-op if the working tree is dirty, but simpler: just skip the workflow by
-including `[skip ci]` in your message and running `npm publish` locally).
+and push. The workflow still produces the GitHub Release tarball. No npm
+registry account or `NPM_TOKEN` is required.
+
+Latest install URL:
+
+```bash
+npx -y https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz
+```
 
 ## When CI goes red
 
@@ -124,8 +129,9 @@ including `[skip ci]` in your message and running `npm publish` locally).
    - Dogfood TestPass uses `TESTPASS_TOKEN`.
    - Dogfood UXPass uses `UXPASS_TOKEN` first, then `CRON_SECRET`.
    - If `public/dogfood/latest.json` flips to `blocked`, treat that as honest evidence and refresh the missing secret instead of forcing a green status.
-3. **`publish-mcp-package.yml` 401/403** - `NPM_TOKEN` expired or wrong type.
-   Generate a new **Automation** token (not Classic) and update the secret.
+3. **`publish-mcp-package.yml` release failure** - open the run logs and check
+   whether the version bump pushed, the tag already exists, or the release
+   asset upload failed. The workflow uses only `GITHUB_TOKEN`.
 4. **`apply-migrations.yml` link failure** - the access token may have been
    rotated. Regenerate at https://supabase.com/dashboard/account/tokens.
 5. **`apply-migrations.yml` migration error** - open the run logs. If it's a

--- a/.github/workflows/publish-channel-package.yml
+++ b/.github/workflows/publish-channel-package.yml
@@ -11,9 +11,12 @@ on:
       - main
   workflow_dispatch:
 
-# Auto-publishes @unclick/channel to npm whenever files under
-# packages/channel-plugin/ change on main. If the package already exists on
-# npm, the workflow bumps the patch version before publishing.
+# GitHub-only distribution for @unclick/channel.
+#
+# No npm account, npm registry, or NPM_TOKEN is required. The workflow builds
+# packages/channel-plugin, bumps the package patch version on main, and
+# publishes a stable GitHub Release tarball at:
+# https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-channel.tgz
 
 concurrency:
   group: publish-channel-package
@@ -36,7 +39,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "PR package check only; skipping publish."
+            echo "PR release check only; skipping publish."
             exit 0
           fi
 
@@ -58,7 +61,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
       - name: Skip if last commit was a bot version bump
@@ -91,82 +93,80 @@ jobs:
           git config user.email "bot@unclick.world"
           git config user.name "UnClick Bot"
 
-      - name: Publish version plan
+      - name: Bump patch version
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        id: version_plan
+        id: version
         working-directory: packages/channel-plugin
         run: |
-          remote_ver=$(npm view @unclick/channel version 2>/dev/null || echo "")
-          new_ver=$(node - "$remote_ver" <<'NODE'
+          new_ver=$(node <<'NODE'
           const fs = require("fs");
-          const remote = process.argv[2] || "";
           const pkgPath = "package.json";
           const lockPath = "../../package-lock.json";
-          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-          const parts = (version) => String(version).split(".").map((part) => Number(part) || 0);
-          const compare = (a, b) => {
-            const aa = parts(a);
-            const bb = parts(b);
-            for (let i = 0; i < 3; i += 1) {
-              if (aa[i] !== bb[i]) return aa[i] - bb[i];
-            }
-            return 0;
+          const bump = (version) => {
+            const parts = String(version).split(".").map((part) => Number(part) || 0);
+            parts[2] += 1;
+            return parts.join(".");
           };
-          if (remote && compare(remote, pkg.version) >= 0) {
-            const next = parts(remote);
-            next[2] += 1;
-            pkg.version = next.join(".");
-            fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-            const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
-            if (lock.packages?.["packages/channel-plugin"]) {
-              lock.packages["packages/channel-plugin"].version = pkg.version;
-            }
-            fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = bump(pkg.version);
+          fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+          const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+          if (lock.packages?.["packages/channel-plugin"]) {
+            lock.packages["packages/channel-plugin"].version = pkg.version;
           }
+          fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
           console.log(pkg.version);
           NODE
           )
           echo "version=${new_ver}" >> "$GITHUB_OUTPUT"
+          git add package.json ../../package-lock.json
+          git commit -m "chore: bump channel package to v${new_ver} [skip ci]"
 
-      - name: Commit version bump
+      - name: Push version bump
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
         run: |
-          if git diff --quiet -- packages/channel-plugin/package.json package-lock.json; then
-            echo "No version bump needed."
-          else
-            git add packages/channel-plugin/package.json package-lock.json
-            git commit -m "chore: bump channel package to v${{ steps.version_plan.outputs.version }} [skip ci]"
-            git push
-          fi
-
-      - name: Publish to npm
-        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        working-directory: packages/channel-plugin
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Force public npm access
-        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        run: npm access set status=public @unclick/channel
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Verify published version
-        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        working-directory: packages/channel-plugin
-        run: |
-          local_ver=$(node -p "require('./package.json').version")
-          echo "Published @unclick/channel@${local_ver}"
-          public_npmrc="$(mktemp)"
-          printf 'registry=https://registry.npmjs.org/\n' > "$public_npmrc"
-          for i in 1 2 3 4 5; do
-            remote_ver=$(NPM_CONFIG_USERCONFIG="$public_npmrc" NODE_AUTH_TOKEN= npm view @unclick/channel version --registry=https://registry.npmjs.org/ 2>/dev/null || echo "")
-            if [ "$remote_ver" = "$local_ver" ]; then
-              echo "Confirmed on public registry."
+          for attempt in 1 2 3; do
+            if git push; then
               exit 0
             fi
-            sleep 4
+            echo "Version bump push failed, rebasing on latest main before retry ${attempt}."
+            git pull --rebase origin main
           done
-          echo "Public registry still shows ${remote_ver:-<missing>}, expected ${local_ver}"
+          git push
+
+      - name: Pack GitHub release tarball
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        id: pack
+        working-directory: packages/channel-plugin
+        run: |
+          mkdir -p ../../release-artifacts
+          packed_file=$(npm pack --pack-destination ../../release-artifacts)
+          cp "../../release-artifacts/${packed_file}" ../../release-artifacts/unclick-channel.tgz
+          echo "asset=release-artifacts/unclick-channel.tgz" >> "$GITHUB_OUTPUT"
+          echo "original=release-artifacts/${packed_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="channel-v${{ steps.version.outputs.version }}"
+          target_sha=$(git rev-parse HEAD)
+          gh release create "$tag" "${{ steps.pack.outputs.asset }}" \
+            --target "$target_sha" \
+            --title "Channel package v${{ steps.version.outputs.version }}" \
+            --notes "GitHub-only Channel package release. Install with: npx -y https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/unclick-channel.tgz"
+
+      - name: Verify GitHub release asset
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="channel-v${{ steps.version.outputs.version }}"
+          if gh release view "$tag" --json assets --jq '.assets[].name' | grep -qx 'unclick-channel.tgz'; then
+            echo "Confirmed GitHub release asset for ${tag}."
+            exit 0
+          fi
+          echo "::error::GitHub release ${tag} is missing unclick-channel.tgz"
           exit 1

--- a/.github/workflows/publish-mcp-package.yml
+++ b/.github/workflows/publish-mcp-package.yml
@@ -4,18 +4,19 @@ on:
   pull_request:
     paths:
       - '.github/workflows/publish-mcp-package.yml'
+      - 'packages/mcp-server/**'
+      - 'package-lock.json'
   push:
     branches:
       - main
   workflow_dispatch:
 
-# Auto-publishes @unclick/mcp-server to npm whenever files under
-# packages/mcp-server/ change on main. Bumps the patch version, pushes the
-# version bump commit back, then publishes. Skips if the last commit is
-# itself the bot bump ([skip ci]).
+# GitHub-only distribution for the MCP server.
 #
-# One-time setup: set the NPM_TOKEN repo secret to an "Automation" type
-# npm token (Bypass 2FA).
+# No npm account, npm registry, or NPM_TOKEN is required. The workflow builds
+# packages/mcp-server, bumps the package patch version on main, and publishes a
+# stable GitHub Release tarball at:
+# https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz
 
 concurrency:
   group: publish-mcp-server
@@ -38,7 +39,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "PR registry check only; skipping publish."
+            echo "PR release check only; skipping publish."
             exit 0
           fi
 
@@ -48,7 +49,7 @@ jobs:
           fi
 
           changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null || git show --name-only --format="" "${{ github.sha }}")
-          if echo "$changed_files" | grep -Eq '^(packages/mcp-server/|package-lock\.json$)'; then
+          if echo "$changed_files" | grep -Eq '^(\.github/workflows/publish-mcp-package\.yml|packages/mcp-server/)'; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
@@ -60,7 +61,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
       - name: Skip if last commit was a bot version bump
@@ -73,51 +73,6 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Preflight npm publish access
-        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        working-directory: packages/mcp-server
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-          pkg_name=$(node -p "require('./package.json').name")
-          scope="${pkg_name%%/*}"
-
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN is not configured; cannot publish ${pkg_name}."
-            exit 1
-          fi
-
-          if ! npm_user=$(npm whoami --registry=https://registry.npmjs.org/ 2>/dev/null); then
-            echo "::error::NPM_TOKEN is invalid or expired; npm whoami failed."
-            exit 1
-          fi
-          echo "NPM token authenticated as ${npm_user}."
-
-          if ! npm view "${pkg_name}" version --registry=https://registry.npmjs.org/ >/tmp/npm-current-version.txt 2>/dev/null; then
-            echo "::error::Unable to read ${pkg_name} from npm registry; check package name and scope."
-            exit 1
-          fi
-          echo "Current published ${pkg_name}@$(cat /tmp/npm-current-version.txt)."
-
-          if ! npm access ls-packages "${scope}" --json --registry=https://registry.npmjs.org/ >/tmp/npm-access.json 2>/dev/null; then
-            echo "::error::NPM_TOKEN cannot inspect ${scope} package access; grant publish/write access to ${pkg_name} or replace NPM_TOKEN."
-            exit 1
-          fi
-
-          node - "${pkg_name}" /tmp/npm-access.json <<'NODE'
-          const fs = require("fs");
-          const pkgName = process.argv[2];
-          const accessPath = process.argv[3];
-          const access = JSON.parse(fs.readFileSync(accessPath, "utf8"));
-          const permission = String(access[pkgName] ?? "");
-          if (!/(write|read-write|owner|admin)/i.test(permission)) {
-            console.error(`::error::NPM_TOKEN lacks write access for ${pkgName}; npm access shows '${permission || "none"}'.`);
-            process.exit(1);
-          }
-          console.log(`NPM publish access confirmed for ${pkgName}.`);
-          NODE
 
       - name: Install (workspace aware)
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
@@ -141,36 +96,30 @@ jobs:
 
       - name: Bump patch version
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        id: version
         working-directory: packages/mcp-server
         run: |
-          remote_ver=$(npm view @unclick/mcp-server version 2>/dev/null || echo "")
-          new_ver=$(node - "$remote_ver" <<'NODE'
+          new_ver=$(node <<'NODE'
           const fs = require("fs");
-          const remote = process.argv[2] || "";
           const pkgPath = "package.json";
           const manifestPath = "server.json";
           const lockPath = "../../package-lock.json";
-          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-          const parts = (version) => version.split(".").map((part) => Number(part));
-          const compare = (a, b) => {
-            const aa = parts(a);
-            const bb = parts(b);
-            for (let i = 0; i < 3; i += 1) {
-              if ((aa[i] || 0) !== (bb[i] || 0)) return (aa[i] || 0) - (bb[i] || 0);
-            }
-            return 0;
+          const bump = (version) => {
+            const parts = String(version).split(".").map((part) => Number(part) || 0);
+            parts[2] += 1;
+            return parts.join(".");
           };
-          const base = remote && compare(remote, pkg.version) > 0 ? remote : pkg.version;
-          const next = parts(base);
-          next[2] = (next[2] || 0) + 1;
-          pkg.version = next.join(".");
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = bump(pkg.version);
           fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
           const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
           manifest.version = pkg.version;
           for (const entry of manifest.packages || []) {
             if (entry.identifier === pkg.name) entry.version = pkg.version;
           }
           fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
           const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
           if (lock.packages?.["packages/mcp-server"]) {
             lock.packages["packages/mcp-server"].version = pkg.version;
@@ -179,6 +128,7 @@ jobs:
           console.log(pkg.version);
           NODE
           )
+          echo "version=${new_ver}" >> "$GITHUB_OUTPUT"
           git add package.json server.json ../../package-lock.json
           git commit -m "chore: bump mcp-server to v${new_ver} [skip ci]"
 
@@ -194,26 +144,38 @@ jobs:
           done
           git push
 
-      - name: Publish to npm
+      - name: Pack GitHub release tarball
         if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
-        working-directory: packages/mcp-server
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Verify published version
-        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        id: pack
         working-directory: packages/mcp-server
         run: |
-          local_ver=$(node -p "require('./package.json').version")
-          echo "Published @unclick/mcp-server@${local_ver}"
-          # Give npm registry a moment to propagate, then confirm.
-          for i in 1 2 3 4 5; do
-            remote_ver=$(npm view @unclick/mcp-server version 2>/dev/null || echo "")
-            if [ "$remote_ver" = "$local_ver" ]; then
-              echo "Confirmed on registry."
-              exit 0
-            fi
-            sleep 4
-          done
-          echo "Warning: registry still shows ${remote_ver}, expected ${local_ver}"
+          mkdir -p ../../release-artifacts
+          packed_file=$(npm pack --pack-destination ../../release-artifacts)
+          cp "../../release-artifacts/${packed_file}" ../../release-artifacts/unclick-mcp-server.tgz
+          echo "asset=release-artifacts/unclick-mcp-server.tgz" >> "$GITHUB_OUTPUT"
+          echo "original=release-artifacts/${packed_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="mcp-server-v${{ steps.version.outputs.version }}"
+          target_sha=$(git rev-parse HEAD)
+          gh release create "$tag" "${{ steps.pack.outputs.asset }}" \
+            --target "$target_sha" \
+            --title "MCP server v${{ steps.version.outputs.version }}" \
+            --notes "GitHub-only MCP server release. Install with: npx -y https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/unclick-mcp-server.tgz"
+
+      - name: Verify GitHub release asset
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="mcp-server-v${{ steps.version.outputs.version }}"
+          if gh release view "$tag" --json assets --jq '.assets[].name' | grep -qx 'unclick-mcp-server.tgz'; then
+            echo "Confirmed GitHub release asset for ${tag}."
+            exit 0
+          fi
+          echo "::error::GitHub release ${tag} is missing unclick-mcp-server.tgz"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @unclick/mcp-server
+# UnClick MCP server
 
 **The app store for AI agents.** [unclick.world](https://unclick.world)
 
@@ -7,13 +7,13 @@
 
 ## Install
 
-**Using `npx` (no installation required):**
+**Using the latest GitHub release (no npm account required):**
 ```json
 {
   "mcpServers": {
     "unclick": {
       "command": "npx",
-      "args": ["@unclick/mcp-server"]
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz"]
     }
   }
 }
@@ -21,9 +21,9 @@
 
 Add this to your `claude_desktop_config.json` (or equivalent for Cursor, Windsurf, etc).
 
-**Or install globally:**
+**Or install globally from GitHub:**
 ```bash
-npm install -g @unclick/mcp-server
+npm install -g https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz
 ```
 
 ## Operational Notes
@@ -67,7 +67,7 @@ Or pass it via the MCP config:
   "mcpServers": {
     "unclick": {
       "command": "npx",
-      "args": ["@unclick/mcp-server"],
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz"],
       "env": {
         "UNCLICK_API_KEY": "your_key_here"
       }

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6962,13 +6962,13 @@
     },
     {
       "source": ".github/workflows/publish-channel-package.yml",
-      "hash": "25c5e6a54858",
-      "bytes": 6832
+      "hash": "1483fedb8bd8",
+      "bytes": 6845
     },
     {
       "source": ".github/workflows/publish-mcp-package.yml",
-      "hash": "a2412e1ef536",
-      "bytes": 8962
+      "hash": "feaa16faf6f8",
+      "bytes": 7239
     },
     {
       "source": ".github/workflows/review-enforcement-warning.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -99,8 +99,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
 | .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |
-| .github/workflows/publish-channel-package.yml | 25c5e6a54858 | 6832 |
-| .github/workflows/publish-mcp-package.yml | a2412e1ef536 | 8962 |
+| .github/workflows/publish-channel-package.yml | 1483fedb8bd8 | 6845 |
+| .github/workflows/publish-mcp-package.yml | feaa16faf6f8 | 7239 |
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
 | .github/workflows/testpass-pr-check.yml | 398a44d83549 | 9548 |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,4 +1,4 @@
-# @unclick/mcp-server
+# UnClick MCP server
 
 **MCP server for the [UnClick](https://unclick.world) tool marketplace.**
 
@@ -17,7 +17,7 @@ Add to your MCP config (Claude Desktop: `~/Library/Application Support/Claude/cl
   "mcpServers": {
     "unclick": {
       "command": "npx",
-      "args": ["-y", "@unclick/mcp-server"],
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz"],
       "env": {
         "UNCLICK_API_KEY": "your_api_key_here"
       }
@@ -37,7 +37,7 @@ Same config snippet as above — Cursor uses the same MCP format.
 ### Local / Development
 
 ```bash
-UNCLICK_API_KEY=unck_... npx @unclick/mcp-server
+UNCLICK_API_KEY=unck_... npx -y https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz
 ```
 
 ## Memory (built in, zero config)
@@ -167,7 +167,7 @@ npm start
 
 ## MCP Registry
 
-This server is published to npm as `@unclick/mcp-server` and can be added to any MCP registry that supports npx-based servers.
+This server is published as a GitHub Release tarball and can be added to MCP clients that support npx-based servers.
 
 ## License
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -3,10 +3,10 @@
 > Agent rails for AI agents: tools, memory, connections, crews, and Pass family checks.
 
 ## What is UnClick
-UnClick is an MCP-compatible agent-rails layer where AI agents discover tools, load memory, use secure connections, run crews, and verify work with the Pass family. One npm package gives access to 450+ callable endpoints across 60+ integrations. No per-tool installs. No configuration per service.
+UnClick is an MCP-compatible agent-rails layer where AI agents discover tools, load memory, use secure connections, run crews, and verify work with the Pass family. One GitHub release package gives access to 450+ callable endpoints across 60+ integrations. No per-tool installs. No configuration per service.
 
 ## How agents connect
-Install: npx @unclick/mcp-server
+Install: npx -y https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz
 The package exposes 4 meta-tools:
 - unclick_search: Find tools by keyword or description
 - unclick_browse: List all tools, optionally filtered by category
@@ -18,7 +18,7 @@ Text processing, data utilities, media (image/QR/color), timestamps, networking,
 
 ## Links
 - Website: https://unclick.world
-- npm: https://www.npmjs.com/package/@unclick/mcp-server
+- GitHub Releases: https://github.com/malamutemayhem/unclick/releases
 - GitHub: https://github.com/malamutemayhem/unclick
 - Arena (AI competition): https://unclick.world/arena
 - Developer platform: https://unclick.world/developers

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,7 +17,7 @@ const RESOURCES_LINKS = [
 const COMPANY_LINKS = [
   { label: "Contact", href: "mailto:hello@unclick.world" },
   { label: "GitHub", href: "https://github.com/malamutemayhem/unclick", external: true },
-  { label: "npm", href: "https://www.npmjs.com/package/@unclick/mcp-server", external: true },
+  { label: "Releases", href: "https://github.com/malamutemayhem/unclick/releases", external: true },
 ];
 
 const LEGAL_LINKS = [

--- a/src/components/InstallSection.tsx
+++ b/src/components/InstallSection.tsx
@@ -18,6 +18,7 @@ type Platform = "Claude" | "ChatGPT" | "Cursor" | "VS Code" | "Other";
 type ClaudeSurface = "Web" | "Desktop" | "Code";
 
 const MCP_ORIGIN = "https://unclick.world/api/mcp";
+const MCP_PACKAGE_URL = "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz";
 const PLACEHOLDER_KEY = "YOUR_API_KEY";
 
 const platforms: Platform[] = ["Claude", "ChatGPT", "Cursor", "VS Code", "Other"];
@@ -40,7 +41,7 @@ function stdioJson(key: string) {
   "mcpServers": {
     "unclick": {
       "command": "npx",
-      "args": ["-y", "@unclick/mcp-server"],
+      "args": ["-y", "${MCP_PACKAGE_URL}"],
       "env": { "UNCLICK_API_KEY": "${key}" }
     }
   }

--- a/src/pages/BackstagePass.tsx
+++ b/src/pages/BackstagePass.tsx
@@ -153,7 +153,7 @@ function PlatformCard({ platform }: { platform: (typeof PLATFORMS)[0] }) {
 
 // ---- Main page ----
 
-const INSTALL_CMD = "npx @unclick/mcp-server";
+const INSTALL_CMD = "npx -y https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz";
 
 const STEPS = [
   {

--- a/src/pages/Dispatch.tsx
+++ b/src/pages/Dispatch.tsx
@@ -47,7 +47,7 @@ const SETUP_STEPS = [
   "mcpServers": {
     "unclick": {
       "command": "npx",
-      "args": ["-y", "@unclick/mcp-server"],
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz"],
       "env": { "UNCLICK_API_KEY": "your-key" }
     },
     "unclick-memory": {

--- a/src/pages/InstallRecover.tsx
+++ b/src/pages/InstallRecover.tsx
@@ -23,7 +23,7 @@ function makeJsonConfig(installCode: string) {
   "mcpServers": {
     "unclick": {
       "command": "npx",
-      "args": ["-y", "@unclick/mcp-server"],
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz"],
       "env": { "UNCLICK_API_KEY": "${installCode}" }
     }
   }

--- a/src/pages/MemorySetup.tsx
+++ b/src/pages/MemorySetup.tsx
@@ -115,7 +115,7 @@ export default function MemorySetupPage() {
         mcpServers: {
           unclick: {
             command: "npx",
-            args: ["-y", "@unclick/mcp-server"],
+            args: ["-y", "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz"],
             env: {
               UNCLICK_API_KEY: apiKey || "your_api_key_here",
             },


### PR DESCRIPTION
## What changed
- Removed npm publish, npm registry auth, and NPM_TOKEN from the MCP and Channel release workflows.
- Publish path is now GitHub Releases only, with stable tarball assets:
  - unclick-mcp-server.tgz
  - unclick-channel.tgz
- Updated install docs and in-app config snippets to use the latest GitHub release tarball.
- Updated operations docs so npm is no longer the blocker.

## Proof
- npm ci --no-audit --no-fund
- npm run build --workspace=@unclick/mcp-server
- npm pack --dry-run in packages/mcp-server
- node --test packages/channel-plugin/*.test.js
- npm pack --dry-run in packages/channel-plugin
- npm run build
- YAML parse check for both publish workflows
- grep check for old npm install/publish references

## Notes
- This still uses the npm CLI as a local build/pack tool, but not npmjs.com, npm auth, or npm publish.
- package names stay stable internally; distribution moves to GitHub release tarballs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the release/distribution path for `@unclick/mcp-server` and `@unclick/channel` from npm publishing to GitHub Release assets, which can break installs and automation if tagging/asset upload logic misbehaves.
> 
> **Overview**
> Moves package distribution off npm and onto **GitHub Releases** for both the MCP server and channel plugin: workflows now bump patch versions, `npm pack` into stable assets (`unclick-mcp-server.tgz`, `unclick-channel.tgz`), create versioned release tags, and verify the assets exist—removing `NPM_TOKEN`/registry auth and all `npm publish` steps.
> 
> Updates docs and UI install snippets (README, `packages/mcp-server/README.md`, `public/llms.txt`, Footer link, and multiple pages/components) to install via `npx -y https://github.com/.../releases/latest/download/unclick-mcp-server.tgz`, and adjusts ops guidance/troubleshooting to reflect GitHub-only release failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e37b9f0d8f70ba66beab77dd5889db7db0909a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->