### PR TITLE
fix(commonsensepass): build package before app deploy

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6900,7 +6900,7 @@
     ],
     [
       "build",
-      "vite build"
+      "npm run build --workspace=@unclick/commonsensepass && vite build"
     ],
     [
       "build:dev",
@@ -7018,8 +7018,8 @@
     },
     {
       "source": "package.json",
-      "hash": "e6096faac8c4",
-      "bytes": 4380
+      "hash": "f416df3bc693",
+      "bytes": 4434
     },
     {
       "source": "seed/skills/agent-handoff-packet-writer.skill.md",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -29,7 +29,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/lib/skillLibrarySeeds.ts | 51ca658707f8 | 652 |
 | .github/workflows/ci.yml | b0a209c9c627 | 1559 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
-| package.json | e6096faac8c4 | 4380 |
+| package.json | f416df3bc693 | 4434 |
 | seed/skills/agent-handoff-packet-writer.skill.md | f9c498e48796 | 938 |
 | seed/skills/browser-qa-tester.skill.md | b57ce8b2e63a | 1115 |
 | seed/skills/builder-implementation-packet.skill.md | 1fcda17af905 | 1276 |
@@ -1121,7 +1121,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | --- | --- |
 | brainmap:check | node scripts/UnClick-brainmap.mjs --check |
 | brainmap:generate | node scripts/UnClick-brainmap.mjs |
-| build | vite build |
+| build | npm run build --workspace=@unclick/commonsensepass && vite build |
 | build:dev | vite build --mode development |
 | lint | eslint . |
 | test | vitest run |

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "vite",
     "dev:api": "npm run dev --workspace=apps/api",
-    "build": "vite build",
+    "build": "npm run build --workspace=@unclick/commonsensepass && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/packages/commonsensepass/package.json
+++ b/packages/commonsensepass/package.json
@@ -40,6 +40,7 @@
     }
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc --project tsconfig.json",
     "dogfood": "npm run build && node ../../scripts/build-commonsensepass-dogfood.mjs",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Build @unclick/commonsensepass before the root Vercel app build so /api/mcp can import its dist entry at runtime.
- Add a prepare script to the CommonSensePass package for package lifecycle consistency.

## Proof
- npm run build
- npm test -- --testTimeout=15000
- npm test --workspace=@unclick/commonsensepass
- npm run build --workspace=@unclick/mcp-server
- git diff --check

## Why
Production /api/mcp returned FUNCTION_INVOCATION_FAILED after CommonSensePass merged because the root app build did not guarantee packages/commonsensepass/dist existed for the MCP server import.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-order and npm lifecycle changes only; no runtime auth, data, or API behavior changes beyond fixing missing dist on deploy.
> 
> **Overview**
> The root **`build`** script now runs **`@unclick/commonsensepass`** before **`vite build`**, so production deploys (e.g. Vercel) always have **`packages/commonsensepass/dist`** available when **`/api/mcp`** imports the package—addressing **`FUNCTION_INVOCATION_FAILED`** when only the app was built.
> 
> **`@unclick/commonsensepass`** gains a **`prepare`** hook that runs **`build`** on install for consistent workspace lifecycle behavior. Generated brainmap docs were refreshed to record the updated **`build`** command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d91e84066cabd9cc23e2bff5c0820655317ce37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->