### PR TITLE
fix(xpass): cross-check every package in dogfood sweep

### DIFF
--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -204,6 +204,24 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
   const output = path.join(dir, "latest.json");
   const sweepPath = path.join(dir, "xpass-package-sweep.json");
+  const packageRows = [
+    { id: "sloppass", name: "SlopPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/sloppass"] },
+    { id: "seopass", name: "SEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/seopass"] },
+    { id: "copypass", name: "CopyPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/copypass"] },
+    { id: "legalpass", name: "LegalPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/legalpass"] },
+    { id: "commonsensepass", name: "CommonSensePass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/commonsensepass"] },
+    { id: "flowpass", name: "FlowPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/flowpass"] },
+    { id: "geopass", name: "GEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/geopass"] },
+  ];
+  const reviewerNames = new Map([
+    ["testpass", "TestPass"],
+    ["commonsensepass", "CommonSensePass"],
+    ["sloppass", "SlopPass"],
+  ]);
+  const reviewersFor = (targetId) => ["testpass", "commonsensepass", "sloppass"]
+    .filter((id) => id !== targetId)
+    .slice(0, 2)
+    .map((id) => ({ id, name: reviewerNames.get(id), status: "passing" }));
 
   try {
     await fs.writeFile(sweepPath, JSON.stringify({
@@ -211,33 +229,12 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
       run_id: "xpass-package-sweep-123",
       target_sha: "abc123",
       status: "passing",
-      packages: [
-        { id: "sloppass", name: "SlopPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/sloppass"] },
-        { id: "seopass", name: "SEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/seopass"] },
-        { id: "copypass", name: "CopyPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/copypass"] },
-        { id: "legalpass", name: "LegalPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/legalpass"] },
-        { id: "commonsensepass", name: "CommonSensePass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/commonsensepass"] },
-        { id: "flowpass", name: "FlowPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/flowpass"] },
-        { id: "geopass", name: "GEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/geopass"] },
-      ],
-      cross_pass_matrix: [
-        {
-          target_id: "sloppass",
-          status: "passing",
-          reviewers: [
-            { id: "testpass", name: "TestPass", status: "passing" },
-            { id: "commonsensepass", name: "CommonSensePass", status: "passing" },
-          ],
-        },
-        {
-          target_id: "geopass",
-          status: "passing",
-          reviewers: [
-            { id: "testpass", name: "TestPass", status: "passing" },
-            { id: "seopass", name: "SEOPass", status: "passing" },
-          ],
-        },
-      ],
+      packages: packageRows,
+      cross_pass_matrix: packageRows.map((pkg) => ({
+        target_id: pkg.id,
+        status: "passing",
+        reviewers: reviewersFor(pkg.id),
+      })),
     }));
 
     await execFileAsync(process.execPath, [
@@ -262,6 +259,13 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
     const geopass = report.results.find((result) => result.id === "geopass");
     const securitypass = report.results.find((result) => result.id === "securitypass");
 
+    for (const pkg of packageRows) {
+      const result = report.results.find((entry) => entry.id === pkg.id);
+      assert.equal(result?.status, "passing", `${pkg.name} should promote from a fresh full XPass sweep`);
+      assert.equal(result?.runId, "xpass-package-sweep-123");
+      assert.equal(result?.proof?.kind, "xpass_package_sweep");
+      assert.equal(result?.proof?.packageId, pkg.id);
+    }
     assert.equal(sloppass?.status, "passing");
     assert.equal(sloppass?.runId, "xpass-package-sweep-123");
     assert.equal(sloppass?.proof?.kind, "xpass_package_sweep");

--- a/scripts/build-xpass-package-sweep.mjs
+++ b/scripts/build-xpass-package-sweep.mjs
@@ -94,6 +94,31 @@ export const PASS_PACKAGES = [
 
 export const CROSS_PASS_MATRIX = [
   {
+    targetId: "testpass",
+    reviewers: [
+      { id: "commonsensepass", role: "proof honesty and false-DONE gate coverage" },
+      { id: "securitypass", role: "MCP and safe local security boundary review" },
+      { id: "sloppass", role: "fixture quality and failure-message review" },
+    ],
+  },
+  {
+    targetId: "uxpass",
+    reviewers: [
+      { id: "testpass", role: "package tests must pass before public UX proof is trusted" },
+      { id: "flowpass", role: "route, journey, and handoff overlap" },
+      { id: "copypass", role: "interface copy and public wording clarity" },
+      { id: "commonsensepass", role: "proof-claim sanity" },
+    ],
+  },
+  {
+    targetId: "securitypass",
+    reviewers: [
+      { id: "testpass", role: "package tests must pass before security proof is trusted" },
+      { id: "commonsensepass", role: "scope-gate and proof-claim sanity" },
+      { id: "legalpass", role: "safe guidance boundary and non-certification wording" },
+    ],
+  },
+  {
     targetId: "sloppass",
     reviewers: [
       { id: "testpass", role: "package tests must pass before public proof is trusted" },

--- a/scripts/build-xpass-package-sweep.test.mjs
+++ b/scripts/build-xpass-package-sweep.test.mjs
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import { promisify } from "node:util";
 
 import {
+  CROSS_PASS_MATRIX,
   PASS_PACKAGES,
   buildXPassPackageSweep,
   defaultRunCommand,
@@ -43,6 +44,28 @@ test("XPass package sweep records package and cross-pass proof", async () => {
     "copypass",
   ]);
   assert.deepEqual(receipt.action_needed, []);
+});
+
+test("XPass package sweep cross-checks every pass package", async () => {
+  const receipt = await buildXPassPackageSweep({
+    now: "2026-05-28T00:00:00.000Z",
+    targetSha: "abc123",
+    runCommand: async () => ({ status: "passing", exitCode: 0, durationMs: 12, failureHint: "" }),
+  });
+  const packageIds = new Set(PASS_PACKAGES.map((pkg) => pkg.id));
+  const targetIds = new Set(receipt.cross_pass_matrix.map((row) => row.target_id));
+
+  assert.deepEqual(targetIds, packageIds);
+  assert.equal(CROSS_PASS_MATRIX.length, PASS_PACKAGES.length);
+
+  for (const row of receipt.cross_pass_matrix) {
+    assert.equal(row.status, "passing");
+    assert.ok(row.reviewers.length >= 2, `${row.target_id} needs at least two cross-pass reviewers`);
+    for (const reviewer of row.reviewers) {
+      assert.notEqual(reviewer.id, row.target_id, `${row.target_id} should not review itself`);
+      assert.ok(packageIds.has(reviewer.id), `${row.target_id} references unknown reviewer ${reviewer.id}`);
+    }
+  }
 });
 
 test("XPass package sweep fails honestly when a package reviewer fails", async () => {


### PR DESCRIPTION
- XPass dogfood sweep now includes cross-pass review rows for TestPass, UXPass, and SecurityPass, closing the gap where 3 of 10 packages were tested but not explicit review targets.
- Added a guard that the cross-pass matrix target set must equal the pass package set, with no self-review and only known reviewer ids.
- Widened dogfood report coverage so a fresh full XPass sweep must promote every package-ready pass, not just example rows.

Proof run locally:
- node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs scripts/pinballwake-xpass-gate-room.test.mjs scripts/pinballwake-dogfood-room.test.mjs
- node scripts/build-xpass-package-sweep.mjs --target-sha 5702ed92931049ec6a05a4e65bafa59051be1929 --output $TEMP/xpass-package-sweep-local.json --timeout-ms 180000
- npm run dogfood:commonsensepass
- npm run brainmap:check
- npm run test:brainmap
- npm run build
- npm test -- --run
- npx eslint scripts/build-xpass-package-sweep.mjs scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs

Note: npm run lint remains red repo-wide on pre-existing files outside this patch, so this PR uses changed-file lint plus the product/test/build gates above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to XPass sweep matrix config and dogfood/sweep test scripts; no production auth or runtime paths.
> 
> **Overview**
> The XPass package sweep **cross-pass matrix** now explicitly targets **TestPass**, **UXPass**, and **SecurityPass** (with reviewer roles), so every entry in `PASS_PACKAGES` has a defined cross-check row instead of only the package-ready subset.
> 
> New sweep tests assert the matrix **covers all pass packages** (`CROSS_PASS_MATRIX.length` matches `PASS_PACKAGES`), that matrix targets match the package set, and that each row has at least two reviewers with **no self-review** and only known package ids.
> 
> The dogfood report test builds a **full** sweep receipt (matrix row per package) and asserts **every** package-ready pass in the fixture is promoted to `passing` with `xpass_package_sweep` proof—not only spot checks like SlopPass and GEOPass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 896bbbf5257b1a2cf7a0daab7b2cae61ef604d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->