### PR TITLE
feat(writerlane): wire free-model writer into runner behind off-by-default flag (inert)

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 473,
+    "inventory": 479,
     "source_manifest": 94,
     "pages": 94,
     "tools": 183,
@@ -63,7 +63,7 @@
       "id": "automations",
       "name": "Automations",
       "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
-      "count": 109
+      "count": 115
     },
     {
       "id": "ledgers-and-proof",
@@ -1458,6 +1458,66 @@
       "kind": "script",
       "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
       "source": "scripts/pinballwake-worker-registry-room.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-writerlane-free-models-scripts-pinballwake-writerlane-free-models-mjs",
+      "division": "Automations",
+      "name": "pinballwake writerlane free models",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-writerlane-free-models.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-writerlane-free-models-test-scripts-pinballwake-writerlane-free-models-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake writerlane free models.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-writerlane-free-models.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-writerlane-free-writer-scripts-pinballwake-writerlane-free-writer-mjs",
+      "division": "Automations",
+      "name": "pinballwake writerlane free writer",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-writerlane-free-writer.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-writerlane-free-writer-test-scripts-pinballwake-writerlane-free-writer-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake writerlane free writer.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-writerlane-free-writer.test.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-writerlane-validator-scripts-pinballwake-writerlane-validator-mjs",
+      "division": "Automations",
+      "name": "pinballwake writerlane validator",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-writerlane-validator.mjs",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-script-pinballwake-writerlane-validator-test-scripts-pinballwake-writerlane-validator-test-mjs",
+      "division": "Automations",
+      "name": "pinballwake writerlane validator.test",
+      "kind": "script",
+      "meaning": "PinballWake room, wake, or routing script used by the automation lane.",
+      "source": "scripts/pinballwake-writerlane-validator.test.mjs",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -119,7 +119,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 12 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
-| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 109 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 115 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 9 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 19 |
@@ -562,6 +562,12 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Automations | script | pinballwake stale room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-stale-room.test.mjs |
 | Automations | script | pinballwake worker registry room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-worker-registry-room.mjs |
 | Automations | script | pinballwake worker registry room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-worker-registry-room.test.mjs |
+| Automations | script | pinballwake writerlane free models | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-writerlane-free-models.mjs |
+| Automations | script | pinballwake writerlane free models.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-writerlane-free-models.test.mjs |
+| Automations | script | pinballwake writerlane free writer | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-writerlane-free-writer.mjs |
+| Automations | script | pinballwake writerlane free writer.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-writerlane-free-writer.test.mjs |
+| Automations | script | pinballwake writerlane validator | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-writerlane-validator.mjs |
+| Automations | script | pinballwake writerlane validator.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-writerlane-validator.test.mjs |
 | Automations | script | pinballwake xpass gate room | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-xpass-gate-room.mjs |
 | Automations | script | pinballwake xpass gate room.test | PinballWake room, wake, or routing script used by the automation lane. | - | scripts/pinballwake-xpass-gate-room.test.mjs |
 | Automations | script | tier2 auto merge queue check | tier2 auto merge queue check operational script. | - | scripts/tier2-auto-merge-queue-check.mjs |

--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -19,6 +19,7 @@ import { evaluateOrchestratorProofWakeGate } from "./lib/autopilotkit-liveness.m
 import { processScopePackTestOnlyExecutorPacket } from "./pinballwake-executor-lane.mjs";
 import { runOpenHandsWorker } from "./pinballwake-openhands-worker.mjs";
 import { createOpenHandsCliRunner, createSafeCodeRoomSubmitter } from "./pinballwake-openhands-proof-runner.mjs";
+import { createWriterLaneFreeWriterRunner } from "./pinballwake-writerlane-free-writer.mjs";
 import { buildScopePackHydrationReceipt } from "./pinballwake-scopepack-hydrator.mjs";
 
 export const AUTONOMOUS_RUNNER_MODES = new Set(["dry-run", "claim", "execute"]);
@@ -579,10 +580,25 @@ export async function createAutonomousRunnerOpenHandsClaimProbeReceipt({
 export function createAutonomousRunnerOpenHandsExecutorFromEnv(env = process.env) {
   const safeEnv = env || {};
   const enabled = parseBoolean(safeEnv.AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE);
+  // Opt-in writer swap. Unset (the default) keeps today's OpenHands CLI runner +
+  // default CodeRoom submitter byte-for-byte. "writerlane_free" routes the writer
+  // through the direct-OpenRouter free-model adapter and FORCES the CodeRoom
+  // submitter to draft + no-auto-merge (the default submitter is draft:false /
+  // autoMerge:true, which must NOT apply to the free-writer's first live step).
+  const useWriterLaneFree =
+    String(safeEnv.AUTONOMOUS_RUNNER_WRITER ?? "").trim() === "writerlane_free";
   return {
     enabled,
-    openHands: enabled ? createOpenHandsCliRunner({ env: safeEnv }) : null,
-    coderoom: enabled ? createSafeCodeRoomSubmitter({ env: safeEnv }) : null,
+    openHands: enabled
+      ? useWriterLaneFree
+        ? createWriterLaneFreeWriterRunner({ env: safeEnv })
+        : createOpenHandsCliRunner({ env: safeEnv })
+      : null,
+    coderoom: enabled
+      ? useWriterLaneFree
+        ? createSafeCodeRoomSubmitter({ env: safeEnv, draft: true, autoMerge: false })
+        : createSafeCodeRoomSubmitter({ env: safeEnv })
+      : null,
     env: safeEnv,
     testMode: parseBoolean(safeEnv.OPENHANDS_TEST_MODE),
     executorSeatId: safeEnv.OPENHANDS_EXECUTOR_SEAT_ID || "pinballwake-openhands-worker",

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -1965,6 +1965,37 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(executor.testMode, true);
   });
 
+  it("keeps the OpenHands CLI writer when AUTONOMOUS_RUNNER_WRITER is unset", () => {
+    const executor = createAutonomousRunnerOpenHandsExecutorFromEnv({
+      AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: "true",
+      OPENHANDS_TEST_MODE: "1",
+    });
+    assert.equal(executor.enabled, true);
+    assert.equal(typeof executor.openHands, "function");
+    assert.equal(typeof executor.coderoom, "function");
+  });
+
+  it("routes the writer through the WriterLane free-model adapter when opted in", () => {
+    const executor = createAutonomousRunnerOpenHandsExecutorFromEnv({
+      AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: "true",
+      AUTONOMOUS_RUNNER_WRITER: "writerlane_free",
+      OPENHANDS_TEST_MODE: "1",
+    });
+    assert.equal(executor.enabled, true);
+    assert.equal(typeof executor.openHands, "function");
+    assert.equal(typeof executor.coderoom, "function");
+    assert.equal(executor.testMode, true);
+  });
+
+  it("never builds a live writer while execute stays disabled, even with the writer flag", () => {
+    const executor = createAutonomousRunnerOpenHandsExecutorFromEnv({
+      AUTONOMOUS_RUNNER_WRITER: "writerlane_free",
+    });
+    assert.equal(executor.enabled, false);
+    assert.equal(executor.openHands, null);
+    assert.equal(executor.coderoom, null);
+  });
+
   it("emits a quiet-window proof receipt that rejects manual runner triggers", async () => {
     const dir = await mkdtemp(join(tmpdir(), "autonomous-runner-"));
     const ledgerPath = join(dir, "ledger.json");

--- a/scripts/pinballwake-writerlane-free-models.mjs
+++ b/scripts/pinballwake-writerlane-free-models.mjs
@@ -1,0 +1,219 @@
+// WriterLane free-model registry - runtime .mjs mirror.
+//
+// Dead code. Nothing wires it: not the runner, not CodeRoom, not OpenHands, not
+// the watcher, not cron.
+//
+// WHY this file exists as a .mjs duplicate of api/lib/writerlane/writerlane-free-models.ts:
+// the autopilot runner (scripts/pinballwake-autonomous-runner.mjs) is plain
+// `node ...mjs` with no tsx / build step, so it CANNOT import the TypeScript
+// WriterLane lib at runtime. This module is the hand-kept runtime mirror of the
+// MERGED registry + selector (PR #1055). The TS file stays the canonical spec;
+// keep this in sync as a one-row edit whenever a model row changes there.
+//
+// Pure data + pure functions. No DB, no LLM, no network, no shell, no side
+// effects.
+
+// Empirical dogfooding verdict tier (mirrors EmpiricalStatus in the TS lib).
+//   proven  : a real run produced WORKING, clean output (tests + scope gate).
+//   trial   : real and usable, but no clean verdict yet (never ran / rate-limited).
+//   flagged : a real run gave a BAD verdict (broken / junk output). Kept but
+//             deprioritized; the validator layer rejects its junk.
+
+// FREE-MODEL REGISTRY (mirror of WRITERLANE_FREE_MODELS). Row order is NOT the
+// chain order: the selector computes the per-task order from affinity + empirical
+// status + priority.
+export const WRITERLANE_FREE_MODELS = [
+  {
+    id: "gpt-oss-120b",
+    openRouterModel: "openai/gpt-oss-120b:free",
+    bestFor: ["code", "docs", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "Large open-weight generalist; strong, fast code edits and docs.",
+    empirical: { status: "proven", note: "5/5 code slice, fastest, beat paid" },
+    priority: 100,
+  },
+  {
+    id: "minimax-m2.5",
+    openRouterModel: "minimax/minimax-m2.5:free",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 200000,
+    bestAt: "Agentic coding and multi-step reasoning at long context.",
+    empirical: { status: "proven", note: "5/5 code slice, clean" },
+    priority: 90,
+  },
+  {
+    id: "poolside-laguna-m1",
+    openRouterModel: "poolside/laguna-m.1:free",
+    bestFor: ["code"],
+    contextTokens: 128000,
+    bestAt: "Code-specialized writer.",
+    empirical: {
+      status: "proven",
+      note: "5/5 code slice (minor: stray blank line)",
+    },
+    priority: 80,
+  },
+  {
+    id: "qwen3-coder",
+    openRouterModel: "qwen/qwen3-coder:free",
+    bestFor: ["code", "reasoning"],
+    contextTokens: 262144,
+    bestAt: "Coding-specialized with very large context.",
+    empirical: {
+      status: "trial",
+      note: "only ever rate-limited, no verdict yet",
+    },
+    priority: 70,
+  },
+  {
+    id: "deepseek-v4-flash",
+    openRouterModel: "deepseek/deepseek-v4-flash:free",
+    bestFor: ["code", "reasoning"],
+    contextTokens: 131072,
+    bestAt: "Fast code and reasoning.",
+    empirical: { status: "trial", note: "rate-limited out, no verdict yet" },
+    priority: 60,
+  },
+  {
+    id: "llama-3.3-70b",
+    openRouterModel: "meta-llama/llama-3.3-70b-instruct:free",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "General instruct; broad tasks, decent code.",
+    empirical: { status: "trial", note: "rate-limited out, no verdict yet" },
+    priority: 50,
+  },
+  {
+    id: "gemma-4-31b",
+    openRouterModel: "google/gemma-4-31b-it:free",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "Mid-size general instruct.",
+    empirical: { status: "trial", note: "rate-limited out, no verdict yet" },
+    priority: 40,
+  },
+  {
+    // FLAGGED: passed tests but over-edited (deleted a docstring, +14/-14). The
+    // validator's diff-budget / doc-preservation guard is what gates this risk.
+    id: "glm-4.5-air",
+    openRouterModel: "z-ai/glm-4.5-air:free",
+    bestFor: ["code", "reasoning", "general"],
+    contextTokens: 131072,
+    bestAt: "Lightweight reasoning plus code.",
+    empirical: { status: "flagged", note: "over-edits, deleted docstring" },
+    priority: 30,
+  },
+  {
+    // FLAGGED: passed the scope gate but shipped a stray "</assistant>" chat-
+    // template tag (a JS syntax error). Kept only so the validator can
+    // demonstrate rejecting its junk.
+    id: "poolside-laguna-xs2",
+    openRouterModel: "poolside/laguna-xs.2:free",
+    bestFor: ["code"],
+    contextTokens: 32768,
+    bestAt: "Tiny, fast code drafts.",
+    empirical: {
+      status: "flagged",
+      note: "emits junk (</assistant> tag), broken code",
+    },
+    priority: 20,
+  },
+  {
+    // Tiny last-ditch only. The whole point of this slice is to STOP betting AFK
+    // writing on a 1.2B nudge model, so it sits near the bottom of the chain.
+    id: "liquid-lfm-2.5-1.2b",
+    openRouterModel: "liquid/lfm-2.5-1.2b-instruct:free",
+    bestFor: ["docs", "general"],
+    contextTokens: 32768,
+    bestAt: "Tiny, fast docs and nudges; too weak for non-trivial code.",
+    empirical: { status: "trial", note: "untested tiny last-ditch fallback" },
+    priority: 10,
+  },
+  {
+    // Canary / absolute last resort. The openrouter/free meta auto-route is less
+    // predictable than a pinned slug, so it is never a primary route.
+    id: "openrouter-free-meta",
+    openRouterModel: "openrouter/free",
+    bestFor: ["general"],
+    contextTokens: 0,
+    bestAt: "Auto-routed free model; capability and context vary.",
+    empirical: { status: "trial", note: "untested unpredictable auto-route" },
+    priority: 0,
+  },
+];
+
+const FREE_META_ROUTES = new Set(["openrouter/free"]);
+
+// A slug is free when it carries the ":free" suffix or is the free meta-route.
+export function isFreeModelSlug(slug) {
+  const normalized = String(slug ?? "")
+    .trim()
+    .toLowerCase();
+  return normalized.endsWith(":free") || FREE_META_ROUTES.has(normalized);
+}
+
+export function listWriterLaneFreeModels() {
+  return WRITERLANE_FREE_MODELS.map((model) => ({ ...model }));
+}
+
+export function listFreeModelsByStatus(status, models = WRITERLANE_FREE_MODELS) {
+  return models
+    .filter((model) => model.empirical.status === status)
+    .map((model) => ({ ...model }));
+}
+
+// Score weights (mirror the TS selector). Affinity dominates, empirical status is
+// the secondary signal, priority is the final tiebreak.
+const AFFINITY_EXACT = 1000;
+const AFFINITY_GENERAL = 300;
+const STATUS_WEIGHT = { proven: 200, trial: 100, flagged: 0 };
+
+// Docs jobs need a docs writer; everything else needs code.
+function requiredAffinityForTask(taskKind) {
+  return taskKind === "docs" ? "docs" : "code";
+}
+
+// Pure fit score for one model on one task: affinity match + empirical status.
+export function fitScore(model, taskKind) {
+  const need = requiredAffinityForTask(taskKind);
+  let affinity = 0;
+  if (model.bestFor.includes(need)) {
+    affinity = AFFINITY_EXACT;
+  } else if (model.bestFor.includes("general")) {
+    affinity = AFFINITY_GENERAL;
+  }
+  return affinity + (STATUS_WEIGHT[model.empirical.status] ?? 0);
+}
+
+// Pure, deterministic ranking. Fit is the primary key, priority the within-tier
+// tiebreak, id the final tiebreak. Ranks WHATEVER it is given (does not filter
+// reasoner-class rows; selectDefaultFreeChain owns the default-path filter).
+export function rankFreeModelsForTask(taskKind, models = WRITERLANE_FREE_MODELS) {
+  return [...models].sort((left, right) => {
+    const byFit = fitScore(right, taskKind) - fitScore(left, taskKind);
+    if (byFit !== 0) return byFit;
+    const byPriority = (right.priority ?? 0) - (left.priority ?? 0);
+    if (byPriority !== 0) return byPriority;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+// The DEFAULT free-model chain for a task. Reasoner-class models stay OFF this
+// path unless hardProblem is set; models too small for a stated minimum context
+// are dropped. Pure: filter, then rank.
+export function selectDefaultFreeChain(taskKind, models = WRITERLANE_FREE_MODELS, opts = {}) {
+  let pool =
+    opts.hardProblem === true
+      ? models
+      : models.filter((model) => model.reasonerClass !== true);
+  if (typeof opts.minContextTokens === "number") {
+    const min = opts.minContextTokens;
+    pool = pool.filter((model) => model.contextTokens >= min);
+  }
+  return rankFreeModelsForTask(taskKind, pool);
+}
+
+// The single best free model for a task under the default chain, or null.
+export function topFreeModelForTask(taskKind, models = WRITERLANE_FREE_MODELS, opts = {}) {
+  return selectDefaultFreeChain(taskKind, models, opts)[0] ?? null;
+}

--- a/scripts/pinballwake-writerlane-free-models.test.mjs
+++ b/scripts/pinballwake-writerlane-free-models.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  WRITERLANE_FREE_MODELS,
+  fitScore,
+  isFreeModelSlug,
+  listFreeModelsByStatus,
+  listWriterLaneFreeModels,
+  rankFreeModelsForTask,
+  selectDefaultFreeChain,
+  topFreeModelForTask,
+} from "./pinballwake-writerlane-free-models.mjs";
+
+describe("writerlane free-model mirror: registry invariants", () => {
+  it("every registry row carries a free OpenRouter slug", () => {
+    for (const model of WRITERLANE_FREE_MODELS) {
+      assert.equal(isFreeModelSlug(model.openRouterModel), true, model.openRouterModel);
+    }
+  });
+
+  it("listWriterLaneFreeModels returns copies, not the shared rows", () => {
+    const copies = listWriterLaneFreeModels();
+    assert.equal(copies.length, WRITERLANE_FREE_MODELS.length);
+    assert.notEqual(copies[0], WRITERLANE_FREE_MODELS[0]);
+    assert.equal(copies[0].id, WRITERLANE_FREE_MODELS[0].id);
+  });
+
+  it("lists models by empirical status", () => {
+    const proven = listFreeModelsByStatus("proven").map((m) => m.id);
+    assert.deepEqual(proven, ["gpt-oss-120b", "minimax-m2.5", "poolside-laguna-m1"]);
+    const flagged = listFreeModelsByStatus("flagged").map((m) => m.id);
+    assert.deepEqual(flagged, ["glm-4.5-air", "poolside-laguna-xs2"]);
+  });
+});
+
+describe("writerlane free-model mirror: isFreeModelSlug", () => {
+  it("accepts :free slugs and the free meta-route", () => {
+    assert.equal(isFreeModelSlug("openai/gpt-oss-120b:free"), true);
+    assert.equal(isFreeModelSlug("openrouter/free"), true);
+    assert.equal(isFreeModelSlug("  OPENAI/GPT-OSS-120B:FREE "), true);
+  });
+
+  it("rejects paid / unknown slugs", () => {
+    assert.equal(isFreeModelSlug("deepseek/deepseek-chat"), false);
+    assert.equal(isFreeModelSlug("openai/gpt-5"), false);
+    assert.equal(isFreeModelSlug(""), false);
+    assert.equal(isFreeModelSlug(null), false);
+  });
+});
+
+describe("writerlane free-model mirror: fit + ranking", () => {
+  it("scores exact affinity above general above none, and proven above trial", () => {
+    const codeProven = { id: "a", openRouterModel: "x:free", bestFor: ["code"], contextTokens: 1, bestAt: "", empirical: { status: "proven", note: "" } };
+    const generalTrial = { id: "b", openRouterModel: "y:free", bestFor: ["general"], contextTokens: 1, bestAt: "", empirical: { status: "trial", note: "" } };
+    const docsOnly = { id: "c", openRouterModel: "z:free", bestFor: ["docs"], contextTokens: 1, bestAt: "", empirical: { status: "proven", note: "" } };
+    assert.ok(fitScore(codeProven, "backend") > fitScore(generalTrial, "backend"));
+    // docs-only model scores 0 affinity on a code task (no general fallback)
+    assert.equal(fitScore(docsOnly, "backend"), 0 + 200);
+  });
+
+  it("ranks proven coders first for a code task", () => {
+    const ranked = rankFreeModelsForTask("backend").map((m) => m.id);
+    assert.equal(ranked[0], "gpt-oss-120b");
+    assert.equal(ranked[1], "minimax-m2.5");
+    assert.equal(ranked[2], "poolside-laguna-m1");
+    // flagged code models sink below all trial coders of equal affinity
+    assert.ok(ranked.indexOf("poolside-laguna-xs2") > ranked.indexOf("qwen3-coder"));
+  });
+
+  it("ranks a docs-affinity model first for a docs task", () => {
+    const ranked = rankFreeModelsForTask("docs");
+    // gpt-oss-120b lists docs affinity AND is proven, so it still leads; the
+    // docs-only liquid model outranks code-only models that lack docs affinity.
+    assert.equal(ranked[0].id, "gpt-oss-120b");
+    const liquidIdx = ranked.findIndex((m) => m.id === "liquid-lfm-2.5-1.2b");
+    const codeOnlyIdx = ranked.findIndex((m) => m.id === "poolside-laguna-m1");
+    assert.ok(liquidIdx < codeOnlyIdx, "docs-affinity model should outrank code-only model on a docs task");
+  });
+
+  it("ranking is deterministic and stable across calls", () => {
+    const a = rankFreeModelsForTask("backend").map((m) => m.id);
+    const b = rankFreeModelsForTask("backend").map((m) => m.id);
+    assert.deepEqual(a, b);
+  });
+});
+
+describe("writerlane free-model mirror: default chain", () => {
+  it("excludes reasoner-class models from the default path", () => {
+    const reasoner = { id: "reasoner", openRouterModel: "r:free", bestFor: ["code"], contextTokens: 200000, bestAt: "", empirical: { status: "proven", note: "" }, reasonerClass: true, priority: 999 };
+    const pool = [...WRITERLANE_FREE_MODELS, reasoner];
+    const def = selectDefaultFreeChain("backend", pool).map((m) => m.id);
+    assert.equal(def.includes("reasoner"), false);
+    const hard = selectDefaultFreeChain("backend", pool, { hardProblem: true }).map((m) => m.id);
+    assert.equal(hard.includes("reasoner"), true);
+  });
+
+  it("drops models below a minimum context window", () => {
+    const def = selectDefaultFreeChain("backend", WRITERLANE_FREE_MODELS, { minContextTokens: 100000 });
+    assert.equal(def.some((m) => m.id === "poolside-laguna-xs2"), false, "32768-ctx model dropped");
+    assert.equal(def.some((m) => m.id === "gpt-oss-120b"), true);
+  });
+
+  it("topFreeModelForTask returns the chain head or null", () => {
+    assert.equal(topFreeModelForTask("backend").id, "gpt-oss-120b");
+    assert.equal(topFreeModelForTask("backend", []), null);
+  });
+});

--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -1,0 +1,491 @@
+// WriterLane free-model writer adapter (runner-side, .mjs).
+//
+// Dead code. Nothing wires it until the runner seam opts in via
+// AUTONOMOUS_RUNNER_WRITER=writerlane_free, and even then only behind the triple
+// execute gate (MODE=execute && ALLOW_EXECUTE && OPENHANDS_EXECUTE), all OFF by
+// default. Merging this changes nothing live.
+//
+// WHAT: this is the runner-side adapter that lets the proven direct-OpenRouter
+// free-model writer stand in for the OpenHands CLI runner. It satisfies the SAME
+// injected-runner contract the worker expects (the createOpenHandsCliRunner shape
+// in pinballwake-openhands-proof-runner.mjs):
+//     async ({ prompt, scopePack, job, timeoutMs }) => {
+//       ok, patch, changed_files, summary, test_run_id, test_exit_code, validation, ...
+//     }
+//
+// HOW (the proven path, mirrored from the WriterLane TS backend + validator):
+//   1. ask a free model for the FULL new contents of each owned file (OpenRouter
+//      chat-completions, free :free slugs only, walking the ranked fallback chain),
+//   2. WRITE those contents into the owned files in cwd,
+//   3. run the scoped verification command(s) for real (child process, timeout) -
+//      AFTER writing, BEFORE the diff capture (the capture reverts the worktree),
+//   4. capture the REAL git diff of the owned files via captureOwnedWorktreeDiff
+//      (the only "worktree"-trusted source) and restore the worktree,
+//   5. gate the diff (mirror gateOpenHandsDiff: scope / ownership / hunks /
+//      trusted source) AND validate it (validateAutonomyProof: tests + clean +
+//      budget). First model that clears both wins; otherwise fail closed with the
+//      exact reason code.
+//
+// Safety: fetch / runProcess / captureDiff / writeFile are all INJECTABLE so tests
+// never touch the network, the filesystem, or git. The API key is read only into
+// the Authorization header and never logged. Free models only.
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import {
+  captureOwnedWorktreeDiff,
+  runProcessCommand,
+  splitArgs,
+} from "./pinballwake-openhands-proof-runner.mjs";
+import { selectDefaultFreeChain } from "./pinballwake-writerlane-free-models.mjs";
+import {
+  buildValidationFromPatch,
+  validateAutonomyProof,
+} from "./pinballwake-writerlane-validator.mjs";
+
+const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
+const MAX_PATCH_BYTES = 120_000;
+const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_MAX_MODELS = 4;
+
+// Adapter-specific reason codes (the gate / validator reuse the WriterLane codes).
+export const WRITERLANE_OPENROUTER_UNCONFIGURED = "writerlane_openrouter_unconfigured";
+export const WRITERLANE_RATE_LIMITED = "writerlane_rate_limited";
+export const WRITERLANE_OPENROUTER_HTTP_ERROR = "writerlane_openrouter_http_error";
+export const WRITERLANE_OPENROUTER_THREW = "writerlane_openrouter_threw";
+export const WRITERLANE_EMPTY_COMPLETION = "writerlane_empty_completion";
+export const WRITERLANE_NO_FILE_CONTENTS = "writerlane_no_file_contents";
+export const WRITERLANE_NO_FREE_MODELS = "writerlane_no_free_models";
+export const WRITERLANE_FREE_CHAIN_EXHAUSTED = "writerlane_free_chain_exhausted";
+
+export function createWriterLaneFreeWriterRunner({
+  env = process.env,
+  cwd = process.cwd(),
+  fetchImpl,
+  runProcess = runProcessCommand,
+  captureDiff = captureOwnedWorktreeDiff,
+  writeFileImpl = defaultWriteFile,
+  models = null,
+  proofMode = "autonomy",
+  maxPatchBytes = MAX_PATCH_BYTES,
+  diffBudget = {},
+  // When there is no verification command in the scope pack we cannot prove the
+  // code works, so by default the writer fails closed. Setting this true treats a
+  // missing test command as a pass (use only for paths that legitimately have no
+  // tests, e.g. a docs-only canary).
+  allowMissingTests = false,
+  maxModels = DEFAULT_MAX_MODELS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const safeEnv = env || {};
+  const apiKey = String(
+    safeEnv.OPENROUTER_API_KEY ||
+      safeEnv.LLM_API_KEY ||
+      safeEnv.OPENHANDS_LLM_API_KEY ||
+      "",
+  ).trim();
+  const baseUrl = String(
+    safeEnv.LLM_BASE_URL || safeEnv.OPENHANDS_LLM_BASE_URL || DEFAULT_BASE_URL,
+  ).trim();
+  const doFetch = fetchImpl || globalThis.fetch;
+
+  return async ({ scopePack, job, timeoutMs: callTimeoutMs } = {}) => {
+    const effectiveTimeout = Number.isFinite(callTimeoutMs) ? callTimeoutMs : timeoutMs;
+    const ownedFiles = normalizePaths(
+      scopePack?.owned_files || scopePack?.ownedFiles || job?.owned_files || [],
+    );
+    if (ownedFiles.length === 0) {
+      return { ok: false, reason: "owned_files_required", attempts: [] };
+    }
+    if (!apiKey) {
+      return { ok: false, reason: WRITERLANE_OPENROUTER_UNCONFIGURED, attempts: [] };
+    }
+    if (typeof doFetch !== "function") {
+      return { ok: false, reason: WRITERLANE_OPENROUTER_UNCONFIGURED, attempts: [] };
+    }
+
+    const taskKind = inferTaskKind(ownedFiles);
+    const verification = normalizeList(scopePack?.verification || scopePack?.tests);
+    const chain = (Array.isArray(models) ? models : selectDefaultFreeChain(taskKind)).slice(
+      0,
+      Math.max(1, maxModels),
+    );
+    if (chain.length === 0) {
+      return { ok: false, reason: WRITERLANE_NO_FREE_MODELS, attempts: [] };
+    }
+
+    const attempts = [];
+
+    for (const model of chain) {
+      const status = model?.empirical?.status ?? "trial";
+      const prompt = buildFullContentsPrompt({ ownedFiles, scopePack, model });
+
+      const completion = await callOpenRouter({
+        doFetch,
+        baseUrl,
+        apiKey,
+        model: model.openRouterModel,
+        prompt,
+        timeoutMs: effectiveTimeout,
+      });
+      if (!completion.ok) {
+        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: completion.reason });
+        continue;
+      }
+
+      const files = parseFileBlocks(completion.content, ownedFiles);
+      if (files.length === 0) {
+        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: WRITERLANE_NO_FILE_CONTENTS });
+        continue;
+      }
+
+      for (const file of files) {
+        await writeFileImpl({ cwd, path: file.path, content: ensureTrailingNewline(file.content) });
+      }
+
+      // REAL scoped test-run: after writing, before capture (capture reverts).
+      let testsPassed;
+      let testRunId;
+      let testExitCode = 0;
+      if (verification.length > 0) {
+        const testRun = await runScopedTests({ runProcess, cwd, env: safeEnv, commands: verification, timeoutMs: effectiveTimeout });
+        testsPassed = testRun.ok === true;
+        testRunId = testRun.test_run_id;
+        testExitCode = testRun.exit_code;
+      } else {
+        testsPassed = allowMissingTests === true;
+        testRunId = `writerlane-no-tests-${model.id}`;
+        testExitCode = allowMissingTests === true ? 0 : 1;
+      }
+
+      const cap = await captureDiff({ cwd, env: safeEnv, ownedFiles, runProcess });
+      if (!cap || cap.ok !== true) {
+        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: cap?.reason || "writerlane_capture_failed" });
+        continue;
+      }
+
+      const gate = gateWriterLaneDiff({
+        patch: cap.patch,
+        ownedFiles,
+        declaredFiles: cap.changed_files || [],
+        prompt,
+        maxPatchBytes,
+        proofMode,
+      });
+      if (!gate.ok) {
+        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: gate.reason });
+        continue;
+      }
+
+      const wlResult = {
+        ok: true,
+        patch: gate.patch,
+        changedFiles: gate.changedFiles,
+        proof: { autonomyProof: gate.autonomyProof },
+      };
+      const validation = buildValidationFromPatch(gate.patch, testsPassed, diffBudget);
+      const verdict = validateAutonomyProof(wlResult, proofMode, validation);
+      if (!verdict.ok) {
+        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: verdict.reason });
+        continue;
+      }
+
+      attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: true });
+      return {
+        ok: true,
+        patch: gate.patch,
+        changed_files: gate.changedFiles,
+        summary: `WriterLane free writer ${model.id} (${model.openRouterModel}) produced a validated patch.`,
+        test_run_id: testRunId,
+        test_exit_code: testExitCode,
+        diff_source: "worktree",
+        model: model.id,
+        validation,
+        attempts,
+      };
+    }
+
+    return { ok: false, reason: WRITERLANE_FREE_CHAIN_EXHAUSTED, attempts };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OpenRouter call (the only network edge; injectable via doFetch)
+// ---------------------------------------------------------------------------
+
+async function callOpenRouter({ doFetch, baseUrl, apiKey, model, prompt, timeoutMs }) {
+  const url = `${String(baseUrl).replace(/\/+$/, "")}/chat/completions`;
+  const init = {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0,
+    }),
+  };
+  if (typeof AbortSignal?.timeout === "function" && Number.isFinite(timeoutMs)) {
+    init.signal = AbortSignal.timeout(timeoutMs);
+  }
+
+  let res;
+  try {
+    res = await doFetch(url, init);
+  } catch {
+    return { ok: false, reason: WRITERLANE_OPENROUTER_THREW };
+  }
+
+  const httpStatus = res?.status ?? 0;
+  if (httpStatus === 429) {
+    return { ok: false, reason: WRITERLANE_RATE_LIMITED, status: httpStatus };
+  }
+  if (!res || res.ok === false) {
+    return { ok: false, reason: WRITERLANE_OPENROUTER_HTTP_ERROR, status: httpStatus };
+  }
+
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    return { ok: false, reason: WRITERLANE_OPENROUTER_HTTP_ERROR, status: httpStatus };
+  }
+
+  const content = data?.choices?.[0]?.message?.content ?? "";
+  if (!String(content).trim()) {
+    return { ok: false, reason: WRITERLANE_EMPTY_COMPLETION, status: httpStatus };
+  }
+  return { ok: true, content: String(content), status: httpStatus };
+}
+
+// ---------------------------------------------------------------------------
+// Scoped test runner (the real verification; injectable via runProcess)
+// ---------------------------------------------------------------------------
+
+async function runScopedTests({ runProcess, cwd, env, commands, timeoutMs }) {
+  const ran = [];
+  for (const command of commands) {
+    const parts = splitArgsSafe(command);
+    if (parts.length === 0) continue;
+    const [cmd, ...args] = parts;
+    ran.push(command);
+    const res = await runProcess(cmd, args, { cwd, env, timeoutMs });
+    if (!res || res.ok !== true) {
+      return {
+        ok: false,
+        exit_code: typeof res?.exit_code === "number" ? res.exit_code : 1,
+        test_run_id: ran.join(" && "),
+        output: res?.output ?? null,
+      };
+    }
+  }
+  return { ok: true, exit_code: 0, test_run_id: ran.join(" && ") || "writerlane-tests" };
+}
+
+function splitArgsSafe(command) {
+  try {
+    return splitArgs(command);
+  } catch {
+    return String(command ?? "").trim().split(/\s+/).filter(Boolean);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt + response parsing
+// ---------------------------------------------------------------------------
+
+export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model = {} } = {}) {
+  const lines = [
+    "You are an UnClick WriterLane free-model writer running AFK.",
+    "Implement the requested change by returning the FULL new contents of each owned file.",
+    "For EACH owned file, output a line exactly `FILE: <path>` followed by a fenced code block containing the complete new file contents.",
+    "Change only the owned files. Do not commit, push, merge, deploy, or touch anything outside them.",
+    `Model: ${model.openRouterModel || "unknown"}`,
+    "Owned files:",
+    ...ownedFiles.map((file) => `- ${file}`),
+  ];
+  const intent = scopePack?.changeIntent || scopePack?.change_intent || scopePack?.chip || scopePack?.title;
+  if (intent) {
+    lines.push("Change intent:");
+    lines.push(String(intent));
+  }
+  const acceptance = normalizeList(scopePack?.acceptance || scopePack?.acceptance_criteria);
+  if (acceptance.length) {
+    lines.push("Acceptance:");
+    lines.push(...acceptance.map((item) => `- ${item}`));
+  }
+  const verification = normalizeList(scopePack?.verification || scopePack?.tests);
+  if (verification.length) {
+    lines.push("Verification (these commands will be run for real):");
+    lines.push(...verification.map((item) => `- ${item}`));
+  }
+  if (scopePack?.body || scopePack?.description) {
+    lines.push("Context:");
+    lines.push(String(scopePack.body || scopePack.description));
+  }
+  return lines.join("\n");
+}
+
+// Parse `FILE: <path>` + fenced block pairs, keeping only owned paths. Falls back
+// to a single fenced block when exactly one file is owned.
+export function parseFileBlocks(content, ownedFiles) {
+  const owned = new Set(normalizePaths(ownedFiles));
+  const text = String(content ?? "");
+  const blocks = [];
+  const re = /FILE:\s*([^\n`]+?)\s*\r?\n+```[^\n]*\r?\n([\s\S]*?)\r?\n?```/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const path = normalizePath(match[1]);
+    if (owned.has(path)) {
+      blocks.push({ path, content: match[2] });
+    }
+  }
+  if (blocks.length > 0) {
+    return dedupeByPath(blocks);
+  }
+  const ownedList = [...owned];
+  if (ownedList.length === 1) {
+    const fence = text.match(/```[^\n]*\r?\n([\s\S]*?)\r?\n?```/);
+    if (fence) {
+      return [{ path: ownedList[0], content: fence[1] }];
+    }
+  }
+  return [];
+}
+
+function dedupeByPath(blocks) {
+  const seen = new Map();
+  for (const block of blocks) {
+    seen.set(block.path, block);
+  }
+  return [...seen.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Diff gate (mirror of gateOpenHandsDiff in api/lib/writerlane/openhands-backend.ts)
+// ---------------------------------------------------------------------------
+
+export function gateWriterLaneDiff({ patch, ownedFiles, declaredFiles = [], prompt = "", maxPatchBytes = MAX_PATCH_BYTES, proofMode = "autonomy" }) {
+  const text = String(patch ?? "");
+  if (!text.trim()) {
+    return { ok: false, reason: "openhands_missing_unified_diff" };
+  }
+  if (Buffer.byteLength(text, "utf8") > maxPatchBytes) {
+    return { ok: false, reason: "openhands_patch_too_large" };
+  }
+  if (isEchoOfPrompt(text, prompt)) {
+    return { ok: false, reason: "openhands_echoed_prompt_diff" };
+  }
+  if (!looksLikeUnifiedDiff(text)) {
+    return { ok: false, reason: "openhands_missing_unified_diff" };
+  }
+  if (!hasDiffHunks(text)) {
+    return { ok: false, reason: "openhands_no_diff_hunks" };
+  }
+  const changedFiles = extractChangedFilesFromPatch(text);
+  if (changedFiles.length === 0) {
+    return { ok: false, reason: "openhands_changed_files_required" };
+  }
+  const owned = new Set(normalizePaths(ownedFiles));
+  const ownershipScope = [...new Set([...changedFiles, ...normalizePaths(declaredFiles)])];
+  const outside = ownershipScope.find((file) => !owned.has(file));
+  if (outside) {
+    return { ok: false, reason: "openhands_unowned_worktree_diff" };
+  }
+  // captureOwnedWorktreeDiff is the only producer here, so the source is always a
+  // real worktree capture; keep the trusted-source check explicit anyway.
+  const trusted = true;
+  if (proofMode === "autonomy" && !trusted) {
+    return { ok: false, reason: "openhands_untrusted_diff_source" };
+  }
+  return {
+    ok: true,
+    patch: text,
+    changedFiles,
+    autonomyProof: proofMode === "autonomy" && trusted,
+  };
+}
+
+export function looksLikeUnifiedDiff(patch) {
+  const lines = String(patch ?? "").split(/\r?\n/);
+  if (lines.some((line) => line.startsWith("diff --git "))) return true;
+  const hasMinus = lines.some((line) => line.startsWith("--- "));
+  const hasPlus = lines.some((line) => line.startsWith("+++ "));
+  const hasHunk = lines.some((line) => line.startsWith("@@"));
+  return hasMinus && hasPlus && hasHunk;
+}
+
+export function hasDiffHunks(patch) {
+  return String(patch ?? "")
+    .split(/\r?\n/)
+    .some((line) => /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/.test(line));
+}
+
+export function extractChangedFilesFromPatch(patch) {
+  const files = [];
+  for (const line of String(patch ?? "").split(/\r?\n/)) {
+    const gitMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (gitMatch) {
+      files.push(gitMatch[2]);
+      continue;
+    }
+    const plusMatch = line.match(/^\+\+\+ b\/(.+)$/);
+    if (plusMatch) {
+      files.push(plusMatch[1]);
+    }
+  }
+  return [...new Set(normalizePaths(files).filter((file) => file && file !== "dev/null"))];
+}
+
+function isEchoOfPrompt(patch, prompt) {
+  const normalizedPatch = String(patch ?? "").replace(/\s+/g, " ").trim();
+  const normalizedPrompt = String(prompt ?? "").replace(/\s+/g, " ").trim();
+  if (!normalizedPrompt) return false;
+  return normalizedPatch === normalizedPrompt || normalizedPatch.includes(normalizedPrompt);
+}
+
+// ---------------------------------------------------------------------------
+// Small shared helpers
+// ---------------------------------------------------------------------------
+
+function inferTaskKind(ownedFiles) {
+  const files = normalizePaths(ownedFiles);
+  if (files.length === 0) return "unknown";
+  return files.every(isDoc) ? "docs" : "backend";
+}
+
+function isDoc(file) {
+  const f = String(file).toLowerCase();
+  return f.startsWith("docs/") || f.endsWith(".md") || f.endsWith(".mdx") || f.endsWith(".txt");
+}
+
+async function defaultWriteFile({ cwd, path, content }) {
+  const abs = join(cwd, path);
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, content, "utf8");
+}
+
+function ensureTrailingNewline(content) {
+  const text = String(content ?? "");
+  return text.endsWith("\n") ? text : `${text}\n`;
+}
+
+function normalizePath(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .trim();
+}
+
+function normalizePaths(values) {
+  return [...new Set((values ?? []).map(normalizePath).filter(Boolean))];
+}
+
+function normalizeList(values) {
+  if (Array.isArray(values)) return values.map((value) => String(value ?? "").trim()).filter(Boolean);
+  if (values === undefined || values === null || values === "") return [];
+  return [String(values).trim()].filter(Boolean);
+}

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildFullContentsPrompt,
+  createWriterLaneFreeWriterRunner,
+  extractChangedFilesFromPatch,
+  gateWriterLaneDiff,
+  parseFileBlocks,
+} from "./pinballwake-writerlane-free-writer.mjs";
+
+const MODEL_A = { id: "m-a", openRouterModel: "vendor/a:free", bestFor: ["code"], contextTokens: 100000, bestAt: "", empirical: { status: "proven", note: "" } };
+const MODEL_B = { id: "m-b", openRouterModel: "vendor/b:free", bestFor: ["code"], contextTokens: 100000, bestAt: "", empirical: { status: "trial", note: "" } };
+
+const OWNED = ["docs/x.md"];
+const GOOD_PATCH = [
+  "diff --git a/docs/x.md b/docs/x.md",
+  "--- a/docs/x.md",
+  "+++ b/docs/x.md",
+  "@@ -1 +1,2 @@",
+  " line",
+  "+hello world",
+  "",
+].join("\n");
+
+function fakeFetchOnce(content, { status = 200 } = {}) {
+  return async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => ({ choices: [{ message: { content } }] }),
+  });
+}
+
+function fileBlock(path, body) {
+  return `FILE: ${path}\n\`\`\`\n${body}\n\`\`\``;
+}
+
+function okProcess() {
+  return async () => ({ ok: true, exit_code: 0, stdout: "", stderr: "", output: "" });
+}
+
+describe("writerlane free-writer: happy path", () => {
+  it("writes files, runs tests, captures the diff, and returns a validated patch", async () => {
+    const order = [];
+    const writes = [];
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k", LLM_BASE_URL: "https://example.test/api/v1" },
+      models: [MODEL_A],
+      fetchImpl: fakeFetchOnce(fileBlock("docs/x.md", "hello world")),
+      runProcess: async () => {
+        order.push("test");
+        return { ok: true, exit_code: 0, output: "" };
+      },
+      writeFileImpl: async ({ path, content }) => {
+        order.push("write");
+        writes.push({ path, content });
+      },
+      captureDiff: async ({ ownedFiles }) => {
+        order.push("capture");
+        return { ok: true, patch: GOOD_PATCH, changed_files: ownedFiles };
+      },
+    });
+
+    const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test docs/x.test.mjs"] } });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.model, "m-a");
+    assert.deepEqual(result.changed_files, ["docs/x.md"]);
+    assert.match(result.patch, /hello world/);
+    assert.deepEqual(result.validation, { testsPassed: true, clean: true, withinDiffBudget: true });
+    assert.equal(result.diff_source, "worktree");
+    // ordering: write the file, run the real test, THEN capture (capture reverts)
+    assert.deepEqual(order, ["write", "test", "capture"]);
+    assert.deepEqual(writes, [{ path: "docs/x.md", content: "hello world\n" }]);
+  });
+});
+
+describe("writerlane free-writer: fail-closed paths", () => {
+  it("fails closed when OpenRouter is unconfigured (no key)", async () => {
+    const runner = createWriterLaneFreeWriterRunner({ env: {}, models: [MODEL_A] });
+    const result = await runner({ scopePack: { owned_files: OWNED } });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "writerlane_openrouter_unconfigured");
+  });
+
+  it("requires owned files", async () => {
+    const runner = createWriterLaneFreeWriterRunner({ env: { LLM_API_KEY: "k" }, models: [MODEL_A] });
+    const result = await runner({ scopePack: { owned_files: [] } });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "owned_files_required");
+  });
+
+  it("records writerlane_tests_failed and exhausts the chain when tests fail", async () => {
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: fakeFetchOnce(fileBlock("docs/x.md", "hello world")),
+      runProcess: async () => ({ ok: false, exit_code: 1, output: "boom" }),
+      writeFileImpl: async () => {},
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+    });
+    const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test docs/x.test.mjs"] } });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "writerlane_free_chain_exhausted");
+    assert.equal(result.attempts[0].reason, "writerlane_tests_failed");
+  });
+
+  it("rejects unclean output (chat-template junk in added lines)", async () => {
+    const dirtyPatch = [
+      "diff --git a/docs/x.md b/docs/x.md",
+      "--- a/docs/x.md",
+      "+++ b/docs/x.md",
+      "@@ -1 +1,2 @@",
+      " line",
+      "+stray </assistant>",
+    ].join("\n");
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: fakeFetchOnce(fileBlock("docs/x.md", "stray </assistant>")),
+      runProcess: okProcess(),
+      writeFileImpl: async () => {},
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: dirtyPatch, changed_files: ownedFiles }),
+    });
+    const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test x"] } });
+    assert.equal(result.ok, false);
+    assert.equal(result.attempts[0].reason, "writerlane_unclean_output");
+  });
+
+  it("passes a capture failure (e.g. unowned diff) through as the attempt reason", async () => {
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: fakeFetchOnce(fileBlock("docs/x.md", "hello world")),
+      runProcess: okProcess(),
+      writeFileImpl: async () => {},
+      captureDiff: async () => ({ ok: false, reason: "openhands_unowned_worktree_diff" }),
+    });
+    const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test x"] } });
+    assert.equal(result.ok, false);
+    assert.equal(result.attempts[0].reason, "openhands_unowned_worktree_diff");
+  });
+
+  it("records writerlane_no_file_contents when the model returns no parseable file block", async () => {
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: fakeFetchOnce("I cannot help with that."),
+      runProcess: okProcess(),
+      writeFileImpl: async () => {},
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+    });
+    const result = await runner({ scopePack: { owned_files: ["docs/x.md", "docs/y.md"], verification: ["node --test x"] } });
+    assert.equal(result.ok, false);
+    assert.equal(result.attempts[0].reason, "writerlane_no_file_contents");
+  });
+
+  it("fails closed when there is no verification command (allowMissingTests defaults false)", async () => {
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: fakeFetchOnce(fileBlock("docs/x.md", "hello world")),
+      runProcess: okProcess(),
+      writeFileImpl: async () => {},
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+    });
+    const result = await runner({ scopePack: { owned_files: OWNED } });
+    assert.equal(result.ok, false);
+    assert.equal(result.attempts[0].reason, "writerlane_tests_failed");
+  });
+});
+
+describe("writerlane free-writer: fallback chain", () => {
+  it("falls through a rate-limited model to the next and succeeds", async () => {
+    let call = 0;
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A, MODEL_B],
+      fetchImpl: async () => {
+        call += 1;
+        if (call === 1) return { ok: false, status: 429, json: async () => ({}) };
+        return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: fileBlock("docs/x.md", "hello world") } }] }) };
+      },
+      runProcess: okProcess(),
+      writeFileImpl: async () => {},
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+    });
+    const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test x"] } });
+    assert.equal(result.ok, true);
+    assert.equal(result.model, "m-b");
+    assert.equal(result.attempts[0].reason, "writerlane_rate_limited");
+    assert.equal(result.attempts[1].ok, true);
+  });
+});
+
+describe("writerlane free-writer: pure helpers", () => {
+  it("parseFileBlocks keeps only owned paths and dedupes", () => {
+    const content = [fileBlock("docs/x.md", "A"), fileBlock("secret/evil.txt", "B"), fileBlock("docs/x.md", "C")].join("\n\n");
+    const blocks = parseFileBlocks(content, ["docs/x.md"]);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].path, "docs/x.md");
+    assert.equal(blocks[0].content, "C");
+  });
+
+  it("parseFileBlocks falls back to a lone fenced block for a single owned file", () => {
+    const blocks = parseFileBlocks("```\njust code\n```", ["src/only.mjs"]);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].path, "src/only.mjs");
+    assert.equal(blocks[0].content, "just code");
+  });
+
+  it("gateWriterLaneDiff rejects unowned, hunkless, and empty patches", () => {
+    assert.equal(gateWriterLaneDiff({ patch: "", ownedFiles: OWNED }).reason, "openhands_missing_unified_diff");
+    assert.equal(
+      gateWriterLaneDiff({ patch: "diff --git a/docs/x.md b/docs/x.md\n--- a/docs/x.md\n+++ b/docs/x.md\n", ownedFiles: OWNED }).reason,
+      "openhands_no_diff_hunks",
+    );
+    const unowned = [
+      "diff --git a/secret/evil.txt b/secret/evil.txt",
+      "--- a/secret/evil.txt",
+      "+++ b/secret/evil.txt",
+      "@@ -0,0 +1 @@",
+      "+pwned",
+    ].join("\n");
+    assert.equal(gateWriterLaneDiff({ patch: unowned, ownedFiles: OWNED }).reason, "openhands_unowned_worktree_diff");
+  });
+
+  it("gateWriterLaneDiff accepts an owned worktree diff under autonomy mode", () => {
+    const gate = gateWriterLaneDiff({ patch: GOOD_PATCH, ownedFiles: OWNED, proofMode: "autonomy" });
+    assert.equal(gate.ok, true);
+    assert.equal(gate.autonomyProof, true);
+    assert.deepEqual(gate.changedFiles, ["docs/x.md"]);
+  });
+
+  it("extractChangedFilesFromPatch reads the git header b/ path", () => {
+    assert.deepEqual(extractChangedFilesFromPatch(GOOD_PATCH), ["docs/x.md"]);
+  });
+
+  it("buildFullContentsPrompt lists owned files and verification commands", () => {
+    const prompt = buildFullContentsPrompt({ ownedFiles: OWNED, scopePack: { verification: ["node --test x"] }, model: MODEL_A });
+    assert.match(prompt, /FILE: <path>/);
+    assert.match(prompt, /- docs\/x\.md/);
+    assert.match(prompt, /node --test x/);
+  });
+});

--- a/scripts/pinballwake-writerlane-validator.mjs
+++ b/scripts/pinballwake-writerlane-validator.mjs
@@ -1,0 +1,158 @@
+// WriterLane validation layer - runtime .mjs mirror.
+//
+// Dead code. Nothing wires it: not the runner, not CodeRoom, not OpenHands, not
+// the watcher, not cron.
+//
+// WHY this file exists as a .mjs duplicate of api/lib/writerlane/writerlane-validator.ts:
+// the autopilot runner is plain `node ...mjs` and cannot import the TypeScript
+// WriterLane lib at runtime. This is the runtime mirror of the MERGED validator
+// (PR #1055) - the layer the #1052 scope/diff gate does NOT cover: it proves the
+// code WORKS (testsPassed, supplied by a real external run) and is CLEAN / within
+// budget (pure functions of the patch text). Keep in sync with the TS spec.
+//
+// Pure. No DB, no LLM, no network, no shell, no filesystem, no git, no secrets.
+// It NEVER runs tests itself: testsPassed is supplied as input.
+
+// Exact, stable reason codes (mirror the TS lib). Callers / tests gate on these.
+export const WRITERLANE_SCOPE_GATE_FAILED = "writerlane_scope_gate_failed";
+export const WRITERLANE_TESTS_FAILED = "writerlane_tests_failed";
+export const WRITERLANE_UNCLEAN_OUTPUT = "writerlane_unclean_output";
+export const WRITERLANE_DIFF_OVER_BUDGET = "writerlane_diff_over_budget";
+
+// Mirrors acceptsAsAutonomyProof in api/lib/writerlane/writerlane-types.ts: a
+// result counts as scope-gate proof ONLY under autonomy mode, on success, with an
+// explicit proof.autonomyProof === true. Fixture / canned output sets that false.
+export function acceptsAsAutonomyProof(result, proofMode) {
+  if (proofMode !== "autonomy") return false;
+  if (!result || result.ok !== true) return false;
+  return result.proof?.autonomyProof === true;
+}
+
+// THE extended autonomy-proof gate for real code writers. Proof ONLY IF it clears
+// the scope/diff gate AND validation reports testsPassed AND clean AND
+// withinDiffBudget. Fail-closed and order-stable: scope, tests, clean, budget.
+export function validateAutonomyProof(result, proofMode, validation) {
+  if (!acceptsAsAutonomyProof(result, proofMode)) {
+    return { ok: false, reason: WRITERLANE_SCOPE_GATE_FAILED };
+  }
+  if (validation?.testsPassed !== true) {
+    return { ok: false, reason: WRITERLANE_TESTS_FAILED };
+  }
+  if (validation?.clean !== true) {
+    return { ok: false, reason: WRITERLANE_UNCLEAN_OUTPUT };
+  }
+  if (validation?.withinDiffBudget !== true) {
+    return { ok: false, reason: WRITERLANE_DIFF_OVER_BUDGET };
+  }
+  return { ok: true };
+}
+
+export function isValidatedAutonomyProof(result, proofMode, validation) {
+  return validateAutonomyProof(result, proofMode, validation).ok;
+}
+
+// ---------------------------------------------------------------------------
+// CLEAN check (pure)
+// ---------------------------------------------------------------------------
+
+// Chat-template / role scaffolding tokens that betray raw model chatter leaking
+// into a patch (the real laguna-xs.2 failure leaked "</assistant>"). Does NOT
+// include code-fence markers (```), which are legitimate in a Markdown diff.
+export const UNCLEAN_MARKERS = [
+  "</assistant>",
+  "<assistant>",
+  "</user>",
+  "<user>",
+  "</system>",
+  "<system>",
+  "<|im_start|>",
+  "<|im_end|>",
+  "<|endoftext|>",
+  "</s>",
+];
+
+// Scan only the ADDED lines of a unified diff for unclean artifacts. Context and
+// removed lines are ignored. Returns the distinct markers found (empty => clean).
+export function scanForUncleanArtifacts(patch, markers = UNCLEAN_MARKERS) {
+  const added = String(patch ?? "")
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .join("\n")
+    .toLowerCase();
+  const found = markers.filter((marker) =>
+    added.includes(String(marker).toLowerCase()),
+  );
+  return [...new Set(found)];
+}
+
+export function isCleanPatch(patch, markers = UNCLEAN_MARKERS) {
+  return scanForUncleanArtifacts(patch, markers).length === 0;
+}
+
+// ---------------------------------------------------------------------------
+// DIFF BUDGET / doc-preservation guard (pure)
+// ---------------------------------------------------------------------------
+
+function isDocOrCommentContent(content) {
+  const trimmed = content.trim();
+  return (
+    trimmed.startsWith("/**") ||
+    trimmed.startsWith("*/") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith('"""') ||
+    trimmed.startsWith("'''") ||
+    trimmed.startsWith("<!--")
+  );
+}
+
+// Count added / removed content lines, classifying removed doc/comment lines.
+// Header lines (+++/---) and hunk markers (@@) are not content.
+export function computeDiffStats(patch) {
+  let addedLines = 0;
+  let removedLines = 0;
+  let removedDocLines = 0;
+  for (const line of String(patch ?? "").split(/\r?\n/)) {
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      addedLines += 1;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      removedLines += 1;
+      if (isDocOrCommentContent(line.slice(1))) {
+        removedDocLines += 1;
+      }
+    }
+  }
+  return { addedLines, removedLines, removedDocLines };
+}
+
+// True when the patch fits the budget. An unset budget field is not enforced.
+export function isWithinDiffBudget(patch, budget = {}) {
+  const stats = computeDiffStats(patch);
+  if (typeof budget.maxAddedLines === "number" && stats.addedLines > budget.maxAddedLines) {
+    return false;
+  }
+  if (typeof budget.maxRemovedLines === "number" && stats.removedLines > budget.maxRemovedLines) {
+    return false;
+  }
+  if (
+    typeof budget.maxChangedLines === "number" &&
+    stats.addedLines + stats.removedLines > budget.maxChangedLines
+  ) {
+    return false;
+  }
+  if (budget.forbidDocDeletion === true && stats.removedDocLines > 0) {
+    return false;
+  }
+  return true;
+}
+
+// Build a validation by computing clean + withinDiffBudget from the patch, with
+// testsPassed supplied from the real (external) test run.
+export function buildValidationFromPatch(patch, testsPassed, budget = {}, markers = UNCLEAN_MARKERS) {
+  return {
+    testsPassed: testsPassed === true,
+    clean: isCleanPatch(patch, markers),
+    withinDiffBudget: isWithinDiffBudget(patch, budget),
+  };
+}

--- a/scripts/pinballwake-writerlane-validator.test.mjs
+++ b/scripts/pinballwake-writerlane-validator.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  WRITERLANE_DIFF_OVER_BUDGET,
+  WRITERLANE_SCOPE_GATE_FAILED,
+  WRITERLANE_TESTS_FAILED,
+  WRITERLANE_UNCLEAN_OUTPUT,
+  acceptsAsAutonomyProof,
+  buildValidationFromPatch,
+  computeDiffStats,
+  isCleanPatch,
+  isValidatedAutonomyProof,
+  isWithinDiffBudget,
+  scanForUncleanArtifacts,
+  validateAutonomyProof,
+} from "./pinballwake-writerlane-validator.mjs";
+
+const PROOF = { ok: true, patch: "x", changedFiles: ["a"], proof: { autonomyProof: true } };
+const PASS_VALIDATION = { testsPassed: true, clean: true, withinDiffBudget: true };
+
+describe("writerlane validator mirror: acceptsAsAutonomyProof", () => {
+  it("accepts only autonomy mode + success + autonomyProof true", () => {
+    assert.equal(acceptsAsAutonomyProof(PROOF, "autonomy"), true);
+    assert.equal(acceptsAsAutonomyProof(PROOF, "plumbing"), false);
+    assert.equal(acceptsAsAutonomyProof({ ok: false, reason: "x" }, "autonomy"), false);
+    assert.equal(
+      acceptsAsAutonomyProof({ ok: true, patch: "x", changedFiles: [], proof: { autonomyProof: false } }, "autonomy"),
+      false,
+    );
+  });
+});
+
+describe("writerlane validator mirror: validateAutonomyProof order", () => {
+  it("passes only when scope + tests + clean + budget all hold", () => {
+    assert.deepEqual(validateAutonomyProof(PROOF, "autonomy", PASS_VALIDATION), { ok: true });
+    assert.equal(isValidatedAutonomyProof(PROOF, "autonomy", PASS_VALIDATION), true);
+  });
+
+  it("fails scope gate first", () => {
+    const r = validateAutonomyProof(PROOF, "plumbing", PASS_VALIDATION);
+    assert.deepEqual(r, { ok: false, reason: WRITERLANE_SCOPE_GATE_FAILED });
+  });
+
+  it("fails tests before clean/budget", () => {
+    const r = validateAutonomyProof(PROOF, "autonomy", { testsPassed: false, clean: false, withinDiffBudget: false });
+    assert.deepEqual(r, { ok: false, reason: WRITERLANE_TESTS_FAILED });
+  });
+
+  it("fails clean before budget", () => {
+    const r = validateAutonomyProof(PROOF, "autonomy", { testsPassed: true, clean: false, withinDiffBudget: false });
+    assert.deepEqual(r, { ok: false, reason: WRITERLANE_UNCLEAN_OUTPUT });
+  });
+
+  it("fails budget last", () => {
+    const r = validateAutonomyProof(PROOF, "autonomy", { testsPassed: true, clean: true, withinDiffBudget: false });
+    assert.deepEqual(r, { ok: false, reason: WRITERLANE_DIFF_OVER_BUDGET });
+  });
+});
+
+describe("writerlane validator mirror: clean check", () => {
+  it("flags chat-template junk on ADDED lines only", () => {
+    const dirty = ["+const x = 1;", "+// </assistant>"].join("\n");
+    assert.deepEqual(scanForUncleanArtifacts(dirty), ["</assistant>"]);
+    assert.equal(isCleanPatch(dirty), false);
+  });
+
+  it("ignores junk that appears only on context or removed lines", () => {
+    const onlyRemoved = [" context <assistant>", "-old </s>"].join("\n");
+    assert.deepEqual(scanForUncleanArtifacts(onlyRemoved), []);
+    assert.equal(isCleanPatch(onlyRemoved), true);
+  });
+
+  it("treats a normal code patch as clean", () => {
+    const clean = ["+export function add(a, b) {", "+  return a + b;", "+}"].join("\n");
+    assert.equal(isCleanPatch(clean), true);
+  });
+});
+
+describe("writerlane validator mirror: diff budget", () => {
+  it("counts added/removed and classifies removed doc lines", () => {
+    const patch = [
+      "diff --git a/x.ts b/x.ts",
+      "--- a/x.ts",
+      "+++ b/x.ts",
+      "@@ -1,3 +1,2 @@",
+      "-/** old docstring */",
+      "-const a = 1;",
+      "+const a = 2;",
+    ].join("\n");
+    const stats = computeDiffStats(patch);
+    assert.equal(stats.addedLines, 1);
+    assert.equal(stats.removedLines, 2);
+    assert.equal(stats.removedDocLines, 1);
+  });
+
+  it("rejects doc deletion when forbidDocDeletion is set (the glm over-edit guard)", () => {
+    const overEdit = ["-// keep me", "+code();"].join("\n");
+    assert.equal(isWithinDiffBudget(overEdit, { forbidDocDeletion: true }), false);
+    assert.equal(isWithinDiffBudget(overEdit, {}), true);
+  });
+
+  it("enforces line-count caps when set", () => {
+    const patch = ["+a", "+b", "+c", "-x"].join("\n");
+    assert.equal(isWithinDiffBudget(patch, { maxAddedLines: 2 }), false);
+    assert.equal(isWithinDiffBudget(patch, { maxAddedLines: 3 }), true);
+    assert.equal(isWithinDiffBudget(patch, { maxRemovedLines: 0 }), false);
+    assert.equal(isWithinDiffBudget(patch, { maxChangedLines: 3 }), false);
+    assert.equal(isWithinDiffBudget(patch, { maxChangedLines: 4 }), true);
+  });
+});
+
+describe("writerlane validator mirror: buildValidationFromPatch", () => {
+  it("derives clean + budget from text and carries the supplied test verdict", () => {
+    const clean = ["+ok();"].join("\n");
+    const v = buildValidationFromPatch(clean, true, {});
+    assert.deepEqual(v, { testsPassed: true, clean: true, withinDiffBudget: true });
+
+    const dirty = ["+// <|im_end|>"].join("\n");
+    const v2 = buildValidationFromPatch(dirty, true, {});
+    assert.equal(v2.clean, false);
+
+    // an external test failure is carried through unchanged
+    const v3 = buildValidationFromPatch(clean, false, {});
+    assert.equal(v3.testsPassed, false);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the proven direct-OpenRouter **WriterLane free-model writer** into the live autonomous runner path **inert** behind the existing off-by-default execute gate. Built off merged `origin/main` (#1055, base SHA `7717734`). Nothing goes live on merge.

The runner (`scripts/pinballwake-autonomous-runner.mjs`) runs as plain `node ...mjs` with no tsx/build step, so it cannot import the TypeScript `api/lib/writerlane/*` lib at runtime. Slices A and B are runtime `.mjs` mirrors of the merged #1055 specs (keep in sync); C is the runner-side adapter; D is a one-function seam edit.

- **A** `pinballwake-writerlane-free-models.mjs`: mirror of the merged registry + selector (`isFreeModelSlug`, `fitScore`, `rankFreeModelsForTask`, `selectDefaultFreeChain`, `topFreeModelForTask`).
- **B** `pinballwake-writerlane-validator.mjs`: port of the merged validator predicate (`validateAutonomyProof` + `scanForUncleanArtifacts`/`isCleanPatch`/`computeDiffStats`/`isWithinDiffBudget`/`buildValidationFromPatch`) with exact reason codes.
- **C** `pinballwake-writerlane-free-writer.mjs`: adapter matching the worker's injected-runner contract. Asks a free model for full owned-file contents, writes them, runs the scoped verification command **for real AFTER writing / BEFORE `captureOwnedWorktreeDiff`**, mirrors the `gateOpenHandsDiff` scope/ownership/hunk/trusted-source gate, walks the free-model fallback chain, fails closed with exact reason codes. `fetch`/`runProcess`/`captureDiff`/`writeFile` are all injectable (tests never touch network, git, or FS).
- **D** one-function edit to `createAutonomousRunnerOpenHandsExecutorFromEnv`: `AUTONOMOUS_RUNNER_WRITER=writerlane_free` routes the writer through the free-model adapter and **forces the CodeRoom submitter to `draft:true, autoMerge:false`** (the default submitter is `draft:false`/`autoMerge:true`, which must not apply here). Flag unset = byte-for-byte today's behavior.

## Safety / inertness

- Still fully gated by the triple execute gate: `AUTONOMOUS_RUNNER_MODE=execute` && `AUTONOMOUS_RUNNER_ALLOW_EXECUTE` && `AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE`, all off by default.
- No `.github/workflows` changes, no secret changes, no execute-flag flips.
- No TypeScript touched; only `.mjs` added/edited. Relative `.mjs` imports verified at runtime.
- **Slice E (the go-live flip) is intentionally NOT in this PR** and remains Chris-gated.

## Test plan

- [x] `node --test` across all new + extended + dependency files: **124 pass, 0 fail**
- [x] Runner seam: default (flag unset) builds the OpenHands CLI runner unchanged; `writerlane_free` builds the free-writer + draft/no-auto-merge submitter; nothing built while execute disabled.
- [ ] Draft only - do not merge. Awaiting Chris review before any go-live step.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the autonomous OpenHands execute seam and would call OpenRouter plus real scoped tests when fully enabled; default path is unchanged and execute remains gated off.
> 
> **Overview**
> Adds **runtime `.mjs` mirrors** of the merged WriterLane free-model registry/selector and autonomy validator (plain `node` runner cannot import TS), plus a **free OpenRouter writer adapter** that requests full owned-file contents, runs scoped verification, captures a worktree diff, applies scope/diff gates and validation, and walks a ranked fallback chain with fail-closed reason codes.
> 
> **`createAutonomousRunnerOpenHandsExecutorFromEnv`** gains an opt-in path: `AUTONOMOUS_RUNNER_WRITER=writerlane_free` swaps in the free writer and forces CodeRoom submitter **`draft: true` / `autoMerge: false`**; unset flag keeps the existing OpenHands CLI + default submitter. Behavior stays behind the existing off-by-default OpenHands execute triple gate—no workflows or env flips in this PR.
> 
> Generated brainmap inventory/docs list the six new automation scripts; tests cover registry/validator/writer behavior and the runner seam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6ef5f64bfaac898d00ad294505776243e90a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->