### PR TITLE
feat(writerlane): add free backend router

### DIFF
--- a/api/lib/writerlane/writerlane-router.ts
+++ b/api/lib/writerlane/writerlane-router.ts
@@ -1,0 +1,294 @@
+import {
+  FIXTURE_BACKEND_KIND,
+  type WriterLaneInput,
+} from "./writerlane-types.js";
+
+export type WriterLaneBackendCost =
+  | "free"
+  | "paid"
+  | "subscription"
+  | "fixture";
+
+export type WriterLaneBackendStatus =
+  | "available"
+  | "disabled"
+  | "unconfigured";
+
+export type WriterLaneTaskKind =
+  | "docs"
+  | "tests"
+  | "backend"
+  | "frontend"
+  | "script"
+  | "config"
+  | "mixed"
+  | "unknown";
+
+// Small, pure routing metadata. The real backend object still lives elsewhere;
+// this profile lets the lane choose among free writers before execution.
+export interface WriterLaneBackendProfile {
+  readonly kind: string;
+  readonly cost: WriterLaneBackendCost;
+  readonly status: WriterLaneBackendStatus;
+  readonly strengths: WriterLaneTaskKind[];
+  readonly supportsAutonomyProof: boolean;
+  readonly maxOwnedFiles?: number;
+  readonly requiresWarmSeat?: boolean;
+  readonly priority?: number;
+  readonly notes?: string;
+}
+
+export interface WriterLaneSelectionPolicy {
+  readonly allowPaid?: boolean;
+  readonly allowSubscription?: boolean;
+  readonly allowFixture?: boolean;
+  readonly preferFree?: boolean;
+  readonly warmSeatAvailable?: boolean;
+  readonly preferredKinds?: string[];
+}
+
+export interface WriterLaneCandidateScore {
+  readonly kind: string;
+  readonly score: number;
+  readonly eligible: boolean;
+  readonly reasons: string[];
+}
+
+export interface WriterLaneSelectionSuccess {
+  readonly ok: true;
+  readonly selected: WriterLaneBackendProfile;
+  readonly taskKind: WriterLaneTaskKind;
+  readonly candidates: WriterLaneCandidateScore[];
+}
+
+export interface WriterLaneSelectionFailure {
+  readonly ok: false;
+  readonly reason: string;
+  readonly taskKind: WriterLaneTaskKind;
+  readonly candidates: WriterLaneCandidateScore[];
+}
+
+export type WriterLaneSelection =
+  | WriterLaneSelectionSuccess
+  | WriterLaneSelectionFailure;
+
+export function chooseWriterLaneBackend(
+  input: WriterLaneInput,
+  profiles: WriterLaneBackendProfile[],
+  policy: WriterLaneSelectionPolicy = {},
+): WriterLaneSelection {
+  const taskKind = inferWriterLaneTaskKind(input);
+  const candidates = profiles
+    .map((profile) => scoreProfile(profile, input, taskKind, policy))
+    .sort(compareCandidates);
+
+  const selected = candidates.find((candidate) => candidate.eligible);
+  if (!selected) {
+    return {
+      ok: false,
+      reason: "writerlane_no_eligible_backend",
+      taskKind,
+      candidates,
+    };
+  }
+
+  const selectedProfile = profiles.find(
+    (profile) => profile.kind === selected.kind,
+  );
+  if (!selectedProfile) {
+    return {
+      ok: false,
+      reason: "writerlane_selected_backend_missing",
+      taskKind,
+      candidates,
+    };
+  }
+
+  return {
+    ok: true,
+    selected: selectedProfile,
+    taskKind,
+    candidates,
+  };
+}
+
+export function inferWriterLaneTaskKind(
+  input: Pick<WriterLaneInput, "scopePack">,
+): WriterLaneTaskKind {
+  const files = input.scopePack.ownedFiles.map((file) =>
+    file.replace(/\\/g, "/").toLowerCase(),
+  );
+  if (files.length === 0) return "unknown";
+
+  const kinds = new Set(files.map(kindForPath));
+  const singleKind = kinds.size === 1 ? [...kinds][0] : null;
+  if (singleKind && singleKind !== "unknown") return singleKind;
+  if (allDocs(files)) return "docs";
+  if (allTests(files)) return "tests";
+
+  const intent = input.scopePack.changeIntent.toLowerCase();
+  if (/\b(doc|copy|readme|markdown)\b/.test(intent)) return "docs";
+  if (/\b(test|spec|coverage|vitest|playwright)\b/.test(intent)) {
+    return "tests";
+  }
+  if (/\b(api|backend|server|runner|worker|mcp)\b/.test(intent)) {
+    return "backend";
+  }
+  if (/\b(ui|frontend|component|page|tsx|react)\b/.test(intent)) {
+    return "frontend";
+  }
+
+  return singleKind ?? "mixed";
+}
+
+function scoreProfile(
+  profile: WriterLaneBackendProfile,
+  input: WriterLaneInput,
+  taskKind: WriterLaneTaskKind,
+  policy: WriterLaneSelectionPolicy,
+): WriterLaneCandidateScore {
+  const reasons: string[] = [];
+  let eligible = true;
+  let score = profile.priority ?? 0;
+  const preferFree = policy.preferFree ?? true;
+
+  if (profile.status !== "available") {
+    eligible = false;
+    reasons.push(`status:${profile.status}`);
+  }
+
+  if (input.proofMode === "autonomy" && !profile.supportsAutonomyProof) {
+    eligible = false;
+    reasons.push("no_autonomy_proof");
+  }
+
+  if (profile.cost === "paid" && !policy.allowPaid) {
+    eligible = false;
+    reasons.push("paid_not_allowed");
+  }
+
+  if (profile.cost === "subscription" && !policy.allowSubscription) {
+    eligible = false;
+    reasons.push("subscription_not_allowed");
+  }
+
+  if (profile.requiresWarmSeat && !policy.warmSeatAvailable) {
+    eligible = false;
+    reasons.push("warm_seat_missing");
+  }
+
+  if (profile.cost === "fixture" && !policy.allowFixture) {
+    eligible = false;
+    reasons.push("fixture_not_allowed");
+  }
+
+  if (
+    profile.kind === FIXTURE_BACKEND_KIND &&
+    input.proofMode === "autonomy"
+  ) {
+    eligible = false;
+    reasons.push("fixture_never_autonomy");
+  }
+
+  if (
+    typeof profile.maxOwnedFiles === "number" &&
+    input.scopePack.ownedFiles.length > profile.maxOwnedFiles
+  ) {
+    eligible = false;
+    reasons.push("too_many_owned_files");
+  }
+
+  if (policy.preferredKinds?.includes(profile.kind)) {
+    score += 100;
+    reasons.push("preferred");
+  }
+
+  if (profile.strengths.includes(taskKind)) {
+    score += 50;
+    reasons.push(`strong:${taskKind}`);
+  } else if (profile.strengths.includes("mixed")) {
+    score += 15;
+    reasons.push("generalist");
+  }
+
+  if (profile.cost === "free" && preferFree) {
+    score += 30;
+    reasons.push("free_first");
+  }
+
+  if (profile.cost === "paid") {
+    score -= 30;
+  }
+
+  if (profile.cost === "fixture") {
+    score -= 100;
+  }
+
+  return {
+    kind: profile.kind,
+    score: eligible ? score : Number.NEGATIVE_INFINITY,
+    eligible,
+    reasons,
+  };
+}
+
+function compareCandidates(
+  left: WriterLaneCandidateScore,
+  right: WriterLaneCandidateScore,
+): number {
+  if (left.eligible !== right.eligible) return left.eligible ? -1 : 1;
+  if (left.score !== right.score) return right.score - left.score;
+  return left.kind.localeCompare(right.kind);
+}
+
+function kindForPath(file: string): WriterLaneTaskKind {
+  if (isDoc(file)) return "docs";
+  if (isTest(file)) return "tests";
+  if (file.startsWith("api/") || file.startsWith("packages/")) {
+    return "backend";
+  }
+  if (
+    file.startsWith("src/") ||
+    file.endsWith(".tsx") ||
+    file.endsWith(".jsx") ||
+    file.endsWith(".css")
+  ) {
+    return "frontend";
+  }
+  if (file.startsWith("scripts/")) return "script";
+  if (
+    file.startsWith(".github/") ||
+    file.endsWith(".json") ||
+    file.endsWith(".yml") ||
+    file.endsWith(".yaml") ||
+    file.endsWith(".toml")
+  ) {
+    return "config";
+  }
+  return "unknown";
+}
+
+function allDocs(files: string[]): boolean {
+  return files.every(isDoc);
+}
+
+function allTests(files: string[]): boolean {
+  return files.every(isTest);
+}
+
+function isDoc(file: string): boolean {
+  return (
+    file.startsWith("docs/") ||
+    file.endsWith(".md") ||
+    file.endsWith(".mdx") ||
+    file.endsWith(".txt")
+  );
+}
+
+function isTest(file: string): boolean {
+  return (
+    file.includes(".test.") ||
+    file.includes(".spec.") ||
+    file.startsWith("tests/")
+  );
+}

--- a/api/lib/writerlane/writerlane.test.ts
+++ b/api/lib/writerlane/writerlane.test.ts
@@ -11,6 +11,11 @@ import {
   FIXTURE_PATCH,
   fixtureWriterLaneBackend,
 } from "./fixture-backend";
+import {
+  chooseWriterLaneBackend,
+  inferWriterLaneTaskKind,
+  type WriterLaneBackendProfile,
+} from "./writerlane-router";
 
 const scopePack = {
   ownedFiles: ["api/lib/writerlane/example.ts"],
@@ -81,5 +86,158 @@ describe("acceptsAsAutonomyProof - the contract gate", () => {
   it("never accepts a failure as autonomy proof", () => {
     const failure: WriterLaneResult = { ok: false, reason: "no diff produced" };
     expect(acceptsAsAutonomyProof(failure, "autonomy")).toBe(false);
+  });
+});
+
+describe("writer backend router", () => {
+  const docsFree: WriterLaneBackendProfile = {
+    kind: "free-docs-writer",
+    cost: "free",
+    status: "available",
+    strengths: ["docs"],
+    supportsAutonomyProof: true,
+    maxOwnedFiles: 4,
+  };
+
+  const codeFree: WriterLaneBackendProfile = {
+    kind: "free-code-writer",
+    cost: "free",
+    status: "available",
+    strengths: ["backend", "script", "tests", "mixed"],
+    supportsAutonomyProof: true,
+    maxOwnedFiles: 8,
+  };
+
+  const paidGeneralist: WriterLaneBackendProfile = {
+    kind: "paid-generalist",
+    cost: "paid",
+    status: "available",
+    strengths: ["docs", "backend", "frontend", "script", "tests", "mixed"],
+    supportsAutonomyProof: true,
+  };
+
+  const warmSubscription: WriterLaneBackendProfile = {
+    kind: "subscription-warm-seat",
+    cost: "subscription",
+    status: "available",
+    strengths: ["backend", "frontend", "mixed"],
+    supportsAutonomyProof: true,
+    requiresWarmSeat: true,
+  };
+
+  const fixtureProfile: WriterLaneBackendProfile = {
+    kind: "fixture",
+    cost: "fixture",
+    status: "available",
+    strengths: ["mixed"],
+    supportsAutonomyProof: false,
+  };
+
+  it("infers task kind from the ScopePack owned files", () => {
+    expect(
+      inferWriterLaneTaskKind({
+        scopePack: {
+          ownedFiles: ["docs/writerlane.md"],
+          changeIntent: "add docs",
+          proofRequirements: [],
+        },
+      }),
+    ).toBe("docs");
+
+    expect(
+      inferWriterLaneTaskKind({
+        scopePack: {
+          ownedFiles: ["api/lib/writerlane/router.ts"],
+          changeIntent: "wire backend selector",
+          proofRequirements: [],
+        },
+      }),
+    ).toBe("backend");
+  });
+
+  it("chooses the strongest free backend for the job by default", () => {
+    const selection = chooseWriterLaneBackend(
+      {
+        proofMode: "autonomy",
+        scopePack: {
+          ownedFiles: ["docs/writerlane-free-backends.md"],
+          changeIntent: "document free backend routing",
+          proofRequirements: ["vitest passes"],
+        },
+      },
+      [codeFree, docsFree, paidGeneralist],
+    );
+
+    expect(selection.ok).toBe(true);
+    if (!selection.ok) throw new Error("free docs backend should be selected");
+    expect(selection.selected.kind).toBe("free-docs-writer");
+    expect(selection.taskKind).toBe("docs");
+  });
+
+  it("does not use paid, subscription, or fixture backends unless policy allows them", () => {
+    const selection = chooseWriterLaneBackend(autonomyInput, [
+      paidGeneralist,
+      warmSubscription,
+      fixtureProfile,
+    ]);
+
+    expect(selection.ok).toBe(false);
+    expect(selection.reason).toBe("writerlane_no_eligible_backend");
+    expect(selection.candidates.map((candidate) => candidate.kind)).toEqual(
+      expect.arrayContaining([
+        "paid-generalist",
+        "subscription-warm-seat",
+        "fixture",
+      ]),
+    );
+  });
+
+  it("can fall back across multiple free backends when the best fit is unavailable", () => {
+    const disabledDocsFree: WriterLaneBackendProfile = {
+      ...docsFree,
+      status: "unconfigured",
+    };
+
+    const selection = chooseWriterLaneBackend(
+      {
+        proofMode: "autonomy",
+        scopePack: {
+          ownedFiles: ["docs/writerlane-routing.md"],
+          changeIntent: "small docs update",
+          proofRequirements: ["vitest passes"],
+        },
+      },
+      [disabledDocsFree, codeFree],
+    );
+
+    expect(selection.ok).toBe(true);
+    if (!selection.ok) throw new Error("fallback free backend should win");
+    expect(selection.selected.kind).toBe("free-code-writer");
+  });
+
+  it("allows a warm subscription backend only when explicitly requested", () => {
+    const cold = chooseWriterLaneBackend(
+      autonomyInput,
+      [warmSubscription, codeFree],
+      { allowSubscription: true },
+    );
+
+    expect(cold.ok).toBe(true);
+    if (!cold.ok) throw new Error("free backend should be selected cold");
+    expect(cold.selected.kind).toBe("free-code-writer");
+
+    const warm = chooseWriterLaneBackend(
+      autonomyInput,
+      [warmSubscription, codeFree],
+      {
+        allowSubscription: true,
+        warmSeatAvailable: true,
+        preferredKinds: ["subscription-warm-seat"],
+      },
+    );
+
+    expect(warm.ok).toBe(true);
+    if (!warm.ok) throw new Error("warm subscription should be selectable");
+    expect(warm.selected.kind).toBe("subscription-warm-seat");
   });
 });


### PR DESCRIPTION
Summary:
- add a pure WriterLane router for scoring multiple backend profiles
- default to free backends while keeping paid, subscription, and fixture backends out unless explicitly allowed
- add tests for task-kind inference, free-first selection, fallback, and warm-seat opt-in

Proof:
- npm test -- api/lib/writerlane/writerlane.test.ts

Notes:
- no runner wiring, no execution, no paid API path enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure selection logic and unit tests only; no execution, runner, or paid API paths are wired in this PR.
> 
> **Overview**
> Adds a **pure** WriterLane backend router (`writerlane-router.ts`) that picks a writer profile from metadata before any execution runs.
> 
> `chooseWriterLaneBackend` infers a **task kind** from `ScopePack` paths and change intent, scores each `WriterLaneBackendProfile` (availability, autonomy proof, cost policy, warm seat, file limits, strengths), and returns the best eligible backend or a structured failure with ranked candidates. **Paid**, **subscription**, and **fixture** backends are excluded by default; **free-first** scoring and explicit policy flags gate paid/subscription/fixture and warm-seat use.
> 
> `writerlane.test.ts` gains coverage for task-kind inference, default free selection, ineligible-only pools, free-backend fallback, and subscription opt-in with warm seat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b3abaa098c4e5c4e9fcfb6549d38a7269c5a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->