### PR TITLE
feat(autopilot): surface zero-touch scoreboard in context

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -1,6 +1,10 @@
 import {
   inspectOrchestratorActiveState,
 } from "./commonsensepass-bridge.js";
+import {
+  createAutopilotZeroTouchMetrics,
+  type AutopilotTouchMetricsRow,
+} from "./autopilot-control-ledger.js";
 import type { CommonSensePassResult } from "../../packages/commonsensepass/src/index.js";
 
 export interface OrchestratorProfileRow {
@@ -158,6 +162,7 @@ export interface BuildOrchestratorContextInput {
   library: OrchestratorLibraryRow[];
   businessContext: OrchestratorBusinessContextRow[];
   conversationTurns: OrchestratorConversationTurnRow[];
+  autopilotEvents?: AutopilotTouchMetricsRow[];
 }
 
 export interface OrchestratorSourceLink {
@@ -233,6 +238,19 @@ export interface OrchestratorRollingSnapshot {
   source_pointers: OrchestratorSourceLink[];
 }
 
+export interface OrchestratorZeroTouchScoreboard {
+  events_scanned: number;
+  total_refs: number;
+  zero_touch_refs: number;
+  human_touched_refs: number;
+  human_touch_count: number;
+  automation_event_count: number;
+  top_human_touch_reason: string | null;
+  top_human_touch_count: number;
+  touch_reason_counts: Record<string, number>;
+  summary: string;
+}
+
 export interface OrchestratorSeatHandshake {
   mode: "fresh-seat-pickup";
   summary: string;
@@ -281,9 +299,11 @@ export interface OrchestratorContext {
       library: number;
       business_context: number;
       conversation_turns: number;
+      autopilot_events: number;
     };
     next_actions: string[];
     blockers: string[];
+    zero_touch_scoreboard: OrchestratorZeroTouchScoreboard;
     // health_verdict (added 2026-05-12 by PR #746): CommonSensePass R1
     // verdict computed from the same todos+profiles input used to derive
     // active_jobs. Any seat reading the state card can use this as the
@@ -432,6 +452,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   const profiles = compact ? allProfiles.slice(0, maxSummaries) : allProfiles;
   const activeSeatCount = allProfiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
   const humanOperatorTime = buildOperatorTimeContext(input.businessContext, input.generatedAt);
+  const zeroTouchScoreboard = buildZeroTouchScoreboard(input.autopilotEvents ?? []);
 
   const activeTodoRows = input.todos
     .filter((todo) => todo.status === "open" || todo.status === "in_progress")
@@ -578,9 +599,11 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
         library: input.library.length,
         business_context: input.businessContext.length,
         conversation_turns: input.conversationTurns.length,
+        autopilot_events: input.autopilotEvents?.length ?? 0,
       },
       next_actions: nextActions,
       blockers,
+      zero_touch_scoreboard: zeroTouchScoreboard,
       health_verdict: healthVerdict,
       harness_card: buildHarnessCard({
         activeJobsCount,
@@ -608,6 +631,36 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
       library_snapshots_available: allLibrarySnapshots.length,
       library_snapshots_truncated: allLibrarySnapshots.length > librarySnapshots.length,
     },
+  };
+}
+
+function buildZeroTouchScoreboard(rows: AutopilotTouchMetricsRow[]): OrchestratorZeroTouchScoreboard {
+  const metrics = createAutopilotZeroTouchMetrics(rows);
+  const topHumanTouch = Object.entries(metrics.touch_reason_counts).sort(
+    ([leftReason, leftCount], [rightReason, rightCount]) =>
+      rightCount - leftCount || leftReason.localeCompare(rightReason),
+  )[0];
+  const topReason = topHumanTouch?.[0] ?? null;
+  const topCount = topHumanTouch?.[1] ?? 0;
+  const summary =
+    metrics.total_refs === 0
+      ? "No AutoPilot ledger refs scanned yet."
+      : compactText(
+          `${metrics.zero_touch_refs} zero-touch refs, ${metrics.human_touched_refs} human-touched refs, ${metrics.human_touch_count} human touch${metrics.human_touch_count === 1 ? "" : "es"}. Top leak: ${topReason ?? "none"}.`,
+          180,
+        );
+
+  return {
+    events_scanned: rows.length,
+    total_refs: metrics.total_refs,
+    zero_touch_refs: metrics.zero_touch_refs,
+    human_touched_refs: metrics.human_touched_refs,
+    human_touch_count: metrics.human_touch_count,
+    automation_event_count: metrics.automation_event_count,
+    top_human_touch_reason: topReason,
+    top_human_touch_count: topCount,
+    touch_reason_counts: metrics.touch_reason_counts,
+    summary,
   };
 }
 

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -8816,6 +8816,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .limit(smallerLimit);
         if (turnSearchFilter) chatMessagesQuery = chatMessagesQuery.or(turnSearchFilter);
 
+        let autopilotEventsQuery = supabase
+          .from("mc_autopilot_events")
+          .select("event_type, actor_agent_id, ref_kind, ref_id, payload, created_at")
+          .eq("api_key_hash", apiKeyHash)
+          .order("created_at", { ascending: false })
+          .limit(Math.min(smallerLimit, 500));
+        if (searchPattern) {
+          autopilotEventsQuery = autopilotEventsQuery.or(
+            `event_type.ilike.${searchPattern},actor_agent_id.ilike.${searchPattern},ref_kind.ilike.${searchPattern},ref_id.ilike.${searchPattern}`,
+          );
+        }
+
         const [
           profilesResult,
           messagesResult,
@@ -8829,6 +8841,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           businessContextResult,
           conversationTurnsResult,
           chatMessagesResult,
+          autopilotEventsResult,
         ] = await Promise.all([
           supabase
             .from("mc_fishbowl_profiles")
@@ -8862,6 +8875,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             .limit(16),
           conversationTurnsQuery,
           chatMessagesQuery,
+          autopilotEventsQuery,
         ]);
 
         const errors = [
@@ -8877,6 +8891,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           businessContextResult.error,
           conversationTurnsResult.error,
           chatMessagesResult.error,
+          autopilotEventsResult.error,
         ].filter(Boolean);
         if (errors.length > 0) throw errors[0];
 
@@ -8927,6 +8942,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             library: (libraryResult.data ?? []) as OrchestratorLibraryRow[],
             businessContext: (businessContextResult.data ?? []) as OrchestratorBusinessContextRow[],
             conversationTurns,
+            autopilotEvents: (autopilotEventsResult.data ?? []) as Array<{
+              event_type: string;
+              actor_agent_id: string;
+              ref_kind: string;
+              ref_id: string;
+              payload: Record<string, unknown> | null;
+              created_at: string;
+            }>,
           }),
         });
       }

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -136,6 +136,24 @@ describe("orchestrator context", () => {
           created_at: "2026-05-09T10:46:00.000Z",
         },
       ],
+      autopilotEvents: [
+        {
+          event_type: "claim",
+          actor_agent_id: "github-action-queuepush",
+          ref_kind: "todo",
+          ref_id: "todo-1",
+          payload: { source: "wakepass" },
+          created_at: "2026-05-09T10:33:00.000Z",
+        },
+        {
+          event_type: "merge_decision",
+          actor_agent_id: "chatgpt-codex-seat",
+          ref_kind: "pr",
+          ref_id: "700",
+          payload: { trigger_source: "operator_chat" },
+          created_at: "2026-05-09T10:52:00.000Z",
+        },
+      ],
     });
 
     expect(context.version).toBe("orchestrator-context-v1");
@@ -147,6 +165,16 @@ describe("orchestrator context", () => {
     expect(context.current_state_card.active_jobs).toBe(1);
     expect(context.current_state_card.active_seat_count).toBe(1);
     expect(context.current_state_card.blocker_count).toBe(1);
+    expect(context.current_state_card.live_sources.autopilot_events).toBe(2);
+    expect(context.current_state_card.zero_touch_scoreboard).toMatchObject({
+      events_scanned: 2,
+      total_refs: 2,
+      zero_touch_refs: 1,
+      human_touched_refs: 1,
+      human_touch_count: 1,
+      top_human_touch_reason: "trigger_source:operator_chat",
+    });
+    expect(context.current_state_card.zero_touch_scoreboard.summary).toContain("zero-touch refs");
     expect(context.current_state_card.next_actions[0]).toContain("Orchestrator context layer");
     expect(context.profile_cards.find((profile) => profile.agent_id === "human-chris")?.role).toBe("human");
     expect(context.profile_cards.find((profile) => profile.agent_id === "chatgpt-codex-seat")?.freshness_label).toBe("Live");


### PR DESCRIPTION
## Summary\n- add zero-touch scoreboard to the Orchestrator current state card\n- include recent AutoPilot ledger events in orchestrator_context_read\n- cover the scoreboard in Orchestrator context tests\n\n## Proof\n- npm exec vitest -- --config ./.tmp-vitest.node.config.mjs api/orchestrator-context.test.ts api/autopilot-control-ledger.test.ts --run (45 passed)\n- npm run brainmap:check\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new fields to the orchestrator context response and a new `mc_autopilot_events` query path, which may impact API consumers and performance but doesn’t touch auth or mutation logic.
> 
> **Overview**
> Adds optional `autopilotEvents` input to `buildOrchestratorContext` and surfaces a new `current_state_card.zero_touch_scoreboard` plus `live_sources.autopilot_events` counts, computed via `createAutopilotZeroTouchMetrics`.
> 
> Extends `orchestrator_context_read` in `memory-admin.ts` to query recent `mc_autopilot_events` (with search filtering and a 500-row cap) and pass them into context building, and updates `orchestrator-context.test.ts` to assert the new scoreboard and source counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c033c65081181387f76231540d877887379000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->