### PR TITLE
[codex] add safe CodeRoom submitter

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -18,7 +18,7 @@ import {
 import { evaluateOrchestratorProofWakeGate } from "./lib/autopilotkit-liveness.mjs";
 import { processScopePackTestOnlyExecutorPacket } from "./pinballwake-executor-lane.mjs";
 import { runOpenHandsWorker } from "./pinballwake-openhands-worker.mjs";
-import { createOpenHandsCliRunner } from "./pinballwake-openhands-proof-runner.mjs";
+import { createOpenHandsCliRunner, createSafeCodeRoomSubmitter } from "./pinballwake-openhands-proof-runner.mjs";
 import { buildScopePackHydrationReceipt } from "./pinballwake-scopepack-hydrator.mjs";
 
 export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
@@ -570,6 +570,7 @@ export function createAutonomousRunnerOpenHandsExecutorFromEnv(env = process.env
   return {
     enabled,
     openHands: enabled ? createOpenHandsCliRunner({ env: safeEnv }) : null,
+    coderoom: enabled ? createSafeCodeRoomSubmitter({ env: safeEnv }) : null,
     env: safeEnv,
     testMode: parseBoolean(safeEnv.OPENHANDS_TEST_MODE),
     executorSeatId: safeEnv.OPENHANDS_EXECUTOR_SEAT_ID || "pinballwake-openhands-worker",

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
+  createAutonomousRunnerOpenHandsExecutorFromEnv,
   createAutonomousRunnerTestOnlyExecutorReceipt,
   assertRunnerOnFreshMain,
   evaluateAutonomousRunnerCommonSensePass,
@@ -1536,6 +1537,19 @@ describe("PinballWake autonomous Runner seat", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("wires explicitly enabled OpenHands execute to the safe CodeRoom submitter", () => {
+    const executor = createAutonomousRunnerOpenHandsExecutorFromEnv({
+      AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: "true",
+      OPENHANDS_TEST_MODE: "1",
+      AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES: "false",
+    });
+
+    assert.equal(executor.enabled, true);
+    assert.equal(typeof executor.openHands, "function");
+    assert.equal(typeof executor.coderoom, "function");
+    assert.equal(executor.testMode, true);
   });
 
   it("emits a quiet-window proof receipt that rejects manual runner triggers", async () => {

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -9,8 +9,17 @@ import { runOpenHandsWorker } from "./pinballwake-openhands-worker.mjs";
 const DEFAULT_PROOF_FILE = "docs/openhands-proof-fixture.md";
 const DEFAULT_TODO_ID = "036de894-82a1-49c7-ac19-67335950c626";
 const DEFAULT_BRANCH_PREFIX = "codex/openhands-proof";
+const DEFAULT_SUBMITTER_BRANCH_PREFIX = "codex/openhands-submit";
 const DEFAULT_TITLE = "test(autopilot): prove OpenHands docs patch path";
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
+
+export const DEFAULT_CODEROOM_PROTECTED_PATH_PATTERNS = [
+  { reason: "protected_workflow_path", pattern: /^\.github\/workflows\//i },
+  { reason: "protected_ruleset_path", pattern: /^\.github\/rulesets?\//i },
+  { reason: "protected_supabase_migration_path", pattern: /^supabase\/migrations\//i },
+  { reason: "protected_env_path", pattern: /(^|\/)\.env(?:\.|$)/i },
+  { reason: "protected_secret_path", pattern: /(^|\/)(secrets?|credentials?|private[-_]?keys?|keychain)(\/|\.|$)/i },
+];
 
 function parseBoolean(value) {
   const raw = String(value ?? "").trim().toLowerCase();
@@ -44,6 +53,15 @@ function safeStamp(value = new Date()) {
   return String(value instanceof Date ? value.toISOString() : value)
     .replace(/[^0-9A-Za-z._:-]/g, "-")
     .slice(0, 80);
+}
+
+function safeSlug(value, fallback = "job") {
+  const slug = String(value || fallback)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 72);
+  return slug || fallback;
 }
 
 export function splitArgs(value) {
@@ -331,6 +349,147 @@ export function createDraftPrCoderoom({
       test_run_id: testRunId || null,
       test_exit_code: 0,
       status: "draft_pr_created",
+    };
+  };
+}
+
+export function inspectSafeCoderoomPatchPaths({
+  changedFiles = [],
+  ownedFiles = [],
+  allowProtectedSurfaces = false,
+  protectedPathPatterns = DEFAULT_CODEROOM_PROTECTED_PATH_PATTERNS,
+} = {}) {
+  const normalizedChanged = (changedFiles || []).map(normalizePath).filter(Boolean);
+  const owned = new Set((ownedFiles || []).map(normalizePath).filter(Boolean));
+  const outside = normalizedChanged.find((file) => !owned.has(file));
+  if (outside) {
+    return { ok: false, reason: "patch_file_outside_ownership", file: outside };
+  }
+
+  if (!allowProtectedSurfaces) {
+    for (const file of normalizedChanged) {
+      const match = protectedPathPatterns.find((entry) => entry.pattern.test(file));
+      if (match) {
+        return { ok: false, reason: match.reason, file };
+      }
+    }
+  }
+
+  return { ok: true, changed_files: normalizedChanged };
+}
+
+export function createSafeCodeRoomSubmitter({
+  cwd = process.cwd(),
+  env = process.env,
+  branchName,
+  title = "",
+  body = "",
+  draft = false,
+  autoMerge = true,
+  allowProtectedSurfaces,
+  runProcess = runProcessCommand,
+  now = new Date(),
+} = {}) {
+  return async ({ job, scopePack, patch, changedFiles, summary, testRunId }) => {
+    const ownedFiles = job?.owned_files?.length ? job.owned_files : scopePack?.owned_files || [];
+    const validation = validateCodingRoomBuildPatch({
+      patch,
+      ownedFiles,
+    });
+    if (!validation.ok) {
+      return {
+        ok: false,
+        reason: validation.reason,
+        file: validation.file || null,
+      };
+    }
+
+    const normalizedChanged = (changedFiles?.length ? changedFiles : validation.changed_files).map(normalizePath);
+    const safety = inspectSafeCoderoomPatchPaths({
+      changedFiles: normalizedChanged,
+      ownedFiles,
+      allowProtectedSurfaces:
+        typeof allowProtectedSurfaces === "boolean"
+          ? allowProtectedSurfaces
+          : parseBoolean(env.AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES),
+    });
+    if (!safety.ok) return safety;
+
+    const status = await runProcess("git", ["status", "--porcelain"], { cwd, env });
+    if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
+    if (status.stdout.trim()) return { ok: false, reason: "dirty_worktree" };
+
+    const todoId = safeSlug(job?.todo_id || job?.id || job?.job_id || safeStamp(now));
+    const branch = branchName || `${DEFAULT_SUBMITTER_BRANCH_PREFIX}-${todoId}`;
+    const existing = await runProcess(
+      "gh",
+      ["pr", "list", "--head", branch, "--state", "open", "--json", "url", "--jq", ".[0].url // \"\""],
+      { cwd, env },
+    );
+    if (!existing.ok) return { ok: false, reason: "gh_pr_list_failed", output: existing.output };
+    const existingUrl = existing.stdout.trim();
+    if (existingUrl) {
+      return {
+        ok: true,
+        pr_url: existingUrl,
+        head_sha_after: null,
+        test_run_id: testRunId || null,
+        test_exit_code: 0,
+        status: "existing_pr",
+        idempotent: true,
+      };
+    }
+
+    const prTitle = title || `autopilot: submit ${compactOutput(job?.title || job?.job_id || todoId, 80)}`;
+    const bodyText =
+      body ||
+      [
+        "OpenHands CodeRoom submitter PR.",
+        "",
+        `Todo: ${job?.todo_id || job?.id || "unknown"}`,
+        `Summary: ${summary || "OpenHands produced a scoped patch."}`,
+        `Test run: ${testRunId || "not supplied"}`,
+        "",
+        "Safety: protected paths rejected before branch creation; patch limited to owned files.",
+      ].join("\n");
+
+    const commands = [
+      ["git", ["checkout", "-b", branch]],
+      ["git", ["apply", "--check", "--whitespace=error", "-"], { stdin: patch }],
+      ["git", ["apply", "--whitespace=nowarn", "-"], { stdin: patch }],
+      ["git", ["diff", "--check"]],
+      ["git", ["add", ...normalizedChanged]],
+      ["git", ["commit", "-m", prTitle]],
+      ["git", ["push", "-u", "origin", branch]],
+      ["gh", ["pr", "create", ...(draft ? ["--draft"] : []), "--title", prTitle, "--body", bodyText]],
+    ];
+
+    let prUrl = "";
+    for (const [command, args, options = {}] of commands) {
+      const result = await runProcess(command, args, { cwd, env, ...options });
+      if (!result.ok) return { ok: false, reason: `${command}_failed`, output: result.output };
+      if (command === "gh" && args[1] === "create") prUrl = result.stdout.trim();
+    }
+
+    const sha = await runProcess("git", ["rev-parse", "HEAD"], { cwd, env });
+    if (!sha.ok) return { ok: false, reason: "git_rev_parse_failed", output: sha.output };
+
+    let autoMergeResult = { ok: true, skipped: true, reason: draft ? "draft_pr" : "auto_merge_disabled" };
+    if (autoMerge && !draft) {
+      autoMergeResult = await runProcess("gh", ["pr", "merge", "--auto", "--squash", prUrl], { cwd, env });
+      if (!autoMergeResult.ok) {
+        return { ok: false, reason: "gh_auto_merge_failed", output: autoMergeResult.output, pr_url: prUrl };
+      }
+    }
+
+    return {
+      ok: true,
+      pr_url: prUrl || null,
+      head_sha_after: sha.stdout.trim() || null,
+      test_run_id: testRunId || null,
+      test_exit_code: 0,
+      status: autoMerge && !draft ? "pr_created_auto_merge_enabled" : "pr_created",
+      auto_merge_enabled: Boolean(autoMerge && !draft),
     };
   };
 }

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -12,6 +12,7 @@ const DEFAULT_BRANCH_PREFIX = "codex/openhands-proof";
 const DEFAULT_SUBMITTER_BRANCH_PREFIX = "codex/openhands-submit";
 const DEFAULT_TITLE = "test(autopilot): prove OpenHands docs patch path";
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
+const CODEROOM_APP_TOKEN_ENV_KEYS = ["CODEROOM_GITHUB_APP_TOKEN", "AUTONOMOUS_RUNNER_GITHUB_APP_TOKEN"];
 
 export const DEFAULT_CODEROOM_PROTECTED_PATH_PATTERNS = [
   { reason: "protected_workflow_path", pattern: /^\.github\/workflows\//i },
@@ -104,6 +105,29 @@ export function splitArgs(value) {
   }
 
   return parts;
+}
+
+export function resolveCodeRoomSubmitterAuthEnv(env = process.env) {
+  const source = CODEROOM_APP_TOKEN_ENV_KEYS.find((key) => String(env[key] || "").trim());
+  if (!source) {
+    return { ok: false, reason: "missing_scoped_app_token" };
+  }
+
+  const token = String(env[source] || "").trim();
+  const defaultToken = String(env.GITHUB_TOKEN || "").trim();
+  if (defaultToken && token === defaultToken) {
+    return { ok: false, reason: "app_token_matches_default_github_token", token_source: source };
+  }
+
+  return {
+    ok: true,
+    token_source: source,
+    env: {
+      ...env,
+      GH_TOKEN: token,
+      GITHUB_TOKEN: token,
+    },
+  };
 }
 
 export function buildOpenHandsCliArgs({ prompt, argsTemplate = "" } = {}) {
@@ -415,7 +439,17 @@ export function createSafeCodeRoomSubmitter({
     });
     if (!safety.ok) return safety;
 
-    const status = await runProcess("git", ["status", "--porcelain"], { cwd, env });
+    const auth = resolveCodeRoomSubmitterAuthEnv(env);
+    if (!auth.ok) {
+      return {
+        ok: false,
+        reason: auth.reason,
+        token_source: auth.token_source || null,
+      };
+    }
+    const submitterEnv = auth.env;
+
+    const status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
     if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
     if (status.stdout.trim()) return { ok: false, reason: "dirty_worktree" };
 
@@ -424,7 +458,7 @@ export function createSafeCodeRoomSubmitter({
     const existing = await runProcess(
       "gh",
       ["pr", "list", "--head", branch, "--state", "open", "--json", "url", "--jq", ".[0].url // \"\""],
-      { cwd, env },
+      { cwd, env: submitterEnv },
     );
     if (!existing.ok) return { ok: false, reason: "gh_pr_list_failed", output: existing.output };
     const existingUrl = existing.stdout.trim();
@@ -460,23 +494,27 @@ export function createSafeCodeRoomSubmitter({
       ["git", ["diff", "--check"]],
       ["git", ["add", ...normalizedChanged]],
       ["git", ["commit", "-m", prTitle]],
+      ["gh", ["auth", "setup-git"]],
       ["git", ["push", "-u", "origin", branch]],
       ["gh", ["pr", "create", ...(draft ? ["--draft"] : []), "--title", prTitle, "--body", bodyText]],
     ];
 
     let prUrl = "";
     for (const [command, args, options = {}] of commands) {
-      const result = await runProcess(command, args, { cwd, env, ...options });
+      const result = await runProcess(command, args, { cwd, env: submitterEnv, ...options });
       if (!result.ok) return { ok: false, reason: `${command}_failed`, output: result.output };
       if (command === "gh" && args[1] === "create") prUrl = result.stdout.trim();
     }
 
-    const sha = await runProcess("git", ["rev-parse", "HEAD"], { cwd, env });
+    const sha = await runProcess("git", ["rev-parse", "HEAD"], { cwd, env: submitterEnv });
     if (!sha.ok) return { ok: false, reason: "git_rev_parse_failed", output: sha.output };
 
     let autoMergeResult = { ok: true, skipped: true, reason: draft ? "draft_pr" : "auto_merge_disabled" };
     if (autoMerge && !draft) {
-      autoMergeResult = await runProcess("gh", ["pr", "merge", "--auto", "--squash", prUrl], { cwd, env });
+      autoMergeResult = await runProcess("gh", ["pr", "merge", "--auto", "--squash", prUrl], {
+        cwd,
+        env: submitterEnv,
+      });
       if (!autoMergeResult.ok) {
         return { ok: false, reason: "gh_auto_merge_failed", output: autoMergeResult.output, pr_url: prUrl };
       }

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -10,6 +10,7 @@ import {
   createFixtureOpenHandsRunner,
   createOpenHandsCliRunner,
   createSafeCodeRoomSubmitter,
+  resolveCodeRoomSubmitterAuthEnv,
   runOpenHandsProof,
   splitArgs,
 } from "./pinballwake-openhands-proof-runner.mjs";
@@ -206,9 +207,42 @@ describe("draft PR coderoom binding", () => {
 });
 
 describe("safe CodeRoom submitter", () => {
+  test("refuses default GITHUB_TOKEN-only auth before git or gh calls", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { GITHUB_TOKEN: "default-actions-token" },
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-token", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: token refusal" }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "missing_scoped_app_token");
+    assert.deepEqual(calls, []);
+  });
+
+  test("rejects an app token that matches the default GITHUB_TOKEN", () => {
+    const result = resolveCodeRoomSubmitterAuthEnv({
+      GITHUB_TOKEN: "same-token",
+      CODEROOM_GITHUB_APP_TOKEN: "same-token",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "app_token_matches_default_github_token");
+    assert.equal(result.token_source, "CODEROOM_GITHUB_APP_TOKEN");
+  });
+
   test("rejects protected paths before git or gh writes", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
       runProcess: async (command, args) => {
         calls.push([command, args]);
         return { ok: true, stdout: "", stderr: "", output: "" };
@@ -230,6 +264,7 @@ describe("safe CodeRoom submitter", () => {
   test("returns existing PR before creating a duplicate branch", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
       branchName: "codex/openhands-submit-todo-1",
       runProcess: async (command, args) => {
         calls.push([command, args]);
@@ -265,10 +300,11 @@ describe("safe CodeRoom submitter", () => {
   test("creates a PR and enables auto-merge only after validation", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
       branchName: "codex/openhands-submit-todo-2",
       title: "docs: submit OpenHands patch",
       runProcess: async (command, args, options = {}) => {
-        calls.push([command, args, Boolean(options.stdin)]);
+        calls.push([command, args, Boolean(options.stdin), options.env?.GH_TOKEN, options.env?.GITHUB_TOKEN]);
         if (command === "gh" && args[1] === "list") {
           return { ok: true, stdout: "", stderr: "", output: "" };
         }
@@ -304,6 +340,7 @@ describe("safe CodeRoom submitter", () => {
         "git diff --check",
         "git add docs/openhands-proof-fixture.md",
         "git commit -m docs: submit OpenHands patch",
+        "gh auth setup-git",
         "git push -u origin",
         "gh pr create --title",
         "git rev-parse HEAD",
@@ -312,11 +349,13 @@ describe("safe CodeRoom submitter", () => {
     );
     assert.equal(calls[3][2], true);
     assert.equal(calls[4][2], true);
+    assert.ok(calls.every((call) => call[3] === "app-token" && call[4] === "app-token"));
   });
 
   test("fails closed when git apply check fails", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
       branchName: "codex/openhands-submit-todo-3",
       runProcess: async (command, args) => {
         calls.push([command, args]);

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -9,6 +9,7 @@ import {
   createDraftPrCoderoom,
   createFixtureOpenHandsRunner,
   createOpenHandsCliRunner,
+  createSafeCodeRoomSubmitter,
   runOpenHandsProof,
   splitArgs,
 } from "./pinballwake-openhands-proof-runner.mjs";
@@ -201,5 +202,146 @@ describe("draft PR coderoom binding", () => {
       ],
     );
     assert.equal(calls[2][2], true);
+  });
+});
+
+describe("safe CodeRoom submitter", () => {
+  test("rejects protected paths before git or gh writes", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-protected", owned_files: [".github/workflows/ci.yml"] },
+      changedFiles: [".github/workflows/ci.yml"],
+      patch:
+        "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n--- a/.github/workflows/ci.yml\n+++ b/.github/workflows/ci.yml\n@@ -1 +1 @@\n-old\n+new\n",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "protected_workflow_path");
+    assert.deepEqual(calls, []);
+  });
+
+  test("returns existing PR before creating a duplicate branch", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      branchName: "codex/openhands-submit-todo-1",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/930\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-1", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: idempotent" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.equal(result.idempotent, true);
+    assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/930");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      ["git status --porcelain", "gh pr list"],
+    );
+  });
+
+  test("creates a PR and enables auto-merge only after validation", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      branchName: "codex/openhands-submit-todo-2",
+      title: "docs: submit OpenHands patch",
+      runProcess: async (command, args, options = {}) => {
+        calls.push([command, args, Boolean(options.stdin)]);
+        if (command === "gh" && args[1] === "list") {
+          return { ok: true, stdout: "", stderr: "", output: "" };
+        }
+        if (command === "gh" && args[1] === "create") {
+          return { ok: true, stdout: "https://github.com/malamutemayhem/unclick/pull/931\n", stderr: "", output: "" };
+        }
+        if (command === "git" && args[0] === "rev-parse") {
+          return { ok: true, stdout: "abc123\n", stderr: "", output: "" };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-2", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: auto-merge" }),
+      summary: "Docs-only submitter proof.",
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "pr_created_auto_merge_enabled");
+    assert.equal(result.auto_merge_enabled, true);
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 3).join(" ")}`),
+      [
+        "git status --porcelain",
+        "gh pr list --head",
+        "git checkout -b codex/openhands-submit-todo-2",
+        "git apply --check --whitespace=error",
+        "git apply --whitespace=nowarn -",
+        "git diff --check",
+        "git add docs/openhands-proof-fixture.md",
+        "git commit -m docs: submit OpenHands patch",
+        "git push -u origin",
+        "gh pr create --title",
+        "git rev-parse HEAD",
+        "gh pr merge --auto",
+      ],
+    );
+    assert.equal(calls[3][2], true);
+    assert.equal(calls[4][2], true);
+  });
+
+  test("fails closed when git apply check fails", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      branchName: "codex/openhands-submit-todo-3",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "gh" && args[1] === "list") {
+          return { ok: true, stdout: "", stderr: "", output: "" };
+        }
+        if (command === "git" && args[0] === "apply" && args[1] === "--check") {
+          return { ok: false, stdout: "", stderr: "patch does not apply", output: "patch does not apply" };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-3", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: fail closed" }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "git_failed");
+    assert.match(result.output, /patch does not apply/);
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      ["git status --porcelain", "gh pr list", "git checkout -b", "git apply --check"],
+    );
   });
 });


### PR DESCRIPTION
## What changed
- Added a safe CodeRoom submitter for OpenHands patches.
- Wired explicit OpenHands execute mode to use that submitter instead of the build-receipt-only fallback.
- Added tests for protected-path rejection, owned-file enforcement through the existing patch validator, dirty/idempotent PR flow, auto-merge command ordering, and execute wiring.

## Why
AutoPilot could claim work and call OpenHands, but OpenHands output stopped at a build receipt. This is the missing bridge toward unattended backlog chewing: patch -> protected-rail PR.

## Safety
- No workflow or ruleset edits.
- Protected paths fail closed before git or GitHub writes.
- Dirty worktrees fail closed.
- Existing open PRs are reused by branch name so one job does not fan out duplicate PRs.
- The runner still requires explicit execute mode before this path is active.

## Validation
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check

Boardroom: 5ea7aeb5-d025-4430-ba9f-915d99a9e3d8
Proof comments: 3fda9501-398f-4ed3-8779-780284e5a9a9, 208ffba2-60ab-4d60-a0c4-3b86be6881b1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated `git`/`gh` PR creation path for OpenHands patches, which can push branches and enable auto-merge; safety checks reduce but don’t eliminate risk of unintended repo writes or token misconfiguration.
> 
> **Overview**
> Adds a **safe CodeRoom submitter** that can take an OpenHands-produced patch and turn it into a PR via `git`/`gh`, with guardrails: requires a scoped app token, refuses dirty worktrees, enforces owned-file patch validation, and blocks writes to protected paths (e.g. workflows, rulesets, migrations, secrets).
> 
> Wires the autonomous runner’s explicitly enabled OpenHands execute mode to use this submitter (`createAutonomousRunnerOpenHandsExecutorFromEnv` now provides `coderoom`). Expands tests to cover auth gating, protected-path rejection, idempotent “existing PR” behavior, command ordering/auto-merge enabling, fail-closed patch apply, and execute wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba627d0851b5bf7594f1adbefc35b40439ea157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->