### PR TITLE
fix(autopilot): record openhands proof packets

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1839,6 +1839,7 @@ function createQuietWindowAutonomyProofReceipt({
   }
 
   if (openHandsExecute?.receipt) {
+    const evidence = openHandsExecute.receipt.evidence || {};
     events.push({
       rung: "execution_packet",
       at: now,
@@ -1852,6 +1853,22 @@ function createQuietWindowAutonomyProofReceipt({
       receipt_type: openHandsExecute.receipt.receipt_type || null,
       ok: Boolean(openHandsExecute.ok),
     });
+    if (openHandsExecute.ok && (evidence.pr_url || evidence.head_sha_after || evidence.changed_files?.length)) {
+      events.push({
+        rung: "proof_packet",
+        at: now,
+        pr_url: evidence.pr_url || null,
+        head_sha_after: evidence.head_sha_after || null,
+        changed_files: evidence.changed_files || [],
+        receipt_type: openHandsExecute.receipt.receipt_type || null,
+      });
+      events.push({
+        rung: "terminal_receipt",
+        at: now,
+        status: evidence.coderoom_status || "openhands_build_attempt_recorded",
+        receipt_type: openHandsExecute.receipt.receipt_type || null,
+      });
+    }
   }
 
   if (blockedResult || commonsensepass.verdict !== "PASS") {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1823,6 +1823,16 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.todo_claim_sync.reason, "openhands_build_attempt_recorded");
       assert.equal(result.todo_claim_sync.openhands_execute.receipt.receipt_type, "openhands_worker_pass");
       assert.equal(result.todo_claim_sync.openhands_execute.receipt.evidence.pr_url, "https://github.com/malamutemayhem/unclick/pull/920");
+      assert.equal(result.quiet_window_autonomy_proof.verdict, "PASS");
+      assert.deepEqual(result.quiet_window_autonomy_proof.evidence.observed_rungs, [
+        "tick",
+        "buildbait_crumb",
+        "claim_or_lease",
+        "execution_packet",
+        "build_attempt_or_commonsense_blocker",
+        "proof_packet",
+        "terminal_receipt",
+      ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -240,6 +240,7 @@ export function createOpenHandsCliRunner({
     if (!result.ok) {
       return {
         ok: false,
+        reason: "openhands_cli_failed",
         exit_code: result.exit_code,
         output: result.output,
       };

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -113,6 +113,31 @@ describe("OpenHands proof runner helpers", () => {
     assert.deepEqual(calls[0][1], ["--headless", "--json", "--override-with-envs", "--task", "Patch a docs file"]);
   });
 
+  test("returns a specific reason when the OpenHands CLI exits before a patch", async () => {
+    const runner = createOpenHandsCliRunner({
+      env: {
+        OPENHANDS_ARGS: "--headless --json --override-with-envs --task {prompt}",
+        LLM_API_KEY: "secret",
+        LLM_MODEL: "openai/gpt-5",
+      },
+      runProcess: async () => ({
+        ok: false,
+        exit_code: 1,
+        output: "OpenHands exited before producing a trusted unified diff.",
+      }),
+    });
+
+    const result = await runner({
+      prompt: "Patch a docs file",
+      scopePack: { owned_files: [FIXTURE] },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_cli_failed");
+    assert.equal(result.exit_code, 1);
+    assert.match(result.output, /trusted unified diff/);
+  });
+
   test("runs fixture OpenHands through the worker and coderoom", async () => {
     let coderoomCalls = 0;
     const result = await runOpenHandsProof({

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -100,7 +100,7 @@ export async function runOpenHandsWorker({
       job: normalizedJob,
       executorSeatId,
       now: safeNow,
-      reason: "openhands_reported_failure",
+      reason: result?.reason || "openhands_reported_failure",
       evidence: {
         exit_code: result?.exit_code ?? null,
         output: clipOutput(result?.output, 2000),

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -166,6 +166,26 @@ describe("runOpenHandsWorker", () => {
     assert.match(result.receipt.evidence.output, /tests failed/);
   });
 
+  test("preserves a specific OpenHands runner failure reason", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({
+        ok: false,
+        reason: "openhands_cli_failed",
+        exit_code: 1,
+        output: "OpenHands exited before producing a patch.",
+      }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_cli_failed");
+    assert.equal(result.receipt.hold_reason, "openhands_cli_failed");
+    assert.match(result.receipt.evidence.output, /before producing a patch/);
+  });
+
   test("keeps the tail of long OpenHands failure output", async () => {
     const output = `${"installing dependency\n".repeat(400)}FINAL ERROR: missing model config`;
     const result = await runOpenHandsWorker({


### PR DESCRIPTION
## Summary
- records a trusted quiet-window proof_packet and terminal_receipt when OpenHands produces a valid CodeRoom PR/proof receipt
- preserves specific OpenHands CLI failure reasons instead of flattening them into openhands_reported_failure
- adds focused tests for successful proof packets and CLI failure classification

## Root cause
The post-#1037 scheduled canary reached the correct seed and recorded execution/build-attempt proof, but the quiet-window ladder still had no trusted proof_packet rung. Separately, CLI exits before patch production were flattened into a generic OpenHands failure, making the next repair signal less actionable.

## Validation
- node --test scripts/pinballwake-openhands-worker.test.mjs
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run brainmap:check
- git diff --check

## Safety
No canary re-arm. No workflow, ruleset, secrets, billing, DNS, production data, or broad refactor changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Autopilot proof-event and hold-reason plumbing only; no auth, secrets, or production workflow changes.
> 
> **Overview**
> Fixes the **quiet-window autonomy ladder** so a successful OpenHands → CodeRoom path records **`proof_packet`** and **`terminal_receipt`** rungs (PR URL, head SHA, changed files) instead of stopping after execution/build-attempt only.
> 
> **OpenHands failure reasons** are threaded through the stack: the proof runner sets **`openhands_cli_failed`** when the CLI exits before a patch; the worker keeps that reason on holds instead of collapsing everything to **`openhands_reported_failure`**.
> 
> Tests cover the full observed-rungs PASS case and CLI-specific failure classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 695d0f5f5e1b4e5f584605a623baf02dd01e16c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->