### PR TITLE
fix(admin): slow jobs page polling

### DIFF
--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import AdminJobs from "./AdminJobs";
+import AdminJobs, { JOBS_REFRESH_INTERVAL_MS } from "./AdminJobs";
 
 vi.mock("@/lib/auth", () => ({
   useSession: () => ({
@@ -210,5 +210,15 @@ describe("AdminJobs", () => {
     expect(completedSection).not.toBeNull();
     expect(within(nextSection as HTMLElement).getByText("Reopened truth job")).toBeInTheDocument();
     expect(within(completedSection as HTMLElement).queryByText("Reopened truth job")).not.toBeInTheDocument();
+  });
+
+  it("polls the jobs API on a quieter 60-second cadence", async () => {
+    const intervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    render(React.createElement(AdminJobs));
+
+    await screen.findByText("Alpha ready job");
+    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), JOBS_REFRESH_INTERVAL_MS);
+    expect(JOBS_REFRESH_INTERVAL_MS).toBe(60_000);
   });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -83,6 +83,7 @@ type SectionPreferences = {
 const ORDER_STORAGE_KEY = "unclick_jobs_manual_order_v1";
 const SECTION_PREF_STORAGE_KEY = "unclick_jobs_section_preferences_v1";
 const SECTION_PAGE_SIZE = 10;
+export const JOBS_REFRESH_INTERVAL_MS = 60_000;
 // Completed section uses bigger batches: 50 visible by default, +100 per "Show more"
 // click. Server-side completed history is fetched in matching batches via the
 // `before_created_at` cursor until exhausted.
@@ -1167,7 +1168,7 @@ export default function AdminJobs() {
     const id = setInterval(() => {
       void loadJobs();
       setPollSeq((s) => s + 1);
-    }, 10_000);
+    }, JOBS_REFRESH_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(id);


### PR DESCRIPTION
## Summary
- change /admin/jobs polling from every 10 seconds to every 60 seconds
- add a focused regression test so the cadence stays quiet

## Test plan
- npx vitest run src/pages/admin/AdminJobs.test.tsx
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only polling cadence change with no auth, data, or API contract changes; job list may feel slightly less fresh.
> 
> **Overview**
> Slows automatic refresh on the admin **Jobs** board by introducing a shared **`JOBS_REFRESH_INTERVAL_MS`** constant (**60 seconds**) and wiring the existing `setInterval` poll to use it instead of a hard-coded **10 second** interval.
> 
> Adds a Vitest case that asserts `AdminJobs` registers polling with that exported interval so the cadence does not drift back to aggressive polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f7cc214d4da953f3edbf1ba79ac9f038bef378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->