### PR TITLE
fix(testpass): verify MCP tool risk annotations

### DIFF
--- a/packages/testpass/packs/testpass-core.yaml
+++ b/packages/testpass/packs/testpass-core.yaml
@@ -192,6 +192,33 @@ items:
     tags: [lifecycle, capabilities, spec-compliance]
     profiles: [standard, deep]
 
+  # ── MCP tool metadata and risk annotations ────────────────────────────────
+
+  - id: TOOL-META-001
+    title: Every tool declares MCP risk annotations
+    category: tool-hygiene
+    severity: high
+    check_type: deterministic
+    description: >
+      Call tools/list and confirm every advertised tool includes boolean
+      annotations for readOnlyHint, destructiveHint, idempotentHint, and
+      openWorldHint. These hints are not a hard safety boundary, but they are
+      the current MCP risk vocabulary clients use for approval prompts,
+      retry policy, and open-world trust warnings.
+    expected:
+      annotations:
+        readOnlyHint: boolean
+        destructiveHint: boolean
+        idempotentHint: boolean
+        openWorldHint: boolean
+    on_fail: >
+      Add annotations to every tool definition. Use readOnlyHint true only for
+      non-mutating tools, destructiveHint true for tools that can overwrite or
+      delete, idempotentHint true only when safe to retry with the same input,
+      and openWorldHint true when the tool touches external or untrusted data.
+    tags: [tools, annotations, security, approval, spec-hygiene]
+    profiles: [standard, deep]
+
   # ── UnClick tool surface ───────────────────────────────────────────────────
 
   - id: TOOL-001

--- a/packages/testpass/src/__tests__/deterministic.test.ts
+++ b/packages/testpass/src/__tests__/deterministic.test.ts
@@ -96,6 +96,51 @@ function makeStrictSseMcpServer(): Promise<{ url: string; close: () => void }> {
   });
 }
 
+function makeToolListMcpServer(
+  tools: Array<Record<string, unknown>>,
+): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let raw = "";
+      req.on("data", (c: Buffer) => (raw += c.toString()));
+      req.on("end", () => {
+        const rpc = JSON.parse(raw) as { id?: number; method: string };
+        if (rpc.id === undefined) {
+          res.writeHead(204).end();
+          return;
+        }
+
+        let payload: unknown;
+        if (rpc.method === "initialize") {
+          payload = {
+            protocolVersion: "2024-11-05",
+            serverInfo: { name: "tool-list-mcp", version: "1.0.0" },
+            capabilities: { tools: {} },
+            instructions: "Tool metadata fixture.",
+          };
+        } else if (rpc.method === "tools/list") {
+          payload = { tools };
+        } else {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            jsonrpc: "2.0",
+            id: rpc.id,
+            error: { code: -32601, message: "Method not found" },
+          }));
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result: payload }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() });
+    });
+  });
+}
+
 function mockResult(method: string): unknown {
   if (method === "initialize") {
     return {
@@ -315,6 +360,83 @@ items:
       expect(mcp005?.[3].verdict).toBe("check");
     } finally {
       strictSrv.close();
+    }
+  });
+
+  it("passes tools/list shape and tool annotation checks for well-described tools", async () => {
+    const toolSrv = await makeToolListMcpServer([
+      {
+        name: "search_memory",
+        description: "Search durable user memory with a query string.",
+        inputSchema: { type: "object", properties: { q: { type: "string" } } },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+    ]);
+    const metadataPack = loadPackFromYaml(`
+id: tool-metadata
+name: Tool Metadata
+version: 0.1.0
+items:
+  - id: MCP-007
+    title: tools/list shape
+    category: mcp-lifecycle
+    severity: critical
+    check_type: deterministic
+  - id: TOOL-META-001
+    title: annotations
+    category: tool-hygiene
+    severity: high
+    check_type: deterministic
+`);
+
+    try {
+      await runDeterministicChecks(config, "run-tools", toolSrv.url, metadataPack, "standard");
+      const mcp007 = mockUpdateItem.mock.calls.find((c) => c[2] === "MCP-007");
+      const meta001 = mockUpdateItem.mock.calls.find((c) => c[2] === "TOOL-META-001");
+      expect(mcp007?.[3].verdict).toBe("check");
+      expect(meta001?.[3].verdict).toBe("check");
+    } finally {
+      toolSrv.close();
+    }
+  });
+
+  it("fails the tool annotation check when a tool omits boolean MCP risk hints", async () => {
+    const toolSrv = await makeToolListMcpServer([
+      {
+        name: "save_fact",
+        description: "Persist a durable memory fact for the signed-in user.",
+        inputSchema: { type: "object", properties: { fact: { type: "string" } } },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+        },
+      },
+    ]);
+    const metadataPack = loadPackFromYaml(`
+id: tool-metadata
+name: Tool Metadata
+version: 0.1.0
+items:
+  - id: TOOL-META-001
+    title: annotations
+    category: tool-hygiene
+    severity: high
+    check_type: deterministic
+`);
+
+    try {
+      await runDeterministicChecks(config, "run-tools-missing", toolSrv.url, metadataPack, "standard");
+      const meta001 = mockUpdateItem.mock.calls.find((c) => c[2] === "TOOL-META-001");
+      expect(meta001?.[3].verdict).toBe("fail");
+      expect(meta001?.[3].on_fail_comment).toMatch(/idempotentHint/);
+      expect(meta001?.[3].on_fail_comment).toMatch(/openWorldHint/);
+    } finally {
+      toolSrv.close();
     }
   });
 });

--- a/packages/testpass/src/runner/deterministic.ts
+++ b/packages/testpass/src/runner/deterministic.ts
@@ -88,6 +88,73 @@ async function runGitStatusPorcelain(
 
 type CheckHandler = (targetUrl: string, config: RunManagerConfig) => Promise<CheckOutcome>;
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function responseResult(responseBody: unknown): Record<string, unknown> | null {
+  return asRecord(asRecord(responseBody)?.result);
+}
+
+function toolListFromResult(result: Record<string, unknown> | null): Array<Record<string, unknown>> | null {
+  const tools = result?.tools;
+  if (!Array.isArray(tools)) return null;
+  const records = tools.map(asRecord);
+  return records.every(Boolean) ? records as Array<Record<string, unknown>> : null;
+}
+
+async function initializeThenListTools(
+  url: string,
+  baseId: number,
+  timeoutMs = 10_000,
+): Promise<{ traces: HttpTrace[]; tools: Array<Record<string, unknown>> | null; failure?: string }> {
+  const initReq = rpcReq("initialize", {
+    protocolVersion: "2024-11-05",
+    clientInfo: { name: "testpass-runner", version: "0.1.0" },
+    capabilities: {},
+  }, baseId);
+  const notifReq = { jsonrpc: "2.0", method: "notifications/initialized", params: {} };
+  const toolsReq = rpcReq("tools/list", {}, baseId + 1);
+
+  const initR = await send(url, initReq, timeoutMs);
+  const notifR = await send(url, notifReq, timeoutMs);
+  const toolsR = await send(url, toolsReq, timeoutMs);
+  const traces: HttpTrace[] = [
+    { request: { url, body: initReq }, response: initR },
+    { request: { url, body: notifReq }, response: notifR },
+    { request: { url, body: toolsReq }, response: toolsR },
+  ];
+
+  const initResult = responseResult(initR.body);
+  if (!initResult) return { traces, tools: null, failure: `initialize did not return a result: ${JSON.stringify(initR.body)}` };
+
+  const toolsBody = asRecord(toolsR.body);
+  const toolsError = asRecord(toolsBody?.error);
+  if (toolsError) return { traces, tools: null, failure: `tools/list returned error: ${JSON.stringify(toolsError)}` };
+
+  const toolsResult = responseResult(toolsR.body);
+  const tools = toolListFromResult(toolsResult);
+  if (!tools) return { traces, tools: null, failure: `tools/list did not return a tools array: ${JSON.stringify(toolsResult)}` };
+  return { traces, tools };
+}
+
+function missingToolShapeFields(tool: Record<string, unknown>): string[] {
+  const missing: string[] = [];
+  if (typeof tool.name !== "string" || tool.name.trim() === "") missing.push("name");
+  if (typeof tool.description !== "string" || tool.description.trim() === "") missing.push("description");
+  if (!asRecord(tool.inputSchema)) missing.push("inputSchema");
+  return missing;
+}
+
+function missingToolAnnotationFields(tool: Record<string, unknown>): string[] {
+  const annotations = asRecord(tool.annotations);
+  const required = ["readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"];
+  if (!annotations) return required;
+  return required.filter((field) => typeof annotations[field] !== "boolean");
+}
+
 function apiKeyHash(): string | null {
   const token = process.env.TESTPASS_TOKEN?.trim();
   if (!token) return null;
@@ -322,6 +389,52 @@ const HANDLERS: Record<string, CheckHandler> = {
     if (err?.code === -32601) return { verdict: "check", traces: [trace] };
     if (err) return { verdict: "fail", note: `Expected error.code -32601, got ${JSON.stringify(err.code)}`, traces: [trace] };
     return { verdict: "fail", note: `Unknown method must return error, got ${JSON.stringify(body)}`, traces: [trace] };
+  },
+
+  // MCP-007: tools/list must expose renderable tool definitions.
+  "MCP-007": async (url) => {
+    const { traces, tools, failure } = await initializeThenListTools(url, 360);
+    if (failure) return { verdict: "fail", note: failure, traces };
+    if (!tools || tools.length === 0) {
+      return { verdict: "fail", note: "tools/list returned no tools.", traces };
+    }
+
+    const badTools = tools
+      .map((tool) => ({ name: String(tool.name ?? "<unnamed>"), missing: missingToolShapeFields(tool) }))
+      .filter((tool) => tool.missing.length > 0);
+    if (badTools.length === 0) return { verdict: "check", traces };
+
+    return {
+      verdict: "fail",
+      note: `Tool definitions missing required fields: ${badTools
+        .slice(0, 8)
+        .map((tool) => `${tool.name}(${tool.missing.join(",")})`)
+        .join("; ")}`,
+      traces,
+    };
+  },
+
+  // TOOL-META-001: first-class tools should declare MCP risk annotations.
+  "TOOL-META-001": async (url) => {
+    const { traces, tools, failure } = await initializeThenListTools(url, 380);
+    if (failure) return { verdict: "fail", note: failure, traces };
+    if (!tools || tools.length === 0) {
+      return { verdict: "fail", note: "tools/list returned no tools to inspect for annotations.", traces };
+    }
+
+    const badTools = tools
+      .map((tool) => ({ name: String(tool.name ?? "<unnamed>"), missing: missingToolAnnotationFields(tool) }))
+      .filter((tool) => tool.missing.length > 0);
+    if (badTools.length === 0) return { verdict: "check", traces };
+
+    return {
+      verdict: "fail",
+      note: `MCP tool annotations missing or not boolean: ${badTools
+        .slice(0, 8)
+        .map((tool) => `${tool.name}(${tool.missing.join(",")})`)
+        .join("; ")}`,
+      traces,
+    };
   },
 
   // FB-010: github_action failures must create tenant-scoped Signals with


### PR DESCRIPTION
- Adds a deterministic TestPass Core standard/deep check for MCP tool risk annotations: readOnlyHint, destructiveHint, idempotentHint, and openWorldHint.
- Makes MCP-007 tools/list shape checking deterministic so TestPass proves advertised tools have name, description, and inputSchema before agent-only judgment.
- Adds passing and failing fixture coverage for tools/list metadata and missing annotation hints.

Why:
- The original TestPass research brief called out MCP tool-annotation hygiene as a key Core gap.
- Current MCP annotation guidance still names these hints as the basic risk vocabulary for approvals, retries, and open-world trust warnings.
- Kept this out of smoke profile so fast PR TestPass smoke remains stable while standard/deep TestPass can expose missing annotation coverage honestly.

Proof run locally:
- npm run test --workspace=@unclick/testpass
- npm run build --workspace=@unclick/testpass
- npx eslint packages/testpass/src/runner/deterministic.ts packages/testpass/src/__tests__/deterministic.test.ts
- node scripts/build-xpass-package-sweep.mjs --target-sha 4f2e05ac2d562d6910004cac6dfd5f42cd61b623 --output $TEMP/xpass-package-sweep-postcommit.json --timeout-ms 180000
- node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs scripts/pinballwake-xpass-gate-room.test.mjs scripts/pinballwake-dogfood-room.test.mjs
- npm run dogfood:commonsensepass
- npm run brainmap:check
- npm run test:brainmap
- npm run build
- npm test -- --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to TestPass pack definitions, deterministic runner checks, and tests; they do not alter production MCP server auth or tool execution.
> 
> **Overview**
> TestPass now **deterministically** exercises MCP tool discovery metadata: after `initialize` + `notifications/initialized`, it calls `tools/list` and enforces tool shape (`name`, `description`, `inputSchema`) via **MCP-007**, and requires boolean risk hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) on every tool via new pack item **TOOL-META-001** (standard/deep only, not smoke).
> 
> The runner gains shared `initializeThenListTools` plumbing and per-tool validation helpers; unit tests use a local `tools/list` fixture server for pass and fail paths (missing annotation fields surface in `on_fail_comment`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c822cd28ab46f3baf686811406b55b659813462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->