### PR TITLE
feat(autopilotiq): Phase 0 kill switches + per-job circuit breakers (scaffold, capture-only)

### DIFF
--- a/api/autopilotiq-circuit-breakers.test.ts
+++ b/api/autopilotiq-circuit-breakers.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOPILOTIQ_COMPONENTS,
+  CIRCUIT_BREAK_REASONS,
+  DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+  DEFAULT_CIRCUIT_BREAKER_LIMITS,
+  evaluateCircuitBreaker,
+  isComponentAllowed,
+  isComponentPaused,
+  isSelfImprovementKilled,
+  recordCircuitBreak,
+  type AutopilotIQComponent,
+  type AutopilotIQSafetyConfig,
+  type CircuitBreakerLimits,
+  type CircuitBreakRecord,
+} from "./lib/autopilotiq-circuit-breakers";
+
+describe("evaluateCircuitBreaker (Layer 1)", () => {
+  it("allows when no resource has been used and defaults apply", () => {
+    const v = evaluateCircuitBreaker({});
+    expect(v.allow).toBe(true);
+    expect(v.breached).toBeNull();
+    expect(v.detail).toContain("within all configured limits");
+  });
+
+  it("allows when usage is exactly at the limit (strict > triggers breach)", () => {
+    const limits: CircuitBreakerLimits = { max_actions: 8 };
+    expect(evaluateCircuitBreaker({ actions: 8 }, limits).allow).toBe(true);
+    expect(evaluateCircuitBreaker({ actions: 9 }, limits).allow).toBe(false);
+  });
+
+  it("treats an undefined limit as uncapped for that resource", () => {
+    const limits: CircuitBreakerLimits = { max_actions: 8 }; // tokens uncapped
+    const v = evaluateCircuitBreaker({ actions: 1, tokens: 1_000_000 }, limits);
+    expect(v.allow).toBe(true);
+  });
+
+  it("breaches circuit_break_actions with a clear detail line", () => {
+    const v = evaluateCircuitBreaker({ actions: 12 }, { max_actions: 8 });
+    expect(v.allow).toBe(false);
+    expect(v.breached).toBe("circuit_break_actions");
+    expect(v.detail).toContain("actions=12");
+    expect(v.detail).toContain("limit=8");
+  });
+
+  it("breaches circuit_break_tokens when tokens exceed the cap", () => {
+    const v = evaluateCircuitBreaker({ tokens: 300_000 }, { max_tokens: 200_000 });
+    expect(v.breached).toBe("circuit_break_tokens");
+  });
+
+  it("breaches circuit_break_cost when usd exceeds the cap", () => {
+    const v = evaluateCircuitBreaker({ usd: 1.25 }, { max_usd: 1.0 });
+    expect(v.breached).toBe("circuit_break_cost");
+    expect(v.detail).toContain("usd=1.25");
+  });
+
+  it("breaches circuit_break_time when wall_ms exceeds the cap", () => {
+    const v = evaluateCircuitBreaker({ wall_ms: 600_000 }, { max_wall_ms: 5 * 60_000 });
+    expect(v.breached).toBe("circuit_break_time");
+  });
+
+  it("breaches circuit_break_retries when retries exceed the cap", () => {
+    const v = evaluateCircuitBreaker({ retries: 4 }, { max_retries: 3 });
+    expect(v.breached).toBe("circuit_break_retries");
+  });
+
+  it("returns the first deterministic breach when multiple limits are exceeded", () => {
+    // actions is checked first (actions > tokens > cost > time > retries)
+    const v = evaluateCircuitBreaker(
+      { actions: 99, tokens: 9_999_999, usd: 99 },
+      { max_actions: 8, max_tokens: 200_000, max_usd: 1.0 },
+    );
+    expect(v.breached).toBe("circuit_break_actions");
+  });
+
+  it("uses DEFAULT_CIRCUIT_BREAKER_LIMITS when no limits are provided", () => {
+    const v = evaluateCircuitBreaker({ actions: 9 });
+    expect(v.breached).toBe("circuit_break_actions");
+    expect(v.limits).toBe(DEFAULT_CIRCUIT_BREAKER_LIMITS);
+  });
+
+  it("every reason in CIRCUIT_BREAK_REASONS can be produced by some breach", () => {
+    const breachedReasons = new Set<string>();
+    breachedReasons.add(evaluateCircuitBreaker({ actions: 99 }, { max_actions: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ tokens: 99 }, { max_tokens: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ usd: 99 }, { max_usd: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ wall_ms: 99 }, { max_wall_ms: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ retries: 99 }, { max_retries: 1 }).breached!);
+    for (const reason of CIRCUIT_BREAK_REASONS) {
+      expect(breachedReasons.has(reason)).toBe(true);
+    }
+  });
+});
+
+describe("isSelfImprovementKilled (Layer 3)", () => {
+  it("defaults to false", () => {
+    expect(isSelfImprovementKilled()).toBe(false);
+    expect(isSelfImprovementKilled(DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG)).toBe(false);
+  });
+
+  it("returns true when the flag is set", () => {
+    expect(isSelfImprovementKilled({ self_improvement_kill: true })).toBe(true);
+  });
+});
+
+describe("isComponentPaused (Layer 2)", () => {
+  it("defaults to not paused", () => {
+    for (const component of AUTOPILOTIQ_COMPONENTS) {
+      expect(isComponentPaused(component)).toBe(false);
+    }
+  });
+
+  it("returns true only for the named paused components", () => {
+    const config: AutopilotIQSafetyConfig = {
+      paused_components: ["seat_intelligence", "creative_evolution"],
+    };
+    expect(isComponentPaused("seat_intelligence", config)).toBe(true);
+    expect(isComponentPaused("creative_evolution", config)).toBe(true);
+    expect(isComponentPaused("autopilotiq_tuner", config)).toBe(false);
+  });
+
+  it("the global kill switch trumps the per-component list", () => {
+    const config: AutopilotIQSafetyConfig = {
+      self_improvement_kill: true,
+      paused_components: [], // explicitly empty
+    };
+    for (const component of AUTOPILOTIQ_COMPONENTS) {
+      expect(isComponentPaused(component, config)).toBe(true);
+    }
+  });
+});
+
+describe("isComponentAllowed (compound)", () => {
+  it("reports allowed=true with reason='ok' under default config", () => {
+    expect(isComponentAllowed("autopilotiq_tuner")).toEqual({ allowed: true, reason: "ok" });
+  });
+
+  it("reports reason='kill_switch' when the global kill is engaged", () => {
+    const v = isComponentAllowed("autopilotiq_tuner", { self_improvement_kill: true });
+    expect(v).toEqual({ allowed: false, reason: "kill_switch" });
+  });
+
+  it("reports reason='component_paused' when only that component is paused", () => {
+    const v = isComponentAllowed("retry_tuner", {
+      self_improvement_kill: false,
+      paused_components: ["retry_tuner"],
+    });
+    expect(v).toEqual({ allowed: false, reason: "component_paused" });
+  });
+
+  it("kill_switch is reported instead of component_paused when both apply", () => {
+    const v = isComponentAllowed("retry_tuner", {
+      self_improvement_kill: true,
+      paused_components: ["retry_tuner"],
+    });
+    expect(v.reason).toBe("kill_switch");
+  });
+});
+
+describe("recordCircuitBreak", () => {
+  it("returns null and never calls the recorder when the verdict allows", async () => {
+    let called = 0;
+    const record = await recordCircuitBreak({
+      jobId: "job-1",
+      verdict: evaluateCircuitBreaker({ actions: 1 }, { max_actions: 8 }),
+      recorder: () => {
+        called += 1;
+      },
+    });
+    expect(record).toBeNull();
+    expect(called).toBe(0);
+  });
+
+  it("builds a record with the Slice 0a adapter shape on breach", async () => {
+    const verdict = evaluateCircuitBreaker(
+      { actions: 99, tokens: 1234, usd: 5.5, wall_ms: 12_000, retries: 2 },
+      { max_actions: 8 },
+    );
+    const record = await recordCircuitBreak({
+      jobId: "job-cb-1",
+      parentJobId: "epic-1",
+      attemptN: 3,
+      receiptId: "receipt-x",
+      routeTaken: { seat: "builder", model: "openai/gpt-oss-120b:free", tool_set: ["edit"] },
+      verdict,
+    });
+
+    expect(record).not.toBeNull();
+    const r = record as CircuitBreakRecord;
+    expect(r.jobId).toBe("job-cb-1");
+    expect(r.parentJobId).toBe("epic-1");
+    expect(r.taskType).toBe("circuit_break");
+    expect(r.attemptN).toBe(3);
+    expect(r.outcome).toBe("fail");
+    expect(r.outcomeReason).toBe("policy_block");
+    expect(r.break_reason).toBe("circuit_break_actions");
+    expect(r.break_detail).toContain("actions=99");
+    expect(r.routeTaken).toEqual({
+      seat: "builder",
+      model: "openai/gpt-oss-120b:free",
+      prompt_version: "circuit_break:circuit_break_actions",
+      tool_set: ["edit"],
+    });
+    expect(r.costSignal).toEqual({ tokens: 1234, wall_ms: 12_000, usd: 5.5, retries: 2 });
+    expect(r.receiptId).toBe("receipt-x");
+  });
+
+  it("calls the injected recorder exactly once per breach with the same record", async () => {
+    const seen: CircuitBreakRecord[] = [];
+    const verdict = evaluateCircuitBreaker({ usd: 2 }, { max_usd: 1 });
+    const record = await recordCircuitBreak({
+      jobId: "job-cb-2",
+      verdict,
+      recorder: (rec) => {
+        seen.push(rec);
+      },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe(record);
+    expect(seen[0].break_reason).toBe("circuit_break_cost");
+  });
+
+  it("returns the record even when no recorder is provided", async () => {
+    const verdict = evaluateCircuitBreaker({ retries: 5 }, { max_retries: 3 });
+    const record = await recordCircuitBreak({ jobId: "job-cb-3", verdict });
+    expect(record?.break_reason).toBe("circuit_break_retries");
+  });
+});

--- a/api/lib/autopilotiq-circuit-breakers.ts
+++ b/api/lib/autopilotiq-circuit-breakers.ts
@@ -1,0 +1,273 @@
+// AutopilotIQ circuit breakers + kill switches (Phase 0, Slice 0c) - safety
+// scaffolding, capture-only.
+//
+// Three layers of safety, built BEFORE anything acts (the spec is explicit:
+// build in Phase 0, never retrofit):
+//   1. Per-job circuit breaker - hard ceilings on actions/cost/tokens/wall/
+//      retries with CLOSED reason codes (circuit_break_*).
+//   2. Component pause flags - a readable per-component paused model, default
+//      safe and explicit.
+//   3. Global self-improvement kill switch - one boolean halts every
+//      autonomous self-improvement path.
+//
+// Pure / config-driven. Additive: nothing in this slice halts live production
+// jobs; later phases call these. The breach recorder is dependency-injected,
+// so this slice does not couple to Slice 0a's outcome ledger (PR #1144) and
+// stays independently mergeable. Natural production wiring once 0a lands is a
+// thin adapter that forwards CircuitBreakRecord to recordAutopilotOutcome.
+
+export const CIRCUIT_BREAK_REASONS = [
+  "circuit_break_actions",
+  "circuit_break_tokens",
+  "circuit_break_cost",
+  "circuit_break_time",
+  "circuit_break_retries",
+] as const;
+export type CircuitBreakReason = (typeof CIRCUIT_BREAK_REASONS)[number];
+
+export const AUTOPILOTIQ_COMPONENTS = [
+  "autopilotiq_tuner",
+  "seat_intelligence",
+  "creative_evolution",
+  "retry_tuner",
+  "shadow_learner",
+  "gated_learner",
+] as const;
+export type AutopilotIQComponent = (typeof AUTOPILOTIQ_COMPONENTS)[number];
+
+// Layer 1 inputs ---------------------------------------------------------
+
+export interface CircuitBreakerLimits {
+  // Each limit is optional; when undefined the corresponding resource is
+  // uncapped for this evaluation. Hard ceilings: usage > limit triggers a
+  // breach.
+  max_actions?: number;
+  max_tokens?: number;
+  max_usd?: number;
+  max_wall_ms?: number;
+  max_retries?: number;
+}
+
+export interface CircuitBreakerUsage {
+  actions?: number;
+  tokens?: number;
+  usd?: number;
+  wall_ms?: number;
+  retries?: number;
+}
+
+export interface CircuitBreakerVerdict {
+  allow: boolean;
+  breached: CircuitBreakReason | null;
+  detail: string;
+  limits: CircuitBreakerLimits;
+  usage: CircuitBreakerUsage;
+}
+
+// Conservative defaults. These are explicit and easy to tune; they intentionally
+// favour halting on uncertainty over continuing past safety budgets.
+export const DEFAULT_CIRCUIT_BREAKER_LIMITS: CircuitBreakerLimits = Object.freeze({
+  max_actions: 8,
+  max_tokens: 200_000,
+  max_usd: 1.0,
+  max_wall_ms: 5 * 60_000,
+  max_retries: 3,
+});
+
+// Layer 2 + 3 config ----------------------------------------------------
+
+export interface AutopilotIQSafetyConfig {
+  // Global kill switch. When true, every autonomous self-improvement path is
+  // considered halted regardless of per-component pause flags.
+  self_improvement_kill?: boolean;
+  // Per-component pauses. Default: empty (no components paused).
+  paused_components?: readonly AutopilotIQComponent[];
+}
+
+export const DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG: AutopilotIQSafetyConfig = Object.freeze({
+  self_improvement_kill: false,
+  paused_components: [],
+});
+
+// ----------------------------------------------------------------------
+// Layer 1: per-job circuit breaker
+// ----------------------------------------------------------------------
+
+/**
+ * Evaluate hard ceilings for a single job's resource usage. Pure - no I/O.
+ * Returns the first deterministic breach (order: actions, tokens, cost, time,
+ * retries) so callers see the most economically obvious cap first. A limit of
+ * `undefined` means uncapped for that resource; usage of `undefined` counts as
+ * zero. Breach when `usage > limit` (strict): equality is still allowed.
+ */
+export function evaluateCircuitBreaker(
+  usage: CircuitBreakerUsage,
+  limits: CircuitBreakerLimits = DEFAULT_CIRCUIT_BREAKER_LIMITS,
+): CircuitBreakerVerdict {
+  const checks: Array<{
+    used: number;
+    limit: number | undefined;
+    reason: CircuitBreakReason;
+    label: string;
+  }> = [
+    { used: usage.actions ?? 0, limit: limits.max_actions, reason: "circuit_break_actions", label: "actions" },
+    { used: usage.tokens ?? 0, limit: limits.max_tokens, reason: "circuit_break_tokens", label: "tokens" },
+    { used: usage.usd ?? 0, limit: limits.max_usd, reason: "circuit_break_cost", label: "usd" },
+    { used: usage.wall_ms ?? 0, limit: limits.max_wall_ms, reason: "circuit_break_time", label: "wall_ms" },
+    { used: usage.retries ?? 0, limit: limits.max_retries, reason: "circuit_break_retries", label: "retries" },
+  ];
+
+  for (const check of checks) {
+    if (typeof check.limit !== "number") continue;
+    if (check.used > check.limit) {
+      return {
+        allow: false,
+        breached: check.reason,
+        detail: `${check.label}=${check.used} > limit=${check.limit}`,
+        limits,
+        usage,
+      };
+    }
+  }
+
+  return {
+    allow: true,
+    breached: null,
+    detail: "within all configured limits",
+    limits,
+    usage,
+  };
+}
+
+// ----------------------------------------------------------------------
+// Layer 2 + 3: component pause / global kill
+// ----------------------------------------------------------------------
+
+/**
+ * True when the global self-improvement kill switch is engaged. Pure read.
+ */
+export function isSelfImprovementKilled(
+  config: AutopilotIQSafetyConfig = DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+): boolean {
+  return Boolean(config.self_improvement_kill);
+}
+
+/**
+ * True when a specific component is paused. The global kill switch trumps
+ * everything (any component is paused when the kill is engaged); otherwise
+ * `paused_components` decides.
+ */
+export function isComponentPaused(
+  name: AutopilotIQComponent,
+  config: AutopilotIQSafetyConfig = DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+): boolean {
+  if (isSelfImprovementKilled(config)) return true;
+  const paused = config.paused_components ?? [];
+  return paused.includes(name);
+}
+
+export interface ComponentAllowance {
+  allowed: boolean;
+  reason: "ok" | "kill_switch" | "component_paused";
+}
+
+/**
+ * Compound check: returns allowed=false with the precise reason. Use this on
+ * any code path that's about to invoke an AutopilotIQ component so the cause
+ * of a halt is always explicit.
+ */
+export function isComponentAllowed(
+  name: AutopilotIQComponent,
+  config: AutopilotIQSafetyConfig = DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+): ComponentAllowance {
+  if (isSelfImprovementKilled(config)) return { allowed: false, reason: "kill_switch" };
+  const paused = config.paused_components ?? [];
+  if (paused.includes(name)) return { allowed: false, reason: "component_paused" };
+  return { allowed: true, reason: "ok" };
+}
+
+// ----------------------------------------------------------------------
+// Breach record (Slice 0a adapter shape)
+// ----------------------------------------------------------------------
+
+// Field names mirror the camelCase input of Slice 0a's recordAutopilotOutcome
+// (api/lib/autopilotiq-outcome-ledger.ts in PR #1144) so a one-line adapter
+// can forward these once 0a lands. outcomeReason="policy_block" is the
+// natural fit in 0a's closed taxonomy.
+export interface CircuitBreakRecord {
+  jobId: string;
+  parentJobId: string | null;
+  taskType: "circuit_break";
+  attemptN: number;
+  outcome: "fail";
+  outcomeReason: "policy_block";
+  routeTaken: {
+    seat: string | null;
+    model: string | null;
+    prompt_version: string;
+    tool_set: string[] | null;
+  };
+  costSignal: {
+    tokens: number | null;
+    wall_ms: number | null;
+    usd: number | null;
+    retries: number | null;
+  };
+  receiptId: string | null;
+  break_reason: CircuitBreakReason;
+  break_detail: string;
+}
+
+export type CircuitBreakRecorder = (record: CircuitBreakRecord) => Promise<void> | void;
+
+export interface RecordCircuitBreakInput {
+  jobId: string;
+  parentJobId?: string | null;
+  attemptN?: number;
+  verdict: CircuitBreakerVerdict;
+  recorder?: CircuitBreakRecorder;
+  receiptId?: string | null;
+  routeTaken?: Partial<CircuitBreakRecord["routeTaken"]>;
+}
+
+/**
+ * Build a circuit-break record and emit it through an optional recorder.
+ * Returns `null` when the verdict is allow-true (no breach to record) and the
+ * built record otherwise. Capture-only: the caller decides whether to also
+ * halt the job; this helper just preserves the breach as evidence.
+ */
+export async function recordCircuitBreak(
+  input: RecordCircuitBreakInput,
+): Promise<CircuitBreakRecord | null> {
+  if (input.verdict.allow || input.verdict.breached === null) return null;
+
+  const route = input.routeTaken ?? {};
+  const record: CircuitBreakRecord = {
+    jobId: input.jobId,
+    parentJobId: input.parentJobId ?? null,
+    taskType: "circuit_break",
+    attemptN: input.attemptN ?? 1,
+    outcome: "fail",
+    outcomeReason: "policy_block",
+    routeTaken: {
+      seat: route.seat ?? null,
+      model: route.model ?? null,
+      prompt_version: route.prompt_version ?? `circuit_break:${input.verdict.breached}`,
+      tool_set: route.tool_set ?? null,
+    },
+    costSignal: {
+      tokens: input.verdict.usage.tokens ?? null,
+      wall_ms: input.verdict.usage.wall_ms ?? null,
+      usd: input.verdict.usage.usd ?? null,
+      retries: input.verdict.usage.retries ?? null,
+    },
+    receiptId: input.receiptId ?? null,
+    break_reason: input.verdict.breached,
+    break_detail: input.verdict.detail,
+  };
+
+  if (input.recorder) {
+    await Promise.resolve(input.recorder(record));
+  }
+  return record;
+}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 515,
+    "inventory": 516,
     "source_manifest": 189,
     "pages": 82,
     "tools": 186,
@@ -63,7 +63,7 @@
       "id": "automations",
       "name": "Automations",
       "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
-      "count": 115
+      "count": 116
     },
     {
       "id": "ledgers-and-proof",
@@ -558,6 +558,16 @@
       "kind": "autopilot module",
       "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
       "source": "api/lib/autopilot-control-ledger.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilotiq-circuit-breakers-api-lib-autopilotiq-circuit-breakers-ts-no-route",
+      "division": "Automations",
+      "name": "autopilotiq circuit breakers",
+      "kind": "autopilot module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/autopilotiq-circuit-breakers.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -214,7 +214,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 14 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
-| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 115 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 116 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 61 |
@@ -573,6 +573,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Signals Settings | Admin surface for Signals Settings. | /admin/signals/settings | src/pages/admin/signals/SignalsSettings.tsx |
 | Admin surfaces | admin page | Test Pass Catalog | Admin surface for Test Pass Catalog. | /admin/testpass | src/pages/admin/testpass/TestPassCatalog.tsx |
 | Automations | autopilot module | autopilot control ledger | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilot-control-ledger.ts |
+| Automations | autopilot module | autopilotiq circuit breakers | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilotiq-circuit-breakers.ts |
 | Automations | autopilot module | autopilotkit liveness | autopilotkit liveness shared frontend logic. | - | scripts/lib/autopilotkit-liveness.mjs |
 | Automations | autopilot module | pinballwake autopilot master loop | pinballwake autopilot master loop UnClick module. | - | scripts/pinballwake-autopilot-master-loop.mjs |
 | Automations | autopilot module | pinballwake autopilot triage | pinballwake autopilot triage UnClick module. | - | scripts/pinballwake-autopilot-triage.mjs |


### PR DESCRIPTION
## Boardroom job
`9e131baf` - AutopilotIQ learning layer. **Phase 0, Slice 0c** of the self-improvement layer. Completes Phase 0 alongside #1144 (outcome ledger) and #1145 (probe set / honesty anchor).

## Intent
Safety scaffolding built BEFORE anything acts. The research spec is explicit: build these in Phase 0, never retrofit. **Capture-only**: this slice does not halt any live production job - it provides the primitives that later phases (gated learner, retry tuner) call.

## Three layers
1. **Per-job circuit breaker** - pure `evaluateCircuitBreaker(usage, limits)` with hard ceilings on actions / tokens / cost / wall_ms / retries. Closed reason-code set: `circuit_break_actions` / `circuit_break_tokens` / `circuit_break_cost` / `circuit_break_time` / `circuit_break_retries`. Strict `>` comparison so equality is still allowed; deterministic breach order so the most economically obvious cap shows first. Conservative defaults exported as `DEFAULT_CIRCUIT_BREAKER_LIMITS` data (8 actions / 200k tokens / $1 / 5min / 3 retries) - easy to tune.
2. **Component pause flags** - readable per-component paused model for `autopilotiq_tuner` / `seat_intelligence` / `creative_evolution` / `retry_tuner` / `shadow_learner` / `gated_learner`. Default safe; `isComponentPaused` is a pure read.
3. **Global self-improvement kill switch** - `isSelfImprovementKilled` reads one boolean; when set, every autonomous self-improvement path is considered halted. The kill trumps per-component flags.

A compound `isComponentAllowed(name, config)` returns `{ allowed, reason: 'ok' | 'kill_switch' | 'component_paused' }` so any halt is always explicit.

`recordCircuitBreak(...)` builds a `CircuitBreakRecord` shaped to fit Slice 0a's `recordAutopilotOutcome` input (`outcomeReason: 'policy_block'`, `taskType: 'circuit_break'`, `prompt_version: 'circuit_break:<reason>'`) and emits it via an **injected** recorder - so this slice does not couple to PR #1144 and is independently mergeable. One-line adapter once 0a lands.

## Files (4, +516/-3, additive)
- **`api/lib/autopilotiq-circuit-breakers.ts`** - types + closed reason-code constants + `evaluateCircuitBreaker` + `isSelfImprovementKilled` + `isComponentPaused` + `isComponentAllowed` + `recordCircuitBreak` + frozen defaults.
- **`api/autopilotiq-circuit-breakers.test.ts`** - 24 tests: evaluator per breach type, equality vs strict-over semantics, undefined-limit-as-uncapped, deterministic breach order, defaults, full reason-taxonomy coverage; `isSelfImprovementKilled` defaults + trigger; `isComponentPaused` incl. kill-trumps-pause; `isComponentAllowed` compound incl. `kill_switch` reported instead of `component_paused` when both apply; `recordCircuitBreak` no-op on allow, full shape on breach, recorder invoked exactly once.
- **`docs/UnClick-brainmap.generated.{md,json}`** - regenerated for the new lib.

## Verification
- `npx vitest run api/autopilotiq-circuit-breakers.test.ts` -> **24/24 pass**.
- Local `tsc --noEmit` -> **0 errors** (strict types).
- `npm run brainmap:check` -> passes after regen.

## Capture-only / independence
- **NOT wired to halt live production jobs.** Later phases consume these primitives.
- **Slice 0a is NOT imported.** Recorder is dependency-injected; this PR is independently mergeable. Natural wiring once 0a lands:
  ```ts
  recorder: (rec) => recordAutopilotOutcome(supabase, { apiKeyHash, ...rec })
  ```
- ESM-safe (no imports beyond the closed-set constants). No `.github` / workflow / secret changes.

Draft. **Not for merge.**

---

This completes **Phase 0** of AutopilotIQ:
- **#1144** outcome ledger (data spine)
- **#1145** probe set (honesty anchor)
- **#this** kill switches + circuit breakers (safety scaffolding)

All three are capture-only, additive, and dependency-injection-coupled so they can land in any order.