### PR TITLE
ci: add merge queue trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6587,8 +6587,8 @@
     },
     {
       "source": ".github/workflows/ci.yml",
-      "hash": "79e43dd8e26c",
-      "bytes": 1608
+      "hash": "eecbcaab421a",
+      "bytes": 1623
     },
     {
       "source": ".github/workflows/brainmap-auto-update.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -24,7 +24,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
 | src/App.tsx | fd2479b601d8 | 13242 |
 | src/pages/admin/AdminShell.tsx | 7cfbba7277d3 | 19113 |
-| .github/workflows/ci.yml | 79e43dd8e26c | 1608 |
+| .github/workflows/ci.yml | eecbcaab421a | 1623 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | package.json | 9f761ff407b1 | 4232 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |


### PR DESCRIPTION
## Purpose

Add the `merge_group` trigger to CI so GitHub Merge Queue can run the same required checks it already runs on pull requests.

## Scope

- Adds `merge_group` to `.github/workflows/ci.yml`
- Leaves TestPass advisory
- Leaves dirty-branch hygiene advisory
- Does not create or change rulesets

## Verification Gate After Merge

Before creating the `main merge rail v1` ruleset, verify that these exact checks report on both pull_request and merge_group:

- Website (root package)
- MCP server package

This PR should land before the ruleset is posted. Creating the ruleset first can stall the merge queue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only adds a new GitHub Actions trigger; main risk is unexpected CI runs/cancellation behavior under `merge_group`.
> 
> **Overview**
> Enables GitHub Merge Queue to run the existing CI workflow by adding the `merge_group` trigger to `.github/workflows/ci.yml`.
> 
> Updates the auto-generated brainmap manifest files to reflect the workflow file’s new hash/size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74703dd74d7b06d2845a6769e176f210eb8778c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->