### PR TITLE
fix(coderoom): clean patch-owned leftovers before submit

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -521,18 +521,36 @@ export function createSafeCodeRoomSubmitter({
     let blockingDirtyEntries = dirtyEntries.filter((entry) => !isGeneratedRunnerLedgerPath(entry.path));
     if (blockingDirtyEntries.length) {
       const changedSet = new Set(normalizedChanged);
-      const restorable = blockingDirtyEntries.every(
-        (entry) => changedSet.has(entry.path) && !entry.code.includes("?"),
-      );
-      if (!restorable) {
+      const unrelatedDirtyEntries = blockingDirtyEntries.filter((entry) => !changedSet.has(entry.path));
+      if (unrelatedDirtyEntries.length) {
         return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyEntries.map((entry) => entry.path) };
       }
 
-      const restore = await runProcess("git", ["restore", "--staged", "--worktree", "--", ...blockingDirtyEntries.map((entry) => entry.path)], {
-        cwd,
-        env: submitterEnv,
-      });
-      if (!restore.ok) return { ok: false, reason: "git_restore_preexisting_patch_failed", output: restore.output };
+      const trackedDirtyEntries = blockingDirtyEntries.filter((entry) => !entry.code.includes("?"));
+      if (trackedDirtyEntries.length) {
+        const restore = await runProcess(
+          "git",
+          ["restore", "--staged", "--worktree", "--", ...trackedDirtyEntries.map((entry) => entry.path)],
+          {
+            cwd,
+            env: submitterEnv,
+          },
+        );
+        if (!restore.ok) {
+          return { ok: false, reason: "git_restore_preexisting_patch_failed", output: restore.output };
+        }
+      }
+
+      const untrackedDirtyEntries = blockingDirtyEntries.filter((entry) => entry.code.includes("?"));
+      if (untrackedDirtyEntries.length) {
+        const clean = await runProcess("git", ["clean", "-f", "--", ...untrackedDirtyEntries.map((entry) => entry.path)], {
+          cwd,
+          env: submitterEnv,
+        });
+        if (!clean.ok) {
+          return { ok: false, reason: "git_clean_preexisting_patch_failed", output: clean.output };
+        }
+      }
 
       status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
       if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -562,14 +562,30 @@ describe("safe CodeRoom submitter", () => {
     );
   });
 
-  test("does not restore untracked dirty files before CodeRoom submit", async () => {
+  test("cleans an untracked patch-owned file before CodeRoom submit", async () => {
     const calls = [];
+    let statusCalls = 0;
     const submitter = createSafeCodeRoomSubmitter({
       env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-untracked",
       runProcess: async (command, args) => {
         calls.push([command, args]);
         if (command === "git" && args[0] === "status") {
-          return { ok: true, stdout: `?? ${FIXTURE}\n`, stderr: "", output: "" };
+          statusCalls += 1;
+          return {
+            ok: true,
+            stdout: statusCalls === 1 ? `?? ${FIXTURE}\n` : "",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/934\n",
+            stderr: "",
+            output: "",
+          };
         }
         return { ok: true, stdout: "", stderr: "", output: "" };
       },
@@ -581,8 +597,41 @@ describe("safe CodeRoom submitter", () => {
       patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: untracked" }),
     });
 
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 4).join(" ")}`),
+      [
+        "git status --porcelain",
+        "git clean -f -- docs/openhands-proof-fixture.md",
+        "git status --porcelain",
+        "gh pr list --head codex/openhands-submit-todo-untracked",
+      ],
+    );
+  });
+
+  test("does not clean unrelated untracked files before CodeRoom submit", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          return { ok: true, stdout: `?? src/unrelated.ts\n`, stderr: "", output: "" };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-unrelated-untracked", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: unrelated untracked" }),
+    });
+
     assert.equal(result.ok, false);
     assert.equal(result.reason, "dirty_worktree");
+    assert.deepEqual(result.dirty_files, ["src/unrelated.ts"]);
     assert.deepEqual(calls.map(([command, args]) => `${command} ${args[0]}`), ["git status"]);
   });
 

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -173,8 +173,8 @@ export async function runOpenHandsWorker({
       evidence: {
         reason: coderoomResult?.reason ?? "unknown",
         file: coderoomResult?.file ?? null,
+        dirty_files: normalizeChangedFiles(coderoomResult?.dirty_files || []),
         changed_files: changedFiles,
-        dirty_files: coderoomResult?.dirty_files ?? [],
       },
     });
   }


### PR DESCRIPTION
## Summary
- fully restore staged/tracked patch-owned leftovers before CodeRoom applies the captured patch
- clean only untracked files that are already patch-owned, while unrelated dirty files still block
- include CodeRoom dirty file details in OpenHands hold evidence

## Tests
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-autonomous-runner.test.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-submit git restore/clean behavior in the autonomous CodeRoom path; mistakes in ownership matching could remove the wrong untracked files, though cleanup is limited to patch changed paths.
> 
> **Overview**
> Before CodeRoom applies a captured patch, the safe submitter now **clears only patch-owned worktree noise** instead of treating all dirty paths the same. Unrelated dirty files still fail with `dirty_worktree`. For paths in the patch’s changed set, **tracked** leftovers get `git restore --staged --worktree`, and **untracked** (`??`) patch-owned files get targeted `git clean -f`, then status is re-checked.
> 
> Tests cover successful clean of an untracked owned fixture file and a hard stop when an unrelated untracked file is present. OpenHands **hold** evidence now normalizes `dirty_files` from CodeRoom rejections the same way as `changed_files`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec4b332e951af0365fde80231e65a670c00dfe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->