### PR TITLE
[codex] Fix dogfood receipt workflow publishing

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -71,6 +71,9 @@ The public receipt at `public/dogfood/latest.json` should stay honest:
 run IDs, and cross-pass reviewers, but not raw command output or secrets. SecurityPass can pass its local package proof
 while still staying `blocked` in `latest.json` until safe recurring security probes exist.
 
+Because `main` requires pull requests, the dogfood workflow pushes changed receipt files to
+`automation/dogfood-public-receipt` and opens or updates a public receipt PR instead of pushing directly to `main`.
+
 ## Runtime env vars
 
 Everything the app + serverless functions need at runtime lives in Vercel

--- a/.github/workflows/dogfood-report.yml
+++ b/.github/workflows/dogfood-report.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   dogfood-report:
@@ -76,12 +77,12 @@ jobs:
           {
             echo "### Public dogfood receipt"
             echo ""
-            echo "- Last run: \`$(jq -r '.lastRunAt // .generatedAt' public/dogfood/latest.json)\`"
-            echo "- Status: \`$(jq -r '.status // \"unknown\"' public/dogfood/latest.json)\`"
-            echo "- Source: \`$(jq -r '.source // \"unknown\"' public/dogfood/latest.json)\`"
+            printf -- '- Last run: `%s`\n' "$(jq -r '.lastRunAt // .generatedAt' public/dogfood/latest.json)"
+            printf -- '- Status: `%s`\n' "$(jq -r '.status // "unknown"' public/dogfood/latest.json)"
+            printf -- '- Source: `%s`\n' "$(jq -r '.source // "unknown"' public/dogfood/latest.json)"
             echo "- Output: \`public/dogfood/latest.json\`"
-            echo "- XPass package sweep: \`$(jq -r '.status // \"unknown\"' public/dogfood/xpass-package-sweep.json)\` across \`$(jq -r '.packages | length' public/dogfood/xpass-package-sweep.json)\` package(s)"
-            echo "- UXPass site sweep: \`$(jq -r '.status // \"unknown\"' public/dogfood/uxpass-site-sweep.json)\` across \`$(jq -r '.targets | length' public/dogfood/uxpass-site-sweep.json)\` URL(s)"
+            printf -- '- XPass package sweep: `%s` across `%s` package(s)\n' "$(jq -r '.status // "unknown"' public/dogfood/xpass-package-sweep.json)" "$(jq -r '.packages | length' public/dogfood/xpass-package-sweep.json)"
+            printf -- '- UXPass site sweep: `%s` across `%s` URL(s)\n' "$(jq -r '.status // "unknown"' public/dogfood/uxpass-site-sweep.json)" "$(jq -r '.targets | length' public/dogfood/uxpass-site-sweep.json)"
             echo "- Public URL: \`${{ inputs.public_url || 'https://unclick.world' }}\`"
             echo "- MCP URL: \`${{ inputs.mcp_url || 'https://unclick.world/api/mcp' }}\`"
             echo ""
@@ -94,13 +95,28 @@ jobs:
 
       - name: Commit public receipt
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          receipt_branch="automation/dogfood-public-receipt"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$receipt_branch"
           git add public/dogfood/latest.json public/dogfood/xpass-package-sweep.json public/dogfood/uxpass-site-sweep.json
           if git diff --cached --quiet; then
             echo "Dogfood receipt unchanged."
             exit 0
           fi
           git commit -m "chore(dogfood): update public receipt"
-          git push
+          git fetch origin "+refs/heads/$receipt_branch:refs/remotes/origin/$receipt_branch" || true
+          git push --force-with-lease origin "$receipt_branch:$receipt_branch"
+          if pr_url=$(gh pr view "$receipt_branch" --json url --jq .url 2>/dev/null); then
+            echo "Dogfood receipt PR: $pr_url"
+          else
+            gh pr create \
+              --title "chore(dogfood): update public receipt" \
+              --body "Automated public dogfood receipt refresh from workflow run $GITHUB_RUN_ID." \
+              --base main \
+              --head "$receipt_branch"
+          fi

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7833,8 +7833,8 @@
     },
     {
       "source": ".github/workflows/dogfood-report.yml",
-      "hash": "a3f2533f7bef",
-      "bytes": 4805
+      "hash": "8d18a3401b54",
+      "bytes": 5647
     },
     {
       "source": ".github/workflows/event-wake-router.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -190,7 +190,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/autonomous-runner.yml | a1280cfec46b | 15338 |
 | .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
 | .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |
-| .github/workflows/dogfood-report.yml | a3f2533f7bef | 4805 |
+| .github/workflows/dogfood-report.yml | 8d18a3401b54 | 5647 |
 | .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
 | .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |


### PR DESCRIPTION
## What changed
- Fixes the Dogfood Report workflow summary `jq` quoting so the run summary does not print compile errors.
- Stops trying to push generated receipt files directly to protected `main`.
- Pushes changed receipt files to `automation/dogfood-public-receipt` and opens or updates a receipt PR instead.
- Documents the receipt PR branch behavior in operations notes.

## Why
The merged XPass package sweep works, but a live workflow dispatch showed the final receipt publish step was still red because `main` requires pull requests. This keeps the dogfood run honest and green while respecting branch protection.

## Validation
- `node` YAML parse of `.github/workflows/dogfood-report.yml` - passing
- `node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs` - 9/9 passing
- `npm run brainmap:check` - passing
- `git diff HEAD --check` - passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and ops documentation; public receipt content is unchanged except for how it lands on main via PR.
> 
> **Overview**
> Fixes the **Dogfood Report** workflow so it can publish public receipts under branch protection on `main`.
> 
> The run summary step now uses `printf` with correct `jq` quoting so status lines no longer fail at compile time. Publishing no longer pushes receipt JSON straight to `main`; it commits on `automation/dogfood-public-receipt`, pushes with lease, and **opens or reuses a PR** into `main` (with `pull-requests: write`). **Operations** docs describe that receipt PR flow. Brainmap metadata was refreshed for the workflow file change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2664b351c1b982f1997d96fcdb6dbcb5ee7a4464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->