### PR TITLE
fix(xpass): require full sweep before dogfood promotion

### DIFF
--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -3,6 +3,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { PASS_PACKAGES } from "./build-xpass-package-sweep.mjs";
+
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run") || process.env.DOGFOOD_DRY_RUN === "1";
 const outputIndex = process.argv.indexOf("--output");
@@ -18,6 +20,7 @@ const generatedAt = new Date().toISOString();
 const targetSha = process.env.DOGFOOD_TARGET_SHA || process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || "";
 const packageSweepPath = process.env.DOGFOOD_XPASS_PACKAGE_SWEEP_PATH || "public/dogfood/xpass-package-sweep.json";
 let packageSweepState = null;
+const requiredSweepPackageIds = PASS_PACKAGES.map((pkg) => pkg.id);
 
 const statusLegend = {
   passing: "A live check or scheduled package sweep ran and returned a passing result.",
@@ -221,7 +224,7 @@ function packageReadyResult(id, name, summary, evidence, targetUrl, nextProof) {
   const sweepNextProof = sweep && sweep.package.status === "passing" && !sweep.matrix
     ? `Regenerate ${packageSweepPath} with a cross-pass matrix row for ${name} before marking this passing.`
     : packageSweepState?.stale
-      ? `Regenerate ${packageSweepPath} for ${targetSha || "the current commit"} before marking this passing.`
+      ? `Regenerate ${packageSweepPath} as a full current XPass package sweep for ${targetSha || "the current commit"} before marking this passing.`
       : nextProof;
   return pendingResult(id, name, summary, evidence, {
     reasonCode: "package_ready_needs_scheduled_receipt",
@@ -271,6 +274,15 @@ async function readPackageSweepReceipt() {
         actualSha: receipt.target_sha || "",
       };
     }
+    const validation = validatePackageSweepReceipt(receipt);
+    if (!validation.ok) {
+      return {
+        receipt,
+        stale: true,
+        reason: validation.reason,
+        validation,
+      };
+    }
     return { receipt, stale: false, reason: "fresh" };
   } catch (err) {
     if (err?.code === "ENOENT") {
@@ -283,6 +295,46 @@ async function readPackageSweepReceipt() {
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+function normalizedIdSet(values) {
+  return new Set((Array.isArray(values) ? values : [])
+    .map((value) => String(value ?? "").trim().toLowerCase())
+    .filter(Boolean));
+}
+
+function hasExactRequiredPackageIds(values) {
+  const ids = normalizedIdSet(values);
+  return ids.size === requiredSweepPackageIds.length
+    && requiredSweepPackageIds.every((id) => ids.has(id));
+}
+
+function validatePackageSweepReceipt(receipt) {
+  if (receipt?.status !== "passing") {
+    return { ok: false, reason: "xpass_sweep_not_passing" };
+  }
+  if (receipt?.scope !== "full") {
+    return { ok: false, reason: "xpass_sweep_not_full_scope" };
+  }
+  if (receipt?.expected_package_count !== requiredSweepPackageIds.length) {
+    return { ok: false, reason: "xpass_sweep_expected_count_mismatch" };
+  }
+  if (!hasExactRequiredPackageIds(receipt?.expected_package_ids)) {
+    return { ok: false, reason: "xpass_sweep_expected_ids_mismatch" };
+  }
+  if (!hasExactRequiredPackageIds(receipt?.selected_package_ids)) {
+    return { ok: false, reason: "xpass_sweep_selected_ids_mismatch" };
+  }
+  if (normalizedIdSet(receipt?.unknown_package_ids).size > 0) {
+    return { ok: false, reason: "xpass_sweep_unknown_package_ids" };
+  }
+  if (!hasExactRequiredPackageIds((receipt?.packages || []).map((pkg) => pkg.id))) {
+    return { ok: false, reason: "xpass_sweep_package_rows_mismatch" };
+  }
+  if (!hasExactRequiredPackageIds((receipt?.cross_pass_matrix || []).map((row) => row.target_id))) {
+    return { ok: false, reason: "xpass_sweep_matrix_rows_mismatch" };
+  }
+  return { ok: true, reason: "fresh_full_scope" };
 }
 
 function packageSweepProof(id) {

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -12,7 +12,6 @@ import { CROSS_PASS_MATRIX, PASS_PACKAGES } from "./build-xpass-package-sweep.mj
 const execFileAsync = promisify(execFile);
 const packageReadySweepIds = [
   "sloppass",
-  "seopass",
   "copypass",
   "legalpass",
   "commonsensepass",
@@ -291,6 +290,9 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
     assert.equal(sloppass?.proof?.packageId, "sloppass");
     assert.equal(geopass?.status, "passing");
     assert.equal(geopass?.proof?.kind, "xpass_package_sweep");
+    const seopass = report.results.find((result) => result.id === "seopass");
+    assert.equal(seopass?.status, "passing");
+    assert.equal(seopass?.proof?.kind, "seopass_run");
     assert.equal(securitypass?.status, "blocked");
     assert.equal(securitypass?.reasonCode, "scope_gate");
   } finally {

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -7,7 +7,40 @@ import path from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
 
+import { CROSS_PASS_MATRIX, PASS_PACKAGES } from "./build-xpass-package-sweep.mjs";
+
 const execFileAsync = promisify(execFile);
+const packageReadySweepIds = [
+  "sloppass",
+  "seopass",
+  "copypass",
+  "legalpass",
+  "commonsensepass",
+  "flowpass",
+  "geopass",
+];
+
+function passingSweepPackageRows() {
+  return PASS_PACKAGES.map((pkg) => ({
+    id: pkg.id,
+    name: pkg.name,
+    status: "passing",
+    command: ["npm", "run", "test", `--workspace=${pkg.workspace}`],
+  }));
+}
+
+function passingSweepMatrixRows() {
+  const packageNameById = new Map(PASS_PACKAGES.map((pkg) => [pkg.id, pkg.name]));
+  return CROSS_PASS_MATRIX.map((entry) => ({
+    target_id: entry.targetId,
+    status: "passing",
+    reviewers: entry.reviewers.map((reviewer) => ({
+      id: reviewer.id,
+      name: packageNameById.get(reviewer.id) || reviewer.id,
+      status: "passing",
+    })),
+  }));
+}
 
 test("dogfood receipt marks SecurityPass as blocked with a reason", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
@@ -204,24 +237,7 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
   const output = path.join(dir, "latest.json");
   const sweepPath = path.join(dir, "xpass-package-sweep.json");
-  const packageRows = [
-    { id: "sloppass", name: "SlopPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/sloppass"] },
-    { id: "seopass", name: "SEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/seopass"] },
-    { id: "copypass", name: "CopyPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/copypass"] },
-    { id: "legalpass", name: "LegalPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/legalpass"] },
-    { id: "commonsensepass", name: "CommonSensePass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/commonsensepass"] },
-    { id: "flowpass", name: "FlowPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/flowpass"] },
-    { id: "geopass", name: "GEOPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/geopass"] },
-  ];
-  const reviewerNames = new Map([
-    ["testpass", "TestPass"],
-    ["commonsensepass", "CommonSensePass"],
-    ["sloppass", "SlopPass"],
-  ]);
-  const reviewersFor = (targetId) => ["testpass", "commonsensepass", "sloppass"]
-    .filter((id) => id !== targetId)
-    .slice(0, 2)
-    .map((id) => ({ id, name: reviewerNames.get(id), status: "passing" }));
+  const packageRows = passingSweepPackageRows();
 
   try {
     await fs.writeFile(sweepPath, JSON.stringify({
@@ -229,12 +245,14 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
       run_id: "xpass-package-sweep-123",
       target_sha: "abc123",
       status: "passing",
+      scope: "full",
+      package_count: PASS_PACKAGES.length,
+      expected_package_count: PASS_PACKAGES.length,
+      selected_package_ids: PASS_PACKAGES.map((pkg) => pkg.id),
+      expected_package_ids: PASS_PACKAGES.map((pkg) => pkg.id),
+      unknown_package_ids: [],
       packages: packageRows,
-      cross_pass_matrix: packageRows.map((pkg) => ({
-        target_id: pkg.id,
-        status: "passing",
-        reviewers: reviewersFor(pkg.id),
-      })),
+      cross_pass_matrix: passingSweepMatrixRows(),
     }));
 
     await execFileAsync(process.execPath, [
@@ -259,7 +277,7 @@ test("dogfood receipt promotes package-ready passes from a fresh XPass sweep rec
     const geopass = report.results.find((result) => result.id === "geopass");
     const securitypass = report.results.find((result) => result.id === "securitypass");
 
-    for (const pkg of packageRows) {
+    for (const pkg of packageRows.filter((row) => packageReadySweepIds.includes(row.id))) {
       const result = report.results.find((entry) => entry.id === pkg.id);
       assert.equal(result?.status, "passing", `${pkg.name} should promote from a fresh full XPass sweep`);
       assert.equal(result?.runId, "xpass-package-sweep-123");
@@ -321,6 +339,67 @@ test("dogfood receipt rejects a stale XPass sweep receipt", async () => {
     assert.equal(sloppass?.reasonCode, "package_ready_needs_scheduled_receipt");
     assert.equal(sloppass?.proof?.kind, "package_ready");
     assert.match(sloppass?.nextProof ?? "", /Regenerate/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("dogfood receipt rejects partial XPass sweep receipts before promotion", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dogfood-report-"));
+  const output = path.join(dir, "latest.json");
+  const sweepPath = path.join(dir, "xpass-package-sweep.json");
+
+  try {
+    await fs.writeFile(sweepPath, JSON.stringify({
+      kind: "xpass_package_sweep_receipt_v1",
+      run_id: "xpass-package-sweep-partial",
+      target_sha: "abc123",
+      status: "passing",
+      scope: "partial",
+      package_count: 1,
+      expected_package_count: PASS_PACKAGES.length,
+      selected_package_ids: ["legalpass"],
+      expected_package_ids: PASS_PACKAGES.map((pkg) => pkg.id),
+      unknown_package_ids: [],
+      packages: [
+        { id: "legalpass", name: "LegalPass", status: "passing", command: ["npm", "run", "test", "--workspace=@unclick/legalpass"] },
+      ],
+      cross_pass_matrix: [
+        {
+          target_id: "legalpass",
+          status: "passing",
+          reviewers: [
+            { id: "copypass", name: "CopyPass", status: "passing" },
+            { id: "securitypass", name: "SecurityPass", status: "passing" },
+          ],
+        },
+      ],
+    }));
+
+    await execFileAsync(process.execPath, [
+      "scripts/build-dogfood-report.mjs",
+      "--output",
+      output,
+    ], {
+      env: {
+        ...process.env,
+        TESTPASS_TOKEN: "",
+        DOGFOOD_TESTPASS_TOKEN: "",
+        UXPASS_TOKEN: "",
+        DOGFOOD_UXPASS_TOKEN: "",
+        CRON_SECRET: "",
+        DOGFOOD_TARGET_SHA: "abc123",
+        DOGFOOD_XPASS_PACKAGE_SWEEP_PATH: sweepPath,
+      },
+    });
+
+    const report = JSON.parse(await fs.readFile(output, "utf8"));
+    const legalpass = report.results.find((result) => result.id === "legalpass");
+
+    assert.equal(legalpass?.status, "pending");
+    assert.equal(legalpass?.reasonCode, "package_ready_needs_scheduled_receipt");
+    assert.equal(legalpass?.proof?.kind, "package_ready");
+    assert.match(legalpass?.nextProof ?? "", /full current XPass package sweep/i);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Require dogfood promotion to trust only full current XPass package sweep receipts.
- Reject partial, non-passing, unknown-package, missing-package, or incomplete matrix sweep receipts before promoting LegalPass/GEOPass/etc.
- Update dogfood tests to use the full XPass package catalog and add partial-receipt rejection coverage.

## Focused local proof
- node --test scripts/build-dogfood-report.test.mjs scripts/build-xpass-package-sweep.test.mjs
- git diff --check

Local-minimal / cloud-first note: broad build/test/lint intentionally left to GitHub Actions and Vercel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public dogfood status semantics for multiple XPass lanes; incorrect validation could block legitimate promotions or still allow weak receipts, but impact is confined to receipt-building scripts and tests.
> 
> **Overview**
> Dogfood promotion for package-ready passes now treats an XPass sweep receipt as trustworthy only when it is a **full**, **passing** sweep for the current commit: `scope: "full"`, the expected package count and IDs from `PASS_PACKAGES`, no unknown packages, and complete `packages` and `cross_pass_matrix` rows. Partial, incomplete, or otherwise invalid receipts are marked stale, so passes like LegalPass/GEOPass stay **pending** with guidance to regenerate a full sweep instead of promoting from a subset.
> 
> Tests build receipts from the shared `PASS_PACKAGES` / `CROSS_PASS_MATRIX` catalog and add coverage that partial sweeps do not promote package-ready results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af168f8944d462fbcc69557c3c3b1b025413dd00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->