### PR TITLE
fix(wakepass): hydrate assigned canary comments

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -41,6 +41,7 @@ export const DEFAULT_AUTONOMOUS_RUNNER_POLICY = {
 };
 
 export const DEFAULT_UNCLICK_MCP_URL = "https://unclick.world/api/mcp";
+export const UNCLICK_TODO_COMMENT_HYDRATION_LIMIT = 50;
 
 const HOLD_TITLE_PATTERN = /\b(hold|blocker|blocked)\b/i;
 const HOLD_TITLE_MARKER_PATTERN = /^\s*(hold|blocker|blocked|dirty)\s*:/i;
@@ -948,7 +949,7 @@ export async function fetchUnClickAssignedTodos({
       mcpUrl,
       apiKey,
       fetchImpl,
-      limit: 10,
+      limit: UNCLICK_TODO_COMMENT_HYDRATION_LIMIT,
     });
     if (!comments.ok) {
       return {
@@ -959,7 +960,10 @@ export async function fetchUnClickAssignedTodos({
         todo_id: todo.id || null,
       };
     }
-    const latestComment = comments.comments.at(-1);
+    const latestComment = comments.comments
+      .filter(Boolean)
+      .sort((a, b) => String(a.created_at || "").localeCompare(String(b.created_at || "")))
+      .at(-1);
     enrichedTodos.push({
       ...todo,
       recent_comments: comments.comments,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -791,6 +791,26 @@ describe("PinballWake autonomous Runner seat", () => {
       const body = JSON.parse(init.body || "{}");
       calls.push({ tool: body?.params?.name, args: body?.params?.arguments || {} });
       if (body?.params?.name === "list_comments") {
+        const comments = Array.from({ length: 11 }, (_, index) => ({
+          id: `old-comment-${index}`,
+          created_at: `2026-05-24T15:${String(index).padStart(2, "0")}:00.000Z`,
+          text: "Earlier non-ScopePack comment.",
+        }));
+        comments.push({
+          id: "comment-canary-scopepack",
+          created_at: "2026-05-24T18:20:07.608Z",
+          text: [
+            "ScopePack:",
+            "```json",
+            JSON.stringify({
+              owned_files: ["docs/openhands-proof-fixture.md"],
+              tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+              role: "docs_update",
+            }),
+            "```",
+          ].join("\n"),
+        });
+        const requestedLimit = Number(body?.params?.arguments?.limit || 10);
         return {
           ok: true,
           async json() {
@@ -800,21 +820,7 @@ describe("PinballWake autonomous Runner seat", () => {
                   {
                     type: "text",
                     text: JSON.stringify({
-                      comments: [
-                        {
-                          id: "comment-canary-scopepack",
-                          text: [
-                            "ScopePack:",
-                            "```json",
-                            JSON.stringify({
-                              owned_files: ["docs/openhands-proof-fixture.md"],
-                              tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
-                              role: "docs_update",
-                            }),
-                            "```",
-                          ].join("\n"),
-                        },
-                      ],
+                      comments: comments.slice(0, requestedLimit),
                     }),
                   },
                 ],
@@ -873,6 +879,7 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(calls[0].args.assigned_to_agent_id, "pinballwake-autonomous-runner");
     assert.equal(calls[1].tool, "list_comments");
     assert.equal(calls[1].args.target_id, "todo-canary-seed");
+    assert.equal(calls[1].args.limit, 50);
     assert.equal(result.imported, 1);
     assert.equal(result.ledger.jobs[0].job_id, "boardroom-todo:todo-canary-seed");
   });


### PR DESCRIPTION
Summary: Increases assigned PinballWake todo comment hydration so scheduled execute canaries can see later ScopePack comments before eligibility checks. The latest comment is selected by created_at instead of assuming the returned order is enough.

Scope: scripts/pinballwake-autonomous-runner.mjs and scripts/pinballwake-autonomous-runner.test.mjs for the AFK canary 8719dc4f comment-hydration path.

Non-overlap: No workflow schedule changes, no secrets, no environment toggles, no production data changes, no merge or DONE state changes.

Verification: node --test scripts/pinballwake-autonomous-runner.test.mjs; git diff --check.

Risk: Low. It increases a read-only comment fetch limit from 10 to 50 for assigned todos and keeps fail-closed behavior when comments are unavailable.

Follow-up: After review or merge, wait for the scheduled PinballWake run to prove the docs-only canary with an App-identity PR and checks.

Owned scope: PinballWake autonomous runner assigned-todo comment hydration. Draft PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only MCP comment limit increase and safer latest-comment selection; existing fail-closed behavior when comments are unavailable is unchanged.
> 
> **Overview**
> **Assigned PinballWake todos** now pull up to **50** UnClick comments (via `UNCLICK_TODO_COMMENT_HYDRATION_LIMIT`) instead of 10 when hydrating the execute canary queue, so late **ScopePack** comments are less likely to be truncated before eligibility checks.
> 
> **Latest comment text** for each assigned todo is chosen by sorting comments on `created_at` and taking the newest, rather than assuming API return order matches chronology.
> 
> Tests cover the case where a ScopePack comment is newest but would fall outside a limit-10 fetch, and assert `list_comments` is called with **limit 50**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fccc8308ab7f18b8c7456967247bf351f4124b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->