### PR TITLE
fix(coderoom): restore owned dirty files before submit

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -51,11 +51,19 @@ function normalizePath(value) {
 }
 
 function parseGitStatusPaths(output) {
+  return parseGitStatusEntries(output).map((entry) => entry.path);
+}
+
+function parseGitStatusEntries(output) {
   return String(output ?? "")
     .split(/\r?\n/)
-    .map((line) => line.slice(3).trim())
-    .filter(Boolean)
-    .map((path) => normalizePath(path.includes(" -> ") ? path.split(" -> ").pop() : path));
+    .map((line) => {
+      const code = line.slice(0, 2);
+      const rawPath = line.slice(3).trim();
+      const path = normalizePath(rawPath.includes(" -> ") ? rawPath.split(" -> ").pop() : rawPath);
+      return { code, path };
+    })
+    .filter((entry) => entry.path);
 }
 
 function isGeneratedRunnerLedgerPath(path) {
@@ -507,10 +515,31 @@ export function createSafeCodeRoomSubmitter({
     }
     const submitterEnv = auth.env;
 
-    const status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
+    let status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
     if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
-    const dirtyFiles = parseGitStatusPaths(status.stdout);
-    const blockingDirtyFiles = dirtyFiles.filter((file) => !isGeneratedRunnerLedgerPath(file));
+    let dirtyEntries = parseGitStatusEntries(status.stdout);
+    let blockingDirtyEntries = dirtyEntries.filter((entry) => !isGeneratedRunnerLedgerPath(entry.path));
+    if (blockingDirtyEntries.length) {
+      const changedSet = new Set(normalizedChanged);
+      const restorable = blockingDirtyEntries.every(
+        (entry) => changedSet.has(entry.path) && !entry.code.includes("?"),
+      );
+      if (!restorable) {
+        return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyEntries.map((entry) => entry.path) };
+      }
+
+      const restore = await runProcess("git", ["restore", "--worktree", "--", ...blockingDirtyEntries.map((entry) => entry.path)], {
+        cwd,
+        env: submitterEnv,
+      });
+      if (!restore.ok) return { ok: false, reason: "git_restore_preexisting_patch_failed", output: restore.output };
+
+      status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
+      if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
+      dirtyEntries = parseGitStatusEntries(status.stdout);
+      blockingDirtyEntries = dirtyEntries.filter((entry) => !isGeneratedRunnerLedgerPath(entry.path));
+    }
+    const blockingDirtyFiles = blockingDirtyEntries.map((entry) => entry.path);
     if (blockingDirtyFiles.length) {
       return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
     }

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -510,6 +510,82 @@ describe("safe CodeRoom submitter", () => {
     );
   });
 
+  test("restores a pre-applied owned patch before CodeRoom submit", async () => {
+    const calls = [];
+    let statusCalls = 0;
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-preapplied",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          statusCalls += 1;
+          return {
+            ok: true,
+            stdout:
+              statusCalls === 1
+                ? ` M ${FIXTURE}\n M .pinballwake/coding-room-ledger.json\n`
+                : " M .pinballwake/coding-room-ledger.json\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/933\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-preapplied", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: preapplied restored" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 4).join(" ")}`),
+      [
+        "git status --porcelain",
+        "git restore --worktree -- docs/openhands-proof-fixture.md",
+        "git status --porcelain",
+        "gh pr list --head codex/openhands-submit-todo-preapplied",
+      ],
+    );
+  });
+
+  test("does not restore untracked dirty files before CodeRoom submit", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          return { ok: true, stdout: `?? ${FIXTURE}\n`, stderr: "", output: "" };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-untracked", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: untracked" }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "dirty_worktree");
+    assert.deepEqual(calls.map(([command, args]) => `${command} ${args[0]}`), ["git status"]);
+  });
+
   test("creates a PR and enables auto-merge only after validation", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({


### PR DESCRIPTION
## Summary
- allow CodeRoom submitter to clean up a pre-applied tracked dirty file when it is exactly one of the patch's declared owned changed files
- re-check the worktree after restore before creating or reusing a PR
- keep fail-closed behavior for untracked dirty files, generated ledger aside, and unrelated dirty files

## Why
After #1100 the live runner successfully got a parseable WriterLane patch, but CodeRoom rejected it because the owned fixture file was still dirty before submit. This adds the narrow cleanup step needed for that handoff.

## Verification
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check
- npm test
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git worktree handling on the autonomous PR submit path; behavior is narrowly scoped to owned/changed tracked files but incorrect restore logic could drop local edits.
> 
> **Overview**
> Fixes CodeRoom submit failures when an **owned, tracked** file is already dirty in the worktree (e.g. after OpenHands applied the same change) by **restoring** those paths before branch/apply/submit.
> 
> `createSafeCodeRoomSubmitter` now parses `git status --porcelain` with status **codes** (`parseGitStatusEntries`). If the only blocking dirt (aside from `.pinballwake/coding-room-ledger.json`) is exactly the patch’s declared changed files and they are **not untracked**, it runs `git restore --worktree` on them, re-runs status, then continues (e.g. reuse existing PR). **Untracked** (`??`) or **unrelated** dirty files still fail with `dirty_worktree`; restore failures return `git_restore_preexisting_patch_failed`.
> 
> Tests cover the restore-then-submit happy path and that untracked dirty files are not auto-restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55f9c4012b98d146c8bb0930ac78f2ad58d3f07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->