### PR TITLE
[codex] feat(autopilot): hardwire warm chat build rule

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6672,8 +6672,8 @@
     },
     {
       "source": "scripts/pinballwake-planning-room.mjs",
-      "hash": "080c2946a794",
-      "bytes": 9714
+      "hash": "5465541d24a6",
+      "bytes": 9784
     },
     {
       "source": "scripts/pinballwake-post-merge-watch-room.mjs",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -39,7 +39,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | scripts/pinballwake-merge-room.mjs | 3645da5c0c93 | 8431 |
 | scripts/pinballwake-overlap-resolver-room.mjs | 14d03ef6acd3 | 6787 |
 | scripts/pinballwake-personality-room.mjs | c1ca769346f1 | 9644 |
-| scripts/pinballwake-planning-room.mjs | 080c2946a794 | 9714 |
+| scripts/pinballwake-planning-room.mjs | 5465541d24a6 | 9784 |
 | scripts/pinballwake-post-merge-watch-room.mjs | 144227650844 | 5462 |
 | scripts/pinballwake-publish-room.mjs | ec1dbd36ed22 | 7526 |
 | scripts/pinballwake-queue-health-room.mjs | ddefab91d886 | 2842 |

--- a/docs/automation-trigger-playbook.md
+++ b/docs/automation-trigger-playbook.md
@@ -8,6 +8,8 @@ This playbook preserves the proven trigger methods in one durable place so they 
 
 Hard rule: keep only one Codex or local heartbeat schedule. Everything else should run inside UnClick native jobs, receipts, PinballWake, QueuePush, WakePass, or GitHub plumbing.
 
+Hard rule: DraftRoom is the first station for warm subscription chat work. When a capable chat seat has fresh build context, build or fit the smallest safe draft now, then capture it in DraftRoom. Do not park fresh build context for a low-capacity unattended runner unless the exact blocker and next build step are recorded.
+
 ## Ranking
 
 | Rank | Method | Best use | Effectiveness | Worker rule |
@@ -29,14 +31,15 @@ Hard rule: keep only one Codex or local heartbeat schedule. Everything else shou
 Use this order when a job is not moving:
 
 1. Refresh live state: Memory, Orchestrator, Boardroom, Jobs, then repo or PR state if needed.
-2. If there is a critical safety or production blocker, handle only the safe read-only step unless owner approval is explicit.
-3. If the job is vague, add an exact ScopePack instead of trying to build from loose text.
-4. If the job is stale but scoped, claim it, do one bounded step, and post proof.
-5. If another worker owns it and the claim is fresh, leave a narrow handoff or choose another job.
-6. If proof is missing, request the smallest proof: PR link, commit SHA, run id, check result, or blocker line.
-7. If a wake is needed, use NudgeOnly first, IgniteOnly only after verification, and PushOnly only for a compact worker push envelope.
-8. If the job is safe and the checks are green, merge only under the gated autopilot policy.
-9. If blocked, try one safe unblock, then write the blocker in plain English and move down the queue.
+2. If a warm chat seat has fresh build context, build or fit the smallest safe draft in DraftRoom before queueing it for unattended runners.
+3. If there is a critical safety or production blocker, handle only the safe read-only step unless owner approval is explicit.
+4. If the job is vague, add an exact ScopePack instead of trying to build from loose text.
+5. If the job is stale but scoped, claim it, do one bounded step, and post proof.
+6. If another worker owns it and the claim is fresh, leave a narrow handoff or choose another job.
+7. If proof is missing, request the smallest proof: PR link, commit SHA, run id, check result, or blocker line.
+8. If a wake is needed, use NudgeOnly first, IgniteOnly only after verification, and PushOnly only for a compact worker push envelope.
+9. If the job is safe and the checks are green, merge only under the gated autopilot policy.
+10. If blocked, try one safe unblock, then write the blocker in plain English and move down the queue.
 
 ## Trigger Patterns
 
@@ -84,6 +87,7 @@ Minimum fields:
 
 ```text
 ScopePack
+warm_chat_build_rule:
 todo_id:
 lane:
 owned_files:

--- a/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
+++ b/packages/mcp-server/src/__tests__/heartbeat-protocol.test.ts
@@ -15,11 +15,12 @@ describe("heartbeat_protocol payload", () => {
     expect(first).toEqual(second);
     first.procedure[0] = "mutated by caller";
     expect(getHeartbeatProtocol().procedure[0]).toContain("full heartbeat policy");
-    expect(getHeartbeatProtocol().procedure[6]).toContain("save_conversation_turn");
-    expect(getHeartbeatProtocol().procedure[7]).toContain("nudgeonly_receipt_bridge");
-    expect(getHeartbeatProtocol().procedure[10]).toContain("igniteonly_receipt_consumer");
-    expect(getHeartbeatProtocol().procedure[10]).toContain("pushonly_wake_pusher");
-    expect(getHeartbeatProtocol().procedure[11]).toContain("admin_conversation_turn_ingest");
+    expect(getHeartbeatProtocol().procedure[6]).toContain("Warm chat build rule");
+    expect(getHeartbeatProtocol().procedure[7]).toContain("save_conversation_turn");
+    expect(getHeartbeatProtocol().procedure[8]).toContain("nudgeonly_receipt_bridge");
+    expect(getHeartbeatProtocol().procedure[11]).toContain("igniteonly_receipt_consumer");
+    expect(getHeartbeatProtocol().procedure[11]).toContain("pushonly_wake_pusher");
+    expect(getHeartbeatProtocol().procedure[12]).toContain("admin_conversation_turn_ingest");
   });
 
   it("keeps the public payload schema stable", () => {
@@ -33,7 +34,7 @@ describe("heartbeat_protocol payload", () => {
       "watch_state_key",
     ]);
     expect(protocol.version).toMatch(/^\d{4}-\d{2}-\d{2}\.v\d+$/);
-    expect(protocol.procedure).toHaveLength(18);
+    expect(protocol.procedure).toHaveLength(19);
     expect(protocol.procedure[0]).toContain("full heartbeat policy");
     expect(protocol.procedure[1]).toContain("continuity receipts");
     expect(protocol.procedure[2]).toContain("unclick-builder-tether-seat");
@@ -52,19 +53,22 @@ describe("heartbeat_protocol payload", () => {
     expect(protocol.procedure[5]).toContain("free API classifiers may only classify or nudge");
     expect(protocol.procedure[5]).toContain("PushOnly");
     expect(protocol.procedure[5]).toContain("must not create duplicate jobs");
-    expect(protocol.procedure[6]).toContain("After check_signals");
-    expect(protocol.procedure[7]).toContain("compact public fields");
-    expect(protocol.procedure[7]).toContain("owner_silent_minutes");
-    expect(protocol.procedure[7]).toContain("expired ownership lease");
-    expect(protocol.procedure[8]).toContain("smallest safe source text");
-    expect(protocol.procedure[9]).toContain("receipt_line");
-    expect(protocol.procedure[9]).toContain("bridge gap");
-    expect(protocol.procedure[9]).toContain("owner lease expiry");
-    expect(protocol.procedure[10]).toContain("ignite_id");
-    expect(protocol.procedure[10]).toContain("push_id");
-    expect(protocol.procedure[10]).toContain("Do not stop at NudgeOnly alone");
-    expect(protocol.procedure[11]).toContain("read UI");
-    expect(protocol.procedure[16]).toContain("missing capability");
+    expect(protocol.procedure[6]).toContain("Warm chat build rule");
+    expect(protocol.procedure[6]).toContain("DraftRoom is the first station");
+    expect(protocol.procedure[6]).toContain("low-capacity unattended runner");
+    expect(protocol.procedure[7]).toContain("After check_signals");
+    expect(protocol.procedure[8]).toContain("compact public fields");
+    expect(protocol.procedure[8]).toContain("owner_silent_minutes");
+    expect(protocol.procedure[8]).toContain("expired ownership lease");
+    expect(protocol.procedure[9]).toContain("smallest safe source text");
+    expect(protocol.procedure[10]).toContain("receipt_line");
+    expect(protocol.procedure[10]).toContain("bridge gap");
+    expect(protocol.procedure[10]).toContain("owner lease expiry");
+    expect(protocol.procedure[11]).toContain("ignite_id");
+    expect(protocol.procedure[11]).toContain("push_id");
+    expect(protocol.procedure[11]).toContain("Do not stop at NudgeOnly alone");
+    expect(protocol.procedure[12]).toContain("read UI");
+    expect(protocol.procedure[17]).toContain("missing capability");
     expect(protocol.alert_format).toEqual({
       heading: "UnClick alert",
       line_template: "owner -- target -- status -- next safe action",
@@ -88,9 +92,9 @@ describe("heartbeat_protocol payload", () => {
       procedure: [...protocol.procedure, "new instruction"],
     };
 
-    expect(formatHeartbeatProtocolVersion(12)).toBe("2026-05-12.v12");
-    expect(protocol.version).toBe("2026-05-12.v12");
-    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("001d189e68fad33b");
+    expect(formatHeartbeatProtocolVersion(13)).toBe("2026-05-12.v13");
+    expect(protocol.version).toBe("2026-05-12.v13");
+    expect(heartbeatProtocolContentFingerprint(protocol)).toBe("afa067f16a31873f");
     expect(heartbeatProtocolContentFingerprint(changed)).not.toBe(
       heartbeatProtocolContentFingerprint(protocol),
     );

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -174,6 +174,11 @@ describe("runtime tool schema validation", () => {
     for (const toolName of EXPRESSROOM_VISIBLE_TOOL_NAMES) {
       expect(advertisedNames.has(toolName), toolName).toBe(true);
     }
+
+    const createDraft = ADVERTISED_TOOLS.find((tool) => tool.name === "create_expressroom_draft");
+    expect(createDraft?.description).toContain("DraftRoom is the first station");
+    expect(createDraft?.description).toContain("fresh build context");
+    expect(JSON.stringify(createDraft?.inputSchema)).toContain("exact blocker and next build step");
   });
 
   it("advertises AutoPilot ledger tools to connected agents", () => {

--- a/packages/mcp-server/src/heartbeat-protocol.ts
+++ b/packages/mcp-server/src/heartbeat-protocol.ts
@@ -23,7 +23,7 @@ export type HeartbeatProtocol = {
 };
 
 export const HEARTBEAT_PROTOCOL_DATE = "2026-05-12";
-export const HEARTBEAT_PROTOCOL_REVISION = 12;
+export const HEARTBEAT_PROTOCOL_REVISION = 13;
 
 export function formatHeartbeatProtocolVersion(revision: number): string {
   return `${HEARTBEAT_PROTOCOL_DATE}.v${revision}`;
@@ -38,6 +38,7 @@ const HEARTBEAT_PROTOCOL: HeartbeatProtocol = {
     "Call UnClick check_signals first, then always do a compact job hunt before declaring health: read_orchestrator_context if available, list_actionable_todos, list_todos for open or in_progress work, recent dispatches, and recent Boardroom messages. Cap to the most recent items UnClick returns.",
     "Pinned v9 definition: active_jobs = COUNT(todos WHERE status='in_progress' AND owner_last_seen <= 24h). Orchestrator current_state_card.active_jobs uses the same query, so PASS/BLOCKER does not oscillate on identical state. Treat '0 active jobs' as PASS only when actionable_todos is also 0 (or every backlog item is explicitly held with a stated reason in the last 24h). If active_jobs is 0 while unheld actionable backlog exists, this is BLOCKER: queue hydration failure.",
     "Use PinballWake JobHunt Mirror as the fallback path for that failure: mirror compact backlog counts and source pointers into NudgeOnly first, then IgniteOnly only after verifier-backed receipt_bridge output requests a worker wake, then PushOnly only after IgniteOnly emits a verified public wake packet. Target the existing Job Worker or builder tether as executor when it is registered; free API classifiers may only classify or nudge. The mirror may request a wake and PushOnly may emit a worker push envelope, but both must not create duplicate jobs, assign ownership, mark done, merge, close, or edit source state.",
+    "Warm chat build rule: when a capable subscription chat seat is already holding fresh build context, DraftRoom is the first station and the default move is to build or fit the smallest safe draft immediately. Capture code, patch notes, tests, or a ScopePack in DraftRoom; defer to a low-capacity unattended runner only when the chat seat records an exact blocker.",
     "After check_signals, call save_conversation_turn with session_id='unclick-heartbeat-seat', role='assistant', and content containing the safe alert lines plus a brief progress summary and proof id if available.",
     "When UnClick returns action_needed, blocker, stale ACK, missing proof, duplicate wake, unclear owner, owner silence past TTL, or queue hydration failure items, call nudgeonly_receipt_bridge if available using compact public fields only: source_id, source_url, target, owner, painpoint_type, status, created_at, owner_last_seen_at or owner_silent_minutes, and ttl_minutes. Owner silence past TTL is an expired ownership lease, not a model-judgment nudge.",
     "Prefer deterministic painpoint labels from UnClick. Call nudgeonly_api only when no deterministic bucket exists, and only for the smallest safe source text needed to classify the painpoint.",

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -824,7 +824,8 @@ export const VISIBLE_TOOLS = [
     name: "create_expressroom_draft",
     title: "Create a DraftRoom Manual draft",
     description:
-      "Creates a Manual DraftRoom draft. Use this when a chat seat has built a visible first draft while context is fresh and needs to store the brief, job mirror, short description, and supplied draft code. " +
+      "Creates a Manual DraftRoom draft. DraftRoom is the first station when a capable subscription chat seat has fresh build context. Build or fit the smallest safe draft immediately, then store the brief, job mirror, short description, and supplied draft code. " +
+      "Do not park fresh context for a low-capacity unattended runner unless the chat seat records the exact blocker and next build step. " +
       "Alarm bell: this does not mark official work done. It stores untrusted draft material so it can later enter the official Jobs Board conveyor belt, then be integrated, tested, reviewed, and proved.",
     inputSchema: {
       type: "object" as const,
@@ -835,7 +836,11 @@ export const VISIBLE_TOOLS = [
         official_todo_id: { type: "string", description: "Optional existing Jobs Board todo id to mirror." },
         short_description: { type: "string", description: "Quick read of the draft job." },
         brief_markdown: { type: "string", description: "Detailed intake brief from the chat." },
-        supplied_code: { type: "string", description: "Draft code, patch notes, file contents, pseudocode, or test outline supplied by the chat-first builder." },
+        supplied_code: {
+          type: "string",
+          description:
+            "Required capture field for concrete code, patch notes, file contents, pseudocode, ScopePack, or test outline supplied by the chat-first builder. If no code is supplied, record the exact blocker and next build step.",
+        },
         supplied_code_status: { type: "string", enum: ["not_supplied", "partial", "complete", "unknown"], default: "not_supplied" },
         source_chat_session_id: { type: "string", description: "Optional source chat/session id." },
       },
@@ -868,7 +873,7 @@ export const VISIBLE_TOOLS = [
     name: "promote_expressroom_draft",
     title: "Insert DraftRoom draft into Jobs",
     description:
-      "Creates an official Boardroom job from a Manual DraftRoom draft and links the two records. The new job still needs normal UnClick integration, tests, PR or commit proof, and review.",
+      "Creates an official Boardroom job from a Manual DraftRoom draft and links the two records. If the warm chat seat did not supply code, keep the exact blocker and next build step visible. The new job still needs normal UnClick integration, tests, PR or commit proof, and review.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,

--- a/scripts/pinballwake-autopilot-triage.mjs
+++ b/scripts/pinballwake-autopilot-triage.mjs
@@ -26,6 +26,9 @@ const ROUTES = new Set([
 
 const DIFF_BUCKETS = new Set(["under-50", "under-200", "under-500", "over-500"]);
 
+export const WARM_CHAT_BUILD_RULE =
+  "Warm chat build rule: if a capable subscription chat seat has fresh context, build or fit the smallest safe draft in DraftRoom before parking work for unattended runners; if blocked, record the blocker and next build step.";
+
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
   const found = process.argv.find((arg) => arg.startsWith(prefix));
@@ -593,6 +596,7 @@ export function createInlineScopePack(job = {}, route = chooseAutopilotRoute(job
     scopepack_id: job.scopepack_id || `inline:${compactText(job.source || "manual", 40)}:${Date.now()}`,
     route: route.route,
     tier: "inline",
+    warm_chat_build_rule: WARM_CHAT_BUILD_RULE,
     chip_title: compactText(job.title || job.chip || "Untitled Autopilot chip", 120),
     problem_statement: compactText(
       job.problem_statement || job.description || job.context || "Small low-risk chip routed directly to Coding Room.",

--- a/scripts/pinballwake-autopilot-triage.test.mjs
+++ b/scripts/pinballwake-autopilot-triage.test.mjs
@@ -31,6 +31,8 @@ describe("PinballWake Autopilot triage", () => {
     assert.equal(result.route.ack_required, false);
     assert.equal(result.inline_scopepack.chip_title, "Tiny connector copy update");
     assert.deepEqual(result.inline_scopepack.owned_files, ["connectors/lott/index.ts"]);
+    assert.match(result.inline_scopepack.warm_chat_build_rule, /subscription chat seat/);
+    assert.match(result.inline_scopepack.warm_chat_build_rule, /DraftRoom/);
   });
 
   it("routes stuck PRs to Planning Room without Research Room", () => {

--- a/scripts/pinballwake-planning-room.mjs
+++ b/scripts/pinballwake-planning-room.mjs
@@ -2,7 +2,7 @@
 
 import { readFile } from "node:fs/promises";
 
-import { chooseAutopilotRoute, diffBucketForLines, validateScopePack } from "./pinballwake-autopilot-triage.mjs";
+import { WARM_CHAT_BUILD_RULE, chooseAutopilotRoute, diffBucketForLines, validateScopePack } from "./pinballwake-autopilot-triage.mjs";
 
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
@@ -207,6 +207,7 @@ export function createPlanningRoomScopePack(job = {}, options = {}) {
     scopepack_id: compactText(job.scopepack_id || `scopepack:${compactText(job.id || job.job_id || "manual", 60)}:${options.now || Date.now()}`, 120),
     route: route.route,
     tier: route.tier,
+    warm_chat_build_rule: WARM_CHAT_BUILD_RULE,
     chip_title: compactText(job.title || job.chip || "Untitled Planning Room chip", 120),
     problem_statement: compactText(
       job.problem_statement || job.description || job.context || "Planning Room converted this job into an executable ScopePack.",

--- a/scripts/pinballwake-planning-room.test.mjs
+++ b/scripts/pinballwake-planning-room.test.mjs
@@ -30,6 +30,8 @@ describe("PinballWake Planning Room", () => {
       "scripts/pinballwake-runner-loop.mjs",
       "scripts/pinballwake-runner-loop.test.mjs",
     ]);
+    assert.match(result.scopepack.warm_chat_build_rule, /subscription chat seat/);
+    assert.match(result.scopepack.warm_chat_build_rule, /DraftRoom/);
     assert.equal(validateScopePack(result.scopepack).ok, true);
   });
 

--- a/src/pages/admin/AdminExpressBuild.test.tsx
+++ b/src/pages/admin/AdminExpressBuild.test.tsx
@@ -80,9 +80,11 @@ describe("AdminExpressBuild", () => {
 
     expect(screen.getByRole("heading", { name: "DraftRoom" })).toBeInTheDocument();
     expect(screen.getByText("Manual DraftRoom")).toBeInTheDocument();
-    expect(screen.getByText(/first station in the UnClick build line/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/first station in the UnClick build line/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/warm smart chat seat should build or fit/i)).toBeInTheDocument();
     expect(screen.getByText(/Do not claim DONE from DraftRoom/i)).toBeInTheDocument();
-    expect(screen.getByText(/Build while context is fresh/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/build or fit the smallest safe draft/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/exact blocker and next build step/i).length).toBeGreaterThan(0);
     expect(screen.getByText("Manual draft alarm bells")).toBeInTheDocument();
     expect(screen.getAllByText(/Supplied code is untrusted/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Proof Ledger v2")).toBeInTheDocument();

--- a/src/pages/admin/AdminExpressBuild.tsx
+++ b/src/pages/admin/AdminExpressBuild.tsx
@@ -202,8 +202,9 @@ export default function AdminExpressBuild() {
             <h1 className="text-2xl font-semibold tracking-tight text-white">DraftRoom</h1>
             <p className="mt-2 text-sm leading-6 text-white/60">
               DraftRoom is the first station in the UnClick build line. It captures visible
-              chat-first drafts while context is fresh, then sends them into the official Jobs
-              Board conveyor belt for integration, tests, review, and proof.
+              chat-first drafts while context is fresh. A warm smart chat seat should build or fit
+              the smallest safe draft before parking work for unattended runners, then send it into
+              the official Jobs Board conveyor belt for integration, tests, review, and proof.
             </p>
           </div>
           <div className="grid gap-2 text-sm sm:grid-cols-3 lg:min-w-[420px]">
@@ -246,8 +247,9 @@ export default function AdminExpressBuild() {
             <h2 className="text-sm font-semibold text-white">Normal conveyor belt</h2>
           </div>
           <ol className="list-decimal space-y-2 pl-5 text-sm leading-6 text-white/60">
-            <li>Build a visible first draft while the user context is fresh.</li>
+            <li>Build or fit the smallest safe draft while the user context is fresh.</li>
             <li>Capture the Manual brief and supplied code in DraftRoom.</li>
+            <li>If no code is safe yet, write the exact blocker and next build step.</li>
             <li>Mirror or create the official job name so both places make sense.</li>
             <li>Insert into the Jobs Board when the draft needs real UnClick integration.</li>
             <li>Use normal repo fit, tests, PR, review, and proof before any DONE claim.</li>

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -41,7 +41,7 @@ Nudge handoff:
 NudgeOnly is not the executor. If nudgeonly_receipt_bridge returns receipt_request or escalation_request, do not stop there. Continue through IgniteOnly for a verified wake packet, PushOnly for the worker envelope, then let the Action Heartbeat or builder tether do one safe runnable step, or post BLOCKER with the exact missing executor gate.
 
 Active chat build capture:
-When Chris is already in a live Chat/subscription LLM seat and the build context is fresh, prefer getting that active seat to code or fit the change immediately. Capture the build into repo code, a draft PR, or a scoped handoff quickly. Do not leave fresh build context for later heartbeat recovery if the active seat can safely act now.
+When Chris or any user is already in a live Chat/subscription LLM seat and the build context is fresh, DraftRoom is the first station and the default move is to code or fit the smallest safe draft immediately. Capture code, patch notes, tests, a ScopePack, repo code, a draft PR, or the exact blocker plus next build step quickly. Do not leave fresh build context for a low-capacity unattended runner if the active seat can safely act now.
 
 SeatRelay priority:
 Treat SeatRelay as high priority when choosing between safe queue slices because stale worker issues are recurring. Favor fixes that reduce stale owners, stale HOLD loops, unclear reassignment, and weak handoff.

--- a/src/pages/admin/expressroom.test.ts
+++ b/src/pages/admin/expressroom.test.ts
@@ -13,8 +13,11 @@ describe("DraftRoom model", () => {
     expect(EXPRESSROOM_INDUCTION_TEXT).toContain("visible first draft");
     expect(EXPRESSROOM_INDUCTION_TEXT).toContain("official Jobs Board");
     expect(EXPRESSROOM_INDUCTION_TEXT).toContain("Do not claim DONE from DraftRoom");
+    expect(EXPRESSROOM_INDUCTION_TEXT).toContain("Warm smart-seat rule");
+    expect(EXPRESSROOM_INDUCTION_TEXT).toContain("low-capacity unattended runner");
     expect(EXPRESSROOM_GUARDRAILS.join(" ")).toContain("untrusted");
-    expect(EXPRESSROOM_GUARDRAILS.join(" ")).toContain("Build while context is fresh");
+    expect(EXPRESSROOM_GUARDRAILS.join(" ")).toContain("build or fit the smallest safe draft");
+    expect(EXPRESSROOM_GUARDRAILS.join(" ")).toContain("exact blocker and next build step");
   });
 
   it("counts the required fields for a direct chat capture", () => {
@@ -51,6 +54,8 @@ describe("DraftRoom model", () => {
     expect(description).toContain("This is a Manual draft, not finished work.");
     expect(description).toContain("export const draft = true;");
     expect(description).toContain("normal UnClick review and proof gates");
+    expect(description).toContain("Warm smart-seat rule");
+    expect(description).toContain("smallest safe draft or the exact blocker");
     expect(description).toContain("Alarm bells");
     expect(description).toContain("Do not mark this official job done from the draft alone");
   });

--- a/src/pages/admin/expressroom.ts
+++ b/src/pages/admin/expressroom.ts
@@ -27,7 +27,9 @@ export interface ExpressRoomDraftInput {
 }
 
 export const EXPRESSROOM_INDUCTION_TEXT = [
-  "DraftRoom is the Manual front-of-line drafting room.",
+  "DraftRoom is the Manual front-of-line drafting room and first station in the UnClick build line.",
+  "Warm smart-seat rule: when a capable subscription chat seat has fresh context, build or fit the smallest safe draft immediately.",
+  "Do not park fresh build context for a low-capacity unattended runner unless the exact blocker and next build step are written down.",
   "When a user is actively explaining a feature, create a visible first draft while the context is fresh: code sketch, patch, UI fragment, test outline, ScopePack, or implementation notes.",
   "Store the detailed brief, the job name mirror, the short description, and any supplied code here.",
   "Treat every item as Manual draft input until it is inserted into the official Jobs Board and checked through the normal UnClick conveyor belt.",
@@ -37,7 +39,9 @@ export const EXPRESSROOM_INDUCTION_TEXT = [
 
 export const EXPRESSROOM_GUARDRAILS = [
   "Manual draft only. Never treat DraftRoom as source-of-truth completion.",
-  "Build while context is fresh, but safe jobs may get code drafts while risky jobs get pseudocode, tests, ScopePacks, or risk maps first.",
+  "Warm smart-seat rule: build or fit the smallest safe draft while context is fresh.",
+  "Safe jobs may get code drafts while risky jobs get pseudocode, tests, ScopePacks, or risk maps first.",
+  "If no code, patch, test outline, or ScopePack is supplied, the draft must say the exact blocker and next build step.",
   "Supplied code is untrusted until integrated through repo tests and review.",
   "Inserted Jobs Board cards must say Manual DraftRoom import and must not be marked done from draft code alone.",
   "Official completion still requires PR, commit, test, deploy, screenshot, or explicit no-code proof.",
@@ -115,6 +119,7 @@ export function buildExpressRoomOfficialJobDescription(draft: ExpressRoomDraft):
     "",
     "Insertion rule:",
     "This is a Manual draft, not finished work. Fit it into the repo, run checks, create PR or commit proof, then use the normal UnClick review and proof gates before any DONE claim.",
+    "Warm smart-seat rule: if the source chat seat had fresh build context, the official job should preserve the smallest safe draft or the exact blocker and next build step.",
     "",
     "Alarm bells:",
     "- Manual DraftRoom code is untrusted until fitted into the repo.",


### PR DESCRIPTION
## Summary
- hardwires the warm subscription chat-seat build rule into the heartbeat MASTER playbook and DraftRoom MCP tools
- adds the rule to DraftRoom UI/model copy, Planning Room ScopePacks, InlineScope packets, and the automation trigger playbook
- adds tests so future changes keep the rule visible

## Validation
- npx vitest run src/__tests__/heartbeat-protocol.test.ts src/__tests__/tool-schema-validation.test.ts (from packages/mcp-server)
- npm run test -- src/pages/admin/expressroom.test.ts src/pages/admin/AdminExpressBuild.test.tsx
- node --test scripts/pinballwake-planning-room.test.mjs scripts/pinballwake-autopilot-triage.test.mjs
- npm run brainmap:check
- git diff --check
- npm run build
- npm run build --workspace=@unclick/mcp-server
- npx eslint changed files: 0 errors, 4 existing AdminSeatHeartbeat fast-refresh warnings
- npm run lint still fails repo-wide on pre-existing unrelated lint debt

## Notes
- leaves the AFK canary lane untouched: no workflow dispatch, no flag flip, no seed close, no ruleset or tier-2 edits
- leaves unrelated local changes unstaged: packages/channel-plugin/index.js and run-26378685247-artifacts/