### PR TITLE
feat(writerlane): pure open-stale todo release-decision helper (Slice 2a)

### DIFF
--- a/api/fishbowl-todo-open-stale-release.test.ts
+++ b/api/fishbowl-todo-open-stale-release.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+  OPEN_STALE_RECLAIM_ATTEMPT_LIMIT,
+  planOpenStaleTodoRelease,
+  type PlanOpenStaleTodoReleaseInput,
+} from "./lib/fishbowl-todo-open-stale-release";
+
+const NOW = Date.parse("2026-05-26T12:00:00.000Z");
+const NOW_ISO = new Date(NOW).toISOString();
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+// ISO timestamp whose age relative to NOW is exactly `ageMs`.
+const at = (ageMs: number) => new Date(NOW - ageMs).toISOString();
+
+// Baseline input that classifies as stale_assigned_open: open, human assignee,
+// todo older than 6h, owner last seen more than 1h ago, not protected, reclaim 0.
+const staleBase: PlanOpenStaleTodoReleaseInput = {
+  status: "open",
+  assignedToAgentId: "alice",
+  updatedAt: at(7 * HOUR),
+  ownerLastSeenAt: at(2 * HOUR),
+  reclaimCount: 0,
+  isProtected: false,
+  nowMs: NOW,
+};
+
+describe("OPEN_STALE_RECLAIM_ATTEMPT_LIMIT", () => {
+  it("mirrors WORKER_SELF_HEALING_REASSIGN_ATTEMPT_LIMIT (= 3)", () => {
+    expect(OPEN_STALE_RECLAIM_ATTEMPT_LIMIT).toBe(3);
+  });
+});
+
+describe("planOpenStaleTodoRelease - one per classifier state", () => {
+  it("stale_assigned_open: returns a release plan", () => {
+    const plan = planOpenStaleTodoRelease(staleBase);
+    expect(plan).not.toBeNull();
+    expect(plan?.classification).toBe("stale_assigned_open");
+  });
+
+  it("unassigned_open: returns null", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, assignedToAgentId: "" }),
+    ).toBeNull();
+  });
+
+  it("role_assigned_open: returns null", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, assignedToAgentId: "builder" }),
+    ).toBeNull();
+  });
+
+  it("stale_in_progress: returns null (open-only release)", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, status: "in_progress" }),
+    ).toBeNull();
+  });
+
+  it("fresh_owner_do_not_touch: returns null", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, updatedAt: at(1 * HOUR) }),
+    ).toBeNull();
+  });
+});
+
+describe("owner liveness", () => {
+  it("owner seen within 1h => live owner => null", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, ownerLastSeenAt: at(30 * MINUTE) }),
+    ).toBeNull();
+  });
+
+  it("owner dormant (>1h) and todo stale (>6h) => plan", () => {
+    const plan = planOpenStaleTodoRelease({
+      ...staleBase,
+      updatedAt: at(8 * HOUR),
+      ownerLastSeenAt: at(90 * MINUTE),
+    });
+    expect(plan?.classification).toBe("stale_assigned_open");
+  });
+});
+
+describe("strict > boundaries", () => {
+  it("todoAge exactly 6h is not > 6h => null", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, updatedAt: at(6 * HOUR) }),
+    ).toBeNull();
+  });
+
+  it("ownerAge exactly 1h is not > 1h => owner live => null", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, ownerLastSeenAt: at(1 * HOUR) }),
+    ).toBeNull();
+  });
+});
+
+describe("reclaim attempt cap", () => {
+  it("reclaimCount 0 => plan with reclaim_count 1", () => {
+    expect(planOpenStaleTodoRelease(staleBase)?.update.reclaim_count).toBe(1);
+  });
+
+  it("reclaimCount 2 => plan with reclaim_count 3", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, reclaimCount: 2 })?.update.reclaim_count,
+    ).toBe(3);
+  });
+
+  it("reclaimCount 3 (at the limit) => null", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, reclaimCount: 3 }),
+    ).toBeNull();
+  });
+
+  it("null/undefined reclaimCount coerces to 0 => plan with reclaim_count 1", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, reclaimCount: null })?.update.reclaim_count,
+    ).toBe(1);
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, reclaimCount: undefined })?.update.reclaim_count,
+    ).toBe(1);
+  });
+});
+
+describe("protection", () => {
+  it("isProtected true => null even when otherwise stale", () => {
+    expect(
+      planOpenStaleTodoRelease({ ...staleBase, isProtected: true }),
+    ).toBeNull();
+  });
+});
+
+describe("timestamp handling", () => {
+  it("missing ownerLastSeenAt => owner treated dormant => plan", () => {
+    const plan = planOpenStaleTodoRelease({
+      ...staleBase,
+      ownerLastSeenAt: undefined,
+    });
+    expect(plan?.classification).toBe("stale_assigned_open");
+  });
+
+  it("unparseable ownerLastSeenAt => owner treated dormant => plan", () => {
+    const plan = planOpenStaleTodoRelease({
+      ...staleBase,
+      ownerLastSeenAt: "garbage",
+    });
+    expect(plan?.classification).toBe("stale_assigned_open");
+  });
+
+  it("falls back from missing updatedAt to a recent createdAt => fresh => null", () => {
+    expect(
+      planOpenStaleTodoRelease({
+        ...staleBase,
+        updatedAt: undefined,
+        createdAt: at(1 * HOUR),
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back from missing updatedAt to a stale createdAt => plan", () => {
+    const plan = planOpenStaleTodoRelease({
+      ...staleBase,
+      updatedAt: undefined,
+      createdAt: at(7 * HOUR),
+    });
+    expect(plan?.classification).toBe("stale_assigned_open");
+  });
+});
+
+describe("update payload matches the CAS applier (releaseWorkerSelfHealingTodoOwnership)", () => {
+  it("emits exactly the WorkerSelfHealingTodoReleasePlan update shape", () => {
+    const plan = planOpenStaleTodoRelease({ ...staleBase, reclaimCount: 1 });
+    expect(plan).toEqual({
+      classification: "stale_assigned_open",
+      update: {
+        status: "open",
+        assigned_to_agent_id: null,
+        lease_token: null,
+        lease_expires_at: null,
+        reclaim_count: 2,
+        updated_at: NOW_ISO,
+      },
+    });
+  });
+});

--- a/api/lib/fishbowl-todo-open-stale-release.ts
+++ b/api/lib/fishbowl-todo-open-stale-release.ts
@@ -1,0 +1,82 @@
+// WriterLane Slice 2a: pure release-decision helper for stale, human-assigned
+// OPEN todos.
+//
+// Dead code for now. Nothing in this repo wires it yet; the watcher integration
+// lands in Slice 2b. The helper is pure: it classifies via the Slice 1
+// classifyTodoActionability helper and returns a release plan, with no DB, no
+// LLM, no NudgeOnly, and no imports from api/fishbowl-watcher.ts. Protection and
+// the owner-liveness inputs are passed in by the caller rather than recomputed
+// here, so the function stays clock/math only.
+
+import {
+  classifyTodoActionability,
+  type TodoActionability,
+} from "./fishbowl-todo-actionability";
+
+// Mirrors WORKER_SELF_HEALING_REASSIGN_ATTEMPT_LIMIT (= 3) in
+// api/fishbowl-watcher.ts. Duplicated here so this helper stays pure and free of
+// watcher imports; the watcher owns the canonical constant.
+export const OPEN_STALE_RECLAIM_ATTEMPT_LIMIT = 3;
+
+export interface PlanOpenStaleTodoReleaseInput {
+  status: unknown;
+  assignedToAgentId: unknown;
+  updatedAt?: unknown;
+  createdAt?: unknown;
+  ownerLastSeenAt?: unknown;
+  reclaimCount: number | null | undefined;
+  isProtected: boolean;
+  nowMs: number;
+}
+
+// Consumed verbatim by releaseWorkerSelfHealingTodoOwnership (the CAS applier) in
+// api/fishbowl-watcher.ts via plan.update. Must stay byte-identical to
+// WorkerSelfHealingTodoReleasePlan["update"] so Slice 2b can reuse the applier
+// unchanged.
+export interface OpenStaleTodoReleaseUpdate {
+  status: "open";
+  assigned_to_agent_id: null;
+  lease_token: null;
+  lease_expires_at: null;
+  reclaim_count: number;
+  updated_at: string;
+}
+
+export interface OpenStaleTodoReleasePlan {
+  classification: Extract<TodoActionability, "stale_assigned_open">;
+  update: OpenStaleTodoReleaseUpdate;
+}
+
+export function planOpenStaleTodoRelease(
+  input: PlanOpenStaleTodoReleaseInput,
+): OpenStaleTodoReleasePlan | null {
+  if (input.isProtected) return null;
+
+  const reclaimCountRaw = Number(input.reclaimCount ?? 0);
+  const reclaimCount = Number.isFinite(reclaimCountRaw)
+    ? Math.max(0, Math.trunc(reclaimCountRaw))
+    : 0;
+  if (reclaimCount >= OPEN_STALE_RECLAIM_ATTEMPT_LIMIT) return null;
+
+  const classification = classifyTodoActionability({
+    status: input.status,
+    assignedToAgentId: input.assignedToAgentId,
+    updatedAt: input.updatedAt,
+    createdAt: input.createdAt,
+    ownerLastSeenAt: input.ownerLastSeenAt,
+    nowMs: input.nowMs,
+  });
+  if (classification !== "stale_assigned_open") return null;
+
+  return {
+    classification,
+    update: {
+      status: "open",
+      assigned_to_agent_id: null,
+      lease_token: null,
+      lease_expires_at: null,
+      reclaim_count: reclaimCount + 1,
+      updated_at: new Date(input.nowMs).toISOString(),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `api/lib/fishbowl-todo-open-stale-release.ts`: a **pure, dead-code** release-decision helper. `planOpenStaleTodoRelease(input)` calls the Slice 1 `classifyTodoActionability` helper and returns a release plan **only** when the classification is exactly `stale_assigned_open`, `reclaimCount < OPEN_STALE_RECLAIM_ATTEMPT_LIMIT` (3, mirroring `WORKER_SELF_HEALING_REASSIGN_ATTEMPT_LIMIT`), and the todo is not protected. Otherwise returns `null`.
- No runtime wiring, no behavior change (same safe shape as the just-merged Slice 1). No DB, no LLM, no NudgeOnly, no side effects, and no imports from `api/fishbowl-watcher.ts` — `isProtected` is passed in by the caller.
- The plan's `update` payload is byte-identical to `WorkerSelfHealingTodoReleasePlan["update"]`, which the existing CAS applier `releaseWorkerSelfHealingTodoOwnership` consumes, so Slice 2b can reuse that applier unchanged.
- Adds `api/fishbowl-todo-open-stale-release.test.ts`: 20 vitest cases covering each classifier state, owner-liveness, strict `>` boundaries at 6h/1h, the reclaim cap (2→3, 3→null), `isProtected`, missing/unparseable `ownerLastSeenAt`, the `updatedAt ?? createdAt` fallback, and an exact `update`-shape match.

Slice 2b (watcher wiring) is intentionally **not** part of this PR.

## Test plan
- [x] `npx vitest run api/fishbowl-todo-open-stale-release.test.ts` — 20/20 pass
- [x] standalone strict typecheck on the helper (`tsc --ignoreConfig --strict --noEmit`) — clean (api/ has no project tsconfig, as expected)
- [ ] Chris reviews before merge — do not merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead code and tests only; no watcher or DB integration, so no production impact until Slice 2b.
> 
> **Overview**
> Adds **WriterLane Slice 2a**: a pure, unwired `planOpenStaleTodoRelease` helper in `api/lib/fishbowl-todo-open-stale-release.ts` plus **20 vitest cases** in `api/fishbowl-todo-open-stale-release.test.ts`.
> 
> `planOpenStaleTodoRelease` delegates classification to `classifyTodoActionability` and only returns a release plan when the todo is **`stale_assigned_open`**, not **`isProtected`**, and **`reclaimCount` &lt; 3** (`OPEN_STALE_RECLAIM_ATTEMPT_LIMIT`, aligned with worker self-healing). The plan clears assignee/lease fields, bumps **`reclaim_count`**, and sets **`updated_at`**—shaped to match **`WorkerSelfHealingTodoReleasePlan["update"]`** for reuse by **`releaseWorkerSelfHealingTodoOwnership`** in a later watcher slice. **No production wiring** in this PR; behavior is unchanged until Slice 2b.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442aa7ff9e5d8b39d6c8f7d0250b2a8021b60c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->