### PR TITLE
fix(runner): harden WriterLane canary output handling

### DIFF
--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -1,9 +1,8 @@
 // WriterLane free-model writer adapter (runner-side, .mjs).
 //
-// Dead code. Nothing wires it until the runner seam opts in via
-// AUTONOMOUS_RUNNER_WRITER=writerlane_free, and even then only behind the triple
-// execute gate (MODE=execute && ALLOW_EXECUTE && OPENHANDS_EXECUTE), all OFF by
-// default. Merging this changes nothing live.
+// Dormant unless the runner explicitly opts in via AUTONOMOUS_RUNNER_WRITER=
+// writerlane_free, and even then only behind the triple execute gate
+// (MODE=execute && ALLOW_EXECUTE && OPENHANDS_EXECUTE).
 //
 // WHAT: this is the runner-side adapter that lets the proven direct-OpenRouter
 // free-model writer stand in for the OpenHands CLI runner. It satisfies the SAME

--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -315,6 +315,8 @@ function splitArgsSafe(command) {
 // ---------------------------------------------------------------------------
 
 export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model = {}, runnerPrompt = "", currentFiles = [] } = {}) {
+  const cleanRunnerPrompt = normalizeRunnerPromptForFullContents(runnerPrompt);
+  const canaryProofLine = extractCanaryFixtureProofLine(runnerPrompt);
   const lines = [
     "You are an UnClick WriterLane free-model writer running AFK.",
     "Implement the requested change by returning the FULL new contents of each owned file.",
@@ -325,9 +327,15 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     "Owned files:",
     ...ownedFiles.map((file) => `- ${file}`),
   ];
-  if (runnerPrompt) {
+  if (cleanRunnerPrompt) {
     lines.push("Runner task prompt:");
-    lines.push(compactText(runnerPrompt, 8_000));
+    lines.push(compactText(cleanRunnerPrompt, 8_000));
+  }
+  if (canaryProofLine && normalizePaths(ownedFiles).includes("docs/openhands-proof-fixture.md")) {
+    lines.push("Canary fixture task:");
+    lines.push(
+      `Append the line \`${canaryProofLine}\` below \`<!-- openhands-proof-lines -->\` in docs/openhands-proof-fixture.md while preserving the rest of the file.`,
+    );
   }
   const intent = scopePack?.changeIntent || scopePack?.change_intent || scopePack?.chip || scopePack?.title;
   if (intent) {
@@ -363,6 +371,38 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     lines.push(String(scopePack.body || scopePack.description));
   }
   return lines.join("\n");
+}
+
+function normalizeRunnerPromptForFullContents(prompt = "") {
+  const kept = [];
+  let skippingCanaryDiff = false;
+  for (const line of String(prompt ?? "").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "You are OpenHands running in UnClick test mode.") continue;
+    if (/^Return a unified diff patch only\b/i.test(trimmed)) continue;
+    if (
+      trimmed === "Canary fixture diff:" ||
+      trimmed === "For this fixture task, return this unified diff shape and nothing else:"
+    ) {
+      skippingCanaryDiff = true;
+      continue;
+    }
+    if (skippingCanaryDiff) {
+      if (!trimmed || /^(diff --git |--- |\+\+\+ |@@ )/.test(trimmed) || /^[+\- ]/.test(line)) {
+        continue;
+      }
+      skippingCanaryDiff = false;
+    }
+    kept.push(line);
+  }
+  return kept.join("\n").trim();
+}
+
+function extractCanaryFixtureProofLine(prompt = "") {
+  const diffLine = String(prompt ?? "").match(/^\+(-\s*proof run:\s*.+)$/m);
+  if (diffLine) return diffLine[1].trim();
+  const plainLine = String(prompt ?? "").match(/^(-\s*proof run:\s*.+)$/m);
+  return plainLine ? plainLine[1].trim() : "";
 }
 
 // Parse `FILE: <path>` + fenced block pairs, keeping only owned paths. Falls back

--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -321,12 +321,16 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     "You are an UnClick WriterLane free-model writer running AFK.",
     "Implement the requested change by returning the FULL new contents of each owned file.",
     "For EACH owned file, output a line exactly `FILE: <path>` followed by a fenced code block containing the complete new file contents.",
+    "Return only FILE blocks. Do not return a unified diff, prose, bullets, JSON, markdown headings, or explanations.",
     "Change only the owned files. Do not commit, push, merge, deploy, or touch anything outside them.",
     "Use the current file contents below as the source of truth. Preserve unrelated code.",
     `Model: ${model.openRouterModel || "unknown"}`,
     "Owned files:",
     ...ownedFiles.map((file) => `- ${file}`),
   ];
+  if (ownedFiles.length === 1) {
+    lines.push(`Because there is one owned file, your first response line must be: FILE: ${ownedFiles[0]}`);
+  }
   if (cleanRunnerPrompt) {
     lines.push("Runner task prompt:");
     lines.push(compactText(cleanRunnerPrompt, 8_000));

--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -60,6 +60,8 @@ export const WRITERLANE_EMPTY_COMPLETION = "writerlane_empty_completion";
 export const WRITERLANE_NO_FILE_CONTENTS = "writerlane_no_file_contents";
 export const WRITERLANE_NO_FREE_MODELS = "writerlane_no_free_models";
 export const WRITERLANE_FREE_CHAIN_EXHAUSTED = "writerlane_free_chain_exhausted";
+export const WRITERLANE_PATCH_APPLY_CHECK_FAILED = "writerlane_patch_apply_check_failed";
+export const WRITERLANE_PATCH_APPLY_FAILED = "writerlane_patch_apply_failed";
 
 export function createWriterLaneFreeWriterRunner({
   env = process.env,
@@ -147,73 +149,72 @@ export function createWriterLaneFreeWriterRunner({
       }
 
       const files = parseFileBlocks(completion.content, ownedFiles);
-      if (files.length === 0) {
-        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: WRITERLANE_NO_FILE_CONTENTS });
-        continue;
-      }
-
-      for (const file of files) {
-        await writeFileImpl({ cwd, path: file.path, content: ensureTrailingNewline(file.content) });
-      }
-
-      // REAL scoped test-run: after writing, before capture (capture reverts).
-      let testsPassed;
-      let testRunId;
-      let testExitCode = 0;
-      if (verification.length > 0) {
-        const testRun = await runScopedTests({ runProcess, cwd, env: safeEnv, commands: verification, timeoutMs: effectiveTimeout });
-        testsPassed = testRun.ok === true;
-        testRunId = testRun.test_run_id;
-        testExitCode = testRun.exit_code;
+      if (files.length > 0) {
+        for (const file of files) {
+          await writeFileImpl({ cwd, path: file.path, content: ensureTrailingNewline(file.content) });
+        }
       } else {
-        testsPassed = allowMissingTests === true;
-        testRunId = `writerlane-no-tests-${model.id}`;
-        testExitCode = allowMissingTests === true ? 0 : 1;
+        const modelPatch = extractUnifiedDiff(completion.content);
+        if (!modelPatch) {
+          attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: WRITERLANE_NO_FILE_CONTENTS });
+          continue;
+        }
+        const modelPatchGate = gateWriterLaneDiff({
+          patch: modelPatch,
+          ownedFiles,
+          declaredFiles: [],
+          prompt: "",
+          maxPatchBytes,
+          proofMode: "model_patch_preflight",
+        });
+        if (!modelPatchGate.ok) {
+          attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: modelPatchGate.reason });
+          continue;
+        }
+        const applied = await applyUnifiedDiffToWorktree({
+          cwd,
+          env: safeEnv,
+          patch: modelPatchGate.patch,
+          runProcess,
+          timeoutMs: effectiveTimeout,
+        });
+        if (!applied.ok) {
+          attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: applied.reason });
+          continue;
+        }
       }
 
-      const cap = await captureDiff({ cwd, env: safeEnv, ownedFiles, runProcess });
-      if (!cap || cap.ok !== true) {
-        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: cap?.reason || "writerlane_capture_failed" });
-        continue;
-      }
-
-      const gate = gateWriterLaneDiff({
-        patch: cap.patch,
+      const proven = await proveCapturedWorktreePatch({
+        cwd,
+        env: safeEnv,
         ownedFiles,
-        declaredFiles: cap.changed_files || [],
+        verification,
+        allowMissingTests,
+        model,
         prompt,
+        runProcess,
+        captureDiff,
         maxPatchBytes,
         proofMode,
+        diffBudget,
+        timeoutMs: effectiveTimeout,
       });
-      if (!gate.ok) {
-        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: gate.reason });
-        continue;
-      }
-
-      const wlResult = {
-        ok: true,
-        patch: gate.patch,
-        changedFiles: gate.changedFiles,
-        proof: { autonomyProof: gate.autonomyProof },
-      };
-      const validation = buildValidationFromPatch(gate.patch, testsPassed, diffBudget);
-      const verdict = validateAutonomyProof(wlResult, proofMode, validation);
-      if (!verdict.ok) {
-        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: verdict.reason });
+      if (!proven.ok) {
+        attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: false, reason: proven.reason });
         continue;
       }
 
       attempts.push({ modelId: model.id, openRouterModel: model.openRouterModel, status, ok: true });
       return {
         ok: true,
-        patch: gate.patch,
-        changed_files: gate.changedFiles,
+        patch: proven.gate.patch,
+        changed_files: proven.gate.changedFiles,
         summary: `WriterLane free writer ${model.id} (${model.openRouterModel}) produced a validated patch.`,
-        test_run_id: testRunId,
-        test_exit_code: testExitCode,
+        test_run_id: proven.testRunId,
+        test_exit_code: proven.testExitCode,
         diff_source: "worktree",
         model: model.id,
-        validation,
+        validation: proven.validation,
         attempts,
       };
     }
@@ -300,6 +301,92 @@ async function runScopedTests({ runProcess, cwd, env, commands, timeoutMs }) {
     }
   }
   return { ok: true, exit_code: 0, test_run_id: ran.join(" && ") || "writerlane-tests" };
+}
+
+async function applyUnifiedDiffToWorktree({ cwd, env, patch, runProcess, timeoutMs }) {
+  const check = await runProcess("git", ["apply", "--check", "--whitespace=error", "-"], {
+    cwd,
+    env,
+    stdin: patch,
+    timeoutMs,
+  });
+  if (!check || check.ok !== true) {
+    return { ok: false, reason: WRITERLANE_PATCH_APPLY_CHECK_FAILED };
+  }
+
+  const applied = await runProcess("git", ["apply", "--whitespace=nowarn", "-"], {
+    cwd,
+    env,
+    stdin: patch,
+    timeoutMs,
+  });
+  if (!applied || applied.ok !== true) {
+    return { ok: false, reason: WRITERLANE_PATCH_APPLY_FAILED };
+  }
+
+  return { ok: true };
+}
+
+async function proveCapturedWorktreePatch({
+  cwd,
+  env,
+  ownedFiles,
+  verification,
+  allowMissingTests,
+  model,
+  prompt,
+  runProcess,
+  captureDiff,
+  maxPatchBytes,
+  proofMode,
+  diffBudget,
+  timeoutMs,
+}) {
+  // REAL scoped test-run: after writing/applying, before capture (capture reverts).
+  let testsPassed;
+  let testRunId;
+  let testExitCode = 0;
+  if (verification.length > 0) {
+    const testRun = await runScopedTests({ runProcess, cwd, env, commands: verification, timeoutMs });
+    testsPassed = testRun.ok === true;
+    testRunId = testRun.test_run_id;
+    testExitCode = testRun.exit_code;
+  } else {
+    testsPassed = allowMissingTests === true;
+    testRunId = `writerlane-no-tests-${model.id}`;
+    testExitCode = allowMissingTests === true ? 0 : 1;
+  }
+
+  const cap = await captureDiff({ cwd, env, ownedFiles, runProcess });
+  if (!cap || cap.ok !== true) {
+    return { ok: false, reason: cap?.reason || "writerlane_capture_failed" };
+  }
+
+  const gate = gateWriterLaneDiff({
+    patch: cap.patch,
+    ownedFiles,
+    declaredFiles: cap.changed_files || [],
+    prompt,
+    maxPatchBytes,
+    proofMode,
+  });
+  if (!gate.ok) {
+    return { ok: false, reason: gate.reason };
+  }
+
+  const wlResult = {
+    ok: true,
+    patch: gate.patch,
+    changedFiles: gate.changedFiles,
+    proof: { autonomyProof: gate.autonomyProof },
+  };
+  const validation = buildValidationFromPatch(gate.patch, testsPassed, diffBudget);
+  const verdict = validateAutonomyProof(wlResult, proofMode, validation);
+  if (!verdict.ok) {
+    return { ok: false, reason: verdict.reason };
+  }
+
+  return { ok: true, gate, validation, testRunId, testExitCode };
 }
 
 function splitArgsSafe(command) {
@@ -434,6 +521,14 @@ export function parseFileBlocks(content, ownedFiles) {
     }
   }
   return [];
+}
+
+export function extractUnifiedDiff(content) {
+  const text = String(content ?? "");
+  const fenced = text.match(/```(?:diff|patch)?\s*([\s\S]*?diff --git[\s\S]*?)```/i);
+  if (fenced) return fenced[1].trim();
+  const index = text.indexOf("diff --git ");
+  return index === -1 ? "" : text.slice(index).trim();
 }
 
 function dedupeByPath(blocks) {

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -319,6 +319,8 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.doesNotMatch(prompt, /Return a unified diff patch only/);
     assert.doesNotMatch(prompt, /diff --git/);
     assert.match(prompt, /Job: AFK canary seed/);
+    assert.match(prompt, /Return only FILE blocks/);
+    assert.match(prompt, /first response line must be: FILE: docs\/openhands-proof-fixture\.md/);
     assert.match(prompt, /Append the line `- proof run: coding-room-claim:abc123`/);
     assert.match(prompt, /FILE: <path>/);
   });

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -294,4 +294,32 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.match(prompt, /Runner prompt detail/);
     assert.match(prompt, /old file/);
   });
+
+  it("removes OpenHands diff instructions while preserving the canary task", () => {
+    const prompt = buildFullContentsPrompt({
+      ownedFiles: ["docs/openhands-proof-fixture.md"],
+      scopePack: { verification: ["node --test scripts/pinballwake-openhands-proof-runner.test.mjs"] },
+      model: MODEL_A,
+      runnerPrompt: [
+        "You are OpenHands running in UnClick test mode.",
+        "Return a unified diff patch only. Do not commit, push, merge, deploy, or touch secrets.",
+        "Job: AFK canary seed",
+        "Canary fixture diff:",
+        "For this fixture task, return this unified diff shape and nothing else:",
+        "diff --git a/docs/openhands-proof-fixture.md b/docs/openhands-proof-fixture.md",
+        "--- a/docs/openhands-proof-fixture.md",
+        "+++ b/docs/openhands-proof-fixture.md",
+        "@@ -3,4 +3,5 @@",
+        " <!-- openhands-proof-lines -->",
+        "+- proof run: coding-room-claim:abc123",
+      ].join("\n"),
+      currentFiles: [{ path: "docs/openhands-proof-fixture.md", content: "# OpenHands Proof Fixture\n\n<!-- openhands-proof-lines -->\n" }],
+    });
+
+    assert.doesNotMatch(prompt, /Return a unified diff patch only/);
+    assert.doesNotMatch(prompt, /diff --git/);
+    assert.match(prompt, /Job: AFK canary seed/);
+    assert.match(prompt, /Append the line `- proof run: coding-room-claim:abc123`/);
+    assert.match(prompt, /FILE: <path>/);
+  });
 });

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile as writeFileFs } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import {
   buildFullContentsPrompt,
   createWriterLaneFreeWriterRunner,
   extractChangedFilesFromPatch,
+  extractUnifiedDiff,
   gateWriterLaneDiff,
   parseFileBlocks,
 } from "./pinballwake-writerlane-free-writer.mjs";
@@ -114,6 +118,68 @@ describe("writerlane free-writer: happy path", () => {
     assert.match(prompt, /CURRENT FILE: docs\/x\.md/);
     assert.doesNotMatch(prompt, /tail-never-visible/);
     assert.match(prompt, /\[truncated for writer context\]/);
+  });
+
+  it("loads current-file context from cwd with the production reader", async () => {
+    const root = await mkdtemp(join(tmpdir(), "writerlane-context-"));
+    try {
+      await mkdir(join(root, "docs"), { recursive: true });
+      await writeFileFs(join(root, "docs", "x.md"), "current file from disk\n", "utf8");
+
+      let prompt = "";
+      const runner = createWriterLaneFreeWriterRunner({
+        cwd: root,
+        env: { LLM_API_KEY: "k" },
+        models: [MODEL_A],
+        fetchImpl: async (_url, init) => {
+          prompt = JSON.parse(init.body).messages[0].content;
+          return fakeFetchOnce(fileBlock("docs/x.md", "hello world"))();
+        },
+        runProcess: okProcess(),
+        writeFileImpl: async () => {},
+        captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+      });
+
+      const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test docs/x.test.mjs"] } });
+
+      assert.equal(result.ok, true);
+      assert.match(prompt, /CURRENT FILE: docs\/x\.md/);
+      assert.match(prompt, /current file from disk/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("safely falls back when a model follows the runner and returns an owned unified diff", async () => {
+    const commands = [];
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: fakeFetchOnce(GOOD_PATCH),
+      runProcess: async (command, args, options = {}) => {
+        commands.push(`${command} ${args.join(" ")}`);
+        if (command === "git" && args[0] === "apply") {
+          assert.equal(options.stdin, GOOD_PATCH.trimEnd());
+        }
+        return { ok: true, exit_code: 0, stdout: "", stderr: "", output: "" };
+      },
+      writeFileImpl: async () => assert.fail("unified diff fallback should not write full contents directly"),
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+    });
+
+    const result = await runner({
+      prompt: "Return a unified diff patch only.",
+      scopePack: { owned_files: OWNED, verification: ["node --test docs/x.test.mjs"] },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.model, "m-a");
+    assert.deepEqual(result.changed_files, ["docs/x.md"]);
+    assert.deepEqual(commands, [
+      "git apply --check --whitespace=error -",
+      "git apply --whitespace=nowarn -",
+      "node --test docs/x.test.mjs",
+    ]);
   });
 });
 
@@ -276,6 +342,12 @@ describe("writerlane free-writer: pure helpers", () => {
 
   it("extractChangedFilesFromPatch reads the git header b/ path", () => {
     assert.deepEqual(extractChangedFilesFromPatch(GOOD_PATCH), ["docs/x.md"]);
+  });
+
+  it("extractUnifiedDiff reads raw and fenced model patches", () => {
+    assert.equal(extractUnifiedDiff(GOOD_PATCH), GOOD_PATCH.trimEnd());
+    assert.equal(extractUnifiedDiff(`Here:\n\`\`\`diff\n${GOOD_PATCH}\n\`\`\``), GOOD_PATCH.trimEnd());
+    assert.equal(extractUnifiedDiff("no patch here"), "");
   });
 
   it("buildFullContentsPrompt lists owned files and verification commands", () => {


### PR DESCRIPTION
## What changed
- Keeps the WriterLane free writer on full-file `FILE:` blocks for the canary.
- Removes conflicting OpenHands diff instructions from the WriterLane prompt while preserving the canary proof line.
- Adds a safe fallback when a free model still returns an owned unified diff: preflight the patch, apply it only to owned files, capture the real worktree diff, then run the same proof gates.
- Adds tests for cwd file-context loading and owned-diff fallback.

## Proof
- `node --test scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-autonomous-runner.test.mjs` (98/98 passing)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous writer execution (git apply, patch gating, prompt shaping) behind existing execute gates; scope is limited to the opt-in WriterLane adapter and is well covered by tests.
> 
> **Overview**
> Hardens the dormant **WriterLane free writer** so canary runs stay on full-file `FILE:` output while tolerating models that still return OpenHands-style unified diffs.
> 
> When no `FILE` blocks parse, the runner now **extracts** an owned unified diff, **preflights** it with `gateWriterLaneDiff` (`model_patch_preflight`), **`git apply --check` / apply** via new reason codes, then reuses a shared **`proveCapturedWorktreePatch`** path (scoped tests → worktree capture → gate → autonomy proof) instead of inlining that logic.
> 
> **Prompt changes** strip conflicting OpenHands “unified diff only” and sample diff text from the runner brief, keep the canary proof line as an explicit append task for `docs/openhands-proof-fixture.md`, and tighten single-file `FILE:` shape hints.
> 
> **Tests** cover disk-backed current-file context, owned-diff fallback (`git apply` + tests, no direct writes), `extractUnifiedDiff`, and canary prompt sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 612f87173f2832302c93b400a1ace6b48c45b071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->