### PR TITLE
chore(dogfood): update public receipt

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -1,18 +1,18 @@
 {
-  "generatedAt": "2026-05-27T15:57:29.970Z",
-  "lastRunAt": "2026-05-27T15:57:29.970Z",
+  "generatedAt": "2026-05-27T18:16:51.617Z",
+  "lastRunAt": "2026-05-27T18:16:51.617Z",
   "status": "blocked",
-  "source": "dogfood receipt dry run",
+  "source": "nightly dogfood workflow",
   "headline": "We dogfood UnClick on UnClick.",
   "target": "UnClick public and agent-facing product surfaces",
-  "nextAutomation": "Nightly dogfood receipts refresh this board with live scheduled evidence.",
+  "nextAutomation": "Nightly dogfood receipts refresh this board with live checks and scheduled XPass package proof.",
   "statusLegend": {
-    "passing": "A live check ran and returned a passing result.",
-    "failing": "A live check ran and returned a failing result or could not reach its API.",
+    "passing": "A live check or scheduled package sweep ran and returned a passing result.",
+    "failing": "A live check or scheduled package sweep ran and returned a failing result.",
     "blocked": "The check could not run because an action is needed, such as a missing credential or scope gate.",
-    "pending": "The check is planned, package-ready, or scaffolded, but live proof is not available yet."
+    "pending": "The check is planned, package-ready, or scaffolded, but scheduled proof is not available yet."
   },
-  "proofPolicy": "Public dogfood receipts mark passing only when a live check actually ran. Blocked and pending are honest product states, not failures to hide.",
+  "proofPolicy": "Public dogfood receipts mark passing only when a live check or scheduled package sweep actually ran. Blocked and pending are honest product states, not failures to hide.",
   "xpassIndex": [
     {
       "id": "testpass",
@@ -136,22 +136,28 @@
     {
       "id": "testpass",
       "name": "TestPass",
-      "status": "pending",
-      "summary": "Dry-run receipt builder validated the TestPass result shape.",
-      "evidence": "Dry run only. Live workflow calls /api/testpass-run with source=scheduled.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "dry_run_only",
-      "nextProof": "Run the dogfood report without --dry-run and with a TestPass token before marking this passing."
+      "status": "passing",
+      "summary": "Scheduled TestPass completed with 17 checks and 0 failures.",
+      "evidence": "Run a7439422-d3e4-4194-bc78-e2d2b8e955f7 checked https://unclick.world/api/mcp.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "a7439422-d3e4-4194-bc78-e2d2b8e955f7",
+      "targetUrl": "https://unclick.world/api/mcp",
+      "proof": {
+        "kind": "testpass_run",
+        "runId": "a7439422-d3e4-4194-bc78-e2d2b8e955f7",
+        "targetUrl": "https://unclick.world/api/mcp"
+      }
     },
     {
       "id": "uxpass",
       "name": "UXPass",
-      "status": "pending",
-      "summary": "Dry-run receipt builder validated the UXPass result shape.",
-      "evidence": "Dry run only. Live workflow calls /api/uxpass-run against the public URL.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "dry_run_only",
-      "nextProof": "Run the dogfood report without --dry-run and with a UXPass token before marking this passing."
+      "status": "blocked",
+      "summary": "Scheduled UXPass could not run because DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET is missing.",
+      "evidence": "Set one workflow secret so the nightly dogfood workflow can create a fresh uxpass_runs row.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "blockedReason": "Missing DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      "reasonCode": "missing_credential",
+      "nextProof": "Set one UXPass workflow secret, then rerun the dogfood report workflow."
     },
     {
       "id": "securitypass",
@@ -159,7 +165,7 @@
       "status": "blocked",
       "summary": "SecurityPass is blocked until the recurring runner proof is ready.",
       "evidence": "SecurityPass remains scope-gated; the public dogfood receipt does not run security probes yet.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
       "blockedReason": "SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
       "reasonCode": "scope_gate",
       "nextProof": "Land a safe recurring SecurityPass runner receipt before marking this passing."
@@ -167,107 +173,262 @@
     {
       "id": "sloppass",
       "name": "SlopPass",
-      "status": "pending",
-      "summary": "Package-backed quality review exists, but the public dogfood receipt has not run it yet.",
-      "evidence": "SlopPass has a package runner, verdict pack, and dogfood tests; public status stays pending until a scheduled receipt exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/sloppass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed SlopPass.",
+      "evidence": "Receipt xpass-package-sweep-f4b3e91c0e94f4fb ran npm run test --workspace=@unclick/sloppass; cross-checked by TestPass, CommonSensePass, CopyPass.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
       "targetUrl": "packages/sloppass",
-      "nextProof": "Add a recurring SlopPass public receipt before marking this passing."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
+        "packageId": "sloppass",
+        "targetUrl": "packages/sloppass",
+        "targetSha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "false-DONE and proof-claim sanity",
+            "status": "passing"
+          },
+          {
+            "id": "copypass",
+            "name": "CopyPass",
+            "role": "plain-English claims and wording boundary",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "seopass",
       "name": "SEOPass",
-      "status": "pending",
-      "summary": "Package-backed search and metadata review exists, but the public dogfood receipt has not run it yet.",
-      "evidence": "SEOPass has crawler-policy, robots, sitemap, canonical, package, and MCP parity checks; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/seopass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed SEOPass.",
+      "evidence": "Receipt xpass-package-sweep-f4b3e91c0e94f4fb ran npm run test --workspace=@unclick/seopass; cross-checked by TestPass, GEOPass, CommonSensePass.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
       "targetUrl": "packages/seopass",
-      "nextProof": "Add a recurring SEOPass receipt before moving this out of pending."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
+        "packageId": "seopass",
+        "targetUrl": "packages/seopass",
+        "targetSha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "geopass",
+            "name": "GEOPass",
+            "role": "answer-engine overlap for crawler and metadata signals",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "copypass",
       "name": "CopyPass",
-      "status": "pending",
-      "summary": "Package-backed copy quality review exists, but the public dogfood receipt has not run it yet.",
-      "evidence": "CopyPass has deterministic review tooling and CopyRoom boundary checks; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/copypass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed CopyPass.",
+      "evidence": "Receipt xpass-package-sweep-f4b3e91c0e94f4fb ran npm run test --workspace=@unclick/copypass; cross-checked by SlopPass, LegalPass, CommonSensePass.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
       "targetUrl": "packages/copypass",
-      "nextProof": "Add a recurring CopyPass receipt with CopyRoom/source-copy proof."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
+        "packageId": "copypass",
+        "targetUrl": "packages/copypass",
+        "targetSha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "sloppass",
+            "name": "SlopPass",
+            "role": "anti-slop quality review",
+            "status": "passing"
+          },
+          {
+            "id": "legalpass",
+            "name": "LegalPass",
+            "role": "claims and guidance-only boundary",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "legalpass",
       "name": "LegalPass",
-      "status": "pending",
-      "summary": "Package-backed policy and claims guidance exists, but the public dogfood receipt has not run it yet.",
-      "evidence": "LegalPass has guidance tooling, pack schema, and public proof boundaries; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/legalpass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed LegalPass.",
+      "evidence": "Receipt xpass-package-sweep-f4b3e91c0e94f4fb ran npm run test --workspace=@unclick/legalpass; cross-checked by CopyPass, SecurityPass, CommonSensePass.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
       "targetUrl": "packages/legalpass",
-      "nextProof": "Add a recurring LegalPass receipt that stays guidance-only, not legal certification."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
+        "packageId": "legalpass",
+        "targetUrl": "packages/legalpass",
+        "targetSha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "copypass",
+            "name": "CopyPass",
+            "role": "public wording and claims clarity",
+            "status": "passing"
+          },
+          {
+            "id": "securitypass",
+            "name": "SecurityPass",
+            "role": "safe local package proof only",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "certification-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "commonsensepass",
       "name": "CommonSensePass",
-      "status": "pending",
-      "summary": "Worker sanity checks exist, but the public dogfood receipt has not run them yet.",
-      "evidence": "CommonSensePass is routed for proof, queue, claim, false-DONE, and merge-ready sanity; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/commonsensepass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed CommonSensePass.",
+      "evidence": "Receipt xpass-package-sweep-f4b3e91c0e94f4fb ran npm run test --workspace=@unclick/commonsensepass; cross-checked by TestPass, SlopPass.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
       "targetUrl": "packages/commonsensepass",
-      "nextProof": "Add a recurring CommonSensePass proof receipt for worker claims and queue health."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
+        "packageId": "commonsensepass",
+        "targetUrl": "packages/commonsensepass",
+        "targetSha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "sloppass",
+            "name": "SlopPass",
+            "role": "anti-slop claim review",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "flowpass",
       "name": "FlowPass",
-      "status": "pending",
-      "summary": "Package-backed journey checks exist, but the public dogfood receipt has not run them yet.",
-      "evidence": "FlowPass has journey fixtures for onboarding, checkout, handoff, forms, and success/failure states; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/flowpass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed FlowPass.",
+      "evidence": "Receipt xpass-package-sweep-f4b3e91c0e94f4fb ran npm run test --workspace=@unclick/flowpass; cross-checked by UXPass, TestPass, CommonSensePass.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
       "targetUrl": "packages/flowpass",
-      "nextProof": "Add a recurring FlowPass receipt for one public journey target."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
+        "packageId": "flowpass",
+        "targetUrl": "packages/flowpass",
+        "targetSha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "uxpass",
+            "name": "UXPass",
+            "role": "route and UX sweep overlap",
+            "status": "passing"
+          },
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "geopass",
       "name": "GEOPass",
-      "status": "pending",
-      "summary": "Package-backed answer-engine readiness checks exist, but the public dogfood receipt has not run them yet.",
-      "evidence": "GEOPass has AI answer-engine readiness scanning for llms.txt, schema, bots, and metadata; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/geopass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed GEOPass.",
+      "evidence": "Receipt xpass-package-sweep-f4b3e91c0e94f4fb ran npm run test --workspace=@unclick/geopass; cross-checked by TestPass, SEOPass, CommonSensePass.",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
+      "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
       "targetUrl": "packages/geopass",
-      "nextProof": "Add a recurring GEOPass answer-engine readiness receipt."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-f4b3e91c0e94f4fb",
+        "packageId": "geopass",
+        "targetUrl": "packages/geopass",
+        "targetSha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "seopass",
+            "name": "SEOPass",
+            "role": "search-indexing overlap for crawlable answer sources",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "rotatepass",
@@ -275,7 +436,7 @@
       "status": "pending",
       "summary": "Credential lifecycle boundaries are documented and guarded, but no live credential rotation runs in public dogfood.",
       "evidence": "RotatePass stays boundary-only until a safe local receipt can prove redaction and lifecycle behavior without touching real secrets.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
       "reasonCode": "boundary_needs_runner",
       "proof": {
         "kind": "boundary",
@@ -290,7 +451,7 @@
       "status": "pending",
       "summary": "Wake and stale-work visibility exists, but the public dogfood receipt has not run a public-safe stale-work check yet.",
       "evidence": "WakePass powers dispatch, stale ACK, heartbeat, and reclaim visibility; public status stays pending until a public-safe receipt exists.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
       "reasonCode": "boundary_needs_runner",
       "proof": {
         "kind": "boundary",
@@ -305,7 +466,7 @@
       "status": "pending",
       "summary": "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
       "evidence": "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
-      "checkedAt": "2026-05-27T15:57:29.970Z",
+      "checkedAt": "2026-05-27T18:16:51.617Z",
       "reasonCode": "planned_runner",
       "proof": {
         "kind": "planned",
@@ -317,15 +478,15 @@
   "trend": [
     {
       "date": "2026-05-27",
-      "passing": 0,
+      "passing": 8,
       "failing": 0,
-      "blocked": 1,
-      "pending": 12
+      "blocked": 2,
+      "pending": 3
     }
   ],
   "lastActionableFailure": {
-    "title": "SecurityPass needs attention",
-    "detail": "SecurityPass is blocked until the recurring runner proof is ready. Blocked reason: SecurityPass is intentionally deny-all/scope-gated until a safe recurring runner proof lands.",
+    "title": "UXPass needs attention",
+    "detail": "Scheduled UXPass could not run because DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET is missing. Blocked reason: Missing DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
     "owner": "Dogfood automation"
   }
 }

--- a/public/dogfood/uxpass-site-sweep.json
+++ b/public/dogfood/uxpass-site-sweep.json
@@ -2,10 +2,10 @@
   "kind": "uxpass_site_sweep_receipt",
   "check": "uxpass",
   "name": "UXPass",
-  "generated_at": "2026-05-23T17:19:17.312Z",
-  "run_id": "uxpass-site-sweep-3940a83afb23c50f",
+  "generated_at": "2026-05-27T18:16:58.806Z",
+  "run_id": "uxpass-site-sweep-8d444e83ea3bf574",
   "status": "blocked",
-  "target_sha": "07252ebd17d8b6db21b9d67edd1b349e55180e3a",
+  "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
   "min_score": 80,
   "allowed_origins": [
     "https://unclick.world",
@@ -39,7 +39,7 @@
         "kind": "safe_fallback_receipt",
         "reason": "missing_credential",
         "targetUrl": "https://unclick.world/",
-        "target_sha": "07252ebd17d8b6db21b9d67edd1b349e55180e3a"
+        "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8"
       },
       "evidence": {
         "viewports": [
@@ -81,7 +81,7 @@
         "kind": "safe_fallback_receipt",
         "reason": "missing_credential",
         "targetUrl": "https://unclick.world/dashboard",
-        "target_sha": "07252ebd17d8b6db21b9d67edd1b349e55180e3a"
+        "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8"
       },
       "evidence": {
         "viewports": [
@@ -123,7 +123,7 @@
         "kind": "safe_fallback_receipt",
         "reason": "missing_credential",
         "targetUrl": "https://unclick.world/admin/you",
-        "target_sha": "07252ebd17d8b6db21b9d67edd1b349e55180e3a"
+        "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8"
       },
       "evidence": {
         "viewports": [
@@ -161,10 +161,10 @@
     "check": "uxpass",
     "name": "UXPass",
     "status": "blocked",
-    "run_id": "uxpass-site-sweep-3940a83afb23c50f",
-    "target_sha": "07252ebd17d8b6db21b9d67edd1b349e55180e3a",
+    "run_id": "uxpass-site-sweep-8d444e83ea3bf574",
+    "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
     "url": "https://unclick.world",
     "summary": "UXPass site sweep could not run because no token was available.",
-    "generated_at": "2026-05-23T17:19:17.312Z"
+    "generated_at": "2026-05-27T18:16:58.806Z"
   }
 }

--- a/public/dogfood/xpass-package-sweep.json
+++ b/public/dogfood/xpass-package-sweep.json
@@ -1,0 +1,492 @@
+{
+  "kind": "xpass_package_sweep_receipt_v1",
+  "generated_at": "2026-05-27T18:16:34.133Z",
+  "checked_at": "2026-05-27T18:16:34.133Z",
+  "run_id": "xpass-package-sweep-f4b3e91c0e94f4fb",
+  "source": "nightly dogfood workflow",
+  "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+  "status": "passing",
+  "summary": "XPass package sweep passing across 10 package(s).",
+  "package_count": 10,
+  "packages": [
+    {
+      "id": "testpass",
+      "name": "TestPass",
+      "workspace": "@unclick/testpass",
+      "path": "packages/testpass",
+      "stage": "live_gate",
+      "role": "merge proof and MCP smoke gate",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/testpass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 6858,
+      "summary": "TestPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/testpass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/testpass"
+        ]
+      }
+    },
+    {
+      "id": "uxpass",
+      "name": "UXPass",
+      "workspace": "@unclick/uxpass",
+      "path": "packages/uxpass",
+      "stage": "live_dogfood",
+      "role": "public UX and route sweep gate",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/uxpass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 1330,
+      "summary": "UXPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/uxpass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/uxpass"
+        ]
+      }
+    },
+    {
+      "id": "securitypass",
+      "name": "SecurityPass",
+      "workspace": "@unclick/securitypass",
+      "path": "packages/securitypass",
+      "stage": "scope_gated",
+      "role": "safe local security package proof only",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/securitypass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 1507,
+      "summary": "SecurityPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/securitypass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/securitypass"
+        ]
+      }
+    },
+    {
+      "id": "sloppass",
+      "name": "SlopPass",
+      "workspace": "@unclick/sloppass",
+      "path": "packages/sloppass",
+      "stage": "package_ready",
+      "role": "AI-code quality and anti-slop review",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/sloppass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 1400,
+      "summary": "SlopPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/sloppass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/sloppass"
+        ]
+      }
+    },
+    {
+      "id": "seopass",
+      "name": "SEOPass",
+      "workspace": "@unclick/seopass",
+      "path": "packages/seopass",
+      "stage": "package_ready",
+      "role": "crawler, canonical, robots, sitemap, and metadata proof",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/seopass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 872,
+      "summary": "SEOPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/seopass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/seopass"
+        ]
+      }
+    },
+    {
+      "id": "copypass",
+      "name": "CopyPass",
+      "workspace": "@unclick/copypass",
+      "path": "packages/copypass",
+      "stage": "package_ready",
+      "role": "copy quality, claims, and source-copy boundary proof",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/copypass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 1173,
+      "summary": "CopyPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/copypass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/copypass"
+        ]
+      }
+    },
+    {
+      "id": "legalpass",
+      "name": "LegalPass",
+      "workspace": "@unclick/legalpass",
+      "path": "packages/legalpass",
+      "stage": "package_ready",
+      "role": "guidance-only policy and claims proof",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/legalpass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 1369,
+      "summary": "LegalPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/legalpass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/legalpass"
+        ]
+      }
+    },
+    {
+      "id": "commonsensepass",
+      "name": "CommonSensePass",
+      "workspace": "@unclick/commonsensepass",
+      "path": "packages/commonsensepass",
+      "stage": "live_gate",
+      "role": "false-DONE, claim sanity, and proof honesty gate",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/commonsensepass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 1149,
+      "summary": "CommonSensePass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/commonsensepass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/commonsensepass"
+        ]
+      }
+    },
+    {
+      "id": "flowpass",
+      "name": "FlowPass",
+      "workspace": "@unclick/flowpass",
+      "path": "packages/flowpass",
+      "stage": "package_ready",
+      "role": "journey and handoff proof",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/flowpass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 920,
+      "summary": "FlowPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/flowpass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/flowpass"
+        ]
+      }
+    },
+    {
+      "id": "geopass",
+      "name": "GEOPass",
+      "workspace": "@unclick/geopass",
+      "path": "packages/geopass",
+      "stage": "package_ready",
+      "role": "answer-engine readiness and AI-discovery proof",
+      "status": "passing",
+      "checked_at": "2026-05-27T18:16:34.133Z",
+      "command": [
+        "npm",
+        "run",
+        "test",
+        "--workspace=@unclick/geopass"
+      ],
+      "exit_code": 0,
+      "duration_ms": 856,
+      "summary": "GEOPass package tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "workspace_package_test",
+        "workspace": "@unclick/geopass",
+        "command": [
+          "npm",
+          "run",
+          "test",
+          "--workspace=@unclick/geopass"
+        ]
+      }
+    }
+  ],
+  "cross_pass_matrix": [
+    {
+      "target_id": "sloppass",
+      "target_name": "SlopPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "package tests must pass before public proof is trusted",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "false-DONE and proof-claim sanity",
+          "status": "passing"
+        },
+        {
+          "id": "copypass",
+          "name": "CopyPass",
+          "role": "plain-English claims and wording boundary",
+          "status": "passing"
+        }
+      ],
+      "summary": "SlopPass was cross-checked by TestPass, CommonSensePass, CopyPass."
+    },
+    {
+      "target_id": "seopass",
+      "target_name": "SEOPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "package tests must pass before public proof is trusted",
+          "status": "passing"
+        },
+        {
+          "id": "geopass",
+          "name": "GEOPass",
+          "role": "answer-engine overlap for crawler and metadata signals",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "proof-claim sanity",
+          "status": "passing"
+        }
+      ],
+      "summary": "SEOPass was cross-checked by TestPass, GEOPass, CommonSensePass."
+    },
+    {
+      "target_id": "geopass",
+      "target_name": "GEOPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "package tests must pass before public proof is trusted",
+          "status": "passing"
+        },
+        {
+          "id": "seopass",
+          "name": "SEOPass",
+          "role": "search-indexing overlap for crawlable answer sources",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "proof-claim sanity",
+          "status": "passing"
+        }
+      ],
+      "summary": "GEOPass was cross-checked by TestPass, SEOPass, CommonSensePass."
+    },
+    {
+      "target_id": "copypass",
+      "target_name": "CopyPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "sloppass",
+          "name": "SlopPass",
+          "role": "anti-slop quality review",
+          "status": "passing"
+        },
+        {
+          "id": "legalpass",
+          "name": "LegalPass",
+          "role": "claims and guidance-only boundary",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "proof-claim sanity",
+          "status": "passing"
+        }
+      ],
+      "summary": "CopyPass was cross-checked by SlopPass, LegalPass, CommonSensePass."
+    },
+    {
+      "target_id": "legalpass",
+      "target_name": "LegalPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "copypass",
+          "name": "CopyPass",
+          "role": "public wording and claims clarity",
+          "status": "passing"
+        },
+        {
+          "id": "securitypass",
+          "name": "SecurityPass",
+          "role": "safe local package proof only",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "certification-claim sanity",
+          "status": "passing"
+        }
+      ],
+      "summary": "LegalPass was cross-checked by CopyPass, SecurityPass, CommonSensePass."
+    },
+    {
+      "target_id": "commonsensepass",
+      "target_name": "CommonSensePass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "package tests must pass before public proof is trusted",
+          "status": "passing"
+        },
+        {
+          "id": "sloppass",
+          "name": "SlopPass",
+          "role": "anti-slop claim review",
+          "status": "passing"
+        }
+      ],
+      "summary": "CommonSensePass was cross-checked by TestPass, SlopPass."
+    },
+    {
+      "target_id": "flowpass",
+      "target_name": "FlowPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "uxpass",
+          "name": "UXPass",
+          "role": "route and UX sweep overlap",
+          "status": "passing"
+        },
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "package tests must pass before public proof is trusted",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "proof-claim sanity",
+          "status": "passing"
+        }
+      ],
+      "summary": "FlowPass was cross-checked by UXPass, TestPass, CommonSensePass."
+    }
+  ],
+  "action_needed": []
+}


### PR DESCRIPTION
Automated public dogfood receipt refresh from the green Dogfood Report workflow run 26529364302.

Proof:
- XPass package sweep step passed.
- Dogfood receipt build passed.
- UXPass site sweep step passed.
- Artifact upload and summary passed.
- Workflow could not create this PR itself because Actions PR creation is disabled for the repository, so this PR was opened manually from the pushed receipt branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated public JSON only; no runtime or auth logic changes—verify receipt claims match the cited workflow run if auditing trust signals.
> 
> **Overview**
> Refreshes the **public dogfood board** from a real **nightly dogfood workflow** run (replacing the prior dry-run receipt). `public/dogfood/latest.json` now records **live TestPass** proof against `https://unclick.world/api/mcp`, promotes several XPass lanes from pending to **passing** via scheduled package sweep evidence, and updates copy so **passing** can mean live checks or scheduled package sweeps.
> 
> Adds **`public/dogfood/xpass-package-sweep.json`** with run `xpass-package-sweep-f4b3e91c0e94f4fb` (10 workspace test runs, cross-pass matrix). **`uxpass-site-sweep.json`** is re-timestamped for the same commit SHA but stays **blocked** (missing UXPass tokens); the aggregate board’s actionable item is **UXPass** missing `DOGFOOD_UXPASS_TOKEN` / `UXPASS_TOKEN` / `CRON_SECRET`. Overall status remains **blocked** (8 passing, 2 blocked, 3 pending).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e055d39dff7c5d82808104bba095464c8be3f2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->