### PR TITLE
fix(memory): keep Recall Check Top of Mind useful

### DIFF
--- a/api/lib/memory-recall-sections.test.ts
+++ b/api/lib/memory-recall-sections.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRecallFactSections } from "./memory-recall-sections";
+
+function fact(
+  id: string,
+  overrides: Partial<{
+    fact: string;
+    category: string;
+    access_count: number;
+    decay_tier: string;
+  }> = {},
+) {
+  return {
+    id,
+    fact: overrides.fact ?? `fact ${id}`,
+    category: overrides.category ?? "technical",
+    access_count: overrides.access_count ?? 1,
+    decay_tier: overrides.decay_tier ?? "hot",
+  };
+}
+
+describe("memory recall sections", () => {
+  it("uses a broader candidate pool for Top of Mind than raw Most Accessed", () => {
+    const rawMostAccessed = Array.from({ length: 10 }, (_, index) =>
+      fact(`static-${index + 1}`, {
+        fact: `Chris profile preference ${index + 1}`,
+        category: "preference",
+        access_count: 2080 - index,
+      }),
+    );
+    const activeProjectFact = fact("active-project", {
+      fact: "PR #997 made FidelityCopy receipts green",
+      category: "technical",
+      access_count: 42,
+    });
+
+    const sections = buildRecallFactSections(rawMostAccessed, [...rawMostAccessed, activeProjectFact]);
+
+    expect(sections.top_facts).toHaveLength(10);
+    expect(sections.top_facts.every((row) => row.recall_signal === "background-heavy")).toBe(true);
+    expect(sections.top_of_mind_facts.map((row) => row.id)).toContain("active-project");
+    expect(sections.top_of_mind_facts.map((row) => row.id)).not.toContain("static-1");
+    expect(sections.recall_diagnostics).toMatchObject({
+      inspected_top_facts: 10,
+      inspected_top_of_mind_candidates: 11,
+      background_heavy_count: 10,
+      background_heavy_candidate_count: 10,
+    });
+  });
+});

--- a/api/lib/memory-recall-sections.ts
+++ b/api/lib/memory-recall-sections.ts
@@ -1,0 +1,66 @@
+const BACKGROUND_RECALL_CATEGORIES = new Set(["identity", "preference", "standing_rule"]);
+const BACKGROUND_RECALL_PATTERNS = [
+  /^chris('s)?\s/i,
+  /^user\s/i,
+  /should always/i,
+  /never use/i,
+  /operator timezone/i,
+  /standing rule/i,
+  /profile/i,
+  /preference/i,
+];
+
+type RecallFactInput = {
+  category?: string | null;
+  fact?: string | null;
+  access_count?: number | null;
+};
+
+export type RecallSignal = "top-of-mind" | "background-heavy";
+
+export type AnnotatedRecallFact<T extends RecallFactInput> = T & {
+  recall_signal: RecallSignal;
+  recall_note: string;
+};
+
+export function annotateRecallFact<T extends RecallFactInput>(fact: T): AnnotatedRecallFact<T> {
+  const category = String(fact.category ?? "").toLowerCase();
+  const text = String(fact.fact ?? "");
+  const accessCount = Number(fact.access_count ?? 0);
+  const looksStatic =
+    BACKGROUND_RECALL_CATEGORIES.has(category) ||
+    BACKGROUND_RECALL_PATTERNS.some((pattern) => pattern.test(text));
+  const isBackgroundHeavy = accessCount >= 100 && looksStatic;
+
+  return {
+    ...fact,
+    recall_signal: isBackgroundHeavy ? "background-heavy" : "top-of-mind",
+    recall_note: isBackgroundHeavy ? "Startup or heartbeat reads" : "Human-facing recall",
+  };
+}
+
+export function buildRecallFactSections<T extends RecallFactInput>(
+  topFacts: T[],
+  topOfMindCandidates: T[] = topFacts,
+) {
+  const annotatedTopFacts = topFacts.map(annotateRecallFact);
+  const annotatedTopOfMindCandidates = topOfMindCandidates.map(annotateRecallFact);
+  const topOfMindFacts = annotatedTopOfMindCandidates
+    .filter((fact) => fact.recall_signal === "top-of-mind")
+    .slice(0, 10);
+  const backgroundHeavyCount = annotatedTopFacts.filter((fact) => fact.recall_signal === "background-heavy").length;
+  const backgroundHeavyCandidateCount = annotatedTopOfMindCandidates.filter(
+    (fact) => fact.recall_signal === "background-heavy",
+  ).length;
+
+  return {
+    top_facts: annotatedTopFacts,
+    top_of_mind_facts: topOfMindFacts,
+    recall_diagnostics: {
+      inspected_top_facts: annotatedTopFacts.length,
+      inspected_top_of_mind_candidates: annotatedTopOfMindCandidates.length,
+      background_heavy_count: backgroundHeavyCount,
+      background_heavy_candidate_count: backgroundHeavyCandidateCount,
+    },
+  };
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -108,6 +108,7 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { evaluateFishbowlCompletionPolicy } from "./lib/fishbowl-completion-policy.js";
 import { inferFishbowlJobPipeline } from "./lib/fishbowl-job-pipeline.js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
+import { buildRecallFactSections } from "./lib/memory-recall-sections.js";
 import {
   buildOrchestratorContext,
   mergeOrchestratorTodoRows,
@@ -553,31 +554,7 @@ async function upsertAdminLibraryDoc(
   return `Library doc created: "${data.title}" (v1)`;
 }
 
-const BACKGROUND_RECALL_CATEGORIES = new Set(["identity", "preference", "standing_rule"]);
-const BACKGROUND_RECALL_PATTERNS = [
-  /^chris('s)?\s/i,
-  /^user\s/i,
-  /should always/i,
-  /never use/i,
-  /operator timezone/i,
-  /standing rule/i,
-  /profile/i,
-  /preference/i,
-];
-
-function annotateRecallFact<T extends { category?: string | null; fact?: string | null; access_count?: number | null }>(fact: T) {
-  const category = String(fact.category ?? "").toLowerCase();
-  const text = String(fact.fact ?? "");
-  const accessCount = Number(fact.access_count ?? 0);
-  const looksStatic = BACKGROUND_RECALL_CATEGORIES.has(category) || BACKGROUND_RECALL_PATTERNS.some((pattern) => pattern.test(text));
-  const isBackgroundHeavy = accessCount >= 100 && looksStatic;
-
-  return {
-    ...fact,
-    recall_signal: isBackgroundHeavy ? "background-heavy" : "top-of-mind",
-    recall_note: isBackgroundHeavy ? "Startup or heartbeat reads" : "Human-facing recall",
-  };
-}
+const TOP_OF_MIND_CANDIDATE_LIMIT = 110;
 
 function getRequestBaseUrl(req: VercelRequest): string | null {
   const explicit = process.env.EMBED_API_URL?.replace(/\/$/, "");
@@ -4120,19 +4097,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const topFactsLimit = getClampedLimit(req.query.top_facts_limit, 10, 110);
 
-        // Most accessed facts
-        const { data: topFacts } = await supabase
-          .from("mc_extracted_facts")
-          .select("id, fact, category, access_count, decay_tier")
-          .eq("api_key_hash", apiKeyHash)
-          .eq("status", "active")
-          .order("access_count", { ascending: false })
-          .limit(topFactsLimit);
-        const annotatedTopFacts = (topFacts ?? []).map(annotateRecallFact);
-        const topOfMindFacts = annotatedTopFacts
-          .filter((fact) => fact.recall_signal === "top-of-mind")
-          .slice(0, 10);
-        const backgroundHeavyCount = annotatedTopFacts.filter((fact) => fact.recall_signal === "background-heavy").length;
+        // Most Accessed stays the raw inspectable debug list. Top of Mind
+        // inspects a broader pool so static startup facts cannot crowd out
+        // useful current facts before the background-heavy filter runs.
+        const topOfMindCandidateLimit = Math.max(topFactsLimit, TOP_OF_MIND_CANDIDATE_LIMIT);
+        const [topFactsResult, topOfMindCandidateResult] = await Promise.all([
+          supabase
+            .from("mc_extracted_facts")
+            .select("id, fact, category, access_count, decay_tier")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "active")
+            .order("access_count", { ascending: false })
+            .limit(topFactsLimit),
+          supabase
+            .from("mc_extracted_facts")
+            .select("id, fact, category, access_count, decay_tier")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "active")
+            .order("access_count", { ascending: false })
+            .limit(topOfMindCandidateLimit),
+        ]);
+        if (topFactsResult.error) throw topFactsResult.error;
+        if (topOfMindCandidateResult.error) throw topOfMindCandidateResult.error;
+
+        const recallSections = buildRecallFactSections(topFactsResult.data ?? [], topOfMindCandidateResult.data ?? []);
 
         return res.status(200).json({
           facts_by_day: factsByDay,
@@ -4147,13 +4135,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                    (facts.count ?? 0) + (convos.count ?? 0) + (code.count ?? 0),
           },
           top_facts_limit: topFactsLimit,
-          recall_diagnostics: {
-            inspected_top_facts: annotatedTopFacts.length,
-            background_heavy_count: backgroundHeavyCount,
-          },
+          recall_diagnostics: recallSections.recall_diagnostics,
           recent_decay: recentDecay ?? [],
-          top_of_mind_facts: topOfMindFacts,
-          top_facts: annotatedTopFacts,
+          top_of_mind_facts: recallSections.top_of_mind_facts,
+          top_facts: recallSections.top_facts,
         });
       }
 

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 479,
+    "inventory": 480,
     "source_manifest": 94,
     "pages": 94,
     "tools": 183,
@@ -75,7 +75,7 @@
       "id": "source-of-truth",
       "name": "Source of truth",
       "meaning": "Canonical state, queue, memory, and context surfaces.",
-      "count": 9
+      "count": 10
     },
     {
       "id": "modules-and-apps",
@@ -2878,6 +2878,16 @@
       "kind": "state module",
       "meaning": "memory Data Island shared frontend logic.",
       "source": "src/lib/memoryDataIsland.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-memory-recall-sections-api-lib-memory-recall-sections-ts",
+      "division": "Source of truth",
+      "name": "memory recall sections",
+      "kind": "state module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/memory-recall-sections.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -121,7 +121,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 115 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
-| Source of truth | Canonical state, queue, memory, and context surfaces. | 9 |
+| Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 19 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 4 |
 
@@ -704,6 +704,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Source of truth | state module | embed | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory/embed.ts |
 | Source of truth | state module | memory admin | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory-admin.ts |
 | Source of truth | state module | memory Data Island | memory Data Island shared frontend logic. | - | src/lib/memoryDataIsland.ts |
+| Source of truth | state module | memory recall sections | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/memory-recall-sections.ts |
 | Source of truth | state module | memory retrieval eval | memory retrieval eval UnClick module. | - | scripts/memory-retrieval-eval.mjs |
 | Source of truth | state module | memory Taxonomy | memory Taxonomy shared frontend logic. | - | src/lib/memoryTaxonomy.ts |
 | Source of truth | state module | orchestrator context | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/orchestrator-context.ts |

--- a/docs/memory/active_facts-contract-v1.md
+++ b/docs/memory/active_facts-contract-v1.md
@@ -1,7 +1,7 @@
 # Active Facts Contract V1
 
 **Status**: Draft  
-**Last updated**: 2026-04-29  
+**Last updated**: 2026-05-27
 **Owner**: `🦾`  
 **Purpose**: Pre-work contract draft for Cluster A before Chris's design call
 
@@ -291,6 +291,24 @@ If any local path cannot bump metrics yet, it MUST still:
 - return the same surfaced set it would have returned under parity
 - avoid bumping hidden facts
 - document the temporary gap as an implementation limitation rather than a different contract
+
+## Recall Check presentation contract
+
+The admin Recall Check view has two related but different surfaces:
+
+- `top_facts`: the raw Most Accessed debug list
+- `top_of_mind_facts`: the human-facing list of currently useful facts
+
+These surfaces MUST NOT be collapsed into the same trimmed candidate set.
+
+Most Accessed should remain inspectable so background-heavy rows can be audited.
+Top of Mind should inspect a broader candidate pool before filtering, so repeated startup or heartbeat reads of static identity/profile facts cannot crowd out lower-count but more useful current facts before the background-heavy filter runs.
+
+The Recall Check API should expose diagnostics for both inspected pools:
+
+- raw Most Accessed rows inspected
+- broader Top of Mind candidates inspected
+- background-heavy rows found in each pool
 
 ## Recommended V1 rule summary
 

--- a/src/pages/admin/memory/MemoryActivityTab.test.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.test.tsx
@@ -30,7 +30,9 @@ function makeActivity(topFactCount: number) {
     recent_decay: [],
     recall_diagnostics: {
       inspected_top_facts: topFactCount,
+      inspected_top_of_mind_candidates: topFactCount,
       background_heavy_count: 0,
+      background_heavy_candidate_count: 0,
     },
     top_of_mind_facts: topFacts.slice(0, 10),
     top_facts: topFacts,
@@ -105,7 +107,9 @@ describe("MemoryActivityTab", () => {
         ...makeActivity(2),
         recall_diagnostics: {
           inspected_top_facts: 2,
+          inspected_top_of_mind_candidates: 2,
           background_heavy_count: 1,
+          background_heavy_candidate_count: 1,
         },
         top_of_mind_facts: [activeFact],
         top_facts: [backgroundFact, activeFact],
@@ -119,5 +123,47 @@ describe("MemoryActivityTab", () => {
     expect(screen.getAllByText("PR #898 added the Recall Check see more path").length).toBeGreaterThan(0);
     expect(screen.getByText("Background-heavy")).toBeInTheDocument();
     expect(screen.getByText("Startup or heartbeat reads")).toBeInTheDocument();
+  });
+
+  it("keeps Top of Mind useful when raw Most Accessed is all background-heavy", async () => {
+    activityFactory = () => {
+      const backgroundFacts = Array.from({ length: 10 }, (_, index) => ({
+        id: `static-profile-${index + 1}`,
+        fact: `Chris profile preference ${index + 1}`,
+        category: "preference",
+        access_count: 2080 - index,
+        decay_tier: "hot",
+        recall_signal: "background-heavy" as const,
+        recall_note: "Startup or heartbeat reads",
+      }));
+      const activeFact = {
+        id: "active-project",
+        fact: "PR #997 made FidelityCopy receipts green",
+        category: "technical",
+        access_count: 42,
+        decay_tier: "hot",
+        recall_signal: "top-of-mind" as const,
+        recall_note: "Human-facing recall",
+      };
+
+      return {
+        ...makeActivity(10),
+        recall_diagnostics: {
+          inspected_top_facts: 10,
+          inspected_top_of_mind_candidates: 11,
+          background_heavy_count: 10,
+          background_heavy_candidate_count: 10,
+        },
+        top_of_mind_facts: [activeFact],
+        top_facts: backgroundFacts,
+      };
+    };
+
+    render(<MemoryActivityTab apiKey="test-token" />);
+
+    await screen.findByText("Top of Mind");
+
+    expect(screen.getByText("PR #997 made FidelityCopy receipts green")).toBeInTheDocument();
+    expect(screen.getAllByText("Background-heavy")).toHaveLength(10);
   });
 });

--- a/src/pages/admin/memory/MemoryActivityTab.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.tsx
@@ -36,7 +36,9 @@ interface ActivityData {
   top_facts: RecallFact[];
   recall_diagnostics?: {
     inspected_top_facts: number;
+    inspected_top_of_mind_candidates?: number;
     background_heavy_count: number;
+    background_heavy_candidate_count?: number;
   };
 }
 


### PR DESCRIPTION
## Summary

- Extract Recall Check fact annotation and section-building into a tested helper.
- Keep raw Most Accessed facts inspectable while building Top of Mind from a broader 110-row candidate pool.
- Add diagnostics for both inspected pools and cover the background-heavy crowding case in UI tests.
- Update the active facts contract and regenerated Brainmap.

Supersedes the stale draft direction in #1000 with a fresh branch from current `main`.

## Proof

- `npx vitest run api/lib/memory-recall-sections.test.ts src/pages/admin/memory/MemoryActivityTab.test.tsx`
- `npm test` - 97 files, 762 tests passed
- `npm run build`
- `npm run brainmap:generate`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `git diff --check`
- Focused eslint on the new recall helper and MemoryActivityTab files passed

## Live dogfood note

- `load_memory` returned 12 active facts from the current tenant and they are current technical facts, not repeated static profile rows.
- Direct Recall Check admin API proof was not run from this local worktree because no admin API credential was present in the environment.
- Live `search_memory` still reports `cosine_score: 0` on current deployed results; that belongs to the separate semantic retrieval lane and is not claimed closed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin memory presentation and ranking logic only; no auth, persistence schema, or agent recall contract changes beyond documented Recall Check API shape.
> 
> **Overview**
> Recall Check now separates **Most Accessed** (raw debug list) from **Top of Mind** (human-facing facts). Annotation and section building move into `api/lib/memory-recall-sections.ts`; `memory-admin` loads up to **110** access-ranked candidates for Top of Mind while keeping the smaller **Most Accessed** limit for inspection, then applies the existing background-heavy filter only when building Top of Mind.
> 
> **Recall diagnostics** now report both pools (`inspected_top_of_mind_candidates`, `background_heavy_candidate_count`). The active facts contract documents this presentation split; Brainmap inventory is regenerated. UI tests cover the case where all top access rows are background-heavy but a lower-count technical fact still appears in Top of Mind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b476c188d6009ae5bad2e4c2fe3b943c1fc4e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->