### PR TITLE
fix(writerlane): handle missing owned docs in free writer

### DIFF
--- a/scripts/pinballwake-writerlane-free-writer.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.mjs
@@ -411,6 +411,7 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
     "Do not use `CURRENT FILE:` in your answer. That label appears only in the input context.",
     "Change only the owned files. Do not commit, push, merge, deploy, or touch anything outside them.",
     "Use the current file contents below as the source of truth. Preserve unrelated code.",
+    "If a current owned file is missing, create that owned file from scratch and still return its full new contents.",
     `Model: ${model.openRouterModel || "unknown"}`,
     "Owned files:",
     ...ownedFiles.map((file) => `- ${file}`),
@@ -459,6 +460,9 @@ export function buildFullContentsPrompt({ ownedFiles = [], scopePack = {}, model
       lines.push(`CURRENT FILE: ${file.path}`);
       if (file.error) {
         lines.push(`Unreadable: ${file.error}`);
+        if (file.error === "file_missing_new_file_ok") {
+          lines.push("This owned file does not exist yet. Create it from scratch if it is part of the requested change.");
+        }
         continue;
       }
       lines.push("```");
@@ -529,8 +533,32 @@ export function parseFileBlocks(content, ownedFiles) {
     if (fence) {
       return [{ path: ownedList[0], content: fence[1] }];
     }
+    const raw = parseSingleRawFileContent(text, ownedList[0]);
+    if (raw !== null) {
+      return [{ path: ownedList[0], content: raw }];
+    }
   }
   return [];
+}
+
+function parseSingleRawFileContent(text, path) {
+  const body = String(text ?? "").trim();
+  if (!body) return null;
+  const lower = body.toLowerCase();
+  if (
+    lower.startsWith("i cannot ") ||
+    lower.startsWith("i can't ") ||
+    lower.startsWith("sorry") ||
+    lower.startsWith("here is ") ||
+    lower.startsWith("here's ") ||
+    lower.includes("```")
+  ) {
+    return null;
+  }
+  if (isDoc(path) && /^(#\s|##\s|---\r?\n)/.test(body)) {
+    return body;
+  }
+  return null;
 }
 
 function extractFencedBlocks(text) {

--- a/scripts/pinballwake-writerlane-free-writer.test.mjs
+++ b/scripts/pinballwake-writerlane-free-writer.test.mjs
@@ -120,6 +120,32 @@ describe("writerlane free-writer: happy path", () => {
     assert.match(prompt, /\[truncated for writer context\]/);
   });
 
+  it("treats a missing owned file as create-from-scratch context", async () => {
+    let prompt = "";
+    const runner = createWriterLaneFreeWriterRunner({
+      env: { LLM_API_KEY: "k" },
+      models: [MODEL_A],
+      fetchImpl: async (_url, init) => {
+        prompt = JSON.parse(init.body).messages[0].content;
+        return fakeFetchOnce(fileBlock("docs/x.md", "# New file\n\nCreated by the writer."))();
+      },
+      readFileImpl: async () => {
+        const err = new Error("missing");
+        err.code = "ENOENT";
+        throw err;
+      },
+      runProcess: okProcess(),
+      writeFileImpl: async () => {},
+      captureDiff: async ({ ownedFiles }) => ({ ok: true, patch: GOOD_PATCH, changed_files: ownedFiles }),
+    });
+
+    const result = await runner({ scopePack: { owned_files: OWNED, verification: ["node --test x"] } });
+
+    assert.equal(result.ok, true);
+    assert.match(prompt, /file_missing_new_file_ok/);
+    assert.match(prompt, /Create it from scratch/);
+  });
+
   it("loads current-file context from cwd with the production reader", async () => {
     const root = await mkdtemp(join(tmpdir(), "writerlane-context-"));
     try {
@@ -354,6 +380,18 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.equal(blocks[0].content, "just code");
   });
 
+  it("parseFileBlocks accepts raw markdown for one owned docs file", () => {
+    const blocks = parseFileBlocks("# OpenHands proof fixture\n\n- created\n", ["docs/openhands-proof-fixture.md"]);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].path, "docs/openhands-proof-fixture.md");
+    assert.match(blocks[0].content, /^# OpenHands proof fixture/);
+  });
+
+  it("parseFileBlocks does not treat chatty text as a raw docs file", () => {
+    const blocks = parseFileBlocks("Here is the markdown you asked for:\n\n# Title", ["docs/x.md"]);
+    assert.equal(blocks.length, 0);
+  });
+
   it("gateWriterLaneDiff rejects unowned, hunkless, and empty patches", () => {
     assert.equal(gateWriterLaneDiff({ patch: "", ownedFiles: OWNED }).reason, "openhands_missing_unified_diff");
     assert.equal(
@@ -404,6 +442,17 @@ describe("writerlane free-writer: pure helpers", () => {
     assert.match(prompt, /CURRENT FILE: docs\/x\.md/);
     assert.match(prompt, /Runner prompt detail/);
     assert.match(prompt, /old file/);
+  });
+
+  it("buildFullContentsPrompt tells the model missing owned files can be created", () => {
+    const prompt = buildFullContentsPrompt({
+      ownedFiles: OWNED,
+      scopePack: { verification: ["node --test x"] },
+      model: MODEL_A,
+      currentFiles: [{ path: "docs/x.md", content: "", error: "file_missing_new_file_ok" }],
+    });
+    assert.match(prompt, /missing/);
+    assert.match(prompt, /Create it from scratch/);
   });
 
   it("removes OpenHands diff instructions while preserving the canary task", () => {


### PR DESCRIPTION
## Summary
- teaches the WriterLane free writer that a missing owned docs file is a valid create-from-scratch target
- accepts raw markdown only for a single owned docs file when a free model omits the exact FILE wrapper
- keeps chatty/refusal text rejected so `writerlane_no_file_contents` still fails closed

## Proof
- PASS: `node --test scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-autonomous-runner.test.mjs` (104/104)
- PASS: `node --test scripts/pinballwake-xpass-gate-room.test.mjs scripts/build-dogfood-report.test.mjs scripts/uxpass-site-sweep.test.mjs scripts/pinballwake-commonsense-pass.test.mjs scripts/pinballwake-dogfood-room.test.mjs` (43/43)
- PASS: `npm run brainmap:check`
- PASS: `git diff --check origin/main...HEAD`

## QC note
This folds the useful part of #1096 onto current main after #1099 merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to WriterLane prompt/parsing for owned docs; ownership gates and fail-closed parsing for chatty output are unchanged.
> 
> **Overview**
> The WriterLane free writer now treats **missing owned files** as valid create-from-scratch targets: the full-contents prompt tells the model to return complete new file contents when context shows `file_missing_new_file_ok`, with an explicit “create from scratch” line in the current-file section.
> 
> For a **single owned docs file**, `parseFileBlocks` gains a fallback when models skip the `FILE:` wrapper: **raw markdown** is accepted only if it looks like real doc content (e.g. `#` / `##` / `---` headers) and is not chatty refusal or “here is…” preamble—so `writerlane_no_file_contents` still applies to bad replies.
> 
> Tests cover missing-file prompts, raw markdown acceptance, and rejection of chatty pseudo-markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577a9b44fe161debd1f6b9c2f90f8ad430a102ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->