### PR TITLE
fix(copypass): ignore guardrail example catalogs

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7748,8 +7748,8 @@
     },
     {
       "source": "packages/mcp-server/src/copypass-tool.ts",
-      "hash": "4debe88f6f2f",
-      "bytes": 28450
+      "hash": "9cb57c05f879",
+      "bytes": 29686
     },
     {
       "source": "packages/mcp-server/src/crews-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -173,7 +173,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/color-tool.ts | f9aa9c0fec6e | 13643 |
 | packages/mcp-server/src/commonsensepass-tool.ts | bad23b55ea01 | 1995 |
 | packages/mcp-server/src/convertkit-tool.ts | 2f77303a3441 | 8498 |
-| packages/mcp-server/src/copypass-tool.ts | 4debe88f6f2f | 28450 |
+| packages/mcp-server/src/copypass-tool.ts | 9cb57c05f879 | 29686 |
 | packages/mcp-server/src/crews-tool.ts | 111454c76c0a | 13547 |
 | packages/mcp-server/src/csuite-tool.ts | 0ab5af89bb49 | 70236 |
 | packages/mcp-server/src/datadog-tool.ts | 802b808614cd | 5556 |

--- a/docs/copypass-product-brief.md
+++ b/docs/copypass-product-brief.md
@@ -13,6 +13,8 @@ CopyPass is a deterministic product-copy review pass for UnClick. It flags copy 
 
 CopyPass is advisory. It does not promise legal, compliance, revenue, ranking, conversion, accessibility, or safety outcomes. Its job is to make the next human copy review sharper and easier to audit.
 
+When CopyPass is dogfooding another Pass product, explicit guardrail documentation can quote unsafe phrases in order to ban them. CopyPass should treat those doc blocks as policy-example catalogs, not live public claims, when the block is clearly labelled as banned, forbidden, guardrail, linter, or audit wording. The same phrases remain high-risk when they appear in ordinary hero, pricing, ad, email, legal, or product copy.
+
 ## Future Fit
 
 The package is intentionally small so it can later consume shared scanner output from the Pass family without coupling this slice to GEOPass, SEOPass, FlowPass, LegalPass, SlopPass, UXPass, SecurityPass, or TestPass internals. The current safe completion bar is deterministic evidence on supplied copy, not a paid model rewrite, voice-profile humaniser, template engine, or detector-evasion product.

--- a/packages/copypass/src/__tests__/copy-library.test.ts
+++ b/packages/copypass/src/__tests__/copy-library.test.ts
@@ -108,4 +108,40 @@ describe("CopyPass copy library", () => {
     expect(finding?.severity).toBe("high");
     expect(finding?.suggested_fix).toContain("quality");
   });
+
+  it("does not treat explicit banned-phrase documentation as live risky copy", () => {
+    const blocks: CopyPassCopyBlock[] = [
+      {
+        id: "legalpass-guardrail-doc",
+        kind: "doc",
+        label: "LegalPass banned phrases",
+        source_path: "docs/legalpass-product-brief.md",
+        text:
+          "Verdict-linter guardrail examples: banned phrases include `100% compliant`, " +
+          "`risk-free`, `AI lawyer`, `rank #1`, `last chance`, and `fully automated`. " +
+          "Allowed framing includes `may warrant review` and `qualified practitioner review may be warranted`.",
+        public_only: true,
+      },
+    ];
+
+    expect(detectCopyPassFindings(blocks)).toEqual([]);
+  });
+
+  it("still flags the same risky words in live public claim copy", () => {
+    const blocks: CopyPassCopyBlock[] = [
+      {
+        id: "legalpass-hero",
+        kind: "hero",
+        text:
+          "LegalPass is the best AI lawyer, 100% compliant, risk-free, fully automated, and guaranteed to rank #1.",
+        public_only: true,
+      },
+    ];
+
+    const checkIds = detectCopyPassFindings(blocks).map((finding) => finding.check_id);
+
+    expect(checkIds).toContain("unsupported-superiority");
+    expect(checkIds).toContain("risky-guarantee-language");
+    expect(checkIds).toContain("ui-honesty-gap");
+  });
 });

--- a/packages/copypass/src/copy-library.ts
+++ b/packages/copypass/src/copy-library.ts
@@ -285,6 +285,7 @@ export function detectCopyPassFindings(
 
   const blockFindings = blocks.flatMap((block) => {
     const normalized = normalizeCopy(block.text);
+    const isPolicyExample = isPolicyExampleCatalog(block, normalized);
     const findings: CopyPassFinding[] = [];
 
     if (
@@ -335,6 +336,7 @@ export function detectCopyPassFindings(
 
     if (
       isActive(activeCheckIds, "unsupported-superiority") &&
+      !isPolicyExample &&
       containsAny(normalized, SUPERIORITY_TERMS) &&
       !containsAny(normalized, PROOF_TERMS)
     ) {
@@ -364,6 +366,7 @@ export function detectCopyPassFindings(
 
     if (
       isActive(activeCheckIds, "risky-guarantee-language") &&
+      !isPolicyExample &&
       hasRiskyGuarantee(normalized)
     ) {
       findings.push(
@@ -378,6 +381,7 @@ export function detectCopyPassFindings(
 
     if (
       isActive(activeCheckIds, "detector-evasion-claim") &&
+      !isPolicyExample &&
       containsAny(normalized, DETECTOR_EVASION_TERMS)
     ) {
       findings.push(
@@ -392,6 +396,7 @@ export function detectCopyPassFindings(
 
     if (
       isActive(activeCheckIds, "ai-slop-language") &&
+      !isPolicyExample &&
       (containsAny(normalized, AI_SLOP_TERMS) || hasEmDash(block.text))
     ) {
       findings.push(
@@ -421,6 +426,7 @@ export function detectCopyPassFindings(
 
     if (
       isActive(activeCheckIds, "misleading-urgency") &&
+      !isPolicyExample &&
       containsAny(normalized, URGENCY_TERMS) &&
       !hasUrgencySupport(normalized)
     ) {
@@ -436,6 +442,7 @@ export function detectCopyPassFindings(
 
     if (
       isActive(activeCheckIds, "ui-honesty-gap") &&
+      !isPolicyExample &&
       containsAny(normalized, UI_AUTOMATION_TERMS) &&
       !containsAny(normalized, PROOF_TERMS) &&
       !containsAny(normalized, ["beta", "when safe", "preview", "manual review"])
@@ -455,7 +462,11 @@ export function detectCopyPassFindings(
 
   return [
     ...blockFindings,
-    ...detectInternalConsistencyFindings(blocks, activeCheckIds, checkById),
+    ...detectInternalConsistencyFindings(
+      blocks.filter((block) => !isPolicyExampleCatalog(block, normalizeCopy(block.text))),
+      activeCheckIds,
+      checkById,
+    ),
   ];
 }
 
@@ -465,6 +476,54 @@ export function normalizeCopy(value: string): string {
 
 function isPrimaryBlock(block: CopyPassCopyBlock): boolean {
   return block.kind === "hero" || block.kind === "headline";
+}
+
+function isPolicyExampleCatalog(block: CopyPassCopyBlock, normalized: string): boolean {
+  if (block.kind !== "doc") return false;
+
+  const sourceContext = normalizeCopy(
+    [
+      block.label ?? "",
+      block.source_path ?? "",
+      block.source_url ?? "",
+    ].join(" "),
+  );
+  const catalogContext = `${sourceContext} ${normalized}`;
+
+  const hasGuardrailContext = containsAny(catalogContext, [
+    "banned",
+    "forbidden",
+    "blocked",
+    "disallowed",
+    "do not use",
+    "guardrail",
+    "linter",
+    "marketing copy audit",
+    "passguard",
+    "policy",
+  ]);
+  const hasExampleContext = containsAny(catalogContext, [
+    "allowed framing",
+    "banned phrase",
+    "banned phrases",
+    "example",
+    "examples",
+    "phrase",
+    "phrases",
+    "term",
+    "terms",
+    "wording",
+  ]);
+  const hasRiskTerm = containsAny(normalized, [
+    ...SUPERIORITY_TERMS,
+    ...GUARANTEE_TERMS,
+    ...DETECTOR_EVASION_TERMS,
+    ...AI_SLOP_TERMS,
+    ...URGENCY_TERMS,
+    ...UI_AUTOMATION_TERMS,
+  ]);
+
+  return hasGuardrailContext && hasExampleContext && hasRiskTerm;
 }
 
 function isActive(activeCheckIds: Set<CopyPassCheckId>, checkId: CopyPassCheckId): boolean {

--- a/packages/mcp-server/src/copypass-tool.test.ts
+++ b/packages/mcp-server/src/copypass-tool.test.ts
@@ -145,6 +145,48 @@ describe("copypass-tool", () => {
     expect(finding?.severity).toBe("high");
   });
 
+  it("does not treat banned-phrase docs as live risky claims in MCP runs", async () => {
+    const run = (await copypassRun({
+      copy_text:
+        "Verdict-linter guardrail examples: banned phrases include 100% compliant, " +
+        "risk-free, AI lawyer, rank #1, last chance, and fully automated. " +
+        "Allowed framing includes may warrant review.",
+      channel: "legalpass_guardrail_docs",
+      audience: "builders",
+      goal: "document forbidden wording",
+      profile: "standard",
+    })) as {
+      copypass_verdict?: string;
+      finding_count?: number;
+      findings?: Array<{ check_id?: string }>;
+    };
+
+    expect(run.copypass_verdict).toBe("pass");
+    expect(run.finding_count).toBe(0);
+    expect(run.findings).toEqual([]);
+  });
+
+  it("still flags the same words when they are shipped claim copy in MCP runs", async () => {
+    const run = (await copypassRun({
+      copy_text:
+        "LegalPass is the best AI lawyer, 100% compliant, risk-free, fully automated, and guaranteed to rank #1.",
+      channel: "homepage_hero",
+      audience: "founders",
+      goal: "conversion",
+      profile: "standard",
+    })) as {
+      copypass_verdict?: string;
+      findings?: Array<{ check_id?: string }>;
+    };
+
+    const checkIds = run.findings?.map((finding) => finding.check_id) ?? [];
+
+    expect(run.copypass_verdict).toBe("fail");
+    expect(checkIds).toContain("unsupported-superiority");
+    expect(checkIds).toContain("risky-guarantee-language");
+    expect(checkIds).toContain("ui-honesty-gap");
+  });
+
   it("attaches a CopyRoom exact-copy receipt from a source packet", async () => {
     const sourceText = "Line 1\r\nLine 2 with symbols: GBP, EUR, emoji ok";
     const run = (await copypassRun({

--- a/packages/mcp-server/src/copypass-tool.ts
+++ b/packages/mcp-server/src/copypass-tool.ts
@@ -317,6 +317,7 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
   const normalized = normalizeCopy(copyText);
   const findings: CopyFinding[] = [];
   const channel = normalizeCopy(run.target.channel ?? "");
+  const isPolicyExample = isPolicyExampleCatalog(normalized, channel);
 
   if (containsAny(normalized, VAGUE_TERMS) && !containsAny(normalized, VALUE_TERMS)) {
     findings.push(
@@ -357,7 +358,11 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
     );
   }
 
-  if (containsAny(normalized, SUPERIORITY_TERMS) && !containsAny(normalized, PROOF_TERMS)) {
+  if (
+    !isPolicyExample &&
+    containsAny(normalized, SUPERIORITY_TERMS) &&
+    !containsAny(normalized, PROOF_TERMS)
+  ) {
     findings.push(
       createCopyFinding(
         "unsupported-superiority",
@@ -383,7 +388,7 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
     );
   }
 
-  if (hasRiskyGuarantee(normalized)) {
+  if (!isPolicyExample && hasRiskyGuarantee(normalized)) {
     findings.push(
       createCopyFinding(
         "risky-guarantee-language",
@@ -396,7 +401,7 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
     );
   }
 
-  if (containsAny(normalized, DETECTOR_EVASION_TERMS)) {
+  if (!isPolicyExample && containsAny(normalized, DETECTOR_EVASION_TERMS)) {
     findings.push(
       createCopyFinding(
         "detector-evasion-claim",
@@ -412,7 +417,7 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
   const matchedPair = CONSISTENCY_PAIRS.find(([left, right]) =>
     containsAny(normalized, [left]) && containsAny(normalized, [right])
   );
-  if (matchedPair) {
+  if (!isPolicyExample && matchedPair) {
     findings.push(
       createCopyFinding(
         "internal-consistency",
@@ -441,7 +446,10 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
     );
   }
 
-  if (containsAny(normalized, AI_SLOP_TERMS) || /[\u2013\u2014]/u.test(copyText)) {
+  if (
+    !isPolicyExample &&
+    (containsAny(normalized, AI_SLOP_TERMS) || /[\u2013\u2014]/u.test(copyText))
+  ) {
     findings.push(
       createCopyFinding(
         "ai-slop-language",
@@ -454,7 +462,7 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
     );
   }
 
-  if (containsAny(normalized, URGENCY_TERMS) && !hasUrgencySupport(normalized)) {
+  if (!isPolicyExample && containsAny(normalized, URGENCY_TERMS) && !hasUrgencySupport(normalized)) {
     findings.push(
       createCopyFinding(
         "misleading-urgency",
@@ -468,6 +476,7 @@ function detectCopyPassFindings(copyText: string, run: CopyRunRecord): CopyFindi
   }
 
   if (
+    !isPolicyExample &&
     containsAny(normalized, UI_AUTOMATION_TERMS) &&
     !containsAny(normalized, PROOF_TERMS) &&
     !containsAny(normalized, ["beta", "manual review", "preview", "when safe"])
@@ -571,6 +580,48 @@ function normalizeCopy(value: string): string {
 
 function containsAny(value: string, terms: string[]): boolean {
   return terms.some((term) => containsTerm(value, term));
+}
+
+function isPolicyExampleCatalog(normalized: string, channel: string): boolean {
+  if (!containsAny(channel, ["doc", "docs", "policy", "guardrail", "linter", "audit"])) {
+    return false;
+  }
+
+  const catalogContext = `${channel} ${normalized}`;
+  const hasGuardrailContext = containsAny(catalogContext, [
+    "banned",
+    "forbidden",
+    "blocked",
+    "disallowed",
+    "do not use",
+    "guardrail",
+    "linter",
+    "marketing copy audit",
+    "passguard",
+    "policy",
+  ]);
+  const hasExampleContext = containsAny(catalogContext, [
+    "allowed framing",
+    "banned phrase",
+    "banned phrases",
+    "example",
+    "examples",
+    "phrase",
+    "phrases",
+    "term",
+    "terms",
+    "wording",
+  ]);
+  const hasRiskTerm = containsAny(normalized, [
+    ...SUPERIORITY_TERMS,
+    ...GUARANTEE_TERMS,
+    ...DETECTOR_EVASION_TERMS,
+    ...AI_SLOP_TERMS,
+    ...URGENCY_TERMS,
+    ...UI_AUTOMATION_TERMS,
+  ]);
+
+  return hasGuardrailContext && hasExampleContext && hasRiskTerm;
 }
 
 function containsTerm(value: string, term: string): boolean {


### PR DESCRIPTION
## Summary
- teach CopyPass package + MCP CopyPass to treat explicit banned-phrase guardrail docs as policy-example catalogs, not live public claims
- keep the same risky phrases failing in normal hero/claim copy
- add package/MCP regression tests and refresh BrainMap

## Research / QC
- Rechecked Google Search AI features, helpful content, Google AI-content guidance, ABA Rule 7.1, and FTC endorsement guidance.
- Official guidance still supports evidence-first wording, no guaranteed AI/Search placement, no misleading legal marketing, and no compliance/safety certification claims.

## QCPass / Dogtesting
- npm test --workspace=@unclick/copypass
- npm test --workspace=@unclick/mcp-server -- copypass-tool.test.ts
- node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs scripts/pinballwake-xpass-gate-room.test.mjs
- npm run brainmap:check
- npm run build --workspace=@unclick/copypass
- npm run build --workspace=@unclick/mcp-server
- npx eslint packages/copypass/src/copy-library.ts packages/copypass/src/__tests__/copy-library.test.ts packages/mcp-server/src/copypass-tool.ts packages/mcp-server/src/copypass-tool.test.ts
- npm test
- npm run build
- XPass package sweep: passing, 10 packages, 0 action_needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CopyPass verdict behavior for doc/guardrail-shaped input; misclassification could reduce findings on borderline copy, but scope is heuristic and advisory-only.
> 
> **Overview**
> CopyPass now treats **explicit banned-phrase / guardrail documentation** as policy-example catalogs instead of live marketing claims, so dogfooding other Pass products’ linter docs no longer trips superiority, guarantee, urgency, and similar checks on quoted forbidden wording.
> 
> The **`@unclick/copypass`** library adds `isPolicyExampleCatalog` for **`doc`** blocks when label/path/text together signal guardrail + example catalog language and risky terms are present; those blocks skip the affected high-risk rules and are omitted from internal-consistency analysis. The **MCP** `copypass-tool` applies the same idea using **channel** metadata (e.g. `legalpass_guardrail_docs`) plus matching text heuristics. **Regression tests** cover pass-on-guardrail-docs vs fail-on-real hero copy; the product brief notes the behavior; BrainMap entries refresh for `copypass-tool`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e23f0b0fe4d6b3dd20618382983260f4b579638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->