### PR TITLE
fix(mcp): keep FlowPass runtime bundled

### DIFF
--- a/packages/mcp-server/src/flowpass-tool.ts
+++ b/packages/mcp-server/src/flowpass-tool.ts
@@ -16,7 +16,7 @@ import {
   type FlowPassFixture,
   type FlowPassNormalizedPack,
   type FlowPassReport,
-} from "@unclick/flowpass";
+} from "../../flowpass/dist/index.js";
 
 type ReportFormat = "json" | "markdown" | "html" | "fix_prompt";
 


### PR DESCRIPTION
## Summary
- Fixes live MCP HTTP 500 caused by Vercel not resolving @unclick/flowpass inside the MCP server function.
- Uses the already-built FlowPass dist entry by relative path so the serverless bundle can include it directly.

## Proof
- npm run build --workspace=@unclick/mcp-server
- npm test --workspace=@unclick/flowpass
- npm run brainmap:check
- git diff --check

## Production symptom
- Vercel runtime logs showed ERR_MODULE_NOT_FOUND for @unclick/flowpass from packages/mcp-server/src/flowpass-tool.js on /api/mcp.

## Honest gap
- Production MCP must be smoked after this deploys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-path change for serverless bundling; no auth, data, or FlowPass logic changes—verify production MCP after deploy.
> 
> **Overview**
> Fixes **MCP HTTP 500** on Vercel where the serverless function could not resolve `@unclick/flowpass` at runtime (`ERR_MODULE_NOT_FOUND` from `flowpass-tool.js` on `/api/mcp`).
> 
> **`flowpass-tool.ts`** now imports FlowPass APIs from the **prebuilt** package entry via a **relative path** (`../../flowpass/dist/index.js`) instead of the workspace package name, so the deploy bundle can include FlowPass directly. FlowPass behavior in MCP is unchanged; the build still builds `@unclick/flowpass` before `tsc` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37b592e32e9b994d4c4a2eaec4c8b8dad691135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->