### PR TITLE
fix(coderoom): ignore generated ledger dir

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -66,8 +66,13 @@ function parseGitStatusEntries(output) {
     .filter((entry) => entry.path);
 }
 
+function normalizeGitStatusPath(value) {
+  return normalizePath(value).replace(/\/+$/, "");
+}
+
 function isGeneratedRunnerLedgerPath(path) {
-  return normalizePath(path) === ".pinballwake/coding-room-ledger.json";
+  const normalizedPath = normalizeGitStatusPath(path);
+  return normalizedPath === ".pinballwake/coding-room-ledger.json" || normalizedPath === ".pinballwake";
 }
 
 function normalizeList(values) {

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -510,6 +510,49 @@ describe("safe CodeRoom submitter", () => {
     );
   });
 
+  test("ignores the generated autonomous runner ledger directory during clean-worktree checks", async () => {
+    const calls = [];
+    const submitter = createSafeCodeRoomSubmitter({
+      env: { CODEROOM_GITHUB_APP_TOKEN: "app-token" },
+      branchName: "codex/openhands-submit-todo-ledger-dir",
+      runProcess: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "git" && args[0] === "status") {
+          return {
+            ok: true,
+            stdout: "?? .pinballwake/\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        if (command === "gh" && args[1] === "list") {
+          return {
+            ok: true,
+            stdout: "https://github.com/malamutemayhem/unclick/pull/935\n",
+            stderr: "",
+            output: "",
+          };
+        }
+        return { ok: true, stdout: "", stderr: "", output: "" };
+      },
+    });
+
+    const result = await submitter({
+      job: { todo_id: "todo-ledger-dir", owned_files: [FIXTURE] },
+      changedFiles: [FIXTURE],
+      patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: ledger directory ignored" }),
+      testRunId: "unit-test",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "existing_pr");
+    assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/935");
+    assert.deepEqual(
+      calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
+      ["git status --porcelain", "gh pr list"],
+    );
+  });
+
   test("restores a pre-applied owned patch before CodeRoom submit", async () => {
     const calls = [];
     let statusCalls = 0;


### PR DESCRIPTION
Summary: Treat generated .pinballwake ledger directory status entries as runner evidence, same as the ledger file. Adds a regression test for the live dirty-worktree blocker shape. Proof: node runner tests passed, brainmap check passed, brainmap tests passed, git diff check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to git-status filtering for the proof/submit runner; no auth, data, or production paths touched.
> 
> **Overview**
> The OpenHands **CodeRoom submitter** no longer treats an untracked **`.pinballwake/`** directory as a dirty worktree blocker. Path normalization now strips trailing slashes and classifies both **`.pinballwake/coding-room-ledger.json`** and **`.pinballwake`** as generated runner evidence, matching how the ledger file was already ignored.
> 
> A unit test covers **`?? .pinballwake/`** in `git status --porcelain` so submit can proceed to the existing-PR path instead of failing on runner-local artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e37a539cf404dfe19523a3c05d4517e9c61b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->