### PR TITLE
Prefer assigned seed for execute canary

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -229,6 +229,16 @@ function stableTodoJobId(todo = {}) {
   return `boardroom-todo:${String(todo.id || todo.todo_id || "unknown").trim()}`;
 }
 
+function mergeBoardroomTodosById(...todoLists) {
+  const merged = new Map();
+  for (const todo of todoLists.flat()) {
+    const id = String(todo?.id || todo?.todo_id || "").trim();
+    if (!id || merged.has(id)) continue;
+    merged.set(id, todo);
+  }
+  return [...merged.values()];
+}
+
 function priorityWeight(priority) {
   const raw = String(priority || "").trim().toLowerCase();
   if (raw === "urgent") return 100;
@@ -894,6 +904,36 @@ export async function fetchUnClickActionableTodos({
       agent_id: agentId,
       limit,
       include_description: true,
+    },
+  });
+
+  if (!result.ok) return result;
+
+  const todos = Array.isArray(result.data?.todos) ? result.data.todos : [];
+  return {
+    ok: true,
+    todos,
+    response_bounds: result.data?.response_bounds || null,
+  };
+}
+
+export async function fetchUnClickAssignedTodos({
+  agentId = DEFAULT_AUTONOMOUS_RUNNER.id,
+  limit = 10,
+  mcpUrl = DEFAULT_UNCLICK_MCP_URL,
+  apiKey = "",
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const result = await callUnClickMcpTool({
+    mcpUrl,
+    apiKey,
+    fetchImpl,
+    toolName: "list_todos",
+    arguments: {
+      agent_id: agentId,
+      assigned_to_agent_id: agentId,
+      status: "open",
+      limit,
     },
   });
 
@@ -2231,9 +2271,20 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
   allowedTodoRoles = DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedTodoRoles,
   allowProtectedSurfaces = false,
   requireScopePack = false,
+  includeAssignedTodos = false,
 } = {}) {
+  const agentId = runner.agent_id || runner.id || DEFAULT_AUTONOMOUS_RUNNER.id;
+  const assignedFetched = includeAssignedTodos
+    ? await fetchUnClickAssignedTodos({
+        agentId,
+        apiKey,
+        mcpUrl,
+        limit: Math.min(Math.max(limit, 1), 50),
+        fetchImpl,
+      })
+    : { ok: true, todos: [], response_bounds: null, skipped: true, reason: "assigned_queue_source_disabled" };
   const fetched = await fetchUnClickActionableTodos({
-    agentId: runner.agent_id || runner.id || DEFAULT_AUTONOMOUS_RUNNER.id,
+    agentId,
     apiKey,
     mcpUrl,
     limit,
@@ -2246,6 +2297,9 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
       reason: fetched.reason,
       status: fetched.status ?? null,
       error: fetched.error ?? null,
+      assigned_queue_source: assignedFetched.ok
+        ? { ok: true, seen: assignedFetched.todos.length, response_bounds: assignedFetched.response_bounds }
+        : assignedFetched,
       ledger: createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now }),
       imported: 0,
       seen: 0,
@@ -2257,10 +2311,14 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
     };
   }
 
+  const combinedTodos = mergeBoardroomTodosById(
+    assignedFetched.ok ? assignedFetched.todos : [],
+    fetched.todos,
+  );
   const runnerAgentId = autonomousRunnerAgentId(runner);
   const assignedToRunnerWeight = (todo = {}) =>
     runnerAgentId && String(todo.assigned_to_agent_id || "").trim() === runnerAgentId ? 1 : 0;
-  const ordered = [...fetched.todos].sort((a, b) =>
+  const ordered = combinedTodos.sort((a, b) =>
     assignedToRunnerWeight(b) - assignedToRunnerWeight(a) ||
     priorityWeight(b.priority) - priorityWeight(a.priority) ||
     String(a.created_at || "").localeCompare(String(b.created_at || "")),
@@ -2325,6 +2383,9 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
     ledger: next,
     imported,
     seen: ordered.length,
+    assigned_queue_source: assignedFetched.ok
+      ? { ok: true, seen: assignedFetched.todos.length, response_bounds: assignedFetched.response_bounds }
+      : assignedFetched,
     skipped,
     claimability_scorecard: buildClaimabilityScorecard({
       seen: ordered.length,
@@ -2433,7 +2494,7 @@ export function resolveAutonomousRunnerQueueGuard({
 } = {}) {
   const canary = isScheduledExecuteCanaryPolicy({ mode, policy, wakeSource, todoLimit });
   const parsedQueueFetchLimit = Number.parseInt(String(queueFetchLimit ?? ""), 10);
-  const fallbackFetchLimit = canary ? 100 : todoLimit;
+  const fallbackFetchLimit = canary ? 50 : todoLimit;
   const effectiveFetchLimit = Number.isFinite(parsedQueueFetchLimit) ? parsedQueueFetchLimit : fallbackFetchLimit;
 
   return {
@@ -2728,6 +2789,7 @@ export async function runAutonomousRunnerFile({
         allowedTodoRoles: guardedPolicy.allowedTodoRoles,
         allowProtectedSurfaces: guardedPolicy.allowProtectedSurfaces,
         requireScopePack: guardedPolicy.requireScopePack,
+        includeAssignedTodos: queueGuard.scheduled_execute_canary,
       })),
       queue_guard: queueGuard,
     };

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -78,7 +78,7 @@ describe("PinballWake autonomous Runner seat", () => {
 
     assert.equal(guard.scheduled_execute_canary, true);
     assert.equal(guard.require_scope_pack, true);
-    assert.equal(guard.queue_fetch_limit, 100);
+    assert.equal(guard.queue_fetch_limit, 50);
 
     const normal = resolveAutonomousRunnerQueueGuard({
       mode: "claim",
@@ -689,7 +689,9 @@ describe("PinballWake autonomous Runner seat", () => {
     });
     const calls = [];
     const fetchImpl = async (url, init = {}) => {
-      calls.push({ url, init });
+      const body = JSON.parse(init.body || "{}");
+      calls.push({ url, init, tool: body?.params?.name, args: body?.params?.arguments || {} });
+      const isAssigned = body?.params?.name === "list_todos";
       return {
         ok: true,
         async json() {
@@ -699,31 +701,34 @@ describe("PinballWake autonomous Runner seat", () => {
                 {
                   type: "text",
                   text: JSON.stringify({
-                    todos: [
-                      {
-                        id: "todo-old-unscoped",
-                        title: "Old urgent unscoped backlog",
-                        status: "open",
-                        priority: "urgent",
-                        assigned_to_agent_id: null,
-                        actionability_reason: "unassigned_open",
-                        created_at: "2026-05-01T00:00:00.000Z",
-                      },
-                      {
-                        id: "todo-canary-seed",
-                        title: "AFK canary seed: docs-only OpenHands proof fixture",
-                        status: "open",
-                        priority: "urgent",
-                        assigned_to_agent_id: "pinballwake-autonomous-runner",
-                        actionability_reason: "role_assigned_open",
-                        created_at: "2026-05-24T15:00:00.000Z",
-                        scope_pack: {
-                          owned_files: ["docs/openhands-proof-fixture.md"],
-                          tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
-                          role: "docs_update",
+                    todos: isAssigned
+                      ? [
+                        {
+                          id: "todo-canary-seed",
+                          title: "AFK canary seed: docs-only OpenHands proof fixture",
+                          status: "open",
+                          priority: "urgent",
+                          assigned_to_agent_id: "pinballwake-autonomous-runner",
+                          actionability_reason: "role_assigned_open",
+                          created_at: "2026-05-24T15:00:00.000Z",
+                          scope_pack: {
+                            owned_files: ["docs/openhands-proof-fixture.md"],
+                            tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+                            role: "docs_update",
+                          },
                         },
-                      },
-                    ],
+                      ]
+                      : [
+                        {
+                          id: "todo-old-unscoped",
+                          title: "Old urgent unscoped backlog",
+                          status: "open",
+                          priority: "urgent",
+                          assigned_to_agent_id: null,
+                          actionability_reason: "unassigned_open",
+                          created_at: "2026-05-01T00:00:00.000Z",
+                        },
+                      ],
                   }),
                 },
               ],
@@ -738,17 +743,23 @@ describe("PinballWake autonomous Runner seat", () => {
       runner: canaryRunner,
       apiKey: "uc_test",
       mcpUrl: "https://unclick.test/api/mcp",
-      limit: 100,
+      limit: 50,
       fetchImpl,
       wakeSource: "schedule",
       allowedTodoRoles: ["docs_update", "test_fix"],
       requireScopePack: true,
+      includeAssignedTodos: true,
       now: "2026-05-24T15:01:00.000Z",
     });
 
     assert.equal(result.ok, true);
-    assert.equal(calls.length, 1);
-    assert.match(calls[0].init.body, /"limit":100/);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].tool, "list_todos");
+    assert.equal(calls[0].args.assigned_to_agent_id, "pinballwake-autonomous-runner");
+    assert.equal(calls[0].args.limit, 50);
+    assert.equal(calls[1].tool, "list_actionable_todos");
+    assert.equal(calls[1].args.limit, 50);
+    assert.equal(result.assigned_queue_source.seen, 1);
     assert.equal(result.skipped[0].id, "todo-old-unscoped");
     assert.equal(result.skipped[0].reason, "boardroom_todo_missing_scopepack");
     assert.equal(result.imported, 1);


### PR DESCRIPTION
## Summary
- include the runner's open assigned todos before the general actionable backlog during the scheduled execute canary
- keep assigned-source lookup limited to canary mode so normal claim flows stay unchanged
- respect the Boardroom list cap at 50 while still executing at most one todo

## Proof
- node --test scripts/pinballwake-autonomous-runner.test.mjs

## AFK impact
This lets the canary see the intentionally assigned docs-only seed instead of being blocked by the older unassigned backlog page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Boardroom todo the AFK execute canary can see and claim; scoped to canary mode but affects live scheduled automation behavior.
> 
> **Overview**
> For the **scheduled execute canary** only, queue hydration now pulls the runner’s **open assigned todos** via `list_todos` before the usual `list_actionable_todos` backlog, **dedupes by id**, and **sorts assigned-to-this-runner items first** so an intentionally assigned scoped seed can win over older unscoped urgent items on the same page.
> 
> Canary queue intake is capped at **50** (was 100) for both fetches; normal claim flows still use a single actionable list and unchanged limits. Hydration results expose **`assigned_queue_source`** metadata; tests assert the two-call canary path and seed import behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f3fe06fbdd51177fc827c1e7c37cbcdef920e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->