### PR TITLE
fix(autopilot): name OpenHands no-diff holds

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -248,8 +248,23 @@ export function createOpenHandsCliRunner({
 
     const patchFile = String(env.OPENHANDS_PATCH_FILE || "").trim();
     const patch = patchFile ? await readPatchFile(patchFile, "utf8") : extractUnifiedDiff(result.output);
+    if (!String(patch || "").trim()) {
+      return {
+        ok: false,
+        reason: "openhands_missing_unified_diff",
+        exit_code: result.exit_code,
+        output: compactOutput(
+          [
+            "OpenHands CLI completed without a trusted unified diff.",
+            "Expected output must include a diff --git patch for the owned docs fixture.",
+            result.output,
+          ].join("\n"),
+        ),
+      };
+    }
+
     return {
-      ok: Boolean(String(patch || "").trim()),
+      ok: true,
       patch,
       changed_files: scopePack?.owned_files || [],
       summary: "OpenHands CLI produced a test-mode patch.",

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -138,6 +138,32 @@ describe("OpenHands proof runner helpers", () => {
     assert.match(result.output, /trusted unified diff/);
   });
 
+  test("returns a specific reason when OpenHands completes without a trusted patch", async () => {
+    const runner = createOpenHandsCliRunner({
+      env: {
+        OPENHANDS_ARGS: "--headless --json --override-with-envs --task {prompt}",
+        LLM_API_KEY: "secret",
+        LLM_MODEL: "openai/gpt-5",
+      },
+      runProcess: async () => ({
+        ok: true,
+        exit_code: 0,
+        output: "OpenHands finished without a patch block.",
+      }),
+    });
+
+    const result = await runner({
+      prompt: "Patch a docs file",
+      scopePack: { owned_files: [FIXTURE] },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_missing_unified_diff");
+    assert.equal(result.exit_code, 0);
+    assert.match(result.output, /completed without a trusted unified diff/);
+    assert.match(result.output, /diff --git patch/);
+  });
+
   test("runs fixture OpenHands through the worker and coderoom", async () => {
     let coderoomCalls = 0;
     const result = await runOpenHandsProof({


### PR DESCRIPTION
## Summary
- Name successful OpenHands CLI exits with no trusted unified diff as `openhands_missing_unified_diff` instead of falling through to a generic worker hold.
- Keep the existing `openhands_cli_failed` path for non-zero CLI exits.
- Add a focused regression test for the no-diff completion path.

## Proof
- `node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-autonomous-runner.test.mjs` (88/88)
- `npm run brainmap:check`
- `git diff --check`

## AFK canary gate
- Canary remains OFF after failed scheduled run 26375795620.
- No manual workflow dispatch.
- Re-arm only after this repair merges, no daily cap cache is present, and seed 8719dc4f remains open/assigned with ScopePack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-mode proof runner behavior and hold reason strings only; no auth, deploy, or production paths touched.
> 
> **Overview**
> When the OpenHands CLI exits successfully but no trusted unified diff is found in output (or patch file), the proof runner now **fails explicitly** with reason `openhands_missing_unified_diff` and a compact message that calls out the missing `diff --git` patch, instead of returning a vague non-success from `ok: Boolean(patch)`.
> 
> Non-zero CLI failures still use `openhands_cli_failed`. A regression test covers the exit-code-0, no-patch path so autopilot holds can be named distinctly from CLI failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5cd4a283ea438b79f548657be46e24970d4a9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->