### PR TITLE
fix(coderoom): restore staged owned patch dirt

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -528,7 +528,7 @@ export function createSafeCodeRoomSubmitter({
         return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyEntries.map((entry) => entry.path) };
       }
 
-      const restore = await runProcess("git", ["restore", "--worktree", "--", ...blockingDirtyEntries.map((entry) => entry.path)], {
+      const restore = await runProcess("git", ["restore", "--staged", "--worktree", "--", ...blockingDirtyEntries.map((entry) => entry.path)], {
         cwd,
         env: submitterEnv,
       });

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -524,7 +524,7 @@ describe("safe CodeRoom submitter", () => {
             ok: true,
             stdout:
               statusCalls === 1
-                ? ` M ${FIXTURE}\n M .pinballwake/coding-room-ledger.json\n`
+                ? `M  ${FIXTURE}\n M .pinballwake/coding-room-ledger.json\n`
                 : " M .pinballwake/coding-room-ledger.json\n",
             stderr: "",
             output: "",
@@ -555,7 +555,7 @@ describe("safe CodeRoom submitter", () => {
       calls.map(([command, args]) => `${command} ${args.slice(0, 4).join(" ")}`),
       [
         "git status --porcelain",
-        "git restore --worktree -- docs/openhands-proof-fixture.md",
+        "git restore --staged --worktree --",
         "git status --porcelain",
         "gh pr list --head codex/openhands-submit-todo-preapplied",
       ],

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -174,6 +174,7 @@ export async function runOpenHandsWorker({
         reason: coderoomResult?.reason ?? "unknown",
         file: coderoomResult?.file ?? null,
         changed_files: changedFiles,
+        dirty_files: coderoomResult?.dirty_files ?? [],
       },
     });
   }

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -265,6 +265,25 @@ describe("runOpenHandsWorker", () => {
     assert.equal(result.receipt.evidence.file, "src/outside-owned.ts");
   });
 
+  test("includes dirty file detail when coderoom rejects a patch", async () => {
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: true, patch: patchFor("docs/openhands-proof-fixture.md") }),
+      coderoom: async () => ({
+        ok: false,
+        reason: "dirty_worktree",
+        dirty_files: ["docs/openhands-proof-fixture.md"],
+      }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "coderoom_rejected_patch");
+    assert.deepEqual(result.receipt.evidence.dirty_files, ["docs/openhands-proof-fixture.md"]);
+  });
+
   test("default coderoom submit enforces owned files", async () => {
     const result = await runOpenHandsWorker({
       job: job(),


### PR DESCRIPTION
## Summary
- restore owned pre-applied patch files from both index and worktree before CodeRoom submit
- keep refusing untracked or unowned dirty files
- include dirty file details in OpenHands hold receipts when CodeRoom rejects a patch

## Proof
- node --test scripts\\pinballwake-openhands-proof-runner.test.mjs scripts\\pinballwake-openhands-worker.test.mjs scripts\\pinballwake-writerlane-free-writer.test.mjs scripts\\pinballwake-autonomous-runner.test.mjs
- npm run brainmap:check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner/script hygiene and richer hold evidence only; no auth, deploy, or product API changes.
> 
> **Overview**
> Fixes CodeRoom pre-submit cleanup when an owned patch is already **staged** in git, not only modified in the worktree. The safe submitter now runs `git restore --staged --worktree` for restorable owned dirty paths so a pre-applied owned file is fully cleared before apply/commit; untracked or unowned dirty files are still refused.
> 
> OpenHands **hold** receipts for `coderoom_rejected_patch` now carry `dirty_files` from the submitter (e.g. `dirty_worktree`), so operators can see which paths blocked submit without re-running git.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1603a8340b226c165de2dba4fd56854b3e01f275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->