### PR TITLE
fix(runner): expose free-writer attempt reasons

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -1276,6 +1276,11 @@ const BOARDROOM_SCOPING_ACTION_REASONS = new Set([
   "stale_assigned_open",
   "role_assigned_open",
 ]);
+const BOARDROOM_SELF_ASSIGNED_ACTION_REASONS = new Set([
+  "assigned_open",
+  "role_assigned_open",
+  "stale_assigned_open",
+]);
 
 function boardroomClaimAgentId(runner = {}) {
   const safeRunner = createAutonomousRunner(runner);
@@ -2244,6 +2249,9 @@ function formatOpenHandsBuildAttemptReceipt(result) {
   ];
   const holdReason = receipt.hold_reason || result.reason || "";
   if (holdReason) parts.push(`openhands_hold_reason=${holdReason}.`);
+  if (evidence.model) parts.push(`model=${evidence.model}.`);
+  const attemptSummary = formatOpenHandsAttemptSummary(evidence.attempts);
+  if (attemptSummary) parts.push(`attempts=${attemptSummary}.`);
   if (Array.isArray(evidence.changed_files) && evidence.changed_files.length > 0) {
     parts.push(`changed_files=${evidence.changed_files.join(",")}.`);
   }
@@ -2251,7 +2259,19 @@ function formatOpenHandsBuildAttemptReceipt(result) {
   if (evidence.pr_url) parts.push(`pr=${evidence.pr_url}.`);
   if (evidence.head_sha_after) parts.push(`head_sha=${evidence.head_sha_after}.`);
   if (receipt.next_action) parts.push(`openhands_next=${receipt.next_action}.`);
-  return compact(parts.join(" "), 600);
+  return compact(parts.join(" "), 900);
+}
+
+function formatOpenHandsAttemptSummary(attempts) {
+  if (!Array.isArray(attempts) || attempts.length === 0) return "";
+  return attempts
+    .slice(0, 4)
+    .map((attempt) => {
+      const model = compact(attempt?.model_id || attempt?.modelId || "unknown", 50);
+      const reason = attempt?.ok === true ? "ok" : compact(attempt?.reason || "failed", 70);
+      return `${model}:${reason}`;
+    })
+    .join(",");
 }
 
 export function createCodingRoomJobFromBoardroomTodo(todo = {}, { now = new Date().toISOString() } = {}) {
@@ -2342,7 +2362,7 @@ export function evaluateBoardroomTodoAutoClaimEligibility(
   const actionReason = normalizeToken(todo.actionability_reason || "");
   const safeActionReasons = tokenSet(allowedActionReasons, DEFAULT_AUTONOMOUS_RUNNER_POLICY.allowedActionReasons);
   const selfAssignedActionReason =
-    assignedToRunner && (actionReason === "role_assigned_open" || actionReason === "assigned_open");
+    assignedToRunner && BOARDROOM_SELF_ASSIGNED_ACTION_REASONS.has(actionReason);
   if (actionReason && safeActionReasons.size > 0 && !safeActionReasons.has(actionReason) && !selfAssignedActionReason) {
     return { ok: false, reason: "boardroom_todo_action_reason_not_allowed", actionability_reason: actionReason };
   }

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -692,6 +692,30 @@ describe("PinballWake autonomous Runner seat", () => {
     );
   });
 
+  it("allows a stale assigned open todo when it is assigned to this runner", () => {
+    const todo = {
+      id: "todo-stale-canary",
+      title: "AFK canary seed: docs-only OpenHands proof fixture",
+      status: "open",
+      priority: "urgent",
+      assigned_to_agent_id: "runner-plex-1",
+      actionability_reason: "stale_assigned_open",
+      scope_pack: {
+        owned_files: ["docs/openhands-proof-fixture.md"],
+        role: "docs_update",
+        tests: ["node --test scripts/pinballwake-autonomous-runner.test.mjs"],
+      },
+    };
+
+    assert.equal(
+      evaluateBoardroomTodoAutoClaimEligibility(todo, {
+        runner,
+        allowedActionReasons: ["unassigned_open"],
+      }).ok,
+      true,
+    );
+  });
+
   it("requires ScopePack when the canary guard is active", () => {
     const todo = {
       id: "todo-unscoped",
@@ -1956,17 +1980,28 @@ describe("PinballWake autonomous Runner seat", () => {
           testMode: true,
           openHands: async () => ({
             ok: false,
+            reason: "writerlane_free_chain_exhausted",
             exit_code: 0,
             output: "OpenHands completed without a unified diff.",
+            attempts: [
+              {
+                modelId: "gpt-oss-120b",
+                openRouterModel: "openai/gpt-oss-120b:free",
+                status: "proven",
+                ok: false,
+                reason: "writerlane_no_file_contents",
+              },
+            ],
           }),
         },
       });
 
       assert.equal(result.ok, false);
       assert.equal(result.action, "blocked");
-      assert.equal(result.reason, "openhands_reported_failure");
+      assert.equal(result.reason, "writerlane_free_chain_exhausted");
       assert.equal(result.todo_claim_sync.reason, "openhands_build_hold_recorded");
       assert.match(calls[1].body.params.arguments.text, /OpenHands build attempt HOLD/);
+      assert.match(calls[1].body.params.arguments.text, /attempts=gpt-oss-120b:writerlane_no_file_contents/);
       assert.equal(result.quiet_window_autonomy_proof.first_missing_rung, "proof_packet");
       assert.deepEqual(result.quiet_window_autonomy_proof.evidence.observed_rungs, [
         "tick",

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -50,6 +50,18 @@ function normalizePath(value) {
     .trim();
 }
 
+function parseGitStatusPaths(output) {
+  return String(output ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean)
+    .map((path) => normalizePath(path.includes(" -> ") ? path.split(" -> ").pop() : path));
+}
+
+function isGeneratedRunnerLedgerPath(path) {
+  return normalizePath(path) === ".pinballwake/coding-room-ledger.json";
+}
+
 function normalizeList(values) {
   if (Array.isArray(values)) return values.map((value) => String(value ?? "").trim()).filter(Boolean);
   if (values === undefined || values === null || values === "") return [];
@@ -497,7 +509,11 @@ export function createSafeCodeRoomSubmitter({
 
     const status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
     if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
-    if (status.stdout.trim()) return { ok: false, reason: "dirty_worktree" };
+    const dirtyFiles = parseGitStatusPaths(status.stdout);
+    const blockingDirtyFiles = dirtyFiles.filter((file) => !isGeneratedRunnerLedgerPath(file));
+    if (blockingDirtyFiles.length) {
+      return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
+    }
 
     const todoId = safeSlug(job?.todo_id || job?.id || job?.job_id || safeStamp(now));
     const branch = branchName || `${DEFAULT_SUBMITTER_BRANCH_PREFIX}-${todoId}`;

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -467,6 +467,49 @@ describe("safe CodeRoom submitter", () => {
     );
   });
 
+  test("ignores the generated autonomous runner ledger during clean-worktree checks", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-ledger",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          return {
+            ok: true,
+            stdout: " M .pinballwake/coding-room-ledger.json\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/932\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-ledger", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: ledger ignored" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/932");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      ["git status --porcelain", "gh pr list"],
+    );
+  });
+
   test("creates a PR and enables auto-merge only after validation", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -104,6 +104,8 @@ export async function runOpenHandsWorker({
       evidence: {
         exit_code: result?.exit_code ?? null,
         output: clipOutput(result?.output, 2000),
+        model: clip(result?.model, 120),
+        attempts: summarizeRunnerAttempts(result?.attempts),
       },
     });
   }
@@ -188,6 +190,8 @@ export async function runOpenHandsWorker({
       test_run_id: coderoomResult.test_run_id ?? result.test_run_id ?? null,
       test_exit_code: coderoomResult.test_exit_code ?? result.test_exit_code ?? null,
       coderoom_status: coderoomResult.job?.status ?? coderoomResult.status ?? null,
+      model: clip(result.model, 120),
+      attempts: summarizeRunnerAttempts(result.attempts),
     },
   });
 }
@@ -416,6 +420,20 @@ function clipOutput(value, max) {
   const head = Math.ceil(budget * 0.35);
   const tail = Math.max(0, budget - head);
   return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`;
+}
+
+function summarizeRunnerAttempts(attempts, maxAttempts = 8) {
+  if (!Array.isArray(attempts)) return [];
+  return attempts
+    .slice(0, maxAttempts)
+    .map((attempt) => ({
+      model_id: clip(attempt?.modelId || attempt?.model_id || "", 80),
+      openrouter_model: clip(attempt?.openRouterModel || attempt?.openrouter_model || "", 140),
+      status: clip(attempt?.status || "", 40),
+      ok: attempt?.ok === true,
+      reason: clip(attempt?.reason || "", 160),
+    }))
+    .filter((attempt) => attempt.model_id || attempt.openrouter_model || attempt.reason);
 }
 
 function toDate(value) {

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -186,6 +186,34 @@ describe("runOpenHandsWorker", () => {
     assert.match(result.receipt.evidence.output, /before producing a patch/);
   });
 
+  test("keeps WriterLane model attempt reasons in HOLD evidence", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({
+        ok: false,
+        reason: "writerlane_free_chain_exhausted",
+        attempts: [
+          {
+            modelId: "gpt-oss-120b",
+            openRouterModel: "openai/gpt-oss-120b:free",
+            status: "proven",
+            ok: false,
+            reason: "writerlane_no_file_contents",
+          },
+        ],
+      }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "writerlane_free_chain_exhausted");
+    assert.equal(result.receipt.evidence.attempts[0].model_id, "gpt-oss-120b");
+    assert.equal(result.receipt.evidence.attempts[0].openrouter_model, "openai/gpt-oss-120b:free");
+    assert.equal(result.receipt.evidence.attempts[0].reason, "writerlane_no_file_contents");
+  });
+
   test("keeps the tail of long OpenHands failure output", async () => {
     const output = `${"installing dependency\n".repeat(400)}FINAL ERROR: missing model config`;
     const result = await runOpenHandsWorker({


### PR DESCRIPTION
## Summary
- keeps WriterLane free-writer model attempt reasons in OpenHands HOLD/PASS receipts
- includes a compact attempt summary in the Boardroom build-attempt comment
- lets stale self-assigned open todos stay claimable, so the runner can pick its own docs canary instead of skipping to harder unassigned work
- lets the safe CodeRoom submitter ignore the generated autonomous-runner ledger when checking for a clean worktree

## Proof
- PASS: node --test scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs, 97 tests
- PASS: git diff --check, line-ending warnings only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner eligibility, receipt text, and git preflight for a generated ledger file only; no auth, billing, or schema changes.
> 
> **Overview**
> OpenHands and Boardroom receipts now carry **WriterLane free-model attempt detail** (model id, per-attempt reasons) through the worker HOLD/PASS evidence and into compact Boardroom build-attempt comments, with failures surfacing the runner’s specific reason (e.g. `writerlane_free_chain_exhausted`) instead of a generic OpenHands failure.
> 
> **Boardroom auto-claim** treats todos assigned to this runner as eligible when the actionability reason is `assigned_open`, `role_assigned_open`, or **`stale_assigned_open`**, even if the policy only allows `unassigned_open`—so scheduled canaries can reclaim their own stale docs work.
> 
> The **safe CodeRoom submitter** no longer blocks on a dirty worktree when the only change is the generated `.pinballwake/coding-room-ledger.json`, aligning submit-time git checks with autonomous-runner hygiene behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d88f3bf0c05220c3b8b35745e03e3f48c424f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->