### PR TITLE
fix(coderoom): set submitter git identity

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -13,6 +13,8 @@ const DEFAULT_SUBMITTER_BRANCH_PREFIX = "codex/openhands-submit";
 const DEFAULT_TITLE = "test(autopilot): prove OpenHands docs patch path";
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
 const CODEROOM_APP_TOKEN_ENV_KEYS = ["CODEROOM_GITHUB_APP_TOKEN", "AUTONOMOUS_RUNNER_GITHUB_APP_TOKEN"];
+const DEFAULT_CODEROOM_GIT_USER_NAME = "github-actions[bot]";
+const DEFAULT_CODEROOM_GIT_USER_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com";
 
 export const DEFAULT_CODEROOM_PROTECTED_PATH_PATTERNS = [
   { reason: "protected_workflow_path", pattern: /^\.github\/workflows\//i },
@@ -41,6 +43,10 @@ export function compactOutput(value, max = 2000) {
   const head = Math.ceil(budget * 0.35);
   const tail = Math.max(0, budget - head);
   return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`;
+}
+
+function describeCommand(command, args = []) {
+  return [command, ...args.slice(0, 3)].join(" ").trim();
 }
 
 function normalizePath(value) {
@@ -622,6 +628,8 @@ export function createSafeCodeRoomSubmitter({
       ["git", ["apply", "--whitespace=nowarn", "-"], { stdin: patch }],
       ["git", ["diff", "--check"]],
       ["git", ["add", ...normalizedChanged]],
+      ["git", ["config", "user.name", DEFAULT_CODEROOM_GIT_USER_NAME]],
+      ["git", ["config", "user.email", DEFAULT_CODEROOM_GIT_USER_EMAIL]],
       ["git", ["commit", "-m", prTitle]],
       ["gh", ["auth", "setup-git"]],
       ["git", ["push", "-u", "origin", branch]],
@@ -631,7 +639,15 @@ export function createSafeCodeRoomSubmitter({
     let prUrl = "";
     for (const [command, args, options = {}] of commands) {
       const result = await runProcess(command, args, { cwd, env: submitterEnv, ...options });
-      if (!result.ok) return { ok: false, reason: `${command}_failed`, output: result.output };
+      if (!result.ok) {
+        return {
+          ok: false,
+          reason: `${command}_failed`,
+          output: result.output,
+          failed_step: describeCommand(command, args),
+          exit_code: result.exit_code ?? null,
+        };
+      }
       if (command === "gh" && args[1] === "create") prUrl = result.stdout.trim();
     }
 

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -852,6 +852,8 @@ describe("safe CodeRoom submitter", () => {
         "git apply --whitespace=nowarn -",
         "git diff --check",
         "git add docs/openhands-proof-fixture.md",
+        "git config user.name github-actions[bot]",
+        "git config user.email 41898282+github-actions[bot]@users.noreply.github.com",
         "git commit -m docs: submit OpenHands patch",
         "gh auth setup-git",
         "git push -u origin",
@@ -890,6 +892,7 @@ describe("safe CodeRoom submitter", () => {
 
     assert.equal(result.ok, false);
     assert.equal(result.reason, "git_failed");
+    assert.equal(result.failed_step, "git apply --check --whitespace=error");
     assert.match(result.output, /patch does not apply/);
     assert.deepEqual(
       calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -175,6 +175,9 @@ export async function runOpenHandsWorker({
         file: coderoomResult?.file ?? null,
         dirty_files: normalizeChangedFiles(coderoomResult?.dirty_files || []),
         changed_files: changedFiles,
+        failed_step: clip(coderoomResult?.failed_step, 200),
+        exit_code: coderoomResult?.exit_code ?? null,
+        output: clipOutput(coderoomResult?.output, 2000),
       },
     });
   }

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -276,12 +276,18 @@ describe("runOpenHandsWorker", () => {
         ok: false,
         reason: "dirty_worktree",
         dirty_files: ["docs/openhands-proof-fixture.md"],
+        failed_step: "git commit -m",
+        exit_code: 128,
+        output: "Author identity unknown",
       }),
     });
 
     assert.equal(result.ok, false);
     assert.equal(result.reason, "coderoom_rejected_patch");
     assert.deepEqual(result.receipt.evidence.dirty_files, ["docs/openhands-proof-fixture.md"]);
+    assert.equal(result.receipt.evidence.failed_step, "git commit -m");
+    assert.equal(result.receipt.evidence.exit_code, 128);
+    assert.match(result.receipt.evidence.output, /Author identity unknown/);
   });
 
   test("default coderoom submit enforces owned files", async () => {


### PR DESCRIPTION
Summary: Set a safe bot git author before CodeRoom commits in GitHub Actions, and carry failed git step/output into OpenHands hold evidence so live failures are readable. Proof: node runner tests passed (134), brainmap check passed, brainmap tests passed, git diff check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OpenHands/CodeRoom submit scripts and hold receipt fields; no production auth or data-path changes.
> 
> **Overview**
> The **CodeRoom safe submitter** now configures **`user.name`** and **`user.email`** to the standard **`github-actions[bot]`** identity immediately before **`git commit`**, so commits succeed in GitHub Actions when no local git author is set.
> 
> When a submitter pipeline step fails, failures now include **`failed_step`** (a short command label) and **`exit_code`** in addition to **`output`**. The **OpenHands worker** forwards those fields (plus clipped output) into **`coderoom_rejected_patch`** hold receipts so operators can see which git/gh step broke (e.g. apply check vs commit) without digging through logs.
> 
> Tests assert the new config steps in the happy path and **`failed_step`** on apply-check failure and in worker hold evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc010d3fe4bbe101a669967f346ac0f69fcd30d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->