### PR TITLE
fix(runner): clean owned CodeRoom residue

### DIFF
--- a/scripts/pinballwake-autonomous-runner.mjs
+++ b/scripts/pinballwake-autonomous-runner.mjs
@@ -612,7 +612,12 @@ export function createAutonomousRunnerOpenHandsExecutorFromEnv(env = process.env
       : null,
     coderoom: enabled
       ? useWriterLaneFree
-        ? createSafeCodeRoomSubmitter({ env: safeEnv, draft: true, autoMerge: false })
+        ? createSafeCodeRoomSubmitter({
+            env: safeEnv,
+            draft: true,
+            autoMerge: false,
+            restoreOwnedDirtyFiles: true,
+          })
         : createSafeCodeRoomSubmitter({ env: safeEnv })
       : null,
     env: safeEnv,

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -469,6 +469,7 @@ export function createSafeCodeRoomSubmitter({
   draft = false,
   autoMerge = true,
   allowProtectedSurfaces,
+  restoreOwnedDirtyFiles = false,
   runProcess = runProcessCommand,
   now = new Date(),
 } = {}) {
@@ -512,7 +513,31 @@ export function createSafeCodeRoomSubmitter({
     const dirtyFiles = parseGitStatusPaths(status.stdout);
     const blockingDirtyFiles = dirtyFiles.filter((file) => !isGeneratedRunnerLedgerPath(file));
     if (blockingDirtyFiles.length) {
-      return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
+      const changedSet = new Set(normalizedChanged);
+      const ownedDirtyFiles = blockingDirtyFiles.filter((file) => changedSet.has(file));
+      const otherDirtyFiles = blockingDirtyFiles.filter((file) => !changedSet.has(file));
+      if (restoreOwnedDirtyFiles && ownedDirtyFiles.length > 0 && otherDirtyFiles.length === 0) {
+        const restore = await runProcess("git", ["restore", "--worktree", "--", ...ownedDirtyFiles], {
+          cwd,
+          env: submitterEnv,
+        });
+        if (!restore.ok) {
+          return {
+            ok: false,
+            reason: "git_restore_owned_dirty_failed",
+            dirty_files: blockingDirtyFiles,
+            output: restore.output,
+          };
+        }
+        const recheck = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
+        if (!recheck.ok) return { ok: false, reason: "git_status_failed", output: recheck.output };
+        const remainingDirtyFiles = parseGitStatusPaths(recheck.stdout).filter((file) => !isGeneratedRunnerLedgerPath(file));
+        if (remainingDirtyFiles.length) {
+          return { ok: false, reason: "dirty_worktree", dirty_files: remainingDirtyFiles };
+        }
+      } else {
+        return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
+      }
     }
 
     const todoId = safeSlug(job?.todo_id || job?.id || job?.job_id || safeStamp(now));

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -510,6 +510,87 @@ describe("safe CodeRoom submitter", () => {
     );
   });
 
+  test("can restore dirty owned files before opening the CodeRoom PR", async () => {
+    const calls = [];
+    let statusCalls = 0;
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-clean-owned",
+      restoreOwnedDirtyFiles: true,
+      runProcess: async (command, args, options = {}) => {
+        calls.push([command, args, Boolean(options.stdin)]);
+        if (command === "git" && args[0] === "status") {
+          statusCalls += 1;
+          return {
+            ok: true,
+            stdout:
+              statusCalls === 1
+                ? " M docs/openhands-proof-fixture.md\n M .pinballwake/coding-room-ledger.json\n"
+                : " M .pinballwake/coding-room-ledger.json\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/933\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-clean-owned", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: clean owned" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 3).join(" ")}`),
+      [
+        "git status --porcelain",
+        "git restore --worktree --",
+        "git status --porcelain",
+        "gh pr list --head",
+      ],
+    );
+  });
+
+  test("reports dirty files when CodeRoom cannot safely clean them", async () => {
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      restoreOwnedDirtyFiles: true,
+      runProcess: async (command, args) => {
+        if (command === "git" && args[0] === "status") {
+          return {
+            ok: true,
+            stdout: " M src/outside.ts\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-dirty", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: dirty" }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "dirty_worktree");
+    assert.deepEqual(result.dirty_files, ["src/outside.ts"]);
+  });
+
   test("creates a PR and enables auto-merge only after validation", async () => {
     const calls = [];
     const submitter = createSafeCodeRoomSubmitter({

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -173,6 +173,8 @@ export async function runOpenHandsWorker({
       evidence: {
         reason: coderoomResult?.reason ?? "unknown",
         file: coderoomResult?.file ?? null,
+        dirty_files: normalizeChangedFiles(coderoomResult?.dirty_files || []),
+        output: clipOutput(coderoomResult?.output, 1000),
         changed_files: changedFiles,
       },
     });

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -265,6 +265,22 @@ describe("runOpenHandsWorker", () => {
     assert.equal(result.receipt.evidence.file, "src/outside-owned.ts");
   });
 
+  test("keeps CodeRoom dirty-file detail in HOLD evidence", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: true, patch: patchFor("src/example.ts") }),
+      coderoom: async () => ({ ok: false, reason: "dirty_worktree", dirty_files: ["src/outside.ts"] }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "coderoom_rejected_patch");
+    assert.equal(result.receipt.evidence.reason, "dirty_worktree");
+    assert.deepEqual(result.receipt.evidence.dirty_files, ["src/outside.ts"]);
+  });
+
   test("default coderoom submit enforces owned files", async () => {
     const result = await runOpenHandsWorker({
       job: job(),


### PR DESCRIPTION
## What changed
- Lets the WriterLane free-writer submitter clean only dirty files that are already in the owned changed-file set before creating the draft PR.
- Keeps the generated runner ledger ignored during CodeRoom cleanliness checks.
- Adds dirty-file detail to OpenHands HOLD receipts so future failures name the blocker.

## Why
The live runner cleared the old `writerlane_no_file_contents` failure and produced a patch, but CodeRoom then rejected the handoff as `dirty_worktree`. This keeps the safety gate strict while allowing the already-owned canary file to be restored before CodeRoom applies the captured patch.

## Proof
- `node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-autonomous-runner.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs` (124/124 passing)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git worktree mutation before PR creation for one runner mode; mistakes could discard intended local edits, though scope is limited to owned changed files with no other dirty paths.
> 
> **Overview**
> For the **WriterLane free-writer** path only, CodeRoom submit now enables **`restoreOwnedDirtyFiles`** so a dirty worktree can be cleared with `git restore` when every blocking dirty path is in the job’s **changed-file set** (generated `.pinballwake/coding-room-ledger.json` still ignored). Unowned or mixed dirty state still fails with **`dirty_worktree`** and returns **`dirty_files`**.
> 
> OpenHands **HOLD** receipts for CodeRoom rejections now surface **`dirty_files`** and clipped **`output`** from the submitter, with tests for restore success, unsafe dirty paths, and worker evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c824dd15182059a0d64c8b143520dc29e43d3f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->