### PR TITLE
fix(runner): restore owned patch files before coderoom submit

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -512,7 +512,34 @@ export function createSafeCodeRoomSubmitter({
     const dirtyFiles = parseGitStatusPaths(status.stdout);
     const blockingDirtyFiles = dirtyFiles.filter((file) => !isGeneratedRunnerLedgerPath(file));
     if (blockingDirtyFiles.length) {
-      return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
+      const changedSet = new Set(normalizedChanged);
+      const patchOwnedDirtyFiles = blockingDirtyFiles.filter((file) => changedSet.has(file));
+      const unrelatedDirtyFiles = blockingDirtyFiles.filter((file) => !changedSet.has(file));
+      if (unrelatedDirtyFiles.length || patchOwnedDirtyFiles.length === 0) {
+        return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
+      }
+
+      const restore = await runProcess("git", ["restore", "--worktree", "--", ...patchOwnedDirtyFiles], {
+        cwd,
+        env: submitterEnv,
+      });
+      if (!restore.ok) {
+        return {
+          ok: false,
+          reason: "git_restore_patch_owned_dirty_failed",
+          output: restore.output,
+          dirty_files: patchOwnedDirtyFiles,
+        };
+      }
+
+      const recheck = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
+      if (!recheck.ok) return { ok: false, reason: "git_status_failed", output: recheck.output };
+      const remainingDirtyFiles = parseGitStatusPaths(recheck.stdout).filter(
+        (file) => !isGeneratedRunnerLedgerPath(file),
+      );
+      if (remainingDirtyFiles.length) {
+        return { ok: false, reason: "dirty_worktree", dirty_files: remainingDirtyFiles };
+      }
     }
 
     const todoId = safeSlug(job?.todo_id || job?.id || job?.job_id || safeStamp(now));

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -510,6 +510,92 @@ describe("safe CodeRoom submitter", () => {
     );
   });
 
+  test("restores patch-owned dirty files before submitting a captured patch", async () => {
+    const calls = [];
+    let statusCalls = 0;
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-owned-dirty",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          statusCalls += 1;
+          return {
+            ok: true,
+            stdout:
+              statusCalls === 1
+                ? ` M ${FIXTURE}\n M .pinballwake/coding-room-ledger.json\n`
+                : " M .pinballwake/coding-room-ledger.json\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "git" && args[0] === "restore") {
+          return { ok: true, stdout: "", stderr: "", output: "" };
+        }
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/933\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-owned-dirty", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: owned dirty restored" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/933");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      ["git status --porcelain", "git restore --worktree", "git status --porcelain", "gh pr list"],
+    );
+  });
+
+  test("still refuses unrelated dirty files before submitting a captured patch", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-unrelated-dirty",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          return {
+            ok: true,
+            stdout: ` M ${FIXTURE}\n M src/unrelated.ts\n`,
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-unrelated-dirty", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: unrelated dirty refused" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "dirty_worktree");
+    assert.deepEqual(result.dirty_files, [FIXTURE, "src/unrelated.ts"]);
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      ["git status --porcelain"],
+    );
+  });
+
   test("creates a PR and enables auto-merge only after validation", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({


### PR DESCRIPTION
## Summary
- restore only patch-owned dirty files before CodeRoom applies the captured patch
- keep unrelated dirty files as a hard stop
- add regression coverage for the live dirty-worktree runner failure

## Tests
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-autonomous-runner.test.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner/git hygiene only for the OpenHands proof submit path; unrelated dirty files remain a hard stop, with new unit tests.
> 
> **Overview**
> The CodeRoom submitter no longer **always** aborts on a dirty worktree when the only blocking edits are files in the patch’s `changedFiles` list.
> 
> **`createSafeCodeRoomSubmitter`** now runs `git restore --worktree` on those patch-owned paths, re-checks `git status`, and continues submit/PR flow if nothing else is dirty. Unrelated modified files still return `dirty_worktree` with no restore. New failure reasons cover failed restore (`git_restore_patch_owned_dirty_failed`) and a still-dirty tree after restore.
> 
> Unit tests cover the restore-then-submit happy path and refusal when an unrelated file (e.g. `src/unrelated.ts`) is dirty alongside an owned file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bed60d9a4f53590dcd8d6a396b9e43ce7af00f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->