### PR TITLE
docs: rerun autopilot ledger canary

### DIFF
--- a/docs/autopilot-zero-touch-scoreboard.md
+++ b/docs/autopilot-zero-touch-scoreboard.md
@@ -47,3 +47,5 @@ The factory is not proven by activity. It is proven by a safe job entering the r
 This metric makes that visible without asking an LLM to judge it.
 
 Canary note: fallback rail checks should prove this path with a tiny docs-only PR before broader AutoPilot traffic uses it.
+
+Canary rerun note: the ledger proof must record claim, check, merge, and close events before the Boardroom job can close.


### PR DESCRIPTION
## What changed
- Adds one docs-only canary rerun note to the AutoPilot zero-touch scoreboard page.

## Why
This PR is the fallback rail rerun canary after the ledger MCP tools were published. It should be auto-merged by GitHub after the two required checks pass, while AutoPilot ledger rows record claim/check/merge/close.

## Validation
- `npm run brainmap:check`
- `git diff --check docs/autopilot-zero-touch-scoreboard.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change; it only adds a note about required ledger events before closing and does not affect runtime behavior.
> 
> **Overview**
> Adds a *canary rerun* note to `docs/autopilot-zero-touch-scoreboard.md` clarifying that the ledger proof must capture claim/check/merge/close events before the Boardroom job is allowed to close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d261b8b82d3d947530063889676dcf9dd68ad8f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->