### PR TITLE
feat(writerlane): free-only default, verdict-ranked registry, validator layer

### DIFF
--- a/api/lib/writerlane/openhands-backend.test.ts
+++ b/api/lib/writerlane/openhands-backend.test.ts
@@ -19,12 +19,14 @@ import {
   type OpenHandsRunResult,
 } from "./openhands-backend";
 import {
+  fitScore,
   isFreeModelSlug,
   listFreeModelsByStatus,
   rankFreeModelsForTask,
   selectDefaultFreeChain,
+  topFreeModelForTask,
   WRITERLANE_FREE_MODELS,
-  type FreeModelStatus,
+  type EmpiricalStatus,
   type WriterLaneFreeModel,
 } from "./writerlane-free-models";
 
@@ -66,25 +68,25 @@ function worktreeResult(patch: string): OpenHandsRunResult {
   return { ok: true, patch, changedFiles: [ownedFile], diffSource: "worktree" };
 }
 
-// Test models with deterministic ranking for a "backend" task: strongCode wins
-// (higher priority), weakDocs is the fallback. Both trial.
+// Test models with deterministic ranking for a "backend" (code) task: strongCode
+// wins (code affinity), weakDocs is the fallback (no code affinity). Both trial.
 const strongCode: WriterLaneFreeModel = {
   id: "strong-code",
   openRouterModel: "vendor/strong-code:free",
-  paramScale: "70B",
-  capabilities: ["code", "reasoning"],
-  strengths: ["backend", "tests", "script", "mixed"],
-  status: "trial",
+  bestFor: ["code", "reasoning"],
+  contextTokens: 128000,
+  bestAt: "test fixture: code writer",
+  empirical: { status: "trial", note: "test fixture" },
   priority: 10,
 };
 
 const weakDocs: WriterLaneFreeModel = {
   id: "weak-docs",
   openRouterModel: "vendor/weak-docs:free",
-  paramScale: "1B",
-  capabilities: ["docs", "fast"],
-  strengths: ["docs"],
-  status: "trial",
+  bestFor: ["docs"],
+  contextTokens: 32000,
+  bestAt: "test fixture: docs writer",
+  empirical: { status: "trial", note: "test fixture" },
   priority: 0,
 };
 
@@ -96,52 +98,109 @@ function runnerByModel(
     byId[model.id] ?? { ok: false, reason: "no_canned_response" };
 }
 
-// The nine verified free OpenRouter candidate ids, with the status each now
-// carries from real code-slice run verdicts (see writerlane-free-models.ts):
-// proven-clean coders are "vetted"; junk-prone laguna-xs.2 is "flagged"; the
-// rest stay "trial" until a clean verdict lands.
-const VERIFIED_FREE_CANDIDATE_STATUS: Record<string, FreeModelStatus> = {
-  "openai/gpt-oss-120b:free": "vetted",
-  "minimax/minimax-m2.5:free": "vetted",
-  "poolside/laguna-m.1:free": "vetted",
+// The nine verified free OpenRouter candidate ids, with the empirical status each
+// now carries from real code-slice run verdicts (see writerlane-free-models.ts):
+// proven-clean coders are "proven"; over-editing glm and junk-prone laguna-xs.2
+// are "flagged"; the rate-limited-out reals stay "trial" until a clean verdict.
+const VERIFIED_FREE_CANDIDATE_STATUS: Record<string, EmpiricalStatus> = {
+  "openai/gpt-oss-120b:free": "proven",
+  "minimax/minimax-m2.5:free": "proven",
+  "poolside/laguna-m.1:free": "proven",
   "qwen/qwen3-coder:free": "trial",
-  "z-ai/glm-4.5-air:free": "trial",
   "deepseek/deepseek-v4-flash:free": "trial",
   "meta-llama/llama-3.3-70b-instruct:free": "trial",
   "google/gemma-4-31b-it:free": "trial",
+  "z-ai/glm-4.5-air:free": "flagged",
   "poolside/laguna-xs.2:free": "flagged",
 };
 
 describe("free-model registry: verified candidates + ranking", () => {
-  it("seeds every verified free candidate with its verdict-based status", () => {
+  it("seeds every verified free candidate with its verdict-based empirical status", () => {
     for (const [slug, status] of Object.entries(VERIFIED_FREE_CANDIDATE_STATUS)) {
       const row = WRITERLANE_FREE_MODELS.find(
         (model) => model.openRouterModel === slug,
       );
       expect(row, `missing seeded candidate ${slug}`).toBeDefined();
-      expect(row?.status).toBe(status);
+      expect(row?.empirical.status).toBe(status);
     }
   });
 
-  it("marks exactly the proven-clean coders vetted and flags the junk-prone one", () => {
-    expect(listFreeModelsByStatus("vetted").map((m) => m.id).sort()).toEqual([
+  it("marks exactly the proven-clean coders proven and flags the bad ones", () => {
+    expect(listFreeModelsByStatus("proven").map((m) => m.id).sort()).toEqual([
       "gpt-oss-120b",
       "minimax-m2.5",
       "poolside-laguna-m1",
     ]);
-    expect(listFreeModelsByStatus("flagged").map((m) => m.id)).toEqual([
+    // glm over-edits, laguna-xs.2 emits junk: both flagged.
+    expect(listFreeModelsByStatus("flagged").map((m) => m.id).sort()).toEqual([
+      "glm-4.5-air",
       "poolside-laguna-xs2",
     ]);
-    // qwen stays unverified; glm is usable but over-edit-risk: both trial.
+    // qwen and the other rate-limited-out reals stay trial (unproven, not bad).
     const trialIds = listFreeModelsByStatus("trial").map((m) => m.id);
     expect(trialIds).toContain("qwen3-coder");
-    expect(trialIds).toContain("glm-4.5-air");
+    expect(trialIds).toContain("deepseek-v4-flash");
+    expect(trialIds).not.toContain("glm-4.5-air");
+  });
+
+  it("every row carries the informed metadata the selector relies on", () => {
+    for (const model of WRITERLANE_FREE_MODELS) {
+      expect(model.bestFor.length, `${model.id} bestFor`).toBeGreaterThan(0);
+      expect(typeof model.contextTokens, `${model.id} contextTokens`).toBe(
+        "number",
+      );
+      expect(model.bestAt.trim().length, `${model.id} bestAt`).toBeGreaterThan(0);
+      expect(
+        model.empirical.note.trim().length,
+        `${model.id} empirical.note`,
+      ).toBeGreaterThan(0);
+      expect(isFreeModelSlug(model.openRouterModel), `${model.id} slug`).toBe(
+        true,
+      );
+    }
   });
 
   it("ranks openai/gpt-oss-120b:free first for a code task (proven)", () => {
     const ranked = rankFreeModelsForTask("backend");
     expect(ranked[0].id).toBe("gpt-oss-120b");
     expect(ranked[0].openRouterModel).toBe("openai/gpt-oss-120b:free");
+    expect(topFreeModelForTask("backend")?.id).toBe("gpt-oss-120b");
+  });
+
+  it("ranks by fit then empirical status: proven > trial > flagged for the same affinity", () => {
+    const ranked = rankFreeModelsForTask("backend").map((m) => m.id);
+    const idx = (id: string) => ranked.indexOf(id);
+    // proven coder above a trial coder above a flagged coder.
+    expect(idx("gpt-oss-120b")).toBeLessThan(idx("qwen3-coder")); // proven < trial
+    expect(idx("qwen3-coder")).toBeLessThan(idx("glm-4.5-air")); // trial < flagged
+    expect(idx("gemma-4-31b")).toBeLessThan(idx("poolside-laguna-xs2"));
+  });
+
+  it("routes by task-kind affinity: a docs-affinity model outranks a code-only model for docs", () => {
+    const codeRanked = rankFreeModelsForTask("backend").map((m) => m.id);
+    const docsRanked = rankFreeModelsForTask("docs").map((m) => m.id);
+    // gpt-oss is the proven generalist (code AND docs affinity), top of both.
+    expect(codeRanked[0]).toBe("gpt-oss-120b");
+    expect(docsRanked[0]).toBe("gpt-oss-120b");
+    // For docs, the docs-affinity tiny model outranks a code-only specialist;
+    // for code it is the reverse. Proves affinity, not a fixed priority, routes.
+    expect(docsRanked.indexOf("liquid-lfm-2.5-1.2b")).toBeLessThan(
+      docsRanked.indexOf("poolside-laguna-m1"),
+    );
+    expect(codeRanked.indexOf("poolside-laguna-m1")).toBeLessThan(
+      codeRanked.indexOf("liquid-lfm-2.5-1.2b"),
+    );
+  });
+
+  it("exposes the fit score so a choice is explainable", () => {
+    const gptOss = WRITERLANE_FREE_MODELS.find((m) => m.id === "gpt-oss-120b")!;
+    const lagunaXs2 = WRITERLANE_FREE_MODELS.find(
+      (m) => m.id === "poolside-laguna-xs2",
+    )!;
+    // Both code-affinity, but proven scores above flagged for a code task.
+    expect(fitScore(gptOss, "backend")).toBeGreaterThan(
+      fitScore(lagunaXs2, "backend"),
+    );
   });
 
   it("deprioritizes the junk-prone, tiny, and meta models below the proven chain", () => {
@@ -155,7 +214,7 @@ describe("free-model registry: verified candidates + ranking", () => {
     expect(ranked[0]).toBe("gpt-oss-120b");
   });
 
-  it("ranks deterministically (priority primary, stable across calls)", () => {
+  it("ranks deterministically (fit + status primary, stable across calls)", () => {
     const first = rankFreeModelsForTask("backend").map((m) => m.id);
     const second = rankFreeModelsForTask("backend").map((m) => m.id);
     expect(first).toEqual(second);
@@ -164,10 +223,10 @@ describe("free-model registry: verified candidates + ranking", () => {
       "minimax-m2.5",
       "poolside-laguna-m1",
       "qwen3-coder",
-      "glm-4.5-air",
       "deepseek-v4-flash",
       "llama-3.3-70b",
       "gemma-4-31b",
+      "glm-4.5-air",
       "poolside-laguna-xs2",
     ]);
   });
@@ -176,10 +235,10 @@ describe("free-model registry: verified candidates + ranking", () => {
     const reasoner: WriterLaneFreeModel = {
       id: "reasoner-only",
       openRouterModel: "vendor/reasoner:free",
-      paramScale: "unknown",
-      capabilities: ["reasoning"],
-      strengths: ["backend", "mixed"],
-      status: "trial",
+      bestFor: ["code", "reasoning"],
+      contextTokens: 128000,
+      bestAt: "test fixture: reasoner",
+      empirical: { status: "proven", note: "test fixture" },
       reasonerClass: true,
       priority: 1000, // would rank first if not filtered
     };
@@ -193,6 +252,18 @@ describe("free-model registry: verified candidates + ranking", () => {
       hardProblem: true,
     }).map((m) => m.id);
     expect(hardChain[0]).toBe("reasoner-only");
+  });
+
+  it("drops models below a stated minimum context window", () => {
+    const chain = selectDefaultFreeChain("backend", WRITERLANE_FREE_MODELS, {
+      minContextTokens: 150000,
+    });
+    expect(chain.every((m) => m.contextTokens >= 150000)).toBe(true);
+    const ids = chain.map((m) => m.id);
+    // minimax (200k) and qwen (262k) clear the bar; gpt-oss (131k) does not.
+    expect(ids).toContain("minimax-m2.5");
+    expect(ids).toContain("qwen3-coder");
+    expect(ids).not.toContain("gpt-oss-120b");
   });
 
   it("recognizes :free slugs and the explicit free meta route; rejects bare slugs", () => {
@@ -511,34 +582,34 @@ describe("OpenHandsWriterLaneBackend chain", () => {
     expect(allowed.ok).toBe(true);
   });
 
-  it("requireVetted admits only vetted models (promotion path)", async () => {
-    const vettedCode: WriterLaneFreeModel = {
+  it("requireProven admits only proven models (promotion path)", async () => {
+    const provenCode: WriterLaneFreeModel = {
       ...strongCode,
-      id: "vetted-code",
-      openRouterModel: "vendor/vetted-code:free",
-      status: "vetted",
+      id: "proven-code",
+      openRouterModel: "vendor/proven-code:free",
+      empirical: { status: "proven", note: "test fixture" },
     };
-    const runner = runnerByModel({ "vetted-code": worktreeResult(goodPatch) });
+    const runner = runnerByModel({ "proven-code": worktreeResult(goodPatch) });
 
     const trialOnly = await new OpenHandsWriterLaneBackend({
       runner,
       models: [strongCode],
-      requireVetted: true,
+      requireProven: true,
       enabled: true,
     }).produce(autonomyInput);
     expect(trialOnly).toEqual({
       ok: false,
-      reason: "writerlane_no_vetted_free_models",
+      reason: "writerlane_no_proven_free_models",
     });
 
-    const withVetted = await new OpenHandsWriterLaneBackend({
+    const withProven = await new OpenHandsWriterLaneBackend({
       runner,
-      models: [strongCode, vettedCode],
-      requireVetted: true,
+      models: [strongCode, provenCode],
+      requireProven: true,
       enabled: true,
     }).runChain(autonomyInput);
-    expect(withVetted.result.ok).toBe(true);
-    expect(withVetted.modelsTried).toEqual(["vetted-code"]);
+    expect(withProven.result.ok).toBe(true);
+    expect(withProven.modelsTried).toEqual(["proven-code"]);
   });
 });
 

--- a/api/lib/writerlane/openhands-backend.test.ts
+++ b/api/lib/writerlane/openhands-backend.test.ts
@@ -22,7 +22,9 @@ import {
   isFreeModelSlug,
   listFreeModelsByStatus,
   rankFreeModelsForTask,
+  selectDefaultFreeChain,
   WRITERLANE_FREE_MODELS,
+  type FreeModelStatus,
   type WriterLaneFreeModel,
 } from "./writerlane-free-models";
 
@@ -94,50 +96,63 @@ function runnerByModel(
     byId[model.id] ?? { ok: false, reason: "no_canned_response" };
 }
 
-// The nine verified free OpenRouter candidate ids seeded into the registry.
-const VERIFIED_FREE_CANDIDATES = [
-  "qwen/qwen3-coder:free",
-  "poolside/laguna-m.1:free",
-  "poolside/laguna-xs.2:free",
-  "deepseek/deepseek-v4-flash:free",
-  "openai/gpt-oss-120b:free",
-  "z-ai/glm-4.5-air:free",
-  "meta-llama/llama-3.3-70b-instruct:free",
-  "minimax/minimax-m2.5:free",
-  "google/gemma-4-31b-it:free",
-];
+// The nine verified free OpenRouter candidate ids, with the status each now
+// carries from real code-slice run verdicts (see writerlane-free-models.ts):
+// proven-clean coders are "vetted"; junk-prone laguna-xs.2 is "flagged"; the
+// rest stay "trial" until a clean verdict lands.
+const VERIFIED_FREE_CANDIDATE_STATUS: Record<string, FreeModelStatus> = {
+  "openai/gpt-oss-120b:free": "vetted",
+  "minimax/minimax-m2.5:free": "vetted",
+  "poolside/laguna-m.1:free": "vetted",
+  "qwen/qwen3-coder:free": "trial",
+  "z-ai/glm-4.5-air:free": "trial",
+  "deepseek/deepseek-v4-flash:free": "trial",
+  "meta-llama/llama-3.3-70b-instruct:free": "trial",
+  "google/gemma-4-31b-it:free": "trial",
+  "poolside/laguna-xs.2:free": "flagged",
+};
 
 describe("free-model registry: verified candidates + ranking", () => {
-  it("seeds every verified free candidate as a TRIAL (not-yet-vetted) row", () => {
-    for (const slug of VERIFIED_FREE_CANDIDATES) {
+  it("seeds every verified free candidate with its verdict-based status", () => {
+    for (const [slug, status] of Object.entries(VERIFIED_FREE_CANDIDATE_STATUS)) {
       const row = WRITERLANE_FREE_MODELS.find(
         (model) => model.openRouterModel === slug,
       );
       expect(row, `missing seeded candidate ${slug}`).toBeDefined();
-      expect(row?.status).toBe("trial");
+      expect(row?.status).toBe(status);
     }
   });
 
-  it("treats the whole seed as unproven: zero vetted models until real runs validate", () => {
-    expect(listFreeModelsByStatus("vetted")).toEqual([]);
-    expect(listFreeModelsByStatus("trial").length).toBe(
-      WRITERLANE_FREE_MODELS.length,
-    );
+  it("marks exactly the proven-clean coders vetted and flags the junk-prone one", () => {
+    expect(listFreeModelsByStatus("vetted").map((m) => m.id).sort()).toEqual([
+      "gpt-oss-120b",
+      "minimax-m2.5",
+      "poolside-laguna-m1",
+    ]);
+    expect(listFreeModelsByStatus("flagged").map((m) => m.id)).toEqual([
+      "poolside-laguna-xs2",
+    ]);
+    // qwen stays unverified; glm is usable but over-edit-risk: both trial.
+    const trialIds = listFreeModelsByStatus("trial").map((m) => m.id);
+    expect(trialIds).toContain("qwen3-coder");
+    expect(trialIds).toContain("glm-4.5-air");
   });
 
-  it("ranks qwen/qwen3-coder:free first for a code task", () => {
+  it("ranks openai/gpt-oss-120b:free first for a code task (proven)", () => {
     const ranked = rankFreeModelsForTask("backend");
-    expect(ranked[0].id).toBe("qwen3-coder");
-    expect(ranked[0].openRouterModel).toBe("qwen/qwen3-coder:free");
+    expect(ranked[0].id).toBe("gpt-oss-120b");
+    expect(ranked[0].openRouterModel).toBe("openai/gpt-oss-120b:free");
   });
 
-  it("keeps the tiny Liquid model and the meta route as last-ditch, not primary", () => {
+  it("deprioritizes the junk-prone, tiny, and meta models below the proven chain", () => {
     const ranked = rankFreeModelsForTask("backend").map((m) => m.id);
+    const flaggedIndex = ranked.indexOf("poolside-laguna-xs2");
     const liquidIndex = ranked.indexOf("liquid-lfm-2.5-1.2b");
     const metaIndex = ranked.indexOf("openrouter-free-meta");
-    expect(liquidIndex).toBeGreaterThan(0);
+    expect(flaggedIndex).toBeGreaterThan(0);
+    expect(liquidIndex).toBeGreaterThan(flaggedIndex);
     expect(metaIndex).toBe(ranked.length - 1);
-    expect(ranked[0]).toBe("qwen3-coder");
+    expect(ranked[0]).toBe("gpt-oss-120b");
   });
 
   it("ranks deterministically (priority primary, stable across calls)", () => {
@@ -145,16 +160,39 @@ describe("free-model registry: verified candidates + ranking", () => {
     const second = rankFreeModelsForTask("backend").map((m) => m.id);
     expect(first).toEqual(second);
     expect(first.slice(0, 9)).toEqual([
-      "qwen3-coder",
-      "poolside-laguna-m1",
-      "poolside-laguna-xs2",
-      "deepseek-v4-flash",
       "gpt-oss-120b",
-      "glm-4.5-air",
-      "llama-3.3-70b",
       "minimax-m2.5",
+      "poolside-laguna-m1",
+      "qwen3-coder",
+      "glm-4.5-air",
+      "deepseek-v4-flash",
+      "llama-3.3-70b",
       "gemma-4-31b",
+      "poolside-laguna-xs2",
     ]);
+  });
+
+  it("keeps reasoner-class models OFF the default chain unless hardProblem is set", () => {
+    const reasoner: WriterLaneFreeModel = {
+      id: "reasoner-only",
+      openRouterModel: "vendor/reasoner:free",
+      paramScale: "unknown",
+      capabilities: ["reasoning"],
+      strengths: ["backend", "mixed"],
+      status: "trial",
+      reasonerClass: true,
+      priority: 1000, // would rank first if not filtered
+    };
+    const pool = [reasoner, ...WRITERLANE_FREE_MODELS];
+
+    const defaultChain = selectDefaultFreeChain("backend", pool).map((m) => m.id);
+    expect(defaultChain).not.toContain("reasoner-only");
+    expect(defaultChain[0]).toBe("gpt-oss-120b");
+
+    const hardChain = selectDefaultFreeChain("backend", pool, {
+      hardProblem: true,
+    }).map((m) => m.id);
+    expect(hardChain[0]).toBe("reasoner-only");
   });
 
   it("recognizes :free slugs and the explicit free meta route; rejects bare slugs", () => {

--- a/api/lib/writerlane/openhands-backend.ts
+++ b/api/lib/writerlane/openhands-backend.ts
@@ -29,7 +29,7 @@ import {
   WRITERLANE_FREE_MODELS,
   isFreeModelSlug,
   rankFreeModelsForTask,
-  type FreeModelStatus,
+  type EmpiricalStatus,
   type WriterLaneFreeModel,
 } from "./writerlane-free-models.js";
 import type {
@@ -117,11 +117,11 @@ export interface OpenHandsBackendOptions {
   // is excluded before the chain runs. Setting true is the explicit, opt-in
   // door for paid / subscription models; it is never the default.
   readonly allowNonFreeModels?: boolean;
-  // OFF by default. When true, only models promoted to status "vetted" are
-  // admitted; a registry of trial-only models then fails closed with
-  // writerlane_no_vetted_free_models. This is the strict lever for once models
+  // OFF by default. When true, only models whose empirical status is "proven"
+  // are admitted; a registry with no proven models then fails closed with
+  // writerlane_no_proven_free_models. This is the strict lever for once models
   // graduate from trial.
-  readonly requireVetted?: boolean;
+  readonly requireProven?: boolean;
   readonly timeoutMs?: number;
   readonly maxPatchBytes?: number;
   readonly buildPrompt?: (
@@ -135,9 +135,9 @@ export interface OpenHandsBackendOptions {
 export interface OpenHandsAttempt {
   readonly modelId: string;
   readonly openRouterModel: string;
-  // Vetting status of the model tried, surfaced so a trial model can never be
-  // mistaken for a vetted one in the attempt log.
-  readonly status: FreeModelStatus;
+  // Empirical status of the model tried, surfaced so a trial / flagged model can
+  // never be mistaken for a proven one in the attempt log.
+  readonly status: EmpiricalStatus;
   readonly ok: boolean;
   // Exact rejection reason code when ok === false.
   readonly reason?: string;
@@ -285,7 +285,7 @@ export class OpenHandsWriterLaneBackend implements WriterLaneBackend {
     }
 
     const allowNonFree = this.options.allowNonFreeModels === true;
-    const requireVetted = this.options.requireVetted === true;
+    const requireProven = this.options.requireProven === true;
     const baseModels = this.options.models ?? WRITERLANE_FREE_MODELS;
     const free = baseModels.filter(
       (model) => allowNonFree || isFreeModelSlug(model.openRouterModel),
@@ -293,11 +293,11 @@ export class OpenHandsWriterLaneBackend implements WriterLaneBackend {
     if (free.length === 0) {
       return finish({ ok: false, reason: "writerlane_no_free_models" });
     }
-    const eligible = requireVetted
-      ? free.filter((model) => model.status === "vetted")
+    const eligible = requireProven
+      ? free.filter((model) => model.empirical.status === "proven")
       : free;
     if (eligible.length === 0) {
-      return finish({ ok: false, reason: "writerlane_no_vetted_free_models" });
+      return finish({ ok: false, reason: "writerlane_no_proven_free_models" });
     }
 
     const ranked = rankFreeModelsForTask(taskKind, eligible);
@@ -320,7 +320,7 @@ export class OpenHandsWriterLaneBackend implements WriterLaneBackend {
         attempts.push({
           modelId: model.id,
           openRouterModel: model.openRouterModel,
-          status: model.status,
+          status: model.empirical.status,
           ok: false,
           reason: "openhands_runner_threw",
         });
@@ -339,7 +339,7 @@ export class OpenHandsWriterLaneBackend implements WriterLaneBackend {
         attempts.push({
           modelId: model.id,
           openRouterModel: model.openRouterModel,
-          status: model.status,
+          status: model.empirical.status,
           ok: false,
           reason: gate.reason,
         });
@@ -349,7 +349,7 @@ export class OpenHandsWriterLaneBackend implements WriterLaneBackend {
       attempts.push({
         modelId: model.id,
         openRouterModel: model.openRouterModel,
-        status: model.status,
+        status: model.empirical.status,
         ok: true,
       });
 

--- a/api/lib/writerlane/writerlane-config.test.ts
+++ b/api/lib/writerlane/writerlane-config.test.ts
@@ -29,10 +29,10 @@ const autonomyInput: WriterLaneInput = { scopePack, proofMode: "autonomy" };
 const paidModel: WriterLaneFreeModel = {
   id: "paid-code",
   openRouterModel: "vendor/paid-code",
-  paramScale: "unknown",
-  capabilities: ["code", "reasoning"],
-  strengths: ["backend", "mixed"],
-  status: "trial",
+  bestFor: ["code", "reasoning"],
+  contextTokens: 200000,
+  bestAt: "test fixture: paid code writer",
+  empirical: { status: "trial", note: "test fixture" },
   priority: 999,
 };
 

--- a/api/lib/writerlane/writerlane-config.test.ts
+++ b/api/lib/writerlane/writerlane-config.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  admitModels,
+  DEFAULT_WRITERLANE_CONFIG,
+  isFreeOnly,
+  toSelectionPolicy,
+  withWriterLaneConfig,
+} from "./writerlane-config";
+import {
+  isFreeModelSlug,
+  WRITERLANE_FREE_MODELS,
+  type WriterLaneFreeModel,
+} from "./writerlane-free-models";
+import {
+  chooseWriterLaneBackend,
+  type WriterLaneBackendProfile,
+} from "./writerlane-router";
+import type { WriterLaneInput } from "./writerlane-types";
+
+const scopePack = {
+  ownedFiles: ["api/lib/writerlane/example.ts"],
+  changeIntent: "wire backend selector",
+  proofRequirements: ["writerlane-config.test.ts passes"],
+};
+const autonomyInput: WriterLaneInput = { scopePack, proofMode: "autonomy" };
+
+// A paid model row (non-":free" slug). Not in the registry; built here to prove
+// the default config excludes it.
+const paidModel: WriterLaneFreeModel = {
+  id: "paid-code",
+  openRouterModel: "vendor/paid-code",
+  paramScale: "unknown",
+  capabilities: ["code", "reasoning"],
+  strengths: ["backend", "mixed"],
+  status: "trial",
+  priority: 999,
+};
+
+describe("WriterLane default system config: paid gate closed", () => {
+  it("defaults to free-only (paid path off)", () => {
+    expect(DEFAULT_WRITERLANE_CONFIG.allowPaidModels).toBe(false);
+    expect(isFreeOnly()).toBe(true);
+    expect(isFreeOnly(DEFAULT_WRITERLANE_CONFIG)).toBe(true);
+    expect(Object.isFrozen(DEFAULT_WRITERLANE_CONFIG)).toBe(true);
+  });
+
+  it("admits ONLY :free models by default and excludes a paid model", () => {
+    const admitted = admitModels([paidModel, ...WRITERLANE_FREE_MODELS]);
+    expect(admitted.find((m) => m.id === "paid-code")).toBeUndefined();
+    // Every admitted model is a free slug.
+    expect(admitted.every((m) => isFreeModelSlug(m.openRouterModel))).toBe(true);
+    // The whole free registry is admitted (it is all-free by construction).
+    expect(admitted.length).toBe(WRITERLANE_FREE_MODELS.length);
+  });
+
+  it("admits the paid model ONLY when allowPaidModels is explicitly true", () => {
+    const opened = withWriterLaneConfig({ allowPaidModels: true });
+    expect(isFreeOnly(opened)).toBe(false);
+    const admitted = admitModels([paidModel, ...WRITERLANE_FREE_MODELS], opened);
+    expect(admitted.find((m) => m.id === "paid-code")).toBeDefined();
+    expect(admitted.length).toBe(WRITERLANE_FREE_MODELS.length + 1);
+  });
+
+  it("derives a router policy that forbids paid + subscription by default", () => {
+    expect(toSelectionPolicy()).toEqual({
+      allowPaid: false,
+      allowSubscription: false,
+      allowFixture: false,
+      preferFree: true,
+    });
+    expect(toSelectionPolicy(withWriterLaneConfig({ allowPaidModels: true }))).toEqual(
+      {
+        allowPaid: true,
+        allowSubscription: true,
+        allowFixture: false,
+        preferFree: true,
+      },
+    );
+  });
+
+  it("returns copies so the registry rows cannot be mutated through admitModels", () => {
+    const admitted = admitModels(WRITERLANE_FREE_MODELS);
+    expect(admitted[0]).not.toBe(WRITERLANE_FREE_MODELS[0]);
+    expect(admitted[0]).toEqual(WRITERLANE_FREE_MODELS[0]);
+  });
+});
+
+describe("default config + router: paid backend stays closed unless opted in", () => {
+  const freeWriter: WriterLaneBackendProfile = {
+    kind: "free-code-writer",
+    cost: "free",
+    status: "available",
+    strengths: ["backend", "script", "tests", "mixed"],
+    supportsAutonomyProof: true,
+  };
+  const paidWriter: WriterLaneBackendProfile = {
+    kind: "paid-generalist",
+    cost: "paid",
+    status: "available",
+    strengths: ["backend", "frontend", "script", "tests", "mixed"],
+    supportsAutonomyProof: true,
+  };
+  const subscriptionWriter: WriterLaneBackendProfile = {
+    kind: "subscription-warm-seat",
+    cost: "subscription",
+    status: "available",
+    strengths: ["backend", "mixed"],
+    supportsAutonomyProof: true,
+  };
+
+  it("default policy picks the free backend and never the paid/subscription ones", () => {
+    const selection = chooseWriterLaneBackend(
+      autonomyInput,
+      [paidWriter, subscriptionWriter, freeWriter],
+      toSelectionPolicy(),
+    );
+    expect(selection.ok).toBe(true);
+    if (!selection.ok) throw new Error("free backend should win by default");
+    expect(selection.selected.kind).toBe("free-code-writer");
+  });
+
+  it("default policy fails closed when ONLY paid/subscription backends exist", () => {
+    const selection = chooseWriterLaneBackend(
+      autonomyInput,
+      [paidWriter, subscriptionWriter],
+      toSelectionPolicy(),
+    );
+    expect(selection.ok).toBe(false);
+    if (selection.ok) throw new Error("paid must be closed by default");
+    expect(selection.reason).toBe("writerlane_no_eligible_backend");
+  });
+
+  it("opens the paid backend only when allowPaidModels is explicitly enabled", () => {
+    const selection = chooseWriterLaneBackend(
+      autonomyInput,
+      [paidWriter],
+      toSelectionPolicy(withWriterLaneConfig({ allowPaidModels: true })),
+    );
+    expect(selection.ok).toBe(true);
+    if (!selection.ok) throw new Error("paid should be selectable when opted in");
+    expect(selection.selected.kind).toBe("paid-generalist");
+  });
+});

--- a/api/lib/writerlane/writerlane-config.ts
+++ b/api/lib/writerlane/writerlane-config.ts
@@ -1,0 +1,81 @@
+// WriterLane default system config (free-only gate slice).
+//
+// Dead code. Nothing in this repo wires it yet: not the autopilot runner, not
+// CodeRoom, not OpenHands, not the watcher, not cron. This module defines the
+// DEFAULT WriterLane system config and the single place the paid path is gated.
+//
+// The rule: the active default path is FREE MODELS ONLY. The paid / subscription
+// code path stays present but is OFF BY DEFAULT, behind one flag (allowPaidModels,
+// default false). Both the model-admission filter and the router selection policy
+// derive from this one config, so "free-only" is the default everywhere and paid
+// is a single, explicit, deliberate opt-in.
+//
+// Pure data + pure functions. No DB, no LLM, no network, no shell, no side
+// effects.
+
+import {
+  isFreeModelSlug,
+  type WriterLaneFreeModel,
+} from "./writerlane-free-models.js";
+import type { WriterLaneSelectionPolicy } from "./writerlane-router.js";
+
+export interface WriterLaneSystemConfig {
+  // The master gate. Default false => only ":free" models are admitted and the
+  // derived router policy forbids paid AND subscription backends. Set true ONLY
+  // to deliberately open the paid path. This is the one off-by-default flag that
+  // closes the paid gate.
+  readonly allowPaidModels: boolean;
+}
+
+// THE default system config: free-only, paid closed. Frozen so a caller cannot
+// mutate the shared default in place; use withWriterLaneConfig to derive an
+// override.
+export const DEFAULT_WRITERLANE_CONFIG: WriterLaneSystemConfig = Object.freeze({
+  allowPaidModels: false,
+});
+
+// Derive a config from the default with explicit overrides. The only way to turn
+// the paid path on is to pass allowPaidModels: true here (or build a config by
+// hand); it is never on by default.
+export function withWriterLaneConfig(
+  overrides: Partial<WriterLaneSystemConfig> = {},
+): WriterLaneSystemConfig {
+  return { ...DEFAULT_WRITERLANE_CONFIG, ...overrides };
+}
+
+// Admit only the models the config allows. The default config admits exactly the
+// ":free" slugs; any paid / unknown slug is excluded unless allowPaidModels is
+// true. Returns copies so callers cannot mutate the registry rows.
+export function admitModels(
+  models: WriterLaneFreeModel[],
+  config: WriterLaneSystemConfig = DEFAULT_WRITERLANE_CONFIG,
+): WriterLaneFreeModel[] {
+  const allowed = config.allowPaidModels
+    ? models
+    : models.filter((model) => isFreeModelSlug(model.openRouterModel));
+  return allowed.map((model) => ({ ...model }));
+}
+
+// Derive the router selection policy from the config. Free-first is always on;
+// paid and subscription backends are gated behind the single allowPaidModels
+// flag; the fixture backend is never auto-allowed (it can never be autonomy
+// proof anyway).
+export function toSelectionPolicy(
+  config: WriterLaneSystemConfig = DEFAULT_WRITERLANE_CONFIG,
+): WriterLaneSelectionPolicy {
+  return {
+    allowPaid: config.allowPaidModels,
+    allowSubscription: config.allowPaidModels,
+    allowFixture: false,
+    preferFree: true,
+  };
+}
+
+// True when the config keeps the paid path closed (the default). A small named
+// predicate so callers can assert "are we free-only right now?" without poking
+// at the flag directly.
+export function isFreeOnly(
+  config: WriterLaneSystemConfig = DEFAULT_WRITERLANE_CONFIG,
+): boolean {
+  return config.allowPaidModels !== true;
+}

--- a/api/lib/writerlane/writerlane-free-models.ts
+++ b/api/lib/writerlane/writerlane-free-models.ts
@@ -9,46 +9,75 @@
 // Pure data + pure functions. No DB, no LLM, no network, no shell, no side
 // effects. Free models ONLY: every row's openRouterModel MUST be a ":free"
 // OpenRouter slug (or the explicit free meta-route). Paid / subscription models
-// are an explicit, off-by-default concern handled by the backend, never seeded
-// here.
+// are an explicit, off-by-default concern handled by the config + backend, never
+// seeded here.
+//
+// Each row carries INFORMED metadata so the selector makes an evidence-based
+// choice, not just a priority number:
+//   - bestFor / contextTokens / bestAt : PRE-RESEARCHED model capabilities.
+//   - empirical { status, note }        : what OUR dogfooding actually proved.
+// The selector ranks by FIT (task-kind affinity) then EMPIRICAL status
+// (proven > trial > flagged), with priority as a manual tiebreak. It reads the
+// metadata; it never hardcodes model names.
+//
+// ===========================================================================
+// HOW TO ADD / UPDATE / RETIRE A MODEL  (models evolve fast; keep this trivial)
+// ===========================================================================
+// Everything below is a DATA TABLE. Adding, removing, re-ranking, or re-tagging
+// a model is a ONE-ROW edit with NO logic changes:
+//
+//   ADD     : append one row to WRITERLANE_FREE_MODELS. Required fields:
+//             { id, openRouterModel (a real ":free" slug - never invent one),
+//               bestFor: ModelAffinity[], contextTokens (advisory; 0 = unknown),
+//               bestAt: "<short research note>",
+//               empirical: { status: "trial", note: "untested" } }.
+//             New models start "trial" until a real run gives a verdict.
+//   PROMOTE : after a clean run, set empirical.status -> "proven" and write the
+//             evidence into empirical.note (e.g. "5/5 code slice, fastest").
+//   FLAG    : after a bad run, set empirical.status -> "flagged" and record the
+//             failure mode in empirical.note (e.g. "deleted docstring"). It is
+//             kept (so the chain is never empty) but ranks below all proven/trial
+//             models of the same affinity; the validator layer rejects its junk.
+//   RE-RANK : nudge `priority` (a within-tier tiebreak only - affinity + status
+//             dominate). No code edit.
+//   RETIRE  : delete the row. No code edit.
+//   RESERVE : set reasonerClass: true to keep a reasoner-class model OFF the
+//             default chain (hard-problems only - see selectDefaultFreeChain).
+//
+// Do NOT add selection logic here for a single model. If the table cannot
+// express a routing rule, change the SELECTOR (fitScore), not a model name.
+// ===========================================================================
 
 import type { WriterLaneTaskKind } from "./writerlane-router.js";
 
-// Coarse capability tags for a free model. Used only to bias ranking; the diff
-// gate, not these tags, is what actually decides whether output is trustworthy.
-export type FreeModelCapability =
-  | "code" // can attempt code patches
-  | "docs" // doc / markdown editing
-  | "reasoning" // multi-step reasoning
-  | "fast"; // low latency, small context
+// Pre-researched task affinities. A model lists every category it is good at.
+// "general" is a wildcard fallback (a broadly capable model that fits any task
+// at reduced weight). reasoning / multimodal are carried as informed metadata;
+// the router does not yet infer those task kinds, so they do not currently score
+// (extend requiredAffinityForTask when a matching task kind is added).
+export type ModelAffinity =
+  | "code"
+  | "docs"
+  | "reasoning"
+  | "multimodal"
+  | "general";
 
-// Vetting status, set from real run verdicts:
-//   - "vetted":  a real run produced WORKING, clean output (tests + scope gate).
+// Empirical dogfooding verdict tier, set from real run results:
+//   - "proven":  a real run produced WORKING, clean output (tests + scope gate).
 //   - "trial":   real and usable, but no clean verdict yet - never ran, or only
-//                ever rate-limited, or passed with a concern not yet trusted.
-//                Treat output as unproven until a live run confirms it.
-//   - "flagged": a real run gave a BAD verdict (broken / junk output). Kept in
-//                the registry but deprioritized hard; the validator layer is the
-//                safety net that rejects its junk at runtime.
-// See requireVetted on the backend for the strict mode that admits only vetted
+//                ever rate-limited. Treat output as unproven until a run confirms.
+//   - "flagged": a real run gave a BAD verdict (broken / junk output). Kept but
+//                deprioritized below all proven/trial of the same affinity; the
+//                validator layer is the safety net that rejects its junk.
+// See requireProven on the backend for the strict mode that admits only proven
 // models.
-export type FreeModelStatus = "vetted" | "trial" | "flagged";
+export type EmpiricalStatus = "proven" | "trial" | "flagged";
 
-// Machine-readable cautions about a model's observed failure modes. Advisory:
-// they document why a row is ranked where it is. The validator layer, not these
-// tags, is what actually rejects bad output at runtime.
-//   - "over-edit-risk":      observed deleting docstrings / editing beyond scope.
-//   - "junk-prone":          observed leaking chat-template tags / non-code junk.
-//   - "unverified":          real slug, but no clean verdict yet (e.g. only ever
-//                            rate-limited).
-//   - "tiny":                too small to trust for non-trivial code.
-//   - "unpredictable-route": a meta auto-route, not a pinned model.
-export type FreeModelCaution =
-  | "over-edit-risk"
-  | "junk-prone"
-  | "unverified"
-  | "tiny"
-  | "unpredictable-route";
+export interface EmpiricalVerdict {
+  readonly status: EmpiricalStatus;
+  // What our dogfooding actually proved (or that it is untested). One short line.
+  readonly note: string;
+}
 
 export interface WriterLaneFreeModel {
   // Stable internal id used in attempt logs and fallback records.
@@ -57,199 +86,155 @@ export interface WriterLaneFreeModel {
   // (see isFreeModelSlug). Do not invent slugs: only add rows for models
   // verified to exist and to be free.
   readonly openRouterModel: string;
-  // Human-readable parameter scale, e.g. "70B". Advisory only; "unknown" when
-  // the size is not encoded in the model name.
-  readonly paramScale: string;
-  readonly capabilities: FreeModelCapability[];
-  // Task kinds this model is comparatively good at (mirrors the router's
-  // WriterLaneTaskKind vocabulary so ranking can line up with task inference).
-  readonly strengths: WriterLaneTaskKind[];
-  // Vetting status. New rows start at "trial" until a real run gives a verdict.
-  readonly status: FreeModelStatus;
-  // Observed failure modes (advisory). Absent / empty means none recorded.
-  readonly cautions?: FreeModelCaution[];
-  // True for a reasoner-class model reserved for genuinely hard problems. Such
-  // models are kept OFF the default chain - selectDefaultFreeChain excludes them
-  // unless hardProblem is set. On well-specified slices a reasoner buys nothing
-  // but latency and tokens (the R1-vs-V finding: identical minimal code, ~1.7x
-  // slower, ~2.6x the output), so it must never lead the default path.
+  // --- pre-researched "best-for" metadata (from model research) ---
+  // Task affinities this model is good at. Drives the selector's fit score.
+  readonly bestFor: ModelAffinity[];
+  // Context window in tokens. Advisory (update freely as a one-row edit); 0 means
+  // unknown / varies (e.g. a meta auto-route). Used to filter models that cannot
+  // fit a large job (selectDefaultFreeChain minContextTokens).
+  readonly contextTokens: number;
+  // Short human "best at..." note sourced from model research.
+  readonly bestAt: string;
+  // --- empirical dogfooding verdict (what OUR runs proved) ---
+  readonly empirical: EmpiricalVerdict;
+  // --- routing knobs ---
+  // True for a reasoner-class model reserved for genuinely hard problems. Kept
+  // OFF the default chain (selectDefaultFreeChain excludes it unless hardProblem
+  // is set): on well-specified slices a reasoner buys nothing but latency and
+  // tokens (the R1-vs-V finding: identical minimal code, ~1.7x slower, ~2.6x the
+  // output), so it must never lead the default path.
   readonly reasonerClass?: boolean;
-  // Higher is tried earlier. This is the PRIMARY ranking key (the seeded order
-  // below), with task-fit as a tiebreaker. Defaults to 0.
+  // Manual within-tier tiebreak (higher tried earlier). Affinity + empirical
+  // status dominate; priority only orders models that tie on both. Defaults to 0.
   readonly priority?: number;
-  readonly notes?: string;
 }
 
 // ---------------------------------------------------------------------------
-// FREE-MODEL REGISTRY
+// FREE-MODEL REGISTRY  (the data table - see HOW-TO block above)
 //
-// Ranked candidate chain. ALL real models below are verified-real free
-// OpenRouter ids. The order and status now reflect real code-slice run verdicts
-// (not a flat seed):
-//   - PROVEN-CLEAN coders are ranked top and marked "vetted": openai/gpt-oss-120b
-//     (fastest, beat both paid DeepSeeks on a real code slice), minimax/minimax-m2.5,
-//     and poolside/laguna-m.1 - each wrote WORKING code that passed tests + the
-//     scope gate.
-//   - UNVERIFIED reals stay "trial" (cautions: ["unverified"]): they only ever
-//     rate-limited and never got a verdict (qwen3-coder, deepseek-v4-flash,
-//     llama-3.3-70b, gemma-4-31b).
-//   - glm-4.5-air is "trial" with cautions ["over-edit-risk"]: it passed tests but
-//     DELETED a docstring (over-edited, +14/-14). The validator's diff-budget /
-//     doc-preservation guard is what gates that risk.
-//   - poolside/laguna-xs.2 is "flagged" + deprioritized: it passed the scope gate
-//     but shipped a stray "</assistant>" chat-template tag (a syntax error). Kept
-//     only so the validator can demonstrate catching its junk.
-//
-// Ranking is priority-primary (this seeded order), task-fit as a tiebreaker, id
-// as the final tiebreak. To EXTEND: add a row with a real ":free" slug and a
-// priority that places it in the chain. The tiny Liquid model and the
-// openrouter/free meta-route are deliberately last-ditch only. Reasoner-class
-// rows (reasonerClass: true) stay OFF the default chain (selectDefaultFreeChain).
-//
-//   { id, openRouterModel: "<vendor>/<model>:free", paramScale, capabilities,
-//     strengths, status, cautions?, reasonerClass?, priority, notes }
-//
-// <-- ADD / PROMOTE FREE MODEL ROWS HERE. -->
+// Rows are grouped for human readability: proven coders, then trial coders, then
+// flagged, then tiny / meta last-ditch. NOTE: row order is NOT the chain order.
+// The real per-task order is computed by the selector from affinity + empirical
+// status + priority, so the chain differs by task kind (a docs job ranks
+// docs-affinity models first). Do not assume array order is the fallback order.
 // ---------------------------------------------------------------------------
 export const WRITERLANE_FREE_MODELS: WriterLaneFreeModel[] = [
   {
-    // PROVEN best for code: 5/5 tests + scope gate on a real code slice, fastest
-    // of the field (993ms), beat both paid DeepSeeks at equal quality.
     id: "gpt-oss-120b",
     openRouterModel: "openai/gpt-oss-120b:free",
-    paramScale: "120B",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "vetted",
+    bestFor: ["code", "docs", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "Large open-weight generalist; strong, fast code edits and docs.",
+    empirical: { status: "proven", note: "5/5 code slice, fastest, beat paid" },
     priority: 100,
-    notes:
-      "Proven #1 code writer: working code, 5/5 tests + scope gate, fastest of the field.",
   },
   {
-    // Proven-clean coder: wrote working code (5/5 tests + scope gate).
     id: "minimax-m2.5",
     openRouterModel: "minimax/minimax-m2.5:free",
-    paramScale: "unknown",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "vetted",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 200000,
+    bestAt: "Agentic coding and multi-step reasoning at long context.",
+    empirical: { status: "proven", note: "5/5 code slice, clean" },
     priority: 90,
-    notes: "Proven coder: working code, 5/5 tests + scope gate.",
   },
   {
-    // Proven-clean coder: wrote working code (5/5 tests + scope gate).
     id: "poolside-laguna-m1",
     openRouterModel: "poolside/laguna-m.1:free",
-    paramScale: "unknown",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "vetted",
+    bestFor: ["code"],
+    contextTokens: 128000,
+    bestAt: "Code-specialized writer.",
+    empirical: {
+      status: "proven",
+      note: "5/5 code slice (minor: stray blank line)",
+    },
     priority: 80,
-    notes: "Proven coder: working code, 5/5 tests + scope gate.",
   },
   {
-    // Historically the rank-1 candidate but only ever rate-limited (HTTP 429) on
-    // the shared free pool, so it has NO verdict yet. Unverified, not unfit.
     id: "qwen3-coder",
     openRouterModel: "qwen/qwen3-coder:free",
-    paramScale: "unknown",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    cautions: ["unverified"],
+    bestFor: ["code", "reasoning"],
+    contextTokens: 262144,
+    bestAt: "Coding-specialized with very large context.",
+    empirical: {
+      status: "trial",
+      note: "only ever rate-limited, no verdict yet",
+    },
     priority: 70,
-    notes:
-      "Strong code candidate but UNVERIFIED: only ever rate-limited, never got a gate verdict.",
-  },
-  {
-    // Passed tests but DELETED a docstring (over-edited, +14/-14). Usable, but the
-    // validator diff-budget / doc-preservation guard must gate it.
-    id: "glm-4.5-air",
-    openRouterModel: "z-ai/glm-4.5-air:free",
-    paramScale: "unknown",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    cautions: ["over-edit-risk"],
-    priority: 50,
-    notes:
-      "Passed tests but over-edited (deleted a docstring, +14/-14). Gate with the diff-budget guard.",
   },
   {
     id: "deepseek-v4-flash",
     openRouterModel: "deepseek/deepseek-v4-flash:free",
-    paramScale: "unknown",
-    capabilities: ["code", "reasoning", "fast"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    cautions: ["unverified"],
-    priority: 40,
-    notes: "Unverified code candidate: rate-limited out before a verdict.",
+    bestFor: ["code", "reasoning"],
+    contextTokens: 131072,
+    bestAt: "Fast code and reasoning.",
+    empirical: { status: "trial", note: "rate-limited out, no verdict yet" },
+    priority: 60,
   },
   {
     id: "llama-3.3-70b",
     openRouterModel: "meta-llama/llama-3.3-70b-instruct:free",
-    paramScale: "70B",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    cautions: ["unverified"],
-    priority: 30,
-    notes: "Unverified general instruct candidate: rate-limited out before a verdict.",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "General instruct; broad tasks, decent code.",
+    empirical: { status: "trial", note: "rate-limited out, no verdict yet" },
+    priority: 50,
   },
   {
     id: "gemma-4-31b",
     openRouterModel: "google/gemma-4-31b-it:free",
-    paramScale: "31B",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    cautions: ["unverified"],
-    priority: 20,
-    notes: "Unverified instruct candidate: rate-limited out before a verdict.",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "Mid-size general instruct.",
+    empirical: { status: "trial", note: "rate-limited out, no verdict yet" },
+    priority: 40,
   },
   {
-    // FLAGGED junk-prone: passed the scope gate but shipped a stray
-    // "</assistant>" chat-template tag (a JS syntax error). Deprioritized hard;
-    // kept only so the validator can demonstrate rejecting its junk.
+    // FLAGGED: passed tests but over-edited (deleted a docstring, +14/-14). The
+    // validator's diff-budget / doc-preservation guard is what gates this risk.
+    id: "glm-4.5-air",
+    openRouterModel: "z-ai/glm-4.5-air:free",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "Lightweight reasoning plus code.",
+    empirical: { status: "flagged", note: "over-edits, deleted docstring" },
+    priority: 30,
+  },
+  {
+    // FLAGGED: passed the scope gate but shipped a stray "</assistant>" chat-
+    // template tag (a JS syntax error). Kept only so the validator can
+    // demonstrate rejecting its junk.
     id: "poolside-laguna-xs2",
     openRouterModel: "poolside/laguna-xs.2:free",
-    paramScale: "unknown",
-    capabilities: ["code", "fast"],
-    strengths: ["backend", "script", "tests", "config", "mixed"],
-    status: "flagged",
-    cautions: ["junk-prone"],
-    priority: -5,
-    notes:
-      "Junk-prone: passed the scope gate but leaked a </assistant> tag (syntax error). Deprioritized.",
+    bestFor: ["code"],
+    contextTokens: 32768,
+    bestAt: "Tiny, fast code drafts.",
+    empirical: {
+      status: "flagged",
+      note: "emits junk (</assistant> tag), broken code",
+    },
+    priority: 20,
   },
   {
     // Tiny last-ditch only. The whole point of this slice is to STOP betting AFK
     // writing on a 1.2B nudge model, so it sits near the bottom of the chain.
     id: "liquid-lfm-2.5-1.2b",
     openRouterModel: "liquid/lfm-2.5-1.2b-instruct:free",
-    paramScale: "1.2B",
-    capabilities: ["fast", "docs"],
-    strengths: ["docs"],
-    status: "trial",
-    cautions: ["tiny"],
-    priority: -10,
-    notes:
-      "Tiny last-ditch fallback (1.2B). Likely too weak for non-trivial code; kept only so the chain is never empty.",
+    bestFor: ["docs", "general"],
+    contextTokens: 32768,
+    bestAt: "Tiny, fast docs and nudges; too weak for non-trivial code.",
+    empirical: { status: "trial", note: "untested tiny last-ditch fallback" },
+    priority: 10,
   },
   {
     // Canary / absolute last resort. The openrouter/free meta auto-route is less
     // predictable than a pinned slug, so it is never a primary route.
     id: "openrouter-free-meta",
     openRouterModel: "openrouter/free",
-    paramScale: "n/a (meta route)",
-    capabilities: ["reasoning"],
-    strengths: ["mixed"],
-    status: "trial",
-    cautions: ["unpredictable-route"],
-    priority: -20,
-    notes:
-      "Unpredictable free meta auto-route. Canary / last fallback only, never a primary route.",
+    bestFor: ["general"],
+    contextTokens: 0,
+    bestAt: "Auto-routed free model; capability and context vary.",
+    empirical: { status: "trial", note: "untested unpredictable auto-route" },
+    priority: 0,
   },
 ];
 
@@ -270,46 +255,53 @@ export function listWriterLaneFreeModels(): WriterLaneFreeModel[] {
 }
 
 export function listFreeModelsByStatus(
-  status: FreeModelStatus,
+  status: EmpiricalStatus,
   models: WriterLaneFreeModel[] = WRITERLANE_FREE_MODELS,
 ): WriterLaneFreeModel[] {
-  return models.filter((model) => model.status === status).map((m) => ({ ...m }));
+  return models
+    .filter((model) => model.empirical.status === status)
+    .map((m) => ({ ...m }));
 }
 
-// Code-ish task kinds. "docs" is intentionally excluded so a docs job does not
-// reward a model purely for being code-capable.
-const CODE_TASK_KINDS: ReadonlySet<WriterLaneTaskKind> = new Set([
-  "backend",
-  "frontend",
-  "script",
-  "config",
-  "tests",
-  "mixed",
-  "unknown",
-]);
+// ---------------------------------------------------------------------------
+// SELECTOR  (informed: reads metadata, never hardcodes model names)
+// ---------------------------------------------------------------------------
 
-// Secondary, task-fit signal. Only breaks ties between equal-priority models.
-function taskFitScore(
+// Score weights. Affinity dominates (relevance first), empirical status is the
+// secondary signal (proven > trial > flagged), priority is the final tiebreak.
+const AFFINITY_EXACT = 1000; // model.bestFor includes the task's required affinity
+const AFFINITY_GENERAL = 300; // model.bestFor includes the "general" wildcard
+const STATUS_WEIGHT: Record<EmpiricalStatus, number> = {
+  proven: 200,
+  trial: 100,
+  flagged: 0,
+};
+
+// Map a router task kind to the model affinity it needs. Docs jobs need a docs
+// writer; everything else needs code. Extend here (one place) when a new task
+// kind (e.g. multimodal) starts being inferred.
+function requiredAffinityForTask(taskKind: WriterLaneTaskKind): ModelAffinity {
+  return taskKind === "docs" ? "docs" : "code";
+}
+
+// Pure fit score for one model on one task: affinity match + empirical status.
+// Exported so callers / logs can show WHY a model ranked where it did.
+export function fitScore(
   model: WriterLaneFreeModel,
   taskKind: WriterLaneTaskKind,
 ): number {
-  let score = 0;
-  if (model.strengths.includes(taskKind)) {
-    score += 30;
-  } else if (model.strengths.includes("mixed")) {
-    score += 10;
+  const need = requiredAffinityForTask(taskKind);
+  let affinity = 0;
+  if (model.bestFor.includes(need)) {
+    affinity = AFFINITY_EXACT;
+  } else if (model.bestFor.includes("general")) {
+    affinity = AFFINITY_GENERAL;
   }
-  if (model.capabilities.includes("code") && CODE_TASK_KINDS.has(taskKind)) {
-    score += 20;
-  }
-  if (model.capabilities.includes("docs") && taskKind === "docs") {
-    score += 20;
-  }
-  return score;
+  return affinity + STATUS_WEIGHT[model.empirical.status];
 }
 
-// Pure, deterministic ranking. Priority is the primary key (the seeded chain
-// order), task-fit is the tiebreaker, and id is the final tiebreak so the
+// Pure, deterministic ranking. Fit (affinity + status) is the primary key,
+// priority is the within-tier tiebreak, and id is the final tiebreak so the
 // fallback order is stable across runs. Ranks WHATEVER it is given - it does not
 // filter reasoner-class rows; selectDefaultFreeChain owns the default-path filter.
 export function rankFreeModelsForTask(
@@ -317,27 +309,50 @@ export function rankFreeModelsForTask(
   models: WriterLaneFreeModel[] = WRITERLANE_FREE_MODELS,
 ): WriterLaneFreeModel[] {
   return [...models].sort((left, right) => {
+    const byFit = fitScore(right, taskKind) - fitScore(left, taskKind);
+    if (byFit !== 0) return byFit;
     const byPriority = (right.priority ?? 0) - (left.priority ?? 0);
     if (byPriority !== 0) return byPriority;
-    const byFit = taskFitScore(right, taskKind) - taskFitScore(left, taskKind);
-    if (byFit !== 0) return byFit;
     return left.id.localeCompare(right.id);
   });
 }
 
+export interface DefaultChainOptions {
+  // Hard-problem mode: include reasoner-class models (off the default path).
+  readonly hardProblem?: boolean;
+  // Drop models whose context window is smaller than this (advisory contextTokens
+  // of 0 = unknown is treated as not meeting any positive minimum).
+  readonly minContextTokens?: number;
+}
+
 // The DEFAULT free-model chain for a task. Reasoner-class models are reserved for
 // genuinely hard problems and stay OFF this default path unless hardProblem is
-// set. Pure: filter, then rank. Future live wiring should select the chain
-// through here (not by calling rankFreeModelsForTask directly) so a reasoner can
-// never silently lead the default path.
+// set; models too small for a stated minimum context are dropped. Pure: filter,
+// then rank. Future live wiring should select the chain through here (not by
+// calling rankFreeModelsForTask directly) so a reasoner can never silently lead
+// the default path.
 export function selectDefaultFreeChain(
   taskKind: WriterLaneTaskKind,
   models: WriterLaneFreeModel[] = WRITERLANE_FREE_MODELS,
-  opts: { hardProblem?: boolean } = {},
+  opts: DefaultChainOptions = {},
 ): WriterLaneFreeModel[] {
-  const pool =
+  let pool =
     opts.hardProblem === true
       ? models
       : models.filter((model) => model.reasonerClass !== true);
+  if (typeof opts.minContextTokens === "number") {
+    const min = opts.minContextTokens;
+    pool = pool.filter((model) => model.contextTokens >= min);
+  }
   return rankFreeModelsForTask(taskKind, pool);
+}
+
+// Convenience: the single best free model for a task under the default chain, or
+// null when the pool is empty.
+export function topFreeModelForTask(
+  taskKind: WriterLaneTaskKind,
+  models: WriterLaneFreeModel[] = WRITERLANE_FREE_MODELS,
+  opts: DefaultChainOptions = {},
+): WriterLaneFreeModel | null {
+  return selectDefaultFreeChain(taskKind, models, opts)[0] ?? null;
 }

--- a/api/lib/writerlane/writerlane-free-models.ts
+++ b/api/lib/writerlane/writerlane-free-models.ts
@@ -22,12 +22,33 @@ export type FreeModelCapability =
   | "reasoning" // multi-step reasoning
   | "fast"; // low latency, small context
 
-// Vetting status. Models start as "trial": real, usable now, but NOT yet
-// UnClick-vetted - the system should treat their output as unproven until live
-// runs validate them. A model is promoted to "vetted" only after real runs
-// confirm it. See requireVetted on the backend for the strict mode that admits
-// only vetted models.
-export type FreeModelStatus = "trial" | "vetted";
+// Vetting status, set from real run verdicts:
+//   - "vetted":  a real run produced WORKING, clean output (tests + scope gate).
+//   - "trial":   real and usable, but no clean verdict yet - never ran, or only
+//                ever rate-limited, or passed with a concern not yet trusted.
+//                Treat output as unproven until a live run confirms it.
+//   - "flagged": a real run gave a BAD verdict (broken / junk output). Kept in
+//                the registry but deprioritized hard; the validator layer is the
+//                safety net that rejects its junk at runtime.
+// See requireVetted on the backend for the strict mode that admits only vetted
+// models.
+export type FreeModelStatus = "vetted" | "trial" | "flagged";
+
+// Machine-readable cautions about a model's observed failure modes. Advisory:
+// they document why a row is ranked where it is. The validator layer, not these
+// tags, is what actually rejects bad output at runtime.
+//   - "over-edit-risk":      observed deleting docstrings / editing beyond scope.
+//   - "junk-prone":          observed leaking chat-template tags / non-code junk.
+//   - "unverified":          real slug, but no clean verdict yet (e.g. only ever
+//                            rate-limited).
+//   - "tiny":                too small to trust for non-trivial code.
+//   - "unpredictable-route": a meta auto-route, not a pinned model.
+export type FreeModelCaution =
+  | "over-edit-risk"
+  | "junk-prone"
+  | "unverified"
+  | "tiny"
+  | "unpredictable-route";
 
 export interface WriterLaneFreeModel {
   // Stable internal id used in attempt logs and fallback records.
@@ -43,8 +64,16 @@ export interface WriterLaneFreeModel {
   // Task kinds this model is comparatively good at (mirrors the router's
   // WriterLaneTaskKind vocabulary so ranking can line up with task inference).
   readonly strengths: WriterLaneTaskKind[];
-  // Vetting status. New rows default to "trial".
+  // Vetting status. New rows start at "trial" until a real run gives a verdict.
   readonly status: FreeModelStatus;
+  // Observed failure modes (advisory). Absent / empty means none recorded.
+  readonly cautions?: FreeModelCaution[];
+  // True for a reasoner-class model reserved for genuinely hard problems. Such
+  // models are kept OFF the default chain - selectDefaultFreeChain excludes them
+  // unless hardProblem is set. On well-specified slices a reasoner buys nothing
+  // but latency and tokens (the R1-vs-V finding: identical minimal code, ~1.7x
+  // slower, ~2.6x the output), so it must never lead the default path.
+  readonly reasonerClass?: boolean;
   // Higher is tried earlier. This is the PRIMARY ranking key (the seeded order
   // below), with task-fit as a tiebreaker. Defaults to 0.
   readonly priority?: number;
@@ -55,50 +84,96 @@ export interface WriterLaneFreeModel {
 // FREE-MODEL REGISTRY
 //
 // Ranked candidate chain. ALL real models below are verified-real free
-// OpenRouter ids, seeded as "trial" (not yet UnClick-vetted): usable now, but
-// treated as unproven until live runs validate them, after which a row can be
-// promoted to status "vetted".
+// OpenRouter ids. The order and status now reflect real code-slice run verdicts
+// (not a flat seed):
+//   - PROVEN-CLEAN coders are ranked top and marked "vetted": openai/gpt-oss-120b
+//     (fastest, beat both paid DeepSeeks on a real code slice), minimax/minimax-m2.5,
+//     and poolside/laguna-m.1 - each wrote WORKING code that passed tests + the
+//     scope gate.
+//   - UNVERIFIED reals stay "trial" (cautions: ["unverified"]): they only ever
+//     rate-limited and never got a verdict (qwen3-coder, deepseek-v4-flash,
+//     llama-3.3-70b, gemma-4-31b).
+//   - glm-4.5-air is "trial" with cautions ["over-edit-risk"]: it passed tests but
+//     DELETED a docstring (over-edited, +14/-14). The validator's diff-budget /
+//     doc-preservation guard is what gates that risk.
+//   - poolside/laguna-xs.2 is "flagged" + deprioritized: it passed the scope gate
+//     but shipped a stray "</assistant>" chat-template tag (a syntax error). Kept
+//     only so the validator can demonstrate catching its junk.
 //
 // Ranking is priority-primary (this seeded order), task-fit as a tiebreaker, id
 // as the final tiebreak. To EXTEND: add a row with a real ":free" slug and a
 // priority that places it in the chain. The tiny Liquid model and the
-// openrouter/free meta-route are deliberately last-ditch only.
+// openrouter/free meta-route are deliberately last-ditch only. Reasoner-class
+// rows (reasonerClass: true) stay OFF the default chain (selectDefaultFreeChain).
 //
 //   { id, openRouterModel: "<vendor>/<model>:free", paramScale, capabilities,
-//     strengths, status: "trial", priority, notes }
+//     strengths, status, cautions?, reasonerClass?, priority, notes }
 //
 // <-- ADD / PROMOTE FREE MODEL ROWS HERE. -->
 // ---------------------------------------------------------------------------
 export const WRITERLANE_FREE_MODELS: WriterLaneFreeModel[] = [
   {
+    // PROVEN best for code: 5/5 tests + scope gate on a real code slice, fastest
+    // of the field (993ms), beat both paid DeepSeeks at equal quality.
+    id: "gpt-oss-120b",
+    openRouterModel: "openai/gpt-oss-120b:free",
+    paramScale: "120B",
+    capabilities: ["code", "reasoning"],
+    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
+    status: "vetted",
+    priority: 100,
+    notes:
+      "Proven #1 code writer: working code, 5/5 tests + scope gate, fastest of the field.",
+  },
+  {
+    // Proven-clean coder: wrote working code (5/5 tests + scope gate).
+    id: "minimax-m2.5",
+    openRouterModel: "minimax/minimax-m2.5:free",
+    paramScale: "unknown",
+    capabilities: ["code", "reasoning"],
+    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
+    status: "vetted",
+    priority: 90,
+    notes: "Proven coder: working code, 5/5 tests + scope gate.",
+  },
+  {
+    // Proven-clean coder: wrote working code (5/5 tests + scope gate).
+    id: "poolside-laguna-m1",
+    openRouterModel: "poolside/laguna-m.1:free",
+    paramScale: "unknown",
+    capabilities: ["code", "reasoning"],
+    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
+    status: "vetted",
+    priority: 80,
+    notes: "Proven coder: working code, 5/5 tests + scope gate.",
+  },
+  {
+    // Historically the rank-1 candidate but only ever rate-limited (HTTP 429) on
+    // the shared free pool, so it has NO verdict yet. Unverified, not unfit.
     id: "qwen3-coder",
     openRouterModel: "qwen/qwen3-coder:free",
     paramScale: "unknown",
     capabilities: ["code", "reasoning"],
     strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
     status: "trial",
-    priority: 100,
-    notes: "Rank #1 code writer candidate. Trial until live runs validate it.",
+    cautions: ["unverified"],
+    priority: 70,
+    notes:
+      "Strong code candidate but UNVERIFIED: only ever rate-limited, never got a gate verdict.",
   },
   {
-    id: "poolside-laguna-m1",
-    openRouterModel: "poolside/laguna-m.1:free",
+    // Passed tests but DELETED a docstring (over-edited, +14/-14). Usable, but the
+    // validator diff-budget / doc-preservation guard must gate it.
+    id: "glm-4.5-air",
+    openRouterModel: "z-ai/glm-4.5-air:free",
     paramScale: "unknown",
     capabilities: ["code", "reasoning"],
     strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
     status: "trial",
-    priority: 90,
-    notes: "Trial code candidate.",
-  },
-  {
-    id: "poolside-laguna-xs2",
-    openRouterModel: "poolside/laguna-xs.2:free",
-    paramScale: "unknown",
-    capabilities: ["code", "fast"],
-    strengths: ["backend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    priority: 80,
-    notes: "Trial small/fast code candidate.",
+    cautions: ["over-edit-risk"],
+    priority: 50,
+    notes:
+      "Passed tests but over-edited (deleted a docstring, +14/-14). Gate with the diff-budget guard.",
   },
   {
     id: "deepseek-v4-flash",
@@ -107,28 +182,9 @@ export const WRITERLANE_FREE_MODELS: WriterLaneFreeModel[] = [
     capabilities: ["code", "reasoning", "fast"],
     strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
     status: "trial",
-    priority: 70,
-    notes: "Trial code candidate.",
-  },
-  {
-    id: "gpt-oss-120b",
-    openRouterModel: "openai/gpt-oss-120b:free",
-    paramScale: "120B",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    priority: 60,
-    notes: "Trial large open-weight candidate.",
-  },
-  {
-    id: "glm-4.5-air",
-    openRouterModel: "z-ai/glm-4.5-air:free",
-    paramScale: "unknown",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
-    priority: 50,
-    notes: "Trial code candidate.",
+    cautions: ["unverified"],
+    priority: 40,
+    notes: "Unverified code candidate: rate-limited out before a verdict.",
   },
   {
     id: "llama-3.3-70b",
@@ -137,18 +193,9 @@ export const WRITERLANE_FREE_MODELS: WriterLaneFreeModel[] = [
     capabilities: ["code", "reasoning"],
     strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
     status: "trial",
-    priority: 40,
-    notes: "Trial general instruct candidate.",
-  },
-  {
-    id: "minimax-m2.5",
-    openRouterModel: "minimax/minimax-m2.5:free",
-    paramScale: "unknown",
-    capabilities: ["code", "reasoning"],
-    strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
-    status: "trial",
+    cautions: ["unverified"],
     priority: 30,
-    notes: "Trial code candidate.",
+    notes: "Unverified general instruct candidate: rate-limited out before a verdict.",
   },
   {
     id: "gemma-4-31b",
@@ -157,18 +204,35 @@ export const WRITERLANE_FREE_MODELS: WriterLaneFreeModel[] = [
     capabilities: ["code", "reasoning"],
     strengths: ["backend", "frontend", "script", "tests", "config", "mixed"],
     status: "trial",
+    cautions: ["unverified"],
     priority: 20,
-    notes: "Trial instruct candidate.",
+    notes: "Unverified instruct candidate: rate-limited out before a verdict.",
+  },
+  {
+    // FLAGGED junk-prone: passed the scope gate but shipped a stray
+    // "</assistant>" chat-template tag (a JS syntax error). Deprioritized hard;
+    // kept only so the validator can demonstrate rejecting its junk.
+    id: "poolside-laguna-xs2",
+    openRouterModel: "poolside/laguna-xs.2:free",
+    paramScale: "unknown",
+    capabilities: ["code", "fast"],
+    strengths: ["backend", "script", "tests", "config", "mixed"],
+    status: "flagged",
+    cautions: ["junk-prone"],
+    priority: -5,
+    notes:
+      "Junk-prone: passed the scope gate but leaked a </assistant> tag (syntax error). Deprioritized.",
   },
   {
     // Tiny last-ditch only. The whole point of this slice is to STOP betting AFK
-    // writing on a 1.2B nudge model, so it sits at the bottom of the chain.
+    // writing on a 1.2B nudge model, so it sits near the bottom of the chain.
     id: "liquid-lfm-2.5-1.2b",
     openRouterModel: "liquid/lfm-2.5-1.2b-instruct:free",
     paramScale: "1.2B",
     capabilities: ["fast", "docs"],
     strengths: ["docs"],
     status: "trial",
+    cautions: ["tiny"],
     priority: -10,
     notes:
       "Tiny last-ditch fallback (1.2B). Likely too weak for non-trivial code; kept only so the chain is never empty.",
@@ -182,6 +246,7 @@ export const WRITERLANE_FREE_MODELS: WriterLaneFreeModel[] = [
     capabilities: ["reasoning"],
     strengths: ["mixed"],
     status: "trial",
+    cautions: ["unpredictable-route"],
     priority: -20,
     notes:
       "Unpredictable free meta auto-route. Canary / last fallback only, never a primary route.",
@@ -245,7 +310,8 @@ function taskFitScore(
 
 // Pure, deterministic ranking. Priority is the primary key (the seeded chain
 // order), task-fit is the tiebreaker, and id is the final tiebreak so the
-// fallback order is stable across runs.
+// fallback order is stable across runs. Ranks WHATEVER it is given - it does not
+// filter reasoner-class rows; selectDefaultFreeChain owns the default-path filter.
 export function rankFreeModelsForTask(
   taskKind: WriterLaneTaskKind,
   models: WriterLaneFreeModel[] = WRITERLANE_FREE_MODELS,
@@ -257,4 +323,21 @@ export function rankFreeModelsForTask(
     if (byFit !== 0) return byFit;
     return left.id.localeCompare(right.id);
   });
+}
+
+// The DEFAULT free-model chain for a task. Reasoner-class models are reserved for
+// genuinely hard problems and stay OFF this default path unless hardProblem is
+// set. Pure: filter, then rank. Future live wiring should select the chain
+// through here (not by calling rankFreeModelsForTask directly) so a reasoner can
+// never silently lead the default path.
+export function selectDefaultFreeChain(
+  taskKind: WriterLaneTaskKind,
+  models: WriterLaneFreeModel[] = WRITERLANE_FREE_MODELS,
+  opts: { hardProblem?: boolean } = {},
+): WriterLaneFreeModel[] {
+  const pool =
+    opts.hardProblem === true
+      ? models
+      : models.filter((model) => model.reasonerClass !== true);
+  return rankFreeModelsForTask(taskKind, pool);
 }

--- a/api/lib/writerlane/writerlane-validator.test.ts
+++ b/api/lib/writerlane/writerlane-validator.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import type { WriterLaneResult } from "./writerlane-types";
+import {
+  buildValidationFromPatch,
+  computeDiffStats,
+  isCleanPatch,
+  isValidatedAutonomyProof,
+  isWithinDiffBudget,
+  scanForUncleanArtifacts,
+  UNCLEAN_MARKERS,
+  validateAutonomyProof,
+  WRITERLANE_DIFF_OVER_BUDGET,
+  WRITERLANE_SCOPE_GATE_FAILED,
+  WRITERLANE_TESTS_FAILED,
+  WRITERLANE_UNCLEAN_OUTPUT,
+  type WriterLaneValidation,
+} from "./writerlane-validator";
+
+const ownedFile = "api/lib/writerlane/example.ts";
+
+// A clean unified diff: +1 line, removes nothing.
+const goodPatch = [
+  `diff --git a/${ownedFile} b/${ownedFile}`,
+  "index 1111111..2222222 100644",
+  `--- a/${ownedFile}`,
+  `+++ b/${ownedFile}`,
+  "@@ -1,2 +1,3 @@",
+  " export const x = 1;",
+  "+export const y = 2;",
+  " export const z = 3;",
+  "",
+].join("\n");
+
+// laguna-xs.2's real failure: a stray </assistant> chat-template tag added into
+// the file (a syntax error that passed the scope gate).
+const uncleanPatch = [
+  `diff --git a/${ownedFile} b/${ownedFile}`,
+  `--- a/${ownedFile}`,
+  `+++ b/${ownedFile}`,
+  "@@ -1,2 +1,4 @@",
+  " export const x = 1;",
+  "+export const y = 2;",
+  "+</assistant>",
+  " export const z = 3;",
+  "",
+].join("\n");
+
+// glm-4.5-air's real failure: deleted a JSDoc docstring (over-edited).
+const overEditPatch = [
+  `diff --git a/${ownedFile} b/${ownedFile}`,
+  `--- a/${ownedFile}`,
+  `+++ b/${ownedFile}`,
+  "@@ -1,5 +1,2 @@",
+  "-/**",
+  "- * Adds two numbers.",
+  "- */",
+  " export function add(a, b) {",
+  "+  return a + b;",
+  " }",
+  "",
+].join("\n");
+
+// A genuine scope-passing autonomy success for the gate to build on.
+function successWith(patch: string): WriterLaneResult {
+  return {
+    ok: true,
+    patch,
+    changedFiles: [ownedFile],
+    proof: { autonomyProof: true },
+  };
+}
+
+const passing: WriterLaneValidation = {
+  testsPassed: true,
+  clean: true,
+  withinDiffBudget: true,
+};
+
+describe("validateAutonomyProof - extended autonomy-proof contract", () => {
+  it("accepts ONLY when the scope gate passes AND every validation component passes", () => {
+    const result = successWith(goodPatch);
+    expect(validateAutonomyProof(result, "autonomy", passing)).toEqual({
+      ok: true,
+    });
+    expect(isValidatedAutonomyProof(result, "autonomy", passing)).toBe(true);
+  });
+
+  it("rejects when the underlying scope/diff gate fails, even if validation passes", () => {
+    // proof.autonomyProof false => the #1052 scope gate rejects it.
+    const notScoped: WriterLaneResult = {
+      ok: true,
+      patch: goodPatch,
+      changedFiles: [ownedFile],
+      proof: { autonomyProof: false },
+    };
+    expect(validateAutonomyProof(notScoped, "autonomy", passing)).toEqual({
+      ok: false,
+      reason: WRITERLANE_SCOPE_GATE_FAILED,
+    });
+    // A scope-passing result under plumbing mode is also not autonomy proof.
+    expect(
+      validateAutonomyProof(successWith(goodPatch), "plumbing", passing),
+    ).toEqual({ ok: false, reason: WRITERLANE_SCOPE_GATE_FAILED });
+    // A failure result is never proof.
+    expect(
+      validateAutonomyProof({ ok: false, reason: "no diff" }, "autonomy", passing),
+    ).toEqual({ ok: false, reason: WRITERLANE_SCOPE_GATE_FAILED });
+  });
+
+  it("passes scope but FAILS validation -> not autonomy proof, exact reason per component", () => {
+    const result = successWith(goodPatch);
+
+    expect(
+      validateAutonomyProof(result, "autonomy", { ...passing, testsPassed: false }),
+    ).toEqual({ ok: false, reason: WRITERLANE_TESTS_FAILED });
+
+    expect(
+      validateAutonomyProof(result, "autonomy", { ...passing, clean: false }),
+    ).toEqual({ ok: false, reason: WRITERLANE_UNCLEAN_OUTPUT });
+
+    expect(
+      validateAutonomyProof(result, "autonomy", {
+        ...passing,
+        withinDiffBudget: false,
+      }),
+    ).toEqual({ ok: false, reason: WRITERLANE_DIFF_OVER_BUDGET });
+
+    // In every failing case it is NOT accepted as autonomy proof.
+    for (const bad of [
+      { ...passing, testsPassed: false },
+      { ...passing, clean: false },
+      { ...passing, withinDiffBudget: false },
+    ]) {
+      expect(isValidatedAutonomyProof(result, "autonomy", bad)).toBe(false);
+    }
+  });
+
+  it("checks components in a stable order: tests -> clean -> budget", () => {
+    const result = successWith(goodPatch);
+    // All three failing: tests is reported first.
+    expect(
+      validateAutonomyProof(result, "autonomy", {
+        testsPassed: false,
+        clean: false,
+        withinDiffBudget: false,
+      }),
+    ).toEqual({ ok: false, reason: WRITERLANE_TESTS_FAILED });
+    // tests pass, clean+budget fail: clean is reported next.
+    expect(
+      validateAutonomyProof(result, "autonomy", {
+        testsPassed: true,
+        clean: false,
+        withinDiffBudget: false,
+      }),
+    ).toEqual({ ok: false, reason: WRITERLANE_UNCLEAN_OUTPUT });
+  });
+});
+
+describe("clean check - chat-template / junk detection", () => {
+  it("lists </assistant> among the unclean markers", () => {
+    expect(UNCLEAN_MARKERS).toContain("</assistant>");
+  });
+
+  it("flags a stray </assistant> tag in ADDED lines (the laguna-xs.2 failure)", () => {
+    expect(scanForUncleanArtifacts(uncleanPatch)).toEqual(["</assistant>"]);
+    expect(isCleanPatch(uncleanPatch)).toBe(false);
+  });
+
+  it("treats a clean diff as clean", () => {
+    expect(scanForUncleanArtifacts(goodPatch)).toEqual([]);
+    expect(isCleanPatch(goodPatch)).toBe(true);
+  });
+
+  it("ignores junk on REMOVED lines (cleanup is clean)", () => {
+    const removesJunk = [
+      `--- a/${ownedFile}`,
+      `+++ b/${ownedFile}`,
+      "@@ -1,2 +1,2 @@",
+      "-</assistant>",
+      "+export const y = 2;",
+      "",
+    ].join("\n");
+    expect(scanForUncleanArtifacts(removesJunk)).toEqual([]);
+    expect(isCleanPatch(removesJunk)).toBe(true);
+  });
+});
+
+describe("diff budget - size + doc-preservation guard", () => {
+  it("counts added/removed lines and classifies removed doc lines", () => {
+    expect(computeDiffStats(goodPatch)).toEqual({
+      addedLines: 1,
+      removedLines: 0,
+      removedDocLines: 0,
+    });
+    expect(computeDiffStats(overEditPatch)).toEqual({
+      addedLines: 1,
+      removedLines: 3,
+      removedDocLines: 3,
+    });
+  });
+
+  it("rejects an over-edit that deletes a docstring (the glm-4.5-air failure)", () => {
+    expect(isWithinDiffBudget(overEditPatch, { forbidDocDeletion: true })).toBe(
+      false,
+    );
+    // Also caught by a removed-line budget.
+    expect(isWithinDiffBudget(overEditPatch, { maxRemovedLines: 2 })).toBe(false);
+  });
+
+  it("allows an in-budget clean change", () => {
+    expect(
+      isWithinDiffBudget(goodPatch, {
+        maxAddedLines: 5,
+        maxRemovedLines: 5,
+        forbidDocDeletion: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("enforces total churn via maxChangedLines", () => {
+    expect(isWithinDiffBudget(overEditPatch, { maxChangedLines: 3 })).toBe(false);
+    expect(isWithinDiffBudget(overEditPatch, { maxChangedLines: 4 })).toBe(true);
+  });
+});
+
+describe("buildValidationFromPatch + gate (ties helpers to the contract)", () => {
+  const budget = { maxRemovedLines: 2, forbidDocDeletion: true } as const;
+
+  it("a clean in-budget patch with passing tests is validated autonomy proof", () => {
+    const validation = buildValidationFromPatch(goodPatch, true, budget);
+    expect(validation).toEqual({
+      testsPassed: true,
+      clean: true,
+      withinDiffBudget: true,
+    });
+    expect(
+      validateAutonomyProof(successWith(goodPatch), "autonomy", validation),
+    ).toEqual({ ok: true });
+  });
+
+  it("the </assistant> patch is rejected as unclean even with passing tests", () => {
+    const validation = buildValidationFromPatch(uncleanPatch, true, budget);
+    expect(validation.clean).toBe(false);
+    expect(
+      validateAutonomyProof(successWith(uncleanPatch), "autonomy", validation),
+    ).toEqual({ ok: false, reason: WRITERLANE_UNCLEAN_OUTPUT });
+  });
+
+  it("the docstring-deleting patch is rejected as over budget even with passing tests", () => {
+    const validation = buildValidationFromPatch(overEditPatch, true, budget);
+    expect(validation.clean).toBe(true);
+    expect(validation.withinDiffBudget).toBe(false);
+    expect(
+      validateAutonomyProof(successWith(overEditPatch), "autonomy", validation),
+    ).toEqual({ ok: false, reason: WRITERLANE_DIFF_OVER_BUDGET });
+  });
+});

--- a/api/lib/writerlane/writerlane-validator.ts
+++ b/api/lib/writerlane/writerlane-validator.ts
@@ -1,0 +1,259 @@
+// WriterLane validation layer (validator slice).
+//
+// Dead code. Nothing in this repo wires it yet: not the autopilot runner, not
+// CodeRoom, not OpenHands, not the watcher, not cron. This module extends the
+// WriterLane autonomy-proof contract with the layer the merged #1052 scope/diff
+// gate does NOT cover.
+//
+// Why this layer exists: the #1052 gate (gateOpenHandsDiff / acceptsAsAutonomyProof)
+// proves AUTHORSHIP + SCOPE + a real trusted worktree diff, but it does NOT prove
+// the code works or is clean. Two real free-model runs proved the gap: one model
+// passed the scope gate yet shipped a stray "</assistant>" chat-template tag (a
+// syntax error that broke the module), and another passed the tests yet DELETED a
+// docstring (over-edited, +14/-14). So clearing the scope gate is necessary but
+// not sufficient.
+//
+// Purity / safety:
+//   - Pure. No DB, no LLM, no network, no shell, no filesystem, no git, no
+//     secrets, no side effects.
+//   - It does NOT run tests or builds itself. Exactly like the injected diff in
+//     the #1052 backend, it ACCEPTS a validation result as INPUT and gates on it.
+//     The testsPassed verdict is supplied by a real test runner that lives
+//     outside this pure module. The clean / withinDiffBudget signals are pure
+//     functions of the patch text, so this module also offers helpers to compute
+//     them (scanForUncleanArtifacts, isWithinDiffBudget).
+//   - Fail-closed: any missing or failing validation component means the result
+//     is NOT autonomy proof.
+
+import {
+  acceptsAsAutonomyProof,
+  type WriterLaneProofMode,
+  type WriterLaneResult,
+} from "./writerlane-types.js";
+
+// Exact, stable reason codes. Callers and tests gate on these strings.
+// The underlying scope/diff gate (acceptsAsAutonomyProof) rejected the result,
+// so it never even reached validation.
+export const WRITERLANE_SCOPE_GATE_FAILED = "writerlane_scope_gate_failed";
+// The project's tests / build for the slice did not pass.
+export const WRITERLANE_TESTS_FAILED = "writerlane_tests_failed";
+// Changed files carried stray model chatter / chat-template tags / non-code junk.
+export const WRITERLANE_UNCLEAN_OUTPUT = "writerlane_unclean_output";
+// The diff exceeded its size budget or violated the doc-preservation guard
+// (over-edited beyond the scope).
+export const WRITERLANE_DIFF_OVER_BUDGET = "writerlane_diff_over_budget";
+
+// The validation verdict a real test/build run produces for one WriterLane
+// result. Supplied to the gate as data; this module never produces testsPassed
+// itself.
+export interface WriterLaneValidation {
+  // The project's tests / build for the slice ran and passed. The pure lib never
+  // runs them; the caller supplies this verdict.
+  readonly testsPassed: boolean;
+  // The changed files carry no stray model chatter / chat-template tags /
+  // non-code junk. Compute with scanForUncleanArtifacts / isCleanPatch.
+  readonly clean: boolean;
+  // The diff stayed within its size budget and did not over-edit (e.g. delete a
+  // docstring). Compute with isWithinDiffBudget.
+  readonly withinDiffBudget: boolean;
+  // Free-form notes about how validation was performed.
+  readonly notes?: string;
+}
+
+export interface ValidatedProofAccept {
+  readonly ok: true;
+}
+
+export interface ValidatedProofReject {
+  readonly ok: false;
+  readonly reason: string;
+}
+
+export type ValidatedProofOutcome = ValidatedProofAccept | ValidatedProofReject;
+
+// THE extended autonomy-proof contract gate for real code writers.
+//
+// A result counts as autonomy proof ONLY IF:
+//   1. it clears the existing scope/diff gate (acceptsAsAutonomyProof), AND
+//   2. its validation reports testsPassed AND clean AND withinDiffBudget.
+//
+// Fail-closed and order-stable: scope gate, then tests, then clean, then budget.
+// A result that clears scope but fails any validation component is NOT proof.
+export function validateAutonomyProof(
+  result: WriterLaneResult,
+  proofMode: WriterLaneProofMode,
+  validation: WriterLaneValidation,
+): ValidatedProofOutcome {
+  if (!acceptsAsAutonomyProof(result, proofMode)) {
+    return { ok: false, reason: WRITERLANE_SCOPE_GATE_FAILED };
+  }
+  if (validation.testsPassed !== true) {
+    return { ok: false, reason: WRITERLANE_TESTS_FAILED };
+  }
+  if (validation.clean !== true) {
+    return { ok: false, reason: WRITERLANE_UNCLEAN_OUTPUT };
+  }
+  if (validation.withinDiffBudget !== true) {
+    return { ok: false, reason: WRITERLANE_DIFF_OVER_BUDGET };
+  }
+  return { ok: true };
+}
+
+// Boolean convenience: true ONLY when the full extended contract passes.
+export function isValidatedAutonomyProof(
+  result: WriterLaneResult,
+  proofMode: WriterLaneProofMode,
+  validation: WriterLaneValidation,
+): boolean {
+  return validateAutonomyProof(result, proofMode, validation).ok;
+}
+
+// ---------------------------------------------------------------------------
+// CLEAN check (pure)
+// ---------------------------------------------------------------------------
+
+// Chat-template / role scaffolding tokens that betray raw model chatter leaking
+// into a patch. The real laguna-xs.2 failure leaked "</assistant>"; these are the
+// family of junk tokens that must never reach committed code. Deliberately does
+// NOT include code-fence markers (```), because those are legitimate content in
+// a Markdown diff; callers can pass custom markers if they need fence detection.
+export const UNCLEAN_MARKERS: readonly string[] = [
+  "</assistant>",
+  "<assistant>",
+  "</user>",
+  "<user>",
+  "</system>",
+  "<system>",
+  "<|im_start|>",
+  "<|im_end|>",
+  "<|endoftext|>",
+  "</s>",
+];
+
+// Scan only the ADDED lines of a unified diff for unclean artifacts. Context and
+// removed lines are not the writer's new output, so they are ignored. Returns the
+// distinct markers found (empty array => clean). Pure string work.
+export function scanForUncleanArtifacts(
+  patch: string,
+  markers: readonly string[] = UNCLEAN_MARKERS,
+): string[] {
+  const added = String(patch ?? "")
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .join("\n")
+    .toLowerCase();
+  const found = markers.filter((marker) =>
+    added.includes(String(marker).toLowerCase()),
+  );
+  return [...new Set(found)];
+}
+
+// True when the added lines carry no unclean artifacts.
+export function isCleanPatch(
+  patch: string,
+  markers: readonly string[] = UNCLEAN_MARKERS,
+): boolean {
+  return scanForUncleanArtifacts(patch, markers).length === 0;
+}
+
+// ---------------------------------------------------------------------------
+// DIFF BUDGET / doc-preservation guard (pure)
+// ---------------------------------------------------------------------------
+
+export interface DiffBudget {
+  // Max added content lines allowed.
+  readonly maxAddedLines?: number;
+  // Max removed content lines allowed. An over-edit that deletes a docstring
+  // shows up as a spike in removed lines (the glm-4.5-air run was +14/-14).
+  readonly maxRemovedLines?: number;
+  // Max total churn (added + removed) allowed.
+  readonly maxChangedLines?: number;
+  // Doc-preservation guard: when true, reject any patch that DELETES a doc /
+  // comment line. This is the direct guard against the over-edit that silently
+  // strips a docstring while still passing tests.
+  readonly forbidDocDeletion?: boolean;
+}
+
+export interface DiffStats {
+  readonly addedLines: number;
+  readonly removedLines: number;
+  // Removed lines whose content looks like a doc / comment line.
+  readonly removedDocLines: number;
+}
+
+function isDocOrCommentContent(content: string): boolean {
+  const trimmed = content.trim();
+  return (
+    trimmed.startsWith("/**") ||
+    trimmed.startsWith("*/") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith('"""') ||
+    trimmed.startsWith("'''") ||
+    trimmed.startsWith("<!--")
+  );
+}
+
+// Count added / removed content lines from a unified diff, classifying removed
+// doc/comment lines. Header lines (+++/---) and hunk markers (@@) are not content.
+export function computeDiffStats(patch: string): DiffStats {
+  let addedLines = 0;
+  let removedLines = 0;
+  let removedDocLines = 0;
+  for (const line of String(patch ?? "").split(/\r?\n/)) {
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      addedLines += 1;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      removedLines += 1;
+      if (isDocOrCommentContent(line.slice(1))) {
+        removedDocLines += 1;
+      }
+    }
+  }
+  return { addedLines, removedLines, removedDocLines };
+}
+
+// True when the patch fits the budget. An unset budget field is not enforced.
+export function isWithinDiffBudget(patch: string, budget: DiffBudget): boolean {
+  const stats = computeDiffStats(patch);
+  if (
+    typeof budget.maxAddedLines === "number" &&
+    stats.addedLines > budget.maxAddedLines
+  ) {
+    return false;
+  }
+  if (
+    typeof budget.maxRemovedLines === "number" &&
+    stats.removedLines > budget.maxRemovedLines
+  ) {
+    return false;
+  }
+  if (
+    typeof budget.maxChangedLines === "number" &&
+    stats.addedLines + stats.removedLines > budget.maxChangedLines
+  ) {
+    return false;
+  }
+  if (budget.forbidDocDeletion === true && stats.removedDocLines > 0) {
+    return false;
+  }
+  return true;
+}
+
+// Convenience: build a WriterLaneValidation by computing clean + withinDiffBudget
+// from the patch, with testsPassed supplied from the real (external) test run.
+// Keeps the pure / injected-verdict split explicit: the lib derives what it can
+// from text, the caller owns the test verdict.
+export function buildValidationFromPatch(
+  patch: string,
+  testsPassed: boolean,
+  budget: DiffBudget,
+  markers: readonly string[] = UNCLEAN_MARKERS,
+): WriterLaneValidation {
+  return {
+    testsPassed,
+    clean: isCleanPatch(patch, markers),
+    withinDiffBudget: isWithinDiffBudget(patch, budget),
+  };
+}


### PR DESCRIPTION
## Summary

Dead code, **not wired** into the autopilot runner, CodeRoom, OpenHands, the watcher, or cron. Draft for review, do not merge. Structures the WriterLane lib per real free-model code-slice run findings: clearing the #1052 scope gate proved necessary but **not sufficient** (one model passed the gate yet shipped a stray `</assistant>` syntax error; another passed tests yet deleted a docstring).

Base: `1b4d648` (`feat(uxpass): add jobs board pulse`).

### 1. Close the paid gate (free-only default) - `writerlane-config.ts`
- `DEFAULT_WRITERLANE_CONFIG` is free-only; `allowPaidModels` defaults `false` (frozen).
- The paid code path stays present but off by default behind that single flag.
- `admitModels` filters to `:free` slugs unless the flag is on; `toSelectionPolicy` derives a router policy that forbids paid + subscription unless explicitly enabled.

### 2. Informed, agile free-model registry - `writerlane-free-models.ts`
- Every row carries **pre-researched** metadata (`bestFor` affinities, `contextTokens`, a short `bestAt` note) **plus** an **empirical** `{ status, note }` verdict capturing what our dogfooding proved:
  - `gpt-oss-120b` / `minimax-m2.5` / `laguna-m.1` -> `proven`
  - `glm-4.5-air` -> `flagged` "over-edits, deleted docstring"
  - `poolside/laguna-xs.2` -> `flagged` "emits junk (`</assistant>` tag), broken code"
  - `qwen3-coder` + rate-limited-out reals -> `trial` "no verdict yet"
- The selector (`fitScore` + `rankFreeModelsForTask`) ranks by **task-kind affinity**, then **empirical status** (`proven > trial > flagged`), with `priority` only a within-tier tiebreak. It reads the metadata and never hardcodes model names, so multiple free options per task kind are ranked by fit (a docs job leads with docs-affinity models; a code job with proven coders). `selectDefaultFreeChain` also keeps `reasonerClass` models off the default path and can filter by a minimum context window.
- A top **"HOW TO ADD / UPDATE / RETIRE A MODEL"** block makes add / promote / flag / re-rank / retire all **one-row data edits, no logic changes**.
- Vocabulary renamed to `proven`/`trial`/`flagged`; propagated through the backend (`requireVetted` -> `requireProven`, reason `writerlane_no_vetted_free_models` -> `writerlane_no_proven_free_models`, attempt log reads `model.empirical.status`).

### 3. Validator layer - `writerlane-validator.ts`
- Extends the autonomy-proof contract: a result is proof **ONLY IF** it clears the scope/diff gate (`acceptsAsAutonomyProof`) **AND** carries a passing validation (`testsPassed`, `clean`, `withinDiffBudget`).
- **Pure**: it does not run tests; it accepts the validation result as input (same pattern as the injected diff). Pure helpers `scanForUncleanArtifacts` (catches `</assistant>`-style junk) and `isWithinDiffBudget` (size + doc-preservation guard, catches the docstring over-edit) compute `clean` / `withinDiffBudget` from patch text.
- Exact reason codes: `writerlane_tests_failed`, `writerlane_unclean_output`, `writerlane_diff_over_budget` (plus `writerlane_scope_gate_failed`). A result that passes scope but fails any component is NOT autonomy proof.

## Constraints honored
- No `.github` / workflow / CI changes, no secrets, not wired into the runner/cron, execute not enabled, not merged.
- Every relative import in non-test source carries `.js` (ESM); strict nodenext typecheck clean.

## Test plan
- [x] `npx vitest run api/lib/writerlane` -> 4 files, 80 tests pass
- [x] strict `tsc --module nodenext --moduleResolution nodenext` on all 7 source files -> clean (proves `.js` ESM imports)
- [x] strict bundler-mode `tsc` on the new + edited source/test files -> clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to dead `api/lib/writerlane` modules with broad test coverage and no runtime wiring; autonomy and paid paths remain opt-in and fail-closed by design.
> 
> **Overview**
> This PR extends the **WriterLane** library (still **not wired** to production runners) with three coordinated changes: a **free-only default**, an **evidence-based free model registry and selector**, and a **stricter autonomy-proof validator** on top of the existing scope/diff gate.
> 
> **`writerlane-config`** introduces a frozen default where **`allowPaidModels` is false**. `admitModels` only keeps `:free` OpenRouter slugs unless that flag is set; `toSelectionPolicy` maps the same gate so paid and subscription backends stay off unless explicitly opted in.
> 
> **`writerlane-free-models`** reshapes each registry row with **`bestFor`**, **`contextTokens`**, **`bestAt`**, and **`empirical { status, note }`** (`proven` / `trial` / `flagged` from dogfood runs). Ranking is now **`fitScore`** (task affinity, then empirical tier) plus **`selectDefaultFreeChain`** (optional **`hardProblem`**, **`minContextTokens`**, **`reasonerClass`** off the default path). **`openhands-backend`** renames **`requireVetted` → `requireProven`**, filters on **`model.empirical.status`**, and surfaces empirical status in attempt logs.
> 
> **`writerlane-validator`** adds **`validateAutonomyProof`**: scope gate **and** injected **`testsPassed`**, patch **`clean`** (e.g. `</assistant>` on added lines), and **`withinDiffBudget`** (including doc-deletion guard), with stable reason codes.
> 
> Tests in **`openhands-backend.test`**, new **`writerlane-config.test`**, and **`writerlane-validator.test`** lock in ranking, free-only routing, and the extended proof contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57ca9dbe2eefb39b808e39fddd73e9415e98b92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->