### PR TITLE
fix(securitypass): harden scanner proofs

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -372,8 +372,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     sessionIdGenerator: undefined, // stateless mode - no sessions in serverless
   });
 
-  const server = await createServer();
-
   // Normalize the Accept header before delegating to the SDK. The SDK's
   // Streamable HTTP transport bounces requests that lack both
   // "application/json" and "text/event-stream" with HTTP 406 + -32000 +
@@ -385,7 +383,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // permissive than the SDK here is safe.
   normalizeAcceptHeader(req);
 
+  let server: Awaited<ReturnType<typeof createServer>> | null = null;
   try {
+    server = await createServer();
     await server.connect(transport);
     // Vercel parses the body automatically; pass it through to avoid re-parsing
     await transport.handleRequest(req, res, req.body);
@@ -401,6 +401,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   } finally {
     // Clean up after the response is sent
-    server.close().catch(() => {});
+    server?.close().catch(() => {});
   }
 }

--- a/packages/securitypass/src/__tests__/gitleaks-probe.test.ts
+++ b/packages/securitypass/src/__tests__/gitleaks-probe.test.ts
@@ -5,9 +5,12 @@ describe("Gitleaks probe scaffold", () => {
   it("builds an inert JSON command spec", () => {
     const spec = buildGitleaksCommand("/repo");
     expect(spec.command).toBe("gitleaks");
-    expect(spec.args).toContain("detect");
+    expect(spec.args).toContain("git");
     expect(spec.args).toContain("--report-format");
     expect(spec.args).toContain("json");
+    expect(spec.args).toContain("--report-path");
+    expect(spec.args).toContain("-");
+    expect(spec.args).toContain("--redact=100");
     expect(spec.timeoutMs).toBeGreaterThan(0);
   });
 
@@ -17,11 +20,14 @@ describe("Gitleaks probe scaffold", () => {
       Description: "Generic API Key",
       File: ".env",
       StartLine: 2,
+      EndLine: 2,
       Secret: "sk_live_secret",
+      Fingerprint: "abc123:.env:generic-api-key:2",
     }]));
     expect(findings).toHaveLength(1);
     expect(findings[0].severity).toBe("critical");
     expect(findings[0].evidence.secret_redacted).toBe("[redacted]");
+    expect(findings[0].evidence.fingerprint).toBe("abc123:.env:generic-api-key:2");
     expect(JSON.stringify(findings)).not.toContain("sk_live_secret");
   });
 

--- a/packages/securitypass/src/__tests__/osv-scanner-probe.test.ts
+++ b/packages/securitypass/src/__tests__/osv-scanner-probe.test.ts
@@ -5,19 +5,44 @@ describe("OSV-Scanner probe scaffold", () => {
   it("builds a recursive JSON command spec", () => {
     const spec = buildOsvScannerCommand("/repo");
     expect(spec.command).toBe("osv-scanner");
-    expect(spec.args).toEqual(["--format", "json", "--recursive", "/repo"]);
+    expect(spec.args).toEqual([
+      "scan",
+      "source",
+      "--format",
+      "json",
+      "--recursive",
+      "--no-call-analysis=rust",
+      "/repo",
+    ]);
     expect(spec.timeoutMs).toBeGreaterThan(0);
   });
 
   it("parses vulnerability findings from OSV JSON", () => {
     const findings = parseOsvScannerJson(JSON.stringify({
       results: [{
+        source: { path: "/repo/package-lock.json", type: "lockfile" },
         packages: [{
-          package: { name: "left-pad", version: "1.0.0" },
+          package: { name: "left-pad", version: "1.0.0", ecosystem: "npm" },
           vulnerabilities: [{
             id: "GHSA-test",
+            aliases: ["CVE-2026-0001"],
             summary: "Prototype pollution",
-            severity: [{ type: "CVSS_V3", score: "HIGH" }],
+            severity: [{ type: "CVSS_V3", score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H" }],
+            affected: [{
+              ranges: [{
+                type: "SEMVER",
+                events: [
+                  { introduced: "0" },
+                  { fixed: "1.0.1" },
+                ],
+              }],
+            }],
+            references: [{ type: "ADVISORY", url: "https://osv.dev/GHSA-test" }],
+            modified: "2026-05-01T00:00:00Z",
+          }],
+          groups: [{
+            ids: ["GHSA-test", "CVE-2026-0001"],
+            experimentalAnalysis: { "GHSA-test": { called: false } },
           }],
         }],
       }],
@@ -26,6 +51,89 @@ describe("OSV-Scanner probe scaffold", () => {
     expect(findings[0].check_id).toBe("securitypass.osv.GHSA-test");
     expect(findings[0].severity).toBe("high");
     expect(findings[0].evidence.package).toBe("left-pad");
+    expect(findings[0].evidence.ecosystem).toBe("npm");
+    expect(findings[0].evidence.source_path).toBe("/repo/package-lock.json");
+    expect(findings[0].evidence.aliases).toEqual(["CVE-2026-0001"]);
+    expect(findings[0].evidence.fixed_versions).toEqual(["1.0.1"]);
+    expect(findings[0].evidence.references).toEqual([{ type: "ADVISORY", url: "https://osv.dev/GHSA-test" }]);
+    expect(findings[0].evidence.modified).toBe("2026-05-01T00:00:00Z");
+    expect(findings[0].evidence.cvss_scores).toEqual([{
+      type: "CVSS_V3",
+      vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      score: 8.8,
+    }]);
+    expect(findings[0].evidence.call_analysis).toEqual([{
+      ids: ["GHSA-test", "CVE-2026-0001"],
+      analysis: { "GHSA-test": { called: false } },
+    }]);
+  });
+
+  it("scores official OSV CVSS vector strings from affected severity entries", () => {
+    const findings = parseOsvScannerJson(JSON.stringify({
+      results: [{
+        packages: [{
+          package: { name: "x509-validation", version: "1.4.0", ecosystem: "Hackage" },
+          vulnerabilities: [{
+            id: "HSEC-2023-0006",
+            summary: "x509-validation does not enforce pathLenConstraint",
+            affected: [{
+              severity: [{
+                type: "CVSS_V3",
+                score: "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:N",
+              }],
+            }],
+          }],
+        }],
+      }],
+    }));
+
+    expect(findings[0].severity).toBe("medium");
+    expect(findings[0].evidence.cvss_scores).toEqual([{
+      type: "CVSS_V3",
+      vector: "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:N",
+      score: 5.7,
+    }]);
+  });
+
+  it("keeps older CVSS v2 vectors from being treated as low text", () => {
+    const findings = parseOsvScannerJson(JSON.stringify({
+      results: [{
+        packages: [{
+          package: { name: "legacy", version: "1.0.0", ecosystem: "npm" },
+          vulnerabilities: [{
+            id: "CVE-LEGACY",
+            severity: [{ type: "CVSS_V2", score: "AV:N/AC:L/Au:N/C:P/I:P/A:P" }],
+          }],
+        }],
+      }],
+    }));
+
+    expect(findings[0].severity).toBe("high");
+    expect(findings[0].evidence.cvss_scores).toEqual([{
+      type: "CVSS_V2",
+      vector: "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+      score: 7.5,
+    }]);
+  });
+
+  it("falls back conservatively for newer CVSS vectors it cannot numerically score yet", () => {
+    const findings = parseOsvScannerJson(JSON.stringify({
+      results: [{
+        packages: [{
+          package: { name: "future-vector", version: "1.0.0", ecosystem: "Ubuntu" },
+          vulnerabilities: [{
+            id: "UBUNTU-CVE-2026-1234",
+            severity: [{
+              type: "CVSS_V4",
+              score: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+            }],
+          }],
+        }],
+      }],
+    }));
+
+    expect(findings[0].severity).toBe("high");
+    expect(findings[0].evidence.cvss_scores).toEqual([]);
   });
 
   it("wraps command output with target metadata", () => {

--- a/packages/securitypass/src/probes/gitleaks.ts
+++ b/packages/securitypass/src/probes/gitleaks.ts
@@ -6,14 +6,27 @@ interface GitleaksLeak {
   Description?: string;
   File?: string;
   StartLine?: number;
+  EndLine?: number;
   Secret?: string;
   Commit?: string;
+  Fingerprint?: string;
 }
 
 export function buildGitleaksCommand(repoPath: string): CommandSpec {
   return {
     command: "gitleaks",
-    args: ["detect", "--source", repoPath, "--report-format", "json", "--no-banner"],
+    args: [
+      "git",
+      "--report-format",
+      "json",
+      "--report-path",
+      "-",
+      "--redact=100",
+      "--no-banner",
+      "--log-level",
+      "error",
+      repoPath,
+    ],
     cwd: repoPath,
     timeoutMs: 120_000,
   };
@@ -34,7 +47,9 @@ export function parseGitleaksJson(stdout: string): SecurityProbeFinding[] {
       rule_id: leak.RuleID ?? null,
       file: leak.File ?? null,
       start_line: leak.StartLine ?? null,
+      end_line: leak.EndLine ?? null,
       commit: leak.Commit ?? null,
+      fingerprint: leak.Fingerprint ?? null,
       secret_redacted: leak.Secret ? "[redacted]" : null,
     },
   }));

--- a/packages/securitypass/src/probes/osv-scanner.ts
+++ b/packages/securitypass/src/probes/osv-scanner.ts
@@ -4,37 +4,262 @@ import type { CommandExecutionResult, CommandSpec, SecurityProbeFinding, Securit
 interface OsvPackage {
   name?: string;
   version?: string;
+  ecosystem?: string;
+}
+
+interface OsvSeverity {
+  type?: string;
+  score?: string;
+}
+
+interface ParsedCvssScore {
+  type: string | null;
+  vector: string;
+  score: number;
+}
+
+interface OsvAffectedRangeEvent {
+  introduced?: string;
+  fixed?: string;
+  last_affected?: string;
+  limit?: string;
+}
+
+interface OsvAffectedRange {
+  type?: string;
+  events?: OsvAffectedRangeEvent[];
+}
+
+interface OsvAffected {
+  severity?: OsvSeverity[];
+  ranges?: OsvAffectedRange[];
+}
+
+interface OsvReference {
+  type?: string;
+  url?: string;
 }
 
 interface OsvVulnerability {
   id?: string;
+  aliases?: string[];
   summary?: string;
   details?: string;
-  severity?: Array<{ type?: string; score?: string }>;
+  severity?: OsvSeverity[];
+  affected?: OsvAffected[];
+  references?: OsvReference[];
+  published?: string;
+  modified?: string;
+}
+
+interface OsvGroup {
+  ids?: string[];
+  experimentalAnalysis?: Record<string, { called?: boolean }>;
 }
 
 interface OsvResult {
+  source?: {
+    path?: string;
+    type?: string;
+  };
   packages?: Array<{
     package?: OsvPackage;
     vulnerabilities?: OsvVulnerability[];
+    groups?: OsvGroup[];
   }>;
 }
 
 export function buildOsvScannerCommand(path: string): CommandSpec {
   return {
     command: "osv-scanner",
-    args: ["--format", "json", "--recursive", path],
+    args: ["scan", "source", "--format", "json", "--recursive", "--no-call-analysis=rust", path],
     cwd: path,
     timeoutMs: 120_000,
   };
 }
 
-function severityFromOsv(vuln: OsvVulnerability): SecurityProbeFinding["severity"] {
-  const score = vuln.severity?.find((s) => s.score)?.score?.toUpperCase() ?? "";
-  if (score.includes("CRITICAL")) return "critical";
-  if (score.includes("HIGH")) return "high";
-  if (score.includes("MEDIUM")) return "medium";
+function roundUp1(score: number): number {
+  return Math.ceil((score + Number.EPSILON) * 10) / 10;
+}
+
+function parseCvssVector(vector: string): Record<string, string> {
+  const metrics: Record<string, string> = {};
+  for (const part of vector.split("/")) {
+    const [key, value] = part.split(":");
+    if (!key || !value || key === "CVSS") continue;
+    metrics[key] = value;
+  }
+  return metrics;
+}
+
+function cvssV3Score(vector: string): number | null {
+  if (!vector.startsWith("CVSS:3.")) return null;
+  const metrics = parseCvssVector(vector);
+  const impactValues = { N: 0, L: 0.22, H: 0.56 } as const;
+  const av = { N: 0.85, A: 0.62, L: 0.55, P: 0.2 }[metrics.AV as "N" | "A" | "L" | "P"];
+  const ac = { L: 0.77, H: 0.44 }[metrics.AC as "L" | "H"];
+  const ui = { N: 0.85, R: 0.62 }[metrics.UI as "N" | "R"];
+  const scope = metrics.S as "U" | "C" | undefined;
+  const pr = scope === "C"
+    ? { N: 0.85, L: 0.68, H: 0.5 }[metrics.PR as "N" | "L" | "H"]
+    : { N: 0.85, L: 0.62, H: 0.27 }[metrics.PR as "N" | "L" | "H"];
+  const c = impactValues[metrics.C as keyof typeof impactValues];
+  const i = impactValues[metrics.I as keyof typeof impactValues];
+  const a = impactValues[metrics.A as keyof typeof impactValues];
+  if (
+    av === undefined ||
+    ac === undefined ||
+    pr === undefined ||
+    ui === undefined ||
+    c === undefined ||
+    i === undefined ||
+    a === undefined ||
+    !scope
+  ) return null;
+
+  const impactSubScore = 1 - (1 - c) * (1 - i) * (1 - a);
+  const impact = scope === "U"
+    ? 6.42 * impactSubScore
+    : 7.52 * (impactSubScore - 0.029) - 3.25 * Math.pow(impactSubScore - 0.02, 15);
+  if (impact <= 0) return 0;
+  const exploitability = 8.22 * av * ac * pr * ui;
+  const base = scope === "U"
+    ? Math.min(impact + exploitability, 10)
+    : Math.min(1.08 * (impact + exploitability), 10);
+  return roundUp1(base);
+}
+
+function cvssV2Score(vector: string): number | null {
+  const metrics = parseCvssVector(vector);
+  const av = { L: 0.395, A: 0.646, N: 1 }[metrics.AV as "L" | "A" | "N"];
+  const ac = { H: 0.35, M: 0.61, L: 0.71 }[metrics.AC as "H" | "M" | "L"];
+  const au = { M: 0.45, S: 0.56, N: 0.704 }[metrics.Au as "M" | "S" | "N"];
+  const impactValues = { N: 0, P: 0.275, C: 0.66 } as const;
+  const c = impactValues[metrics.C as keyof typeof impactValues];
+  const i = impactValues[metrics.I as keyof typeof impactValues];
+  const a = impactValues[metrics.A as keyof typeof impactValues];
+  if (
+    av === undefined ||
+    ac === undefined ||
+    au === undefined ||
+    c === undefined ||
+    i === undefined ||
+    a === undefined
+  ) return null;
+
+  const impact = 10.41 * (1 - (1 - c) * (1 - i) * (1 - a));
+  if (impact <= 0) return 0;
+  const exploitability = 20 * av * ac * au;
+  return roundUp1(((0.6 * impact) + (0.4 * exploitability) - 1.5) * 1.176);
+}
+
+function parsedCvssScoresFromOsv(severityEntries: OsvSeverity[]): ParsedCvssScore[] {
+  return severityEntries.flatMap((severity) => {
+    const rawScore = severity.score?.trim();
+    if (!rawScore) return [];
+    let score: number | null = null;
+    if (rawScore.startsWith("CVSS:3.")) {
+      score = cvssV3Score(rawScore);
+    } else if (severity.type === "CVSS_V2" || /(^|\/)Au:/.test(rawScore)) {
+      score = cvssV2Score(rawScore);
+    }
+    return score === null ? [] : [{
+      type: severity.type ?? null,
+      vector: rawScore,
+      score,
+    }];
+  });
+}
+
+function severityFromScore(score: number): SecurityProbeFinding["severity"] {
+  if (score >= 9) return "critical";
+  if (score >= 7) return "high";
+  if (score >= 4) return "medium";
+  if (score > 0) return "low";
+  return "info";
+}
+
+function fallbackSeverityFromCvssVector(scoreText: string): SecurityProbeFinding["severity"] | null {
+  if (!scoreText.includes("CVSS:")) return null;
+  if (/\/(?:VC|VI|VA|SC|SI|SA|C|I|A):H(?:\/|$)/.test(scoreText)) return "high";
+  if (/\/(?:VC|VI|VA|SC|SI|SA|C|I|A):(?:L|P)(?:\/|$)/.test(scoreText)) return "medium";
   return "low";
+}
+
+function osvSeverityEntries(vuln: OsvVulnerability): OsvSeverity[] {
+  return [
+    ...(vuln.severity ?? []),
+    ...((vuln.affected ?? []).flatMap((affected) => affected.severity ?? [])),
+  ];
+}
+
+function cvssScoresFromOsv(vuln: OsvVulnerability): ParsedCvssScore[] {
+  return parsedCvssScoresFromOsv(osvSeverityEntries(vuln));
+}
+
+function severityFromOsv(vuln: OsvVulnerability): SecurityProbeFinding["severity"] {
+  const severityEntries = osvSeverityEntries(vuln);
+  const scores = severityEntries
+    .map((severity) => severity.score)
+    .filter((score): score is string => Boolean(score));
+  const text = scores.join(" ").toUpperCase();
+  if (text.includes("CRITICAL")) return "critical";
+  if (text.includes("HIGH")) return "high";
+  if (text.includes("MEDIUM")) return "medium";
+  if (text.includes("LOW")) return "low";
+
+  const numericScores = scores
+    .map((score) => Number(String(score).trim()))
+    .filter((score) => Number.isFinite(score));
+  const numericScore = numericScores.length > 0 ? Math.max(...numericScores) : null;
+  if (numericScore !== null) {
+    return severityFromScore(numericScore);
+  }
+
+  const cvssScores = parsedCvssScoresFromOsv(severityEntries);
+  if (cvssScores.length > 0) {
+    return severityFromScore(Math.max(...cvssScores.map((score) => score.score)));
+  }
+
+  for (const score of scores) {
+    const fallback = fallbackSeverityFromCvssVector(score);
+    if (fallback) return fallback;
+  }
+  return "low";
+}
+
+function fixedVersionsFromOsv(vuln: OsvVulnerability): string[] {
+  const fixedVersions = new Set<string>();
+  for (const affected of vuln.affected ?? []) {
+    for (const range of affected.ranges ?? []) {
+      for (const event of range.events ?? []) {
+        if (event.fixed) fixedVersions.add(event.fixed);
+      }
+    }
+  }
+  return [...fixedVersions].sort();
+}
+
+function referencesFromOsv(vuln: OsvVulnerability): Array<{ type: string | null; url: string }> {
+  return (vuln.references ?? [])
+    .filter((reference): reference is OsvReference & { url: string } => Boolean(reference.url))
+    .map((reference) => ({
+      type: reference.type ?? null,
+      url: reference.url,
+    }));
+}
+
+function callAnalysisForVulnerability(
+  pkg: { groups?: OsvGroup[] },
+  vuln: OsvVulnerability,
+): Array<{ ids: string[]; analysis: Record<string, { called?: boolean }> }> {
+  const vulnIds = new Set([vuln.id, ...(vuln.aliases ?? [])].filter(Boolean));
+  return (pkg.groups ?? [])
+    .filter((group) => (group.ids ?? []).some((id) => vulnIds.has(id)))
+    .map((group) => ({
+      ids: group.ids ?? [],
+      analysis: group.experimentalAnalysis ?? {},
+    }));
 }
 
 export function parseOsvScannerJson(stdout: string): SecurityProbeFinding[] {
@@ -54,9 +279,19 @@ export function parseOsvScannerJson(stdout: string): SecurityProbeFinding[] {
           remediation: "Upgrade the affected package, apply a vendor patch, or document an accepted risk.",
           evidence: {
             id: vuln.id ?? null,
+            aliases: vuln.aliases ?? [],
             package: pkg.package?.name ?? null,
             version: pkg.package?.version ?? null,
+            ecosystem: pkg.package?.ecosystem ?? null,
+            fixed_versions: fixedVersionsFromOsv(vuln),
+            references: referencesFromOsv(vuln),
+            published: vuln.published ?? null,
+            modified: vuln.modified ?? null,
+            call_analysis: callAnalysisForVulnerability(pkg, vuln),
+            cvss_scores: cvssScoresFromOsv(vuln),
             severity: vuln.severity ?? [],
+            source_path: result.source?.path ?? null,
+            source_type: result.source?.type ?? null,
           },
         });
       }

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -54,11 +54,11 @@ const xpassIndex = [
   {
     id: "securitypass",
     name: "SecurityPass",
-    stage: "scope_gated",
-    label: "Scope-gated",
-    automation: "Blocked public receipt until safe recurring proof exists",
+    stage: "safe_proof",
+    label: "Safe proof live",
+    automation: "Recurring static safety proof; active probes remain scope-gated",
     mentionProfile: "Low mention volume by design because unsafe probes stay disabled.",
-    nextStep: "Add a deny-by-default recurring runner proof before live security checks.",
+    nextStep: "Add a deny-by-default recurring active-runner proof before live security checks.",
   },
   {
     id: "sloppass",
@@ -674,6 +674,107 @@ function extractSitemapUrls(body) {
   return Array.from(body.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/gi)).map((match) => match[1] || "").filter(Boolean);
 }
 
+async function runSecurityPassSafeProof() {
+  const proofFiles = {
+    runner: "packages/securitypass/src/runner/index.ts",
+    gitleaks: "packages/securitypass/src/probes/gitleaks.ts",
+    osv: "packages/securitypass/src/probes/osv-scanner.ts",
+  };
+
+  try {
+    const [runner, gitleaks, osv] = await Promise.all([
+      fs.readFile(proofFiles.runner, "utf8"),
+      fs.readFile(proofFiles.gitleaks, "utf8"),
+      fs.readFile(proofFiles.osv, "utf8"),
+    ]);
+
+    const skeletonStart = runner.indexOf("export async function runSkeletonScan");
+    const skeletonVerify = runner.indexOf("await verifyScopeOrThrow(target, opts);", skeletonStart);
+    const skeletonCreateRun = runner.indexOf("const run = createRun", skeletonStart);
+    const skeletonHeaderProbe = runner.indexOf("checkSecurityHeaders(url", skeletonStart);
+    const packStart = runner.indexOf("export async function runSecurityPack");
+    const packDeclaredScope = runner.indexOf("assertTargetWithinDeclaredScope(pack, target);", packStart);
+    const packVerify = runner.indexOf("const scopeProof = await verifyScopeOrThrow", packStart);
+
+    const checks = [
+      {
+        name: "runSkeletonScan verifies scope before creating a run.",
+        ok: skeletonStart >= 0 && skeletonVerify > skeletonStart && skeletonCreateRun > skeletonVerify,
+      },
+      {
+        name: "runSkeletonScan verifies scope before fetching security headers.",
+        ok: skeletonStart >= 0 && skeletonVerify > skeletonStart && skeletonHeaderProbe > skeletonVerify,
+      },
+      {
+        name: "runSecurityPack checks declared in-scope/out-of-scope assets before proof verification.",
+        ok: packStart >= 0 && packDeclaredScope > packStart && packVerify > packDeclaredScope,
+      },
+      {
+        name: "Gitleaks uses the current git scan command with scanner-side redaction.",
+        ok: /args:\s*\[\s*"git"/.test(gitleaks) && gitleaks.includes('"--redact=100"'),
+      },
+      {
+        name: "OSV-Scanner uses the v2 source scan command and keeps source-path evidence.",
+        ok: /args:\s*\[\s*"scan",\s*"source"/.test(osv) && osv.includes("source_path"),
+      },
+      {
+        name: "OSV-Scanner keeps Rust call analysis explicitly disabled for safe source scans.",
+        ok: osv.includes('"--no-call-analysis=rust"'),
+      },
+      {
+        name: "OSV-Scanner evidence keeps fixed-version and call-analysis context.",
+        ok: osv.includes("fixed_versions") && osv.includes("call_analysis"),
+      },
+      {
+        name: "OSV-Scanner scores official CVSS vector evidence instead of defaulting it low.",
+        ok: osv.includes("cvss_scores") && osv.includes("cvssV3Score") && osv.includes("cvssV2Score"),
+      },
+    ];
+
+    const failedChecks = checks.filter((check) => !check.ok);
+    const proof = {
+      kind: "securitypass_safe_static_proof",
+      files: proofFiles,
+      checks,
+      activeProbesRun: false,
+    };
+
+    if (failedChecks.length > 0) {
+      return failureResult(
+        "securitypass",
+        "SecurityPass",
+        `SecurityPass safe proof failed ${failedChecks.length} static check(s).`,
+        failedChecks.map((check) => check.name).join(" "),
+        {
+          reasonCode: "safe_proof_failed",
+          proof,
+        },
+      );
+    }
+
+    return passResult(
+      "securitypass",
+      "SecurityPass",
+      "Safe recurring proof verified SecurityPass remains deny-by-default before active probes.",
+      "Static proof checked the runner scope gate plus scanner wrapper safety settings; no active probes were run.",
+      {
+        proof,
+        nextProof: "Add a scoped active-runner receipt before marking live security probes as passing.",
+      },
+    );
+  } catch (err) {
+    return failureResult(
+      "securitypass",
+      "SecurityPass",
+      "SecurityPass safe proof could not read the expected source files.",
+      err instanceof Error ? err.message : String(err),
+      {
+        reasonCode: "safe_proof_unreadable",
+      },
+    );
+  }
+}
+
 function buildTrend(results) {
   const today = generatedAt.slice(0, 10);
   return [{
@@ -714,17 +815,7 @@ packageSweepState = await readPackageSweepReceipt();
 const results = [
   await runTestPass(),
   await runUXPass(),
-  blockedResult(
-    "securitypass",
-    "SecurityPass",
-    "SecurityPass is blocked until the recurring runner proof is ready.",
-    "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
-    "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
-    {
-      reasonCode: "scope_gate",
-      nextProof: "Land a safe recurring SecurityPass runner receipt before marking this passing.",
-    },
-  ),
+  await runSecurityPassSafeProof(),
   packageReadyResult(
     "sloppass",
     "SlopPass",

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -41,7 +41,7 @@ function passingSweepMatrixRows() {
   }));
 }
 
-test("dogfood receipt marks SecurityPass as blocked with a reason", async () => {
+test("dogfood receipt includes a safe SecurityPass proof without active probes", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
   const output = path.join(dir, "latest.json");
 
@@ -65,10 +65,15 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
     assert.equal(testpass?.reasonCode, "dry_run_only");
     assert.equal(uxpass?.status, "pending");
     assert.equal(uxpass?.reasonCode, "dry_run_only");
-    assert.equal(securitypass?.status, "blocked");
-    assert.match(securitypass?.blockedReason ?? "", /scope-gated/i);
-    assert.equal(securitypass?.reasonCode, "scope_gate");
-    assert.match(securitypass?.nextProof ?? "", /safe recurring SecurityPass runner receipt/i);
+    assert.equal(securitypass?.status, "passing");
+    assert.match(securitypass?.summary ?? "", /deny-by-default/i);
+    assert.equal(securitypass?.proof?.kind, "securitypass_safe_static_proof");
+    assert.equal(securitypass?.proof?.activeProbesRun, false);
+    assert.equal(
+      securitypass?.proof?.checks.every((check) => check.ok),
+      true,
+    );
+    assert.match(securitypass?.nextProof ?? "", /scoped active-runner receipt/i);
     assert.equal(copypass?.status, "pending");
     assert.equal(copypass?.reasonCode, "package_ready_needs_scheduled_receipt");
     assert.equal(copypass?.proof?.kind, "package_ready");
@@ -82,12 +87,13 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
       kind: "planned",
       targetUrl: "/enterprise/latest.json",
     });
-    assert.equal(report.status, "blocked");
+    assert.equal(report.status, "pending");
     assert.match(report.statusLegend.blocked, /action is needed/i);
     assert.match(report.statusLegend.pending, /scheduled proof is not available yet/i);
     assert.match(report.proofPolicy, /live check or scheduled package sweep actually ran/i);
-    assert.match(report.lastActionableFailure.detail, /Blocked reason:/);
+    assert.match(report.lastActionableFailure.title, /No actionable dogfood failure/i);
     assert.equal(report.xpassIndex.find((entry) => entry.id === "testpass")?.stage, "live_gate");
+    assert.equal(report.xpassIndex.find((entry) => entry.id === "securitypass")?.stage, "safe_proof");
     assert.match(
       report.xpassIndex.find((entry) => entry.id === "testpass")?.mentionProfile ?? "",
       /protects merges/i,
@@ -293,8 +299,9 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
     const seopass = report.results.find((result) => result.id === "seopass");
     assert.equal(seopass?.status, "passing");
     assert.equal(seopass?.proof?.kind, "seopass_run");
-    assert.equal(securitypass?.status, "blocked");
-    assert.equal(securitypass?.reasonCode, "scope_gate");
+    assert.equal(securitypass?.status, "passing");
+    assert.equal(securitypass?.proof?.kind, "securitypass_safe_static_proof");
+    assert.equal(securitypass?.proof?.activeProbesRun, false);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
+    testTimeout: 10_000,
     include: [
       "src/**/*.{test,spec}.{ts,tsx}",
       "api/**/*.{test,spec}.{ts,tsx}",


### PR DESCRIPTION
## Summary

- Harden SecurityPass scanner proof handling after another research/QC pass.
- Add OSV CVSS vector scoring so vector-only severities do not get underrated.
- Keep OSV Rust call analysis disabled in the scanner wrapper so dependency build scripts are not executed during safe source scans.
- Promote SecurityPass dogfood from blocked draft state to passing safe static proof while active probes remain scope-gated.
- Refresh against current main, preserving FlowPass and SEOPass live proof work.

## Final quiet-mode QC

- ✅ `npm run test --workspace=@unclick/securitypass` passed, 8 files / 67 tests.
- ✅ `npm run build --workspace=@unclick/securitypass` passed.
- ✅ `node --test scripts/build-dogfood-report.test.mjs scripts/build-xpass-package-sweep.test.mjs scripts/pinballwake-xpass-gate-room.test.mjs` passed, 35/35.
- ✅ `npm run brainmap:check` passed.
- ✅ `npx eslint scripts/build-dogfood-report.mjs scripts/build-dogfood-report.test.mjs packages/securitypass/src` passed.
- ✅ `git diff --check` passed.

## Research basis

- NIST SSDF secure software development guidance.
- OWASP Web Security Testing Guide.
- OSV-Scanner docs and OSV schema severity/CVSS shape.
- Gitleaks scanner docs.

## Notes

- SecurityPass active probes still require explicit scope, by design.
- This refresh did not re-fire GitHub Actions. Local proof is current; cloud checks are intentionally quiet while noisy workflows are paused.
- Root/default-branch Dependabot advisories remain outside this SecurityPass slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect security finding severity, scanner CLI behavior, and public dogfood trust signals; MCP change is small defensive cleanup with low blast radius.
> 
> **Overview**
> Hardens **SecurityPass** scanner wrappers and dogfood proof without turning on live probes. **Gitleaks** now uses the `git` scan flow with JSON on stdout and `--redact=100`, and findings carry **fingerprint** / line-range evidence. **OSV-Scanner** switches to the v2 `scan source` CLI, disables Rust call analysis for safe scans, and enriches parsed findings (aliases, fixed versions, references, source path, call-analysis groups) while **scoring CVSS v2/v3 vectors** so vector-only severities are not underrated; unknown vectors (e.g. CVSS v4) get a conservative high fallback.
> 
> The nightly **dogfood** receipt replaces the blocked SecurityPass stub with a **static safe proof** that asserts runner scope ordering and the updated scanner settings (`activeProbesRun: false`), moving the XPass index stage to **safe_proof** and overall dry-run status away from blocked when SecurityPass passes.
> 
> **MCP** (`api/mcp.ts`) defers `createServer()` until inside the request `try` and uses optional cleanup so a failed startup does not call `close()` on an undefined server. Root **Vitest** default timeout is raised to 10s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7dd331ff4a66fc7d6aa51d51a52e3d12833f91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->