### PR TITLE
fix(xpass): add package dogfood sweep

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -9,7 +9,7 @@ What's automated, what secrets are required, and what to do when something goes 
 | `ci.yml` | PRs + push to main | Lint + build the website, typecheck + build the MCP server |
 | `testpass-pr-check.yml` | PRs | Runs the shared TestPass action against the MCP endpoint under test and posts a receipt summary |
 | `testpass-scheduled-smoke.yml` | Every 5 minutes + manual dispatch | Runs scheduled TestPass smoke with explicit token precedence and fail-closed infra reporting |
-| `dogfood-report.yml` | Nightly schedule + manual dispatch | Rebuilds `public/dogfood/latest.json` with honest passing / blocked / pending proof status |
+| `dogfood-report.yml` | Nightly schedule + manual dispatch | Rebuilds `public/dogfood/latest.json`, `public/dogfood/xpass-package-sweep.json`, and `public/dogfood/uxpass-site-sweep.json` with honest passing / blocked / pending proof status |
 | `event-wake-router.yml` | `issue_comment` + workflow fan-in | Routes ready-work wake events without waking healthy quiet cycles |
 | `auto-close-fishbowl-todo.yml` | PR merge hooks | Closes linked Fishbowl todos when a merged PR satisfies them |
 | `publish-mcp-package.yml` | Push to main touching `packages/mcp-server/**` | Bumps patch version and publishes the MCP server GitHub Release tarball |
@@ -59,12 +59,17 @@ Nightly dogfood splits the proof lanes on purpose:
 |---|---|---|
 | TestPass | `TESTPASS_TOKEN` | Exported into the script as `DOGFOOD_TESTPASS_TOKEN`; no cron fallback in the current workflow |
 | UXPass | `UXPASS_TOKEN`, then `CRON_SECRET` | Exported into the script as `DOGFOOD_UXPASS_TOKEN`; a blocked receipt is expected if neither secret exists |
+| XPass package sweep | none | Runs local package tests for TestPass, UXPass, SecurityPass, SlopPass, SEOPass, CopyPass, LegalPass, CommonSensePass, FlowPass, and GEOPass before `latest.json` is built |
 
 The public receipt at `public/dogfood/latest.json` should stay honest:
 
-- `passing` only when the live scheduled check actually completed.
+- `passing` only when the live scheduled check or scheduled XPass package sweep actually completed.
 - `blocked` when the workflow cannot run because a secret path is missing.
 - `pending` for proof families that are intentionally scaffolded but not live yet.
+
+`public/dogfood/xpass-package-sweep.json` is deliberately public-safe. It stores package names, commands, statuses,
+run IDs, and cross-pass reviewers, but not raw command output or secrets. SecurityPass can pass its local package proof
+while still staying `blocked` in `latest.json` until safe recurring security probes exist.
 
 ## Runtime env vars
 

--- a/.github/workflows/dogfood-report.yml
+++ b/.github/workflows/dogfood-report.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build XPass package sweep receipt
+        env:
+          DOGFOOD_TARGET_SHA: ${{ github.sha }}
+        run: node scripts/build-xpass-package-sweep.mjs --output public/dogfood/xpass-package-sweep.json --target-sha "$GITHUB_SHA"
+
       - name: Build receipt
         env:
           DOGFOOD_API_BASE: https://unclick.world
@@ -41,6 +49,7 @@ jobs:
           DOGFOOD_MCP_URL: ${{ inputs.mcp_url || 'https://unclick.world/api/mcp' }}
           DOGFOOD_TESTPASS_TOKEN: ${{ secrets.TESTPASS_TOKEN }}
           DOGFOOD_UXPASS_TOKEN: ${{ secrets.UXPASS_TOKEN || secrets.CRON_SECRET }}
+          DOGFOOD_TARGET_SHA: ${{ github.sha }}
         run: node scripts/build-dogfood-report.mjs
 
       - name: Build UXPass site sweep receipt
@@ -58,6 +67,7 @@ jobs:
           name: dogfood-latest
           path: |
             public/dogfood/latest.json
+            public/dogfood/xpass-package-sweep.json
             public/dogfood/uxpass-site-sweep.json
 
       - name: Summarize receipt
@@ -70,11 +80,14 @@ jobs:
             echo "- Status: \`$(jq -r '.status // \"unknown\"' public/dogfood/latest.json)\`"
             echo "- Source: \`$(jq -r '.source // \"unknown\"' public/dogfood/latest.json)\`"
             echo "- Output: \`public/dogfood/latest.json\`"
+            echo "- XPass package sweep: \`$(jq -r '.status // \"unknown\"' public/dogfood/xpass-package-sweep.json)\` across \`$(jq -r '.packages | length' public/dogfood/xpass-package-sweep.json)\` package(s)"
             echo "- UXPass site sweep: \`$(jq -r '.status // \"unknown\"' public/dogfood/uxpass-site-sweep.json)\` across \`$(jq -r '.targets | length' public/dogfood/uxpass-site-sweep.json)\` URL(s)"
             echo "- Public URL: \`${{ inputs.public_url || 'https://unclick.world' }}\`"
             echo "- MCP URL: \`${{ inputs.mcp_url || 'https://unclick.world/api/mcp' }}\`"
             echo ""
             jq -r '.results[] | "- \(.name): \(.status) - \(.summary)\(if .blockedReason then " Blocked reason: \(.blockedReason)" else "" end)"' public/dogfood/latest.json
+            echo ""
+            jq -r '.packages[] | "- XPass package \(.name): \(.status) - \(.summary)"' public/dogfood/xpass-package-sweep.json
             echo ""
             jq -r '.targets[] | "- UXPass sweep \(.url): \(.status) - \(.summary)"' public/dogfood/uxpass-site-sweep.json
           } >> "$GITHUB_STEP_SUMMARY"
@@ -84,7 +97,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add public/dogfood/latest.json public/dogfood/uxpass-site-sweep.json
+          git add public/dogfood/latest.json public/dogfood/xpass-package-sweep.json public/dogfood/uxpass-site-sweep.json
           if git diff --cached --quiet; then
             echo "Dogfood receipt unchanged."
             exit 0

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7398,8 +7398,8 @@
     },
     {
       "source": "src/pages/DogfoodReport.tsx",
-      "hash": "10f4bfd44859",
-      "bytes": 16045
+      "hash": "a2d54cc557ef",
+      "bytes": 16182
     },
     {
       "source": "src/pages/FAQPage.tsx",
@@ -7833,8 +7833,8 @@
     },
     {
       "source": ".github/workflows/dogfood-report.yml",
-      "hash": "d485b8d37111",
-      "bytes": 3987
+      "hash": "a3f2533f7bef",
+      "bytes": 4805
     },
     {
       "source": ".github/workflows/event-wake-router.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -103,7 +103,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Developers.tsx | 9657fd564797 | 19123 |
 | src/pages/Dispatch.tsx | 2cac7e8758d3 | 15470 |
 | src/pages/Docs.tsx | 490548492455 | 18580 |
-| src/pages/DogfoodReport.tsx | 10f4bfd44859 | 16045 |
+| src/pages/DogfoodReport.tsx | a2d54cc557ef | 16182 |
 | src/pages/FAQPage.tsx | c3c95c39e56f | 723 |
 | src/pages/InstallRecover.tsx | 56c822e69817 | 6971 |
 | src/pages/Jobsmith.tsx | 70f86c37110a | 34772 |
@@ -190,7 +190,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/autonomous-runner.yml | a1280cfec46b | 15338 |
 | .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
 | .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |
-| .github/workflows/dogfood-report.yml | d485b8d37111 | 3987 |
+| .github/workflows/dogfood-report.yml | a3f2533f7bef | 4805 |
 | .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
 | .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -15,16 +15,19 @@ const apiBase = trimTrailingSlash(process.env.DOGFOOD_API_BASE || "https://uncli
 const publicUrl = process.env.DOGFOOD_PUBLIC_URL || "https://unclick.world";
 const mcpUrl = process.env.DOGFOOD_MCP_URL || "https://unclick.world/api/mcp";
 const generatedAt = new Date().toISOString();
+const targetSha = process.env.DOGFOOD_TARGET_SHA || process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || "";
+const packageSweepPath = process.env.DOGFOOD_XPASS_PACKAGE_SWEEP_PATH || "public/dogfood/xpass-package-sweep.json";
+let packageSweepState = null;
 
 const statusLegend = {
-  passing: "A live check ran and returned a passing result.",
-  failing: "A live check ran and returned a failing result or could not reach its API.",
+  passing: "A live check or scheduled package sweep ran and returned a passing result.",
+  failing: "A live check or scheduled package sweep ran and returned a failing result.",
   blocked: "The check could not run because an action is needed, such as a missing credential or scope gate.",
-  pending: "The check is planned, package-ready, or scaffolded, but live proof is not available yet.",
+  pending: "The check is planned, package-ready, or scaffolded, but scheduled proof is not available yet.",
 };
 
 const proofPolicy =
-  "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.";
+  "Public dogfood receipts mark passing only when a live check or scheduled package sweep actually ran. Blocked and pending are honest product states, not failures to hide.";
 
 const xpassIndex = [
   {
@@ -168,11 +171,63 @@ function pendingResult(id, name, summary, evidence, details = {}) {
 }
 
 function packageReadyResult(id, name, summary, evidence, targetUrl, nextProof) {
+  const sweep = packageSweepProof(id);
+  if (sweep) {
+    if (sweep.package.status === "passing" && sweep.matrix?.status === "passing") {
+      return passResult(
+        id,
+        name,
+        `Scheduled XPass package sweep passed ${name}.`,
+        `Receipt ${sweep.runId} ran ${sweep.commandText}; cross-checked by ${sweep.reviewerNames || "package proof"}.`,
+        {
+          runId: sweep.runId,
+          targetUrl,
+          proof: {
+            kind: "xpass_package_sweep",
+            runId: sweep.runId,
+            packageId: id,
+            targetUrl,
+            targetSha: sweep.targetSha || undefined,
+            receiptPath: packageSweepPath,
+            reviewers: sweep.reviewers,
+          },
+        },
+      );
+    }
+
+    if (sweep.package.status === "failing" || sweep.matrix?.status === "failing") {
+      return failureResult(
+        id,
+        name,
+        `Scheduled XPass package sweep failed ${name}.`,
+        sweep.package.failure_hint || sweep.matrix?.summary || `Receipt ${sweep.runId} reported a failing package proof.`,
+        {
+          runId: sweep.runId,
+          targetUrl,
+          proof: {
+            kind: "xpass_package_sweep",
+            runId: sweep.runId,
+            packageId: id,
+            targetUrl,
+            targetSha: sweep.targetSha || undefined,
+            receiptPath: packageSweepPath,
+            reviewers: sweep.reviewers,
+          },
+        },
+      );
+    }
+  }
+
+  const sweepNextProof = sweep && sweep.package.status === "passing" && !sweep.matrix
+    ? `Regenerate ${packageSweepPath} with a cross-pass matrix row for ${name} before marking this passing.`
+    : packageSweepState?.stale
+      ? `Regenerate ${packageSweepPath} for ${targetSha || "the current commit"} before marking this passing.`
+      : nextProof;
   return pendingResult(id, name, summary, evidence, {
     reasonCode: "package_ready_needs_scheduled_receipt",
     proof: { kind: "package_ready", targetUrl },
     targetUrl,
-    nextProof,
+    nextProof: sweepNextProof,
   });
 }
 
@@ -195,6 +250,63 @@ function failureResult(id, name, summary, evidence, details = {}) {
 
 function passResult(id, name, summary, evidence, details = {}) {
   return result(id, name, "passing", summary, evidence, details);
+}
+
+async function readPackageSweepReceipt() {
+  if (dryRun) {
+    return { receipt: null, stale: false, reason: "dry_run" };
+  }
+
+  try {
+    const receipt = JSON.parse(await fs.readFile(packageSweepPath, "utf8"));
+    if (receipt?.kind !== "xpass_package_sweep_receipt_v1") {
+      return { receipt: null, stale: false, reason: "invalid_kind" };
+    }
+    if (targetSha && receipt.target_sha !== targetSha) {
+      return {
+        receipt,
+        stale: true,
+        reason: "target_sha_mismatch",
+        expectedSha: targetSha,
+        actualSha: receipt.target_sha || "",
+      };
+    }
+    return { receipt, stale: false, reason: "fresh" };
+  } catch (err) {
+    if (err?.code === "ENOENT") {
+      return { receipt: null, stale: false, reason: "missing" };
+    }
+    return {
+      receipt: null,
+      stale: false,
+      reason: "unreadable",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function packageSweepProof(id) {
+  const receipt = packageSweepState?.receipt;
+  if (!receipt || packageSweepState.stale) return null;
+  const packageResult = Array.isArray(receipt.packages)
+    ? receipt.packages.find((pkg) => pkg.id === id)
+    : null;
+  if (!packageResult) return null;
+
+  const matrix = Array.isArray(receipt.cross_pass_matrix)
+    ? receipt.cross_pass_matrix.find((row) => row.target_id === id)
+    : null;
+  const reviewers = Array.isArray(matrix?.reviewers) ? matrix.reviewers : [];
+  const reviewerNames = reviewers.map((reviewer) => reviewer.name || reviewer.id).filter(Boolean).join(", ");
+  return {
+    runId: receipt.run_id || "unknown",
+    targetSha: receipt.target_sha || "",
+    package: packageResult,
+    matrix,
+    reviewers,
+    reviewerNames,
+    commandText: Array.isArray(packageResult.command) ? packageResult.command.join(" ") : "the package test command",
+  };
 }
 
 async function postJson(url, token, body) {
@@ -419,6 +531,8 @@ function buildLastActionableFailure(results) {
   };
 }
 
+packageSweepState = await readPackageSweepReceipt();
+
 const results = [
   await runTestPass(),
   await runUXPass(),
@@ -524,7 +638,7 @@ const report = {
   source: dryRun ? "dogfood receipt dry run" : "nightly dogfood workflow",
   headline: "We dogfood UnClick on UnClick.",
   target: "UnClick public and agent-facing product surfaces",
-  nextAutomation: "Nightly dogfood receipts refresh this board with live scheduled evidence.",
+  nextAutomation: "Nightly dogfood receipts refresh this board with live checks and scheduled XPass package proof.",
   statusLegend,
   proofPolicy,
   xpassIndex,

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -52,8 +52,8 @@ test("dogfood receipt marks SecurityPass as blocked with a reason", async () => 
     });
     assert.equal(report.status, "blocked");
     assert.match(report.statusLegend.blocked, /action is needed/i);
-    assert.match(report.statusLegend.pending, /live proof is not available yet/i);
-    assert.match(report.proofPolicy, /passing only when a live check actually ran/i);
+    assert.match(report.statusLegend.pending, /scheduled proof is not available yet/i);
+    assert.match(report.proofPolicy, /live check or scheduled package sweep actually ran/i);
     assert.match(report.lastActionableFailure.detail, /Blocked reason:/);
     assert.equal(report.xpassIndex.find((entry) => entry.id === "testpass")?.stage, "live_gate");
     assert.match(
@@ -128,7 +128,7 @@ test("dogfood receipt includes structured proof for live TestPass and UXPass run
     const testpassRequest = requests.find((request) => request.url === "/api/testpass-run");
     const uxpassRequest = requests.find((request) => request.url === "/api/uxpass-run");
 
-    assert.match(report.statusLegend.passing, /live check ran/i);
+    assert.match(report.statusLegend.passing, /live check or scheduled package sweep ran/i);
     assert.match(report.proofPolicy, /Blocked and pending are honest product states/i);
     assert.deepEqual(report.xpassIndex.map((entry) => entry.id), [
       "testpass",
@@ -195,6 +195,128 @@ test("dogfood receipt uses structured missing-credential proof for blocked UXPas
     assert.equal(uxpass?.status, "blocked");
     assert.equal(uxpass?.reasonCode, "missing_credential");
     assert.match(uxpass?.nextProof ?? "", /rerun the dogfood report workflow/i);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("dogfood receipt promotes package-ready passes from a fresh XPass sweep receipt", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
+  const output = path.join(dir, "latest.json");
+  const sweepPath = path.join(dir, "xpass-package-sweep.json");
+
+  try {
+    await fs.writeFile(sweepPath, JSON.stringify({
+      kind: "xpass_package_sweep_receipt_v1",
+      run_id: "xpass-package-sweep-123",
+      target_sha: "abc123",
+      status: "passing",
+      packages: [
+        { id: "sloppass", name: "SlopPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/sloppass"] },
+        { id: "seopass", name: "SEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/seopass"] },
+        { id: "copypass", name: "CopyPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/copypass"] },
+        { id: "legalpass", name: "LegalPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/legalpass"] },
+        { id: "commonsensepass", name: "CommonSensePass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/commonsensepass"] },
+        { id: "flowpass", name: "FlowPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/flowpass"] },
+        { id: "geopass", name: "GEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/geopass"] },
+      ],
+      cross_pass_matrix: [
+        {
+          target_id: "sloppass",
+          status: "passing",
+          reviewers: [
+            { id: "testpass", name: "TestPass", status: "passing" },
+            { id: "commonsensepass", name: "CommonSensePass", status: "passing" },
+          ],
+        },
+        {
+          target_id: "geopass",
+          status: "passing",
+          reviewers: [
+            { id: "testpass", name: "TestPass", status: "passing" },
+            { id: "seopass", name: "SEOPass", status: "passing" },
+          ],
+        },
+      ],
+    }));
+
+    await execFileAsync(process.execPath, [
+      "scripts/build-dogfood-report.mjs",
+      "--output",
+      output,
+    ], {
+      env: {
+        ...process.env,
+        TESTPASS_TOKEN: "",
+        DOGFOOD_TESTPASS_TOKEN: "",
+        UXPASS_TOKEN: "",
+        DOGFOOD_UXPASS_TOKEN: "",
+        CRON_SECRET: "",
+        DOGFOOD_TARGET_SHA: "abc123",
+        DOGFOOD_XPASS_PACKAGE_SWEEP_PATH: sweepPath,
+      },
+    });
+
+    const report = JSON.parse(await fs.readFile(output, "utf8"));
+    const sloppass = report.results.find((result) => result.id === "sloppass");
+    const geopass = report.results.find((result) => result.id === "geopass");
+    const securitypass = report.results.find((result) => result.id === "securitypass");
+
+    assert.equal(sloppass?.status, "passing");
+    assert.equal(sloppass?.runId, "xpass-package-sweep-123");
+    assert.equal(sloppass?.proof?.kind, "xpass_package_sweep");
+    assert.equal(sloppass?.proof?.targetSha, "abc123");
+    assert.equal(sloppass?.proof?.packageId, "sloppass");
+    assert.equal(geopass?.status, "passing");
+    assert.equal(geopass?.proof?.kind, "xpass_package_sweep");
+    assert.equal(securitypass?.status, "blocked");
+    assert.equal(securitypass?.reasonCode, "scope_gate");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("dogfood receipt rejects a stale XPass sweep receipt", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
+  const output = path.join(dir, "latest.json");
+  const sweepPath = path.join(dir, "xpass-package-sweep.json");
+
+  try {
+    await fs.writeFile(sweepPath, JSON.stringify({
+      kind: "xpass_package_sweep_receipt_v1",
+      run_id: "xpass-package-sweep-old",
+      target_sha: "oldsha",
+      status: "passing",
+      packages: [
+        { id: "sloppass", name: "SlopPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/sloppass"] },
+      ],
+      cross_pass_matrix: [],
+    }));
+
+    await execFileAsync(process.execPath, [
+      "scripts/build-dogfood-report.mjs",
+      "--output",
+      output,
+    ], {
+      env: {
+        ...process.env,
+        TESTPASS_TOKEN: "",
+        DOGFOOD_TESTPASS_TOKEN: "",
+        UXPASS_TOKEN: "",
+        DOGFOOD_UXPASS_TOKEN: "",
+        CRON_SECRET: "",
+        DOGFOOD_TARGET_SHA: "newsha",
+        DOGFOOD_XPASS_PACKAGE_SWEEP_PATH: sweepPath,
+      },
+    });
+
+    const report = JSON.parse(await fs.readFile(output, "utf8"));
+    const sloppass = report.results.find((result) => result.id === "sloppass");
+
+    assert.equal(sloppass?.status, "pending");
+    assert.equal(sloppass?.reasonCode, "package_ready_needs_scheduled_receipt");
+    assert.equal(sloppass?.proof?.kind, "package_ready");
+    assert.match(sloppass?.nextProof ?? "", /Regenerate/);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }

--- a/scripts/build-xpass-package-sweep.mjs
+++ b/scripts/build-xpass-package-sweep.mjs
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const PASS_PACKAGES = [
+  {
+    id: "testpass",
+    name: "TestPass",
+    workspace: "@unclick/testpass",
+    path: "packages/testpass",
+    stage: "live_gate",
+    role: "merge proof and MCP smoke gate",
+  },
+  {
+    id: "uxpass",
+    name: "UXPass",
+    workspace: "@unclick/uxpass",
+    path: "packages/uxpass",
+    stage: "live_dogfood",
+    role: "public UX and route sweep gate",
+  },
+  {
+    id: "securitypass",
+    name: "SecurityPass",
+    workspace: "@unclick/securitypass",
+    path: "packages/securitypass",
+    stage: "scope_gated",
+    role: "safe local security package proof only",
+  },
+  {
+    id: "sloppass",
+    name: "SlopPass",
+    workspace: "@unclick/sloppass",
+    path: "packages/sloppass",
+    stage: "package_ready",
+    role: "AI-code quality and anti-slop review",
+  },
+  {
+    id: "seopass",
+    name: "SEOPass",
+    workspace: "@unclick/seopass",
+    path: "packages/seopass",
+    stage: "package_ready",
+    role: "crawler, canonical, robots, sitemap, and metadata proof",
+  },
+  {
+    id: "copypass",
+    name: "CopyPass",
+    workspace: "@unclick/copypass",
+    path: "packages/copypass",
+    stage: "package_ready",
+    role: "copy quality, claims, and source-copy boundary proof",
+  },
+  {
+    id: "legalpass",
+    name: "LegalPass",
+    workspace: "@unclick/legalpass",
+    path: "packages/legalpass",
+    stage: "package_ready",
+    role: "guidance-only policy and claims proof",
+  },
+  {
+    id: "commonsensepass",
+    name: "CommonSensePass",
+    workspace: "@unclick/commonsensepass",
+    path: "packages/commonsensepass",
+    stage: "live_gate",
+    role: "false-DONE, claim sanity, and proof honesty gate",
+  },
+  {
+    id: "flowpass",
+    name: "FlowPass",
+    workspace: "@unclick/flowpass",
+    path: "packages/flowpass",
+    stage: "package_ready",
+    role: "journey and handoff proof",
+  },
+  {
+    id: "geopass",
+    name: "GEOPass",
+    workspace: "@unclick/geopass",
+    path: "packages/geopass",
+    stage: "package_ready",
+    role: "answer-engine readiness and AI-discovery proof",
+  },
+];
+
+export const CROSS_PASS_MATRIX = [
+  {
+    targetId: "sloppass",
+    reviewers: [
+      { id: "testpass", role: "package tests must pass before public proof is trusted" },
+      { id: "commonsensepass", role: "false-DONE and proof-claim sanity" },
+      { id: "copypass", role: "plain-English claims and wording boundary" },
+    ],
+  },
+  {
+    targetId: "seopass",
+    reviewers: [
+      { id: "testpass", role: "package tests must pass before public proof is trusted" },
+      { id: "geopass", role: "answer-engine overlap for crawler and metadata signals" },
+      { id: "commonsensepass", role: "proof-claim sanity" },
+    ],
+  },
+  {
+    targetId: "geopass",
+    reviewers: [
+      { id: "testpass", role: "package tests must pass before public proof is trusted" },
+      { id: "seopass", role: "search-indexing overlap for crawlable answer sources" },
+      { id: "commonsensepass", role: "proof-claim sanity" },
+    ],
+  },
+  {
+    targetId: "copypass",
+    reviewers: [
+      { id: "sloppass", role: "anti-slop quality review" },
+      { id: "legalpass", role: "claims and guidance-only boundary" },
+      { id: "commonsensepass", role: "proof-claim sanity" },
+    ],
+  },
+  {
+    targetId: "legalpass",
+    reviewers: [
+      { id: "copypass", role: "public wording and claims clarity" },
+      { id: "securitypass", role: "safe local package proof only" },
+      { id: "commonsensepass", role: "certification-claim sanity" },
+    ],
+  },
+  {
+    targetId: "commonsensepass",
+    reviewers: [
+      { id: "testpass", role: "package tests must pass before public proof is trusted" },
+      { id: "sloppass", role: "anti-slop claim review" },
+    ],
+  },
+  {
+    targetId: "flowpass",
+    reviewers: [
+      { id: "uxpass", role: "route and UX sweep overlap" },
+      { id: "testpass", role: "package tests must pass before public proof is trusted" },
+      { id: "commonsensepass", role: "proof-claim sanity" },
+    ],
+  },
+];
+
+function argValue(name, fallback = "") {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((arg) => arg.startsWith(prefix));
+  if (found) return found.slice(prefix.length);
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] ?? fallback : fallback;
+}
+
+function argValues(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg.startsWith(prefix)) values.push(arg.slice(prefix.length));
+    if (arg === `--${name}` && process.argv[index + 1]) values.push(process.argv[index + 1]);
+  }
+  return values;
+}
+
+function compactText(value, max = 400) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function npmCommandParts() {
+  if (process.platform === "win32") {
+    return {
+      command: process.execPath,
+      prefixArgs: [path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js")],
+    };
+  }
+  return { command: "npm", prefixArgs: [] };
+}
+
+function displayCommand(pkg) {
+  return ["npm", "run", "test", `--workspace=${pkg.workspace}`];
+}
+
+function actualCommand(pkg) {
+  const npm = npmCommandParts();
+  return [npm.command, ...npm.prefixArgs, "run", "test", `--workspace=${pkg.workspace}`];
+}
+
+function statusFromPackages(packages) {
+  if (packages.some((pkg) => pkg.status === "failing")) return "failing";
+  if (packages.some((pkg) => pkg.status === "blocked")) return "blocked";
+  if (packages.some((pkg) => pkg.status === "pending")) return "pending";
+  return "passing";
+}
+
+function makeRunId(seed) {
+  return `xpass-package-sweep-${createHash("sha256").update(seed).digest("hex").slice(0, 16)}`;
+}
+
+export async function defaultRunCommand(command, args, { cwd, timeoutMs }) {
+  const started = Date.now();
+  try {
+    await execFileAsync(command, args, {
+      cwd,
+      timeout: timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
+      env: process.env,
+    });
+    return {
+      status: "passing",
+      exitCode: 0,
+      durationMs: Date.now() - started,
+      failureHint: "",
+    };
+  } catch (error) {
+    const exitCode = typeof error?.code === "number" ? error.code : 1;
+    const signal = typeof error?.signal === "string" ? error.signal : "";
+    const hint = signal
+      ? `Process stopped with signal ${signal}.`
+      : compactText(error?.message || "Command failed.");
+    return {
+      status: "failing",
+      exitCode,
+      durationMs: Date.now() - started,
+      failureHint: hint,
+    };
+  }
+}
+
+function normalizePackageResult(pkg, commandResult, now) {
+  const status = commandResult.status === "passing" ? "passing" : "failing";
+  return {
+    id: pkg.id,
+    name: pkg.name,
+    workspace: pkg.workspace,
+    path: pkg.path,
+    stage: pkg.stage,
+    role: pkg.role,
+    status,
+    checked_at: now,
+    command: displayCommand(pkg),
+    exit_code: commandResult.exitCode,
+    duration_ms: commandResult.durationMs,
+    summary: status === "passing"
+      ? `${pkg.name} package tests passed.`
+      : `${pkg.name} package tests failed. See the workflow log for command output.`,
+    failure_hint: commandResult.failureHint || null,
+    proof: {
+      kind: "workspace_package_test",
+      workspace: pkg.workspace,
+      command: displayCommand(pkg),
+    },
+  };
+}
+
+function reviewerRows(matrixEntry, packageById) {
+  return matrixEntry.reviewers.map((reviewer) => {
+    const reviewerPackage = packageById.get(reviewer.id);
+    return {
+      id: reviewer.id,
+      name: reviewerPackage?.name || reviewer.id,
+      role: reviewer.role,
+      status: reviewerPackage?.status || "pending",
+    };
+  });
+}
+
+function buildCrossPassMatrix(packages) {
+  const packageById = new Map(packages.map((pkg) => [pkg.id, pkg]));
+  return CROSS_PASS_MATRIX.map((entry) => {
+    const target = packageById.get(entry.targetId);
+    const reviewers = reviewerRows(entry, packageById);
+    const failingReviewer = reviewers.find((reviewer) => reviewer.status === "failing");
+    const pendingReviewer = reviewers.find((reviewer) => reviewer.status === "pending" || reviewer.status === "blocked");
+    const status = target?.status === "failing" || failingReviewer
+      ? "failing"
+      : target && !pendingReviewer
+        ? "passing"
+        : "pending";
+    return {
+      target_id: entry.targetId,
+      target_name: target?.name || entry.targetId,
+      status,
+      reviewers,
+      summary: status === "passing"
+        ? `${target?.name || entry.targetId} was cross-checked by ${reviewers.map((reviewer) => reviewer.name).join(", ")}.`
+        : `${target?.name || entry.targetId} cross-pass proof is not green yet.`,
+    };
+  });
+}
+
+function actionNeeded(packages, matrix) {
+  return [
+    ...packages
+      .filter((pkg) => pkg.status !== "passing")
+      .map((pkg) => `${pkg.name}: ${pkg.summary}`),
+    ...matrix
+      .filter((row) => row.status !== "passing")
+      .map((row) => `${row.target_name}: ${row.summary}`),
+  ];
+}
+
+export async function buildXPassPackageSweep({
+  cwd = process.cwd(),
+  packages = PASS_PACKAGES,
+  selectedIds = [],
+  targetSha = "",
+  now = new Date().toISOString(),
+  source = "xpass package sweep",
+  timeoutMs = 120000,
+  skipCommands = false,
+  runCommand = defaultRunCommand,
+} = {}) {
+  const selected = selectedIds.length
+    ? packages.filter((pkg) => selectedIds.includes(pkg.id))
+    : packages;
+  const packageResults = [];
+
+  for (const pkg of selected) {
+    const [command, ...args] = actualCommand(pkg);
+    const commandResult = skipCommands
+      ? { status: "passing", exitCode: 0, durationMs: 0, failureHint: "" }
+      : await runCommand(command, args, { cwd, timeoutMs, pkg });
+    packageResults.push(normalizePackageResult(pkg, commandResult, now));
+  }
+
+  const matrix = buildCrossPassMatrix(packageResults);
+  const packageStatus = statusFromPackages(packageResults);
+  const matrixStatus = matrix.some((row) => row.status === "failing")
+    ? "failing"
+    : matrix.some((row) => row.status !== "passing")
+      ? "pending"
+      : "passing";
+  const status = packageStatus === "failing" || matrixStatus === "failing"
+    ? "failing"
+    : packageStatus === "passing" && matrixStatus === "passing"
+      ? "passing"
+      : "pending";
+  const seed = JSON.stringify({ now, targetSha, packages: packageResults.map((pkg) => [pkg.id, pkg.status]) });
+
+  return {
+    kind: "xpass_package_sweep_receipt_v1",
+    generated_at: now,
+    checked_at: now,
+    run_id: makeRunId(seed),
+    source,
+    target_sha: targetSha || null,
+    status,
+    summary: `XPass package sweep ${status} across ${packageResults.length} package(s).`,
+    package_count: packageResults.length,
+    packages: packageResults,
+    cross_pass_matrix: matrix,
+    action_needed: actionNeeded(packageResults, matrix),
+  };
+}
+
+async function main() {
+  const outputPath = argValue("output", "public/dogfood/xpass-package-sweep.json");
+  const targetSha = argValue("target-sha", process.env.DOGFOOD_TARGET_SHA || process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || "");
+  const selectedIds = argValues("package").map((value) => value.toLowerCase());
+  const timeoutMs = Number(argValue("timeout-ms", process.env.XPASS_PACKAGE_SWEEP_TIMEOUT_MS || "120000"));
+  const skipCommands = process.argv.includes("--skip-commands") || process.env.XPASS_PACKAGE_SWEEP_SKIP_COMMANDS === "1";
+  const receipt = await buildXPassPackageSweep({
+    cwd: process.cwd(),
+    selectedIds,
+    targetSha,
+    source: process.env.GITHUB_ACTIONS ? "nightly dogfood workflow" : "local xpass package sweep",
+    timeoutMs,
+    skipCommands,
+  });
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log(JSON.stringify({
+    generated_at: receipt.generated_at,
+    status: receipt.status,
+    packages: receipt.package_count,
+    action_needed: receipt.action_needed.length,
+    output: outputPath,
+  }, null, 2));
+}
+
+const cliPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+const modulePath = fileURLToPath(import.meta.url);
+if (cliPath === modulePath) {
+  await main();
+}

--- a/scripts/build-xpass-package-sweep.mjs
+++ b/scripts/build-xpass-package-sweep.mjs
@@ -224,7 +224,9 @@ export async function defaultRunCommand(command, args, { cwd, timeoutMs }) {
     const signal = typeof error?.signal === "string" ? error.signal : "";
     const hint = signal
       ? `Process stopped with signal ${signal}.`
-      : compactText(error?.message || "Command failed.");
+      : Number.isFinite(exitCode)
+        ? `Process exited with code ${exitCode}.`
+        : "Command failed before completion.";
     return {
       status: "failing",
       exitCode,

--- a/scripts/build-xpass-package-sweep.test.mjs
+++ b/scripts/build-xpass-package-sweep.test.mjs
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import {
   PASS_PACKAGES,
   buildXPassPackageSweep,
+  defaultRunCommand,
 } from "./build-xpass-package-sweep.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -88,4 +89,20 @@ test("XPass package sweep CLI writes a public-safe receipt", async () => {
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
+});
+
+test("XPass package sweep failure hints do not expose raw command output", async () => {
+  const result = await defaultRunCommand(process.execPath, [
+    "-e",
+    "console.error('SECRET_TOKEN=uc_should_not_escape'); process.exit(7)",
+  ], {
+    cwd: process.cwd(),
+    timeoutMs: 5000,
+  });
+
+  assert.equal(result.status, "failing");
+  assert.equal(result.exitCode, 7);
+  assert.match(result.failureHint, /code 7/);
+  assert.doesNotMatch(result.failureHint, /SECRET_TOKEN/i);
+  assert.doesNotMatch(result.failureHint, /uc_should_not_escape/i);
 });

--- a/scripts/build-xpass-package-sweep.test.mjs
+++ b/scripts/build-xpass-package-sweep.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { promisify } from "node:util";
+
+import {
+  PASS_PACKAGES,
+  buildXPassPackageSweep,
+} from "./build-xpass-package-sweep.mjs";
+
+const execFileAsync = promisify(execFile);
+
+test("XPass package sweep records package and cross-pass proof", async () => {
+  const calls = [];
+  const receipt = await buildXPassPackageSweep({
+    now: "2026-05-28T00:00:00.000Z",
+    targetSha: "abc123",
+    runCommand: async (command, args, { pkg }) => {
+      calls.push({ command, args, id: pkg.id });
+      return { status: "passing", exitCode: 0, durationMs: 12, failureHint: "" };
+    },
+  });
+
+  const sloppass = receipt.packages.find((pkg) => pkg.id === "sloppass");
+  const sloppassMatrix = receipt.cross_pass_matrix.find((row) => row.target_id === "sloppass");
+
+  assert.equal(receipt.kind, "xpass_package_sweep_receipt_v1");
+  assert.equal(receipt.status, "passing");
+  assert.equal(receipt.target_sha, "abc123");
+  assert.equal(receipt.package_count, PASS_PACKAGES.length);
+  assert.equal(calls.length, PASS_PACKAGES.length);
+  assert.equal(sloppass?.status, "passing");
+  assert.deepEqual(sloppass?.command, ["npm", "run", "test", "--workspace=@unclick/sloppass"]);
+  assert.equal(sloppass?.proof?.kind, "workspace_package_test");
+  assert.equal(sloppassMatrix?.status, "passing");
+  assert.deepEqual(sloppassMatrix?.reviewers.map((reviewer) => reviewer.id), [
+    "testpass",
+    "commonsensepass",
+    "copypass",
+  ]);
+  assert.deepEqual(receipt.action_needed, []);
+});
+
+test("XPass package sweep fails honestly when a package reviewer fails", async () => {
+  const receipt = await buildXPassPackageSweep({
+    now: "2026-05-28T00:00:00.000Z",
+    targetSha: "abc123",
+    runCommand: async (_command, _args, { pkg }) => ({
+      status: pkg.id === "copypass" ? "failing" : "passing",
+      exitCode: pkg.id === "copypass" ? 1 : 0,
+      durationMs: 8,
+      failureHint: pkg.id === "copypass" ? "CopyPass package test failed." : "",
+    }),
+  });
+
+  const copypass = receipt.packages.find((pkg) => pkg.id === "copypass");
+  const sloppassMatrix = receipt.cross_pass_matrix.find((row) => row.target_id === "sloppass");
+
+  assert.equal(receipt.status, "failing");
+  assert.equal(copypass?.status, "failing");
+  assert.equal(copypass?.failure_hint, "CopyPass package test failed.");
+  assert.equal(sloppassMatrix?.status, "failing");
+  assert.ok(receipt.action_needed.some((item) => /CopyPass/.test(item)));
+});
+
+test("XPass package sweep CLI writes a public-safe receipt", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "xpass-package-sweep-"));
+  const output = path.join(dir, "xpass-package-sweep.json");
+
+  try {
+    await execFileAsync(process.execPath, [
+      "scripts/build-xpass-package-sweep.mjs",
+      "--skip-commands",
+      "--target-sha",
+      "abc123",
+      "--output",
+      output,
+    ]);
+
+    const receipt = JSON.parse(await fs.readFile(output, "utf8"));
+    assert.equal(receipt.status, "passing");
+    assert.equal(receipt.target_sha, "abc123");
+    assert.equal(receipt.packages.find((pkg) => pkg.id === "geopass")?.status, "passing");
+    assert.equal(receipt.cross_pass_matrix.find((row) => row.target_id === "geopass")?.status, "passing");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/__tests__/dogfood-report-proof-policy.test.ts
+++ b/src/__tests__/dogfood-report-proof-policy.test.ts
@@ -4,10 +4,10 @@ import { dogfoodReport } from "@/data/dogfoodReport";
 
 describe("Dogfood report proof policy", () => {
   it("keeps public status wording honest in the fallback receipt", () => {
-    expect(dogfoodReport.statusLegend.passing).toMatch(/live check ran/i);
+    expect(dogfoodReport.statusLegend.passing).toMatch(/live check or scheduled package sweep ran/i);
     expect(dogfoodReport.statusLegend.blocked).toMatch(/action is needed/i);
-    expect(dogfoodReport.statusLegend.pending).toMatch(/live proof is not available yet/i);
-    expect(dogfoodReport.proofPolicy).toMatch(/passing only when a live check actually ran/i);
+    expect(dogfoodReport.statusLegend.pending).toMatch(/scheduled proof is not available yet/i);
+    expect(dogfoodReport.proofPolicy).toMatch(/live check or scheduled package sweep actually ran/i);
 
     const uxpass = dogfoodReport.results.find((result) => result.id === "uxpass");
     const securitypass = dogfoodReport.results.find((result) => result.id === "securitypass");

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -13,9 +13,18 @@ export interface DogfoodPassResult {
   runId?: string;
   targetUrl?: string;
   proof?: {
-    kind: "testpass_run" | "uxpass_run" | "planned" | "package_ready" | "boundary";
+    kind: "testpass_run" | "uxpass_run" | "planned" | "package_ready" | "boundary" | "xpass_package_sweep";
     runId?: string;
+    packageId?: string;
     targetUrl?: string;
+    targetSha?: string;
+    receiptPath?: string;
+    reviewers?: Array<{
+      id: string;
+      name?: string;
+      role?: string;
+      status?: DogfoodStatus | "planned";
+    }>;
   };
 }
 
@@ -46,14 +55,14 @@ export const dogfoodReport = {
   source: "static fallback receipt",
   headline: "We dogfood UnClick on UnClick.",
   target: "UnClick public and agent-facing product surfaces",
-  nextAutomation: "Nightly dogfood receipts refresh this board with live scheduled evidence.",
+  nextAutomation: "Nightly dogfood receipts refresh this board with live checks and scheduled XPass package proof.",
   statusLegend: {
-    passing: "A live check ran and returned a passing result.",
-    failing: "A live check ran and returned a failing result or could not reach its API.",
+    passing: "A live check or scheduled package sweep ran and returned a passing result.",
+    failing: "A live check or scheduled package sweep ran and returned a failing result.",
     blocked: "The check could not run because an action is needed, such as a missing credential or scope gate.",
-    pending: "The check is planned, package-ready, or scaffolded, but live proof is not available yet.",
+    pending: "The check is planned, package-ready, or scaffolded, but scheduled proof is not available yet.",
   } satisfies DogfoodStatusLegend,
-  proofPolicy: "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.",
+  proofPolicy: "Public dogfood receipts mark passing only when a live check or scheduled package sweep actually ran. Blocked and pending are honest product states, not failures to hide.",
   xpassIndex: [
     {
       id: "testpass",

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -49,6 +49,8 @@ const XPASS_STAGE_STYLES: Record<XPassIndexEntry["stage"], string> = {
   live_gate: "border-emerald-400/20 bg-emerald-400/10 text-emerald-200",
   live_dogfood: "border-cyan-400/20 bg-cyan-400/10 text-cyan-200",
   scope_gated: "border-sky-400/25 bg-sky-400/10 text-sky-200",
+  package_ready: "border-amber-400/20 bg-amber-400/10 text-amber-200",
+  boundary: "border-slate-400/25 bg-slate-400/10 text-slate-200",
   planned: "border-amber-400/20 bg-amber-400/10 text-amber-200",
   guidance: "border-violet-400/20 bg-violet-400/10 text-violet-200",
 };


### PR DESCRIPTION
## What changed
- Adds a public-safe XPass package sweep receipt for TestPass, UXPass, SecurityPass, SlopPass, SEOPass, CopyPass, LegalPass, CommonSensePass, FlowPass, and GEOPass.
- Wires the nightly dogfood workflow to install dependencies, run the sweep, publish `public/dogfood/xpass-package-sweep.json`, and feed it into `public/dogfood/latest.json`.
- Promotes package-ready XPass products to `passing` only when the sweep is fresh for the current SHA and the cross-pass matrix is green.
- Keeps SecurityPass scope-gated in the public dogfood report even when its local package proof passes.
- Keeps package-sweep failure hints public-safe by not copying raw command output into public receipts.
- Fixes missing Dogfood page badge styles for `package_ready` and `boundary` stages.

## Why
The old report left package-ready products pending even though their package tests existed. This gives SlopPass and the nearby XPass tools a scheduled, honest proof path without claiming live security or UX/API checks that did not run.

## Research checked
- Google Search Central SEO starter guide: https://developers.google.com/search/docs/fundamentals/seo-starter-guide
- Google Search Central generative AI optimization guide: https://developers.google.com/search/docs/fundamentals/ai-optimization-guide
- W3C WCAG 2.2: https://www.w3.org/TR/WCAG22/
- OWASP ASVS: https://owasp.org/www-project-application-security-verification-standard/
- Vercel protected preview bypass automation: https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation

## Validation
- `node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs scripts/pinballwake-xpass-gate-room.test.mjs scripts/uxpass-site-sweep.test.mjs` - 39/39 passing
- Public-safe receipt smoke generated 10/10 package sweep entries and no secret-shaped text
- `npm run brainmap:check` - passing
- `git diff --check` - passing
- Earlier full local proof on this PR: `npm test -- --testTimeout=15000` passed 105 files / 794 tests; `npm run build` passed with existing bundle-size and Browserslist warnings; local `/dogfood` preview returned HTTP 200

## Current state
- Draft while the fresh GitHub checks for commit `5f5d81f9` complete.
- TestPass was green on the previous commit and is running again on this patch.
- Cursor Bugbot is not used as proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public trust/dogfood status semantics and CI nightly workflow; mitigated by SHA pinning, scope-gating SecurityPass, and tests that block secret leakage in public receipts.
> 
> **Overview**
> Adds a **scheduled XPass package sweep** so package-ready passes can show honest `passing` proof without pretending live API/security probes ran.
> 
> A new `build-xpass-package-sweep.mjs` runs workspace tests for ten XPass packages, writes a **public-safe** `public/dogfood/xpass-package-sweep.json` (statuses, commands, run IDs, cross-pass reviewers—no raw logs or secrets), and applies a **cross-pass matrix** before overall green. Nightly `dogfood-report.yml` now runs `npm ci`, builds that receipt for the current SHA, then feeds it into `build-dogfood-report.mjs`, which promotes package-ready products only when the sweep is **fresh for `DOGFOOD_TARGET_SHA`** and matrix checks pass; stale or missing sweeps stay **pending**. **SecurityPass** stays **blocked** in `latest.json` despite local package tests. Proof policy copy, types, tests, ops docs, and Dogfood UI badge styles for `package_ready` / `boundary` align with the new proof kind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002f7e693c8ee577ded522b0c49691b133d3ad05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->