### PR TITLE
ci(runner): keep writerlane free queue safe

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -41,6 +41,8 @@ export const DEFAULT_AUTONOMOUS_RUNNER_POLICY = {
   allowedTodoRoles: ["builder", "plex-builder", "implementation", "test_fix", "docs_update", "code"],
 };
 
+export const WRITERLANE_FREE_SAFE_TODO_ROLES = ["docs_update", "test_fix"];
+
 export const DEFAULT_UNCLICK_MCP_URL = "https://unclick.world/api/mcp";
 export const UNCLICK_TODO_COMMENT_HYDRATION_LIMIT = 50;
 
@@ -99,6 +101,20 @@ function parseList(value, fallback = []) {
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+export function shouldUseWriterLaneFreeSafeQueue(env = process.env) {
+  const safeEnv = env || {};
+  const writer = String(safeEnv.AUTONOMOUS_RUNNER_WRITER ?? "").trim();
+  return writer === "writerlane_free" && !parseBoolean(safeEnv.AUTONOMOUS_RUNNER_WRITER_ALLOW_BROAD_QUEUE);
+}
+
+export function resolveAutonomousRunnerAllowedTodoRolesFromEnv(env = process.env) {
+  const safeEnv = env || {};
+  if (shouldUseWriterLaneFreeSafeQueue(safeEnv)) {
+    return WRITERLANE_FREE_SAFE_TODO_ROLES;
+  }
+  return safeEnv.AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES;
 }
 
 function getArg(name, fallback = "") {
@@ -3277,7 +3293,7 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "
       maxCycles: parseIntOption(getArg("max-cycles", process.env.AUTONOMOUS_RUNNER_MAX_CYCLES), 1),
       allowedPriorities: process.env.AUTONOMOUS_RUNNER_ALLOWED_PRIORITIES,
       allowedActionReasons: process.env.AUTONOMOUS_RUNNER_ALLOWED_ACTION_REASONS,
-      allowedTodoRoles: process.env.AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES,
+      allowedTodoRoles: resolveAutonomousRunnerAllowedTodoRolesFromEnv(process.env),
     }),
   })
     .then((result) => {

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -29,6 +29,7 @@ import {
   parseAutonomousRunnerGitStatusPorcelain,
   parseMcpEventStreamPayload,
   resolveAutonomousRunnerQueueGuard,
+  resolveAutonomousRunnerAllowedTodoRolesFromEnv,
   evaluateAutonomousRunnerGitHygiene,
   runAutonomousRunnerMainFreshnessCanary,
   runAutonomousRunnerCycle,
@@ -93,6 +94,33 @@ describe("PinballWake autonomous Runner seat", () => {
     assert.equal(normal.scheduled_execute_canary, false);
     assert.equal(normal.require_scope_pack, false);
     assert.equal(normal.queue_fetch_limit, 1);
+  });
+
+  it("keeps writerlane_free on the small safe queue unless explicitly widened", () => {
+    assert.deepEqual(
+      resolveAutonomousRunnerAllowedTodoRolesFromEnv({
+        AUTONOMOUS_RUNNER_WRITER: "writerlane_free",
+        AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES: "builder,plex-builder,implementation,test_fix,docs_update,code",
+      }),
+      ["docs_update", "test_fix"],
+    );
+
+    assert.equal(
+      resolveAutonomousRunnerAllowedTodoRolesFromEnv({
+        AUTONOMOUS_RUNNER_WRITER: "writerlane_free",
+        AUTONOMOUS_RUNNER_WRITER_ALLOW_BROAD_QUEUE: "true",
+        AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES: "builder,docs_update",
+      }),
+      "builder,docs_update",
+    );
+
+    assert.equal(
+      resolveAutonomousRunnerAllowedTodoRolesFromEnv({
+        AUTONOMOUS_RUNNER_WRITER: "openhands",
+        AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES: "builder,docs_update",
+      }),
+      "builder,docs_update",
+    );
   });
 
   it("treats the checked-out SHA as fresh when it matches current main", () => {


### PR DESCRIPTION
Summary:
- keep writerlane_free on the small docs_update,test_fix queue by default
- add AUTONOMOUS_RUNNER_WRITER_ALLOW_BROAD_QUEUE=true as the explicit escape hatch
- cover the queue resolver with a runner unit test

Proof:
- node --test scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-writerlane-free-models.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs
- node --test scripts/UnClick-brainmap.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- npm run brainmap:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner queue policy guard only; no auth or execution path changes beyond limiting which todo roles are claimable for one writer mode.
> 
> **Overview**
> When **`AUTONOMOUS_RUNNER_WRITER`** is **`writerlane_free`**, the autonomous runner CLI no longer honors a broad **`AUTONOMOUS_RUNNER_ALLOWED_TODO_ROLES`** list for queue intake. Policy **`allowedTodoRoles`** is resolved through **`resolveAutonomousRunnerAllowedTodoRolesFromEnv`**, which forces **`docs_update`** and **`test_fix`** only (via **`WRITERLANE_FREE_SAFE_TODO_ROLES`**).
> 
> Operators can still widen the queue by setting **`AUTONOMOUS_RUNNER_WRITER_ALLOW_BROAD_QUEUE=true`**, which restores the env role list. Other writers are unchanged.
> 
> Unit tests cover default narrowing, the broad-queue escape hatch, and non-**`writerlane_free`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e744478e8ce23b43b79035e8dc96149f9f792ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->