### PR TITLE
Honesty slice: claim-only runs report HOLD/execute-disabled in data

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1452,6 +1452,10 @@ export async function syncClaimedBoardroomTodoToUnClick({
     return {
       ok: true,
       skipped: true,
+      action: "hold",
+      hold: true,
+      execute_disabled: true,
+      hold_reason: "claim_only_execute_disabled",
       reason: "test_only_executor_packet_not_active_claim",
       todo_id: todoId,
       assigned_to_agent_id: job?.source_state?.assigned_to_agent_id || null,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1682,6 +1682,14 @@ describe("PinballWake autonomous Runner seat", () => {
       assert.equal(result.todo_claim_sync.ok, true);
       assert.equal(result.todo_claim_sync.skipped, true);
       assert.equal(result.todo_claim_sync.reason, "test_only_executor_packet_not_active_claim");
+      // Honesty slice: a claim-only / execute-disabled run must read as a HOLD in its data,
+      // so a ledger/proof consumer cannot mistake it for a real claim (anti-false-DONE).
+      assert.equal(result.todo_claim_sync.action, "hold");
+      assert.equal(result.todo_claim_sync.hold, true);
+      assert.equal(result.todo_claim_sync.execute_disabled, true);
+      assert.equal(result.todo_claim_sync.hold_reason, "claim_only_execute_disabled");
+      assert.notEqual(result.todo_claim_sync.status, "in_progress");
+      assert.notEqual(result.todo_claim_sync.assigned_to_agent_id, "runner-plex-1");
       assert.equal(result.todo_claim_sync.todo_id, "todo-claim-1");
       assert.equal(result.todo_claim_sync.test_only_executor_packet.receipt.receipt_type, "executor_packet_pass");
       assert.equal(result.todo_claim_sync.openhands_claim_probe.receipt.receipt_type, "openhands_worker_hold");


### PR DESCRIPTION
## False-DONE hazard this closes

In `syncClaimedBoardroomTodoToUnClick` (`scripts/pinballwake-autonomous-runner.mjs`), the claim-to-execute HOLD branch (the claim-only / `execute_enabled=false` path) returned:

```js
{ ok: true, skipped: true, reason: "test_only_executor_packet_not_active_claim",
  assigned_to_agent_id: <echo>, status: <echo>, comment_ok: true, comment_id: ... }
```

The HOLD was only spelled out in the posted comment text. A ledger/proof consumer reading the **data** (not the prose) saw `ok:true` plus an echoed status and could mistake a no-build, no-claim run for a real claim. This is the anti-false-DONE fix: make the HOLD unambiguous in the data itself.

## What was added (ADDITIVE ONLY)

Four top-level flags on that one return object:

- `action: "hold"`
- `hold: true`
- `execute_disabled: true`
- `hold_reason: "claim_only_execute_disabled"`

The existing `reason: "test_only_executor_packet_not_active_claim"` key is **kept unchanged** (something downstream may match on it). Net diff: +12 lines, 0 removals, across the runner and its test.

## Consumer-grep result

- `test_only_executor_packet_not_active_claim`: matched in exactly two places repo-wide: the source line itself and one test assertion. Kept intact, so nothing that matches on it breaks.
- `todo_claim_sync` / `todoClaimSync` consumers (in `runAutonomousRunnerFile`): read only `.ok`, `.openhands_execute(.ok/.reason)`, and `.test_only_executor_packet`. None read `action`/`hold`/`execute_disabled`/`hold_reason`/`status`, so the new keys cannot collide.
- The top-level run result computes its own `action`/`reason` (`finalAction`/`finalReason`) independently of the nested claim-sync object, so adding `action` to the nested object does not change run-level behavior.

## Claim path + behavior unchanged

- The genuine claim path (the one that calls `update_todo` to `in_progress`, posts "status open -> in_progress", and returns `status: "in_progress"`) is untouched.
- No change to whether/what comment is posted. The HOLD run still stays open + unassigned (claim-only) and does not claim or `update_todo`.

## Tests

`node --test scripts/pinballwake-autonomous-runner.test.mjs` -> 61 pass / 0 fail. Added assertions to the existing HOLD-path test ("does not mark UnClick todos in_progress for test-only executor packets") that the claim-only return carries `action:"hold"`, `hold:true`, `execute_disabled:true`, `hold_reason:"claim_only_execute_disabled"`, and is not mistakable for a claim (`status !== "in_progress"`, `assigned_to_agent_id !== runner`).

ESM note: no imports were added or modified; the passing `node --test` run imports the runner module, proving ESM resolution is intact.

DRAFT - do not merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive fields on one return branch in `syncClaimedBoardroomTodoToUnClick`; no change to execute or real-claim behavior, covered by existing integration test.
> 
> **Overview**
> When `syncClaimedBoardroomTodoToUnClick` takes the claim-only / execute-disabled path (test-only executor packet, no `update_todo`), the returned **`todo_claim_sync`** object now includes explicit HOLD metadata: `action: "hold"`, `hold: true`, `execute_disabled: true`, and `hold_reason: "claim_only_execute_disabled"`. The existing `reason: "test_only_executor_packet_not_active_claim"` is unchanged.
> 
> This closes a **false-DONE** gap: consumers that read structured data (not only the Boardroom comment) could previously see `ok: true` with echoed `status` / `assigned_to_agent_id` and infer a real claim. The real claim path (`in_progress` + assignee update) is untouched.
> 
> Tests on the test-only executor packet flow assert the new fields and that sync data is not mistakable for an active claim (`status !== "in_progress"`, assignee not the runner).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c977f843e03ac1ee4b1c3c808a559fe302c5604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->