### PR TITLE
test(xpass): dogfood CopyPass against LegalPass guardrails

### DIFF
--- a/packages/copypass/src/__tests__/dogfood.test.ts
+++ b/packages/copypass/src/__tests__/dogfood.test.ts
@@ -52,4 +52,44 @@ describe("CopyPass dogfood", () => {
     expect(report.findings).toEqual([]);
     expect(report.verdict).toBe("pass");
   });
+
+  it("reviews LegalPass guardrail files without mistaking quoted examples for shipped copy", async () => {
+    const [verdictLinter, disclaimerBanner] = await Promise.all([
+      readFile(repoPath("packages/legalpass/src/passguard/verdict-linter.ts"), "utf8"),
+      readFile(repoPath("packages/legalpass/src/passguard/disclaimer-banner.ts"), "utf8"),
+    ]);
+
+    const report = createDeterministicCopyPassReport({
+      target: {
+        kind: "artifact",
+        label: "LegalPass guardrails",
+        source: "cross-pass dogfood",
+      },
+      blocks: [
+        {
+          id: "legalpass-verdict-linter",
+          kind: "doc",
+          label: "LegalPass forbidden phrase registry",
+          text: verdictLinter,
+          source_path: "packages/legalpass/src/passguard/verdict-linter.ts",
+          public_only: false,
+        },
+        {
+          id: "legalpass-disclaimer-banner",
+          kind: "legal",
+          label: "LegalPass disclaimer banner",
+          text: disclaimerBanner,
+          source_path: "packages/legalpass/src/passguard/disclaimer-banner.ts",
+        },
+      ],
+    });
+
+    expect(report.mode).toBe("deterministic");
+    expect(report.blocks_reviewed).toEqual([
+      "legalpass-verdict-linter",
+      "legalpass-disclaimer-banner",
+    ]);
+    expect(report.findings).toEqual([]);
+    expect(report.verdict).toBe("pass");
+  });
 });

--- a/scripts/build-xpass-package-sweep.test.mjs
+++ b/scripts/build-xpass-package-sweep.test.mjs
@@ -54,8 +54,12 @@ test("XPass package sweep cross-checks every pass package", async () => {
   });
   const packageIds = new Set(PASS_PACKAGES.map((pkg) => pkg.id));
   const targetIds = new Set(receipt.cross_pass_matrix.map((row) => row.target_id));
+  const reviewerIds = new Set(
+    receipt.cross_pass_matrix.flatMap((row) => row.reviewers.map((reviewer) => reviewer.id)),
+  );
 
   assert.deepEqual(targetIds, packageIds);
+  assert.deepEqual(reviewerIds, packageIds);
   assert.equal(CROSS_PASS_MATRIX.length, PASS_PACKAGES.length);
 
   for (const row of receipt.cross_pass_matrix) {


### PR DESCRIPTION
## Summary
- adds a CopyPass dogfood test that reviews LegalPass guardrail files and proves quoted forbidden examples do not create false copy failures
- adds an XPass package sweep assertion that every Pass package is used as a reviewer for at least one peer, not just listed as a target

## Proof
- npm run test --workspace=@unclick/copypass
- node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs scripts/pinballwake-xpass-gate-room.test.mjs
- npm test
- npm run build
- npm run brainmap:check
- node scripts/build-xpass-package-sweep.mjs --target-sha local-post-rebase-qc --output %TEMP%/xpass-package-sweep-post-rebase-qc.json

## Notes
- Built on top of main after #1132, which already merged the stronger CopyPass guardrail-catalog detector.
- Local XPass package sweep passed 10/10 with 0 action needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production logic, auth, or data-path modifications.
> 
> **Overview**
> Adds **cross-pass dogfood coverage** so CopyPass runs deterministically on real **LegalPass** guardrail sources (`verdict-linter.ts`, `disclaimer-banner.ts`) and must **pass with no findings**, locking in that quoted/forbidden examples in those files are not treated as live shipped copy.
> 
> Tightens the **XPass package sweep** integration test so the set of packages appearing as **cross-pass reviewers** matches the full **Pass package** list—not only that every package is a sweep **target**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6a9549e3005b0937399e6cccdecf099d7928ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->