### PR TITLE
docs: add fallback rail canary note

### DIFF
--- a/docs/autopilot-zero-touch-scoreboard.md
+++ b/docs/autopilot-zero-touch-scoreboard.md
@@ -45,3 +45,5 @@ The response returns:
 The factory is not proven by activity. It is proven by a safe job entering the rail and leaving with `human_touch_count=0`.
 
 This metric makes that visible without asking an LLM to judge it.
+
+Canary note: fallback rail checks should prove this path with a tiny docs-only PR before broader AutoPilot traffic uses it.


### PR DESCRIPTION
AutoPilot fallback rail canary.\n\nScope: tiny docs-only change to prove the no-queue fallback rail.\n\nBoardroom canary job: 972f0734-78fe-4129-a16c-d60e8f48522e\n\nExpected proof:\n- PR required by main ruleset\n- Website (root package) reports and passes\n- MCP server package reports and passes\n- strict freshness satisfied before merge\n- automated builder seat merges after green\n- Boardroom/AutoPilot ledger closes the canary job with no human touch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change adding guidance for canarying fallback rail checks; no code paths, data handling, or runtime behavior are affected.
> 
> **Overview**
> Adds a brief canary guidance note to `docs/autopilot-zero-touch-scoreboard.md`, recommending validating the fallback rail check path with a tiny docs-only PR before routing broader AutoPilot traffic through it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3349d683c8705c1219bf300e01482f80d23b132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->