### PR TITLE
fix(coderoom): clean draft submitter owned patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "vite",
     "dev:api": "npm run dev --workspace=apps/api",
-    "build": "vite build",
+    "build": "npm run build --workspace=@unclick/commonsensepass && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -388,11 +388,14 @@ export function createDraftPrCoderoom({
       };
     }
 
-    const status = await runProcess("git", ["status", "--porcelain"], { cwd, env });
-    if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
-    if (status.stdout.trim()) {
-      return { ok: false, reason: "dirty_worktree" };
-    }
+    const clean = await cleanPreappliedOwnedPatch({
+      cwd,
+      env,
+      runProcess,
+      changedFiles: normalizedChanged,
+      restoreFailureReason: "git_restore_preexisting_draft_patch_failed",
+    });
+    if (!clean.ok) return clean;
 
     const branch = branchName || `${DEFAULT_BRANCH_PREFIX}-${safeStamp(new Date())}`;
     const bodyText =
@@ -468,6 +471,45 @@ export function inspectSafeCoderoomPatchPaths({
   return { ok: true, changed_files: normalizedChanged };
 }
 
+async function cleanPreappliedOwnedPatch({
+  cwd,
+  env,
+  runProcess,
+  changedFiles = [],
+  restoreFailureReason = "git_restore_preexisting_patch_failed",
+} = {}) {
+  let status = await runProcess("git", ["status", "--porcelain"], { cwd, env });
+  if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
+
+  let dirtyEntries = parseGitStatusEntries(status.stdout);
+  let blockingDirtyEntries = dirtyEntries.filter((entry) => !isGeneratedRunnerLedgerPath(entry.path));
+  if (blockingDirtyEntries.length) {
+    const changedSet = new Set((changedFiles || []).map(normalizePath));
+    const restorable = blockingDirtyEntries.every((entry) => changedSet.has(entry.path) && !entry.code.includes("?"));
+    if (!restorable) {
+      return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyEntries.map((entry) => entry.path) };
+    }
+
+    const restore = await runProcess("git", ["restore", "--worktree", "--", ...blockingDirtyEntries.map((entry) => entry.path)], {
+      cwd,
+      env,
+    });
+    if (!restore.ok) return { ok: false, reason: restoreFailureReason, output: restore.output };
+
+    status = await runProcess("git", ["status", "--porcelain"], { cwd, env });
+    if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
+    dirtyEntries = parseGitStatusEntries(status.stdout);
+    blockingDirtyEntries = dirtyEntries.filter((entry) => !isGeneratedRunnerLedgerPath(entry.path));
+  }
+
+  const blockingDirtyFiles = blockingDirtyEntries.map((entry) => entry.path);
+  if (blockingDirtyFiles.length) {
+    return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
+  }
+
+  return { ok: true };
+}
+
 export function createSafeCodeRoomSubmitter({
   cwd = process.cwd(),
   env = process.env,
@@ -515,34 +557,13 @@ export function createSafeCodeRoomSubmitter({
     }
     const submitterEnv = auth.env;
 
-    let status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
-    if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
-    let dirtyEntries = parseGitStatusEntries(status.stdout);
-    let blockingDirtyEntries = dirtyEntries.filter((entry) => !isGeneratedRunnerLedgerPath(entry.path));
-    if (blockingDirtyEntries.length) {
-      const changedSet = new Set(normalizedChanged);
-      const restorable = blockingDirtyEntries.every(
-        (entry) => changedSet.has(entry.path) && !entry.code.includes("?"),
-      );
-      if (!restorable) {
-        return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyEntries.map((entry) => entry.path) };
-      }
-
-      const restore = await runProcess("git", ["restore", "--worktree", "--", ...blockingDirtyEntries.map((entry) => entry.path)], {
-        cwd,
-        env: submitterEnv,
-      });
-      if (!restore.ok) return { ok: false, reason: "git_restore_preexisting_patch_failed", output: restore.output };
-
-      status = await runProcess("git", ["status", "--porcelain"], { cwd, env: submitterEnv });
-      if (!status.ok) return { ok: false, reason: "git_status_failed", output: status.output };
-      dirtyEntries = parseGitStatusEntries(status.stdout);
-      blockingDirtyEntries = dirtyEntries.filter((entry) => !isGeneratedRunnerLedgerPath(entry.path));
-    }
-    const blockingDirtyFiles = blockingDirtyEntries.map((entry) => entry.path);
-    if (blockingDirtyFiles.length) {
-      return { ok: false, reason: "dirty_worktree", dirty_files: blockingDirtyFiles };
-    }
+    const clean = await cleanPreappliedOwnedPatch({
+      cwd,
+      env: submitterEnv,
+      runProcess,
+      changedFiles: normalizedChanged,
+    });
+    if (!clean.ok) return clean;
 
     const todoId = safeSlug(job?.todo_id || job?.id || job?.job_id || safeStamp(now));
     const branch = branchName || `${DEFAULT_SUBMITTER_BRANCH_PREFIX}-${todoId}`;

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -337,6 +337,89 @@ describe("draft PR coderoom binding", () => {
     );
     assert.equal(calls[2][2], true);
   });
+
+  test("restores a pre-applied owned docs patch before draft PR creation", async () => {
+    const calls = [];
+    let statusCalls = 0;
+    const coderoom = createDraftPrCoderoom({
+      branchName: "codex/openhands-proof-test",
+      runProcess: async (command, args, options = {}) => {
+        calls.push([command, args, Boolean(options.stdin)]);
+        if (command === "git" && args[0] === "status") {
+          statusCalls += 1;
+          return {
+            ok: true,
+            stdout: statusCalls === 1 ? ` M ${FIXTURE}\n` : "",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "gh") {
+          return { ok: true, stdout: "https://github.com/malamutemayhem/unclick/pull/903\n", stderr: "", output: "" };
+        }
+        if (command === "git" && args[0] === "rev-parse") {
+          return { ok: true, stdout: "def456\n", stderr: "", output: "" };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await coderoom({
+      job: { todo_id: "todo-1", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: draft-pr-restore-test" }),
+      summary: "Docs-only proof.",
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/903");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 3).join(" ")}`),
+      [
+        "git status --porcelain",
+        "git restore --worktree --",
+        "git status --porcelain",
+        "git checkout -b codex/openhands-proof-test",
+        "git apply --whitespace=nowarn -",
+        "git add docs/openhands-proof-fixture.md",
+        "git commit -m test(autopilot): prove OpenHands docs patch path",
+        "git push -u origin",
+        "gh pr create --draft",
+        "git rev-parse HEAD",
+      ],
+    );
+    assert.equal(calls[4][2], true);
+  });
+
+  test("does not restore untracked dirty files before draft PR creation", async () => {
+    const calls = [];
+    const coderoom = createDraftPrCoderoom({
+      branchName: "codex/openhands-proof-test",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          return { ok: true, stdout: `?? ${FIXTURE}\n`, stderr: "", output: "" };
+        }
+        throw new Error(`unexpected command ${command} ${args.join(" ")}`);
+      },
+    });
+
+    const result = await coderoom({
+      job: { todo_id: "todo-1", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: draft-pr-untracked-test" }),
+      summary: "Docs-only proof.",
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "dirty_worktree");
+    assert.deepEqual(result.dirty_files, [FIXTURE]);
+    assert.deepEqual(calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`), [
+      "git status --porcelain",
+    ]);
+  });
 });
 
 describe("safe CodeRoom submitter", () => {


### PR DESCRIPTION
## Summary
- reuse the owned-file cleanup before both CodeRoom submitter paths
- allow the live draft PR canary to restore a tracked pre-applied owned docs patch before applying the trusted patch
- keep fail-closed behavior for untracked dirty files

## Verification
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check
- npm test
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner/git hygiene only in test/autopilot scripts with expanded unit coverage; no production auth or app runtime paths changed.
> 
> **Overview**
> Extracts shared **owned-patch worktree cleanup** into `cleanPreappliedOwnedPatch` and runs it before both **draft PR** creation and the **safe CodeRoom submitter**, instead of failing immediately on any dirty tree.
> 
> For dirtiness limited to **patch-owned** paths, the flow **restores** tracked changes and **`git clean`s** untracked owned files, then re-checks status; **unrelated** dirty files still return **`dirty_worktree`** fail-closed. Generated **`.pinballwake` ledger** paths stay ignored. Draft PR creation gets a dedicated restore failure reason.
> 
> Adds unit tests for draft PR: pre-applied owned restore, untracked owned clean, and refusing unrelated untracked files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208d29855a1654bbec31edc7f096997d14ba3846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->