### PR TITLE
fix orchestrator ledger search visibility

### DIFF
--- a/api/memory-admin-refresh.test.ts
+++ b/api/memory-admin-refresh.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   buildAdminLibraryRefreshPayload,
   parseAdminLibraryRefreshOptions,
@@ -84,5 +85,14 @@ describe("admin library taxonomy refresh safety", () => {
     expect(payload.planned_snapshot_count).toBe(2);
     expect(payload.skipped_secret_count).toBe(1);
     expect(JSON.stringify(payload)).not.toContain("content");
+  });
+
+  it("keeps Orchestrator AutoPilot scoreboard reads unfiltered by search q", () => {
+    const source = readFileSync("api/memory-admin.ts", "utf8");
+    const ledgerQueryBlock = source.match(/let autopilotEventsQuery[\s\S]*?const \[/)?.[0] ?? "";
+
+    expect(ledgerQueryBlock).toContain('.from("mc_autopilot_events")');
+    expect(ledgerQueryBlock).toContain("The zero-touch scoreboard is a safety surface");
+    expect(ledgerQueryBlock).not.toMatch(/autopilotEventsQuery\s*=\s*autopilotEventsQuery\.or/);
   });
 });

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -8822,11 +8822,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .eq("api_key_hash", apiKeyHash)
           .order("created_at", { ascending: false })
           .limit(Math.min(smallerLimit, 500));
-        if (searchPattern) {
-          autopilotEventsQuery = autopilotEventsQuery.or(
-            `event_type.ilike.${searchPattern},actor_agent_id.ilike.${searchPattern},ref_kind.ilike.${searchPattern},ref_id.ilike.${searchPattern}`,
-          );
-        }
+        // The zero-touch scoreboard is a safety surface, not a search result.
+        // Keep recent ledger rows visible even when callers pass q=... for
+        // narrowing messages, todos, comments, or turns.
 
         const [
           profilesResult,


### PR DESCRIPTION
Fixes the Orchestrator read drift where search-scoped context reads could hide AutoPilot ledger rows from the zero-touch scoreboard.

What changed:
- keeps mc_autopilot_events unfiltered for orchestrator_context_read safety scoreboard reads
- leaves search narrowing in place for messages, todos, comments, signals, sessions, and turns
- adds a regression test so q=... cannot accidentally hide ledger proof again

Proof run locally:
- npm test -- --run api/memory-admin-refresh.test.ts api/orchestrator-context.test.ts
- npm run brainmap:check
- npm run build

This does not touch workflows, rulesets, secrets, or protected surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts read-side query behavior so `mc_autopilot_events` is no longer filtered by the `q` search parameter, plus a regression test to prevent reintroducing the filter.
> 
> **Overview**
> Ensures Orchestrator “zero-touch scoreboard” context reads always include recent `mc_autopilot_events` rows, even when callers pass `q=...` to narrow other context results.
> 
> Removes the search-based `.or(...)` filter from `autopilotEventsQuery` in `orchestrator_context_read` and adds a regression test that asserts the ledger query remains unfiltered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5c90175a71c02a8411fda1a4f476fa4d627d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->