### PR TITLE
fix(coderoom): configure submitter git identity

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -13,6 +13,8 @@ const DEFAULT_SUBMITTER_BRANCH_PREFIX = "codex/openhands-submit";
 const DEFAULT_TITLE = "test(autopilot): prove OpenHands docs patch path";
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
 const CODEROOM_APP_TOKEN_ENV_KEYS = ["CODEROOM_GITHUB_APP_TOKEN", "AUTONOMOUS_RUNNER_GITHUB_APP_TOKEN"];
+const DEFAULT_CODEROOM_GIT_USER_NAME = "UnClick Bot";
+const DEFAULT_CODEROOM_GIT_USER_EMAIL = "bot@unclick.world";
 
 export const DEFAULT_CODEROOM_PROTECTED_PATH_PATTERNS = [
   { reason: "protected_workflow_path", pattern: /^\.github\/workflows\//i },
@@ -93,6 +95,28 @@ function safeSlug(value, fallback = "job") {
     .replace(/^-+|-+$/g, "")
     .slice(0, 72);
   return slug || fallback;
+}
+
+function commandFailureReason(command, args = []) {
+  const parts = (args || []).map((arg) => String(arg || "").trim()).filter(Boolean);
+  let actionParts = [parts[0] || "command"];
+  if (command === "git" && actionParts[0] === "-c") {
+    actionParts = [parts[2] || "command"];
+  } else if (command === "git" && parts[0] === "apply" && parts.includes("--check")) {
+    actionParts = ["apply", "check"];
+  } else if (command === "git" && parts[0] === "diff" && parts.includes("--check")) {
+    actionParts = ["diff", "check"];
+  } else if (command === "git" && parts[0] === "config") {
+    actionParts = [parts[0], parts[1]].filter(Boolean);
+  } else if (command === "gh" && parts[0]) {
+    actionParts = [parts[0], parts[1]].filter(Boolean);
+  }
+  const action = actionParts.join("_");
+  return `${command}_${safeSlug(action, "command")}_failed`;
+}
+
+function scopedPushArgs(branch) {
+  return ["-c", "http.https://github.com/.extraheader=", "push", "-u", "origin", branch];
 }
 
 export function splitArgs(value) {
@@ -414,12 +438,16 @@ export function createDraftPrCoderoom({
         "No production data, secrets, deploy, billing, DNS, or auto-merge.",
       ].join("\n");
 
+    const identity = await configureCodeRoomGitIdentity({ cwd, env, runProcess });
+    if (!identity.ok) return identity;
+
     const commands = [
       ["git", ["checkout", "-b", branch]],
       ["git", ["apply", "--whitespace=nowarn", "-"], { stdin: patch }],
       ["git", ["add", ...normalizedChanged]],
       ["git", ["commit", "-m", title]],
-      ["git", ["push", "-u", "origin", branch]],
+      ["gh", ["auth", "setup-git"]],
+      ["git", scopedPushArgs(branch)],
       ["gh", ["pr", "create", "--draft", "--title", title, "--body", bodyText]],
     ];
 
@@ -429,7 +457,7 @@ export function createDraftPrCoderoom({
       if (!result.ok) {
         return {
           ok: false,
-          reason: `${command}_failed`,
+          reason: commandFailureReason(command, args),
           output: result.output,
         };
       }
@@ -527,6 +555,20 @@ async function cleanPreappliedOwnedPatch({
   return { ok: true };
 }
 
+async function configureCodeRoomGitIdentity({ cwd, env = process.env, runProcess = runProcessCommand } = {}) {
+  const name = String(env.CODEROOM_GIT_USER_NAME || DEFAULT_CODEROOM_GIT_USER_NAME).trim();
+  const email = String(env.CODEROOM_GIT_USER_EMAIL || DEFAULT_CODEROOM_GIT_USER_EMAIL).trim();
+  const nameResult = await runProcess("git", ["config", "user.name", name], { cwd, env });
+  if (!nameResult.ok) {
+    return { ok: false, reason: "git_config_user_name_failed", output: nameResult.output };
+  }
+  const emailResult = await runProcess("git", ["config", "user.email", email], { cwd, env });
+  if (!emailResult.ok) {
+    return { ok: false, reason: "git_config_user_email_failed", output: emailResult.output };
+  }
+  return { ok: true };
+}
+
 export function createSafeCodeRoomSubmitter({
   cwd = process.cwd(),
   env = process.env,
@@ -616,6 +658,9 @@ export function createSafeCodeRoomSubmitter({
         "Safety: protected paths rejected before branch creation; patch limited to owned files.",
       ].join("\n");
 
+    const identity = await configureCodeRoomGitIdentity({ cwd, env: submitterEnv, runProcess });
+    if (!identity.ok) return identity;
+
     const commands = [
       ["git", ["checkout", "-b", branch]],
       ["git", ["apply", "--check", "--whitespace=error", "-"], { stdin: patch }],
@@ -624,14 +669,14 @@ export function createSafeCodeRoomSubmitter({
       ["git", ["add", ...normalizedChanged]],
       ["git", ["commit", "-m", prTitle]],
       ["gh", ["auth", "setup-git"]],
-      ["git", ["push", "-u", "origin", branch]],
+      ["git", scopedPushArgs(branch)],
       ["gh", ["pr", "create", ...(draft ? ["--draft"] : []), "--title", prTitle, "--body", bodyText]],
     ];
 
     let prUrl = "";
     for (const [command, args, options = {}] of commands) {
       const result = await runProcess(command, args, { cwd, env: submitterEnv, ...options });
-      if (!result.ok) return { ok: false, reason: `${command}_failed`, output: result.output };
+      if (!result.ok) return { ok: false, reason: commandFailureReason(command, args), output: result.output };
       if (command === "gh" && args[1] === "create") prUrl = result.stdout.trim();
     }
 

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -326,16 +326,19 @@ describe("draft PR coderoom binding", () => {
       calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
       [
         "git status --porcelain",
+        "git config user.name",
+        "git config user.email",
         "git checkout -b",
         "git apply --whitespace=nowarn",
         "git add docs/openhands-proof-fixture.md",
         "git commit -m",
-        "git push -u",
+        "gh auth setup-git",
+        "git -c http.https://github.com/.extraheader=",
         "gh pr create",
         "git rev-parse HEAD",
       ],
     );
-    assert.equal(calls[2][2], true);
+    assert.equal(calls[4][2], true);
   });
 
   test("restores a pre-applied owned docs patch before draft PR creation", async () => {
@@ -380,16 +383,19 @@ describe("draft PR coderoom binding", () => {
         "git status --porcelain",
         "git restore --staged --worktree",
         "git status --porcelain",
+        "git config user.name UnClick Bot",
+        "git config user.email bot@unclick.world",
         "git checkout -b codex/openhands-proof-test",
         "git apply --whitespace=nowarn -",
         "git add docs/openhands-proof-fixture.md",
         "git commit -m test(autopilot): prove OpenHands docs patch path",
-        "git push -u origin",
+        "gh auth setup-git",
+        "git -c http.https://github.com/.extraheader= push",
         "gh pr create --draft",
         "git rev-parse HEAD",
       ],
     );
-    assert.equal(calls[4][2], true);
+    assert.equal(calls[6][2], true);
   });
 
   test("cleans an untracked patch-owned docs file before draft PR creation", async () => {
@@ -429,16 +435,19 @@ describe("draft PR coderoom binding", () => {
         "git status --porcelain",
         "git clean -f -- docs/openhands-proof-fixture.md",
         "git status --porcelain",
+        "git config user.name UnClick Bot",
+        "git config user.email bot@unclick.world",
         "git checkout -b codex/openhands-proof-test",
         "git apply --whitespace=nowarn -",
         "git add docs/openhands-proof-fixture.md",
         "git commit -m test(autopilot): prove OpenHands docs patch path",
-        "git push -u origin codex/openhands-proof-test",
+        "gh auth setup-git",
+        "git -c http.https://github.com/.extraheader= push -u",
         "gh pr create --draft --title",
         "git rev-parse HEAD",
       ],
     );
-    assert.equal(calls[4][2], true);
+    assert.equal(calls[6][2], true);
   });
 
   test("does not clean unrelated untracked files before draft PR creation", async () => {
@@ -847,6 +856,8 @@ describe("safe CodeRoom submitter", () => {
       [
         "git status --porcelain",
         "gh pr list --head",
+        "git config user.name UnClick Bot",
+        "git config user.email bot@unclick.world",
         "git checkout -b codex/openhands-submit-todo-2",
         "git apply --check --whitespace=error",
         "git apply --whitespace=nowarn -",
@@ -854,14 +865,14 @@ describe("safe CodeRoom submitter", () => {
         "git add docs/openhands-proof-fixture.md",
         "git commit -m docs: submit OpenHands patch",
         "gh auth setup-git",
-        "git push -u origin",
+        "git -c http.https://github.com/.extraheader= push",
         "gh pr create --title",
         "git rev-parse HEAD",
         "gh pr merge --auto",
       ],
     );
-    assert.equal(calls[3][2], true);
-    assert.equal(calls[4][2], true);
+    assert.equal(calls[5][2], true);
+    assert.equal(calls[6][2], true);
     assert.ok(calls.every((call) => call[3] === "app-token" && call[4] === "app-token"));
   });
 
@@ -889,11 +900,18 @@ describe("safe CodeRoom submitter", () => {
     });
 
     assert.equal(result.ok, false);
-    assert.equal(result.reason, "git_failed");
+    assert.equal(result.reason, "git_apply_check_failed");
     assert.match(result.output, /patch does not apply/);
     assert.deepEqual(
       calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
-      ["git status --porcelain", "gh pr list", "git checkout -b", "git apply --check"],
+      [
+        "git status --porcelain",
+        "gh pr list",
+        "git config user.name",
+        "git config user.email",
+        "git checkout -b",
+        "git apply --check",
+      ],
     );
   });
 });

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -173,6 +173,7 @@ export async function runOpenHandsWorker({
       evidence: {
         reason: coderoomResult?.reason ?? "unknown",
         file: coderoomResult?.file ?? null,
+        output: clipOutput(coderoomResult?.output, 1200),
         dirty_files: normalizeChangedFiles(coderoomResult?.dirty_files || []),
         changed_files: changedFiles,
       },

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -284,6 +284,29 @@ describe("runOpenHandsWorker", () => {
     assert.deepEqual(result.receipt.evidence.dirty_files, ["docs/openhands-proof-fixture.md"]);
   });
 
+  test("includes clipped command output when coderoom rejects a patch", async () => {
+    const output = `${"checking patch\n".repeat(200)}FINAL ERROR: missing git user.name`;
+    const result = await runOpenHandsWorker({
+      job: job(),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async () => ({ ok: true, patch: patchFor("docs/openhands-proof-fixture.md") }),
+      coderoom: async () => ({
+        ok: false,
+        reason: "git_commit_failed",
+        output,
+      }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "coderoom_rejected_patch");
+    assert.equal(result.receipt.evidence.reason, "git_commit_failed");
+    assert.match(result.receipt.evidence.output, /checking patch/);
+    assert.match(result.receipt.evidence.output, /omitted \d+ chars/);
+    assert.match(result.receipt.evidence.output, /FINAL ERROR: missing git user.name/);
+  });
+
   test("default coderoom submit enforces owned files", async () => {
     const result = await runOpenHandsWorker({
       job: job(),


### PR DESCRIPTION
## Summary
- configure the CodeRoom submitter git identity before commit creation
- push draft PR branches with the app token path instead of inheriting checkout credentials
- keep clearer rejection evidence when CodeRoom rejects a patch

## Tests
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated git commit/push and GitHub CLI auth wiring for CodeRoom PR submission; mistakes could break autopilot PR creation or use wrong credentials, but scope is limited to runner scripts.
> 
> **Overview**
> CodeRoom **draft PR** and **safe submitter** flows now set a dedicated git author (`UnClick Bot` / `bot@unclick.world`, overridable via `CODEROOM_GIT_USER_*`) before commit, run **`gh auth setup-git`**, and push with a **scoped git config** that clears `http.https://github.com/.extraheader` so branches use the app-token path instead of checkout credentials.
> 
> Command failures return **action-specific reasons** (e.g. `git_apply_check_failed`) instead of generic `*_failed`. When CodeRoom rejects a patch, the OpenHands worker **includes clipped command output** in hold evidence for easier debugging.
> 
> Tests were updated to match the new command order and failure shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b48a5453b7e8d7c26d91cb6542038f9996d1a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->