### PR TITLE
fix(writerlane): accept free model file block variants

### DIFF
--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -319,12 +319,23 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     "You are an UnClick WriterLane free-model writer running AFK.",
     "Implement the requested change by returning the FULL new contents of each owned file.",
     "For EACH owned file, output a line exactly `FILE: <path>` followed by a fenced code block containing the complete new file contents.",
+    "Return only file blocks. Do not return JSON, explanations, bullets, markdown headings, or unified diffs.",
+    "Do not use `CURRENT FILE:` in your answer. That label appears only in the input context.",
     "Change only the owned files. Do not commit, push, merge, deploy, or touch anything outside them.",
     "Use the current file contents below as the source of truth. Preserve unrelated code.",
     `Model: ${model.openRouterModel || "unknown"}`,
     "Owned files:",
     ...ownedFiles.map((file) => `- ${file}`),
   ];
+  if (ownedFiles.length) {
+    lines.push("Required response shape:");
+    for (const file of ownedFiles) {
+      lines.push(`FILE: ${file}`);
+      lines.push("```");
+      lines.push("<complete new file contents>");
+      lines.push("```");
+    }
+  }
   if (runnerPrompt) {
     lines.push("Runner task prompt:");
     lines.push(compactText(runnerPrompt, 8_000));
@@ -365,18 +376,19 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
   return lines.join("\n");
 }
 
-// Parse `FILE: <path>` + fenced block pairs, keeping only owned paths. Falls back
-// to a single fenced block when exactly one file is owned.
+// Parse file-path + fenced block pairs, keeping only owned paths. The prompt asks
+// for exact `FILE: <path>` blocks, but cheap/free models often drift into
+// headings, backticked paths, or fence info strings. Accept those safe variants
+// while still refusing unowned paths.
 export function parseFileBlocks(content, ownedFiles) {
   const owned = new Set(normalizePaths(ownedFiles));
   const text = String(content ?? "");
   const blocks = [];
-  const re = /FILE:\s*([^\n`]+?)\s*\r?\n+```[^\n]*\r?\n([\s\S]*?)\r?\n?```/g;
-  let match;
-  while ((match = re.exec(text)) !== null) {
-    const path = normalizePath(match[1]);
-    if (owned.has(path)) {
-      blocks.push({ path, content: match[2] });
+  for (const fence of extractFencedBlocks(text)) {
+    const previousLine = previousNonEmptyLine(text, fence.start);
+    const path = findOwnedPathForFence({ info: fence.info, previousLine, owned });
+    if (path) {
+      blocks.push({ path, content: fence.content });
     }
   }
   if (blocks.length > 0) {
@@ -390,6 +402,49 @@ export function parseFileBlocks(content, ownedFiles) {
     }
   }
   return [];
+}
+
+function extractFencedBlocks(text) {
+  const blocks = [];
+  const re = /```([^\n`]*)\r?\n([\s\S]*?)\r?\n?```/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    blocks.push({
+      start: match.index,
+      info: String(match[1] ?? ""),
+      content: match[2],
+    });
+  }
+  return blocks;
+}
+
+function previousNonEmptyLine(text, index) {
+  const before = String(text ?? "").slice(0, index).split(/\r?\n/);
+  for (let i = before.length - 1; i >= 0; i -= 1) {
+    const line = before[i]?.trim();
+    if (line) return line;
+  }
+  return "";
+}
+
+function findOwnedPathForFence({ info = "", previousLine = "", owned }) {
+  const fromInfo = findOwnedPathInText(info, owned);
+  if (fromInfo) return fromInfo;
+  if (/current\s+file/i.test(previousLine)) return "";
+  return findOwnedPathInText(previousLine, owned);
+}
+
+function findOwnedPathInText(value, owned) {
+  const text = normalizePath(
+    String(value ?? "")
+      .replace(/^[#>\s*-]+/, "")
+      .replace(/\b(file|filename|path)\b\s*[:=]/gi, " ")
+      .replace(/[`"']/g, " "),
+  );
+  for (const path of owned) {
+    if (text.includes(path)) return path;
+  }
+  return "";
 }
 
 function dedupeByPath(blocks) {

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -244,6 +244,43 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.equal(blocks[0].content, "C");
   });
 
+  it("parseFileBlocks accepts common free-model file block variants", () => {
+    const content = [
+      "File: `docs/x.md`",
+      "```markdown",
+      "from file label",
+      "```",
+      "### docs/y.md",
+      "```md",
+      "from heading",
+      "```",
+      "```markdown filename=\"docs/z.md\"",
+      "from info string",
+      "```",
+    ].join("\n");
+    const blocks = parseFileBlocks(content, ["docs/x.md", "docs/y.md", "docs/z.md"]);
+    assert.deepEqual(blocks, [
+      { path: "docs/x.md", content: "from file label" },
+      { path: "docs/y.md", content: "from heading" },
+      { path: "docs/z.md", content: "from info string" },
+    ]);
+  });
+
+  it("parseFileBlocks does not treat echoed current-file context as an output marker", () => {
+    const content = [
+      "CURRENT FILE: docs/x.md",
+      "```",
+      "old context",
+      "```",
+      "FILE: docs/y.md",
+      "```",
+      "new content",
+      "```",
+    ].join("\n");
+    const blocks = parseFileBlocks(content, ["docs/x.md", "docs/y.md"]);
+    assert.deepEqual(blocks, [{ path: "docs/y.md", content: "new content" }]);
+  });
+
   it("parseFileBlocks falls back to a lone fenced block for a single owned file", () => {
     const blocks = parseFileBlocks("```\njust code\n```", ["src/only.mjs"]);
     assert.equal(blocks.length, 1);
@@ -287,6 +324,8 @@ describe("writerlane free-writer: pure helpers", () => {
       currentFiles: [{ path: "docs/x.md", content: "old file" }],
     });
     assert.match(prompt, /FILE: <path>/);
+    assert.match(prompt, /Return only file blocks/);
+    assert.match(prompt, /Required response shape:/);
     assert.match(prompt, /- docs\/x\.md/);
     assert.match(prompt, /node --test x/);
     assert.match(prompt, /Current owned file contents:/);


### PR DESCRIPTION
## Summary
- make the WriterLane free-writer prompt stricter about returning file blocks only
- accept common free-model variants: backticked file labels, markdown headings, and fence info strings with filenames
- refuse echoed CURRENT FILE context as an output marker so prompt echo stays safe

## Why
The latest live autonomous runner reached gpt-oss-120b, but the model still returned no parseable full-file blocks. This keeps the safety gate and makes the parser tolerant of common harmless formatting drift.

## Verification
- node --test scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs
- git diff --check
- npm test
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser changes are confined to owned-path matching and add an echo guard; behavior is test-covered and the adapter remains behind existing execute gates.
> 
> **Overview**
> Tightens the WriterLane **free-model** writer so completions are easier to parse without weakening ownership rules.
> 
> The **prompt** now tells models to return **only** `FILE:` + fenced full-file blocks (no JSON, prose, headings, or diffs), forbids using `CURRENT FILE:` in answers, and adds a per-owned-file **required response shape** example.
> 
> **`parseFileBlocks`** no longer requires a strict `FILE:` line immediately above each fence. It walks every fenced block and maps it to an **owned** path from the fence info string or the previous non-empty line (e.g. `File: \`path\``, markdown headings, `filename=` in the opener). Fences after echoed **`CURRENT FILE:`** context are ignored so prompt echo is not treated as output. Unowned paths and the single-owned-file lone-fence fallback behave as before.
> 
> Tests cover the new variants, the echo case, and updated prompt expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622d6b851c6f83a8a173d6f33081d0bcc19a7a1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->