### PR TITLE
fix(autopilot): harden AFK canary execution proof

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1790,6 +1790,7 @@ function createQuietWindowAutonomyProofReceipt({
   finalReason = "",
   commonsensepass = {},
   testOnlyExecutorPacket = null,
+  openHandsExecute = null,
 } = {}) {
   const triggerSource = normalizeQuietWindowToken(wakeSource || "unknown");
   const imported = numberOption(queueSourceResult.imported, 0);
@@ -1834,6 +1835,22 @@ function createQuietWindowAutonomyProofReceipt({
       at: now,
       packet_id: testOnlyExecutorPacket.packet.packet_id || null,
       receipt_type: testOnlyExecutorPacket.receipt?.receipt_type || null,
+    });
+  }
+
+  if (openHandsExecute?.receipt) {
+    events.push({
+      rung: "execution_packet",
+      at: now,
+      packet_id: openHandsExecute.receipt.job_id || claimedResult?.job?.job_id || null,
+      receipt_type: openHandsExecute.receipt.receipt_type || null,
+    });
+    events.push({
+      rung: "build_attempt",
+      at: now,
+      reason: openHandsExecute.reason || openHandsExecute.receipt.hold_reason || null,
+      receipt_type: openHandsExecute.receipt.receipt_type || null,
+      ok: Boolean(openHandsExecute.ok),
     });
   }
 
@@ -3110,6 +3127,7 @@ export async function runAutonomousRunnerFile({
     finalReason,
     commonsensepass,
     testOnlyExecutorPacket: todoClaimSync.test_only_executor_packet || todoScopingSync.test_only_executor_packet,
+    openHandsExecute: todoClaimSync.openhands_execute,
   });
   claimabilityScorecard = {
     ...claimabilityScorecard,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1828,6 +1828,112 @@ describe("PinballWake autonomous Runner seat", () => {
     }
   });
 
+  it("records OpenHands execute holds as execution packets in quiet-window proof", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
+    const ledgerPath = join(dir, "ledger.json");
+    try {
+      await writeCodingRoomJobLedger(ledgerPath, createCodingRoomJobLedger());
+
+      const calls = [];
+      const fetchImpl = async (_url, init = {}) => {
+        calls.push({ body: JSON.parse(init.body) });
+        const toolName = calls.at(-1).body.params.name;
+        if (toolName === "list_actionable_todos") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        todos: [
+                          {
+                            id: "todo-execute-hold-1",
+                            title: "OpenHands execute packet proof",
+                            status: "open",
+                            priority: "high",
+                            assigned_to_agent_id: "runner-plex-1",
+                            created_at: "2026-05-08T05:00:00.000Z",
+                            scope_pack: {
+                              owned_files: ["docs/runner-scope.md"],
+                              acceptance: ["Execute bridge records OpenHands packet proof"],
+                              verification: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+                            },
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        if (toolName === "comment_on") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({ comment: { id: "comment-execute-hold-1" } }),
+                    },
+                  ],
+                },
+              };
+            },
+          };
+        }
+
+        throw new Error(`unexpected tool ${toolName}`);
+      };
+
+      const result = await runAutonomousRunnerFile({
+        ledgerPath,
+        runner,
+        mode: "execute",
+        policy: { allowExecute: true },
+        queueSource: "unclick",
+        unclickApiKey: "uc_test",
+        unclickMcpUrl: "https://unclick.test/api/mcp",
+        fetchImpl,
+        now: "2026-05-08T05:30:00.000Z",
+        wakeSource: "schedule",
+        openHandsExecutor: {
+          enabled: true,
+          env: { OPENHANDS_TEST_MODE: "1" },
+          testMode: true,
+          openHands: async () => ({
+            ok: false,
+            exit_code: 0,
+            output: "OpenHands completed without a unified diff.",
+          }),
+        },
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.action, "blocked");
+      assert.equal(result.reason, "openhands_reported_failure");
+      assert.equal(result.todo_claim_sync.reason, "openhands_build_hold_recorded");
+      assert.match(calls[1].body.params.arguments.text, /OpenHands build attempt HOLD/);
+      assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "proof_packet");
+      assert.deepEqual(result.quiet_window_autonomy_proof.evidence.observed_rungs, [
+        "tick",
+        "buildbait_crumb",
+        "claim_or_lease",
+        "execution_packet",
+        "build_attempt_or_commonsense_blocker",
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("wires explicitly enabled OpenHands execute to the safe CodeRoom submitter", () => {
     const executor = createAutonomousRunnerOpenHandsExecutorFromEnv({
       AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: "true",

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -196,6 +196,7 @@ export function buildOpenHandsTaskPrompt({ job = {}, scopePack = {} } = {}) {
   const ownedFiles = normalizeChangedFiles(scopePack.owned_files || job.owned_files || []);
   const acceptance = normalizeList(scopePack.acceptance || job.acceptance || job.expected_proof?.tests);
   const verification = normalizeList(scopePack.verification || scopePack.tests || []);
+  const fixtureDiffHint = buildFixtureDiffHint({ job, ownedFiles });
   const lines = [
     "You are OpenHands running in UnClick test mode.",
     "Return a unified diff patch only. Do not commit, push, merge, deploy, or touch secrets.",
@@ -218,7 +219,39 @@ export function buildOpenHandsTaskPrompt({ job = {}, scopePack = {} } = {}) {
     lines.push(compact(scopePack.body || scopePack.description, 4000));
   }
 
+  if (fixtureDiffHint) {
+    lines.push("Canary fixture diff:");
+    lines.push("For this fixture task, return this unified diff shape and nothing else:");
+    lines.push(fixtureDiffHint);
+  }
+
   return lines.join("\n");
+}
+
+function buildFixtureDiffHint({ job = {}, ownedFiles = [] } = {}) {
+  const fixtureFile = ownedFiles.find((file) => file === "docs/openhands-proof-fixture.md");
+  if (!fixtureFile) return "";
+
+  const proofId = compact(
+    job.claim_id ||
+      job.claimId ||
+      job.todo_id ||
+      job.id ||
+      job.job_id ||
+      "openhands-afk-canary",
+    160,
+  );
+  return [
+    `diff --git a/${fixtureFile} b/${fixtureFile}`,
+    `--- a/${fixtureFile}`,
+    `+++ b/${fixtureFile}`,
+    "@@ -3,4 +3,5 @@",
+    " This fixture exists so the autopilot can prove a docs-only patch path without",
+    " touching product code, production data, secrets, billing, DNS, or deploys.",
+    "",
+    " <!-- openhands-proof-lines -->",
+    `+- proof run: ${proofId}`,
+  ].join("\n");
 }
 
 export function isOpenHandsTestMode({ env = process.env, testMode = false } = {}) {

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -49,6 +49,25 @@ describe("buildOpenHandsTaskPrompt", () => {
     assert.match(prompt, /docs\/openhands-integration\.md/);
     assert.match(prompt, /node --test scripts\/pinballwake-openhands-worker\.test\.mjs/);
   });
+
+  test("includes an exact docs fixture diff shape for the AFK canary seed", () => {
+    const prompt = buildOpenHandsTaskPrompt({
+      job: job({
+        todo_id: "8719dc4f-1650-4ea9-bca8-e92a9819f0ba",
+        claim_id: "coding-room-claim:unit-test",
+        title: "AFK canary seed: docs-only OpenHands proof fixture",
+        owned_files: ["docs/openhands-proof-fixture.md"],
+      }),
+      scopePack: scopePack({
+        owned_files: ["docs/openhands-proof-fixture.md"],
+        verification: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+      }),
+    });
+
+    assert.match(prompt, /Canary fixture diff:/);
+    assert.match(prompt, /diff --git a\/docs\/openhands-proof-fixture\.md b\/docs\/openhands-proof-fixture\.md/);
+    assert.match(prompt, /\+- proof run: coding-room-claim:unit-test/);
+  });
 });
 
 describe("runOpenHandsWorker", () => {


### PR DESCRIPTION
## Summary
- teaches the AFK docs fixture prompt to include an exact scoped unified diff shape for docs/openhands-proof-fixture.md
- records OpenHands execute attempts as quiet-window execution packets so future holds point at the real build/proof rung instead of missing execution_packet
- preserves the failure path: a failed OpenHands attempt still blocks and does not close the Boardroom todo

## Proof
- node --test scripts/pinballwake-openhands-worker.test.mjs
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run brainmap:check
- git diff --check

## AFK canary context
Repair for scheduled run 26372945690, which reached seed 8719dc4f but failed before an App-identity PR with openhands_reported_failure and quiet_window_missing_execution_packet.

Do not re-arm the canary until this PR merges and the seed/daily-cap state is re-verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test-mode OpenHands prompts, quiet-window proof telemetry, and runner tests—no auth, billing, or production execution paths.
> 
> **Overview**
> Hardens the **AFK docs canary** so scheduled OpenHands runs leave a complete quiet-window proof ladder instead of failing with a missing `execution_packet` rung.
> 
> **OpenHands worker prompts** for `docs/openhands-proof-fixture.md` now include a **canary fixture diff** block: an exact scoped unified-diff shape keyed off claim/todo id so test-mode runs can return a predictable docs-only patch.
> 
> **Autonomous runner** `createQuietWindowAutonomyProofReceipt` ingests `todoClaimSync.openhands_execute` and records **`execution_packet`** plus **`build_attempt`** (pass or hold). Failed OpenHands execute still **blocks** the run and does not close the Boardroom todo; holds advance proof to the next missing rung (e.g. `proof_packet`) rather than stopping at `execution_packet`.
> 
> New unit coverage asserts the hold path and fixture prompt shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9be44458503e9deaf16bb6d480c67b51b2d65e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->