### PR TITLE
feat(autopilotiq): Phase 0 outcome ledger - capture only, no behaviour change

### DIFF
--- a/api/autopilotiq-outcome-ledger.test.ts
+++ b/api/autopilotiq-outcome-ledger.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOPILOT_OUTCOME_REASONS,
+  AUTOPILOT_OUTCOMES,
+  buildAutopilotOutcomeRow,
+  type AutopilotOutcomeInput,
+} from "./lib/autopilotiq-outcome-ledger";
+
+const now = new Date("2026-05-28T00:00:00.000Z");
+
+function baseInput(overrides: Partial<AutopilotOutcomeInput> = {}): AutopilotOutcomeInput {
+  return {
+    apiKeyHash: "hash_abc",
+    jobId: "job-123",
+    taskType: "coding",
+    outcome: "success",
+    outcomeReason: "proof_landed",
+    now,
+    ...overrides,
+  };
+}
+
+describe("autopilotiq outcome ledger", () => {
+  it("builds an immutable per-attempt row with route, cost, and defaults", () => {
+    const row = buildAutopilotOutcomeRow(
+      baseInput({
+        parentJobId: "epic-1",
+        attemptN: 2,
+        actorAgentId: "runner-seat",
+        routeTaken: {
+          seat: "builder",
+          model: "openai/gpt-oss-120b:free",
+          prompt_version: "v3",
+          tool_set: ["edit", "bash"],
+        },
+        costSignal: { tokens: 1200, wall_ms: 8400, usd: 0.0, retries: 1 },
+        xpassVerdict: "PASS",
+        confidence: "hard_gate",
+        humanTouch: "approved",
+        receiptId: "receipt-9",
+        closedAt: "2026-05-28T00:01:00.000Z",
+        inputs: { brief: "ship the slice", owned_files: ["api/x.ts"] },
+      }),
+    );
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash_abc",
+      job_id: "job-123",
+      parent_job_id: "epic-1",
+      attempt_n: 2,
+      task_type: "coding",
+      actor_agent_id: "runner-seat",
+      xpass_verdict: "PASS",
+      outcome: "success",
+      outcome_reason: "proof_landed",
+      confidence: "hard_gate",
+      human_touch: "approved",
+      receipt_id: "receipt-9",
+      created_at: "2026-05-28T00:00:00.000Z",
+      closed_at: "2026-05-28T00:01:00.000Z",
+    });
+    expect(row.route_taken).toEqual({
+      seat: "builder",
+      model: "openai/gpt-oss-120b:free",
+      prompt_version: "v3",
+      tool_set: ["edit", "bash"],
+    });
+    expect(row.cost_signal).toEqual({ tokens: 1200, wall_ms: 8400, usd: 0, retries: 1 });
+    expect(row.inputs_hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("applies safe defaults when optional fields are omitted", () => {
+    const row = buildAutopilotOutcomeRow(baseInput({ outcome: "hold", outcomeReason: "awaiting_proof" }));
+    expect(row.attempt_n).toBe(1);
+    expect(row.actor_agent_id).toBe("autopilot");
+    expect(row.parent_job_id).toBeNull();
+    expect(row.receipt_id).toBeNull();
+    expect(row.closed_at).toBeNull();
+    expect(row.xpass_verdict).toBe("none");
+    expect(row.confidence).toBe("silence");
+    expect(row.human_touch).toBe("auto");
+    expect(row.route_taken).toEqual({ seat: null, model: null, prompt_version: null, tool_set: null });
+    expect(row.cost_signal).toEqual({ tokens: null, wall_ms: null, usd: null, retries: null });
+  });
+
+  it("hashes inputs deterministically and never stores them raw", () => {
+    const a = buildAutopilotOutcomeRow(baseInput({ inputs: { a: 1, b: 2 } }));
+    const b = buildAutopilotOutcomeRow(baseInput({ inputs: { b: 2, a: 1 } }));
+    const c = buildAutopilotOutcomeRow(baseInput({ inputs: { a: 1, b: 3 } }));
+    // Order-independent (stable) hash; different content => different hash.
+    expect(a.inputs_hash).toBe(b.inputs_hash);
+    expect(a.inputs_hash).not.toBe(c.inputs_hash);
+    // The raw input values must not appear anywhere on the row.
+    expect(JSON.stringify(a)).not.toContain('"a":1');
+    expect("inputs" in (a as Record<string, unknown>)).toBe(false);
+  });
+
+  it("derives a stable idempotency key within the same time bucket", () => {
+    const row1 = buildAutopilotOutcomeRow(baseInput({ inputs: { x: 1 } }));
+    const row2 = buildAutopilotOutcomeRow(baseInput({ inputs: { x: 1 } }));
+    expect(row1.idempotency_key).toBe(row2.idempotency_key);
+    expect(row1.idempotency_key).toContain("job-123:1:success:proof_landed:");
+    const otherAttempt = buildAutopilotOutcomeRow(baseInput({ attemptN: 2, inputs: { x: 1 } }));
+    expect(otherAttempt.idempotency_key).not.toBe(row1.idempotency_key);
+  });
+
+  it("rejects values outside the closed taxonomies", () => {
+    expect(() => buildAutopilotOutcomeRow(baseInput({ outcome: "maybe" }))).toThrow(/outcome/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ outcomeReason: "vibes" }))).toThrow(
+      /outcome_reason/,
+    );
+    expect(() => buildAutopilotOutcomeRow(baseInput({ confidence: "medium" }))).toThrow(/confidence/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ humanTouch: "ignored" }))).toThrow(/human_touch/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ xpassVerdict: "MAYBE" }))).toThrow(/xpass_verdict/);
+  });
+
+  it("refuses secret-shaped inputs and route fields before writing", () => {
+    expect(() => buildAutopilotOutcomeRow(baseInput({ inputs: { api_key: "uc_deadbeefdeadbeef" } }))).toThrow(
+      /sensitive key/,
+    );
+    expect(() =>
+      buildAutopilotOutcomeRow(baseInput({ inputs: { note: "Authorization: Bearer abc.def.ghi" } })),
+    ).toThrow(/sensitive text/);
+    expect(() =>
+      buildAutopilotOutcomeRow(
+        baseInput({ routeTaken: { seat: "builder", token: "sk-abcdef0123456789" } as never }),
+      ),
+    ).toThrow(/sensitive key/);
+  });
+
+  it("validates required fields and attempt_n", () => {
+    expect(() => buildAutopilotOutcomeRow(baseInput({ jobId: "" }))).toThrow(/job_id required/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ taskType: "" }))).toThrow(/task_type required/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ apiKeyHash: "" }))).toThrow(/api_key_hash required/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ attemptN: 0 }))).toThrow(/attempt_n/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ attemptN: 1.5 }))).toThrow(/attempt_n/);
+  });
+
+  it("exposes closed taxonomies as frozen-shaped constants", () => {
+    expect(AUTOPILOT_OUTCOMES).toContain("success");
+    expect(AUTOPILOT_OUTCOMES).toContain("fail");
+    expect(AUTOPILOT_OUTCOMES).toContain("hold");
+    expect(AUTOPILOT_OUTCOME_REASONS).toContain("xpass_fail");
+    expect(AUTOPILOT_OUTCOME_REASONS).toContain("budget_exceeded");
+    expect(AUTOPILOT_OUTCOME_REASONS).toContain("policy_block");
+    // Every reason is unique.
+    expect(new Set(AUTOPILOT_OUTCOME_REASONS).size).toBe(AUTOPILOT_OUTCOME_REASONS.length);
+  });
+});

--- a/api/lib/autopilotiq-outcome-ledger.ts
+++ b/api/lib/autopilotiq-outcome-ledger.ts
@@ -1,0 +1,330 @@
+// AutopilotIQ outcome ledger (Phase 0, Slice 0a) - capture only.
+//
+// Immutable per-attempt record of what AutoPilot tried and how it ended. This
+// module is the data-capture foundation for the AutopilotIQ learning layer
+// (Boardroom 9e131baf). It is ADDITIVE: nothing in this slice reads these rows
+// to change routing, scoring, or behaviour. Later phases read the ledger; they
+// must not rewrite history.
+//
+// Safety: raw inputs are never stored (only a stable inputs_hash), and
+// secret/credential-shaped fields are refused before any row is built.
+
+import { createHash } from "crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const AUTOPILOT_OUTCOMES = ["success", "fail", "hold"] as const;
+export type AutopilotOutcome = (typeof AUTOPILOT_OUTCOMES)[number];
+
+// Closed outcome-reason taxonomy. Grouped by the outcome it usually explains,
+// but the DB does not couple them - any listed reason is valid for any outcome.
+export const AUTOPILOT_OUTCOME_REASONS = [
+  // success
+  "clean_pass",
+  "proof_landed",
+  "recovered",
+  // hold
+  "awaiting_proof",
+  "awaiting_review",
+  "gated_hold",
+  // fail
+  "xpass_fail",
+  "tool_error",
+  "model_refusal",
+  "budget_exceeded",
+  "user_revert",
+  "timeout",
+  "policy_block",
+  "rate_limit",
+  "missing_proof",
+  "duplicate_claim",
+  "stale_owner",
+  "wrong_route",
+  "unknown_error",
+] as const;
+export type AutopilotOutcomeReason = (typeof AUTOPILOT_OUTCOME_REASONS)[number];
+
+export const AUTOPILOT_CONFIDENCE_LEVELS = ["hard_gate", "soft_gate", "silence"] as const;
+export type AutopilotConfidence = (typeof AUTOPILOT_CONFIDENCE_LEVELS)[number];
+
+export const AUTOPILOT_HUMAN_TOUCH_STATES = ["auto", "edited", "reverted", "approved"] as const;
+export type AutopilotHumanTouch = (typeof AUTOPILOT_HUMAN_TOUCH_STATES)[number];
+
+export const AUTOPILOT_XPASS_VERDICTS = [
+  "PASS",
+  "BLOCKER",
+  "HOLD",
+  "SUPPRESS",
+  "ROUTE",
+  "none",
+] as const;
+export type AutopilotXpassVerdict = (typeof AUTOPILOT_XPASS_VERDICTS)[number];
+
+export interface AutopilotRouteTaken {
+  seat?: string | null;
+  model?: string | null;
+  prompt_version?: string | null;
+  tool_set?: string[] | null;
+}
+
+export interface AutopilotCostSignal {
+  tokens?: number | null;
+  wall_ms?: number | null;
+  usd?: number | null;
+  retries?: number | null;
+}
+
+export interface AutopilotOutcomeInput {
+  apiKeyHash: string;
+  jobId: string;
+  parentJobId?: string | null;
+  attemptN?: number;
+  taskType: string;
+  actorAgentId?: string | null;
+  routeTaken?: AutopilotRouteTaken;
+  // Raw inputs are hashed into inputs_hash and then discarded - never stored.
+  inputs?: Record<string, unknown>;
+  xpassVerdict?: AutopilotXpassVerdict | string;
+  outcome: AutopilotOutcome | string;
+  outcomeReason: AutopilotOutcomeReason | string;
+  confidence?: AutopilotConfidence | string;
+  costSignal?: AutopilotCostSignal;
+  humanTouch?: AutopilotHumanTouch | string;
+  receiptId?: string | null;
+  closedAt?: Date | string | null;
+  now?: Date;
+}
+
+export interface AutopilotOutcomeRow {
+  api_key_hash: string;
+  job_id: string;
+  parent_job_id: string | null;
+  attempt_n: number;
+  task_type: string;
+  actor_agent_id: string;
+  route_taken: AutopilotRouteTaken;
+  inputs_hash: string;
+  xpass_verdict: AutopilotXpassVerdict;
+  outcome: AutopilotOutcome;
+  outcome_reason: AutopilotOutcomeReason;
+  confidence: AutopilotConfidence;
+  cost_signal: AutopilotCostSignal;
+  human_touch: AutopilotHumanTouch;
+  receipt_id: string | null;
+  idempotency_key: string;
+  created_at: string;
+  closed_at: string | null;
+}
+
+const OUTCOME_SET = new Set<string>(AUTOPILOT_OUTCOMES);
+const OUTCOME_REASON_SET = new Set<string>(AUTOPILOT_OUTCOME_REASONS);
+const CONFIDENCE_SET = new Set<string>(AUTOPILOT_CONFIDENCE_LEVELS);
+const HUMAN_TOUCH_SET = new Set<string>(AUTOPILOT_HUMAN_TOUCH_STATES);
+const XPASS_VERDICT_SET = new Set<string>(AUTOPILOT_XPASS_VERDICTS);
+
+const SENSITIVE_KEY_RE = /(api[_-]?key|secret|token|password|credential|authorization|cookie)/i;
+const SENSITIVE_TEXT_RE =
+  /(authorization:\s*bearer\s+\S+|uc_[a-f0-9]{16,}|sk-[a-z0-9_-]{12,}|gh[pousr]_[a-z0-9_]{20,})/i;
+
+function compact(value: unknown, max = 500): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fiveSecondBucket(date: Date): string {
+  return String(Math.floor(date.getTime() / 5000));
+}
+
+// Reject secret-shaped keys/text and strip unsupported value types. Used on the
+// inputs (before hashing) and on route_taken so nothing sensitive is captured.
+function sanitizeUnknown(key: string, value: unknown): unknown {
+  if (SENSITIVE_KEY_RE.test(key)) {
+    throw new Error(`Autopilot outcome payload contains sensitive key: ${key}`);
+  }
+  if (typeof value === "string") {
+    const text = compact(value);
+    if (SENSITIVE_TEXT_RE.test(text)) {
+      throw new Error(`Autopilot outcome payload contains sensitive text in: ${key}`);
+    }
+    return text;
+  }
+  if (value == null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeUnknown(key, item));
+  }
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
+        childKey,
+        sanitizeUnknown(childKey, childValue),
+      ]),
+    );
+  }
+  return undefined;
+}
+
+function sanitizeRecord(record: Record<string, unknown> = {}): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (SENSITIVE_KEY_RE.test(key)) {
+      throw new Error(`Autopilot outcome payload contains sensitive key: ${key}`);
+    }
+    const safe = sanitizeUnknown(key, value);
+    if (safe !== undefined) sanitized[key] = safe;
+  }
+  return sanitized;
+}
+
+function normalizeEnum(value: string, set: Set<string>, label: string): string {
+  if (!set.has(value)) throw new Error(`Unsupported autopilot ${label}: ${value}`);
+  return value;
+}
+
+function normalizeRouteTaken(route: AutopilotRouteTaken = {}): AutopilotRouteTaken {
+  const sanitized = sanitizeRecord(route as Record<string, unknown>);
+  const toolSet = Array.isArray(sanitized.tool_set)
+    ? (sanitized.tool_set as unknown[]).map((item) => compact(item, 160)).filter(Boolean)
+    : null;
+  return {
+    seat: sanitized.seat != null ? compact(sanitized.seat, 128) : null,
+    model: sanitized.model != null ? compact(sanitized.model, 128) : null,
+    prompt_version: sanitized.prompt_version != null ? compact(sanitized.prompt_version, 64) : null,
+    tool_set: toolSet,
+  };
+}
+
+function normalizeCostSignal(cost: AutopilotCostSignal = {}): AutopilotCostSignal {
+  const num = (value: unknown): number | null =>
+    typeof value === "number" && Number.isFinite(value) ? value : null;
+  return {
+    tokens: num(cost.tokens),
+    wall_ms: num(cost.wall_ms),
+    usd: num(cost.usd),
+    retries: num(cost.retries),
+  };
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+/**
+ * Build an immutable outcome-ledger row from an AutoPilot attempt. Pure: no I/O.
+ * Validates closed taxonomies, refuses secret-shaped inputs, hashes the inputs
+ * (never stores them raw), and derives a deterministic idempotency key.
+ */
+export function buildAutopilotOutcomeRow(input: AutopilotOutcomeInput): AutopilotOutcomeRow {
+  const now = input.now ?? new Date();
+  if (!input.apiKeyHash) throw new Error("api_key_hash required");
+
+  const jobId = compact(input.jobId, 160);
+  if (!jobId) throw new Error("job_id required");
+  const taskType = compact(input.taskType, 120);
+  if (!taskType) throw new Error("task_type required");
+
+  const attemptN = input.attemptN ?? 1;
+  if (!Number.isInteger(attemptN) || attemptN < 1) {
+    throw new Error(`attempt_n must be an integer >= 1, got: ${input.attemptN}`);
+  }
+
+  const outcome = normalizeEnum(compact(input.outcome, 32), OUTCOME_SET, "outcome") as AutopilotOutcome;
+  const outcomeReason = normalizeEnum(
+    compact(input.outcomeReason, 48),
+    OUTCOME_REASON_SET,
+    "outcome_reason",
+  ) as AutopilotOutcomeReason;
+  const confidence = normalizeEnum(
+    compact(input.confidence ?? "silence", 32),
+    CONFIDENCE_SET,
+    "confidence",
+  ) as AutopilotConfidence;
+  const humanTouch = normalizeEnum(
+    compact(input.humanTouch ?? "auto", 32),
+    HUMAN_TOUCH_SET,
+    "human_touch",
+  ) as AutopilotHumanTouch;
+  const xpassVerdict = normalizeEnum(
+    compact(input.xpassVerdict ?? "none", 16),
+    XPASS_VERDICT_SET,
+    "xpass_verdict",
+  ) as AutopilotXpassVerdict;
+
+  const routeTaken = normalizeRouteTaken(input.routeTaken);
+  const costSignal = normalizeCostSignal(input.costSignal);
+
+  // Inputs are sanitized (secrets refused), hashed, then discarded.
+  const inputsHash = sha256(stableJson(sanitizeRecord(input.inputs ?? {})));
+
+  const actorAgentId = compact(input.actorAgentId ?? "autopilot", 128) || "autopilot";
+  const parentJobId = input.parentJobId != null ? compact(input.parentJobId, 160) || null : null;
+  const receiptId = input.receiptId != null ? compact(input.receiptId, 160) || null : null;
+
+  const idempotencyKey = [
+    jobId,
+    String(attemptN),
+    outcome,
+    outcomeReason,
+    inputsHash,
+    fiveSecondBucket(now),
+  ].join(":");
+
+  return {
+    api_key_hash: input.apiKeyHash,
+    job_id: jobId,
+    parent_job_id: parentJobId,
+    attempt_n: attemptN,
+    task_type: taskType,
+    actor_agent_id: actorAgentId,
+    route_taken: routeTaken,
+    inputs_hash: inputsHash,
+    xpass_verdict: xpassVerdict,
+    outcome,
+    outcome_reason: outcomeReason,
+    confidence,
+    cost_signal: costSignal,
+    human_touch: humanTouch,
+    receipt_id: receiptId,
+    idempotency_key: idempotencyKey,
+    created_at: now.toISOString(),
+    closed_at: toIso(input.closedAt),
+  };
+}
+
+/**
+ * Persist one outcome row. Capture-only: this writes to the ledger and returns;
+ * no caller in this slice reads it back to influence routing or behaviour.
+ */
+export async function recordAutopilotOutcome(
+  supabase: SupabaseClient,
+  input: AutopilotOutcomeInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const row = buildAutopilotOutcomeRow(input);
+    const { error } = await supabase
+      .from("mc_autopilot_outcomes")
+      .upsert(row, { onConflict: "api_key_hash,idempotency_key", ignoreDuplicates: true });
+    if (error) throw error;
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 514,
+    "inventory": 515,
     "source_manifest": 189,
     "pages": 82,
     "tools": 185,
@@ -63,7 +63,7 @@
       "id": "automations",
       "name": "Automations",
       "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
-      "count": 115
+      "count": 116
     },
     {
       "id": "ledgers-and-proof",
@@ -558,6 +558,16 @@
       "kind": "autopilot module",
       "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
       "source": "api/lib/autopilot-control-ledger.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilotiq-outcome-ledger-api-lib-autopilotiq-outcome-ledger-ts-no-route",
+      "division": "Automations",
+      "name": "autopilotiq outcome ledger",
+      "kind": "autopilot module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/autopilotiq-outcome-ledger.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -214,7 +214,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 14 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
-| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 115 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 116 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 61 |
@@ -572,6 +572,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Signals Settings | Admin surface for Signals Settings. | /admin/signals/settings | src/pages/admin/signals/SignalsSettings.tsx |
 | Admin surfaces | admin page | Test Pass Catalog | Admin surface for Test Pass Catalog. | /admin/testpass | src/pages/admin/testpass/TestPassCatalog.tsx |
 | Automations | autopilot module | autopilot control ledger | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilot-control-ledger.ts |
+| Automations | autopilot module | autopilotiq outcome ledger | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilotiq-outcome-ledger.ts |
 | Automations | autopilot module | autopilotkit liveness | autopilotkit liveness shared frontend logic. | - | scripts/lib/autopilotkit-liveness.mjs |
 | Automations | autopilot module | pinballwake autopilot master loop | pinballwake autopilot master loop UnClick module. | - | scripts/pinballwake-autopilot-master-loop.mjs |
 | Automations | autopilot module | pinballwake autopilot triage | pinballwake autopilot triage UnClick module. | - | scripts/pinballwake-autopilot-triage.mjs |

--- a/supabase/migrations/20260528000000_autopilotiq_outcome_ledger.sql
+++ b/supabase/migrations/20260528000000_autopilotiq_outcome_ledger.sql
@@ -1,0 +1,85 @@
+-- AutopilotIQ outcome ledger (Phase 0, Slice 0a) - capture only.
+-- Immutable per-attempt record of what AutoPilot tried and how it ended.
+-- Additive: nothing reads this table to change routing or behaviour yet.
+-- Tenant-scoped and append-only. Raw inputs are never stored (only inputs_hash);
+-- secrets/credentials are refused by the recorder helper before any write.
+
+CREATE TABLE IF NOT EXISTS mc_autopilot_outcomes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  job_id text NOT NULL,
+  parent_job_id text,
+  attempt_n integer NOT NULL DEFAULT 1 CHECK (attempt_n >= 1),
+  task_type text NOT NULL,
+  actor_agent_id text NOT NULL,
+  -- route_taken: { seat, model, prompt_version, tool_set }
+  route_taken jsonb NOT NULL DEFAULT '{}'::jsonb,
+  inputs_hash text NOT NULL,
+  xpass_verdict text NOT NULL DEFAULT 'none'
+    CHECK (xpass_verdict IN ('PASS', 'BLOCKER', 'HOLD', 'SUPPRESS', 'ROUTE', 'none')),
+  outcome text NOT NULL
+    CHECK (outcome IN ('success', 'fail', 'hold')),
+  outcome_reason text NOT NULL
+    CHECK (outcome_reason IN (
+      'clean_pass',
+      'proof_landed',
+      'recovered',
+      'awaiting_proof',
+      'awaiting_review',
+      'gated_hold',
+      'xpass_fail',
+      'tool_error',
+      'model_refusal',
+      'budget_exceeded',
+      'user_revert',
+      'timeout',
+      'policy_block',
+      'rate_limit',
+      'missing_proof',
+      'duplicate_claim',
+      'stale_owner',
+      'wrong_route',
+      'unknown_error'
+    )),
+  confidence text NOT NULL DEFAULT 'silence'
+    CHECK (confidence IN ('hard_gate', 'soft_gate', 'silence')),
+  -- cost_signal: { tokens, wall_ms, usd, retries }
+  cost_signal jsonb NOT NULL DEFAULT '{}'::jsonb,
+  human_touch text NOT NULL DEFAULT 'auto'
+    CHECK (human_touch IN ('auto', 'edited', 'reverted', 'approved')),
+  receipt_id text,
+  idempotency_key text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  closed_at timestamptz,
+  seq bigserial UNIQUE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_idempotency
+  ON mc_autopilot_outcomes(api_key_hash, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_job
+  ON mc_autopilot_outcomes(api_key_hash, job_id, attempt_n DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_task_type
+  ON mc_autopilot_outcomes(api_key_hash, task_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_outcome
+  ON mc_autopilot_outcomes(api_key_hash, outcome, outcome_reason, created_at DESC);
+
+ALTER TABLE mc_autopilot_outcomes ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'mc_autopilot_outcomes'
+      AND policyname = 'mc_autopilot_outcomes_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_autopilot_outcomes_service_role_all"
+      ON mc_autopilot_outcomes FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Boardroom job
`9e131baf` - AutopilotIQ learning layer. **Phase 0, Slice 0a** of the self-improvement layer.

## Intent
**Capture data, change nothing.** Lays the immutable per-attempt OUTCOME LEDGER that later AutopilotIQ phases (probe set, kill switches, replay, shadow recommendations, gated learner) build on. Nothing in this slice reads these rows to alter routing, scoring, or behaviour.

## Collision check
No open PR, no active `codex/*` branch building AutopilotIQ / an outcome ledger. `codex/autopilotiq-scopepack` is the **merged** spec (#947, doc-only). `codex/jobsmith-phase4-outcome` is unrelated JobSmith work. `mc_autopilot_outcomes` / `recordAutopilotOutcome` do not exist on main. Clear to proceed.

## Files (5, +579/-3, additive)
- **`supabase/migrations/20260528000000_autopilotiq_outcome_ledger.sql`** - new table `mc_autopilot_outcomes`. Mirrors `mc_autopilot_events` conventions: tenant-scoped (`api_key_hash`), `bigserial seq UNIQUE`, RLS enabled with a `service_role` ALL policy, append-only by usage. CHECK closed taxonomies on `outcome` (success/fail/hold), `outcome_reason` (19-value closed set incl. `xpass_fail`, `tool_error`, `model_refusal`, `budget_exceeded`, `user_revert`, `timeout`, `policy_block`, `rate_limit`...), `confidence` (hard_gate/soft_gate/silence), `human_touch` (auto/edited/reverted/approved), `xpass_verdict` (PASS/BLOCKER/HOLD/SUPPRESS/ROUTE/none). Unique index on `(api_key_hash, idempotency_key)`; indexes on job/task_type/outcome. `route_taken` and `cost_signal` are jsonb. `NOTIFY pgrst, 'reload schema'`.
- **`api/lib/autopilotiq-outcome-ledger.ts`** - closed-taxonomy `as const` exports (`AUTOPILOT_OUTCOMES`, `AUTOPILOT_OUTCOME_REASONS`, `AUTOPILOT_CONFIDENCE_LEVELS`, `AUTOPILOT_HUMAN_TOUCH_STATES`, `AUTOPILOT_XPASS_VERDICTS`), `AutopilotOutcomeInput` / `AutopilotOutcomeRow` types, pure `buildAutopilotOutcomeRow()` (validates taxonomies, sanitizes `route_taken`+inputs, refuses secret-shaped keys/text, hashes inputs into `inputs_hash` and **never stores them raw**, derives a deterministic `idempotency_key`), and a thin `recordAutopilotOutcome()` upsert that mirrors `recordAutopilotEvent`.
- **`api/autopilotiq-outcome-ledger.test.ts`** - 8 tests: full row build, safe defaults, deterministic `inputs_hash` with raw inputs absent, idempotency stability, closed-taxonomy rejection (outcome/reason/confidence/human_touch/xpass), secret-shaped refusal (keys and bearer/uc_/sk-/gh_ text patterns), required-field + `attempt_n` validation.
- **`docs/UnClick-brainmap.generated.{md,json}`** - regenerated to register the new lib (brainmap stale-guard would otherwise fail CI).

## Verification
- `npx vitest run api/autopilotiq-outcome-ledger.test.ts` -> **8/8 pass**.
- Local `tsc --noEmit` -> **0 errors** (strict types).
- `npm run brainmap:check` -> passes (regenerated).

## Safety
- Additive only - no call site wired in this slice; no behaviour change. (A shadow recorder call site is a deliberate next slice, not this one.)
- Secrets / credentials refused before row build (matches spec hard-stop: nothing sensitive enters learning logs).
- Raw inputs never stored - only `inputs_hash`.
- Append-only intent; RLS allows only `service_role` writes.
- No `.github`/workflow/secret changes. ESM-safe (no relative imports in the new lib).

Draft. **Not for merge.**