### PR TITLE
[codex] add WakePass dispatch terminal cleanup helper

### DIFF
--- a/scripts/reliability-dispatch-complete.mjs
+++ b/scripts/reliability-dispatch-complete.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_API_URL = "https://unclick.world/api/memory-admin";
+const TERMINAL_STATES = new Set(["completed", "failed", "cancelled"]);
+
+function readFlag(argv, name) {
+  const index = argv.indexOf(name);
+  if (index === -1) return null;
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) return "";
+  return value;
+}
+
+function hasFlag(argv, name) {
+  return argv.includes(name);
+}
+
+export function parseDispatchCompleteArgs(argv, env = process.env) {
+  const dispatchId = readFlag(argv, "--dispatch-id") || env.WAKE_DISPATCH_ID || "";
+  const agentId = readFlag(argv, "--agent-id") || env.WAKE_AGENT_ID || "unclick-builder-tether-seat";
+  const state = (readFlag(argv, "--state") || "completed").toLowerCase();
+  const apiUrl = readFlag(argv, "--api-url") || env.UNCLICK_API_URL || DEFAULT_API_URL;
+  const dryRun = hasFlag(argv, "--dry-run") || env.WAKE_DISPATCH_DRY_RUN === "1";
+  const currentTask = readFlag(argv, "--current-task") || "dispatch cleanup";
+  const nextAction = readFlag(argv, "--next-action") || "remove stale WakePass blocker";
+
+  return {
+    dispatchId: dispatchId.trim(),
+    agentId: agentId.trim(),
+    state,
+    apiUrl,
+    dryRun,
+    currentTask,
+    nextAction,
+  };
+}
+
+export function validateDispatchCompleteArgs(args) {
+  if (!args.dispatchId) return "dispatch_id required";
+  if (!args.agentId) return "agent_id required";
+  if (!TERMINAL_STATES.has(args.state)) return "state must be completed, failed, or cancelled";
+  return null;
+}
+
+export function buildDispatchTerminalRequest(args) {
+  if (args.state === "completed") {
+    return {
+      url: `${args.apiUrl}?action=reliability_heartbeats&method=publish`,
+      body: {
+        dispatch_id: args.dispatchId,
+        agent_id: args.agentId,
+        state: "completed",
+        current_task: args.currentTask,
+        next_action: args.nextAction,
+      },
+    };
+  }
+
+  return {
+    url: `${args.apiUrl}?action=reliability_dispatches&method=release`,
+    body: {
+      dispatch_id: args.dispatchId,
+      agent_id: args.agentId,
+      status: args.state,
+    },
+  };
+}
+
+export function buildAuthHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export function redactHeaders(headers) {
+  return {
+    ...headers,
+    Authorization: headers.Authorization ? "Bearer [redacted]" : undefined,
+  };
+}
+
+async function main() {
+  const args = parseDispatchCompleteArgs(process.argv.slice(2));
+  const validationError = validateDispatchCompleteArgs(args);
+  if (validationError) {
+    console.error(`BLOCKER: ${validationError}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const request = buildDispatchTerminalRequest(args);
+  const token = process.env.UNCLICK_API_KEY || process.env.FISHBOWL_WAKE_TOKEN || process.env.FISHBOWL_AUTOCLOSE_TOKEN || "";
+
+  if (args.dryRun) {
+    console.log(JSON.stringify({ dry_run: true, request }, null, 2));
+    return;
+  }
+
+  if (!token) {
+    console.error("BLOCKER: UNCLICK_API_KEY, FISHBOWL_WAKE_TOKEN, or FISHBOWL_AUTOCLOSE_TOKEN is required.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const response = await fetch(request.url, {
+    method: "POST",
+    headers: buildAuthHeaders(token),
+    body: JSON.stringify(request.body),
+  });
+  const responseBody = await response.text();
+  if (!response.ok) {
+    console.error(`BLOCKER: dispatch terminal update failed HTTP ${response.status}: ${responseBody}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        pass: true,
+        status: response.status,
+        dispatch_id: args.dispatchId,
+        terminal_state: args.state,
+        response: responseBody ? JSON.parse(responseBody) : null,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`BLOCKER: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/reliability-dispatch-complete.test.mjs
+++ b/scripts/reliability-dispatch-complete.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildAuthHeaders,
+  buildDispatchTerminalRequest,
+  parseDispatchCompleteArgs,
+  redactHeaders,
+  validateDispatchCompleteArgs,
+} from "./reliability-dispatch-complete.mjs";
+
+describe("reliability dispatch terminal cleanup", () => {
+  it("builds a completed heartbeat request for stale WakePass cleanup", () => {
+    const args = parseDispatchCompleteArgs([
+      "--dispatch-id",
+      "dispatch_d678a93f3052a1ee7c29daf966d90c75",
+      "--agent-id",
+      "unclick-builder-tether-seat",
+      "--state",
+      "completed",
+      "--api-url",
+      "https://unclick.world/api/memory-admin",
+    ]);
+
+    assert.equal(validateDispatchCompleteArgs(args), null);
+    assert.deepEqual(buildDispatchTerminalRequest(args), {
+      url: "https://unclick.world/api/memory-admin?action=reliability_heartbeats&method=publish",
+      body: {
+        dispatch_id: "dispatch_d678a93f3052a1ee7c29daf966d90c75",
+        agent_id: "unclick-builder-tether-seat",
+        state: "completed",
+        current_task: "dispatch cleanup",
+        next_action: "remove stale WakePass blocker",
+      },
+    });
+  });
+
+  it("builds a release request for non-completed terminal states", () => {
+    const args = parseDispatchCompleteArgs([
+      "--dispatch-id",
+      "dispatch_failed_case",
+      "--agent-id",
+      "unclick-builder-tether-seat",
+      "--state",
+      "failed",
+    ]);
+
+    assert.equal(validateDispatchCompleteArgs(args), null);
+    assert.deepEqual(buildDispatchTerminalRequest(args), {
+      url: "https://unclick.world/api/memory-admin?action=reliability_dispatches&method=release",
+      body: {
+        dispatch_id: "dispatch_failed_case",
+        agent_id: "unclick-builder-tether-seat",
+        status: "failed",
+      },
+    });
+  });
+
+  it("validates required dispatch id and terminal state", () => {
+    assert.equal(validateDispatchCompleteArgs(parseDispatchCompleteArgs([])), "dispatch_id required");
+    assert.equal(
+      validateDispatchCompleteArgs(
+        parseDispatchCompleteArgs(["--dispatch-id", "dispatch_1", "--state", "leased"]),
+      ),
+      "state must be completed, failed, or cancelled",
+    );
+  });
+
+  it("redacts authorization headers before debug output", () => {
+    const headers = buildAuthHeaders("secret-token");
+    assert.equal(headers.Authorization, "Bearer secret-token");
+    assert.deepEqual(redactHeaders(headers), {
+      Authorization: "Bearer [redacted]",
+      "Content-Type": "application/json",
+    });
+  });
+});


### PR DESCRIPTION
Adds a tiny safe helper for terminal cleanup of Reliability/WakePass dispatches when proof already exists but the dispatch is still counted as stale.\n\nProof:\n- node --test scripts/reliability-dispatch-complete.test.mjs\n- node scripts/reliability-dispatch-complete.mjs --dispatch-id dispatch_d678a93f3052a1ee7c29daf966d90c75 --agent-id unclick-builder-tether-seat --state completed --dry-run\n\nThis does not mark any Boardroom job DONE. It gives the fleet a GitHub-backed path to complete or fail a specific dispatch with UNCLICK_API_KEY/FISHBOWL token without printing secrets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone Node script and tests that post terminal-state updates to an internal admin API; risk is low because it’s opt-in CLI tooling with validation and dry-run support, but it can change dispatch status if misused with real tokens.
> 
> **Overview**
> Adds `scripts/reliability-dispatch-complete.mjs`, a small CLI helper to mark a Reliability/WakePass dispatch as terminal by POSTing either a `completed` heartbeat publish or a `failed/cancelled` release request to the memory-admin API (with arg/env parsing, validation, and `--dry-run`).
> 
> Includes `scripts/reliability-dispatch-complete.test.mjs` to cover request construction, required-arg/state validation, and auth-header redaction behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc12b60c97c1fd12279fca5de5082aa0d15930bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->