### PR TITLE
[codex] label QueuePush walk-in draft lifts

### DIFF
--- a/scripts/fleet-throughput-watch.mjs
+++ b/scripts/fleet-throughput-watch.mjs
@@ -153,6 +153,14 @@ function normalizeText(value) {
 }
 
 const PROTECTED_OWNER_LIFT_LANE_TERMS = [
+  "operator_only",
+  "operator-only",
+  "operator only",
+  "chris-only",
+  "chris only",
+  "human decision",
+  "human approval",
+  "human policy",
   "rotatepass",
   "xpass",
   "system credential",
@@ -167,6 +175,10 @@ const PROTECTED_OWNER_LIFT_LANE_TERMS = [
   "dns",
   "production data",
   "prod data",
+  "customer data",
+  "live data",
+  "novel product call",
+  "new product call",
   "keychain",
 ];
 
@@ -177,6 +189,20 @@ function isDraftGreenOwnerLiftState(state) {
 function isProtectedOwnerLiftLane(lane) {
   const text = normalizeText(lane);
   return PROTECTED_OWNER_LIFT_LANE_TERMS.some((term) => text.includes(term));
+}
+
+export function queuepushRoutingLabel(pr, files = [], state = "") {
+  if (state === "blocked_chris_only") return "operator_only";
+  if (!isDraftGreenOwnerLiftState(state)) return null;
+  const haystack = normalizeText(
+    [
+      state,
+      pr.title,
+      pr.body,
+      ...files.map((file) => file.filename || file.path || ""),
+    ].join(" "),
+  );
+  return isProtectedOwnerLiftLane(haystack) ? "operator_only" : "walkin_eligible";
 }
 
 function isMissingFinalQcText(text) {
@@ -878,6 +904,8 @@ export function buildQueuePacket(input) {
   const worker = routeWorkerForPr(pr, files, state);
   const packetId = queuepushPacketId(pr, state);
   const jobKind = jobKindForState(state);
+  const routingLabel = queuepushRoutingLabel(pr, files, state);
+  const tags = ["needs-doing", "queuepush", routingLabel].filter(Boolean);
   const chip = `PR #${pr.number} ${state}`;
   const filePreview = files
     .slice(0, 4)
@@ -896,6 +924,7 @@ export function buildQueuePacket(input) {
     packetInstructionForJobKind(jobKind, state),
     `worker: ${worker}`,
     `job kind: ${jobKind}`,
+    ...(routingLabel ? [`routing label: ${routingLabel}`] : []),
     `requires code: ${stateRequiresCode(state) ? "yes" : "no"}`,
     `chip: ${chip}`,
     `context: ${context}`,
@@ -914,6 +943,8 @@ export function buildQueuePacket(input) {
     jobKind,
     requiresCode: stateRequiresCode(state),
     recipient: agentMap[worker] || worker,
+    routingLabel,
+    tags,
     state,
     pr: pr.number,
     text,
@@ -1197,7 +1228,7 @@ async function postQueuePacket(packet) {
   return postMemoryAdmin("fishbowl_post", {
     agent_id: agentId,
     recipients: [packet.recipient],
-    tags: ["needs-doing", "queuepush"],
+    tags: packet.tags || ["needs-doing", "queuepush"],
     text: packet.text,
   });
 }

--- a/scripts/fleet-throughput-watch.test.mjs
+++ b/scripts/fleet-throughput-watch.test.mjs
@@ -16,6 +16,7 @@ import {
   jobKindForState,
   latestCommentSignals,
   queuePushWakeFromPacket,
+  queuepushRoutingLabel,
   resolveQueuePushRunnerRoster,
   routeWorkerForPr,
   runnerCanAcceptQueuePushJob,
@@ -740,6 +741,8 @@ describe("QueuePush routing and packets", () => {
     assert.equal(packet.worker, "🧪");
     assert.equal(packet.recipient, "🧪");
     assert.equal(packet.jobKind, "owner_decision");
+    assert.equal(packet.routingLabel, "operator_only");
+    assert.ok(packet.tags.includes("operator_only"));
     assert.equal(packet.requiresCode, false);
     assert.match(packet.packetId, /^queuepush:v3:pr-506:draft_green_needs_owner_lift:abcdef1:[a-f0-9]{10}$/);
     assert.match(packet.text, /DIRECT DECISION PACKET/);
@@ -747,12 +750,37 @@ describe("QueuePush routing and packets", () => {
     assert.match(packet.text, /non-author lift hat/);
     assert.match(packet.text, /worker: 🧪/);
     assert.match(packet.text, /job kind: owner_decision/);
+    assert.match(packet.text, /routing label: operator_only/);
     assert.match(packet.text, /requires code: no/);
     assert.match(packet.text, /do: Claim with non-author lift hat/);
     assert.match(packet.text, /expected proof: Non-author lift proof/);
     assert.match(packet.text, /fallback: if not ACKed after two pulses/);
     assert.match(packet.text, /ack: done\/blocker/);
     assert.ok(packet.text.length < 1200);
+  });
+
+  it("labels routine draft owner lifts as walk-in eligible", () => {
+    const packet = buildQueuePacket({
+      pr: pr({ number: 548, title: "docs: clarify QueuePush handoff", body: "status: ready" }),
+      state: "draft_green_needs_owner_lift",
+      reason: "Draft PR is green and clean.",
+      files: [{ filename: "docs/reliability-substrate.md" }],
+    });
+
+    assert.equal(packet.routingLabel, "walkin_eligible");
+    assert.ok(packet.tags.includes("walkin_eligible"));
+    assert.match(packet.text, /routing label: walkin_eligible/);
+  });
+
+  it("keeps sensitive routine draft owner lifts operator-only", () => {
+    assert.equal(
+      queuepushRoutingLabel(
+        pr({ title: "RotatePass: harden metadata key redaction guard" }),
+        [{ filename: "src/pages/admin/systemCredentialInventory.ts" }],
+        "draft_green_needs_owner_lift",
+      ),
+      "operator_only",
+    );
   });
 
   it("builds code-required implementation packets for proven builders", () => {


### PR DESCRIPTION
## Summary
- add QueuePush routing labels for draft owner-lift packets
- mark routine green draft lifts as walkin_eligible
- keep protected or human-only lift lanes operator_only

## Proof
- node --test scripts/fleet-throughput-watch.test.mjs (69 passed, 0 failed)

## Boardroom
- AutoPilot Automation Efficiency v1 ScopePack slice: QueuePush routine draft lift routing split
- Proof comment: e5a1467b-d7fa-4ae2-ac90-ec554280fec3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes QueuePush packet tagging and routing metadata for draft owner-lift states, which could affect how work is triaged or filtered in downstream tooling. Logic is small and covered by new/updated tests, limiting blast radius.
> 
> **Overview**
> Adds a `queuepushRoutingLabel` classification for QueuePush packets, splitting *routine* `draft_green_needs_owner_lift` packets into `walkin_eligible` vs `operator_only` based on PR text/changed-file keywords and explicitly treating `blocked_chris_only` as `operator_only`.
> 
> `buildQueuePacket` now includes `routingLabel` and emits it in packet text, and Fishbowl posts use packet-provided `tags` (including the routing label) instead of hardcoded tags; tests are updated to assert the new label/tag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b376b58c52197859919da54ae9fcf50edb784f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->