### PR TITLE
chore(deps): bump hono to 4.12.23

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "@unclick/core": "*",
     "diff": "^8.0.4",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.6.3",
+    "hono": "^4.12.23",
     "marked": "^17.0.6",
     "papaparse": "^5.5.3",
     "qrcode": "^1.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
         "@unclick/core": "*",
         "diff": "^8.0.4",
         "drizzle-orm": "^0.45.2",
-        "hono": "^4.6.3",
+        "hono": "^4.12.23",
         "marked": "^17.0.6",
         "papaparse": "^5.5.3",
         "qrcode": "^1.5.4",
@@ -12414,9 +12414,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -20639,7 +20639,7 @@
       "version": "0.0.1",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
-        "hono": "^4.6.3",
+        "hono": "^4.12.23",
         "ulid": "^2.3.0",
         "zod": "^3.23.8"
       },
@@ -20648,7 +20648,7 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "hono": "^4.6.3"
+        "hono": "^4.12.23"
       }
     },
     "packages/core/node_modules/drizzle-orm": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.6.3",
+    "hono": "^4.12.23",
     "ulid": "^2.3.0",
     "zod": "^3.23.8"
   },
@@ -22,6 +22,6 @@
   },
   "peerDependencies": {
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.6.3"
+    "hono": "^4.12.23"
   }
 }


### PR DESCRIPTION
## Summary
- Rebuild the Hono bump from current main after the Dependabot PR conflicted.
- Update @unclick/api and @unclick/core to hono ^4.12.23.
- Preserve @unclick/core peer dependency coverage and keep the lockfile change narrow.

## Local proof
- npm ci
- npm test: 797/797 passed
- npm run build: passed
- npm run brainmap:check: passed
- npm ls hono --all: resolves hono 4.12.23

## Notes
- npm audit --omit=dev still reports remaining unrelated dependency advisories. This PR only clears the Hono update path safely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with full test/build verification; no logic or API surface edits in the diff.
> 
> **Overview**
> Bumps **Hono** from `^4.6.3` to **`^4.12.23`** in `@unclick/api` and `@unclick/core`, with matching **`peerDependencies`** on core and an updated lockfile. No application source changes—only version pins and resolved `hono@4.12.23`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1130f12311a98d094624a51629d694b9e27c7d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->