### PR TITLE
[codex] Keep dogfood receipt PR creation nonfatal

### DIFF
--- a/.github/OPERATIONS.md
+++ b/.github/OPERATIONS.md
@@ -72,7 +72,8 @@ run IDs, and cross-pass reviewers, but not raw command output or secrets. Securi
 while still staying `blocked` in `latest.json` until safe recurring security probes exist.
 
 Because `main` requires pull requests, the dogfood workflow pushes changed receipt files to
-`automation/dogfood-public-receipt` and opens or updates a public receipt PR instead of pushing directly to `main`.
+`automation/dogfood-public-receipt` and opens or updates a public receipt PR when the token is allowed. If GitHub
+Actions cannot create PRs in this repository, the workflow leaves the branch ready for a human or agent-created PR.
 
 ## Runtime env vars
 

--- a/.github/workflows/dogfood-report.yml
+++ b/.github/workflows/dogfood-report.yml
@@ -114,9 +114,13 @@ jobs:
           if pr_url=$(gh pr view "$receipt_branch" --json url --jq .url 2>/dev/null); then
             echo "Dogfood receipt PR: $pr_url"
           else
-            gh pr create \
+            if gh pr create \
               --title "chore(dogfood): update public receipt" \
               --body "Automated public dogfood receipt refresh from workflow run $GITHUB_RUN_ID." \
               --base main \
-              --head "$receipt_branch"
+              --head "$receipt_branch"; then
+              echo "Dogfood receipt PR created."
+            else
+              echo "::warning::Receipt branch pushed to $receipt_branch, but GitHub Actions is not permitted to create pull requests in this repository."
+            fi
           fi

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7833,8 +7833,8 @@
     },
     {
       "source": ".github/workflows/dogfood-report.yml",
-      "hash": "8d18a3401b54",
-      "bytes": 5647
+      "hash": "7f0699c0a69a",
+      "bytes": 5891
     },
     {
       "source": ".github/workflows/event-wake-router.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -190,7 +190,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/autonomous-runner.yml | a1280cfec46b | 15338 |
 | .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
 | .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |
-| .github/workflows/dogfood-report.yml | 8d18a3401b54 | 5647 |
+| .github/workflows/dogfood-report.yml | 7f0699c0a69a | 5891 |
 | .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
 | .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |


### PR DESCRIPTION
## What changed
- Keeps the dogfood workflow green when GitHub Actions is allowed to push the receipt branch but not allowed to create PRs.
- The workflow now emits a warning after pushing `automation/dogfood-public-receipt` instead of failing.
- Updates operations docs to explain the branch-ready fallback.

## Why
The merged workflow fix proved the summary and branch push path work, but the repository blocks PR creation by the Actions token. This keeps the dogfood run green while still leaving the public receipt branch ready for an operator-created PR.

## Validation
- `node` YAML parse of `.github/workflows/dogfood-report.yml` - passing
- `node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs` - 9/9 passing
- `npm run brainmap:check` - passing
- `git diff HEAD --check` - passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; receipt push behavior is unchanged and failures are surfaced via warnings instead of failing the job.
> 
> **Overview**
> The **dogfood report** workflow no longer fails when `gh pr create` is denied after a successful push to `automation/dogfood-public-receipt`. PR creation is wrapped so a blocked token only emits a **GitHub Actions warning** and the job stays green, with the receipt branch left for a manual or agent PR.
> 
> **OPERATIONS** now states that automated PR opening depends on token permissions and documents the branch-ready fallback. Brainmap metadata reflects the workflow file change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90143e84fa10e3d5917a6eb42f4bf114cb399df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->