### PR TITLE
ci(runner): pass AUTONOMOUS_RUNNER_WRITER var into runner step env

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -253,6 +253,7 @@ jobs:
           AUTONOMOUS_RUNNER_DISABLED: ${{ steps.runner-plan.outputs.disabled }}
           AUTONOMOUS_RUNNER_ALLOW_EXECUTE: ${{ steps.runner-plan.outputs.execute }}
           AUTONOMOUS_RUNNER_OPENHANDS_EXECUTE: ${{ steps.runner-plan.outputs.execute }}
+          AUTONOMOUS_RUNNER_WRITER: ${{ vars.AUTONOMOUS_RUNNER_WRITER }}
           AUTONOMOUS_RUNNER_REQUIRE_ASSIGNED_QUEUE: ${{ steps.runner-plan.outputs.canary_execute == 'true' && 'true' || vars.AUTONOMOUS_RUNNER_REQUIRE_ASSIGNED_QUEUE || 'false' }}
           OPENHANDS_TEST_MODE: ${{ steps.runner-plan.outputs.execute == 'true' && '1' || '' }}
           OPENHANDS_COMMAND: ${{ vars.OPENHANDS_COMMAND || 'uvx' }}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7022,8 +7022,8 @@
     },
     {
       "source": ".github/workflows/autonomous-runner.yml",
-      "hash": "d280b09dbb76",
-      "bytes": 15265
+      "hash": "a1280cfec46b",
+      "bytes": 15338
     },
     {
       "source": ".github/workflows/claude.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -92,7 +92,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/elevenlabs-tool.ts | efcaeeff39d6 | 10833 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
-| .github/workflows/autonomous-runner.yml | d280b09dbb76 | 15265 |
+| .github/workflows/autonomous-runner.yml | a1280cfec46b | 15338 |
 | .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
 | .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |
 | .github/workflows/dogfood-report.yml | d485b8d37111 | 3987 |


### PR DESCRIPTION
## Summary

One-line passthrough fix. The `.github/workflows/autonomous-runner.yml` "Run autonomous Runner" step did not pass the `AUTONOMOUS_RUNNER_WRITER` repo variable into the step process `env`. As a result the live runner saw `safeEnv.AUTONOMOUS_RUNNER_WRITER` as undefined and fell back to the default OpenHands CLI writer path instead of the merged direct ranked free-writer path.

This adds exactly one env entry so the variable reaches the runner:

```yaml
AUTONOMOUS_RUNNER_WRITER: ${{ vars.AUTONOMOUS_RUNNER_WRITER }}
```

Setting the repo variable to `writerlane_free` then activates the merged `writerlane_free` path, which ranks `openai/gpt-oss-120b:free` first and keeps draft-PR / auto-merge-off behavior.

## Scope

- Single added line in the "Run autonomous Runner" step `env:` block.
- Brainmap generated files refreshed for the workflow file hash/size change.
- No secrets, execute-gate logic, runner logic, or workflow steps changed.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/autonomous-runner.yml'))"`: pass.
- PR CI: Website/root package pass.
- PR CI: MCP server package pass.
- PR CI: TestPass smoke run pass.
- PR CI: Review enforcement warning pass.
- PR CI: dirty-branch hygiene pass.
- Vercel preview: success.

## Merge Note

Leaving this unmerged until Chris reviews workflow changes himself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single env passthrough plus brainmap metadata; no execute gates, secrets, or runner logic changes.
> 
> **Overview**
> The **Run autonomous Runner** workflow step now forwards the repo variable **`AUTONOMOUS_RUNNER_WRITER`** into the step `env`, so `createAutonomousRunnerOpenHandsExecutorFromEnv` can see it instead of always behaving as unset.
> 
> With **`writerlane_free`** configured on the repo, execute runs can opt into the **WriterLane free-model** writer path (ranked free OpenRouter model) and the matching **draft / no-auto-merge** CodeRoom submitter; without the passthrough, the runner kept the default **OpenHands CLI** writer regardless of the variable.
> 
> Generated **UnClick brainmap** entries for `autonomous-runner.yml` were refreshed for the workflow file hash/size change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d34fb0c5d9c5bfbbaba785dcba50a1dc4b175ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->