### PR TITLE
fix(jobs-truth): cap reopened cards below shipped

### DIFF
--- a/api/fishbowl-job-pipeline.test.ts
+++ b/api/fishbowl-job-pipeline.test.ts
@@ -120,6 +120,26 @@ describe("Fishbowl job pipeline inference", () => {
     });
   });
 
+  it("does not let open jobs look shipped from old merge receipts", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "Agentic AI",
+          status: "open",
+        },
+        ["Old receipt: PR #928 merged into main. Tests passed."],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 3,
+      pipeline_progress: 70,
+      pipeline_source: "receipt: proof",
+      pipeline_evidence: ["build", "proof"],
+      proof_state: "stale",
+      effective_status: "open",
+      release_blocked: false,
+    });
+  });
+
   it("surfaces missing UI proof as a structured proof state", () => {
     expect(
       inferFishbowlJobPipeline(

--- a/api/lib/fishbowl-job-pipeline.ts
+++ b/api/lib/fishbowl-job-pipeline.ts
@@ -260,6 +260,7 @@ export function inferFishbowlJobPipeline(
   }
 
   if (
+    baseStatus === "done" &&
     positiveStageHit(
       corpus,
       /\b(pr\s*#?\d+\s+merged|merged\s+#?\d+|merged into main|deployed|published|shipped|live on production|production live)\b/i,

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -174,4 +174,32 @@ describe("AdminJobs", () => {
     expect(within(activeSection as HTMLElement).getByText("False green proof job")).toBeInTheDocument();
     expect(within(completedSection as HTMLElement).queryByText("False green proof job")).not.toBeInTheDocument();
   });
+
+  it("caps open jobs below shipped when stale pipeline data says complete", async () => {
+    currentJobs = [
+      {
+        id: "open-false-green-job",
+        title: "Open false green job",
+        description: "Old merged PR comment exists, but this job is still open.",
+        status: "open",
+        priority: "urgent",
+        created_by_agent_id: "tester",
+        assigned_to_agent_id: null,
+        created_at: "2026-05-14T12:00:00.000Z",
+        completed_at: null,
+        updated_at: "2026-05-14T12:55:00.000Z",
+        comment_count: 4,
+        pipeline_stage_count: 5,
+        pipeline_progress: 100,
+        pipeline_source: "receipt: ship",
+        pipeline_evidence: ["build", "proof", "ship"],
+      },
+    ];
+
+    render(React.createElement(AdminJobs));
+
+    expect(await screen.findByText("Open false green job")).toBeInTheDocument();
+    expect(screen.getByText("85%")).toBeInTheDocument();
+    expect(screen.getByTestId("job-row-title")).not.toHaveClass("line-through");
+  });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -297,7 +297,10 @@ function displayStatusFor(todo: JobTodo): DisplayStatus {
 }
 
 function progressFor(todo: JobTodo): number {
-  if (Number.isFinite(todo.pipeline_progress)) return Number(todo.pipeline_progress);
+  if (Number.isFinite(todo.pipeline_progress)) {
+    const progress = Math.min(Math.max(Number(todo.pipeline_progress), 0), 100);
+    return todo.status === "done" ? progress : Math.min(progress, 85);
+  }
   if (todo.status === "done") return 100;
   if (todo.status === "in_progress") return 55;
   if (todo.assigned_to_agent_id) return 25;
@@ -306,7 +309,8 @@ function progressFor(todo: JobTodo): number {
 
 function activeStageCount(todo: JobTodo): number {
   if (Number.isFinite(todo.pipeline_stage_count)) {
-    return Math.min(Math.max(Number(todo.pipeline_stage_count), 1), STAGES.length);
+    const maxStage = todo.status === "done" ? STAGES.length : STAGES.length - 1;
+    return Math.min(Math.max(Number(todo.pipeline_stage_count), 1), maxStage);
   }
   if (todo.status === "done") return STAGES.length;
   if (todo.status === "in_progress") return 2;


### PR DESCRIPTION
Summary:
- Prevent stale merge or ship receipts from promoting open jobs to the Ship stage.
- Cap explicit Admin Jobs progress and stage counts below complete unless the job status is done.
- Add regression coverage for stale open-job receipts and UI cards with stale 100 percent pipeline data.

Scope:
- Owned files for todo 6819cb82: api/lib/fishbowl-job-pipeline.ts, api/fishbowl-job-pipeline.test.ts, src/pages/admin/AdminJobs.tsx, src/pages/admin/AdminJobs.test.tsx.

Non-overlap:
- Did not touch workflow rules, secrets, deploy config, CopyRoom, proof ledger, or unrelated queues.
- Did not mark todo 6819cb82 done. Live /admin/jobs screenshot proof is still required before closure.

Verification:
- npm ci
- npm run test -- api/fishbowl-job-pipeline.test.ts src/pages/admin/AdminJobs.test.tsx
- git diff --check

Risk:
- Low UI risk. Done jobs can still show 100 percent and Ship. Non-done jobs are visually capped below completion to avoid false green cards.
- No auth, migration, secret, cron, or API contract change.

Follow-up:
- Get authenticated /admin/jobs screenshot or deploy preview proof before any DONE action.