### PR TITLE
[codex] expose autopilot ledger mcp tools

### DIFF
--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { ENDPOINT_MAP } from "../catalog.js";
 import {
   ADVERTISED_TOOLS,
+  AUTOPILOT_VISIBLE_TOOLS,
   EXPRESSROOM_VISIBLE_TOOL_NAMES,
   validateToolArgumentsForRuntime,
 } from "../server.js";
@@ -61,6 +62,20 @@ describe("runtime tool schema validation", () => {
     },
     { name: "unclick_generate_uuid", args: { count: 1, bogus_field: "should reject" } },
     { name: "unclick_random_password", args: { length: 8, bogus_field: "should reject" } },
+    {
+      name: "autopilot_record_event",
+      args: {
+        event_type: "claim",
+        actor_agent_id: "strict-probe",
+        ref_kind: "todo",
+        ref_id: "todo-123",
+        bogus_field: "should reject",
+      },
+    },
+    {
+      name: "autopilot_zero_touch_metrics",
+      args: { ref_kind: "todo", ref_id: "todo-123", bogus_field: "should reject" },
+    },
   ];
 
   it("rejects extra fields before handlers can run", () => {
@@ -123,6 +138,18 @@ describe("runtime tool schema validation", () => {
       max_snapshots: 4,
       max_sources_per_snapshot: 3,
     })).toBeNull();
+    expect(validateToolArgumentsForRuntime("autopilot_record_event", {
+      event_type: "proof_result",
+      actor_agent_id: "strict-probe",
+      ref_kind: "pr",
+      ref_id: "1022",
+      payload: { check: "Website (root package)", conclusion: "success" },
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("autopilot_zero_touch_metrics", {
+      ref_kind: "pr",
+      ref_id: "1022",
+      limit: 25,
+    })).toBeNull();
   });
 
   it("exposes Memory taxonomy snapshot refresh as a dry-run-first catalog endpoint", () => {
@@ -146,6 +173,14 @@ describe("runtime tool schema validation", () => {
 
     for (const toolName of EXPRESSROOM_VISIBLE_TOOL_NAMES) {
       expect(advertisedNames.has(toolName), toolName).toBe(true);
+    }
+  });
+
+  it("advertises AutoPilot ledger tools to connected agents", () => {
+    const advertisedNames = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
+
+    for (const tool of AUTOPILOT_VISIBLE_TOOLS) {
+      expect(advertisedNames.has(tool.name), tool.name).toBe(true);
     }
   });
 });

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1548,6 +1548,103 @@ export const EXPRESSROOM_VISIBLE_TOOL_NAMES = [
   "promote_expressroom_draft",
 ] as const;
 
+export const AUTOPILOT_VISIBLE_TOOLS = [
+  {
+    name: "autopilot_record_event",
+    title: "Record AutoPilot ledger event",
+    description:
+      "Writes one sanitized AutoPilot proof event to the tenant ledger. Use this for claim, check, merge, close, proof, and blocker receipts before claiming zero-touch proof.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        event_type: {
+          type: "string",
+          enum: [
+            "claim",
+            "lease_grant",
+            "lease_refresh",
+            "lease_expired",
+            "lane_check",
+            "lane_violation",
+            "release",
+            "build_start",
+            "build_end",
+            "proof_request",
+            "proof_result",
+            "ack",
+            "blocker",
+            "merge_decision",
+            "watch_start",
+            "watch_end",
+            "dispatch",
+            "pick",
+            "todo_state_change",
+          ],
+          description: "Typed ledger event. Use proof_result for check results and todo_state_change for close.",
+        },
+        actor_agent_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 128,
+          description: "Automation seat or App identity that performed the action.",
+        },
+        ref_kind: {
+          type: "string",
+          enum: ["todo", "pr", "dispatch", "agent", "run"],
+          description: "Stable object type this event proves.",
+        },
+        ref_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 160,
+          description: "Stable object id, such as a PR number, todo UUID, dispatch id, or run id.",
+        },
+        payload: {
+          type: "object",
+          description: "Non-secret proof details. Secret-looking keys or values are rejected by the API.",
+          default: {},
+        },
+      },
+      required: ["event_type", "actor_agent_id", "ref_kind", "ref_id"],
+    },
+  },
+  {
+    name: "autopilot_zero_touch_metrics",
+    title: "Read AutoPilot zero-touch metrics",
+    description:
+      "Reads AutoPilot ledger rows and returns zero-touch scoring. Use before closing a canary or claiming human_touch_count=0.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: {
+          type: "number",
+          minimum: 1,
+          maximum: 1000,
+          default: 250,
+          description: "Maximum recent ledger rows to scan.",
+        },
+        ref_kind: {
+          type: "string",
+          enum: ["todo", "pr", "dispatch", "agent", "run"],
+          description: "Optional object type filter.",
+        },
+        ref_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 160,
+          description: "Optional object id filter.",
+        },
+      },
+    },
+  },
+] as const;
+
+for (const tool of AUTOPILOT_VISIBLE_TOOLS) {
+  registerToolInputSchema(tool);
+}
+
 // DraftRoom needs friendly connected-agent tools, while the rest of the
 // internal meta layer stays hidden from tools/list.
 const EXPRESSROOM_VISIBLE_TOOLS = INTERNAL_TOOLS.filter((tool) =>
@@ -1557,6 +1654,7 @@ const EXPRESSROOM_VISIBLE_TOOLS = INTERNAL_TOOLS.filter((tool) =>
 export const ADVERTISED_TOOLS = [
   ...VISIBLE_TOOLS,
   ...EXPRESSROOM_VISIBLE_TOOLS,
+  ...AUTOPILOT_VISIBLE_TOOLS,
   ...ADDITIONAL_TOOLS,
 ];
 
@@ -1956,6 +2054,42 @@ export function createServer(): Server {
         comment_on: "fishbowl_comment_on",
         list_comments: "fishbowl_list_comments",
       };
+
+      const AUTOPILOT_TOOL_ACTIONS: Record<string, string> = {
+        autopilot_record_event: "autopilot_record_event",
+        autopilot_zero_touch_metrics: "autopilot_zero_touch_metrics",
+      };
+
+      if (AUTOPILOT_TOOL_ACTIONS[name]) {
+        const apiKey = process.env.UNCLICK_API_KEY;
+        const base =
+          process.env.UNCLICK_MEMORY_BASE_URL ||
+          process.env.UNCLICK_SITE_URL ||
+          "https://unclick.world";
+        if (!apiKey) {
+          return {
+            content: [
+              { type: "text", text: "AutoPilot ledger unavailable: no UNCLICK_API_KEY configured. Run the UnClick setup wizard." },
+            ],
+            isError: true,
+          };
+        }
+        const action = AUTOPILOT_TOOL_ACTIONS[name];
+        const resp = await fetch(`${base}/api/memory-admin?action=${action}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(args),
+        });
+        const respBody = await resp.json().catch(() => ({}));
+        return {
+          content: [{ type: "text", text: JSON.stringify(respBody, null, 2) }],
+          isError: !resp.ok,
+        };
+      }
+
       if (FISHBOWL_TOOL_ACTIONS[name]) {
         const apiKey = process.env.UNCLICK_API_KEY;
         const base =


### PR DESCRIPTION
## What changed
- Exposes `autopilot_record_event` as a connected-agent MCP tool so automation can write proof events into the existing AutoPilot ledger.
- Exposes `autopilot_zero_touch_metrics` as a connected-agent MCP tool so seats can verify `human_touch_count=0` before closing a canary.
- Adds strict schema coverage so extra fields are rejected and both tools are advertised.

## Why
The fallback rail can merge safely now, but the canary cannot be marked zero-touch until claim/check/merge/close events are written to the ledger and scored.

## Validation
- `npm run build --workspace=@unclick/mcp-server`
- `npx vitest run src/__tests__/tool-schema-validation.test.ts` from `packages/mcp-server`
- `npm run brainmap:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds two new advertised MCP tools that proxy to the `/api/memory-admin` AutoPilot ledger endpoints, which changes the externally callable surface area and introduces new remote-write/read paths gated by `UNCLICK_API_KEY`. Risk is moderate due to potential schema/validation or API integration issues affecting automation workflows.
> 
> **Overview**
> Exposes AutoPilot ledger capabilities to connected MCP agents by adding two new tools: `autopilot_record_event` (write a typed ledger event) and `autopilot_zero_touch_metrics` (read zero-touch scoring).
> 
> These tools are **advertised** in `tools/list`, have strict `additionalProperties: false` runtime schemas registered for AJV validation, and are wired in `CallTool` to POST through to `/api/memory-admin?action=autopilot_record_event|autopilot_zero_touch_metrics` with `UNCLICK_API_KEY` required.
> 
> Updates test coverage to ensure both tools reject extra fields, accept valid payloads, and are included in `ADVERTISED_TOOLS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d4393834f1cca3c83d43173dc87ebce09245322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->