### PR TITLE
Guard scheduled execute canary selection

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -33,6 +33,7 @@ export const DEFAULT_AUTONOMOUS_RUNNER_POLICY = {
   disabled: false,
   allowProtectedSurfaces: false,
   allowExecute: false,
+  requireScopePack: false,
   maxCycles: 1,
   allowedPriorities: ["urgent", "high"],
   allowedActionReasons: ["unassigned_open"],
@@ -2133,11 +2134,15 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
     allowedActionReasons = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons,
     allowedTodoRoles = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles,
     allowProtectedSurfaces = false,
+    requireScopePack = false,
     runner = DEFAULT_AUTONOMOUS_RUNNER,
     now = new Date().toISOString(),
   } = {},
 ) {
   if (!scopePack.hasScopePack) {
+    if (requireScopePack) {
+      return { ok: false, reason: "boardroom_todo_missing_scopepack" };
+    }
     return { ok: true, reason: "missing_scopepack_kept_for_scoping" };
   }
 
@@ -2225,6 +2230,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
   allowedActionReasons = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons,
   allowedTodoRoles = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles,
   allowProtectedSurfaces = false,
+  requireScopePack = false,
 } = {}) {
   const fetched = await fetchUnClickActionableTodos({
     agentId: runner.agent_id || runner.id || DEFAULT_AUTONOMOUS_RUNNER.id,
@@ -2251,7 +2257,11 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
     };
   }
 
+  const runnerAgentId = autonomousRunnerAgentId(runner);
+  const assignedToRunnerWeight = (todo = {}) =>
+    runnerAgentId && String(todo.assigned_to_agent_id || "").trim() === runnerAgentId ? 1 : 0;
   const ordered = [...fetched.todos].sort((a, b) =>
+    assignedToRunnerWeight(b) - assignedToRunnerWeight(a) ||
     priorityWeight(b.priority) - priorityWeight(a.priority) ||
     String(a.created_at || "").localeCompare(String(b.created_at || "")),
   );
@@ -2268,6 +2278,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
       allowedActionReasons,
       allowedTodoRoles,
       allowProtectedSurfaces,
+      requireScopePack,
       runner,
       now,
     });
@@ -2379,6 +2390,7 @@ export function createAutonomousRunnerPolicy(input = {}) {
     disabled: Boolean(input.disabled),
     allowProtectedSurfaces: Boolean(input.allowProtectedSurfaces),
     allowExecute: Boolean(input.allowExecute),
+    requireScopePack: Boolean(input.requireScopePack),
     maxCycles: Math.max(1, Number.isFinite(input.maxCycles) ? input.maxCycles : DEFAULT_AUTONOMOUS_RUNNER_POLICY.maxCycles),
     allowedPriorities: parseList(input.allowedPriorities, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedPriorities),
     allowedActionReasons: parseList(input.allowedActionReasons, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons),
@@ -2389,6 +2401,46 @@ export function createAutonomousRunnerPolicy(input = {}) {
 export function normalizeAutonomousRunnerMode(value) {
   const mode = String(value || "dry-run").trim().toLowerCase();
   return AUTONOMOUS_RUNNER_MODES.has(mode) ? mode : "dry-run";
+}
+
+export function isScheduledExecuteCanaryPolicy({
+  mode = "dry-run",
+  policy = DEFAULT_AUTONOMOUS_RUNNER_POLICY,
+  wakeSource = "unknown",
+  todoLimit = 10,
+} = {}) {
+  const safeMode = normalizeAutonomousRunnerMode(mode);
+  const safePolicy = createAutonomousRunnerPolicy(policy);
+  const roles = new Set(safePolicy.allowedTodoRoles.map(normalizeToken).filter(Boolean));
+
+  return (
+    safeMode === "execute" &&
+    safePolicy.allowExecute &&
+    normalizeToken(wakeSource) === "schedule" &&
+    Number(todoLimit) === 1 &&
+    roles.size === 2 &&
+    roles.has("docs_update") &&
+    roles.has("test_fix")
+  );
+}
+
+export function resolveAutonomousRunnerQueueGuard({
+  mode = "dry-run",
+  policy = DEFAULT_AUTONOMOUS_RUNNER_POLICY,
+  wakeSource = "unknown",
+  todoLimit = 10,
+  queueFetchLimit = null,
+} = {}) {
+  const canary = isScheduledExecuteCanaryPolicy({ mode, policy, wakeSource, todoLimit });
+  const parsedQueueFetchLimit = Number.parseInt(String(queueFetchLimit ?? ""), 10);
+  const fallbackFetchLimit = canary ? 100 : todoLimit;
+  const effectiveFetchLimit = Number.isFinite(parsedQueueFetchLimit) ? parsedQueueFetchLimit : fallbackFetchLimit;
+
+  return {
+    scheduled_execute_canary: canary,
+    queue_fetch_limit: Math.max(Number(todoLimit) || 1, effectiveFetchLimit || 1),
+    require_scope_pack: canary || Boolean(policy?.requireScopePack),
+  };
 }
 
 export function inspectAutonomousRunnerJobSafety(job) {
@@ -2547,6 +2599,7 @@ export async function runAutonomousRunnerFile({
   unclickApiKey = "",
   unclickMcpUrl = DEFAULT_UNCLICK_MCP_URL,
   todoLimit = 10,
+  queueFetchLimit = null,
   fetchImpl = globalThis.fetch,
   now = new Date().toISOString(),
   leaseSeconds,
@@ -2607,8 +2660,19 @@ export async function runAutonomousRunnerFile({
     return { ok: false, reason: "missing_ledger_path", main_freshness_canary: mainFreshnessCanary };
   }
 
-  const safePolicy = createAutonomousRunnerPolicy(policy);
   const safeMode = normalizeAutonomousRunnerMode(mode);
+  const safePolicy = createAutonomousRunnerPolicy(policy);
+  const queueGuard = resolveAutonomousRunnerQueueGuard({
+    mode: safeMode,
+    policy: safePolicy,
+    wakeSource,
+    todoLimit,
+    queueFetchLimit,
+  });
+  const guardedPolicy = createAutonomousRunnerPolicy({
+    ...safePolicy,
+    requireScopePack: queueGuard.require_scope_pack,
+  });
   let ledger = await readCodingRoomJobLedger(ledgerPath);
   let queueSourceResult = {
     ok: true,
@@ -2640,6 +2704,7 @@ export async function runAutonomousRunnerFile({
         ledger,
         ledger_path: ledgerPath,
         queue_source: queueSourceResult,
+        queue_guard: queueGuard,
         git_hygiene: gitHygiene,
         main_freshness_canary: mainFreshnessCanary,
       };
@@ -2655,14 +2720,16 @@ export async function runAutonomousRunnerFile({
         now,
         apiKey: unclickApiKey,
         mcpUrl: unclickMcpUrl,
-        limit: todoLimit,
+        limit: queueGuard.queue_fetch_limit,
         fetchImpl,
         wakeSource,
-        allowedPriorities: safePolicy.allowedPriorities,
-        allowedActionReasons: safePolicy.allowedActionReasons,
-        allowedTodoRoles: safePolicy.allowedTodoRoles,
-        allowProtectedSurfaces: safePolicy.allowProtectedSurfaces,
+        allowedPriorities: guardedPolicy.allowedPriorities,
+        allowedActionReasons: guardedPolicy.allowedActionReasons,
+        allowedTodoRoles: guardedPolicy.allowedTodoRoles,
+        allowProtectedSurfaces: guardedPolicy.allowProtectedSurfaces,
+        requireScopePack: guardedPolicy.requireScopePack,
       })),
+      queue_guard: queueGuard,
     };
     ledger = queueSourceResult.ledger || ledger;
 
@@ -2678,6 +2745,7 @@ export async function runAutonomousRunnerFile({
         ledger,
         ledger_path: ledgerPath,
         queue_source: queueSourceResult,
+        queue_guard: queueGuard,
         claimability_scorecard: queueSourceResult.claimability_scorecard,
         main_freshness_canary: mainFreshnessCanary,
       };
@@ -2691,7 +2759,7 @@ export async function runAutonomousRunnerFile({
       ledger,
       runner,
       mode: safeMode,
-      policy: safePolicy,
+      policy: guardedPolicy,
       now,
       leaseSeconds,
     });
@@ -2773,6 +2841,7 @@ export async function runAutonomousRunnerFile({
         ledger,
         ledger_path: ledgerPath,
         queue_source: queueSourceResult,
+        queue_guard: queueGuard,
         claimability_scorecard: claimabilityScorecard,
         todo_claim_sync: todoClaimSync,
         main_freshness_canary: mainFreshnessCanary,
@@ -2809,6 +2878,7 @@ export async function runAutonomousRunnerFile({
         ledger,
         ledger_path: ledgerPath,
         queue_source: queueSourceResult,
+        queue_guard: queueGuard,
         claimability_scorecard: claimabilityScorecard,
         todo_claim_sync: todoClaimSync,
         todo_scoping_sync: todoScopingSync,
@@ -2890,6 +2960,7 @@ export async function runAutonomousRunnerFile({
     ledger,
     ledger_path: ledgerPath,
     queue_source: queueSourceResult,
+    queue_guard: queueGuard,
     claimability_scorecard: claimabilityScorecard,
     commonsensepass,
     quiet_window_autonomy_proof: quietWindowAutonomyProof,
@@ -2913,6 +2984,7 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
     unclickApiKey: getArg("unclick-api-key", process.env.UNCLICK_API_KEY || ""),
     unclickMcpUrl: getArg("unclick-mcp-url", process.env.UNCLICK_MCP_URL || DEFAULT_UNCLICK_MCP_URL),
     todoLimit: parseIntOption(getArg("todo-limit", process.env.AUTONOMOUS_RUNNER_TODO_LIMIT), 10),
+    queueFetchLimit: getArg("queue-fetch-limit", process.env.AUTONOMOUS_RUNNER_QUEUE_FETCH_LIMIT || ""),
     leaseSeconds: parseIntOption(getArg("lease-seconds", process.env.CODING_ROOM_LEASE_SECONDS), undefined),
     wakeSource: getArg("wake-source", process.env.AUTONOMOUS_RUNNER_WAKE_SOURCE || process.env.GITHUB_EVENT_NAME || "unknown"),
     orchestratorProof: parseBoolean(getArg("orchestrator-proof", process.env.AUTONOMOUS_RUNNER_ORCHESTRATOR_PROOF)),
@@ -2964,6 +3036,7 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
       disabled: parseBoolean(process.env.AUTONOMOUS_RUNNER_DISABLED),
       allowProtectedSurfaces: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES),
       allowExecute: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_EXECUTE),
+      requireScopePack: parseBoolean(process.env.AUTONOMOUS_RUNNER_REQUIRE_SCOPEPACK),
       maxCycles: parseIntOption(getArg("max-cycles", process.env.AUTONOMOUS_RUNNER_MAX_CYCLES), 1),
       allowedPriorities: process.env.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES,
       allowedActionReasons: process.env.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -22,11 +22,13 @@ import {
   extractBoardroomTodoIdFromCodingRoomJob,
   fetchUnClickActionableTodos,
   fetchUnClickOrchestratorContext,
+  hydrateAutonomousRunnerLedgerFromUnClick,
   inspectAutonomousRunnerJobSafety,
   markUnsafeJobsBlockedForAutonomousRunner,
   normalizeAutonomousRunnerMode,
   parseAutonomousRunnerGitStatusPorcelain,
   parseMcpEventStreamPayload,
+  resolveAutonomousRunnerQueueGuard,
   evaluateAutonomousRunnerGitHygiene,
   runAutonomousRunnerMainFreshnessCanary,
   runAutonomousRunnerCycle,
@@ -61,6 +63,36 @@ describe("PinballWake autonomous Runner seat", () => {
   it("defaults unknown modes back to dry-run", () => {
     assert.equal(normalizeAutonomousRunnerMode("claim"), "claim");
     assert.equal(normalizeAutonomousRunnerMode("ship-it"), "dry-run");
+  });
+
+  it("tightens queue intake for the scheduled execute canary", () => {
+    const guard = resolveAutonomousRunnerQueueGuard({
+      mode: "execute",
+      wakeSource: "schedule",
+      todoLimit: 1,
+      policy: {
+        allowExecute: true,
+        allowedTodoRoles: "docs_update,test_fix",
+      },
+    });
+
+    assert.equal(guard.scheduled_execute_canary, true);
+    assert.equal(guard.require_scope_pack, true);
+    assert.equal(guard.queue_fetch_limit, 100);
+
+    const normal = resolveAutonomousRunnerQueueGuard({
+      mode: "claim",
+      wakeSource: "schedule",
+      todoLimit: 1,
+      policy: {
+        allowExecute: false,
+        allowedTodoRoles: "docs_update,test_fix",
+      },
+    });
+
+    assert.equal(normal.scheduled_execute_canary, false);
+    assert.equal(normal.require_scope_pack, false);
+    assert.equal(normal.queue_fetch_limit, 1);
   });
 
   it("treats the checked-out SHA as fresh when it matches current main", () => {
@@ -630,6 +662,97 @@ describe("PinballWake autonomous Runner seat", () => {
       }).reason,
       "boardroom_todo_role_not_allowed",
     );
+  });
+
+  it("requires ScopePack when the canary guard is active", () => {
+    const todo = {
+      id: "todo-unscoped",
+      title: "Old urgent backlog item",
+      status: "open",
+      priority: "urgent",
+      assigned_to_agent_id: null,
+      actionability_reason: "unassigned_open",
+    };
+
+    assert.equal(evaluateBoardroomTodoAutoClaimEligibility(todo).ok, true);
+    assert.equal(
+      evaluateBoardroomTodoAutoClaimEligibility(todo, { requireScopePack: true }).reason,
+      "boardroom_todo_missing_scopepack",
+    );
+  });
+
+  it("prefers an assigned scoped canary seed over older unscoped backlog", async () => {
+    const canaryRunner = createAutonomousRunner({
+      id: "pinballwake-autonomous-runner",
+      agentId: "pinballwake-autonomous-runner",
+      capabilities: ["docs_update", "test_fix"],
+    });
+    const calls = [];
+    const fetchImpl = async (url, init = {}) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    todos: [
+                      {
+                        id: "todo-old-unscoped",
+                        title: "Old urgent unscoped backlog",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: null,
+                        actionability_reason: "unassigned_open",
+                        created_at: "2026-05-01T00:00:00.000Z",
+                      },
+                      {
+                        id: "todo-canary-seed",
+                        title: "AFK canary seed: docs-only OpenHands proof fixture",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: "pinballwake-autonomous-runner",
+                        actionability_reason: "role_assigned_open",
+                        created_at: "2026-05-24T15:00:00.000Z",
+                        scope_pack: {
+                          owned_files: ["docs/openhands-proof-fixture.md"],
+                          tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+                          role: "docs_update",
+                        },
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          };
+        },
+      };
+    };
+
+    const result = await hydrateAutonomousRunnerLedgerFromUnClick({
+      ledger: createCodingRoomJobLedger(),
+      runner: canaryRunner,
+      apiKey: "uc_test",
+      mcpUrl: "https://unclick.test/api/mcp",
+      limit: 100,
+      fetchImpl,
+      wakeSource: "schedule",
+      allowedTodoRoles: ["docs_update", "test_fix"],
+      requireScopePack: true,
+      now: "2026-05-24T15:01:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].init.body, /"limit":100/);
+    assert.equal(result.skipped[0].id, "todo-old-unscoped");
+    assert.equal(result.skipped[0].reason, "boardroom_todo_missing_scopepack");
+    assert.equal(result.imported, 1);
+    assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-canary-seed");
   });
 
   it("keeps watcher and tether runners off unassigned builder ScopePacks unless exactly assigned", async () => {


### PR DESCRIPTION
## Summary
- guard the scheduled execute canary so it fetches enough Boardroom candidates while still executing at most one todo
- require a real ScopePack for scheduled execute canary claims so old unscoped backlog cannot be grabbed
- prefer todos explicitly assigned to the autonomous runner when hydrating the queue

## Proof
- node --test scripts/pinballwake-autonomous-runner.test.mjs

## AFK impact
This keeps the live canary switch off until GitHub checks pass and a fresh docs/test seed can be staged deterministically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous job claiming and scheduled execute behavior; misconfiguration could block the canary or still pick the wrong todo, but scope is limited to the runner script and tests.
> 
> **Overview**
> The autonomous runner gains a **queue guard** for the **scheduled execute canary**: when mode is `execute`, execute is allowed, wake is `schedule`, `todo_limit` is 1, and roles are exactly `docs_update` + `test_fix`, intake tightens—**ScopePack is required** for claims, UnClick fetch uses a higher **queue fetch limit** (default 100) while still running at most one job, and run output includes **`queue_guard`**.
> 
> Policy adds **`requireScopePack`** (env `AUTONOMOUS_RUNNER_REQUIRE_SCOPEPACK`, optional `queue-fetch-limit`). Hydration **sorts** actionable todos so items **assigned to the runner** win over older unscoped backlog before priority/age.
> 
> **Tests** cover the guard matrix, missing-ScopePack rejection under the canary, and assigned scoped seed selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e18522828f74b3282aa63f7d8621cccc00d0de46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->