### PR TITLE
[codex] complete leased WakePass dispatches on auto-close

### DIFF
--- a/.github/workflows/auto-close-fishbowl-todo.yml
+++ b/.github/workflows/auto-close-fishbowl-todo.yml
@@ -177,23 +177,20 @@ jobs:
                     fi
                   fi
 
-                  if [ "${dispatch_status}" != "leased" ] || [ -z "${lease_owner:-}" ]; then
-                    release_payload=$(jq -n \
-                      --arg agent_id "$AGENT_ID" \
-                      --arg dispatch_id "$dispatch_id" \
-                      '{method: "release", agent_id: $agent_id, dispatch_id: $dispatch_id, status: "completed"}')
-                    release_http=$(curl -sS -o wakepass-release.json -w "%{http_code}" \
-                      --connect-timeout 10 --max-time 30 \
-                      -X POST "${API_URL}?action=reliability_dispatches" \
-                      -H "Authorization: Bearer ${UNCLICK_API_KEY}" \
-                      -H "Content-Type: application/json" \
-                      -d "$release_payload") || release_http="000"
-                    if [ "$release_http" -ge 400 ] 2>/dev/null || [ "$release_http" = "000" ]; then
-                      echo "::warning::Could not complete WakePass dispatch ${dispatch_id} for PR #${pr_number} (HTTP ${release_http})."
-                      fail_count=$((fail_count + 1))
-                    else
-                      wakepass_complete_count=$((wakepass_complete_count + 1))
-                    fi
+                  echo "Completing WakePass dispatch ${dispatch_id} for PR #${pr_number} (${dispatch_status:-unknown}, lease owner: ${lease_owner:-none})."
+                  if node scripts/reliability-dispatch-complete.mjs \
+                    --dispatch-id "$dispatch_id" \
+                    --agent-id "$AGENT_ID" \
+                    --state completed \
+                    --api-url "$API_URL" \
+                    --current-task "merged PR #${pr_number} WakePass cleanup" \
+                    --next-action "remove stale WakePass blocker" \
+                    > wakepass-complete.json 2>wakepass-complete.err; then
+                    cat wakepass-complete.json
+                    wakepass_complete_count=$((wakepass_complete_count + 1))
+                  else
+                    echo "::warning::Could not complete WakePass dispatch ${dispatch_id} for PR #${pr_number}: $(cat wakepass-complete.err)"
+                    fail_count=$((fail_count + 1))
                   fi
                 done
               fi

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6922,8 +6922,8 @@
     },
     {
       "source": ".github/workflows/auto-close-fishbowl-todo.yml",
-      "hash": "07564f004cb2",
-      "bytes": 11830
+      "hash": "d11ec31e1d22",
+      "bytes": 11599
     },
     {
       "source": ".github/workflows/autonomous-runner.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -91,7 +91,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/ebird-tool.ts | 3deedf3fde19 | 6262 |
 | packages/mcp-server/src/elevenlabs-tool.ts | efcaeeff39d6 | 10833 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
-| .github/workflows/auto-close-fishbowl-todo.yml | 07564f004cb2 | 11830 |
+| .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
 | .github/workflows/autonomous-runner.yml | 5aead42a5ec9 | 8340 |
 | .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
 | .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |


### PR DESCRIPTION
## Summary
- route auto-close WakePass cleanup through the terminal dispatch helper
- complete matched WakePass dispatches even when they are leased
- keep the existing ACK and warning-only behavior for merge cleanup

## Proof
- node --test scripts/reliability-dispatch-complete.test.mjs
- git diff --check

## Notes
This is aimed at the remaining stale PR #1012 blocker pattern where merge proof exists but the dispatch stays leased/stale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that alters how WakePass dispatches are marked terminal; main risk is unintended completion of the wrong dispatch due to changes in completion criteria or helper behavior.
> 
> **Overview**
> Updates the PR-merge auto-close workflow to **always attempt to complete matched WakePass dispatches (including leased ones)** by invoking `scripts/reliability-dispatch-complete.mjs` instead of posting a direct `reliability_dispatches` release call.
> 
> Keeps the existing warning-only/exit-0 behavior but improves logging and captures helper output/errors; regenerates the `UnClick-brainmap` docs to reflect the workflow change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7f34b50a130bd221cdfb478c3196cc626518e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->