### PR TITLE
fix(release): keep package latest downloads stable

### DIFF
--- a/.github/workflows/publish-channel-package.yml
+++ b/.github/workflows/publish-channel-package.yml
@@ -3,9 +3,9 @@ name: Publish Channel package
 on:
   pull_request:
     paths:
-      - '.github/workflows/publish-channel-package.yml'
-      - 'packages/channel-plugin/**'
-      - 'package-lock.json'
+      - ".github/workflows/publish-channel-package.yml"
+      - "packages/channel-plugin/**"
+      - "package-lock.json"
   push:
     branches:
       - main
@@ -170,3 +170,28 @@ jobs:
           fi
           echo "::error::GitHub release ${tag} is missing unclick-channel.tgz"
           exit 1
+
+      - name: Update rolling latest package release
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          rolling_tag="unclick-packages-latest"
+          rolling_title="UnClick package downloads"
+          rolling_notes="Rolling GitHub-only package release for stable latest/download package URLs."
+          asset="${{ steps.pack.outputs.asset }}"
+
+          if ! gh release view "$rolling_tag" >/dev/null 2>&1; then
+            gh release create "$rolling_tag" "$asset" \
+              --target "$(git rev-parse HEAD)" \
+              --title "$rolling_title" \
+              --notes "$rolling_notes" || true
+          fi
+
+          gh release upload "$rolling_tag" "$asset" --clobber
+          gh release edit "$rolling_tag" --latest --title "$rolling_title" --notes "$rolling_notes"
+
+      - name: Verify stable latest download
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        run: |
+          curl --fail --location --head "https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/unclick-channel.tgz"

--- a/.github/workflows/publish-mcp-package.yml
+++ b/.github/workflows/publish-mcp-package.yml
@@ -3,9 +3,9 @@ name: Publish MCP server
 on:
   pull_request:
     paths:
-      - '.github/workflows/publish-mcp-package.yml'
-      - 'packages/mcp-server/**'
-      - 'package-lock.json'
+      - ".github/workflows/publish-mcp-package.yml"
+      - "packages/mcp-server/**"
+      - "package-lock.json"
   push:
     branches:
       - main
@@ -179,3 +179,28 @@ jobs:
           fi
           echo "::error::GitHub release ${tag} is missing unclick-mcp-server.tgz"
           exit 1
+
+      - name: Update rolling latest package release
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          rolling_tag="unclick-packages-latest"
+          rolling_title="UnClick package downloads"
+          rolling_notes="Rolling GitHub-only package release for stable latest/download package URLs."
+          asset="${{ steps.pack.outputs.asset }}"
+
+          if ! gh release view "$rolling_tag" >/dev/null 2>&1; then
+            gh release create "$rolling_tag" "$asset" \
+              --target "$(git rev-parse HEAD)" \
+              --title "$rolling_title" \
+              --notes "$rolling_notes" || true
+          fi
+
+          gh release upload "$rolling_tag" "$asset" --clobber
+          gh release edit "$rolling_tag" --latest --title "$rolling_title" --notes "$rolling_notes"
+
+      - name: Verify stable latest download
+        if: steps.scope.outputs.should_publish == 'true' && steps.skip_check.outputs.skip == 'false'
+        run: |
+          curl --fail --location --head "https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/unclick-mcp-server.tgz"

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6962,13 +6962,13 @@
     },
     {
       "source": ".github/workflows/publish-channel-package.yml",
-      "hash": "1483fedb8bd8",
-      "bytes": 6845
+      "hash": "5c9197848ca9",
+      "bytes": 8046
     },
     {
       "source": ".github/workflows/publish-mcp-package.yml",
-      "hash": "feaa16faf6f8",
-      "bytes": 7239
+      "hash": "868a5bc10985",
+      "bytes": 8443
     },
     {
       "source": ".github/workflows/review-enforcement-warning.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -99,8 +99,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
 | .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |
-| .github/workflows/publish-channel-package.yml | 1483fedb8bd8 | 6845 |
-| .github/workflows/publish-mcp-package.yml | feaa16faf6f8 | 7239 |
+| .github/workflows/publish-channel-package.yml | 5c9197848ca9 | 8046 |
+| .github/workflows/publish-mcp-package.yml | 868a5bc10985 | 8443 |
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
 | .github/workflows/testpass-pr-check.yml | 398a44d83549 | 9548 |


### PR DESCRIPTION
## Summary
- keep a rolling GitHub release for stable latest/download package URLs
- upload MCP and Channel package assets into the rolling release from their publish workflows
- verify the stable latest download URL inside each workflow

## Proof
- npx prettier --check .github/workflows/publish-mcp-package.yml .github/workflows/publish-channel-package.yml
- git diff --check
- Manual release proof: https://github.com/malamutemayhem/unclick/releases/tag/unclick-packages-latest
- Stable URLs verified with curl -I -L for unclick-mcp-server.tgz and unclick-channel.tgz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions release/publish workflows, which can impact package publishing and the `releases/latest` download URLs if misconfigured. No product/runtime code paths are modified.
> 
> **Overview**
> Adds a **rolling GitHub Release** (`unclick-packages-latest`) to both Channel and MCP publish workflows, uploading the newly built tarball on each publish and marking that rolling release as `--latest` so the `releases/latest/download/*.tgz` URLs remain stable.
> 
> Each workflow now also **verifies** the stable download URL with a `curl --head` check after publishing, and includes minor workflow formatting/quoting updates; generated brainmap docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93c3eac305f5b7cf3e3c98dc7d39cb9f508801a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->