### PR TITLE
fix(runner): convert OpenHands prompts for WriterLane

### DIFF
--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -319,6 +319,8 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     "You are an UnClick WriterLane free-model writer running AFK.",
     "Implement the requested change by returning the FULL new contents of each owned file.",
     "For EACH owned file, output a line exactly `FILE: <path>` followed by a fenced code block containing the complete new file contents.",
+    "Do not return a unified diff. Do not return markdown explanation. Return FILE blocks only.",
+    "The runner task prompt may come from a different adapter that asked for a patch; use it for intent only and convert any patch hint into full final file contents.",
     "Change only the owned files. Do not commit, push, merge, deploy, or touch anything outside them.",
     "Use the current file contents below as the source of truth. Preserve unrelated code.",
     `Model: ${model.openRouterModel || "unknown"}`,
@@ -327,7 +329,7 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
   ];
   if (runnerPrompt) {
     lines.push("Runner task prompt:");
-    lines.push(compactText(runnerPrompt, 8_000));
+    lines.push(normalizeRunnerPromptForFullContents(runnerPrompt));
   }
   const intent = scopePack?.changeIntent || scopePack?.change_intent || scopePack?.chip || scopePack?.title;
   if (intent) {
@@ -363,6 +365,20 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     lines.push(String(scopePack.body || scopePack.description));
   }
   return lines.join("\n");
+}
+
+export function normalizeRunnerPromptForFullContents(runnerPrompt = "") {
+  const text = compactText(runnerPrompt, 8_000);
+  if (!text) return "";
+  return text
+    .replace(
+      /^Return a unified diff patch only\..*$/gim,
+      "Use any requested diff as a change description. WriterLane must return FILE blocks with complete final contents.",
+    )
+    .replace(
+      /^For this fixture task, return this unified diff shape and nothing else:.*$/gim,
+      "For this fixture task, convert the diff shape below into complete final file contents.",
+    );
 }
 
 // Parse `FILE: <path>` + fenced block pairs, keeping only owned paths. Falls back

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -6,6 +6,7 @@ import {
   createWriterLaneFreeWriterRunner,
   extractChangedFilesFromPatch,
   gateWriterLaneDiff,
+  normalizeRunnerPromptForFullContents,
   parseFileBlocks,
 } from "./pinballwake-writerlane-free-writer.mjs";
 
@@ -293,5 +294,26 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.match(prompt, /CURRENT FILE: docs\/x\.md/);
     assert.match(prompt, /Runner prompt detail/);
     assert.match(prompt, /old file/);
+  });
+
+  it("buildFullContentsPrompt converts OpenHands diff instructions into WriterLane file-block instructions", () => {
+    const runnerPrompt = [
+      "Return a unified diff patch only. Do not commit, push, merge, deploy, or touch secrets.",
+      "Canary fixture diff:",
+      "For this fixture task, return this unified diff shape and nothing else:",
+      "diff --git a/docs/openhands-proof-fixture.md b/docs/openhands-proof-fixture.md",
+    ].join("\n");
+    const prompt = buildFullContentsPrompt({
+      ownedFiles: ["docs/openhands-proof-fixture.md"],
+      scopePack: { verification: ["node --test scripts/pinballwake-openhands-proof-runner.test.mjs"] },
+      model: MODEL_A,
+      runnerPrompt,
+      currentFiles: [{ path: "docs/openhands-proof-fixture.md", content: "# OpenHands Proof Fixture\n" }],
+    });
+    assert.match(prompt, /Do not return a unified diff/);
+    assert.match(prompt, /Return FILE blocks only/);
+    assert.match(prompt, /WriterLane must return FILE blocks with complete final contents/);
+    assert.match(prompt, /convert the diff shape below into complete final file contents/);
+    assert.doesNotMatch(normalizeRunnerPromptForFullContents(runnerPrompt), /^Return a unified diff patch only/m);
   });
 });


### PR DESCRIPTION
## Summary
- make WriterLane treat OpenHands runner prompts as intent only when they ask for unified diffs
- add explicit FILE-block-only instructions so free models return parseable full contents
- add regression coverage for the AFK canary prompt bridge

## Proof
- node --test scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes in the opt-in WriterLane free writer path; no auth, data, or live runner behavior changes by default.
> 
> **Overview**
> WriterLane’s free-model prompt now **forbids unified diffs** and tells models to return **`FILE:` + fenced full contents only**, including when the injected runner brief came from an OpenHands-style “patch only” task.
> 
> A new **`normalizeRunnerPromptForFullContents`** helper rewrites those diff-only lines in the runner task prompt into “use the diff as intent, emit complete files” wording before the prompt is sent to OpenRouter. **`buildFullContentsPrompt`** uses it instead of passing the raw runner text through unchanged.
> 
> Regression coverage asserts the AFK canary / OpenHands fixture prompt is bridged correctly end-to-end in the built prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708370a9ed198f17add4ab1734d6a4546727dbec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->