### PR TITLE
fix(coderoom): ignore generated ledger directory

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -67,7 +67,11 @@ function parseGitStatusEntries(output) {
 }
 
 function isGeneratedRunnerLedgerPath(path) {
-  return normalizePath(path) === ".pinballwake/coding-room-ledger.json";
+  const normalized = normalizePath(path).replace(/\/+$/, "");
+  return (
+    normalized === ".pinballwake" ||
+    normalized === ".pinballwake/coding-room-ledger.json"
+  );
 }
 
 function normalizeList(values) {

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -510,6 +510,49 @@ describe("safe CodeRoom submitter", () => {
     );
   });
 
+  test("ignores the generated autonomous runner ledger directory entry", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-ledger-dir",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          return {
+            ok: true,
+            stdout: "?? .pinballwake/\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/934\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-ledger-dir", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: ledger dir ignored" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/934");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      ["git status --porcelain", "gh pr list"],
+    );
+  });
+
   test("restores a pre-applied owned patch before CodeRoom submit", async () => {
     const calls = [];
     let statusCalls = 0;


### PR DESCRIPTION
Fixes the live autonomous runner hold where CodeRoom rejected an otherwise-owned docs patch because Git reported the generated runner state as \.pinballwake/\.\n\nProof:\n- node --test scripts\\pinballwake-openhands-proof-runner.test.mjs scripts\\pinballwake-openhands-worker.test.mjs scripts\\pinballwake-autonomous-runner.test.mjs\n- npm run brainmap:check\n- git diff --check origin/main...HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to dirty-worktree filtering in the OpenHands/CodeRoom proof runner plus a regression test; no auth or production deploy paths.
> 
> **Overview**
> **CodeRoom’s safe submitter** no longer treats an untracked **`.pinballwake/`** directory as a dirty worktree blocker. **`isGeneratedRunnerLedgerPath`** now normalizes trailing slashes and ignores both **`.pinballwake`** and **`.pinballwake/coding-room-ledger.json`**, so autonomous runner state in that folder does not block an otherwise valid owned patch submit.
> 
> A new unit test covers **`git status`** showing **`?? .pinballwake/`** and expects the submitter to proceed to **`gh pr list`** (existing PR path) instead of failing with **`dirty_worktree`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef8b5cc8d8dc4b74a57fbf3940b9e6766c65185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->