### PR TITLE
fix(testpass): wait for PR preview before smoke

### DIFF
--- a/.github/workflows/testpass-pr-check.yml
+++ b/.github/workflows/testpass-pr-check.yml
@@ -47,9 +47,58 @@ jobs:
             echo "has_token=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Wait for Vercel preview
+        id: vercel
+        if: ${{ github.event_name == 'pull_request' && steps.token.outputs.has_token == 'true' }}
+        uses: actions/github-script@v9
+        env:
+          VERCEL_STATUS_CONTEXT: Vercel
+          VERCEL_WAIT_SECONDS: "120"
+          VERCEL_WAIT_INTERVAL_SECONDS: "10"
+        with:
+          script: |
+            const { pathToFileURL } = require('node:url');
+            const helperUrl = pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/testpass-pr-target.mjs`).href;
+            const { selectLatestStatusContext } = await import(helperUrl);
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = context.payload.pull_request?.head?.sha || context.sha;
+            const statusContext = process.env.VERCEL_STATUS_CONTEXT || 'Vercel';
+            const timeoutMs = Math.max(1, Number(process.env.VERCEL_WAIT_SECONDS || 900)) * 1000;
+            const intervalMs = Math.max(1, Number(process.env.VERCEL_WAIT_INTERVAL_SECONDS || 10)) * 1000;
+            const startedAt = Date.now();
+
+            while (true) {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref,
+              });
+              const status = selectLatestStatusContext(data.statuses || [], statusContext);
+              const state = status?.state || 'missing';
+              core.notice(`${statusContext} status for ${ref}: ${state}`);
+
+              if (state === 'success') {
+                core.notice(`${statusContext} preview is ready: ${status.target_url || '(no target URL)'}`);
+                core.setOutput('ready', 'true');
+                return;
+              }
+              if (state === 'failure' || state === 'error') {
+                throw new Error(`${statusContext} preview is ${state}. TestPass will not run against a failed preview.`);
+              }
+              if (Date.now() - startedAt >= timeoutMs) {
+                core.warning(`${statusContext} preview is still ${state}; TestPass will wait for a ready preview instead of testing a stale target.`);
+                core.setOutput('ready', 'false');
+                return;
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, intervalMs));
+            }
+
       - name: Resolve TestPass target
         id: target
-        if: ${{ steps.token.outputs.has_token == 'true' }}
+        if: ${{ steps.token.outputs.has_token == 'true' && steps.vercel.outputs.ready != 'false' }}
         uses: actions/github-script@v9
         env:
           DISPATCH_SERVER_URL: ${{ inputs.server_url || 'https://unclick.world/api/mcp' }}
@@ -165,7 +214,7 @@ jobs:
 
       - name: Run TestPass
         id: testpass
-        if: ${{ steps.token.outputs.has_token == 'true' }}
+        if: ${{ steps.token.outputs.has_token == 'true' && steps.vercel.outputs.ready != 'false' }}
         # Don't abort the workflow on infra failures - we still want to post a
         # PR comment that explains what happened so reviewers can tell infra
         # noise (stale token, transport blip) from a real product regression.
@@ -183,7 +232,7 @@ jobs:
       - name: Post PR comment
         # Run regardless of TestPass step outcome - infra failures still need a
         # human-readable comment so the PR doesn't look mysteriously broken.
-        if: ${{ always() && github.event_name == 'pull_request' && steps.token.outputs.has_token == 'true' }}
+        if: ${{ always() && github.event_name == 'pull_request' && steps.token.outputs.has_token == 'true' && steps.vercel.outputs.ready != 'false' }}
         uses: actions/github-script@v9
         env:
           RUN_ID: ${{ steps.testpass.outputs.run_id }}
@@ -263,6 +312,54 @@ jobs:
               body,
             });
 
+      - name: Post Vercel pending TestPass comment
+        if: ${{ always() && github.event_name == 'pull_request' && steps.token.outputs.has_token == 'true' && steps.vercel.outputs.ready == 'false' }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { pathToFileURL } = require('node:url');
+            const helperUrl = pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/testpass-pr-comment.mjs`).href;
+            const {
+              selectExistingTestPassComment,
+              TESTPASS_PR_COMMENT_MARKER,
+            } = await import(helperUrl);
+
+            const body = [
+              TESTPASS_PR_COMMENT_MARKER,
+              '### TestPass: :hourglass_flowing_sand: waiting on Vercel',
+              '',
+              'The Vercel preview is still pending, so TestPass did not run against a stale or protected preview URL.',
+              '',
+              '_Re-run TestPass after Vercel is green, or push a fresh commit to trigger it again._',
+            ].join('\n');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = selectExistingTestPassComment(comments);
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
       - name: Explain Dependabot TestPass skip
         if: ${{ always() && github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && steps.token.outputs.has_token != 'true' }}
         uses: actions/github-script@v9
@@ -292,7 +389,7 @@ jobs:
         # Keep PR trust fail-closed: only a complete TestPass run with zero
         # failed checks is green. Running, unknown, and infra states must stay
         # visible/retryable instead of looking like evaluated product passes.
-        if: ${{ always() && steps.token.outputs.has_token == 'true' && (steps.testpass.outputs.status != 'complete' || steps.testpass.outputs.fail_count != '0') }}
+        if: ${{ always() && steps.token.outputs.has_token == 'true' && steps.vercel.outputs.ready != 'false' && (steps.testpass.outputs.status != 'complete' || steps.testpass.outputs.fail_count != '0') }}
         shell: bash
         env:
           STATUS: ${{ steps.testpass.outputs.status }}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7936,8 +7936,8 @@
     },
     {
       "source": ".github/workflows/testpass-pr-check.yml",
-      "hash": "439715253466",
-      "bytes": 12906
+      "hash": "3f15309a71f0",
+      "bytes": 17290
     },
     {
       "source": ".github/workflows/testpass-scheduled-smoke.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -199,7 +199,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
 | .github/workflows/scheduled-build-self-test.yml | 1362b535ff33 | 1024 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
-| .github/workflows/testpass-pr-check.yml | 439715253466 | 12906 |
+| .github/workflows/testpass-pr-check.yml | 3f15309a71f0 | 17290 |
 | .github/workflows/testpass-scheduled-smoke.yml | 46f9a65b1dbb | 1673 |
 | .github/workflows/tier2-auto-merge-queue-check.yml | f26a538f2ee9 | 896 |
 

--- a/scripts/testpass-pr-target.mjs
+++ b/scripts/testpass-pr-target.mjs
@@ -9,7 +9,7 @@ function authorLogin(comment) {
 }
 
 function createdTime(comment) {
-  const value = comment?.created_at || comment?.createdAt || 0;
+  const value = comment?.updated_at || comment?.updatedAt || comment?.created_at || comment?.createdAt || 0;
   const parsed = Date.parse(value);
   return Number.isFinite(parsed) ? parsed : 0;
 }
@@ -62,4 +62,9 @@ export function resolveTestPassPrTarget(input = {}) {
   }
 
   return { serverUrl: requestedServerUrl || defaultServerUrl, source: "default" };
+}
+export function selectLatestStatusContext(statuses = [], contextName = "Vercel") {
+  return statuses
+    .filter((status) => safeText(status?.context) === contextName)
+    .sort((a, b) => createdTime(b) - createdTime(a))[0] || null;
 }

--- a/scripts/testpass-pr-target.test.mjs
+++ b/scripts/testpass-pr-target.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   extractVercelPreviewUrls,
   resolveTestPassPrTarget,
+  selectLatestStatusContext,
   selectLatestVercelPreviewUrl,
   toMcpServerUrl,
 } from "./testpass-pr-target.mjs";
@@ -71,4 +72,14 @@ test("prefers explicit workflow input, then preview, then production default", (
     serverUrl: "https://unclick.world/api/mcp",
     source: "default",
   });
+});
+test("selects the newest named commit status", () => {
+  const statuses = [
+    { context: "Vercel", state: "pending", updated_at: "2026-05-28T10:00:00Z" },
+    { context: "Other", state: "success", updated_at: "2026-05-28T10:30:00Z" },
+    { context: "Vercel", state: "success", updated_at: "2026-05-28T10:20:00Z" },
+  ];
+
+  assert.deepEqual(selectLatestStatusContext(statuses, "Vercel"), statuses[2]);
+  assert.equal(selectLatestStatusContext(statuses, "Missing"), null);
 });


### PR DESCRIPTION
## Summary

- Waits for the Vercel PR preview status to turn green before running TestPass smoke.
- Keeps TestPass pointed at the PR preview MCP URL instead of racing a stale branch alias.
- Adds focused helper coverage for newest Vercel status selection.

## Proof

- node --test scripts/testpass-pr-target.test.mjs scripts/testpass-pr-comment.test.mjs passed, 8/8.
- npm run brainmap:check passed.
- git diff --check github/main..HEAD passed.

## Notes

This is the tiny follow-up from PR #1142: Crews is already merged, but this hardens the TestPass PR gate so future runs do not start before Vercel has finished deploying.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only gating and helper tests; no runtime product, auth, or data-path changes.
> 
> **Overview**
> The TestPass PR workflow now **polls the PR head’s combined `Vercel` commit status** (via a new `selectLatestStatusContext` helper) before resolving the target, running smoke, posting results, or failing the job. On **success** it continues as before; on **failure/error** the job errors out; on **timeout** it sets `ready=false` and **skips** TestPass so it does not hit a stale or protected preview.
> 
> When Vercel is still not ready in time, a **dedicated PR comment** explains that TestPass is waiting (reusing the existing TestPass comment upsert path). Comment/status ordering now prefers **`updated_at`** when picking the newest Vercel preview link or status. Brainmap metadata reflects the larger workflow file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca974092afedccbbf8b317fc5055ffdc4256fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->