### PR TITLE
fix(vercel): build CommonSensePass before website

### DIFF
--- a/api/mcp-runtime-dependencies.test.ts
+++ b/api/mcp-runtime-dependencies.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("/api/mcp runtime workspace dependencies", () => {
+  const rootPackageJson = JSON.parse(
+    readFileSync(path.resolve(process.cwd(), "package.json"), "utf8"),
+  ) as {
+    dependencies?: Record<string, string>;
+    scripts?: Record<string, string>;
+  };
+
+  it("keeps CommonSensePass available to the Vercel serverless bundle", () => {
+    expect(rootPackageJson.dependencies?.["@unclick/commonsensepass"]).toBe("*");
+    expect(rootPackageJson.scripts?.build).toMatch(
+      /build --workspace=@unclick\/commonsensepass/,
+    );
+    expect(rootPackageJson.scripts?.["build:dev"]).toMatch(
+      /build --workspace=@unclick\/commonsensepass/,
+    );
+  });
+});

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -6900,11 +6900,11 @@
     ],
     [
       "build",
-      "vite build"
+      "npm run build --workspace=@unclick/commonsensepass && vite build"
     ],
     [
       "build:dev",
-      "vite build --mode development"
+      "npm run build --workspace=@unclick/commonsensepass && vite build --mode development"
     ],
     [
       "lint",
@@ -7018,8 +7018,8 @@
     },
     {
       "source": "package.json",
-      "hash": "e6096faac8c4",
-      "bytes": 4380
+      "hash": "63c99124a722",
+      "bytes": 4525
     },
     {
       "source": "seed/skills/agent-handoff-packet-writer.skill.md",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -29,7 +29,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/lib/skillLibrarySeeds.ts | 51ca658707f8 | 652 |
 | .github/workflows/ci.yml | b0a209c9c627 | 1559 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
-| package.json | e6096faac8c4 | 4380 |
+| package.json | 63c99124a722 | 4525 |
 | seed/skills/agent-handoff-packet-writer.skill.md | f9c498e48796 | 938 |
 | seed/skills/browser-qa-tester.skill.md | b57ce8b2e63a | 1115 |
 | seed/skills/builder-implementation-packet.skill.md | 1fcda17af905 | 1276 |
@@ -1121,8 +1121,8 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | --- | --- |
 | brainmap:check | node scripts/UnClick-brainmap.mjs --check |
 | brainmap:generate | node scripts/UnClick-brainmap.mjs |
-| build | vite build |
-| build:dev | vite build --mode development |
+| build | npm run build --workspace=@unclick/commonsensepass && vite build |
+| build:dev | npm run build --workspace=@unclick/commonsensepass && vite build --mode development |
 | lint | eslint . |
 | test | vitest run |
 | test:api | npm run test --workspace=apps/api |

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@supabase/supabase-js": "^2.101.1",
         "@tanstack/react-query": "^5.100.10",
+        "@unclick/commonsensepass": "*",
         "@vercel/analytics": "^2.0.1",
         "ai": "^6.0.168",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "dev": "vite",
     "dev:api": "npm run dev --workspace=apps/api",
-    "build": "vite build",
-    "build:dev": "vite build --mode development",
+    "build": "npm run build --workspace=@unclick/commonsensepass && vite build",
+    "build:dev": "npm run build --workspace=@unclick/commonsensepass && vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
@@ -66,6 +66,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/supabase-js": "^2.101.1",
     "@tanstack/react-query": "^5.100.10",
+    "@unclick/commonsensepass": "*",
     "@vercel/analytics": "^2.0.1",
     "ai": "^6.0.168",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- build @unclick/commonsensepass before the Vercel website build
- add the workspace package as a root dependency so the MCP function import resolves in production

## Proof
- npm run build
- npm run test --workspace=@unclick/mcp-server
- local /api/mcp initialize probe returns HTTP 200 SSE after the package build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/build-script and dependency wiring only; no runtime auth or business-logic changes beyond ensuring the MCP bundle can import the workspace package.
> 
> **Overview**
> **Vercel/MCP production builds** now compile `@unclick/commonsensepass` before the Vite site so serverless handlers that import it resolve at deploy time.
> 
> Root `package.json` and lockfile add `@unclick/commonsensepass` as a workspace dependency (`*`), and `build` / `build:dev` prepend `npm run build --workspace=@unclick/commonsensepass`. Generated brainmap artifacts reflect the new script commands. A Vitest guard in `api/mcp-runtime-dependencies.test.ts` asserts the dependency and build-script wiring stay in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad466893f9f371b4746b6e69bafd254621338c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->