### PR TITLE
fix(wakepass): allow same-runner canary claim sync

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1250,7 +1250,7 @@ function boardroomClaimAgentId(runner = {}) {
   return safeRunner.agent_id || safeRunner.id || DEFAULT_AUTONOMOUS_RUNNER.id;
 }
 
-function validateBoardroomClaimSourceState(job = {}) {
+function validateBoardroomClaimSourceState(job = {}, { agentId = "" } = {}) {
   const state = job?.source_state || {};
   if (!state || typeof state !== "object") {
     return { ok: false, reason: "missing_boardroom_claim_source_state" };
@@ -1262,7 +1262,8 @@ function validateBoardroomClaimSourceState(job = {}) {
   }
 
   const sourceAssignee = String(state.assigned_to_agent_id || "").trim();
-  if (sourceAssignee) {
+  const runnerAgentId = String(agentId || "").trim();
+  if (sourceAssignee && sourceAssignee !== runnerAgentId) {
     return {
       ok: false,
       reason: "boardroom_todo_already_assigned",
@@ -1301,7 +1302,7 @@ export async function syncClaimedBoardroomTodoToUnClick({
   }
 
   const agentId = boardroomClaimAgentId(runner);
-  const sourceState = validateBoardroomClaimSourceState(job);
+  const sourceState = validateBoardroomClaimSourceState(job, { agentId });
   if (!sourceState.ok) {
     return {
       ok: false,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1731,7 +1731,7 @@ describe("PinballWake autonomous Runner seat", () => {
                             title: "OpenHands execute bridge proof",
                             status: "open",
                             priority: "high",
-                            assigned_to_agent_id: null,
+                            assigned_to_agent_id: "runner-plex-1",
                             created_at: "2026-05-08T05:00:00.000Z",
                             scope_pack: {
                               owned_files: ["docs/runner-scope.md"],


### PR DESCRIPTION
## Summary
- Treat a Boardroom todo already assigned to the same runner as an idempotent claim-source state instead of a mismatch.
- Preserve the existing block when the todo is assigned to a different runner.
- Covers the AFK canary failure in scheduled run 26371604086, where seed 8719dc4f was already assigned to pinballwake-autonomous-runner and therefore stopped before OpenHands/PR.

## Verification
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run brainmap:check
- git diff --check

## AFK canary note
Do not re-arm until this PR merges, no stale daily cap exists, and Boardroom seed 8719dc4f is re-verified open/assigned with ScopePack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard change in autonomous runner claim validation with a targeted test update; no auth, billing, or broad API surface changes.
> 
> **Overview**
> **Boardroom claim sync** no longer treats “already assigned” as a hard failure when the assignee is the **same runner** that is claiming. `validateBoardroomClaimSourceState` now takes the claiming `agentId` and only returns `boardroom_todo_already_assigned` when `assigned_to_agent_id` is set to a **different** agent; a match is allowed so scheduled execute/canary paths can proceed (e.g. seed already on `pinballwake-autonomous-runner`).
> 
> The execute-bridge test was updated so the fixture todo is pre-assigned to `runner-plex-1`, matching that idempotent case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec0fda976a869ab9d1fae990c1380d175466a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->