### PR TITLE
feat(watcher): release stale open+assigned Boardroom todos (WriterLane Slice 2b)

### DIFF
--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -9,6 +9,7 @@ import {
   WAKEPASS_REROUTE_LEASE_SECONDS,
   buildDispatchReclaimSignal,
   buildMissedCheckinDispatch,
+  buildOpenStaleTodoReleasePlan,
   buildWorkerMovementWorkflowPilotProofText,
   buildWakepassAutoReroutePlan,
   buildWorkerSelfHealingSignal,
@@ -26,6 +27,7 @@ import {
   planWorkerSelfHealingTodoSignal,
   resolveWakepassRerouteTarget,
   shouldMarkDispatchStaleAfterReclaimSignalInsert,
+  workerSelfHealingProtectedReason,
   type DispatchRow,
   type FishbowlMessageAckRow,
   type ProfileRow,
@@ -997,6 +999,249 @@ describe("worker self-healing decision plan", () => {
         apiKeyHash: "hash_123",
         decision,
         emittedAt: "2026-05-01T01:22:01.000Z",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("WriterLane Slice 2b open-stale todo release wiring", () => {
+  // Fixed reference clock. Thresholds (from fishbowl-todo-actionability): an
+  // open assigned todo is "stale" only after 6h of age AND a dormant owner
+  // (last seen > 1h ago, or no profile, or a role assignee).
+  const NOW = "2026-05-26T12:00:00.000Z";
+  const nowMs = Date.parse(NOW);
+  const HOUR = 60 * 60 * 1000;
+  const agedUpdatedAt = new Date(nowMs - 8 * HOUR).toISOString(); // > 6h: aged
+  const freshUpdatedAt = new Date(nowMs - 3 * HOUR).toISOString(); // < 6h: not aged
+  const dormantSeenAt = new Date(nowMs - 2 * HOUR).toISOString(); // > 1h: dormant
+  const liveSeenAt = new Date(nowMs - 7 * 60 * 1000).toISOString(); // < 1h: live
+
+  const openStaleTodo = (overrides: Record<string, unknown> = {}) => ({
+    id: "todo-open-stale",
+    status: "open",
+    assigned_to_agent_id: "worker-7",
+    lease_token: null,
+    lease_expires_at: null,
+    reclaim_count: 0,
+    updated_at: agedUpdatedAt,
+    created_at: agedUpdatedAt,
+    ...overrides,
+  });
+
+  const buildPlan = (
+    overrides: Record<string, unknown> = {},
+    extra: { ownerLastSeenAt?: string | null; isProtected?: boolean } = {},
+  ) =>
+    buildOpenStaleTodoReleasePlan({
+      apiKeyHash: "hash_123",
+      todo: openStaleTodo(overrides) as never,
+      ownerLastSeenAt:
+        "ownerLastSeenAt" in extra ? extra.ownerLastSeenAt ?? null : dormantSeenAt,
+      isProtected: extra.isProtected ?? false,
+      releasedAt: NOW,
+      nowMs,
+    });
+
+  it("releases a genuinely stale open todo with a dormant non-role owner", () => {
+    const plan = buildPlan();
+    expect(plan).toMatchObject({
+      signal: {
+        action: "worker_self_healing_stale_owner_released",
+        severity: "info",
+      },
+      insert: {
+        api_key_hash: "hash_123",
+        tool: "fishbowl",
+        action: "worker_self_healing_stale_owner_released",
+        deep_link: "/admin/jobs#todo-todo-open-stale",
+        payload: {
+          todo_id: "todo-open-stale",
+          classification: "stale_assigned_open",
+          previous_status: "open",
+          previous_assigned_to_agent_id: "worker-7",
+          next_status: "open",
+          released_stale_owner: true,
+          bonded_handoff_required: true,
+          reclaim_count: 0,
+          next_reclaim_count: 1,
+        },
+      },
+      update: {
+        status: "open",
+        assigned_to_agent_id: null,
+        lease_token: null,
+        lease_expires_at: null,
+        reclaim_count: 1,
+        updated_at: NOW,
+      },
+    });
+  });
+
+  it("releases when the owner has no profile (treated as dormant)", () => {
+    const plan = buildPlan({}, { ownerLastSeenAt: null });
+    expect(plan).not.toBeNull();
+    expect(plan!.update.assigned_to_agent_id).toBeNull();
+    expect(plan!.update.reclaim_count).toBe(1);
+  });
+
+  it("leaves a fresh-owner open todo untouched (live within 1h)", () => {
+    expect(buildPlan({}, { ownerLastSeenAt: liveSeenAt })).toBeNull();
+  });
+
+  it("leaves a not-yet-aged open todo untouched even with a dormant owner", () => {
+    expect(buildPlan({ updated_at: freshUpdatedAt, created_at: freshUpdatedAt })).toBeNull();
+  });
+
+  it("leaves role-assigned open todos untouched", () => {
+    for (const role of ["master", "coordinator", "pinballwake-job-runner"]) {
+      expect(buildPlan({ assigned_to_agent_id: role })).toBeNull();
+    }
+  });
+
+  it("never touches in_progress todos via this path", () => {
+    // status=in_progress classifies as stale_in_progress, not stale_assigned_open,
+    // so the open-stale helper declines and the existing in_progress planner owns it.
+    expect(buildPlan({ status: "in_progress" })).toBeNull();
+  });
+
+  it("never releases when the caller marks the todo protected", () => {
+    // The watcher computes isProtected via workerSelfHealingProtectedReason and
+    // passes it in; the helper trusts that flag and refuses to plan a release.
+    expect(buildPlan({}, { isProtected: true })).toBeNull();
+    expect(
+      buildPlan(
+        { title: "human_blocker: owner must approve before any move" },
+        { isProtected: true },
+      ),
+    ).toBeNull();
+    expect(
+      buildPlan({ assigned_to_agent_id: "human-chris" }, { isProtected: true }),
+    ).toBeNull();
+  });
+
+  it("protection gate (watcher input) flags human/manual todos and clears normal ones", () => {
+    // This is the gate the watcher runs before planning a release. It must flag
+    // human/manual work so isProtected=true reaches the helper.
+    expect(
+      workerSelfHealingProtectedReason({
+        id: "t",
+        status: "open",
+        assigned_to_agent_id: "worker-7",
+        title: "human_blocker: needs owner approval",
+      } as never),
+    ).toBe("human_blocker_protected");
+    expect(
+      workerSelfHealingProtectedReason({
+        id: "t",
+        status: "open",
+        assigned_to_agent_id: "worker-7",
+        title: "manual-only deploy step",
+      } as never),
+    ).toBe("manual_only_protected");
+    expect(
+      workerSelfHealingProtectedReason({
+        id: "t",
+        status: "open",
+        assigned_to_agent_id: "human-chris",
+        title: "ordinary task",
+      } as never),
+    ).toBe("human_owned_work_protected");
+    // A plain worker-owned open todo is NOT protected -> relies on age/liveness.
+    expect(
+      workerSelfHealingProtectedReason({
+        id: "t",
+        status: "open",
+        assigned_to_agent_id: "worker-7",
+        title: "ordinary task",
+      } as never),
+    ).toBeNull();
+  });
+
+  it("respects the reclaim cap (< 3) and bumps reclaim_count", () => {
+    expect(buildPlan({ reclaim_count: 3 })).toBeNull();
+    const plan = buildPlan({ reclaim_count: 2 });
+    expect(plan).not.toBeNull();
+    expect(plan!.update.reclaim_count).toBe(3);
+    expect(plan!.insert.payload.reclaim_count).toBe(2);
+    expect(plan!.insert.payload.next_reclaim_count).toBe(3);
+  });
+
+  // ── Canary safety (AFK canary seed 8719dc4f-1650-4ea9-bca8-e92a9819f0ba) ──
+  // The canary is an open todo assigned to the autonomous runner. In a healthy
+  // system it is continuously exercised (re-opened with a fresh updated_at) and
+  // its owner is active, so it is protected by BOTH the age gate and the
+  // owner-liveness gate. These tests assert the canary is left untouched while
+  // fresh and/or protected.
+  const canaryTodo = (overrides: Record<string, unknown> = {}) =>
+    openStaleTodo({
+      id: "8719dc4f-1650-4ea9-bca8-e92a9819f0ba",
+      title: "AFK canary seed: docs-only OpenHands proof fixture",
+      assigned_to_agent_id: "pinballwake-autonomous-runner",
+      priority: "urgent",
+      ...overrides,
+    });
+
+  it("documents that the canary is NOT keyword-protected (safety rests on age/liveness)", () => {
+    expect(workerSelfHealingProtectedReason(canaryTodo() as never)).toBeNull();
+  });
+
+  it("leaves the canary untouched when its owner is live (< 1h)", () => {
+    const plan = buildOpenStaleTodoReleasePlan({
+      apiKeyHash: "hash_123",
+      todo: canaryTodo() as never,
+      ownerLastSeenAt: liveSeenAt,
+      isProtected: false,
+      releasedAt: NOW,
+      nowMs,
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("leaves the canary untouched via the age gate even if its owner is dormant", () => {
+    // Primary protection in a healthy system: the canary is re-exercised
+    // regularly so updated_at stays < 6h and it is never even classified stale.
+    const plan = buildOpenStaleTodoReleasePlan({
+      apiKeyHash: "hash_123",
+      todo: canaryTodo({ updated_at: freshUpdatedAt, created_at: freshUpdatedAt }) as never,
+      ownerLastSeenAt: dormantSeenAt,
+      isProtected: false,
+      releasedAt: NOW,
+      nowMs,
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("leaves the canary untouched when explicitly protected", () => {
+    const plan = buildOpenStaleTodoReleasePlan({
+      apiKeyHash: "hash_123",
+      todo: canaryTodo() as never,
+      ownerLastSeenAt: dormantSeenAt,
+      isProtected: true,
+      releasedAt: NOW,
+      nowMs,
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("returns null for blank apiKeyHash or releasedAt (no-op guard)", () => {
+    expect(
+      buildOpenStaleTodoReleasePlan({
+        apiKeyHash: "  ",
+        todo: openStaleTodo() as never,
+        ownerLastSeenAt: dormantSeenAt,
+        isProtected: false,
+        releasedAt: NOW,
+        nowMs,
+      }),
+    ).toBeNull();
+    expect(
+      buildOpenStaleTodoReleasePlan({
+        apiKeyHash: "hash_123",
+        todo: openStaleTodo() as never,
+        ownerLastSeenAt: dormantSeenAt,
+        isProtected: false,
+        releasedAt: "   ",
+        nowMs,
       }),
     ).toBeNull();
   });

--- a/api/fishbowl-watcher.test.ts
+++ b/api/fishbowl-watcher.test.ts
@@ -1167,11 +1167,12 @@ describe("WriterLane Slice 2b open-stale todo release wiring", () => {
   });
 
   // ── Canary safety (AFK canary seed 8719dc4f-1650-4ea9-bca8-e92a9819f0ba) ──
-  // The canary is an open todo assigned to the autonomous runner. In a healthy
-  // system it is continuously exercised (re-opened with a fresh updated_at) and
-  // its owner is active, so it is protected by BOTH the age gate and the
-  // owner-liveness gate. These tests assert the canary is left untouched while
-  // fresh and/or protected.
+  // The canary is an open todo assigned to the autonomous runner. It is now
+  // protected-by-id: workerSelfHealingProtectedReason returns a protected reason
+  // for its exact todo id, so the watcher never releases it regardless of age or
+  // owner liveness. Defense-in-depth still holds via the age + owner-liveness
+  // gates in a healthy system. The protection is scoped to this seed id only and
+  // does NOT protect the runner agent globally.
   const canaryTodo = (overrides: Record<string, unknown> = {}) =>
     openStaleTodo({
       id: "8719dc4f-1650-4ea9-bca8-e92a9819f0ba",
@@ -1181,8 +1182,54 @@ describe("WriterLane Slice 2b open-stale todo release wiring", () => {
       ...overrides,
     });
 
-  it("documents that the canary is NOT keyword-protected (safety rests on age/liveness)", () => {
-    expect(workerSelfHealingProtectedReason(canaryTodo() as never)).toBeNull();
+  it("protects the canary seed by id (returns canary_seed_protected)", () => {
+    expect(workerSelfHealingProtectedReason(canaryTodo() as never)).toBe(
+      "canary_seed_protected",
+    );
+    // Case-insensitive id match (UUIDs may arrive upper-cased).
+    expect(
+      workerSelfHealingProtectedReason(
+        canaryTodo({ id: "8719DC4F-1650-4EA9-BCA8-E92A9819F0BA" }) as never,
+      ),
+    ).toBe("canary_seed_protected");
+  });
+
+  it("does NOT release the canary even when aged AND owner dormant (protected-by-id)", () => {
+    // Worst case for the canary: aged > 6h with a dormant owner — exactly the
+    // sustained-outage edge. The watcher computes isProtected via the gate, so
+    // the open-stale sweep must refuse to plan a release.
+    const todo = canaryTodo({ updated_at: agedUpdatedAt, created_at: agedUpdatedAt });
+    const isProtected = workerSelfHealingProtectedReason(todo as never) !== null;
+    expect(isProtected).toBe(true);
+    const plan = buildOpenStaleTodoReleasePlan({
+      apiKeyHash: "hash_123",
+      todo: todo as never,
+      ownerLastSeenAt: dormantSeenAt,
+      isProtected,
+      releasedAt: NOW,
+      nowMs,
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("does NOT protect a different runner-owned open todo (scoped to seed id only)", () => {
+    // A legitimate stale runner-owned job (NOT the canary id) must stay
+    // releasable; per-seed protection must not become global runner protection.
+    const todo = openStaleTodo({
+      id: "11111111-2222-3333-4444-555555555555",
+      assigned_to_agent_id: "pinballwake-autonomous-runner",
+    });
+    expect(workerSelfHealingProtectedReason(todo as never)).toBeNull();
+    const plan = buildOpenStaleTodoReleasePlan({
+      apiKeyHash: "hash_123",
+      todo: todo as never,
+      ownerLastSeenAt: dormantSeenAt,
+      isProtected: false,
+      releasedAt: NOW,
+      nowMs,
+    });
+    expect(plan).not.toBeNull();
+    expect(plan!.update.assigned_to_agent_id).toBeNull();
   });
 
   it("leaves the canary untouched when its owner is live (< 1h)", () => {

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -30,6 +30,11 @@ import {
   type AgentDispatch,
   type DispatchSource,
 } from "../packages/mcp-server/src/reliability.js";
+import {
+  classifyTodoActionability,
+  STALE_OPEN_ASSIGNED_MS,
+} from "./lib/fishbowl-todo-actionability.js";
+import { planOpenStaleTodoRelease } from "./lib/fishbowl-todo-open-stale-release.js";
 
 export interface ProfileRow {
   api_key_hash: string;
@@ -530,6 +535,85 @@ export function planWorkerSelfHealingTodoRelease(params: {
   };
 }
 
+// WriterLane Slice 2b: route a stale, human-assigned OPEN todo (no active lease)
+// through the pure planOpenStaleTodoRelease helper and, when it returns a plan,
+// wrap it as a WorkerSelfHealingTodoReleasePlan so the existing CAS applier
+// (releaseWorkerSelfHealingTodoOwnership) and signal insert path are reused
+// unchanged. Clock/math gating lives entirely in the pure helper/classifier:
+// protection, owner-liveness (real ownerLastSeenAt), the 6h age threshold, and
+// the reclaim cap. This function adds no new gating of its own.
+export function buildOpenStaleTodoReleasePlan(params: {
+  apiKeyHash: string;
+  todo: WorkerSelfHealingTodoState & { updated_at?: unknown; created_at?: unknown };
+  ownerLastSeenAt: string | null;
+  isProtected: boolean;
+  releasedAt: string;
+  nowMs: number;
+}): WorkerSelfHealingTodoReleasePlan | null {
+  const apiKeyHash = nonEmptyString(params.apiKeyHash);
+  const releasedAt = nonEmptyString(params.releasedAt);
+  if (!apiKeyHash || !releasedAt) return null;
+
+  const plan = planOpenStaleTodoRelease({
+    status: params.todo.status,
+    assignedToAgentId: params.todo.assigned_to_agent_id,
+    updatedAt: params.todo.updated_at,
+    createdAt: params.todo.created_at,
+    ownerLastSeenAt: params.ownerLastSeenAt,
+    reclaimCount: params.todo.reclaim_count,
+    isProtected: params.isProtected,
+    nowMs: params.nowMs,
+  });
+  if (!plan) return null;
+
+  const previousAssignee = nonEmptyString(params.todo.assigned_to_agent_id);
+  const reclaimCountRaw = Number(params.todo.reclaim_count ?? 0);
+  const reclaimCount = Number.isFinite(reclaimCountRaw)
+    ? Math.max(0, Math.trunc(reclaimCountRaw))
+    : 0;
+  const payload: Record<string, unknown> = {
+    todo_id: params.todo.id,
+    assigned_to_agent_id: previousAssignee,
+    has_lease_token: false,
+    lease_expires_at: null,
+    classification: plan.classification,
+    owner_last_seen_at: params.ownerLastSeenAt,
+    reclaim_count: reclaimCount,
+    next_reclaim_count: plan.update.reclaim_count,
+    previous_status: params.todo.status,
+    previous_assigned_to_agent_id: previousAssignee,
+    next_status: "open",
+    released_stale_owner: true,
+    released_at: releasedAt,
+    bonded_handoff_required: true,
+    bonded_handoff_rule:
+      "Next worker must make a fresh claim and leave proof before moving the job.",
+    reassignment_attempts_capped_at: WORKER_SELF_HEALING_REASSIGN_ATTEMPT_LIMIT,
+  };
+  const signal: WorkerSelfHealingSignal = {
+    action: "worker_self_healing_stale_owner_released",
+    severity: "info",
+    summary: `SeatRelay released stale open-todo owner ${
+      previousAssignee ?? "unknown"
+    } from todo ${params.todo.id}.`,
+    payload,
+  };
+
+  return {
+    signal,
+    insert: {
+      api_key_hash: apiKeyHash,
+      tool: "fishbowl",
+      action: signal.action,
+      severity: signal.severity,
+      summary: signal.summary,
+      deep_link: `/admin/jobs#todo-${params.todo.id}`,
+      payload,
+    },
+    update: plan.update,
+  };
+}
+
 export function hasRecentWorkerSelfHealingTodoSignal(
   signals: Array<{ action: string; payload: Record<string, unknown> | null }>,
   plan: WorkerSelfHealingTodoSignalPlan,
@@ -736,7 +820,7 @@ function nonEmptyString(value: unknown): string | null {
   return trimmed ? trimmed : null;
 }
 
-function workerSelfHealingProtectedReason(todo: WorkerSelfHealingTodoState): string | null {
+export function workerSelfHealingProtectedReason(todo: WorkerSelfHealingTodoState): string | null {
   const status = normalizeToken(todo.status);
   if (status === "human_blocker") return "human_blocker_protected";
   if (status === "manual_only") return "manual_only_protected";
@@ -1280,6 +1364,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let workerSelfHealingSignalsEmitted = 0;
   let workerSelfHealingSignalsDeduped = 0;
   let workerSelfHealingTodosReleased = 0;
+  let workerSelfHealingOpenStaleCandidates = 0;
+  let workerSelfHealingOpenStaleReleased = 0;
   let digestSignalsEmitted = 0;
   let staleStatusesCleared = 0;
 
@@ -1639,6 +1725,96 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   }
 
+  // 3b. WriterLane Slice 2b: release stale, human-assigned OPEN todos that have
+  // no active lease. The existing sweep above never fetches this shape (the
+  // lease sweep requires a non-null lease; the owner sweep requires
+  // in_progress), so today these aged open todos are detected by the
+  // list-actionable endpoint but never released. This sweep fetches only
+  // open + assigned + unleased rows aged past the classifier's 6h threshold,
+  // resolves the owner's real last_seen_at the same way the list endpoint does
+  // (mc_fishbowl_profiles join), and routes each candidate through the pure
+  // classifier-gated planOpenStaleTodoRelease helper. Protection, owner
+  // liveness, age, and the reclaim cap are decided in the helper. The existing
+  // CAS applier is reused unchanged so the release is idempotent: once an owner
+  // is cleared the row no longer matches this fetch, and a concurrent change
+  // makes the optimistic update a zero-row no-op.
+  const openStaleTodoCutoff = new Date(nowMs - STALE_OPEN_ASSIGNED_MS).toISOString();
+  const { data: staleOpenAssignedRows, error: staleOpenAssignedErr } = await supabase
+    .from("mc_fishbowl_todos")
+    .select("id, api_key_hash, title, description, status, priority, created_by_agent_id, assigned_to_agent_id, lease_token, lease_expires_at, reclaim_count, updated_at, created_at")
+    .eq("status", "open")
+    .not("assigned_to_agent_id", "is", null)
+    .is("lease_expires_at", null)
+    .lt("updated_at", openStaleTodoCutoff)
+    .order("updated_at", { ascending: true })
+    .limit(WORKER_SELF_HEALING_TODO_SWEEP_LIMIT);
+
+  if (staleOpenAssignedErr) {
+    console.error(
+      "[fishbowl-watcher] worker self-healing open-stale fetch error:",
+      staleOpenAssignedErr.message,
+    );
+    return res.status(500).json({ error: staleOpenAssignedErr.message });
+  }
+
+  type OpenStaleTodoSweepRow = WorkerSelfHealingTodoSweepRow & {
+    updated_at?: string | null;
+    created_at?: string | null;
+  };
+
+  for (const todo of (staleOpenAssignedRows ?? []) as OpenStaleTodoSweepRow[]) {
+    let profiles = profileCache.get(todo.api_key_hash);
+    if (!profiles) {
+      profiles = await listProfilesForTenant(supabase, todo.api_key_hash);
+      profileCache.set(todo.api_key_hash, profiles);
+    }
+    const ownerProfile = findWorkerSelfHealingProfileForTodo(profiles, todo);
+    const ownerLastSeenAt = ownerProfile?.last_seen_at ?? null;
+
+    const classification = classifyTodoActionability({
+      status: todo.status,
+      assignedToAgentId: todo.assigned_to_agent_id,
+      updatedAt: todo.updated_at,
+      createdAt: todo.created_at,
+      ownerLastSeenAt,
+      nowMs,
+    });
+    if (classification === "stale_assigned_open") {
+      workerSelfHealingOpenStaleCandidates++;
+    }
+
+    const isProtected = workerSelfHealingProtectedReason(todo) !== null;
+    const releasePlan = buildOpenStaleTodoReleasePlan({
+      apiKeyHash: todo.api_key_hash,
+      todo,
+      ownerLastSeenAt,
+      isProtected,
+      releasedAt: nowIso,
+      nowMs,
+    });
+    if (!releasePlan) continue;
+
+    const released = await releaseWorkerSelfHealingTodoOwnership(
+      supabase,
+      todo,
+      releasePlan,
+    );
+    if (!released) continue;
+    workerSelfHealingOpenStaleReleased++;
+
+    const { error: openStaleSignalErr } = await supabase
+      .from("mc_signals")
+      .insert(releasePlan.insert);
+    if (openStaleSignalErr) {
+      console.error(
+        "[fishbowl-watcher] worker self-healing open-stale signal insert error:",
+        openStaleSignalErr.message,
+      );
+    } else {
+      workerSelfHealingSignalsEmitted++;
+    }
+  }
+
   // ── 4. Unread mention digest ────────────────────────────────────────────
   const mentionAgeCutoff = new Date(nowMs - MENTION_AGE_THRESHOLD_MS).toISOString();
   const { data: unreadMentions } = await supabase
@@ -1738,6 +1914,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     worker_self_healing_signals_emitted: workerSelfHealingSignalsEmitted,
     worker_self_healing_signals_deduped: workerSelfHealingSignalsDeduped,
     worker_self_healing_todos_released: workerSelfHealingTodosReleased,
+    worker_self_healing_open_stale_candidates: workerSelfHealingOpenStaleCandidates,
+    worker_self_healing_open_stale_released: workerSelfHealingOpenStaleReleased,
     digest_signals_emitted: digestSignalsEmitted,
     stale_statuses_cleared: staleStatusesCleared,
     overdue_candidates: candidates.length,

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -99,11 +99,11 @@ export const WAKEPASS_REROUTE_LEASE_SECONDS = 600;
 // paths (workerSelfHealingProtectedReason); the runner's claim/build/complete
 // flow is a separate code path and is unaffected.
 //
-// - 8719dc4f-1650-4ea9-bca8-e92a9819f0ba: AFK canary seed (docs-only OpenHands
-//   proof fixture), assigned to pinballwake-autonomous-runner, linked Boardroom
-//   coding-room job bf58d19d. The seed must stay assigned/open during a runner
-//   outage so AFK detection keeps working; releasing it would trip the runner's
-//   assigned_canary_seed_missing check.
+// - 8719dc4f-1650-4ea9-bca8-e92a9819f0ba: AFK canary proof-fixture seed
+//   (docs-only OpenHands proof fixture), assigned to pinballwake-autonomous-runner.
+//   The seed must stay assigned/open during a runner outage so AFK detection
+//   keeps working; releasing it would trip the runner's assigned_canary_seed_missing
+//   check.
 export const WORKER_SELF_HEALING_PROTECTED_TODO_IDS = new Set<string>([
   "8719dc4f-1650-4ea9-bca8-e92a9819f0ba",
 ]);

--- a/api/fishbowl-watcher.ts
+++ b/api/fishbowl-watcher.ts
@@ -91,6 +91,23 @@ const WORKER_SELF_HEALING_TODO_SWEEP_LIMIT = 50;
 export const WORKER_SELF_HEALING_REASSIGN_ATTEMPT_LIMIT = 3;
 export const WAKEPASS_REROUTE_LEASE_SECONDS = 600;
 
+// Specific Boardroom todo ids that the self-healing watcher must NEVER release,
+// regardless of age or owner liveness. This is a precise, per-seed allowlist:
+// it protects ONLY these exact todo rows from the release/reclaim paths and does
+// NOT protect their owner agents in general (legitimate stale runner-owned jobs
+// must still be releasable). It only gates the watcher's release/decision/proof
+// paths (workerSelfHealingProtectedReason); the runner's claim/build/complete
+// flow is a separate code path and is unaffected.
+//
+// - 8719dc4f-1650-4ea9-bca8-e92a9819f0ba: AFK canary seed (docs-only OpenHands
+//   proof fixture), assigned to pinballwake-autonomous-runner, linked Boardroom
+//   coding-room job bf58d19d. The seed must stay assigned/open during a runner
+//   outage so AFK detection keeps working; releasing it would trip the runner's
+//   assigned_canary_seed_missing check.
+export const WORKER_SELF_HEALING_PROTECTED_TODO_IDS = new Set<string>([
+  "8719dc4f-1650-4ea9-bca8-e92a9819f0ba",
+]);
+
 interface WakepassRerouteTarget {
   agentId: string;
   recipient: string;
@@ -821,6 +838,11 @@ function nonEmptyString(value: unknown): string | null {
 }
 
 export function workerSelfHealingProtectedReason(todo: WorkerSelfHealingTodoState): string | null {
+  const todoId = nonEmptyString(todo.id)?.toLowerCase();
+  if (todoId && WORKER_SELF_HEALING_PROTECTED_TODO_IDS.has(todoId)) {
+    return "canary_seed_protected";
+  }
+
   const status = normalizeToken(todo.status);
   if (status === "human_blocker") return "human_blocker_protected";
   if (status === "manual_only") return "manual_only_protected";


### PR DESCRIPTION
## WriterLane Slice 2b — FIRST real behavior change

> **DRAFT / do not merge without review.** Slices 1 (`classifyTodoActionability`) and 2a (`planOpenStaleTodoRelease`) added pure, dead-code helpers. **This is the first slice that changes live behavior**: the 15-min watcher cron now *releases* stale `open + stale_assigned_open` Boardroom todos that today are detected but never released.

### What changed
`api/fishbowl-watcher.ts` (+ tests only):
1. Import `classifyTodoActionability` + `planOpenStaleTodoRelease` (and `STALE_OPEN_ASSIGNED_MS`).
2. New **section 3b** sweep: a third fetch scoped to the gap the existing sweep never touches — `status=open`, `assigned_to_agent_id` not null, **no active lease** (`lease_expires_at IS NULL`), `updated_at` aged past the classifier's 6h threshold.
3. Resolve each owner's real `last_seen_at` via the **same `mc_fishbowl_profiles` join the list-actionable endpoint uses**, then route through the pure, classifier-gated `planOpenStaleTodoRelease`.
4. Apply returned plans via the **existing `releaseWorkerSelfHealingTodoOwnership` CAS applier, unchanged**.
5. New `buildOpenStaleTodoReleasePlan` wraps the pure plan as a `WorkerSelfHealingTodoReleasePlan` so the applier + signal-insert path are reused verbatim.
6. New cron-response metrics: `worker_self_healing_open_stale_candidates`, `worker_self_healing_open_stale_released`.

The existing **in_progress / expired-lease path and `decideStaleLease` are completely untouched**; `planWorkerSelfHealingTodoRelease` behavior is unchanged.

### Guardrails (all hold)
- **Classifier-only gating.** Clock/math decides via `classifyTodoActionability` only. No NudgeOnly anywhere in the watcher (kept that way).
- **Never release a live owner.** Real `ownerLastSeenAt` is passed; the classifier's 1h live-owner rule applies.
- **Reclaim cap `< 3`**, bumps `reclaim_count + 1` (in the pure helper).
- **Never release protected todos.** `workerSelfHealingProtectedReason` is computed before planning and passed as `isProtected`.
- **Optimistic concurrency via the existing CAS only; idempotent.** Once an owner is cleared the row no longer matches this fetch; a concurrent change makes the update a zero-row no-op.
- **Scoped to the no-active-lease gap.** Open todos with *expired* leases stay on the existing signal-only path (no double-processing); active leases are never touched.

### ✅ Canary safety — edge closed (protected-by-id)
The AFK canary seed (`8719dc4f-1650-4ea9-bca8-e92a9819f0ba`, linked Boardroom job `bf58d19d`) is an **open** todo assigned to `pinballwake-autonomous-runner`.

**Update:** the canary is now **protected by id**. A precise per-seed allowlist `WORKER_SELF_HEALING_PROTECTED_TODO_IDS` is checked first in `workerSelfHealingProtectedReason`, returning `canary_seed_protected` for the exact todo id, so the watcher **never** releases it — even in the previously-flagged sustained-outage edge (`updated_at` aged `> 6h` AND owner dormant `> 1h`).

- **Scoped to the seed id only.** It does **not** add `pinballwake-autonomous-runner` (or any owner/role) to a global protected/role set, so legitimate stale runner-owned jobs remain releasable (the whole point of this slice). Verified by test.
- **Release path only.** `workerSelfHealingProtectedReason` is referenced solely by the watcher's release/decision/proof paths. The runner's **claim** flow (`list_actionable_todos` → which uses `classifyTodoActionability`, untouched → claim) and **complete** flow (`evaluateFishbowlCompletionPolicy`, a separate gate) never consult it, so the canary can still be claimed and built normally. Confirmed by reading the claim/complete endpoints.
- **Defense-in-depth still holds:** in a healthy system the canary is also protected by the age gate (continuously re-exercised, `updated_at < 6h`) and the owner-liveness gate.
- **Verified by tests:** protected-by-id (incl. case-insensitive id); not released even when aged AND owner dormant; a *different* runner-owned open todo stays releasable; plus the layered fresh/age/explicit-protected cases.

### Tests / proof
- `vitest`: **53/53** in `api/fishbowl-watcher.test.ts`, **53/53** in the two imported-helper suites.
- Standalone `tsc --strict` on touched files: the new logic (`buildOpenStaleTodoReleasePlan`, the classifier/protection calls, the per-seed allowlist + id check, the row cast) is **strict-clean**. The only strict deltas vs `origin/main` are pre-existing-class supabase `never`-generics warnings (identical to existing call sites; not present in the project's actual build) and 1 extensionless-import warning inside the imported Slice 2a helper file.

### Out of scope / untouched
`scripts/pinballwake-autonomous-runner.mjs`, `.github/workflows/*`, `api/lib/fishbowl-todo-handoff.ts`, `packages/mcp-server/src/reliability.ts`, DB/migrations, the canary seed row, rulesets, and the in_progress planner's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> First live behavior change on the worker self-healing cron: it mutates todo ownership in production, though gated by classifier, protection, liveness, and reclaim cap.
> 
> **Overview**
> The **15-minute fishbowl watcher** now **releases** Boardroom todos that are **`open`, assigned, and unleased** but were only classified as stale before: a new **section 3b** sweep loads rows past the **6h** threshold, resolves owner **`last_seen_at`** from profiles, and applies **`planOpenStaleTodoRelease`** via **`buildOpenStaleTodoReleasePlan`** and the existing **CAS** release path plus **`worker_self_healing_stale_owner_released`** signals.
> 
> **`workerSelfHealingProtectedReason`** is exported and extended with a **per-todo-id allowlist** (including the **AFK canary seed**) so those rows are never released; other runner-owned jobs stay releasable. Cron JSON gains **`worker_self_healing_open_stale_*`** metrics. **`in_progress` / lease** self-healing is unchanged. Tests cover gates, reclaim cap, and canary scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d16e71ee64edf1d1323f3792407af0e89336fc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->