### PR TITLE
fix(runner): default to autonomous canary id

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -2625,7 +2625,7 @@ export function createAutonomousRunnerFromEnv(env = process.env) {
   const base = createCodingRoomRunnerFromEnv(env);
   return createAutonomousRunner({
     ...base,
-    id: env.AUTONOMOUS_RUNNER_ID || base.id || DEFAULT_AUTONOMOUS_RUNNER.id,
+    id: env.AUTONOMOUS_RUNNER_ID || env.CODING_ROOM_RUNNER_ID || DEFAULT_AUTONOMOUS_RUNNER.id,
     readiness: env.AUTONOMOUS_RUNNER_READINESS || base.readiness || DEFAULT_AUTONOMOUS_RUNNER.readiness,
     capabilities: parseList(
       env.AUTONOMOUS_RUNNER_CAPABILITIES,

--- a/scripts/pinballwake-autonomous-runner.test.mjs
+++ b/scripts/pinballwake-autonomous-runner.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   createCodingRoomJobFromBoardroomTodo,
   createAutonomousRunner,
+  createAutonomousRunnerFromEnv,
   createAutonomousRunnerOpenHandsExecutorFromEnv,
   createAutonomousRunnerTestOnlyExecutorReceipt,
   assertRunnerOnFreshMain,
@@ -64,6 +65,21 @@ describe("PinballWake autonomous Runner seat", () => {
   it("defaults unknown modes back to dry-run", () => {
     assert.equal(normalizeAutonomousRunnerMode("claim"), "claim");
     assert.equal(normalizeAutonomousRunnerMode("ship-it"), "dry-run");
+  });
+
+  it("defaults the autonomous runner id to the assigned canary seat", () => {
+    assert.equal(createAutonomousRunnerFromEnv({}).id, "pinballwake-autonomous-runner");
+    assert.equal(
+      createAutonomousRunnerFromEnv({ CODING_ROOM_RUNNER_ID: "custom-coding-seat" }).id,
+      "custom-coding-seat",
+    );
+    assert.equal(
+      createAutonomousRunnerFromEnv({
+        AUTONOMOUS_RUNNER_ID: "custom-autonomous-seat",
+        CODING_ROOM_RUNNER_ID: "custom-coding-seat",
+      }).id,
+      "custom-autonomous-seat",
+    );
   });
 
   it("tightens queue intake for the scheduled execute canary", () => {


### PR DESCRIPTION
## Summary
- default autonomous runner identity to the canary runner instead of the generic Coding Room runner default
- preserve explicit AUTONOMOUS_RUNNER_ID and CODING_ROOM_RUNNER_ID overrides
- add regression coverage so assigned AFK canary jobs stay claimable

## Proof
- node --test scripts\\pinballwake-autonomous-runner.test.mjs scripts\\pinballwake-openhands-worker.test.mjs scripts\\pinballwake-openhands-proof-runner.test.mjs
- npm run brainmap:check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to env-based runner identity resolution with unit tests; no auth, data, or execution-path changes beyond matching the correct agent id for claims.
> 
> **Overview**
> **Autonomous runner identity** now resolves from `AUTONOMOUS_RUNNER_ID`, then `CODING_ROOM_RUNNER_ID`, then the fixed default `pinballwake-autonomous-runner`. It no longer inherits the generic Coding Room runner id from `createCodingRoomRunnerFromEnv`, so scheduled AFK canary runs use the canary seat id UnClick expects for assigned todos.
> 
> Regression tests cover the default id, a coding-room override, and autonomous id taking precedence when both env vars are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252fcaafa53ede25f25ad7f1b99f1c33c322322b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->