### PR TITLE
feat(autopilotiq): Phase 0 probe set - known-answer honesty anchor

### DIFF
--- a/api/autopilotiq-probe-set.test.ts
+++ b/api/autopilotiq-probe-set.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROBE_CHECK_KINDS,
+  PROBE_SET_V0,
+  PROBE_TASK_TYPES,
+  aggregateProbeResults,
+  checkProbeDrift,
+  checkScoreboardHonesty,
+  runProbeSuite,
+  scoreProbe,
+  type Probe,
+  type ProbeOutcomeRecord,
+  type ProbeResult,
+} from "./lib/autopilotiq-probe-set";
+
+function probe(overrides: Partial<Probe> & Pick<Probe, "expected" | "check_kind">): Probe {
+  return {
+    id: overrides.id ?? "probe.test.example",
+    task_type: overrides.task_type ?? "format",
+    prompt: overrides.prompt ?? "test prompt",
+    description: overrides.description ?? "test description",
+    expected: overrides.expected,
+    check_kind: overrides.check_kind,
+  };
+}
+
+describe("autopilotiq probe set v0 - data integrity", () => {
+  it("exposes a non-empty, frozen probe set with unique ids and valid taxonomies", () => {
+    expect(PROBE_SET_V0.length).toBeGreaterThanOrEqual(6);
+    const ids = PROBE_SET_V0.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const p of PROBE_SET_V0) {
+      expect(PROBE_TASK_TYPES).toContain(p.task_type);
+      expect(PROBE_CHECK_KINDS).toContain(p.check_kind);
+      expect(p.prompt.length).toBeGreaterThan(0);
+      expect(p.expected.length).toBeGreaterThan(0);
+      expect(p.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("scoreProbe", () => {
+  it("equals: exact match passes, others fail with a reason", () => {
+    const p = probe({ expected: "yes", check_kind: "equals" });
+    expect(scoreProbe(p, "yes")).toEqual({ pass: true, reason: "exact match" });
+    expect(scoreProbe(p, "Yes").pass).toBe(false);
+    expect(scoreProbe(p, "no").reason).toContain("expected 'yes'");
+  });
+
+  it("equals_trimmed: ignores surrounding whitespace", () => {
+    const p = probe({ expected: "foo_bar_baz", check_kind: "equals_trimmed" });
+    expect(scoreProbe(p, "  foo_bar_baz\n").pass).toBe(true);
+    expect(scoreProbe(p, "foo bar baz").pass).toBe(false);
+  });
+
+  it("includes: substring presence", () => {
+    const p = probe({ expected: "needle", check_kind: "includes" });
+    expect(scoreProbe(p, "a haystack needle inside").pass).toBe(true);
+    expect(scoreProbe(p, "a haystack").pass).toBe(false);
+  });
+
+  it("regex: pattern match against actual", () => {
+    const p = probe({ expected: "^\\d{4}-\\d{2}-\\d{2}$", check_kind: "regex" });
+    expect(scoreProbe(p, "2026-05-28").pass).toBe(true);
+    expect(scoreProbe(p, "May 28, 2026").pass).toBe(false);
+  });
+
+  it("regex: invalid pattern fails cleanly without throwing", () => {
+    const p = probe({ expected: "[unterminated", check_kind: "regex" });
+    const result = scoreProbe(p, "anything");
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("invalid regex");
+  });
+
+  it("json_equal: order-independent equality on parsed JSON", () => {
+    const p = probe({ expected: '[1,2,3]', check_kind: "json_equal" });
+    expect(scoreProbe(p, "[1,2,3]").pass).toBe(true);
+    expect(scoreProbe(p, "[ 1, 2, 3 ]").pass).toBe(true);
+    expect(scoreProbe(p, "[3,2,1]").pass).toBe(false);
+
+    const obj = probe({ expected: '{"a":1,"b":2}', check_kind: "json_equal" });
+    expect(scoreProbe(obj, '{"b":2,"a":1}').pass).toBe(true);
+    expect(scoreProbe(obj, "not json").pass).toBe(false);
+  });
+
+  it("length_at_least: minimum character count", () => {
+    const p = probe({ expected: "10", check_kind: "length_at_least" });
+    expect(scoreProbe(p, "1234567890").pass).toBe(true);
+    expect(scoreProbe(p, "short").pass).toBe(false);
+  });
+});
+
+describe("aggregateProbeResults", () => {
+  function res(overrides: Partial<ProbeResult>): ProbeResult {
+    return {
+      probe_id: overrides.probe_id ?? "p",
+      task_type: overrides.task_type ?? "format",
+      pass: overrides.pass ?? true,
+      reason: overrides.reason ?? "",
+      actual: overrides.actual ?? "",
+      wall_ms: overrides.wall_ms ?? 0,
+      started_at: overrides.started_at ?? "2026-05-28T00:00:00.000Z",
+      finished_at: overrides.finished_at ?? "2026-05-28T00:00:00.000Z",
+    };
+  }
+
+  it("computes pass_rate and a per-task-type breakdown", () => {
+    const results = [
+      res({ probe_id: "a", task_type: "json_extract", pass: true }),
+      res({ probe_id: "b", task_type: "json_extract", pass: false }),
+      res({ probe_id: "c", task_type: "regex_match", pass: true }),
+      res({ probe_id: "d", task_type: "regex_match", pass: true }),
+    ];
+    const board = aggregateProbeResults(results, {
+      suiteRunId: "run-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+    });
+    expect(board.total).toBe(4);
+    expect(board.passed).toBe(3);
+    expect(board.failed).toBe(1);
+    expect(board.pass_rate).toBeCloseTo(0.75, 5);
+    expect(board.by_task_type.json_extract).toEqual({ total: 2, passed: 1, pass_rate: 0.5 });
+    expect(board.by_task_type.regex_match).toEqual({ total: 2, passed: 2, pass_rate: 1 });
+    expect(board.suite_run_id).toBe("run-1");
+  });
+
+  it("returns pass_rate=0 (not NaN) for an empty result set", () => {
+    const board = aggregateProbeResults([], {
+      suiteRunId: "run-empty",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+    });
+    expect(board.total).toBe(0);
+    expect(board.pass_rate).toBe(0);
+    expect(board.by_task_type).toEqual({});
+  });
+});
+
+describe("checkProbeDrift", () => {
+  it("classifies stable when |delta| < threshold", () => {
+    const r = checkProbeDrift({ baseline_pass_rate: 0.8, current_pass_rate: 0.82, threshold: 0.05 });
+    expect(r.verdict).toBe("stable");
+    expect(r.delta).toBeCloseTo(0.02, 5);
+  });
+
+  it("classifies drifting_up when delta exceeds threshold positive", () => {
+    const r = checkProbeDrift({ baseline_pass_rate: 0.6, current_pass_rate: 0.8, threshold: 0.05 });
+    expect(r.verdict).toBe("drifting_up");
+  });
+
+  it("classifies drifting_down when delta exceeds threshold negative", () => {
+    const r = checkProbeDrift({ baseline_pass_rate: 0.9, current_pass_rate: 0.7, threshold: 0.05 });
+    expect(r.verdict).toBe("drifting_down");
+  });
+});
+
+describe("checkScoreboardHonesty (catches lying scoreboard)", () => {
+  it("flags an 'improving' claim against flat probes as dishonest", () => {
+    const v = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: 0.8,
+      current_pass_rate: 0.81,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(false);
+    expect(v.observed_verdict).toBe("stable");
+    expect(v.reason).toContain("contradicts observed");
+  });
+
+  it("flags an 'improving' claim against a real drop as dishonest", () => {
+    const v = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: 0.9,
+      current_pass_rate: 0.7,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(false);
+    expect(v.observed_verdict).toBe("drifting_down");
+  });
+
+  it("accepts an honest 'improving' claim when probes actually drift up", () => {
+    const v = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: 0.6,
+      current_pass_rate: 0.8,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(true);
+    expect(v.observed_verdict).toBe("drifting_up");
+  });
+
+  it("accepts an honest 'stable' claim", () => {
+    const v = checkScoreboardHonesty({
+      claim: "stable",
+      baseline_pass_rate: 0.8,
+      current_pass_rate: 0.79,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(true);
+    expect(v.observed_verdict).toBe("stable");
+  });
+
+  it("flags a 'stable' claim when probes are actually degrading", () => {
+    const v = checkScoreboardHonesty({
+      claim: "stable",
+      baseline_pass_rate: 0.9,
+      current_pass_rate: 0.6,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(false);
+    expect(v.observed_verdict).toBe("drifting_down");
+  });
+});
+
+describe("runProbeSuite (end-to-end harness)", () => {
+  it("runs the suite with an oracle executor and yields a green scoreboard", async () => {
+    let tick = 0;
+    const out = await runProbeSuite({
+      executor: (p) => p.expected, // oracle: always return the expected answer
+      suiteRunId: "run-oracle",
+      now: () => new Date(Date.parse("2026-05-28T00:00:00.000Z") + ++tick * 5),
+    });
+    expect(out.scoreboard.total).toBe(PROBE_SET_V0.length);
+    expect(out.scoreboard.passed).toBe(PROBE_SET_V0.length);
+    expect(out.scoreboard.pass_rate).toBe(1);
+    for (const result of out.results) {
+      expect(result.pass).toBe(true);
+      expect(result.wall_ms).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("runs the suite with a degenerate executor and yields a red scoreboard", async () => {
+    const out = await runProbeSuite({
+      executor: () => "definitely wrong",
+      suiteRunId: "run-bad",
+    });
+    expect(out.scoreboard.passed).toBe(0);
+    expect(out.scoreboard.pass_rate).toBe(0);
+    expect(out.results.every((r) => !r.pass)).toBe(true);
+  });
+
+  it("captures executor failures cleanly without throwing", async () => {
+    const out = await runProbeSuite({
+      executor: () => {
+        throw new Error("executor offline");
+      },
+    });
+    expect(out.scoreboard.failed).toBe(PROBE_SET_V0.length);
+    expect(out.results[0].reason).toContain("executor threw");
+  });
+
+  it("emits ProbeOutcomeRecord shaped for the Slice 0a recorder", async () => {
+    const records: ProbeOutcomeRecord[] = [];
+    await runProbeSuite({
+      executor: (p) => p.expected,
+      recorder: (record) => {
+        records.push(record);
+      },
+      suiteRunId: "run-record",
+      routeTaken: { seat: "builder", model: "openai/gpt-oss-120b:free", tool_set: ["edit"] },
+    });
+    expect(records).toHaveLength(PROBE_SET_V0.length);
+    const first = records[0];
+    expect(first.taskType).toBe("probe");
+    expect(first.parentJobId).toBe("run-record");
+    expect(first.outcome).toBe("success");
+    expect(first.outcomeReason).toBe("clean_pass");
+    expect(first.attemptN).toBe(1);
+    expect(first.routeTaken.prompt_version).toMatch(/^probe:/);
+    expect(first.routeTaken.seat).toBe("builder");
+    expect(first.routeTaken.tool_set).toEqual(["edit"]);
+    expect(first.costSignal.wall_ms).toBeGreaterThanOrEqual(0);
+    expect(first.prompt_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(first.expected_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(first.actual_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect("prompt" in (first as Record<string, unknown>)).toBe(false);
+    expect("expected" in (first as Record<string, unknown>)).toBe(false);
+    expect("actual" in (first as Record<string, unknown>)).toBe(false);
+  });
+
+  it("emits outcomeReason='wrong_route' for a failed probe via the recorder", async () => {
+    const records: ProbeOutcomeRecord[] = [];
+    await runProbeSuite({
+      executor: () => "definitely wrong",
+      recorder: (record) => {
+        records.push(record);
+      },
+    });
+    expect(records.every((r) => r.outcome === "fail")).toBe(true);
+    expect(records.every((r) => r.outcomeReason === "wrong_route")).toBe(true);
+  });
+
+  it("integrates with the honesty check: oracle vs degenerate runs map to claims", async () => {
+    const oracle = await runProbeSuite({ executor: (p) => p.expected });
+    const degenerate = await runProbeSuite({ executor: () => "wrong" });
+
+    // Pretend the prior baseline was the degenerate run; the oracle run is a
+    // real improvement, so an "improving" claim should be honest.
+    const honest = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: degenerate.scoreboard.pass_rate,
+      current_pass_rate: oracle.scoreboard.pass_rate,
+      threshold: 0.05,
+    });
+    expect(honest.honest).toBe(true);
+    expect(honest.observed_verdict).toBe("drifting_up");
+
+    // Conversely: baseline was the oracle, but we now ship the degenerate run
+    // and try to claim "stable"; the honesty check must reject that lie.
+    const dishonest = checkScoreboardHonesty({
+      claim: "stable",
+      baseline_pass_rate: oracle.scoreboard.pass_rate,
+      current_pass_rate: degenerate.scoreboard.pass_rate,
+      threshold: 0.05,
+    });
+    expect(dishonest.honest).toBe(false);
+    expect(dishonest.observed_verdict).toBe("drifting_down");
+  });
+});

--- a/api/lib/autopilotiq-probe-set.ts
+++ b/api/lib/autopilotiq-probe-set.ts
@@ -1,0 +1,500 @@
+// AutopilotIQ probe set (Phase 0, Slice 0b) - capture only, scoreboard honesty anchor.
+//
+// A small set of DETERMINISTIC known-answer probes plus a pure scorer, an
+// aggregate scoreboard, and a drift / scoreboard-honesty check. The point: if a
+// future scoreboard claims "improving" while probe pass-rate is flat or down,
+// scoreboard honesty fails. Capture-only and additive - no nightly schedule is
+// wired by this slice; the recorder is dependency-injected so this module does
+// not depend on Slice 0a (the outcome ledger), and stays independently
+// testable. Natural production wiring: pass an adapter that calls
+// recordAutopilotOutcome(supabase, ...) from autopilotiq-outcome-ledger.ts.
+
+import { createHash } from "crypto";
+
+export const PROBE_CHECK_KINDS = [
+  "equals",
+  "equals_trimmed",
+  "includes",
+  "regex",
+  "json_equal",
+  "length_at_least",
+] as const;
+export type ProbeCheckKind = (typeof PROBE_CHECK_KINDS)[number];
+
+export const PROBE_TASK_TYPES = [
+  "json_extract",
+  "string_transform",
+  "regex_match",
+  "count",
+  "sort",
+  "format",
+] as const;
+export type ProbeTaskType = (typeof PROBE_TASK_TYPES)[number];
+
+export interface Probe {
+  id: string;
+  task_type: ProbeTaskType;
+  prompt: string;
+  expected: string;
+  check_kind: ProbeCheckKind;
+  description: string;
+}
+
+export interface ProbeResult {
+  probe_id: string;
+  task_type: string;
+  pass: boolean;
+  reason: string;
+  actual: string;
+  wall_ms: number;
+  started_at: string;
+  finished_at: string;
+}
+
+export interface ProbeTaskTypeScoreboard {
+  total: number;
+  passed: number;
+  pass_rate: number;
+}
+
+export interface ProbeScoreboard {
+  total: number;
+  passed: number;
+  failed: number;
+  pass_rate: number;
+  by_task_type: Record<string, ProbeTaskTypeScoreboard>;
+  generated_at: string;
+  suite_run_id: string;
+}
+
+export type ProbeDriftVerdict = "stable" | "drifting_up" | "drifting_down";
+
+export interface ProbeDriftReport {
+  baseline_pass_rate: number;
+  current_pass_rate: number;
+  delta: number;
+  threshold: number;
+  verdict: ProbeDriftVerdict;
+}
+
+export type ScoreboardClaim = "improving" | "stable" | "degrading";
+
+export interface ScoreboardHonestyVerdict {
+  honest: boolean;
+  claim: ScoreboardClaim;
+  observed_verdict: ProbeDriftVerdict;
+  delta: number;
+  threshold: number;
+  reason: string;
+}
+
+// Capture record emitted per probe attempt. Field names mirror the camelCase
+// input of the Slice 0a recorder (recordAutopilotOutcome) so a thin adapter can
+// pass these through once 0a merges, without coupling this slice to 0a's table.
+export interface ProbeOutcomeRecord {
+  jobId: string; // stable per-probe id (e.g. probe.json_extract.user_email_v1)
+  parentJobId: string; // suite_run_id - groups all probes from one suite run
+  taskType: "probe";
+  attemptN: number;
+  outcome: "success" | "fail";
+  outcomeReason: string; // structural; adapter maps to slice 0a's closed taxonomy
+  routeTaken: {
+    seat?: string | null;
+    model?: string | null;
+    prompt_version: string; // "probe:<task_type>:<probe_id_suffix>"
+    tool_set?: string[] | null;
+  };
+  costSignal: {
+    wall_ms: number;
+  };
+  receiptId: string | null;
+  prompt_hash: string;
+  expected_hash: string;
+  actual_hash: string;
+}
+
+export type ProbeExecutor = (probe: Probe) => Promise<string> | string;
+export type ProbeRecorder = (record: ProbeOutcomeRecord) => Promise<void> | void;
+
+// ----------------------------------------------------------------------------
+// Probe set v0
+// ----------------------------------------------------------------------------
+
+// Deterministic, language-agnostic probes. Each is a tiny, fixed task whose
+// correct answer never changes - that is the honesty anchor: if pass-rate
+// against this set drifts, the lane is changing in ways the scoreboard cannot
+// hide. Extend by adding more entries; do not edit existing ids.
+export const PROBE_SET_V0: readonly Probe[] = Object.freeze([
+  {
+    id: "probe.json_extract.user_email_v1",
+    task_type: "json_extract",
+    prompt: 'From {"name":"Ada","email":"ada@example.com","age":36}, output only the value of the "email" field.',
+    expected: "ada@example.com",
+    check_kind: "equals_trimmed",
+    description: "JSON field extraction; trivial but anchors follow-instruction fidelity.",
+  },
+  {
+    id: "probe.string.kebab_to_snake_v1",
+    task_type: "string_transform",
+    prompt: "Convert 'foo-bar-baz' to snake_case by replacing each '-' with '_'. Output only the result.",
+    expected: "foo_bar_baz",
+    check_kind: "equals_trimmed",
+    description: "Deterministic string transform; probes literal-output discipline.",
+  },
+  {
+    id: "probe.regex.uuid_present_v1",
+    task_type: "regex_match",
+    prompt:
+      "Does 'session 550e8400-e29b-41d4-a716-446655440000 was started' contain a UUID? Answer exactly 'yes' or 'no'.",
+    expected: "yes",
+    check_kind: "equals_trimmed",
+    description: "Detection task with a one-word constrained answer.",
+  },
+  {
+    id: "probe.count.unique_words_v1",
+    task_type: "count",
+    prompt:
+      "Count the unique whitespace-separated lowercase tokens in 'the quick brown the lazy quick'. Output only the integer.",
+    expected: "4",
+    check_kind: "equals_trimmed",
+    description: "Cardinality / counting task with a single-integer answer.",
+  },
+  {
+    id: "probe.sort.ascending_json_v1",
+    task_type: "sort",
+    prompt:
+      "Sort [3,1,4,1,5,9,2,6,5,3,5] in ascending order and output the result as a JSON array on a single line.",
+    expected: "[1,1,2,3,3,4,5,5,5,6,9]",
+    check_kind: "json_equal",
+    description: "Multi-element sort with stable JSON output.",
+  },
+  {
+    id: "probe.format.iso_date_v1",
+    task_type: "format",
+    prompt: "Convert the ISO-8601 timestamp '2026-05-28T14:30:00Z' to a YYYY-MM-DD date string. Output only the date.",
+    expected: "2026-05-28",
+    check_kind: "equals_trimmed",
+    description: "Formatting a known timestamp to a date string.",
+  },
+]);
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function truncate(value: string, max = 120): string {
+  return value.length > max ? `${value.slice(0, max - 3)}...` : value;
+}
+
+// ----------------------------------------------------------------------------
+// Scoring
+// ----------------------------------------------------------------------------
+
+/**
+ * Score one probe attempt. Pure: no I/O. Returns pass + a short reason that
+ * explains a fail without leaking the full prompt.
+ */
+export function scoreProbe(
+  probe: Probe,
+  actual: string,
+): { pass: boolean; reason: string } {
+  switch (probe.check_kind) {
+    case "equals": {
+      const pass = actual === probe.expected;
+      return {
+        pass,
+        reason: pass
+          ? "exact match"
+          : `expected '${truncate(probe.expected)}' got '${truncate(actual)}'`,
+      };
+    }
+    case "equals_trimmed": {
+      const a = (actual ?? "").trim();
+      const e = probe.expected.trim();
+      const pass = a === e;
+      return {
+        pass,
+        reason: pass
+          ? "exact match (trimmed)"
+          : `expected '${truncate(e)}' got '${truncate(a)}'`,
+      };
+    }
+    case "includes": {
+      const pass = String(actual ?? "").includes(probe.expected);
+      return {
+        pass,
+        reason: pass ? "substring present" : `'${truncate(probe.expected)}' not found in actual`,
+      };
+    }
+    case "regex": {
+      let re: RegExp;
+      try {
+        re = new RegExp(probe.expected);
+      } catch (err) {
+        return { pass: false, reason: `invalid regex in probe expected: ${(err as Error).message}` };
+      }
+      const pass = re.test(String(actual ?? ""));
+      return {
+        pass,
+        reason: pass ? "regex matched" : `regex '${truncate(probe.expected)}' did not match actual`,
+      };
+    }
+    case "json_equal": {
+      let expectedParsed: unknown;
+      let actualParsed: unknown;
+      try {
+        expectedParsed = JSON.parse(probe.expected);
+      } catch (err) {
+        return { pass: false, reason: `invalid JSON in probe expected: ${(err as Error).message}` };
+      }
+      try {
+        actualParsed = JSON.parse(String(actual ?? ""));
+      } catch (err) {
+        return { pass: false, reason: `actual is not valid JSON: ${(err as Error).message}` };
+      }
+      const pass = stableJson(expectedParsed) === stableJson(actualParsed);
+      return {
+        pass,
+        reason: pass
+          ? "JSON shapes equal"
+          : `expected JSON '${truncate(stableJson(expectedParsed))}' got '${truncate(stableJson(actualParsed))}'`,
+      };
+    }
+    case "length_at_least": {
+      const min = Number.parseInt(probe.expected, 10);
+      if (!Number.isFinite(min)) {
+        return { pass: false, reason: `invalid length threshold in probe expected: ${probe.expected}` };
+      }
+      const pass = String(actual ?? "").length >= min;
+      return {
+        pass,
+        reason: pass ? `length>=${min}` : `expected length>=${min}, got length=${String(actual ?? "").length}`,
+      };
+    }
+    default: {
+      const exhaustive: never = probe.check_kind;
+      return { pass: false, reason: `unsupported check_kind: ${String(exhaustive)}` };
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Aggregate
+// ----------------------------------------------------------------------------
+
+/**
+ * Aggregate probe results into a scoreboard. pass_rate is `passed/total`
+ * (NaN-free: 0 when total is 0). by_task_type lets callers see which capability
+ * is degrading even when the overall rate is flat.
+ */
+export function aggregateProbeResults(
+  results: ProbeResult[],
+  options: { suiteRunId: string; generatedAt: string },
+): ProbeScoreboard {
+  const total = results.length;
+  const passed = results.filter((result) => result.pass).length;
+  const failed = total - passed;
+  const passRate = total === 0 ? 0 : passed / total;
+
+  const byTaskType: Record<string, ProbeTaskTypeScoreboard> = {};
+  for (const result of results) {
+    const bucket = byTaskType[result.task_type] ?? { total: 0, passed: 0, pass_rate: 0 };
+    bucket.total += 1;
+    if (result.pass) bucket.passed += 1;
+    bucket.pass_rate = bucket.total === 0 ? 0 : bucket.passed / bucket.total;
+    byTaskType[result.task_type] = bucket;
+  }
+
+  return {
+    total,
+    passed,
+    failed,
+    pass_rate: passRate,
+    by_task_type: byTaskType,
+    generated_at: options.generatedAt,
+    suite_run_id: options.suiteRunId,
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Drift + scoreboard honesty
+// ----------------------------------------------------------------------------
+
+/**
+ * Compare a current pass-rate to a baseline. Verdict is "stable" when |delta|
+ * < threshold; otherwise "drifting_up" or "drifting_down". Threshold defaults
+ * to 0.05 (5 percentage points) - tune per probe-set size.
+ */
+export function checkProbeDrift(input: {
+  current_pass_rate: number;
+  baseline_pass_rate: number;
+  threshold?: number;
+}): ProbeDriftReport {
+  const threshold = input.threshold ?? 0.05;
+  const delta = input.current_pass_rate - input.baseline_pass_rate;
+  let verdict: ProbeDriftVerdict;
+  if (Math.abs(delta) < threshold) verdict = "stable";
+  else if (delta > 0) verdict = "drifting_up";
+  else verdict = "drifting_down";
+  return {
+    baseline_pass_rate: input.baseline_pass_rate,
+    current_pass_rate: input.current_pass_rate,
+    delta,
+    threshold,
+    verdict,
+  };
+}
+
+/**
+ * Catch a lying scoreboard. A claim of "improving" is honest only if the probe
+ * set is drifting up; "degrading" only if drifting down; "stable" only if the
+ * |delta| is below threshold. Anything else means the scoreboard's narrative
+ * does not match the probe-anchored truth.
+ */
+export function checkScoreboardHonesty(input: {
+  claim: ScoreboardClaim;
+  current_pass_rate: number;
+  baseline_pass_rate: number;
+  threshold?: number;
+}): ScoreboardHonestyVerdict {
+  const drift = checkProbeDrift({
+    current_pass_rate: input.current_pass_rate,
+    baseline_pass_rate: input.baseline_pass_rate,
+    threshold: input.threshold,
+  });
+  const expectedFor: Record<ScoreboardClaim, ProbeDriftVerdict> = {
+    improving: "drifting_up",
+    stable: "stable",
+    degrading: "drifting_down",
+  };
+  const honest = drift.verdict === expectedFor[input.claim];
+  const reason = honest
+    ? `claim '${input.claim}' matches observed '${drift.verdict}' (delta=${drift.delta.toFixed(3)})`
+    : `claim '${input.claim}' contradicts observed '${drift.verdict}' (delta=${drift.delta.toFixed(3)}, threshold=${drift.threshold})`;
+  return {
+    honest,
+    claim: input.claim,
+    observed_verdict: drift.verdict,
+    delta: drift.delta,
+    threshold: drift.threshold,
+    reason,
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Harness
+// ----------------------------------------------------------------------------
+
+export interface RunProbeSuiteInput {
+  probes?: readonly Probe[];
+  executor: ProbeExecutor;
+  recorder?: ProbeRecorder;
+  suiteRunId?: string;
+  routeTaken?: Pick<ProbeOutcomeRecord["routeTaken"], "seat" | "model" | "tool_set">;
+  now?: () => Date;
+}
+
+export interface RunProbeSuiteOutput {
+  scoreboard: ProbeScoreboard;
+  results: ProbeResult[];
+}
+
+/**
+ * Run a probe suite end-to-end with an injected executor. For each probe:
+ *   1. call executor(probe) and measure wall_ms,
+ *   2. score actual vs expected,
+ *   3. optionally emit a ProbeOutcomeRecord via the injected recorder.
+ *
+ * Capture-only: this function never reads the recorder's output back to alter
+ * behaviour. Probe-set choice does not influence the scorer. The recorder is
+ * optional so the harness is fully usable without persistence (e.g. in CI or
+ * a local smoke run).
+ */
+export async function runProbeSuite(input: RunProbeSuiteInput): Promise<RunProbeSuiteOutput> {
+  const probes = input.probes ?? PROBE_SET_V0;
+  const now = input.now ?? (() => new Date());
+  const suiteRunId = input.suiteRunId ?? `probe-suite-${now().toISOString()}`;
+  const route = input.routeTaken ?? {};
+  const results: ProbeResult[] = [];
+
+  for (const probe of probes) {
+    const startedAt = now();
+    let actual: string;
+    let executorError: Error | null = null;
+    try {
+      const value = await Promise.resolve(input.executor(probe));
+      actual = String(value ?? "");
+    } catch (err) {
+      executorError = err as Error;
+      actual = "";
+    }
+    const finishedAt = now();
+    const wallMs = finishedAt.getTime() - startedAt.getTime();
+
+    let pass: boolean;
+    let reason: string;
+    if (executorError) {
+      pass = false;
+      reason = `executor threw: ${executorError.message}`;
+    } else {
+      const scored = scoreProbe(probe, actual);
+      pass = scored.pass;
+      reason = scored.reason;
+    }
+
+    results.push({
+      probe_id: probe.id,
+      task_type: probe.task_type,
+      pass,
+      reason,
+      actual,
+      wall_ms: wallMs,
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+    });
+
+    if (input.recorder) {
+      const record: ProbeOutcomeRecord = {
+        jobId: probe.id,
+        parentJobId: suiteRunId,
+        taskType: "probe",
+        attemptN: 1,
+        outcome: pass ? "success" : "fail",
+        outcomeReason: pass ? "clean_pass" : executorError ? "tool_error" : "wrong_route",
+        routeTaken: {
+          seat: route.seat ?? null,
+          model: route.model ?? null,
+          prompt_version: `probe:${probe.task_type}:${probe.id}`,
+          tool_set: route.tool_set ?? null,
+        },
+        costSignal: { wall_ms: wallMs },
+        receiptId: null,
+        prompt_hash: sha256(probe.prompt),
+        expected_hash: sha256(probe.expected),
+        actual_hash: sha256(actual),
+      };
+      await Promise.resolve(input.recorder(record));
+    }
+  }
+
+  const scoreboard = aggregateProbeResults(results, {
+    suiteRunId,
+    generatedAt: now().toISOString(),
+  });
+  return { scoreboard, results };
+}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 514,
+    "inventory": 515,
     "source_manifest": 189,
     "pages": 82,
     "tools": 185,
@@ -63,7 +63,7 @@
       "id": "automations",
       "name": "Automations",
       "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
-      "count": 115
+      "count": 116
     },
     {
       "id": "ledgers-and-proof",
@@ -558,6 +558,16 @@
       "kind": "autopilot module",
       "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
       "source": "api/lib/autopilot-control-ledger.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilotiq-probe-set-api-lib-autopilotiq-probe-set-ts-no-route",
+      "division": "Automations",
+      "name": "autopilotiq probe set",
+      "kind": "autopilot module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/autopilotiq-probe-set.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -214,7 +214,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 14 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
-| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 115 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 116 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 61 |
@@ -572,6 +572,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Signals Settings | Admin surface for Signals Settings. | /admin/signals/settings | src/pages/admin/signals/SignalsSettings.tsx |
 | Admin surfaces | admin page | Test Pass Catalog | Admin surface for Test Pass Catalog. | /admin/testpass | src/pages/admin/testpass/TestPassCatalog.tsx |
 | Automations | autopilot module | autopilot control ledger | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilot-control-ledger.ts |
+| Automations | autopilot module | autopilotiq probe set | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilotiq-probe-set.ts |
 | Automations | autopilot module | autopilotkit liveness | autopilotkit liveness shared frontend logic. | - | scripts/lib/autopilotkit-liveness.mjs |
 | Automations | autopilot module | pinballwake autopilot master loop | pinballwake autopilot master loop UnClick module. | - | scripts/pinballwake-autopilot-master-loop.mjs |
 | Automations | autopilot module | pinballwake autopilot triage | pinballwake autopilot triage UnClick module. | - | scripts/pinballwake-autopilot-triage.mjs |


### PR DESCRIPTION
## Boardroom job
`9e131baf` - AutopilotIQ learning layer. **Phase 0, Slice 0b** of the self-improvement layer (follows draft #1144 outcome ledger).

## Intent
**Capture data, change nothing.** Provides the *scoreboard-honesty anchor* for later phases: if a future AutopilotIQ scoreboard claims "improving" but the deterministic probe pass-rate is flat or down, the scoreboard is **lying**. This slice gives us the data to call that lie.

## Files (4, +833/-3, additive)
- **`api/lib/autopilotiq-probe-set.ts`** -
  - `PROBE_SET_V0` (frozen): six deterministic known-answer probes spanning task_types `json_extract` / `string_transform` / `regex_match` / `count` / `sort` / `format`. Extend by appending; existing ids are stable.
  - `scoreProbe` - pure scorer per closed `check_kind` taxonomy (`equals`, `equals_trimmed`, `includes`, `regex`, `json_equal`, `length_at_least`). Handles invalid regex / non-JSON cleanly.
  - `aggregateProbeResults` - scoreboard with overall + per-task-type pass rates; NaN-free for empty input.
  - `checkProbeDrift` - current vs baseline pass-rate against a threshold (default 0.05) -> `stable` / `drifting_up` / `drifting_down`.
  - **`checkScoreboardHonesty`** - takes a scoreboard `claim` (`improving`/`stable`/`degrading`) and the observed probe drift, and returns `honest: false` when the claim contradicts reality. This is the explicit lying-scoreboard catcher.
  - `runProbeSuite` - end-to-end harness with dependency-injected `executor` (the lane under test) and an **optional** `recorder` callback. The recorder receives a `ProbeOutcomeRecord` whose field names mirror Slice 0a's `recordAutopilotOutcome` input (`taskType: 'probe'`, `routeTaken.prompt_version` namespaced as `probe:<task_type>:<probe_id>`, `costSignal.wall_ms`, plus `prompt_hash` / `expected_hash` / `actual_hash` - never the raw text).
- **`api/autopilotiq-probe-set.test.ts`** - 24 tests: data integrity (unique ids, valid taxonomies), scorer per check_kind incl. invalid regex/JSON, aggregate incl. empty input, drift verdicts, scoreboard honesty across every claim/observation pairing, end-to-end `runProbeSuite` with oracle / degenerate / throwing executors, recorder shape verification (incl. raw-text never persisted), and the canonical lying-scoreboard scenario.
- **`docs/UnClick-brainmap.generated.{md,json}`** - regenerated for the new lib (stale-guard would otherwise fail CI).

## Verification
- `npx vitest run api/autopilotiq-probe-set.test.ts` -> **24/24 pass**.
- Local `tsc --noEmit` -> **0 errors** (strict types).
- `npm run brainmap:check` -> passes after regen.

## Capture-only / independence
- **No nightly schedule, no Vercel endpoint, no behaviour change.** The vitest suite itself is the runnable harness for Slice 0b.
- **Slice 0a is NOT imported.** The recorder is dependency-injected, so this slice merges independently from PR #1144. Natural production wiring once 0a lands is a one-line adapter:
  ```ts
  recorder: (rec) => recordAutopilotOutcome(supabase, { apiKeyHash, ...rec })
  ```
- Strict types, ESM-safe (only `crypto` builtin). No `.github`/workflow/secret changes.

Draft. **Not for merge.**