### PR TITLE
fix(ci): disable tier2 auto-merge execute and remove Bugbot check

### DIFF
--- a/.github/workflows/tier2-auto-merge-queue-check.yml
+++ b/.github/workflows/tier2-auto-merge-queue-check.yml
@@ -23,10 +23,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TIER2_AUTOMERGE_PR_LIMIT: "30"
-          TIER2_AUTOMERGE_EXECUTE: "true"
+          TIER2_AUTOMERGE_EXECUTE: "false"
           TIER2_AUTOMERGE_ALLOW_UNREVIEWED_LOW_RISK: "true"
           TIER2_AUTOMERGE_ALLOW_REVIEW_PROOF_COMMENTS: "true"
           TIER2_AUTOMERGE_MAX_MERGES: "1"
-          TIER2_AUTOMERGE_OPTIONAL_PENDING_CHECKS: "Cursor Bugbot"
           TIER2_AUTOMERGE_HYDRATE_POTENTIAL_CANDIDATES: "true"
         run: node scripts/tier2-auto-merge-queue-check.mjs


### PR DESCRIPTION
## Containment: tier2 auto-merge cron safety stop

**Blocker since:** 2026-05-23T10:46 UTC (4+ hours unresolved)
**Routed by:** Lenovo Scout 🧭 (14:43 UTC) - any builder seat with GitHub push access
**Owner blocked:** unclick-builder-tether-seat stuck on MASTER login redirect (JS shell only)

### What this changes

1. `TIER2_AUTOMERGE_EXECUTE: "false"` - stops the 10-min cron from merging PRs without real review
2. Removes `TIER2_AUTOMERGE_OPTIONAL_PENDING_CHECKS: "Cursor Bugbot"` - Bugbot is removed from the operating model (standing rule, Chris explicit)

### What does NOT change

The cron still runs every 10 min for dry-run reporting. No merges fire. Everything else (`ALLOW_UNREVIEWED_LOW_RISK`, `MAX_MERGES`, `HYDRATE_POTENTIAL_CANDIDATES`) is left as-is so the hardened v1 rebuild has a clean base to work from.

### After merge

Operator should re-enable `EXECUTE` only after the hardened v1 rail is in place:
- App token (not `github.token`)
- Real counted approval (not Bugbot bypass)
- Ledger writes
- Boardroom close trail

### Proof

- Diff: 2 lines changed, exact scope confirmed
- Live blob pre-fix: sha `5828aee21b53ccd8df449e1cbb1a8a0b73416503`
- Boardroom BLOCKER trail: builder-tether 10:46, 10:56, 11:05 UTC; Scout 12:42, 13:40, 14:41, 14:43 UTC

**Operator: merge this draft to kill the live cron risk.**

https://claude.ai/code/session_01Ghg9MfudMnckg9oMs3nDDX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ghg9MfudMnckg9oMs3nDDX)_