### PR TITLE
fix(coderoom): preserve proof identity on reruns

### DIFF
--- a/scripts/pinballwake-openhands-proof-runner.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.mjs
@@ -115,6 +115,35 @@ function commandFailureReason(command, args = []) {
   return `${command}_${safeSlug(action, "command")}_failed`;
 }
 
+function resolveJobTodoId(job = {}) {
+  return String(
+    job?.todo_id ||
+      job?.todoId ||
+      job?.id ||
+      job?.source_state?.todo_id ||
+      job?.sourceState?.todo_id ||
+      "",
+  ).trim();
+}
+
+function parseExistingPr(stdout = "") {
+  const text = String(stdout || "").trim();
+  if (!text) return null;
+  if (/^https?:\/\//i.test(text)) return { url: text, headRefOid: null };
+  try {
+    const entries = JSON.parse(text);
+    const first = Array.isArray(entries) ? entries[0] : entries;
+    const url = String(first?.url || "").trim();
+    if (!url) return null;
+    return {
+      url,
+      headRefOid: String(first?.headRefOid || first?.head_sha_after || "").trim() || null,
+    };
+  } catch {
+    return { url: text, headRefOid: null };
+  }
+}
+
 function scopedPushArgs(branch) {
   return ["-c", "http.https://github.com/.extraheader=", "push", "-u", "origin", branch];
 }
@@ -624,20 +653,21 @@ export function createSafeCodeRoomSubmitter({
     });
     if (!clean.ok) return clean;
 
-    const todoId = safeSlug(job?.todo_id || job?.id || job?.job_id || safeStamp(now));
+    const displayTodoId = resolveJobTodoId(job);
+    const todoId = safeSlug(job?.todo_id || job?.id || job?.job_id || displayTodoId || safeStamp(now));
     const branch = branchName || `${DEFAULT_SUBMITTER_BRANCH_PREFIX}-${todoId}`;
     const existing = await runProcess(
       "gh",
-      ["pr", "list", "--head", branch, "--state", "open", "--json", "url", "--jq", ".[0].url // \"\""],
+      ["pr", "list", "--head", branch, "--state", "open", "--json", "url,headRefOid"],
       { cwd, env: submitterEnv },
     );
     if (!existing.ok) return { ok: false, reason: "gh_pr_list_failed", output: existing.output };
-    const existingUrl = existing.stdout.trim();
-    if (existingUrl) {
+    const existingPr = parseExistingPr(existing.stdout);
+    if (existingPr?.url) {
       return {
         ok: true,
-        pr_url: existingUrl,
-        head_sha_after: null,
+        pr_url: existingPr.url,
+        head_sha_after: existingPr.headRefOid,
         test_run_id: testRunId || null,
         test_exit_code: 0,
         status: "existing_pr",
@@ -651,7 +681,7 @@ export function createSafeCodeRoomSubmitter({
       [
         "OpenHands CodeRoom submitter PR.",
         "",
-        `Todo: ${job?.todo_id || job?.id || "unknown"}`,
+        `Todo: ${displayTodoId || "unknown"}`,
         `Summary: ${summary || "OpenHands produced a scoped patch."}`,
         `Test run: ${testRunId || "not supplied"}`,
         "",

--- a/scripts/pinballwake-openhands-proof-runner.test.mjs
+++ b/scripts/pinballwake-openhands-proof-runner.test.mjs
@@ -582,7 +582,12 @@ describe("safe CodeRoom submitter", () => {
         if (command === "gh" && args[1] === "list") {
           return {
             ok: true,
-            stdout: "https://github.com/malamutemayhem/unclick/pull/930\n",
+            stdout: JSON.stringify([
+              {
+                url: "https://github.com/malamutemayhem/unclick/pull/930",
+                headRefOid: "def456",
+              },
+            ]),
             stderr: "",
             output: "",
           };
@@ -602,6 +607,8 @@ describe("safe CodeRoom submitter", () => {
     assert.equal(result.status, "existing_pr");
     assert.equal(result.idempotent, true);
     assert.equal(result.pr_url, "https://github.com/malamutemayhem/unclick/pull/930");
+    assert.equal(result.head_sha_after, "def456");
+    assert.ok(calls[1][1].includes("url,headRefOid"));
     assert.deepEqual(
       calls.map(([command, args]) => `${command} ${args.slice(0, 2).join(" ")}`),
       ["git status --porcelain", "gh pr list"],
@@ -841,7 +848,7 @@ describe("safe CodeRoom submitter", () => {
     });
 
     const result = await submitter({
-      job: { todo_id: "todo-2", owned_files: [FIXTURE] },
+      job: { source_state: { todo_id: "todo-2" }, owned_files: [FIXTURE] },
       changedFiles: [FIXTURE],
       patch: buildDocsOnlyFixturePatch({ filePath: FIXTURE, proofLine: "- proof run: auto-merge" }),
       summary: "Docs-only submitter proof.",
@@ -851,6 +858,8 @@ describe("safe CodeRoom submitter", () => {
     assert.equal(result.ok, true);
     assert.equal(result.status, "pr_created_auto_merge_enabled");
     assert.equal(result.auto_merge_enabled, true);
+    const createCall = calls.find(([command, args]) => command === "gh" && args[1] === "create");
+    assert.match(createCall?.[1].join("\n") || "", /Todo: todo-2/);
     assert.deepEqual(
       calls.map(([command, args]) => `${command} ${args.slice(0, 3).join(" ")}`),
       [

--- a/scripts/pinballwake-openhands-worker.mjs
+++ b/scripts/pinballwake-openhands-worker.mjs
@@ -208,7 +208,7 @@ export function buildOpenHandsTaskPrompt({ job = {}, scopePack = {} } = {}) {
     "Return a unified diff patch only. Do not commit, push, merge, deploy, or touch secrets.",
     `Job: ${compact(job.title || job.job_id || job.id || "untitled job", 300)}`,
     `Chip: ${compact(job.chip || "none", 300)}`,
-    `Todo: ${job.todo_id || job.id || "unknown"}`,
+    `Todo: ${resolveJobTodoId(job) || "unknown"}`,
     "Owned files:",
     ...ownedFiles.map((file) => `- ${file}`),
     "Acceptance:",
@@ -241,8 +241,7 @@ function buildFixtureDiffHint({ job = {}, ownedFiles = [] } = {}) {
   const proofId = compact(
     job.claim_id ||
       job.claimId ||
-      job.todo_id ||
-      job.id ||
+      resolveJobTodoId(job) ||
       job.job_id ||
       "openhands-afk-canary",
     160,
@@ -309,6 +308,7 @@ async function defaultCoderoomSubmit({ job, changedFiles, summary, testRunId }) 
 }
 
 function pass({ job, executorSeatId, now, evidence }) {
+  const todoId = resolveJobTodoId(job);
   return {
     ok: true,
     reason: "openhands_worker_pass",
@@ -316,7 +316,7 @@ function pass({ job, executorSeatId, now, evidence }) {
       receipt_type: RECEIPT_TYPE_PASS,
       emitted_at: now.toISOString(),
       job_id: job?.job_id ?? null,
-      todo_id: job?.todo_id ?? job?.id ?? null,
+      todo_id: todoId || null,
       executor_seat_id: executorSeatId,
       evidence,
       proof_required: PROOF_REQUIRED,
@@ -327,6 +327,7 @@ function pass({ job, executorSeatId, now, evidence }) {
 }
 
 function hold({ job, executorSeatId, now, reason, evidence }) {
+  const todoId = resolveJobTodoId(job);
   return {
     ok: false,
     reason,
@@ -334,7 +335,7 @@ function hold({ job, executorSeatId, now, reason, evidence }) {
       receipt_type: RECEIPT_TYPE_HOLD,
       emitted_at: now.toISOString(),
       job_id: job?.job_id ?? null,
-      todo_id: job?.todo_id ?? job?.id ?? null,
+      todo_id: todoId || null,
       executor_seat_id: executorSeatId,
       hold_reason: reason,
       evidence,
@@ -368,6 +369,17 @@ function normalizeJob(job, scopePack) {
       requires_tests: true,
     },
   };
+}
+
+function resolveJobTodoId(job = {}) {
+  return String(
+    job?.todo_id ||
+      job?.todoId ||
+      job?.id ||
+      job?.source_state?.todo_id ||
+      job?.sourceState?.todo_id ||
+      "",
+  ).trim();
 }
 
 function normalizeChangedFiles(values) {

--- a/scripts/pinballwake-openhands-worker.test.mjs
+++ b/scripts/pinballwake-openhands-worker.test.mjs
@@ -119,6 +119,34 @@ describe("runOpenHandsWorker", () => {
     assert.equal(coderoomCalls, 1);
   });
 
+  test("uses Boardroom source todo id in prompt and pass receipt", async () => {
+    let promptText = "";
+    const result = await runOpenHandsWorker({
+      job: job({
+        todo_id: undefined,
+        source_state: { todo_id: "boardroom-source-todo" },
+      }),
+      scopePack: scopePack(),
+      testMode: true,
+      now: NOW,
+      openHands: async ({ prompt }) => {
+        promptText = prompt;
+        return { ok: true, patch: patchFor(), test_run_id: "unit-test", test_exit_code: 0 };
+      },
+      coderoom: async () => ({
+        ok: true,
+        pr_url: "https://github.com/malamutemayhem/unclick/pull/874",
+        head_sha_after: "source123",
+        test_run_id: "unit-test",
+        test_exit_code: 0,
+      }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(promptText, /Todo: boardroom-source-todo/);
+    assert.equal(result.receipt.todo_id, "boardroom-source-todo");
+  });
+
   test("returns HOLD when test mode is not enabled", async () => {
     const result = await runOpenHandsWorker({
       job: job(),


### PR DESCRIPTION
## Summary
- keep Boardroom todo ids in OpenHands prompts, receipts, and PR body text
- read existing draft PR head SHAs on idempotent reruns instead of returning null
- keep the existing branch lookup stable so reruns find the same draft PR

## Tests
- node --test scripts/pinballwake-openhands-proof-runner.test.mjs scripts/pinballwake-openhands-worker.test.mjs scripts/pinballwake-writerlane-free-writer.test.mjs scripts/pinballwake-autonomous-runner.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OpenHands/CodeRoom test-mode automation and PR metadata; no auth or production data paths, with behavior covered by unit tests.
> 
> **Overview**
> Unifies **Boardroom todo identity** across the OpenHands worker and CodeRoom submitter so reruns keep the same proof context instead of falling back to job ids or `"unknown"`.
> 
> A shared **`resolveJobTodoId`** now reads `todo_id` / `todoId` / `id` and nested **`source_state.todo_id`** (and camelCase variant). That value drives OpenHands **prompts**, **pass/hold receipts**, fixture **proof-line** hints, and submitter **PR body** text.
> 
> On **idempotent** submit paths, **`gh pr list`** now requests **`url,headRefOid`**; **`parseExistingPr`** parses JSON (or legacy plain URL) and returns **`head_sha_after`** on existing-PR short-circuit instead of `null`, so downstream proof can anchor to the draft head SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef34d60ae6790cba7aed1f20bafe2afd6cfccf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->