### PR TITLE
docs(xpass): add research-backed SEO and legal guardrails

### DIFF
--- a/docs/geopass-product-brief.md
+++ b/docs/geopass-product-brief.md
@@ -29,3 +29,29 @@ GEOPass owns the shared scanner contract for the Pass family. SEOPass should bec
 - No paid API calls.
 - No credentials, auth, billing, domains, migrations, or production database writes.
 - Source-linked public evidence only.
+
+## 2026 research refresh: Google AI features
+
+Google Search Central's current AI features guidance says the same foundational SEO best practices still apply to AI Overviews and AI Mode. There are no extra technical requirements or special "GEO hacks" for inclusion. A page needs to be indexed, eligible to appear in Google Search with a snippet, technically accessible, policy-compliant, and useful to people.
+
+GEOPass should therefore score readiness, not promise placement. The product should reward:
+
+- crawlable public pages with index/snippet eligibility
+- helpful, reliable, people-first content
+- visible source evidence, author/entity clarity, and clean internal linking
+- structured data that truthfully represents visible page content
+- topical coverage that survives query fan-out across related subtopics
+
+GEOPass should penalize:
+
+- hidden, misleading, or irrelevant schema
+- scaled AI pages with little added value
+- scraped or stitched content with no original usefulness
+- "guaranteed AI citation", "ranked in AI Mode", or similar unverifiable claims
+
+Reference sources:
+
+- https://developers.google.com/search/docs/appearance/ai-features
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+- https://developers.google.com/search/docs/appearance/structured-data/sd-policies
+- https://developers.google.com/search/docs/essentials/spam-policies

--- a/docs/legalpass-product-brief.md
+++ b/docs/legalpass-product-brief.md
@@ -169,6 +169,30 @@ components: verdict-linter, disclaimer-banner, escalation-router,
 action-gate, audit-log, insurance-rider-map, ToS-shared,
 jurisdiction-resolver, consent-ledger.
 
+## 10.1 Legal SEO and advertising copy guardrails
+
+If LegalPass is used as the legal-market SEO skin for law-firm pages,
+practice-area pages, testimonials, badges, directory copy, or AI-search copy,
+the Marketing Claims hat must treat lawyer advertising rules as a first-class
+risk area, not a later polish pass.
+
+For the US default source pack, the minimum issue-spotting checks are:
+
+- no false or misleading communication about a lawyer or legal service
+- no material fact or law misstatement, and no omission that makes the overall claim misleading
+- no result, comparison, fee, award, or "best" claim unless the claim is factually supportable and qualified where needed
+- no specialist or certified-specialist claim unless the certifying body is valid and named
+- no paid endorsement, testimonial, referral, affiliate, or lead-gen relationship without a clear disclosure where one is needed
+- any legal-service communication must leave the responsible lawyer or firm identifiable where the governing rule requires it
+
+The output remains issue-spotting only. LegalPass can flag "this claim may be risky under the selected source pack" and cite the source. It must not decide whether a page is lawful, compliant, or safe to publish.
+
+Reference sources:
+
+- https://www.americanbar.org/groups/professional_responsibility/publications/model_rules_of_professional_conduct/rule_7_1_communication_concerning_a_lawyer_s_services/
+- https://www.americanbar.org/groups/professional_responsibility/publications/model_rules_of_professional_conduct/rule_7_2_advertising/
+- https://www.ftc.gov/business-guidance/resources/ftcs-endorsement-guides-what-people-are-asking
+
 ## 11. Out of scope for this brief
 
 Pricing experiments, marketplace economics, Phase 2 jurisdictions,

--- a/docs/seopass-product-brief.md
+++ b/docs/seopass-product-brief.md
@@ -34,3 +34,24 @@ The current adapter is plan-only and public-safe. It accepts GEOPass-shaped sour
 ## Positioning
 
 TestPass checks agent tools. UXPass checks user experience. SEOPass checks whether the public web can find and trust the page.
+
+## 2026 research refresh: SEO plus AI search
+
+SEOPass and GEOPass should share one rule: AI search readiness is not a separate promise from search quality. Google says AI Overviews and AI Mode use the same foundational SEO requirements, with no extra technical requirements beyond being indexed, snippet-eligible, accessible, policy-compliant, and useful.
+
+That keeps SEOPass focused on boring, provable facts:
+
+- robots, sitemap, canonical, redirects, status codes, and internal links
+- metadata and visible page structure
+- structured data that matches visible content
+- people-first content and clear evidence for claims
+- Search Console / analytics framing that measures traffic and engagement without promising AI placement
+
+SEOPass must not claim it can guarantee rank, guarantee rich results, guarantee AI Overview inclusion, or certify that AI systems will cite a page. Structured data should be treated as an eligibility and clarity signal, not a ranking guarantee.
+
+Reference sources:
+
+- https://developers.google.com/search/docs/appearance/ai-features
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+- https://developers.google.com/search/docs/appearance/structured-data/sd-policies
+- https://developers.google.com/search/docs/essentials/spam-policies


### PR DESCRIPTION
## Summary
- add current Google AI features guidance to GEOPass and SEOPass product briefs
- lock the no-guaranteed-rank/no-guaranteed-citation posture for SEO/GEO products
- add LegalPass legal SEO advertising-copy guardrails for lawyer-service claims, specialist claims, testimonials, endorsements, referrals, and responsible-firm identity

## Sources checked
- Google Search Central AI features and your website
- Google helpful people-first content guidance
- Google structured data guidelines and spam policies
- ABA Model Rules 7.1 and 7.2
- FTC Endorsement Guides FAQ

## Verification
- npm run brainmap:check
- git diff --check
- latest main before this branch also passed npm test and npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to product briefs; no code, auth, or data paths change.
> 
> **Overview**
> Documents **2026 research-backed product guardrails** in three Pass family briefs—no runtime or schema changes.
> 
> **GEOPass** and **SEOPass** each gain a *2026 research refresh* section anchored on Google Search Central: AI Overviews and AI Mode follow the same foundational SEO as classic search (index/snippet eligibility, accessibility, policy compliance, people-first usefulness)—not separate “GEO hacks.” Both briefs spell out what to **reward** vs **penalize** and explicitly forbid guaranteed rank, citation, rich-result, or AI Overview language; structured data is framed as eligibility/clarity, not a ranking promise, with links to Google AI features, helpful content, structured data, and spam policies.
> 
> **LegalPass** adds **§10.1 Legal SEO and advertising copy guardrails** for law-firm / practice-area / testimonial / AI-search copy when used as a legal-market SEO skin: the Marketing Claims hat must issue-spot against ABA Model Rules 7.1/7.2 and FTC endorsement guidance (misleading claims, unsupported results/comparisons, specialist claims, paid endorsements/disclosures, responsible-firm identification)—still issue-spotting only, with primary-source citations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901efaeaea475de157df40d6a4b9ebe604337363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->