### PR TITLE
feat(autopilot): add zero-touch scoreboard

### DIFF
--- a/api/autopilot-control-ledger.test.ts
+++ b/api/autopilot-control-ledger.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildAutopilotEventRow,
+  createAutopilotZeroTouchMetrics,
   planAutoPilotKitRecommendationLedgerEvents,
   planFishbowlPostLedgerEvent,
   planTodoLedgerEvents,
@@ -246,5 +247,81 @@ describe("autopilot control ledger helpers", () => {
     })[0];
 
     expect(() => buildAutopilotEventRow({ ...event, apiKeyHash: "hash_123" })).toThrow(/sensitive text/);
+  });
+
+  it("scores refs with only automation events as zero-touch", () => {
+    const metrics = createAutopilotZeroTouchMetrics([
+      {
+        event_type: "claim",
+        actor_agent_id: "github-action-queuepush",
+        ref_kind: "todo",
+        ref_id: "todo-123",
+        payload: { source: "wakepass" },
+        created_at: "2026-05-09T00:00:00.000Z",
+      },
+      {
+        event_type: "proof_result",
+        actor_agent_id: "unclick-builder-tether-seat",
+        ref_kind: "todo",
+        ref_id: "todo-123",
+        payload: { result: "pass" },
+        created_at: "2026-05-09T00:05:00.000Z",
+      },
+    ]);
+
+    expect(metrics).toMatchObject({
+      total_refs: 1,
+      zero_touch_refs: 1,
+      human_touched_refs: 0,
+      human_touch_count: 0,
+      automation_event_count: 2,
+    });
+    expect(metrics.refs[0]).toMatchObject({
+      ref_kind: "todo",
+      ref_id: "todo-123",
+      zero_touch: true,
+      human_touch_count: 0,
+    });
+  });
+
+  it("counts operator chat and human actors as human touches", () => {
+    const metrics = createAutopilotZeroTouchMetrics([
+      {
+        event_type: "dispatch",
+        actor_agent_id: "github-action-queuepush",
+        ref_kind: "pr",
+        ref_id: "1015",
+        payload: { source: "wakepass" },
+        created_at: "2026-05-09T00:00:00.000Z",
+      },
+      {
+        event_type: "merge_decision",
+        actor_agent_id: "unclick-builder-tether-seat",
+        ref_kind: "pr",
+        ref_id: "1015",
+        payload: { trigger_source: "operator_chat" },
+        created_at: "2026-05-09T00:02:00.000Z",
+      },
+      {
+        event_type: "ack",
+        actor_agent_id: "human-616d4beb-4960-451d-bbd3-4d4347a7f9f5",
+        ref_kind: "todo",
+        ref_id: "todo-operator",
+        payload: { blocker: "answered" },
+        created_at: "2026-05-09T00:03:00.000Z",
+      },
+    ]);
+
+    expect(metrics).toMatchObject({
+      total_refs: 2,
+      zero_touch_refs: 0,
+      human_touched_refs: 2,
+      human_touch_count: 2,
+      automation_event_count: 1,
+    });
+    expect(metrics.touch_reason_counts).toMatchObject({
+      "trigger_source:operator_chat": 1,
+      human_actor: 1,
+    });
   });
 });

--- a/api/lib/autopilot-control-ledger.ts
+++ b/api/lib/autopilot-control-ledger.ts
@@ -49,6 +49,37 @@ export interface AutopilotEventRow {
   created_at: string;
 }
 
+export interface AutopilotTouchMetricsRow {
+  event_type: string;
+  actor_agent_id: string;
+  ref_kind: string;
+  ref_id: string;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AutopilotZeroTouchRefMetric {
+  ref_kind: string;
+  ref_id: string;
+  event_count: number;
+  automation_event_count: number;
+  human_touch_count: number;
+  zero_touch: boolean;
+  first_human_touch_at: string | null;
+  last_event_at: string | null;
+  human_touch_reasons: Record<string, number>;
+}
+
+export interface AutopilotZeroTouchMetrics {
+  total_refs: number;
+  zero_touch_refs: number;
+  human_touched_refs: number;
+  human_touch_count: number;
+  automation_event_count: number;
+  touch_reason_counts: Record<string, number>;
+  refs: AutopilotZeroTouchRefMetric[];
+}
+
 export interface TodoLedgerPlanInput {
   todoId: string;
   actorAgentId: string;
@@ -87,6 +118,10 @@ function compact(value: unknown, max = 500): string {
   return text.length > max ? `${text.slice(0, max - 3)}...` : text;
 }
 
+function lowerText(value: unknown): string {
+  return compact(value, 240).toLowerCase();
+}
+
 function stableJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
   if (value && typeof value === "object") {
@@ -114,6 +149,49 @@ function normalizeEventType(value: string): AutopilotEventType {
 function normalizeRefKind(value: string): AutopilotRefKind {
   if (!REF_KIND_SET.has(value)) throw new Error(`Unsupported autopilot ref_kind: ${value}`);
   return value as AutopilotRefKind;
+}
+
+function incrementCount(map: Record<string, number>, key: string): void {
+  map[key] = (map[key] ?? 0) + 1;
+}
+
+const HUMAN_ACTOR_RE = /(^human[-_:]|^operator[-_:]|^chris$|^malamutemayhem$|\boperator\b|\bhuman\b)/i;
+const HUMAN_TOUCH_RE =
+  /\b(human|operator|chris|manual|operator_chat|human_operator_chat|live_chat|user_chat|walk[-_ ]?in)\b/i;
+const HUMAN_TOUCH_BOOLEAN_KEYS = new Set([
+  "human_touch",
+  "operator_touch",
+  "manual_touch",
+  "requires_operator",
+]);
+const HUMAN_TOUCH_TEXT_KEYS = new Set([
+  "actor_kind",
+  "decision_source",
+  "input_source",
+  "origin",
+  "route_source",
+  "source",
+  "trigger",
+  "trigger_source",
+  "wake_source",
+]);
+
+function humanTouchReasons(row: AutopilotTouchMetricsRow): string[] {
+  const reasons = new Set<string>();
+  if (HUMAN_ACTOR_RE.test(row.actor_agent_id)) reasons.add("human_actor");
+
+  const payload = row.payload ?? {};
+  for (const [key, value] of Object.entries(payload)) {
+    const normalizedKey = key.toLowerCase();
+    if (HUMAN_TOUCH_BOOLEAN_KEYS.has(normalizedKey) && value === true) {
+      reasons.add(normalizedKey);
+    }
+    if (HUMAN_TOUCH_TEXT_KEYS.has(normalizedKey) && HUMAN_TOUCH_RE.test(lowerText(value))) {
+      reasons.add(`${normalizedKey}:${lowerText(value).slice(0, 40)}`);
+    }
+  }
+
+  return [...reasons].sort();
 }
 
 function sanitizeUnknown(key: string, value: unknown): unknown {
@@ -188,6 +266,72 @@ export function buildAutopilotEventRow(input: AutopilotEventInput): AutopilotEve
     payload,
     idempotency_key: idempotencyKey,
     created_at: now.toISOString(),
+  };
+}
+
+export function createAutopilotZeroTouchMetrics(
+  rows: AutopilotTouchMetricsRow[],
+): AutopilotZeroTouchMetrics {
+  const refs = new Map<string, AutopilotZeroTouchRefMetric>();
+  const touchReasonCounts: Record<string, number> = {};
+  let humanTouchCount = 0;
+  let automationEventCount = 0;
+
+  for (const row of rows) {
+    const refKind = compact(row.ref_kind, 64) || "unknown";
+    const refId = compact(row.ref_id, 160) || "unknown";
+    const key = `${refKind}:${refId}`;
+    const metric =
+      refs.get(key) ??
+      {
+        ref_kind: refKind,
+        ref_id: refId,
+        event_count: 0,
+        automation_event_count: 0,
+        human_touch_count: 0,
+        zero_touch: true,
+        first_human_touch_at: null,
+        last_event_at: null,
+        human_touch_reasons: {},
+      };
+
+    metric.event_count++;
+    if (!metric.last_event_at || row.created_at > metric.last_event_at) {
+      metric.last_event_at = row.created_at;
+    }
+
+    const reasons = humanTouchReasons(row);
+    if (reasons.length > 0) {
+      metric.zero_touch = false;
+      metric.human_touch_count++;
+      humanTouchCount++;
+      if (!metric.first_human_touch_at || row.created_at < metric.first_human_touch_at) {
+        metric.first_human_touch_at = row.created_at;
+      }
+      for (const reason of reasons) {
+        incrementCount(metric.human_touch_reasons, reason);
+        incrementCount(touchReasonCounts, reason);
+      }
+    } else {
+      metric.automation_event_count++;
+      automationEventCount++;
+    }
+
+    refs.set(key, metric);
+  }
+
+  const refMetrics = [...refs.values()].sort((left, right) =>
+    String(right.last_event_at ?? "").localeCompare(String(left.last_event_at ?? "")),
+  );
+
+  return {
+    total_refs: refMetrics.length,
+    zero_touch_refs: refMetrics.filter((metric) => metric.zero_touch).length,
+    human_touched_refs: refMetrics.filter((metric) => !metric.zero_touch).length,
+    human_touch_count: humanTouchCount,
+    automation_event_count: automationEventCount,
+    touch_reason_counts: touchReasonCounts,
+    refs: refMetrics,
   };
 }
 

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -82,6 +82,8 @@
  *                      memory row scoped to the user's api_key_hash.
  *   - orchestrator_context_read: GET/POST read-only compact cross-seat state
  *                                from Memory, Boardroom, dispatches, signals.
+ *   - autopilot_zero_touch_metrics: GET/POST grouped human-touch metrics from
+ *                                  the AutoPilot control ledger.
  *
  * Conflict detection actions (competing memory tools):
  *   - conflict_detect: POST with Bearer + { tool, platform? } -- log detection,
@@ -150,6 +152,7 @@ import {
 import {
   planFishbowlPostLedgerEvent,
   planTodoLedgerEvents,
+  createAutopilotZeroTouchMetrics,
   recordAutopilotEvent,
   recordAutopilotEvents,
 } from "./lib/autopilot-control-ledger.js";
@@ -8271,6 +8274,54 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
         if (!result.ok) return res.status(400).json({ error: result.error });
         return res.status(200).json({ ok: true });
+      }
+
+      case "autopilot_zero_touch_metrics": {
+        if (req.method !== "GET" && req.method !== "POST") {
+          return res.status(405).json({ error: "GET or POST required" });
+        }
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) {
+          return res.status(401).json({
+            error: "Authorization header required",
+            how_to_fix: "Pass your UnClick API key as 'Authorization: Bearer <api_key>'.",
+          });
+        }
+        const body = (req.body ?? {}) as {
+          limit?: unknown;
+          ref_kind?: unknown;
+          ref_id?: unknown;
+        };
+        const limit = getClampedLimit(req.query.limit ?? body.limit, 250, 1000);
+        const refKindFilter = parseOptionalFilterToken(req.query.ref_kind ?? body.ref_kind, "ref_kind", 64);
+        if (refKindFilter.error) return res.status(400).json({ error: refKindFilter.error });
+        const refIdFilter = parseOptionalFilterToken(req.query.ref_id ?? body.ref_id, "ref_id", 160);
+        if (refIdFilter.error) return res.status(400).json({ error: refIdFilter.error });
+
+        let query = supabase
+          .from("mc_autopilot_events")
+          .select("event_type, actor_agent_id, ref_kind, ref_id, payload, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(limit);
+
+        if (refKindFilter.value) query = query.eq("ref_kind", refKindFilter.value);
+        if (refIdFilter.value) query = query.eq("ref_id", refIdFilter.value);
+
+        const { data, error } = await query;
+        if (error) throw error;
+        const rows = (data ?? []) as Array<{
+          event_type: string;
+          actor_agent_id: string;
+          ref_kind: string;
+          ref_id: string;
+          payload: Record<string, unknown> | null;
+          created_at: string;
+        }>;
+        return res.status(200).json({
+          events_scanned: rows.length,
+          metrics: createAutopilotZeroTouchMetrics(rows),
+        });
       }
 
       case "fishbowl_post": {

--- a/docs/autopilot-zero-touch-scoreboard.md
+++ b/docs/autopilot-zero-touch-scoreboard.md
@@ -1,0 +1,47 @@
+# AutoPilot zero-touch scoreboard
+
+UnClick should not count merged PRs as automation proof. The useful question is:
+
+```text
+Did this job move without a human touch?
+```
+
+The scoreboard reads `mc_autopilot_events` and groups events by `ref_kind` + `ref_id`.
+
+## Zero-touch rule
+
+A ref is `zero_touch=true` when every recorded event for that ref came from automation.
+
+A ref is human-touched when any event has one of these signals:
+
+- a human-looking actor id, such as `human-*`, `operator-*`, `chris`, or `malamutemayhem`
+- explicit payload flags such as `human_touch`, `operator_touch`, or `manual_touch`
+- payload source fields such as `trigger_source=operator_chat`, `source=manual`, or `origin=live_chat`
+
+## API
+
+```text
+GET /api/memory-admin?action=autopilot_zero_touch_metrics&limit=250
+```
+
+Optional filters:
+
+- `ref_kind`
+- `ref_id`
+- `limit`, capped at 1000
+
+The response returns:
+
+- `events_scanned`
+- total refs
+- zero-touch refs
+- human-touched refs
+- human touch count
+- reason counts
+- per-ref breakdown
+
+## Why this matters
+
+The factory is not proven by activity. It is proven by a safe job entering the rail and leaving with `human_touch_count=0`.
+
+This metric makes that visible without asking an LLM to judge it.


### PR DESCRIPTION
## What changed
- Adds AutoPilot zero-touch metrics for the control ledger.
- Exposes `autopilot_zero_touch_metrics` from `memory-admin` so the rail can report `human_touch_count`, zero-touch refs, and human-touched refs.
- Documents the scoreboard rule: PR count is not proof, `human_touch_count=0` is the proof signal.

## Why
The lingering AutoPilot issue is not only stuck workers. It is that we could not measure whether a job moved without Chris. This gives the factory a boring scoreboard for hands-off proof.

## Validation
- PASS: focused Vitest with clean temporary node config: `api/autopilot-control-ledger.test.ts`, `api/throughput-observability.test.ts` (15 tests)
- PASS: `npm run brainmap:check`
- PASS: `git diff --check`
- NOTE: normal local Vitest config is blocked by existing local `node_modules` corruption around `@vitejs/plugin-react-swc`; the focused temporary config avoids that local install issue.

## Research note
Matches the pattern seen in GitHub Copilot cloud agent, OpenAI Codex Cloud, Factory Droid, Replit Agent, Cursor Background Agents, and Temporal workflows: let agents build and judge, but keep lifecycle/proof metrics deterministic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new metrics computation and exposes it via `memory-admin`, which changes admin API surface and relies on heuristic classification of “human touch” from event payloads/actor IDs. Risk is moderate due to potential misclassification and query/load impact when scanning up to 1000 ledger events.
> 
> **Overview**
> Adds a deterministic **“zero-touch” scoring** layer over AutoPilot control-ledger events, grouping by `ref_kind`+`ref_id` and marking refs as `zero_touch=false` when any event shows human involvement (human-like `actor_agent_id` or specific payload flags/source fields).
> 
> Exposes this via a new `memory-admin` action, `autopilot_zero_touch_metrics`, which queries recent `mc_autopilot_events` (optional `ref_kind`/`ref_id` filters, `limit` capped at 1000) and returns aggregated counts plus per-ref breakdown and reason tallies. Includes new Vitest coverage for zero-touch vs human-touched cases and adds documentation for the scoreboard rule and API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d1710574660b4c8c1d3ae1aec7679eae3ab498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->