### PR TITLE
fix(autopilot): hydrate assigned canary ScopePacks from comments

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -940,9 +940,69 @@ export async function fetchUnClickAssignedTodos({
   if (!result.ok) return result;
 
   const todos = Array.isArray(result.data?.todos) ? result.data.todos : [];
+  const enrichedTodos = [];
+  for (const todo of todos) {
+    const comments = await fetchUnClickTodoComments({
+      agentId,
+      todoId: todo.id,
+      mcpUrl,
+      apiKey,
+      fetchImpl,
+      limit: 10,
+    });
+    if (!comments.ok) {
+      return {
+        ok: false,
+        reason: "assigned_todo_comments_unavailable",
+        status: comments.status ?? null,
+        error: comments.error ?? comments.reason ?? null,
+        todo_id: todo.id || null,
+      };
+    }
+    const latestComment = comments.comments.at(-1);
+    enrichedTodos.push({
+      ...todo,
+      recent_comments: comments.comments,
+      latest_comment_text: todo.latest_comment_text || latestComment?.text || latestComment?.body || null,
+    });
+  }
   return {
     ok: true,
-    todos,
+    todos: enrichedTodos,
+    response_bounds: result.data?.response_bounds || null,
+  };
+}
+
+export async function fetchUnClickTodoComments({
+  agentId = DEFAULT_AUTONOMOUS_RUNNER.id,
+  todoId = "",
+  limit = 10,
+  mcpUrl = DEFAULT_UNCLICK_MCP_URL,
+  apiKey = "",
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (!todoId) {
+    return { ok: true, comments: [], response_bounds: null, skipped: true, reason: "missing_todo_id" };
+  }
+
+  const result = await callUnClickMcpTool({
+    mcpUrl,
+    apiKey,
+    fetchImpl,
+    toolName: "list_comments",
+    arguments: {
+      agent_id: agentId,
+      target_kind: "todo",
+      target_id: todoId,
+      limit,
+    },
+  });
+
+  if (!result.ok) return result;
+
+  return {
+    ok: true,
+    comments: Array.isArray(result.data?.comments) ? result.data.comments : [],
     response_bounds: result.data?.response_bounds || null,
   };
 }

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -691,6 +691,18 @@ describe("PinballWake autonomous Runner seat", () => {
     const fetchImpl = async (url, init = {}) => {
       const body = JSON.parse(init.body || "{}");
       calls.push({ url, init, tool: body?.params?.name, args: body?.params?.arguments || {} });
+      if (body?.params?.name === "list_comments") {
+        return {
+          ok: true,
+          async json() {
+            return {
+              result: {
+                content: [{ type: "text", text: JSON.stringify({ comments: [] }) }],
+              },
+            };
+          },
+        };
+      }
       const isAssigned = body?.params?.name === "list_todos";
       return {
         ok: true,
@@ -753,12 +765,14 @@ describe("PinballWake autonomous Runner seat", () => {
     });
 
     assert.equal(result.ok, true);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 3);
     assert.equal(calls[0].tool, "list_todos");
     assert.equal(calls[0].args.assigned_to_agent_id, "pinballwake-autonomous-runner");
     assert.equal(calls[0].args.limit, 50);
-    assert.equal(calls[1].tool, "list_actionable_todos");
-    assert.equal(calls[1].args.limit, 50);
+    assert.equal(calls[1].tool, "list_comments");
+    assert.equal(calls[1].args.target_id, "todo-canary-seed");
+    assert.equal(calls[2].tool, "list_actionable_todos");
+    assert.equal(calls[2].args.limit, 50);
     assert.equal(result.assigned_queue_source.seen, 1);
     assert.equal(result.skipped[0].id, "todo-old-unscoped");
     assert.equal(result.skipped[0].reason, "boardroom_todo_missing_scopepack");
@@ -776,6 +790,39 @@ describe("PinballWake autonomous Runner seat", () => {
     const fetchImpl = async (_url, init = {}) => {
       const body = JSON.parse(init.body || "{}");
       calls.push({ tool: body?.params?.name, args: body?.params?.arguments || {} });
+      if (body?.params?.name === "list_comments") {
+        return {
+          ok: true,
+          async json() {
+            return {
+              result: {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      comments: [
+                        {
+                          id: "comment-canary-scopepack",
+                          text: [
+                            "ScopePack:",
+                            "```json",
+                            JSON.stringify({
+                              owned_files: ["docs/openhands-proof-fixture.md"],
+                              tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+                              role: "docs_update",
+                            }),
+                            "```",
+                          ].join("\n"),
+                        },
+                      ],
+                    }),
+                  },
+                ],
+              },
+            };
+          },
+        };
+      }
       assert.equal(body?.params?.name, "list_todos");
       return {
         ok: true,
@@ -795,11 +842,6 @@ describe("PinballWake autonomous Runner seat", () => {
                         assigned_to_agent_id: "pinballwake-autonomous-runner",
                         actionability_reason: "role_assigned_open",
                         created_at: "2026-05-24T15:00:00.000Z",
-                        scope_pack: {
-                          owned_files: ["docs/openhands-proof-fixture.md"],
-                          tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
-                          role: "docs_update",
-                        },
                       },
                     ],
                   }),
@@ -827,8 +869,10 @@ describe("PinballWake autonomous Runner seat", () => {
     });
 
     assert.equal(result.ok, true);
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.equal(calls[0].args.assigned_to_agent_id, "pinballwake-autonomous-runner");
+    assert.equal(calls[1].tool, "list_comments");
+    assert.equal(calls[1].args.target_id, "todo-canary-seed");
     assert.equal(result.imported, 1);
     assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-canary-seed");
   });


### PR DESCRIPTION
## Summary
- hydrate comments for assigned Boardroom todos before canary eligibility
- let assigned canary seeds carry ScopePacks in comments when `list_todos` returns compact rows
- keep failure closed if assigned comments cannot be fetched

## Proof / context
- scheduled run `26368291535` fired after PR #1033 and used main `e836d25d34fce856912648e1a5f2856d8358c18a`
- it saw the assigned seed `8719dc4f-1650-4ea9-bca8-e92a9819f0ba`, but skipped it with `boardroom_todo_missing_scopepack` because assigned `list_todos` did not include description/comments/scope_pack
- daily cap was not saved, and the canary flag has been turned off

## Tests
- `node --test scripts/pinballwake-autonomous-runner.test.mjs`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduled execute-canary queue intake and adds per-todo MCP calls; misconfiguration or comment API failures can block the canary entirely via the new fail-closed path.
> 
> **Overview**
> **Assigned Boardroom todos are now hydrated with comments** before the scheduled execute canary evaluates ScopePack eligibility. After `list_todos`, the runner calls `list_comments` per assigned todo and attaches `recent_comments` / `latest_comment_text` so ScopePacks embedded only in comments (when `list_todos` returns compact rows) still parse via existing text extraction.
> 
> **Failure is closed:** if comments cannot be fetched for an assigned todo, hydration aborts with `assigned_todo_comments_unavailable` instead of proceeding without comment context.
> 
> Tests mock `list_comments` and assert the canary seed can import from comment-only ScopePacks when `requireAssignedQueue` is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18629b379850d20875cd22425eff25ac69493af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->