### PR TITLE
fix(watcher): add missing .js extension to stale-release ESM import (prod crash)

### DIFF
--- a/api/lib/fishbowl-todo-open-stale-release.ts
+++ b/api/lib/fishbowl-todo-open-stale-release.ts
@@ -11,7 +11,7 @@
 import {
   classifyTodoActionability,
   type TodoActionability,
-} from "./fishbowl-todo-actionability";
+} from "./fishbowl-todo-actionability.js";
 
 // Mirrors WORKER_SELF_HEALING_REASSIGN_ATTEMPT_LIMIT (= 3) in
 // api/fishbowl-watcher.ts. Duplicated here so this helper stays pure and free of


### PR DESCRIPTION
## Summary

Hotfix for a **live production crash**: the `fishbowl-watcher` cron was hard-crashing on **every 15-minute run** with:

```
ERR_MODULE_NOT_FOUND: Cannot find module '/var/task/api/lib/fishbowl-todo-actionability'
imported from /var/task/api/lib/fishbowl-todo-open-stale-release.js
```

Because the watcher crashed at module load, it did no work — so stale open/assigned jobs were never released.

**Root cause:** `api/lib/fishbowl-todo-open-stale-release.ts` imported `./fishbowl-todo-actionability` without the `.js` extension. The package is `"type": "module"`, so Vercel's Node ESM loader requires explicit extensions on relative specifiers and throws `ERR_MODULE_NOT_FOUND`. (`api/fishbowl-watcher.ts` already imports both helpers with `.js`, so `.js` is the correct convention here.)

**The fix:** one character of intent — add `.js`:

```diff
-} from "./fishbowl-todo-actionability";
+} from "./fishbowl-todo-actionability.js";
```

## Why local tests didn't catch it

- The `api/` workspace has no typecheck gate in CI.
- Vitest resolves extensionless relative imports fine, so all suites passed locally despite the broken-at-runtime specifier.

## Defensive scan

Checked the watcher's full runtime import chain for the same bug class:
- `api/lib/fishbowl-todo-open-stale-release.ts` — fixed (was the only offender).
- `api/lib/fishbowl-todo-actionability.ts` — pure leaf, no relative imports.
- `api/fishbowl-watcher.ts` — all 3 relative imports already end in `.js`.

Casing verified against git: file is `fishbowl-todo-actionability.ts` (all lowercase), import matches (case-sensitive on Linux).

## Verification

- `vitest run` of the watcher + both helper suites: **106/106 passed** (3 files).
- **ESM resolution proof** (mirrors Vercel: transpiled to ESM `.js` via esbuild, run under `"type": "module"` with node's loader):
  - Fixed module imports cleanly → exports `OPEN_STALE_RECLAIM_ATTEMPT_LIMIT, planOpenStaleTodoRelease`.
  - The extensionless form reproduces the exact production error code: `ERR_MODULE_NOT_FOUND`.

## Test plan

- [x] Watcher + helper vitest suites green (106/106)
- [x] ESM loader resolves the fixed module under `"type": "module"`
- [x] Extensionless form reproduces `ERR_MODULE_NOT_FOUND`
- [ ] Confirm next scheduled `fishbowl-watcher` run no longer crashes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line import path fix with no logic changes; restores a broken cron path rather than altering business rules.
> 
> **Overview**
> **Hotfix** for a production crash: the `fishbowl-watcher` cron failed on every run with `ERR_MODULE_NOT_FOUND` because `api/lib/fishbowl-todo-open-stale-release.ts` imported `./fishbowl-todo-actionability` without a `.js` suffix. Under `"type": "module"`, Node on Vercel requires explicit extensions on relative imports.
> 
> The change updates that single import to `./fishbowl-todo-actionability.js`, matching `api/fishbowl-watcher.ts` and other API helpers. No behavior change beyond restoring module load so stale open/assigned todo release logic can run again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5085f911024d5c1ff6bc35ec14d228738f74643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->