### PR TITLE
[codex] ci: add scheduled build self-test

### DIFF
--- a/.github/workflows/scheduled-build-self-test.yml
+++ b/.github/workflows/scheduled-build-self-test.yml
@@ -1,0 +1,48 @@
+name: Scheduled Build Self-Test
+
+on:
+  schedule:
+    - cron: "7,17,27,37,47,57 * * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/scheduled-build-self-test.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/**"
+      - "src/**"
+      - "apps/**"
+      - "packages/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-build-self-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-self-test:
+    name: Build self-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install
+        run: npm ci --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Brainmap guard
+        run: npm run brainmap:check
+
+      - name: PinballWake proof-runner smoke
+        run: node --test scripts/pinballwake-openhands-proof-runner.test.mjs

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,8 +9,8 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 472,
-    "source_manifest": 93,
+    "inventory": 473,
+    "source_manifest": 94,
     "pages": 94,
     "tools": 183,
     "rooms": 23,
@@ -63,7 +63,7 @@
       "id": "automations",
       "name": "Automations",
       "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
-      "count": 108
+      "count": 109
     },
     {
       "id": "ledgers-and-proof",
@@ -1658,6 +1658,16 @@
       "kind": "workflow",
       "meaning": "review enforcement warning GitHub automation workflow.",
       "source": ".github/workflows/review-enforcement-warning.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-scheduled-build-self-test-yml-github-workflows-scheduled-build-self-test-yml",
+      "division": "Automations",
+      "name": "scheduled build self test.yml",
+      "kind": "workflow",
+      "meaning": "scheduled build self test GitHub automation workflow.",
+      "source": ".github/workflows/scheduled-build-self-test.yml",
       "route": "",
       "tags": []
     },
@@ -6974,6 +6984,11 @@
       "source": ".github/workflows/review-enforcement-warning.yml",
       "hash": "64b27fdddfe8",
       "bytes": 548
+    },
+    {
+      "source": ".github/workflows/scheduled-build-self-test.yml",
+      "hash": "1362b535ff33",
+      "bytes": 1024
     },
     {
       "source": ".github/workflows/seed-vault.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -102,6 +102,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/publish-channel-package.yml | 5c9197848ca9 | 8046 |
 | .github/workflows/publish-mcp-package.yml | 9ab3fed97fef | 5749 |
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
+| .github/workflows/scheduled-build-self-test.yml | 1362b535ff33 | 1024 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
 | .github/workflows/testpass-pr-check.yml | 398a44d83549 | 9548 |
 | .github/workflows/testpass-scheduled-smoke.yml | 46f9a65b1dbb | 1673 |
@@ -118,7 +119,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 12 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
-| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 108 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 109 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 9 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 19 |
@@ -581,6 +582,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Automations | workflow | publish channel package.yml | publish channel package GitHub automation workflow. | - | .github/workflows/publish-channel-package.yml |
 | Automations | workflow | publish mcp package.yml | publish mcp package GitHub automation workflow. | - | .github/workflows/publish-mcp-package.yml |
 | Automations | workflow | review enforcement warning.yml | review enforcement warning GitHub automation workflow. | - | .github/workflows/review-enforcement-warning.yml |
+| Automations | workflow | scheduled build self test.yml | scheduled build self test GitHub automation workflow. | - | .github/workflows/scheduled-build-self-test.yml |
 | Automations | workflow | seed vault.yml | seed vault GitHub automation workflow. | - | .github/workflows/seed-vault.yml |
 | Automations | workflow | testpass pr check.yml | testpass pr check GitHub automation workflow. | - | .github/workflows/testpass-pr-check.yml |
 | Automations | workflow | testpass scheduled smoke.yml | testpass scheduled smoke GitHub automation workflow. | - | .github/workflows/testpass-scheduled-smoke.yml |


### PR DESCRIPTION
## What changed

Adds a separate GitHub-native Scheduled Build Self-Test workflow. It wakes every 10 minutes on its own, installs dependencies, runs the production build, checks the generated brainmap, and runs the PinballWake proof-runner smoke test.

## Why

This gives visible proof for the simple question: did GitHub wake up and build? It is separate from the AFK canary and does not touch the seed, canary flag, runner dispatch, ruleset, or tier-2 workflow.

## Validation

- YAML parsed cleanly
- npm run build
- npm run brainmap:check
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with read permissions and standard build/guard scripts; no runtime auth, data, or merge automation changes.
> 
> **Overview**
> Adds a **Scheduled Build Self-Test** GitHub Actions workflow that runs on a ~10-minute cron, on path-filtered PRs, and via `workflow_dispatch`. Each run checks out the repo, runs `npm ci`, **`npm run build`**, **`npm run brainmap:check`**, and the PinballWake proof-runner smoke test (`node --test scripts/pinballwake-openhands-proof-runner.test.mjs`). Concurrency is scoped per ref with cancel-in-progress; permissions are read-only on `contents`.
> 
> Generated **UnClick brainmap** JSON/Markdown are updated so the new workflow appears under Automations (inventory/source manifest counts bumped accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73740168810c1799f38806480e5911243c1596fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->