### PR TITLE
fix(runner): expose CodeRoom dirty files

### DIFF
--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -173,6 +173,8 @@ export async function runOpenHandsWorker({
       evidence: {
         reason: coderoomResult?.reason ?? "unknown",
         file: coderoomResult?.file ?? null,
+        dirty_files: normalizeChangedFiles(coderoomResult?.dirty_files || []),
+        output: clipOutput(coderoomResult?.output, 1000),
         changed_files: changedFiles,
       },
     });

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -265,6 +265,22 @@ describe("runOpenHandsWorker", () => {
     assert.equal(result.receipt.evidence.file, "src/outside-owned.ts");
   });
 
+  test("keeps CodeRoom dirty-file detail in HOLD evidence", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: true, patch: patchFor("src/example.ts") }),
+      coderoom: async () => ({ ok: false, reason: "dirty_worktree", dirty_files: ["src/outside.ts"] }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "coderoom_rejected_patch");
+    assert.equal(result.receipt.evidence.reason, "dirty_worktree");
+    assert.deepEqual(result.receipt.evidence.dirty_files, ["src/outside.ts"]);
+  });
+
   test("default coderoom submit enforces owned files", async () => {
     const result = await runOpenHandsWorker({
       job: job(),


### PR DESCRIPTION
## What changed
- Adds `dirty_files` and clipped `output` to OpenHands CodeRoom rejection receipts.
- Adds a regression test proving dirty-worktree failures expose the file list.

## Why
The latest live runner moved past `writerlane_no_file_contents` and produced a patch, but CodeRoom still rejects with `dirty_worktree`. This makes the next live run tell us the exact file instead of hiding the blocker.

## Proof
- `node --test scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-openhands-proof-runner.test.mjs` (35/35 passing)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to HOLD receipt evidence and a unit test; no change to patch submission or safety gate logic.
> 
> **Overview**
> When CodeRoom rejects an OpenHands patch, **HOLD** receipts under `coderoom_rejected_patch` now carry **`dirty_files`** (normalized paths from the gate) and a **clipped `output`** snippet, alongside the existing reason, file, and changed-files fields.
> 
> A regression test asserts that a `dirty_worktree` rejection surfaces the dirty file list in receipt evidence so live runs can see which paths blocked submission instead of only the generic reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102d03a61eb810cec051b6159c0f42419599f3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->