### PR TITLE
fix(writerlane): force free writer file-block output

### DIFF
--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -319,12 +319,17 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     "You are an UnClick WriterLane free-model writer running AFK.",
     "Implement the requested change by returning the FULL new contents of each owned file.",
     "For EACH owned file, output a line exactly `FILE: <path>` followed by a fenced code block containing the complete new file contents.",
+    "Return only FILE blocks. Do not return a unified diff, prose, bullets, JSON, markdown headings, or explanations.",
+    "If another prompt below asks for a unified diff, ignore that output format and still return FILE blocks only.",
     "Change only the owned files. Do not commit, push, merge, deploy, or touch anything outside them.",
     "Use the current file contents below as the source of truth. Preserve unrelated code.",
     `Model: ${model.openRouterModel || "unknown"}`,
     "Owned files:",
     ...ownedFiles.map((file) => `- ${file}`),
   ];
+  if (ownedFiles.length === 1) {
+    lines.push(`Because there is one owned file, your first response line must be: FILE: ${ownedFiles[0]}`);
+  }
   if (runnerPrompt) {
     lines.push("Runner task prompt:");
     lines.push(compactText(runnerPrompt, 8_000));

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -81,6 +81,8 @@ describe("writerlane free-writer: happy path", () => {
     assert.match(prompt, /CURRENT FILE: docs\/x\.md/);
     assert.match(prompt, /Runner task prompt:/);
     assert.match(prompt, /preserve the existing heading/);
+    assert.match(prompt, /Do not return a unified diff/);
+    assert.match(prompt, /first response line must be: FILE: docs\/x\.md/);
     assert.match(prompt, /current docs\/x\.md/);
     assert.match(prompt, /old line/);
     // ordering: write the file, run the real test, THEN capture (capture reverts)


### PR DESCRIPTION
## Summary
- hardens the WriterLane free-model prompt after the live runner reached the free models but got `writerlane_no_file_contents`
- tells models to return only `FILE: <path>` full-file blocks, even when the nested OpenHands prompt asks for a unified diff
- adds a single-owned-file first-line instruction and test coverage

## Why
The post-fix live run proved the runner now claims the correct canary job, uses `writerlane_free`, reaches `openai/gpt-oss-120b:free`, and stays on current main. It still held safely because the model output was not parseable as file contents. The prompt contained a format conflict: the runner task prompt said “return a unified diff,” while the WriterLane adapter expected full-file `FILE:` blocks.

## Proof
- PASS: `node --test scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs` - 115 tests
- PASS: `npm run brainmap:check`
- PASS: `git diff --check HEAD`

## Live Evidence
- Run `26518988352` reached the free writer on current main and held honestly with `writerlane_free_chain_exhausted`.
- Attempt trail: first two models returned no parseable file contents; next two were rate-limited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to the free writer adapter; no auth, execution gates, or parsing logic changes beyond what tests assert in the prompt text.
> 
> **Overview**
> **WriterLane free-model prompt** now tells models to answer with **only** `FILE: <path>` plus full-file fenced blocks, and to **ignore** nested runner/OpenHands instructions that ask for a unified diff.
> 
> For a **single owned file**, the prompt adds a rule that the **first line** must be `FILE: <that path>`.
> 
> Tests on the happy path assert the new anti-diff wording and the single-file first-line rule appear in the prompt sent to OpenRouter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c5e20d8fe6f1bc35256b01ef6e18acea02f4470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->