### PR TITLE
fix(autopilot): keep execute canary on assigned seed

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -244,6 +244,8 @@ jobs:
         env:
           CODING_ROOM_LEDGER_PATH: ${{ vars.CODING_ROOM_LEDGER_PATH || '.pinballwake/coding-room-ledger.json' }}
           CODING_ROOM_LEASE_SECONDS: ${{ vars.CODING_ROOM_LEASE_SECONDS || '1800' }}
+          AUTONOMOUS_RUNNER_ID: ${{ steps.runner-plan.outputs.canary_execute == 'true' && 'pinballwake-autonomous-runner' || vars.AUTONOMOUS_RUNNER_ID || '' }}
+          CODING_ROOM_RUNNER_AGENT_ID: ${{ steps.runner-plan.outputs.canary_execute == 'true' && 'pinballwake-autonomous-runner' || vars.CODING_ROOM_RUNNER_AGENT_ID || '' }}
           AUTONOMOUS_RUNNER_QUEUE_SOURCE: ${{ vars.AUTONOMOUS_RUNNER_QUEUE_SOURCE || 'unclick' }}
           AUTONOMOUS_RUNNER_WAKE_SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.wake_source || github.event_name == 'workflow_run' && 'queuepush' || github.event_name }}
           AUTONOMOUS_RUNNER_TODO_LIMIT: ${{ steps.runner-plan.outputs.todo_limit }}
@@ -251,6 +253,7 @@ jobs:
           AUTONOMOUS_RUNNER_DISABLED: ${{ steps.runner-plan.outputs.disabled }}
           AUTONOMOUS_RUNNER_ALLOW_EXECUTE: ${{ steps.runner-plan.outputs.execute }}
           AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: ${{ steps.runner-plan.outputs.execute }}
+          AUTONOMOUS_RUNNER_REQUIRE_ASSIGNED_QUEUE: ${{ steps.runner-plan.outputs.canary_execute == 'true' && 'true' || vars.AUTONOMOUS_RUNNER_REQUIRE_ASSIGNED_QUEUE || 'false' }}
           OPENHANDS_TEST_MODE: ${{ steps.runner-plan.outputs.execute == 'true' && '1' || '' }}
           OPENHANDS_COMMAND: ${{ vars.OPENHANDS_COMMAND || 'uvx' }}
           OPENHANDS_ARGS: ${{ vars.OPENHANDS_ARGS || '--python 3.12 openhands --headless --json --override-with-envs --task {prompt}' }}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6927,8 +6927,8 @@
     },
     {
       "source": ".github/workflows/autonomous-runner.yml",
-      "hash": "f0d32d805710",
-      "bytes": 14751
+      "hash": "d280b09dbb76",
+      "bytes": 15265
     },
     {
       "source": ".github/workflows/claude.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -92,7 +92,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/elevenlabs-tool.ts | efcaeeff39d6 | 10833 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
-| .github/workflows/autonomous-runner.yml | f0d32d805710 | 14751 |
+| .github/workflows/autonomous-runner.yml | d280b09dbb76 | 15265 |
 | .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
 | .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |
 | .github/workflows/dogfood-report.yml | d485b8d37111 | 3987 |

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -2272,6 +2272,7 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
   allowProtectedSurfaces = false,
   requireScopePack = false,
   includeAssignedTodos = false,
+  requireAssignedQueue = false,
 } = {}) {
   const agentId = runner.agent_id || runner.id || DEFAULT_AUTONOMOUS_RUNNER.id;
   const assignedFetched = includeAssignedTodos
@@ -2283,13 +2284,47 @@ export async function hydrateAutonomousRunnerLedgerFromUnClick({
         fetchImpl,
       })
     : { ok: true, todos: [], response_bounds: null, skipped: true, reason: "assigned_queue_source_disabled" };
-  const fetched = await fetchUnClickActionableTodos({
-    agentId,
-    apiKey,
-    mcpUrl,
-    limit,
-    fetchImpl,
-  });
+  if (includeAssignedTodos && requireAssignedQueue && !assignedFetched.ok) {
+    return {
+      ok: false,
+      reason: "assigned_queue_source_unavailable",
+      status: assignedFetched.status ?? null,
+      error: assignedFetched.error ?? null,
+      assigned_queue_source: assignedFetched,
+      ledger: createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now }),
+      imported: 0,
+      seen: 0,
+      claimability_scorecard: {
+        ...buildClaimabilityScorecard(),
+        state: "queue_unavailable",
+        healthy: false,
+      },
+    };
+  }
+  if (includeAssignedTodos && requireAssignedQueue && assignedFetched.todos.length === 0) {
+    return {
+      ok: false,
+      reason: "assigned_canary_seed_missing",
+      assigned_queue_source: { ok: true, seen: 0, response_bounds: assignedFetched.response_bounds },
+      ledger: createCodingRoomJobLedger({ jobs: ledger?.jobs || [], updatedAt: ledger?.updated_at || now }),
+      imported: 0,
+      seen: 0,
+      claimability_scorecard: {
+        ...buildClaimabilityScorecard(),
+        state: "blocked_no_claimable",
+        healthy: false,
+      },
+    };
+  }
+  const fetched = includeAssignedTodos && requireAssignedQueue
+    ? { ok: true, todos: [], response_bounds: null, skipped: true, reason: "assigned_queue_required" }
+    : await fetchUnClickActionableTodos({
+        agentId,
+        apiKey,
+        mcpUrl,
+        limit,
+        fetchImpl,
+      });
 
   if (!fetched.ok) {
     return {
@@ -2684,6 +2719,7 @@ export async function runAutonomousRunnerFile({
   worktreeCwd = process.cwd(),
   gitHygieneIgnoredPaths = [],
   openHandsExecutor = null,
+  requireAssignedQueue = false,
 } = {}) {
   if (orchestratorProof) {
     return runOrchestratorSeatHandshakeProof({
@@ -2790,6 +2826,7 @@ export async function runAutonomousRunnerFile({
         allowProtectedSurfaces: guardedPolicy.allowProtectedSurfaces,
         requireScopePack: guardedPolicy.requireScopePack,
         includeAssignedTodos: queueGuard.scheduled_execute_canary,
+        requireAssignedQueue: queueGuard.scheduled_execute_canary && requireAssignedQueue,
       })),
       queue_guard: queueGuard,
     };
@@ -2911,6 +2948,16 @@ export async function runAutonomousRunnerFile({
     }
   }
 
+  const openHandsExecuteHold =
+    safeMode === "execute" &&
+    safePolicy.allowExecute &&
+    todoClaimSync?.openhands_execute &&
+    !todoClaimSync.openhands_execute.ok;
+  if (openHandsExecuteHold) {
+    finalAction = "blocked";
+    finalReason = todoClaimSync.openhands_execute.reason || "openhands_execute_failed";
+  }
+
   if (shouldPersist && todoForScoping) {
     todoScopingSync = await syncBoardroomTodoScopingRequestToUnClick({
       todo: todoForScoping,
@@ -3012,7 +3059,12 @@ export async function runAutonomousRunnerFile({
 
   return {
     ...last,
-    ok: commonsensepass.verdict === "PASS" && results.every((result) => result.ok) && todoClaimSync.ok && todoScopingSync.ok,
+    ok:
+      commonsensepass.verdict === "PASS" &&
+      results.every((result) => result.ok) &&
+      todoClaimSync.ok &&
+      todoScopingSync.ok &&
+      !openHandsExecuteHold,
     action: finalAction,
     reason: finalReason,
     mode: safeMode,
@@ -3094,6 +3146,9 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
       getArg("skip-git-hygiene-preflight", process.env.AUTONOMOUS_RUNNER_SKIP_GIT_HYGIENE_PREFLIGHT),
     ),
     openHandsExecutor: createAutonomousRunnerOpenHandsExecutorFromEnv(process.env),
+    requireAssignedQueue: parseBoolean(
+      getArg("require-assigned-queue", process.env.AUTONOMOUS_RUNNER_REQUIRE_ASSIGNED_QUEUE),
+    ),
     policy: createAutonomousRunnerPolicy({
       disabled: parseBoolean(process.env.AUTONOMOUS_RUNNER_DISABLED),
       allowProtectedSurfaces: parseBoolean(process.env.AUTONOMOUS_RUNNER_ALLOW_PROTECTED_SURFACES),

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -766,6 +766,110 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-canary-seed");
   });
 
+  it("keeps the execute canary on the assigned seed queue when required", async () => {
+    const canaryRunner = createAutonomousRunner({
+      id: "pinballwake-autonomous-runner",
+      agentId: "pinballwake-autonomous-runner",
+      capabilities: ["docs_update", "test_fix"],
+    });
+    const calls = [];
+    const fetchImpl = async (_url, init = {}) => {
+      const body = JSON.parse(init.body || "{}");
+      calls.push({ tool: body?.params?.name, args: body?.params?.arguments || {} });
+      assert.equal(body?.params?.name, "list_todos");
+      return {
+        ok: true,
+        async json() {
+          return {
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    todos: [
+                      {
+                        id: "todo-canary-seed",
+                        title: "AFK canary seed: docs-only OpenHands proof fixture",
+                        status: "open",
+                        priority: "urgent",
+                        assigned_to_agent_id: "pinballwake-autonomous-runner",
+                        actionability_reason: "role_assigned_open",
+                        created_at: "2026-05-24T15:00:00.000Z",
+                        scope_pack: {
+                          owned_files: ["docs/openhands-proof-fixture.md"],
+                          tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+                          role: "docs_update",
+                        },
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          };
+        },
+      };
+    };
+
+    const result = await hydrateAutonomousRunnerLedgerFromUnClick({
+      ledger: createCodingRoomJobLedger(),
+      runner: canaryRunner,
+      apiKey: "uc_test",
+      mcpUrl: "https://unclick.test/api/mcp",
+      limit: 50,
+      fetchImpl,
+      wakeSource: "schedule",
+      allowedTodoRoles: ["docs_update", "test_fix"],
+      requireScopePack: true,
+      includeAssignedTodos: true,
+      requireAssignedQueue: true,
+      now: "2026-05-24T15:01:00.000Z",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].args.assigned_to_agent_id, "pinballwake-autonomous-runner");
+    assert.equal(result.imported, 1);
+    assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-canary-seed");
+  });
+
+  it("blocks the execute canary when the assigned seed queue is empty", async () => {
+    const canaryRunner = createAutonomousRunner({
+      id: "pinballwake-autonomous-runner",
+      agentId: "pinballwake-autonomous-runner",
+      capabilities: ["docs_update", "test_fix"],
+    });
+    const fetchImpl = async () => ({
+      ok: true,
+      async json() {
+        return {
+          result: {
+            content: [{ type: "text", text: JSON.stringify({ todos: [] }) }],
+          },
+        };
+      },
+    });
+
+    const result = await hydrateAutonomousRunnerLedgerFromUnClick({
+      ledger: createCodingRoomJobLedger(),
+      runner: canaryRunner,
+      apiKey: "uc_test",
+      mcpUrl: "https://unclick.test/api/mcp",
+      limit: 50,
+      fetchImpl,
+      wakeSource: "schedule",
+      allowedTodoRoles: ["docs_update", "test_fix"],
+      requireScopePack: true,
+      includeAssignedTodos: true,
+      requireAssignedQueue: true,
+      now: "2026-05-24T15:01:00.000Z",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "assigned_canary_seed_missing");
+    assert.equal(result.imported, 0);
+  });
+
   it("keeps watcher and tether runners off unassigned builder ScopePacks unless exactly assigned", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");
@@ -2880,8 +2984,11 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.match(workflow, /todo_limit="1"/);
     assert.match(workflow, /roles="docs_update,test_fix"/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_MODE:.*steps\.runner-plan\.outputs\.mode/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_ID:.*canary_execute.*pinballwake-autonomous-runner/);
+    assert.match(workflow, /CODING_ROOM_RUNNER_AGENT_ID:.*canary_execute.*pinballwake-autonomous-runner/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_ALLOW_EXECUTE:.*steps\.runner-plan\.outputs\.execute/);
     assert.match(workflow, /AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE:.*steps\.runner-plan\.outputs\.execute/);
+    assert.match(workflow, /AUTONOMOUS_RUNNER_REQUIRE_ASSIGNED_QUEUE:.*canary_execute.*true/);
     assert.match(workflow, /OPENHANDS_TEST_MODE:.*steps\.runner-plan\.outputs\.execute == 'true'.*'1'/);
     assert.match(workflow, /Set up uv for OpenHands execute/);
     assert.match(workflow, /uses:\s*astral-sh\/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b/);


### PR DESCRIPTION
## Summary
- keep scheduled execute canary under the `pinballwake-autonomous-runner` identity
- require the canary to hydrate only the assigned seed queue, so old backlog cannot be selected
- make OpenHands execute holds fail the runner result so the daily canary cap is not spent without a proof PR

## Proof / context
- AFK scheduled run `26366919296` fired from GitHub schedule, but selected Boardroom todo `d0aae03c-d43d-4b47-8564-e84e93ae047d` instead of assigned seed `8719dc4f-1650-4ea9-bca8-e92a9819f0ba`
- root cause: live workflow identity was still `pinballwake-job-runner`, so the assigned seed lookup missed and the generic backlog path stayed available

## Tests
- `node --test scripts/pinballwake-autonomous-runner.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous runner queue selection and execute success semantics for scheduled canaries; misconfiguration could block canaries or still affect production runner identity via env overrides.
> 
> **Overview**
> The scheduled **OpenHands execute canary** now runs as **`pinballwake-autonomous-runner`** and, when `canary_execute` is set, forces **`AUTONOMOUS_RUNNER_REQUIRE_ASSIGNED_QUEUE`** so hydration only uses **assigned** todos—skipping the generic actionable backlog and failing fast if the assigned queue is missing or empty.
> 
> In **`hydrateAutonomousRunnerLedgerFromUnClick`**, a new **`requireAssignedQueue`** path returns errors like `assigned_queue_source_unavailable` / `assigned_canary_seed_missing` and does not call **`list_actionable_todos`**. The main runner run treats a failed **`openhands_execute`** sync as a **blocked** outcome and sets **`ok: false`**, so a failed execute bridge does not count as a successful canary day (protecting the daily cap). Tests and generated brainmap docs were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2d378fafcb1d7d3d8e1ca3640e780b046c3d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->