### PR TITLE
test(mcp): guard production route imports

### DIFF
--- a/api/mcp-import.test.ts
+++ b/api/mcp-import.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+describe("/api/mcp production import", () => {
+  it("loads the MCP handler with all production workspace dependencies built", async () => {
+    const mod = await import("./mcp");
+
+    expect(typeof mod.default).toBe("function");
+  });
+});


### PR DESCRIPTION
Adds a tiny Vitest guard that imports /api/mcp directly, so missing built workspace dependencies fail in CI instead of becoming live HTTP 500s.

Proof run locally on latest main:
- npm run brainmap:check
- npx vitest run api/mcp-import.test.ts api/mcp-auth-env.test.ts packages/testpass/src/__tests__/mcp-http.test.ts
- node --test scripts/testpass-pr-target.test.mjs
- npm run build

Notes:
- Build is green.
- Existing warnings remain: old Browserslist data and large Vite chunks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or production behavior impact.
> 
> **Overview**
> Adds a **Vitest** smoke test in `api/mcp-import.test.ts` that dynamically imports `./mcp` and asserts the default export is a **function**.
> 
> This catches cases where production workspace dependencies are not built—failures surface in **CI** instead of as live **HTTP 500**s on the MCP route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88d06df7cef741d591519b617ece6e49810113d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->