### PR TITLE
fix(autopilot): capture OpenHands owned worktree diffs

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -50,6 +50,12 @@ function normalizePath(value) {
     .trim();
 }
 
+function normalizeList(values) {
+  if (Array.isArray(values)) return values.map((value) => String(value ?? "").trim()).filter(Boolean);
+  if (values === undefined || values === null || values === "") return [];
+  return [String(values).trim()].filter(Boolean);
+}
+
 function safeStamp(value = new Date()) {
   return String(value instanceof Date ? value.toISOString() : value)
     .replace(/[^0-9A-Za-z._:-]/g, "-")
@@ -247,7 +253,29 @@ export function createOpenHandsCliRunner({
     }
 
     const patchFile = String(env.OPENHANDS_PATCH_FILE || "").trim();
-    const patch = patchFile ? await readPatchFile(patchFile, "utf8") : extractUnifiedDiff(result.output);
+    const outputPatch = patchFile ? await readPatchFile(patchFile, "utf8") : extractUnifiedDiff(result.output);
+    const worktreeCapture = await captureOwnedWorktreeDiff({
+      cwd,
+      env,
+      ownedFiles: scopePack?.owned_files || [],
+      runProcess,
+    });
+    if (!worktreeCapture.ok) {
+      return {
+        ok: false,
+        reason: worktreeCapture.reason,
+        exit_code: result.exit_code,
+        output: compactOutput(
+          [
+            "OpenHands left an unsafe or unrestorable worktree diff.",
+            worktreeCapture.output || "",
+            result.output || "",
+          ].join("\n"),
+        ),
+      };
+    }
+
+    const patch = outputPatch || worktreeCapture.patch;
     if (!String(patch || "").trim()) {
       return {
         ok: false,
@@ -266,8 +294,10 @@ export function createOpenHandsCliRunner({
     return {
       ok: true,
       patch,
-      changed_files: scopePack?.owned_files || [],
-      summary: "OpenHands CLI produced a test-mode patch.",
+      changed_files: worktreeCapture.changed_files?.length ? worktreeCapture.changed_files : scopePack?.owned_files || [],
+      summary: outputPatch
+        ? "OpenHands CLI produced a test-mode patch."
+        : "OpenHands CLI applied an owned-file patch captured from git diff.",
       test_run_id: result.run_id || "openhands-cli",
       test_exit_code: result.exit_code,
       output: result.output,
@@ -643,6 +673,61 @@ export async function runProcessCommand(command, args = [], options = {}) {
     }
     child.stdin.end();
   });
+}
+
+export async function captureOwnedWorktreeDiff({
+  cwd = process.cwd(),
+  env = process.env,
+  ownedFiles = [],
+  runProcess = runProcessCommand,
+} = {}) {
+  const owned = [...new Set((ownedFiles || []).map(normalizePath).filter(Boolean))];
+  if (owned.length === 0) return { ok: true, patch: "", changed_files: [] };
+
+  const changed = await runProcess("git", ["diff", "--name-only", "--"], { cwd, env });
+  if (!changed.ok) {
+    return { ok: false, reason: "git_diff_name_only_failed", output: changed.output };
+  }
+
+  const changedFiles = normalizeList(changed.stdout)
+    .flatMap((text) => text.split(/\r?\n/))
+    .map(normalizePath)
+    .filter(Boolean);
+  if (changedFiles.length === 0) return { ok: true, patch: "", changed_files: [] };
+
+  const ownedSet = new Set(owned);
+  const outside = changedFiles.filter((file) => !ownedSet.has(file));
+  if (outside.length) {
+    return {
+      ok: false,
+      reason: "openhands_unowned_worktree_diff",
+      output: `Changed files outside ownership: ${outside.join(", ")}`,
+      changed_files: changedFiles,
+      outside_files: outside,
+    };
+  }
+
+  const diff = await runProcess("git", ["diff", "--", ...changedFiles], { cwd, env });
+  if (!diff.ok) {
+    return { ok: false, reason: "git_diff_capture_failed", output: diff.output, changed_files: changedFiles };
+  }
+
+  const restore = await runProcess("git", ["restore", "--worktree", "--", ...changedFiles], { cwd, env });
+  if (!restore.ok) {
+    return { ok: false, reason: "git_restore_owned_diff_failed", output: restore.output, changed_files: changedFiles };
+  }
+
+  const verify = await runProcess("git", ["diff", "--quiet", "--", ...changedFiles], { cwd, env });
+  if (!verify.ok) {
+    return {
+      ok: false,
+      reason: "git_restore_owned_diff_unclean",
+      output: verify.output,
+      changed_files: changedFiles,
+    };
+  }
+
+  return { ok: true, patch: diff.stdout || diff.output || "", changed_files: changedFiles };
 }
 
 function extractUnifiedDiff(output) {

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -4,6 +4,7 @@ import { describe, test } from "node:test";
 import {
   buildDocsOnlyFixturePatch,
   buildOpenHandsCliArgs,
+  captureOwnedWorktreeDiff,
   checkOpenHandsHeadlessSettings,
   compactOutput,
   createDraftPrCoderoom,
@@ -108,9 +109,11 @@ describe("OpenHands proof runner helpers", () => {
     });
 
     assert.equal(result.ok, true);
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.equal(calls[0][0], "openhands");
     assert.deepEqual(calls[0][1], ["--headless", "--json", "--override-with-envs", "--task", "Patch a docs file"]);
+    assert.equal(calls[1][0], "git");
+    assert.deepEqual(calls[1][1], ["diff", "--name-only", "--"]);
   });
 
   test("returns a specific reason when the OpenHands CLI exits before a patch", async () => {
@@ -162,6 +165,85 @@ describe("OpenHands proof runner helpers", () => {
     assert.equal(result.exit_code, 0);
     assert.match(result.output, /completed without a trusted unified diff/);
     assert.match(result.output, /diff --git patch/);
+  });
+
+  test("captures an owned-file worktree diff when OpenHands edits instead of printing a patch", async () => {
+    const calls = [];
+    const patch = buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: worktree-capture" });
+    const runner = createOpenHandsCliRunner({
+      env: {
+        OPENHANDS_ARGS: "--headless --json --override-with-envs --task {prompt}",
+        LLM_API_KEY: "secret",
+        LLM_MODEL: "openai/gpt-5",
+      },
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command !== "git") {
+          return { ok: true, exit_code: 0, output: "OpenHands edited the fixture file directly." };
+        }
+        if (args[0] === "diff" && args[1] === "--name-only") {
+          return { ok: true, stdout: `${FIXTURE}\n`, stderr: "", output: `${FIXTURE}\n` };
+        }
+        if (args[0] === "diff" && args[1] === "--") {
+          return { ok: true, stdout: patch, stderr: "", output: patch };
+        }
+        if (args[0] === "restore") {
+          return { ok: true, stdout: "", stderr: "", output: "" };
+        }
+        if (args[0] === "diff" && args[1] === "--quiet") {
+          return { ok: true, stdout: "", stderr: "", output: "" };
+        }
+        throw new Error(`unexpected git command ${args.join(" ")}`);
+      },
+    });
+
+    const result = await runner({
+      prompt: "Patch a docs file",
+      scopePack: { owned_files: [FIXTURE] },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.patch, patch);
+    assert.deepEqual(result.changed_files, [FIXTURE]);
+    assert.match(result.summary, /captured from git diff/);
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 3).join(" ")}`),
+      [
+        "openhands --headless --json --override-with-envs",
+        "git diff --name-only --",
+        "git diff -- docs/openhands-proof-fixture.md",
+        "git restore --worktree --",
+        "git diff --quiet --",
+      ],
+    );
+  });
+
+  test("fails closed when OpenHands edits outside owned files", async () => {
+    const runner = createOpenHandsCliRunner({
+      env: {
+        OPENHANDS_ARGS: "--headless --json --override-with-envs --task {prompt}",
+        LLM_API_KEY: "secret",
+        LLM_MODEL: "openai/gpt-5",
+      },
+      runProcess: async (command, args) => {
+        if (command !== "git") {
+          return { ok: true, exit_code: 0, output: "OpenHands edited files directly." };
+        }
+        if (args[0] === "diff" && args[1] === "--name-only") {
+          return { ok: true, stdout: "src/not-owned.ts\n", stderr: "", output: "src/not-owned.ts\n" };
+        }
+        throw new Error(`unexpected git command ${args.join(" ")}`);
+      },
+    });
+
+    const result = await runner({
+      prompt: "Patch a docs file",
+      scopePack: { owned_files: [FIXTURE] },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "openhands_unowned_worktree_diff");
+    assert.match(result.output, /outside ownership/);
   });
 
   test("runs fixture OpenHands through the worker and coderoom", async () => {
@@ -258,6 +340,43 @@ describe("draft PR coderoom binding", () => {
 });
 
 describe("safe CodeRoom submitter", () => {
+  test("captures and restores owned worktree diffs", async () => {
+    const calls = [];
+    const patch = buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: helper" });
+    const result = await captureOwnedWorktreeDiff({
+      ownedFiles: [FIXTURE],
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (args[0] === "diff" && args[1] === "--name-only") {
+          return { ok: true, stdout: `${FIXTURE}\n`, stderr: "", output: `${FIXTURE}\n` };
+        }
+        if (args[0] === "diff" && args[1] === "--") {
+          return { ok: true, stdout: patch, stderr: "", output: patch };
+        }
+        if (args[0] === "restore") {
+          return { ok: true, stdout: "", stderr: "", output: "" };
+        }
+        if (args[0] === "diff" && args[1] === "--quiet") {
+          return { ok: true, stdout: "", stderr: "", output: "" };
+        }
+        throw new Error(`unexpected command ${command} ${args.join(" ")}`);
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.patch, patch);
+    assert.deepEqual(result.changed_files, [FIXTURE]);
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 3).join(" ")}`),
+      [
+        "git diff --name-only --",
+        "git diff -- docs/openhands-proof-fixture.md",
+        "git restore --worktree --",
+        "git diff --quiet --",
+      ],
+    );
+  });
+
   test("refuses default GITHUB_TOKEN-only auth before git or gh calls", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({


### PR DESCRIPTION
## Summary
- capture OpenHands-owned worktree edits as a trusted git diff when the CLI succeeds without printing a unified diff
- fail closed if OpenHands leaves changes outside the ScopePack owned files
- restore owned worktree edits before handing the captured patch to CodeRoom

## Tests
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs
- node --test scripts/pinballwake-openhands-worker.test.mjs
- node --test scripts/pinballwake-autonomous-runner.test.mjs
- npm run brainmap:check
- git diff --check

## Safety
- docs fixture path only: docs/openhands-proof-fixture.md
- no workflow, ruleset, canary flag, seed close, or manual dispatch changes
- targets the latest observed AFK canary failure: openhands_missing_unified_diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds post-CLI git diff/restore on the runner worktree with ownership checks; behavior is fail-closed and limited to the proof script path, but incorrect restore logic could drop or mishandle local edits during canary runs.
> 
> **Overview**
> When the OpenHands CLI succeeds but does not emit a trusted unified diff in stdout, the proof runner now **falls back to a scoped git worktree capture** instead of failing with `openhands_missing_unified_diff`.
> 
> After each successful CLI run it calls new **`captureOwnedWorktreeDiff`**: list changed files, reject any path outside the ScopePack **owned files**, snapshot the owned **`git diff`**, **`git restore --worktree`** those paths, and verify the tree is clean before returning the patch to CodeRoom. CLI output or patch file still wins when present; worktree capture only fills the gap.
> 
> **Tests** cover direct worktree edits on owned docs, refusal when edits land outside ownership, and the restore/diff command sequence on the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86f14cce5d373563e279c8eae1235af3d8bb6672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->