### PR TITLE
fix(xpass): mark partial package sweeps explicitly

### DIFF
--- a/scripts/build-xpass-package-sweep.mjs
+++ b/scripts/build-xpass-package-sweep.mjs
@@ -287,23 +287,32 @@ function normalizePackageResult(pkg, commandResult, now) {
   };
 }
 
-function reviewerRows(matrixEntry, packageById) {
+function normalizeSelectedIds(selectedIds) {
+  return [...new Set(selectedIds
+    .map((id) => String(id ?? "").trim().toLowerCase())
+    .filter(Boolean))];
+}
+
+function reviewerRows(matrixEntry, resultById, catalogById) {
   return matrixEntry.reviewers.map((reviewer) => {
-    const reviewerPackage = packageById.get(reviewer.id);
+    const reviewerResult = resultById.get(reviewer.id);
+    const reviewerPackage = reviewerResult || catalogById.get(reviewer.id);
     return {
       id: reviewer.id,
       name: reviewerPackage?.name || reviewer.id,
       role: reviewer.role,
-      status: reviewerPackage?.status || "pending",
+      status: reviewerResult?.status || "pending",
     };
   });
 }
 
-function buildCrossPassMatrix(packages) {
-  const packageById = new Map(packages.map((pkg) => [pkg.id, pkg]));
+function buildCrossPassMatrix(packageResults, packageCatalog = packageResults) {
+  const packageById = new Map(packageResults.map((pkg) => [pkg.id, pkg]));
+  const catalogById = new Map(packageCatalog.map((pkg) => [pkg.id, pkg]));
   return CROSS_PASS_MATRIX.map((entry) => {
     const target = packageById.get(entry.targetId);
-    const reviewers = reviewerRows(entry, packageById);
+    const catalogTarget = catalogById.get(entry.targetId);
+    const reviewers = reviewerRows(entry, packageById, catalogById);
     const failingReviewer = reviewers.find((reviewer) => reviewer.status === "failing");
     const pendingReviewer = reviewers.find((reviewer) => reviewer.status === "pending" || reviewer.status === "blocked");
     const status = target?.status === "failing" || failingReviewer
@@ -311,20 +320,32 @@ function buildCrossPassMatrix(packages) {
       : target && !pendingReviewer
         ? "passing"
         : "pending";
+    const targetName = target?.name || catalogTarget?.name || entry.targetId;
     return {
       target_id: entry.targetId,
-      target_name: target?.name || entry.targetId,
+      target_name: targetName,
       status,
       reviewers,
       summary: status === "passing"
-        ? `${target?.name || entry.targetId} was cross-checked by ${reviewers.map((reviewer) => reviewer.name).join(", ")}.`
-        : `${target?.name || entry.targetId} cross-pass proof is not green yet.`,
+        ? `${targetName} was cross-checked by ${reviewers.map((reviewer) => reviewer.name).join(", ")}.`
+        : `${targetName} cross-pass proof is not green yet.`,
     };
   });
 }
 
-function actionNeeded(packages, matrix) {
+function actionNeeded(packages, matrix, {
+  scope = "full",
+  expectedPackageCount = packages.length,
+  selectedPackageCount = packages.length,
+  unknownPackageIds = [],
+} = {}) {
   return [
+    ...(unknownPackageIds.length
+      ? [`XPass package sweep: unknown selected package id(s): ${unknownPackageIds.join(", ")}.`]
+      : []),
+    ...(scope === "partial"
+      ? [`XPass package sweep: partial selected run checked ${selectedPackageCount} of ${expectedPackageCount} package(s); run the full package sweep before treating this as complete cross-pass dogfood.`]
+      : []),
     ...packages
       .filter((pkg) => pkg.status !== "passing")
       .map((pkg) => `${pkg.name}: ${pkg.summary}`),
@@ -345,9 +366,17 @@ export async function buildXPassPackageSweep({
   skipCommands = false,
   runCommand = defaultRunCommand,
 } = {}) {
-  const selected = selectedIds.length
-    ? packages.filter((pkg) => selectedIds.includes(pkg.id))
+  const expectedPackageIds = packages.map((pkg) => pkg.id);
+  const expectedPackageIdSet = new Set(expectedPackageIds);
+  const requestedSelectedIds = normalizeSelectedIds(selectedIds);
+  const unknownPackageIds = requestedSelectedIds.filter((id) => !expectedPackageIdSet.has(id));
+  const selected = requestedSelectedIds.length
+    ? packages.filter((pkg) => requestedSelectedIds.includes(pkg.id))
     : packages;
+  const selectedPackageIds = selected.map((pkg) => pkg.id);
+  const scope = selectedPackageIds.length === packages.length && unknownPackageIds.length === 0
+    ? "full"
+    : "partial";
   const packageResults = [];
 
   for (const pkg of selected) {
@@ -358,19 +387,30 @@ export async function buildXPassPackageSweep({
     packageResults.push(normalizePackageResult(pkg, commandResult, now));
   }
 
-  const matrix = buildCrossPassMatrix(packageResults);
+  const matrix = buildCrossPassMatrix(packageResults, packages);
   const packageStatus = statusFromPackages(packageResults);
   const matrixStatus = matrix.some((row) => row.status === "failing")
     ? "failing"
     : matrix.some((row) => row.status !== "passing")
       ? "pending"
       : "passing";
+  const selectionStatus = unknownPackageIds.length ? "pending" : "passing";
   const status = packageStatus === "failing" || matrixStatus === "failing"
     ? "failing"
-    : packageStatus === "passing" && matrixStatus === "passing"
+    : packageStatus === "passing" && matrixStatus === "passing" && selectionStatus === "passing"
       ? "passing"
       : "pending";
-  const seed = JSON.stringify({ now, targetSha, packages: packageResults.map((pkg) => [pkg.id, pkg.status]) });
+  const seed = JSON.stringify({
+    now,
+    targetSha,
+    scope,
+    selectedPackageIds,
+    unknownPackageIds,
+    packages: packageResults.map((pkg) => [pkg.id, pkg.status]),
+  });
+  const summary = scope === "full"
+    ? `XPass package sweep ${status} across all ${packages.length} package(s).`
+    : `XPass package sweep ${status} across ${packageResults.length} selected package(s); full cross-pass dogfood requires ${packages.length} package(s).`;
 
   return {
     kind: "xpass_package_sweep_receipt_v1",
@@ -380,11 +420,21 @@ export async function buildXPassPackageSweep({
     source,
     target_sha: targetSha || null,
     status,
-    summary: `XPass package sweep ${status} across ${packageResults.length} package(s).`,
+    scope,
+    summary,
     package_count: packageResults.length,
+    expected_package_count: packages.length,
+    selected_package_ids: selectedPackageIds,
+    expected_package_ids: expectedPackageIds,
+    unknown_package_ids: unknownPackageIds,
     packages: packageResults,
     cross_pass_matrix: matrix,
-    action_needed: actionNeeded(packageResults, matrix),
+    action_needed: actionNeeded(packageResults, matrix, {
+      scope,
+      expectedPackageCount: packages.length,
+      selectedPackageCount: packageResults.length,
+      unknownPackageIds,
+    }),
   };
 }
 
@@ -408,7 +458,9 @@ async function main() {
   console.log(JSON.stringify({
     generated_at: receipt.generated_at,
     status: receipt.status,
+    scope: receipt.scope,
     packages: receipt.package_count,
+    expected_packages: receipt.expected_package_count,
     action_needed: receipt.action_needed.length,
     output: outputPath,
   }, null, 2));

--- a/scripts/build-xpass-package-sweep.test.mjs
+++ b/scripts/build-xpass-package-sweep.test.mjs
@@ -31,8 +31,14 @@ test("XPass package sweep records package and cross-pass proof", async () => {
 
   assert.equal(receipt.kind, "xpass_package_sweep_receipt_v1");
   assert.equal(receipt.status, "passing");
+  assert.equal(receipt.scope, "full");
   assert.equal(receipt.target_sha, "abc123");
   assert.equal(receipt.package_count, PASS_PACKAGES.length);
+  assert.equal(receipt.expected_package_count, PASS_PACKAGES.length);
+  assert.deepEqual(receipt.selected_package_ids, PASS_PACKAGES.map((pkg) => pkg.id));
+  assert.deepEqual(receipt.expected_package_ids, PASS_PACKAGES.map((pkg) => pkg.id));
+  assert.deepEqual(receipt.unknown_package_ids, []);
+  assert.match(receipt.summary, /across all/);
   assert.equal(calls.length, PASS_PACKAGES.length);
   assert.equal(sloppass?.status, "passing");
   assert.deepEqual(sloppass?.command, ["npm", "run", "test", "--workspace=@unclick/sloppass"]);
@@ -44,6 +50,60 @@ test("XPass package sweep records package and cross-pass proof", async () => {
     "copypass",
   ]);
   assert.deepEqual(receipt.action_needed, []);
+});
+
+test("XPass package sweep labels selected-only runs as partial dogfood", async () => {
+  const calls = [];
+  const receipt = await buildXPassPackageSweep({
+    now: "2026-05-28T00:00:00.000Z",
+    targetSha: "abc123",
+    selectedIds: ["LegalPass"],
+    runCommand: async (_command, _args, { pkg }) => {
+      calls.push(pkg.id);
+      return { status: "passing", exitCode: 0, durationMs: 12, failureHint: "" };
+    },
+  });
+  const legalpassMatrix = receipt.cross_pass_matrix.find((row) => row.target_id === "legalpass");
+
+  assert.equal(receipt.status, "pending");
+  assert.equal(receipt.scope, "partial");
+  assert.equal(receipt.package_count, 1);
+  assert.equal(receipt.expected_package_count, PASS_PACKAGES.length);
+  assert.deepEqual(receipt.selected_package_ids, ["legalpass"]);
+  assert.deepEqual(receipt.expected_package_ids, PASS_PACKAGES.map((pkg) => pkg.id));
+  assert.deepEqual(receipt.unknown_package_ids, []);
+  assert.deepEqual(calls, ["legalpass"]);
+  assert.match(receipt.summary, /selected package/);
+  assert.match(receipt.summary, /full cross-pass dogfood requires/);
+  assert.equal(legalpassMatrix?.target_name, "LegalPass");
+  assert.equal(legalpassMatrix?.status, "pending");
+  assert.deepEqual(legalpassMatrix?.reviewers.map((reviewer) => reviewer.name), [
+    "CopyPass",
+    "SecurityPass",
+    "CommonSensePass",
+  ]);
+  assert.ok(receipt.action_needed.some((item) => /partial selected run/.test(item)));
+  assert.ok(receipt.action_needed.some((item) => /LegalPass cross-pass proof is not green yet/.test(item)));
+});
+
+test("XPass package sweep reports unknown selected package ids", async () => {
+  const calls = [];
+  const receipt = await buildXPassPackageSweep({
+    now: "2026-05-28T00:00:00.000Z",
+    targetSha: "abc123",
+    selectedIds: ["legalpass", "notapass"],
+    runCommand: async (_command, _args, { pkg }) => {
+      calls.push(pkg.id);
+      return { status: "passing", exitCode: 0, durationMs: 12, failureHint: "" };
+    },
+  });
+
+  assert.equal(receipt.status, "pending");
+  assert.equal(receipt.scope, "partial");
+  assert.deepEqual(receipt.selected_package_ids, ["legalpass"]);
+  assert.deepEqual(receipt.unknown_package_ids, ["notapass"]);
+  assert.deepEqual(calls, ["legalpass"]);
+  assert.ok(receipt.action_needed.some((item) => /unknown selected package id\(s\): notapass/.test(item)));
 });
 
 test("XPass package sweep cross-checks every pass package", async () => {
@@ -106,7 +166,9 @@ test("XPass package sweep CLI writes a public-safe receipt", async () => {
 
     const receipt = JSON.parse(await fs.readFile(output, "utf8"));
     assert.equal(receipt.status, "passing");
+    assert.equal(receipt.scope, "full");
     assert.equal(receipt.target_sha, "abc123");
+    assert.equal(receipt.expected_package_count, PASS_PACKAGES.length);
     assert.equal(receipt.packages.find((pkg) => pkg.id === "geopass")?.status, "passing");
     assert.equal(receipt.cross_pass_matrix.find((row) => row.target_id === "geopass")?.status, "passing");
   } finally {


### PR DESCRIPTION
## Summary
- Label XPass package sweep receipts as full or partial scope.
- Include expected package ids, selected package ids, and unknown package ids so selected-only runs cannot look like full dogfood.
- Keep partial LegalPass sweeps pending until the full cross-pass matrix is green.

## Verification
- node --test scripts/build-xpass-package-sweep.test.mjs
- node --test scripts/build-dogfood-report.test.mjs scripts/pinballwake-xpass-gate-room.test.mjs
- npm run brainmap:check
- node scripts/build-xpass-package-sweep.mjs --target-sha <head> --output C:\\G\\UnClick\\tmp\\xpass-package-sweep-third-pass-20260528-after-commit.json
- npm test
- npm run build
- npx eslint scripts/build-xpass-package-sweep.mjs scripts/build-xpass-package-sweep.test.mjs

Note: repo-wide npm run lint still reports existing unrelated lint backlog outside these files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dogfood receipt and sweep-script behavior only; no auth, security, or production runtime paths changed.
> 
> **Overview**
> XPass package sweep receipts now distinguish **full** vs **partial** runs so a `--package` subset cannot read as complete cross-pass dogfood.
> 
> Receipts gain **`scope`**, **`expected_package_count`**, **`expected_package_ids`**, **`selected_package_ids`**, and **`unknown_package_ids`** (with normalized, case-insensitive selection). Partial or unknown-id runs stay **`pending`**, cross-pass matrix rows use the full package catalog for target/reviewer names and treat unrunnable reviewers as pending, and **`action_needed`** calls out partial sweeps and invalid ids. Run id seeding and CLI summary output include the new scope metadata; tests cover full, partial LegalPass-only, and unknown package id cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20866de6462b859c747eec2a17653780a593071e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->