### PR TITLE
fix(writerlane): handle missing owned docs files

### DIFF
--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -321,6 +321,7 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     "For EACH owned file, output a line exactly `FILE: <path>` followed by a fenced code block containing the complete new file contents.",
     "Change only the owned files. Do not commit, push, merge, deploy, or touch anything outside them.",
     "Use the current file contents below as the source of truth. Preserve unrelated code.",
+    "If a current owned file is missing, create that owned file from scratch and still return its full new contents.",
     `Model: ${model.openRouterModel || "unknown"}`,
     "Owned files:",
     ...ownedFiles.map((file) => `- ${file}`),
@@ -351,6 +352,9 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
       lines.push(`CURRENT FILE: ${file.path}`);
       if (file.error) {
         lines.push(`Unreadable: ${file.error}`);
+        if (file.error === "file_missing_new_file_ok") {
+          lines.push("This owned file does not exist yet. Create it from scratch if it is part of the requested change.");
+        }
         continue;
       }
       lines.push("```");
@@ -388,8 +392,32 @@ export function parseFileBlocks(content, ownedFiles) {
     if (fence) {
       return [{ path: ownedList[0], content: fence[1] }];
     }
+    const raw = parseSingleRawFileContent(text, ownedList[0]);
+    if (raw !== null) {
+      return [{ path: ownedList[0], content: raw }];
+    }
   }
   return [];
+}
+
+function parseSingleRawFileContent(text, path) {
+  const body = String(text ?? "").trim();
+  if (!body) return null;
+  const lower = body.toLowerCase();
+  if (
+    lower.startsWith("i cannot ") ||
+    lower.startsWith("i can't ") ||
+    lower.startsWith("sorry") ||
+    lower.startsWith("here is ") ||
+    lower.startsWith("here's ") ||
+    lower.includes("```")
+  ) {
+    return null;
+  }
+  if (isDoc(path) && /^(#\s|##\s|---\r?\n)/.test(body)) {
+    return body;
+  }
+  return null;
 }
 
 function dedupeByPath(blocks) {

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -115,6 +115,32 @@ describe("writerlane free-writer: happy path", () => {
     assert.doesNotMatch(prompt, /tail-never-visible/);
     assert.match(prompt, /\[truncated for writer context\]/);
   });
+
+  it("treats a missing owned file as create-from-scratch context", async () => {
+    let prompt = "";
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: async (_url, init) => {
+        prompt = JSON.parse(init.body).messages[0].content;
+        return fakeFetchOnce(fileBlock("docs/x.md", "# New file\n\nCreated by the writer."))();
+      },
+      readFileImpl: async () => {
+        const err = new Error("missing");
+        err.code = "ENOENT";
+        throw err;
+      },
+      runProcess: okProcess(),
+      writeFileImpl: async () => {},
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+    });
+
+    const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test x"] } });
+
+    assert.equal(result.ok, true);
+    assert.match(prompt, /file_missing_new_file_ok/);
+    assert.match(prompt, /Create it from scratch/);
+  });
 });
 
 describe("writerlane free-writer: fail-closed paths", () => {
@@ -251,6 +277,18 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.equal(blocks[0].content, "just code");
   });
 
+  it("parseFileBlocks accepts raw markdown for one owned docs file", () => {
+    const blocks = parseFileBlocks("# OpenHands proof fixture\n\n- created\n", ["docs/openhands-proof-fixture.md"]);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].path, "docs/openhands-proof-fixture.md");
+    assert.match(blocks[0].content, /^# OpenHands proof fixture/);
+  });
+
+  it("parseFileBlocks does not treat chatty text as a raw docs file", () => {
+    const blocks = parseFileBlocks("Here is the markdown you asked for:\n\n# Title", ["docs/x.md"]);
+    assert.equal(blocks.length, 0);
+  });
+
   it("gateWriterLaneDiff rejects unowned, hunkless, and empty patches", () => {
     assert.equal(gateWriterLaneDiff({ patch: "", ownedFiles: OWNED }).reason, "openhands_missing_unified_diff");
     assert.equal(
@@ -293,5 +331,16 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.match(prompt, /CURRENT FILE: docs\/x\.md/);
     assert.match(prompt, /Runner prompt detail/);
     assert.match(prompt, /old file/);
+  });
+
+  it("buildFullContentsPrompt tells the model missing owned files can be created", () => {
+    const prompt = buildFullContentsPrompt({
+      ownedFiles: OWNED,
+      scopePack: { verification: ["node --test x"] },
+      model: MODEL_A,
+      currentFiles: [{ path: "docs/x.md", content: "", error: "file_missing_new_file_ok" }],
+    });
+    assert.match(prompt, /missing/);
+    assert.match(prompt, /Create it from scratch/);
   });
 });


### PR DESCRIPTION
## Summary
- Teach WriterLane free-writer prompt that missing owned files are valid create-from-scratch targets.
- Add a safe single-owned-doc raw markdown fallback when a free model omits the exact FILE wrapper.
- Keep chatty/refusal text rejected so writerlane_no_file_contents still fails closed.

## Proof
- node --test scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-writerlane-free-models.test.mjs scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs
- npm run brainmap:check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the opt-in free-writer script’s prompt and response parsing, with conservative heuristics and existing diff/test gates unchanged.
> 
> **Overview**
> WriterLane’s **free-writer** path now treats **missing owned files** as valid **create-from-scratch** targets: the AFK prompt says to return full contents for new files, and when context reports `file_missing_new_file_ok` it adds explicit “create it from scratch” guidance (wired from `ENOENT` reads).
> 
> For a **single owned doc**, `parseFileBlocks` gains a narrow fallback: if the model skips the `FILE:` + fence format, **raw markdown** that looks like a real doc (e.g. starts with `#` / `##` / front matter) is accepted; **chatty** or refusal-style replies still yield no blocks so `writerlane_no_file_contents` stays fail-closed.
> 
> Tests cover missing-file prompts, raw-doc parsing, and rejection of preamble text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06582e06d0b778d84c773a63a5ba54c23f71c621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->