### PR TITLE
[codex] fix reopened job card truth state

### DIFF
--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -174,4 +174,41 @@ describe("AdminJobs", () => {
     expect(within(activeSection as HTMLElement).getByText("False green proof job")).toBeInTheDocument();
     expect(within(completedSection as HTMLElement).queryByText("False green proof job")).not.toBeInTheDocument();
   });
+
+  it("treats reopened jobs as open even when stale completion fields remain", async () => {
+    currentJobs = [
+      {
+        id: "reopened-job",
+        title: "Reopened truth job",
+        description: "Old closeout data should not make this look shipped.",
+        status: "done",
+        effective_status: "open",
+        priority: "urgent",
+        created_by_agent_id: "tester",
+        assigned_to_agent_id: null,
+        created_at: "2026-05-14T12:00:00.000Z",
+        completed_at: "2026-05-14T12:30:00.000Z",
+        updated_at: "2026-05-14T12:55:00.000Z",
+        comment_count: 3,
+        pipeline_stage_count: 5,
+        pipeline_progress: 100,
+        pipeline_evidence: ["build", "proof", "ship"],
+      },
+    ];
+
+    render(React.createElement(AdminJobs));
+
+    expect(await screen.findByText("Reopened truth job")).toBeInTheDocument();
+    expect(screen.getByText("open")).toBeInTheDocument();
+    expect(screen.getByText("live")).toBeInTheDocument();
+    expect(screen.getByText("10%")).toBeInTheDocument();
+    expect(screen.getByTestId("job-row-title")).not.toHaveClass("line-through");
+
+    const nextSection = screen.getByRole("button", { name: /Next up/i }).closest("section");
+    const completedSection = screen.getByRole("button", { name: /Completed/i }).closest("section");
+    expect(nextSection).not.toBeNull();
+    expect(completedSection).not.toBeNull();
+    expect(within(nextSection as HTMLElement).getByText("Reopened truth job")).toBeInTheDocument();
+    expect(within(completedSection as HTMLElement).queryByText("Reopened truth job")).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -296,20 +296,34 @@ function displayStatusFor(todo: JobTodo): DisplayStatus {
   return backendDisplayStatusFor(todo) ?? (needsProofAfterDone(todo) ? "needs_proof" : todo.status);
 }
 
-function progressFor(todo: JobTodo): number {
-  if (Number.isFinite(todo.pipeline_progress)) return Number(todo.pipeline_progress);
-  if (todo.status === "done") return 100;
-  if (todo.status === "in_progress") return 55;
+function hasReopenedCompletionState(todo: JobTodo): boolean {
+  const displayStatus = displayStatusFor(todo);
+  return todo.status === "done" && displayStatus !== "done" && displayStatus !== "needs_proof";
+}
+
+function defaultProgressForStatus(todo: JobTodo, displayStatus = displayStatusFor(todo)): number {
+  if (displayStatus === "done") return 100;
+  if (displayStatus === "in_progress") return 55;
   if (todo.assigned_to_agent_id) return 25;
   return 10;
 }
 
+function progressFor(todo: JobTodo): number {
+  if (hasReopenedCompletionState(todo)) return defaultProgressForStatus(todo);
+  if (Number.isFinite(todo.pipeline_progress)) return Number(todo.pipeline_progress);
+  return defaultProgressForStatus(todo);
+}
+
 function activeStageCount(todo: JobTodo): number {
+  if (hasReopenedCompletionState(todo)) {
+    return displayStatusFor(todo) === "in_progress" ? 2 : 1;
+  }
   if (Number.isFinite(todo.pipeline_stage_count)) {
     return Math.min(Math.max(Number(todo.pipeline_stage_count), 1), STAGES.length);
   }
-  if (todo.status === "done") return STAGES.length;
-  if (todo.status === "in_progress") return 2;
+  const displayStatus = displayStatusFor(todo);
+  if (displayStatus === "done") return STAGES.length;
+  if (displayStatus === "in_progress") return 2;
   if (todo.assigned_to_agent_id) return 1;
   return 1;
 }
@@ -333,7 +347,7 @@ function StageStrip({ todo }: { todo: JobTodo }) {
               index < active
                 ? displayStatus === "needs_proof"
                   ? "bg-red-300/85 text-black/70"
-                  : todo.status === "done"
+                  : displayStatus === "done"
                   ? "bg-green-400/85 text-black/70"
                   : "bg-[#61C1C4]/90 text-black/70"
                 : "bg-white/[0.08] text-white/30"
@@ -467,7 +481,7 @@ function matchesJobSearch(todo: JobTodo, query: string): boolean {
 }
 
 function isStaleActive(todo: JobTodo): boolean {
-  if (todo.status !== "in_progress") return false;
+  if (displayStatusFor(todo) !== "in_progress") return false;
   const updated = new Date(todo.updated_at).getTime();
   if (!Number.isFinite(updated)) return false;
   return Date.now() - updated > 12 * 60 * 60 * 1000;
@@ -576,12 +590,15 @@ function SortHeader({
 }
 
 function groupJobs(todos: JobTodo[]): Record<JobSectionKey, JobTodo[]> {
-  const active = todos.filter((todo) => todo.status === "in_progress" || needsProofAfterDone(todo)).sort(sortJobs);
-  const open = todos.filter((todo) => todo.status === "open").sort(sortJobs);
+  const active = todos.filter((todo) => {
+    const displayStatus = displayStatusFor(todo);
+    return displayStatus === "in_progress" || displayStatus === "needs_proof";
+  }).sort(sortJobs);
+  const open = todos.filter((todo) => displayStatusFor(todo) === "open").sort(sortJobs);
   const next = open.filter((todo) => todo.priority === "urgent" || todo.priority === "high");
   const inline = open.filter((todo) => todo.priority === "normal" || todo.priority === "low");
   const done = todos
-    .filter((todo) => todo.status === "done" && !needsProofAfterDone(todo))
+    .filter((todo) => displayStatusFor(todo) === "done")
     .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
   return { active, next, inline, done };
 }
@@ -733,7 +750,7 @@ function JobRow({
         >
           <p
             className={`truncate text-[11px] font-semibold leading-4 hover:text-white ${
-              todo.status === "done" && displayStatus !== "needs_proof" ? "text-white/35 line-through" : "text-white/85"
+              displayStatus === "done" ? "text-white/35 line-through" : "text-white/85"
             }`}
             data-testid="job-row-title"
           >
@@ -766,10 +783,10 @@ function JobRow({
           <span className="flex items-center gap-1 text-[11px] text-white/45">
             <span
               className={`h-1.5 w-1.5 rounded-full ${
-                displayStatus === "needs_proof" || isStaleActive(todo) ? "bg-red-300" : todo.status === "done" ? "bg-green-300" : "bg-green-400"
+                displayStatus === "needs_proof" || isStaleActive(todo) ? "bg-red-300" : displayStatus === "done" ? "bg-green-300" : "bg-green-400"
               }`}
             />
-            {displayStatus === "needs_proof" ? "proof" : todo.status === "done" ? "ship" : isStaleActive(todo) ? "stale" : "live"}
+            {displayStatus === "needs_proof" ? "proof" : displayStatus === "done" ? "ship" : isStaleActive(todo) ? "stale" : "live"}
           </span>
           <span className="text-[11px] font-medium text-white/55">
             <StageStrip todo={todo} />


### PR DESCRIPTION
## What changed
- Treat reopened/open Jobs cards using their effective status instead of stale completed status fields.
- Ignore stale 100% progress/stage data when a completed job has been reopened by the backend.
- Add a focused regression test for a reopened job that still carries old completion fields.

## Boardroom
- Todo: 6819cb82-bd2e-432e-a872-d0c69e3c4d8f
- Canary: real AutoPilot job canary, proof-gated close only.

## Validation
- npm run test -- src/pages/admin/AdminJobs.test.tsx
- npm run brainmap:check
- npx tsc --noEmit
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job state derivation and grouping/progress rendering in the admin Jobs board, which can affect what appears under Active/Completed and how progress is shown. Risk is limited to UI/visual correctness but could mislead operators if status mapping is wrong.
> 
> **Overview**
> Fixes the admin Jobs board to **treat reopened jobs based on `effective_status`** rather than stale completion fields, preventing reopened items from being shown as shipped/completed.
> 
> When a job has `status: "done"` but a non-done `displayStatus`, the UI now **ignores stale `pipeline_progress`/stage counts** and falls back to status-based defaults for progress, stage strip coloring, stale detection, and section grouping.
> 
> Adds a regression test ensuring a reopened job with leftover completion metadata renders as open/live (not struck through) and appears in the open queue instead of Completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41749f90a656652e1be714073a1f765281da5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->