### PR TITLE
feat(crews): recommend council from xpass gate

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 518,
+    "inventory": 519,
     "source_manifest": 189,
     "pages": 82,
     "tools": 187,
@@ -87,7 +87,7 @@
       "id": "launch-and-onboarding",
       "name": "Launch and onboarding",
       "meaning": "Launchpad, Heartbeat, Brainmap, and first-seat orientation.",
-      "count": 4
+      "count": 5
     }
   ],
   "inventory": [
@@ -1709,6 +1709,16 @@
       "meaning": "Un Click brainmap UnClick module.",
       "source": "scripts/UnClick-brainmap.mjs",
       "route": "",
+      "tags": []
+    },
+    {
+      "id": "launch-and-onboarding-judgement-prompt-crews-council-induction-scripts-pinballwake-launchpad-room-mjs-admin-pinballwake",
+      "division": "Launch and onboarding",
+      "name": "Crews Council Induction",
+      "kind": "judgement prompt",
+      "meaning": "Launchpad prompt that runs Council Lite on material work and asks for a full Crews Council only when launch, risk, mixed proof, or broad XPass evidence needs judgement.",
+      "source": "scripts/pinballwake-launchpad-room.mjs",
+      "route": "/admin/pinballwake",
       "tags": []
     },
     {
@@ -5804,20 +5814,27 @@
     ],
     [
       "6",
+      "Ask Crews Council if needed",
+      "Run Council Lite on material work, then prompt full Crews Council for launch, risk, mixed proof, or broad XPass evidence.",
+      "Crews Council",
+      "scripts/pinballwake-launchpad-room.mjs"
+    ],
+    [
+      "7",
       "Check proof gates",
       "Name required PR, commit, test, CI, live, screenshot, CopyRoom, or NO_CODE_NEEDED proof before closing.",
       "Proof Ledger",
       "docs/agent-observability.md"
     ],
     [
-      "7",
+      "8",
       "Dogtest the outcome",
       "Run the focused local tests and browser or live proof that match the touched surface.",
       "XPass and CI",
       "package.json"
     ],
     [
-      "8",
+      "9",
       "Reply and log proof",
       "End with PASS or BLOCKER, proof link or id, cleanup state, and next safe step.",
       "Boardroom and Orchestrator",
@@ -7591,8 +7608,8 @@
     },
     {
       "source": "scripts/pinballwake-launchpad-room.mjs",
-      "hash": "64cc89cd3253",
-      "bytes": 12693
+      "hash": "9ee3556460d0",
+      "bytes": 20544
     },
     {
       "source": "scripts/pinballwake-merge-room.mjs",
@@ -7661,8 +7678,8 @@
     },
     {
       "source": "scripts/pinballwake-xpass-gate-room.mjs",
-      "hash": "92b4e63503f5",
-      "bytes": 20902
+      "hash": "fe12df43cac0",
+      "bytes": 25613
     },
     {
       "source": "packages/mcp-server/src/abn-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -130,7 +130,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | scripts/pinballwake-dogfood-room.mjs | d161028d1382 | 2782 |
 | scripts/pinballwake-event-ledger-room.mjs | e8f8f9f84123 | 16104 |
 | scripts/pinballwake-jobs-room.mjs | c77c394081c2 | 14217 |
-| scripts/pinballwake-launchpad-room.mjs | 64cc89cd3253 | 12693 |
+| scripts/pinballwake-launchpad-room.mjs | 9ee3556460d0 | 20544 |
 | scripts/pinballwake-merge-room.mjs | 3645da5c0c93 | 8431 |
 | scripts/pinballwake-overlap-resolver-room.mjs | 14d03ef6acd3 | 6787 |
 | scripts/pinballwake-personality-room.mjs | c1ca769346f1 | 9644 |
@@ -144,7 +144,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | scripts/pinballwake-rollback-room.mjs | c63e73fd2716 | 4158 |
 | scripts/pinballwake-stale-room.mjs | 8927de850588 | 3880 |
 | scripts/pinballwake-worker-registry-room.mjs | e8c9f4a764e3 | 20616 |
-| scripts/pinballwake-xpass-gate-room.mjs | 92b4e63503f5 | 20902 |
+| scripts/pinballwake-xpass-gate-room.mjs | fe12df43cac0 | 25613 |
 | packages/mcp-server/src/abn-tool.ts | 5105de2d357d | 3682 |
 | packages/mcp-server/src/abuseipdb-tool.ts | 21d5283c8dba | 4673 |
 | packages/mcp-server/src/airtable-tool.ts | cca3eed693da | 7132 |
@@ -218,12 +218,13 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 62 |
-| Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 4 |
+| Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 5 |
 
 ## UnClick Structure
 
 - UnClick is the platform: tools, memory, agents, proof, and admin surfaces.
 - Launchpad is the control hub for Autopilot work.
+- Crews Council induction is a Launchpad prompt, not a new Pass product; it uses Council Lite for light dissent and asks for full Crews only when judgement is needed.
 - Rooms are the operational stages that route work through research, planning, build, proof, review, safety, merge, publish, repair, and improvement.
 - Heartbeat Master at `/admin/agents/heartbeat` teaches scheduled AI seats how to pulse safely.
 - Heartbeat policy changes must update the `/admin/agents/heartbeat` source and verify the MASTER induction text. Memory and Brainmap entries are pointers, not the runtime MASTER.
@@ -240,9 +241,10 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | 3 | Open Boardroom Jobs | Use Jobs as the source of truth for active work, proof state, blockers, and safe next action. | Boardroom Jobs | /admin/jobs |
 | 4 | Pass through Brainmap | Use the generated ecosystem map to find current routes, tools, rooms, workers, aliases, and safety gates. | Ecosystem Brainmap | /admin/brainmap |
 | 5 | Choose the Launchpad lane | Route the work through the safest current Autopilot lane before acting or handing off. | Launchpad | /admin/pinballwake |
-| 6 | Check proof gates | Name required PR, commit, test, CI, live, screenshot, CopyRoom, or NO_CODE_NEEDED proof before closing. | Proof Ledger | docs/agent-observability.md |
-| 7 | Dogtest the outcome | Run the focused local tests and browser or live proof that match the touched surface. | XPass and CI | package.json |
-| 8 | Reply and log proof | End with PASS or BLOCKER, proof link or id, cleanup state, and next safe step. | Boardroom and Orchestrator | /admin/jobs |
+| 6 | Ask Crews Council if needed | Run Council Lite on material work, then prompt full Crews Council for launch, risk, mixed proof, or broad XPass evidence. | Crews Council | scripts/pinballwake-launchpad-room.mjs |
+| 7 | Check proof gates | Name required PR, commit, test, CI, live, screenshot, CopyRoom, or NO_CODE_NEEDED proof before closing. | Proof Ledger | docs/agent-observability.md |
+| 8 | Dogtest the outcome | Run the focused local tests and browser or live proof that match the touched surface. | XPass and CI | package.json |
+| 9 | Reply and log proof | End with PASS or BLOCKER, proof link or id, cleanup state, and next safe step. | Boardroom and Orchestrator | /admin/jobs |
 
 ## Pages and Meaning
 
@@ -689,6 +691,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Automations | workflow | testpass scheduled smoke.yml | testpass scheduled smoke GitHub automation workflow. | - | .github/workflows/testpass-scheduled-smoke.yml |
 | Automations | workflow | tier2 auto merge queue check.yml | tier2 auto merge queue check GitHub automation workflow. | - | .github/workflows/tier2-auto-merge-queue-check.yml |
 | Launch and onboarding | brainmap source | Un Click brainmap | Un Click brainmap UnClick module. | - | scripts/UnClick-brainmap.mjs |
+| Launch and onboarding | judgement prompt | Crews Council Induction | Launchpad prompt that runs Council Lite on material work and asks for a full Crews Council only when launch, risk, mixed proof, or broad XPass evidence needs judgement. | /admin/pinballwake | scripts/pinballwake-launchpad-room.mjs |
 | Launch and onboarding | map | Ecosystem Brainmap | Generated sitemap and system map that teaches seats what UnClick contains. | /admin/brainmap | src/pages/admin/AdminBrainmap.tsx |
 | Launch and onboarding | policy | Heartbeat Master | Canonical schedule prompt and procedure for safe heartbeat seats. | /admin/agents/heartbeat | src/pages/admin/AdminSeatHeartbeat.tsx |
 | Launch and onboarding | route | Launchpad | Control hub that points seats to the next safe operating lane. | /admin/pinballwake | scripts/pinballwake-launchpad-room.mjs |
@@ -1112,6 +1115,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 ## Launchpad Route
 
 - Launchpad routes work from Coordinator to Builder, Tester, Reviewer, Safety Checker, and Ledger PASS.
+- Launchpad checks Council induction so Council Lite is always visible on material work, and full Crews appears when launch, risk, mixed XPass proof, or broad evidence needs judgement.
 - Launchpad readiness is represented in `scripts/pinballwake-launchpad-room.mjs` and related tests.
 - User-facing control lives in Autopilot admin surfaces, with worker discussion in Boardroom.
 

--- a/docs/prd/crews.md
+++ b/docs/prd/crews.md
@@ -61,6 +61,36 @@ Recommended use:
 
 The practical mental model: XPass is the checklist and evidence ledger; Crews is the council table where specialists argue over what that evidence means.
 
+## Auto-trigger contract
+
+Crews should not run on every conversation and should not run on every XPass receipt. It should be surfaced when there is a real judgement call.
+
+The XPass gate may recommend a Crews Council when any of these are true:
+
+- the request asks for a decision, launch call, go/no-go, tradeoff, opinion, taste call, or risk acceptance
+- four or more XPass checks are selected for one target
+- legal, security, credential, or common-sense checks overlap with public copy, UX, SEO, pricing, enterprise, or compliance work
+- Pass evidence is mixed, such as one check passing while another blocks
+- a multi-pass target skipped a relevant check and needs a recorded accepted exclusion
+- Crews or Council itself changed and should dogfood its own judgement layer
+
+This trigger is a recommendation, not a token-spending autopilot. The receipt should say whether a Council is `not_needed`, `consider`, or `recommended`, include a trigger score, and point to `start_crew_run` only when a Council would add useful judgement.
+
+Do not create a separate `CouncilPass` product. "Pass" means proof/check. Council is a Crews template/mode that XPass can call when proof needs interpretation.
+
+## Council Lite
+
+Crews should also provide a low-friction anti-rubber-stamp layer. This is not a full multi-agent run and should not spend tokens by default.
+
+Council Lite asks four questions on material work:
+
+- what would make this answer or change wrong?
+- what evidence is missing, stale, or too weak?
+- who would object: user, maintainer, reviewer, legal, security, or operator?
+- what is the smallest proof needed before saying ready?
+
+If Council Lite exposes real uncertainty, Launchpad or XPass should escalate to a full Crews Council. If it does not, the work can proceed through the normal proof gates without bloating every run.
+
 ## Platform philosophy alignment
 
 - **Idiot-proof UX.** The Crew Composer uses plain-language role names (Writer, Researcher, Critic) and a card-based builder. No YAML, no prompt templates, no orchestration glossary.

--- a/docs/prd/xpass.md
+++ b/docs/prd/xpass.md
@@ -120,6 +120,12 @@ Every XPass receipt must show:
    Clear next step when a result needs owner action.
 6. **Staleness**
    When the receipt was generated and whether newer code, credentials, or deploys may invalidate it.
+7. **Crews Council recommendation**
+   Whether this target needs no Council, should consider a Council, or should run a recommended Council before owners treat the evidence as a final decision.
+
+XPass should recommend full Crews only for judgement-heavy targets. It should not call a full Council for every run. Examples that deserve a Council recommendation: launch go/no-go, legal/security plus public claims, conflicting Pass evidence, accepted skipped checks on broad targets, or Crews/Council product changes.
+
+For material targets, XPass may also attach `lite_check` anti-rubber-stamp questions. Council Lite is a prompt/checklist, not a full Crews run. It keeps dissent visible without bloating every proof run.
 
 ## Public copy rules
 

--- a/scripts/UnClick-brainmap.mjs
+++ b/scripts/UnClick-brainmap.mjs
@@ -91,20 +91,27 @@ const SEAT_INDUCTION = [
   ],
   [
     "6",
+    "Ask Crews Council if needed",
+    "Run Council Lite on material work, then prompt full Crews Council for launch, risk, mixed proof, or broad XPass evidence.",
+    "Crews Council",
+    "scripts/pinballwake-launchpad-room.mjs",
+  ],
+  [
+    "7",
     "Check proof gates",
     "Name required PR, commit, test, CI, live, screenshot, CopyRoom, or NO_CODE_NEEDED proof before closing.",
     "Proof Ledger",
     "docs/agent-observability.md",
   ],
   [
-    "7",
+    "8",
     "Dogtest the outcome",
     "Run the focused local tests and browser or live proof that match the touched surface.",
     "XPass and CI",
     "package.json",
   ],
   [
-    "8",
+    "9",
     "Reply and log proof",
     "End with PASS or BLOCKER, proof link or id, cleanup state, and next safe step.",
     "Boardroom and Orchestrator",
@@ -129,6 +136,7 @@ const DIVISIONS = [
 
 const STATIC_SYSTEMS = [
   ["Launch and onboarding", "Launchpad", "route", "Control hub that points seats to the next safe operating lane.", "scripts/pinballwake-launchpad-room.mjs", "/admin/pinballwake"],
+  ["Launch and onboarding", "Crews Council Induction", "judgement prompt", "Launchpad prompt that runs Council Lite on material work and asks for a full Crews Council only when launch, risk, mixed proof, or broad XPass evidence needs judgement.", "scripts/pinballwake-launchpad-room.mjs", "/admin/pinballwake"],
   ["Launch and onboarding", "Heartbeat Master", "policy", "Canonical schedule prompt and procedure for safe heartbeat seats.", "src/pages/admin/AdminSeatHeartbeat.tsx", "/admin/agents/heartbeat"],
   ["Launch and onboarding", "Ecosystem Brainmap", "map", "Generated sitemap and system map that teaches seats what UnClick contains.", "src/pages/admin/AdminBrainmap.tsx", "/admin/brainmap"],
   ["Source of truth", "Boardroom Jobs", "queue", "Primary work source for open, in-progress, done, and dropped chips.", "src/pages/admin/AdminJobs.tsx", "/admin/jobs"],
@@ -633,6 +641,7 @@ export async function generateBrainmap({ root = process.cwd() } = {}) {
     "",
     "- UnClick is the platform: tools, memory, agents, proof, and admin surfaces.",
     "- Launchpad is the control hub for Autopilot work.",
+    "- Crews Council induction is a Launchpad prompt, not a new Pass product; it uses Council Lite for light dissent and asks for full Crews only when judgement is needed.",
     "- Rooms are the operational stages that route work through research, planning, build, proof, review, safety, merge, publish, repair, and improvement.",
     "- Heartbeat Master at `/admin/agents/heartbeat` teaches scheduled AI seats how to pulse safely.",
     "- Heartbeat policy changes must update the `/admin/agents/heartbeat` source and verify the MASTER induction text. Memory and Brainmap entries are pointers, not the runtime MASTER.",
@@ -681,6 +690,7 @@ export async function generateBrainmap({ root = process.cwd() } = {}) {
     "## Launchpad Route",
     "",
     "- Launchpad routes work from Coordinator to Builder, Tester, Reviewer, Safety Checker, and Ledger PASS.",
+    "- Launchpad checks Council induction so Council Lite is always visible on material work, and full Crews appears when launch, risk, mixed XPass proof, or broad evidence needs judgement.",
     "- Launchpad readiness is represented in `scripts/pinballwake-launchpad-room.mjs` and related tests.",
     "- User-facing control lives in Autopilot admin surfaces, with worker discussion in Boardroom.",
     "",

--- a/scripts/UnClick-brainmap.test.mjs
+++ b/scripts/UnClick-brainmap.test.mjs
@@ -57,6 +57,9 @@ describe("UnClick ecosystem Brainmap", () => {
     assert.match(generated, /\| Coordinator \| Routes work/);
     assert.match(generated, /\| 4 \| Pass through Brainmap \| Use the generated ecosystem map/);
     assert.match(generated, /\| 5 \| Choose the Launchpad lane \| Route the work/);
+    assert.match(generated, /\| 6 \| Ask Crews Council if needed \| Run Council Lite on material work/);
+    assert.match(generated, /\| Launch and onboarding \| judgement prompt \| Crews Council Induction/);
+    assert.match(generated, /Council Lite for light dissent/);
     assert.match(generated, /Admin-only surfaces use `RequireAdmin`/);
     assert.match(generated, /IgniteOnly can request worker wake packets only/);
     assert.match(generated, /Memory and Brainmap entries are pointers, not the runtime MASTER/);
@@ -92,7 +95,9 @@ describe("UnClick ecosystem Brainmap", () => {
     assert.ok(data.inventory.some((item) => item.name === "CopyRoom" && item.division === "Passes and gates"));
     assert.ok(data.inventory.some((item) => item.name === "JobSmith" && item.division === "Modules and apps"));
     assert.ok(data.inventory.some((item) => item.name === "Ecosystem Brainmap" && item.route === "/admin/brainmap"));
+    assert.ok(data.inventory.some((item) => item.name === "Crews Council Induction" && item.division === "Launch and onboarding"));
     assert.ok(data.inductionRows.some((row) => row[1] === "Pass through Brainmap"));
+    assert.ok(data.inductionRows.some((row) => row[1] === "Ask Crews Council if needed"));
   });
 
   it("uses real app routes instead of filename guesses", async () => {

--- a/scripts/pinballwake-launchpad-room.mjs
+++ b/scripts/pinballwake-launchpad-room.mjs
@@ -2,6 +2,8 @@
 
 import { readFile } from "node:fs/promises";
 
+import { evaluateXPassGate } from "./pinballwake-xpass-gate-room.mjs";
+
 function getArg(name, fallback = "") {
   const prefix = `--${name}=`;
   const found = process.argv.find((arg) => arg.startsWith(prefix));
@@ -81,6 +83,13 @@ const ROOM_REQUIREMENTS = {
 };
 
 const DEFAULT_ROOMS = ["build", "proof", "qc", "safety", "research", "planning", "status"];
+
+const LAUNCHPAD_COUNCIL_LITE_QUESTIONS = [
+  "What would make this answer or change wrong?",
+  "What evidence is missing, stale, or too weak?",
+  "Who would object: user, maintainer, reviewer, legal, security, or operator?",
+  "What is the smallest proof needed before saying ready?",
+];
 
 function capabilityMatches(seat, room) {
   const needed = ROOM_REQUIREMENTS[room] || [room];
@@ -194,6 +203,150 @@ function evaluateOrchestratorControl({
   };
 }
 
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== "");
+}
+
+function launchpadWorkInput(input = {}) {
+  const work = input.work || input.work_item || input.workItem || input.launch || {};
+  const target = input.target || work.target || {};
+  return {
+    title: firstValue(input.title, work.title, target.title),
+    description: firstValue(input.description, work.description, target.description),
+    context: firstValue(input.context, work.context, input.body, work.body),
+    summary: firstValue(input.summary, work.summary),
+    tags: firstValue(input.tags, work.tags),
+    changed_files: firstValue(
+      input.changed_files,
+      input.changedFiles,
+      input.files,
+      work.changed_files,
+      work.changedFiles,
+      work.files,
+      target.changed_files,
+      target.files,
+    ),
+    pass_results: firstValue(input.pass_results, input.passResults, input.results, work.pass_results, work.passResults, work.results),
+    available_checks: firstValue(input.available_checks, input.availableChecks, work.available_checks, work.availableChecks),
+    target: {
+      type: firstValue(target.type, input.target_type, input.targetType, work.target_type, "launch"),
+      id: firstValue(target.id, input.id, input.pr_number, input.prNumber, work.id, work.pr_number),
+      sha: firstValue(target.sha, input.sha, input.head_sha, input.headSha, work.sha, work.head_sha),
+      url: firstValue(target.url, input.url, work.url),
+      title: firstValue(target.title, input.title, work.title),
+      description: firstValue(target.description, input.description, work.description),
+      changed_files: firstValue(target.changed_files, target.files, input.changed_files, input.files, work.changed_files),
+    },
+  };
+}
+
+function hasCouncilSignal(workInput = {}) {
+  return Boolean(
+    workInput.title ||
+    workInput.description ||
+    workInput.context ||
+    workInput.summary ||
+    safeList(workInput.tags).length ||
+    safeList(workInput.changed_files).length ||
+    safeList(workInput.pass_results).length ||
+    workInput.target?.url ||
+    workInput.target?.id,
+  );
+}
+
+function normalizeCouncilRun(value = {}) {
+  const status = normalize(value.status || value.result || value.state);
+  const complete = ["complete", "completed", "passed", "green", "done"].includes(status);
+  return {
+    run_id: compactText(value.run_id || value.runId || value.id || "", 120),
+    status: status || "missing",
+    complete,
+    url: compactText(value.url || value.details_url || value.detailsUrl || "", 500),
+  };
+}
+
+function normalizeCouncilLite(value = {}, fallbackNeeded = false) {
+  const needed = value.needed === true || fallbackNeeded;
+  return {
+    needed,
+    status: value.status || (needed ? "baseline" : "not_needed"),
+    suggested_template: value.suggested_template || value.suggestedTemplate || (needed ? "Council Lite" : null),
+    mode: value.mode || (needed ? "anti_rubber_stamp" : null),
+    questions: needed
+      ? (safeList(value.questions).length ? safeList(value.questions) : LAUNCHPAD_COUNCIL_LITE_QUESTIONS).map((question) => compactText(question, 220))
+      : [],
+    note: compactText(value.note || (needed ? "Use the light dissent questions before ready claims; escalate only if they expose real uncertainty." : ""), 300),
+  };
+}
+
+function normalizeCouncilRecommendation(value = {}) {
+  const deepNeeded = value.needed === true;
+  const liteFallback = deepNeeded || value.status === "consider" || value.status === "recommended";
+  return {
+    needed: deepNeeded,
+    status: value.status || (deepNeeded ? "consider" : "not_needed"),
+    trigger_score: Number.isFinite(value.trigger_score) ? value.trigger_score : Number.parseInt(String(value.triggerScore ?? 0), 10) || 0,
+    suggested_template: value.suggested_template || value.suggestedTemplate || (deepNeeded ? "Council" : null),
+    suggested_tool: value.suggested_tool || value.suggestedTool || (deepNeeded ? "start_crew_run" : null),
+    reasons: safeList(value.reasons).map((reason) => compactText(reason, 240)),
+    note: compactText(value.note || "", 300),
+    lite_check: normalizeCouncilLite(value.lite_check || value.liteCheck || {}, liteFallback),
+  };
+}
+
+function createCouncilPrompt(recommendation, workInput = {}) {
+  const reasons = safeList(recommendation.reasons);
+  const reasonText = reasons.length ? reasons.map((reason) => `- ${reason}`).join("\n") : "- Launchpad needs a judgement check before final ready.";
+  const targetLine = compactText(workInput.title || workInput.target?.title || workInput.target?.url || workInput.target?.id || "this launch target", 240);
+  return `Launchpad Council check:
+Use Crews only if this needs judgement, debate, or a launch decision.
+
+Target:
+${targetLine}
+
+Why Launchpad is asking:
+${reasonText}
+
+Next action:
+Call start_crew_run with the Council template, include the XPass receipt/evidence, then record the Council run id before treating this as launch-ready.`;
+}
+
+function evaluateCouncilInduction(input = {}) {
+  const provided = input.councilRecommendation || input.council_recommendation || input.xpassGate?.crews_council || input.xpass_gate?.crews_council;
+  const workInput = launchpadWorkInput(input);
+  const recommendation = provided
+    ? normalizeCouncilRecommendation(provided)
+    : hasCouncilSignal(workInput)
+      ? normalizeCouncilRecommendation(evaluateXPassGate(workInput).crews_council)
+      : {
+          needed: false,
+          status: "not_checked",
+          trigger_score: 0,
+          suggested_template: null,
+          suggested_tool: null,
+          reasons: ["No launch target or XPass receipt supplied yet."],
+          note: "Before launch-ready claims, Launchpad should ask XPass whether a Crews Council is needed.",
+          lite_check: normalizeCouncilLite({}, false),
+        };
+  const councilRun = normalizeCouncilRun(input.crewsCouncilRun || input.crews_council_run || input.councilRun || input.council_run || {});
+  const completed = recommendation.needed && councilRun.complete;
+  const prompt = recommendation.needed && !completed ? createCouncilPrompt(recommendation, workInput) : null;
+
+  return {
+    source: "launchpad_council_induction",
+    needed: recommendation.needed,
+    status: completed ? "completed" : recommendation.status,
+    trigger_score: recommendation.trigger_score,
+    suggested_template: recommendation.suggested_template,
+    suggested_tool: recommendation.suggested_tool,
+    reasons: recommendation.reasons,
+    note: recommendation.note,
+    lite_check: recommendation.lite_check,
+    prompt,
+    council_run: councilRun.run_id || councilRun.status !== "missing" ? councilRun : null,
+  };
+}
+
 export function createLaunchpadHeartbeatPrompt({
   minutes = 15,
   name = "UnClick Launchpad Autopilot heartbeat",
@@ -206,9 +359,10 @@ I am the UnClick Launchpad Wizard. My job is to wake one master chat only, then 
 On each heartbeat:
 1. Open Launchpad Room.
 2. Refresh worker seats, account capacity, active jobs, PRs/checks, Fishbowl/Coding Room ledgers, and stale work.
-3. Decide one next safe action: stay quiet, create/update one job, route one worker packet, call one blocker, or ask Master for a merge/lift decision.
-4. Do not directly spam every worker. Use UnClick rooms and delivery adapters.
-5. Report to Chris only when material changed or Chris action is needed.
+3. Check Launchpad Council induction. Use Council Lite anti-rubber-stamp questions on material work; if XPass says Crews is recommended, prompt a Council run before any launch-ready claim.
+4. Decide one next safe action: stay quiet, create/update one job, route one worker packet, call one blocker, or ask Master for a merge/lift decision.
+5. Do not directly spam every worker. Use UnClick rooms and delivery adapters.
+6. Report to Chris only when material changed or Chris action is needed.
 
 Safety:
 No secrets, auth, billing, DNS/domains, migrations, raw keys, destructive cleanup, force-pushes, or draft/HOLD/DIRTY merges.
@@ -230,11 +384,13 @@ export function evaluateLaunchpadRoom({
   legacyWorkerSchedules = [],
   heartbeatMinutes = 15,
   now = new Date().toISOString(),
+  ...councilInput
 } = {}) {
   const normalizedSeats = safeList(seats).map(normalizeSeat);
   const wantedRooms = safeList(rooms).length ? safeList(rooms).map(normalize) : DEFAULT_ROOMS;
   const setup = [];
   const orchestratorControl = evaluateOrchestratorControl({ orchestrator, orchestrators, now });
+  const councilInduction = evaluateCouncilInduction(councilInput);
 
   if (!orchestratorControl.ready) {
     setup.push(setupStep(
@@ -251,6 +407,15 @@ export function evaluateLaunchpadRoom({
   const legacy = safeList(legacyWorkerSchedules).filter((schedule) => normalize(schedule.status || "enabled") !== "disabled");
   if (legacy.length > 0) {
     setup.push(setupStep("consolidate_worker_schedules", `Consolidate ${legacy.length} worker schedules into Launchpad-managed routing.`, 85));
+  }
+
+  if (councilInduction.needed && councilInduction.status !== "completed") {
+    const priority = councilInduction.status === "recommended" ? 82 : 65;
+    setup.push(setupStep(
+      "prompt_crews_council",
+      `Launchpad should prompt a Crews Council before final readiness: ${councilInduction.reasons[0] || "Council judgement recommended."}`,
+      priority,
+    ));
   }
 
   for (const seat of normalizedSeats) {
@@ -292,6 +457,7 @@ export function evaluateLaunchpadRoom({
       recommended_minutes: heartbeatMinutes,
       prompt: heartbeatReady(masterHeartbeat) ? null : createLaunchpadHeartbeatPrompt({ minutes: heartbeatMinutes }),
     },
+    council_induction: councilInduction,
     orchestrator_control: orchestratorControl,
     seats: normalizedSeats,
     room_coverage: roomCoverage,
@@ -304,8 +470,8 @@ export function evaluateLaunchpadRoom({
     wizard_packet: {
       worker: "master",
       chip: "Launchpad onboarding wizard",
-      context: "Register accounts/PCs as worker seats, consolidate worker schedules, and run one master heartbeat into Launchpad Room.",
-      expected_proof: "Post seat registry, heartbeat status, missing adapters, and next safe setup step.",
+      context: "Register accounts/PCs as worker seats, consolidate worker schedules, run one master heartbeat into Launchpad Room, and check Council Lite or deeper Crews Council before launch-ready claims.",
+      expected_proof: "Post seat registry, heartbeat status, missing adapters, Council Lite status, Council induction status, and next safe setup step.",
       deadline: "next setup pulse",
       ack: "done/blocker",
     },

--- a/scripts/pinballwake-launchpad-room.test.mjs
+++ b/scripts/pinballwake-launchpad-room.test.mjs
@@ -49,6 +49,8 @@ describe("PinballWake Launchpad Room", () => {
     assert.equal(result.result, "ready");
     assert.equal(result.single_heartbeat.ready, true);
     assert.equal(result.orchestrator_control.result, "single_active_orchestrator");
+    assert.equal(result.council_induction.status, "not_checked");
+    assert.equal(result.council_induction.lite_check.needed, false);
     assert.deepEqual(result.room_coverage.map((room) => room.covered), [true, true, true, true, true, true, true]);
     assert.equal(result.setup_steps.length, 0);
   });
@@ -66,6 +68,7 @@ describe("PinballWake Launchpad Room", () => {
     assert.match(result.single_heartbeat.prompt, /recurring heartbeat every 17 minutes/);
     assert.equal(result.setup_steps[0].kind, "create_single_master_heartbeat");
     assert.equal(result.wizard_packet.worker, "master");
+    assert.match(result.single_heartbeat.prompt, /Launchpad Council induction/);
   });
 
   it("treats accounts as capacity and chooses the best available seat per room", () => {
@@ -200,7 +203,68 @@ describe("PinballWake Launchpad Room", () => {
 
     assert.match(prompt, /Launchpad Wizard/);
     assert.match(prompt, /one master chat only/);
+    assert.match(prompt, /Launchpad Council induction/);
+    assert.match(prompt, /Council Lite anti-rubber-stamp/);
+    assert.match(prompt, /Crews is recommended/);
     assert.match(prompt, /Do not directly spam every worker/);
     assert.match(prompt, /No secrets/);
+  });
+
+  it("prompts a Crews Council for launch work that needs judgement", () => {
+    const result = evaluateLaunchpadRoom({
+      masterHeartbeat: { enabled: true, target: "launchpad" },
+      orchestrator: activeOrchestrator(),
+      seats: [
+        seat({ id: "builder", capabilities: ["implementation", "proof", "status_relay"] }),
+        seat({ id: "reviewer", capabilities: ["qc_review", "release_safety", "research", "planning"] }),
+      ],
+      rooms: ["build", "proof", "qc", "safety", "research", "planning", "status"],
+      title: "Launch pricing and compliance readiness decision",
+      context: "Need a go/no-go judgement before this public enterprise page ships.",
+      changed_files: [
+        "docs/enterprisepass-product-brief.md",
+        "docs/legal/pricing-claims.md",
+        "src/pages/Enterprise.tsx",
+      ],
+    });
+
+    assert.equal(result.result, "setup_needed");
+    assert.equal(result.council_induction.needed, true);
+    assert.equal(result.council_induction.status, "recommended");
+    assert.equal(result.council_induction.lite_check.needed, true);
+    assert.equal(result.council_induction.lite_check.mode, "anti_rubber_stamp");
+    assert.ok(result.council_induction.lite_check.questions.length >= 4);
+    assert.match(result.council_induction.prompt, /start_crew_run/);
+    assert.ok(result.setup_steps.some((step) => step.kind === "prompt_crews_council"));
+    assert.match(result.wizard_packet.expected_proof, /Council Lite status/);
+  });
+
+  it("accepts a completed Crews Council run as launch induction proof", () => {
+    const result = evaluateLaunchpadRoom({
+      masterHeartbeat: { enabled: true, target: "launchpad" },
+      orchestrator: activeOrchestrator(),
+      seats: [
+        seat({ id: "builder", capabilities: ["implementation", "proof", "status_relay"] }),
+        seat({ id: "reviewer", capabilities: ["qc_review", "release_safety", "research", "planning"] }),
+      ],
+      rooms: ["build", "proof", "qc", "safety", "research", "planning", "status"],
+      xpassGate: {
+        crews_council: {
+          needed: true,
+          status: "recommended",
+          trigger_score: 82,
+          suggested_template: "Council",
+          suggested_tool: "start_crew_run",
+          reasons: ["Pass evidence is mixed."],
+        },
+      },
+      crewsCouncilRun: { id: "crew-run-1", status: "complete" },
+    });
+
+    assert.equal(result.result, "ready");
+    assert.equal(result.council_induction.status, "completed");
+    assert.equal(result.council_induction.lite_check.needed, true);
+    assert.equal(result.council_induction.council_run.run_id, "crew-run-1");
+    assert.ok(!result.setup_steps.some((step) => step.kind === "prompt_crews_council"));
   });
 });

--- a/scripts/pinballwake-xpass-gate-room.mjs
+++ b/scripts/pinballwake-xpass-gate-room.mjs
@@ -58,6 +58,47 @@ const ENTERPRISE_READINESS_TERMS = [
   "training data",
 ];
 
+const COUNCIL_TRIGGER_TERMS = [
+  "ambiguous",
+  "council",
+  "crew",
+  "crews",
+  "debate",
+  "decide",
+  "decision",
+  "dissent",
+  "good enough",
+  "go no go",
+  "go/no-go",
+  "judgement",
+  "judgment",
+  "launch",
+  "opinion",
+  "opinions",
+  "positioning",
+  "ready to ship",
+  "risk acceptance",
+  "strategy",
+  "taste",
+  "trade-off",
+  "tradeoff",
+  "unclear",
+];
+
+const COUNCIL_HIGH_JUDGMENT_CHECKS = new Set([
+  "securitypass",
+  "legalpass",
+  "commonsensepass",
+  "rotatepass",
+]);
+
+const COUNCIL_LITE_QUESTIONS = [
+  "What would make this answer or change wrong?",
+  "What evidence is missing, stale, or too weak?",
+  "Who would object: user, maintainer, reviewer, legal, security, or operator?",
+  "What is the smallest proof needed before saying ready?",
+];
+
 const PASS_STATUS = new Set(["pass", "passed", "success", "green", "ok"]);
 const BLOCKER_STATUS = new Set(["fail", "failed", "failure", "blocker", "blocked", "red"]);
 const SKIP_STATUS = new Set(["skip", "skipped", "not_applicable", "not-applicable"]);
@@ -446,6 +487,82 @@ function isUnscopedForTarget(result, inspectedTarget) {
   return Boolean(result && inspectedTarget?.sha && !result.target_sha);
 }
 
+export function selectCrewsCouncilTrigger(input = {}, selected = selectXPassChecks(input), results = resultMap(input.pass_results || input.passResults || input.results)) {
+  const files = changedFiles(input);
+  const text = targetText(input);
+  const allText = `${text} ${files.join(" ")}`;
+  const selectedChecks = selected.map((check) => check.check);
+  const selectedSet = new Set(selectedChecks);
+  const providedResults = [...results.values()];
+  const passedResults = providedResults.filter((result) => result.status === "passed");
+  const blockerResults = providedResults.filter((result) => result.status === "blocker");
+  const skippedResults = providedResults.filter((result) => result.status === "skipped");
+  const highJudgmentChecks = selectedChecks.filter((check) => COUNCIL_HIGH_JUDGMENT_CHECKS.has(check));
+  const reasons = new Set();
+
+  if (input.require_council === true || input.requireCouncil === true || input.force_council === true || input.forceCouncil === true) {
+    reasons.add("Council explicitly requested for this target.");
+  }
+
+  if (hasAny(allText, COUNCIL_TRIGGER_TERMS)) {
+    reasons.add("Target language asks for judgement, debate, launch readiness, or a decision.");
+  }
+
+  if (files.some((path) => path.includes("/crews/") || path.includes("crews") || path.includes("council"))) {
+    reasons.add("Crews or Council surface changed; dogfood Crews with its own Council judgement.");
+  }
+
+  if (selectedChecks.length >= 4) {
+    reasons.add(`Broad XPass surface selected ${selectedChecks.length} checks; use a Council to interpret the combined evidence.`);
+  }
+
+  if (highJudgmentChecks.length >= 2) {
+    reasons.add(`High-judgement checks overlap: ${highJudgmentChecks.map((check) => CHECK_LABELS[check]).join(", ")}.`);
+  }
+
+  if (
+    (selectedSet.has("legalpass") || selectedSet.has("securitypass")) &&
+    (selectedSet.has("copypass") || selectedSet.has("uxpass") || selectedSet.has("seopass")) &&
+    hasAny(allText, ["public", "publish", "release", "launch", "pricing", "homepage", "landing", "claims", "enterprise", "compliance"])
+  ) {
+    reasons.add("Public, commercial, legal, or security evidence needs a named final judgement before release.");
+  }
+
+  if (blockerResults.length > 0 && passedResults.length > 0) {
+    reasons.add("Pass evidence is mixed; a Council should decide what the blockers mean before owners treat the target as ready.");
+  }
+
+  if (skippedResults.length > 0 && selectedChecks.length >= 3) {
+    reasons.add("Some checks were skipped on a multi-pass target; use a Council to record accepted exclusions.");
+  }
+
+  const triggerScore = Math.min(100, (reasons.size * 22) + Math.min(30, selectedChecks.length * 5));
+  const needed = reasons.size > 0;
+  const liteNeeded = Boolean(files.length || text || selectedChecks.length || providedResults.length);
+
+  return {
+    needed,
+    status: needed ? (triggerScore >= 55 ? "recommended" : "consider") : "not_needed",
+    trigger_score: triggerScore,
+    suggested_template: needed ? "Council" : null,
+    suggested_tool: needed ? "start_crew_run" : null,
+    reasons: [...reasons],
+    note: needed
+      ? "Crews should interpret the evidence; XPass still owns the checks and receipts."
+      : "XPass can handle this without a Crews Council.",
+    lite_check: {
+      needed: liteNeeded,
+      status: liteNeeded ? "baseline" : "not_needed",
+      suggested_template: liteNeeded ? "Council Lite" : null,
+      mode: "anti_rubber_stamp",
+      questions: liteNeeded ? COUNCIL_LITE_QUESTIONS : [],
+      note: liteNeeded
+        ? "Use this tiny dissent check before treating the answer as ready; escalate to full Council only when the recommendation says consider or recommended."
+        : "No meaningful target was supplied for a light Crews check.",
+    },
+  };
+}
+
 function makeReceipt({
   inspectedTarget,
   selected,
@@ -455,6 +572,7 @@ function makeReceipt({
   stale,
   unscoped,
   skipped,
+  council,
   now,
 }) {
   return {
@@ -487,6 +605,7 @@ function makeReceipt({
       unscoped_checks: unscoped.map((result) => result.check),
       target_sha: inspectedTarget.sha || null,
     },
+    crews_council: council,
   };
 }
 
@@ -500,6 +619,7 @@ export function evaluateXPassGate(input = {}) {
   const available = new Set(safeList(input.available_checks || input.availableChecks).map(normalizeCheckName));
   const hasAvailability = available.size > 0;
   const results = resultMap(input.pass_results || input.passResults || input.results);
+  const council = selectCrewsCouncilTrigger(input, selected, results);
 
   const skipped = [];
   const missing = [];
@@ -547,6 +667,7 @@ export function evaluateXPassGate(input = {}) {
     stale,
     unscoped,
     skipped,
+    council,
     now,
   });
 
@@ -585,6 +706,7 @@ export function evaluateXPassGate(input = {}) {
     stale_checks: stale.map((result) => result.check),
     unscoped_checks: unscoped.map((result) => result.check),
     skipped_checks: skipped,
+    crews_council: council,
     receipt,
   };
 }

--- a/scripts/pinballwake-xpass-gate-room.test.mjs
+++ b/scripts/pinballwake-xpass-gate-room.test.mjs
@@ -107,6 +107,20 @@ describe("PinballWake XPass Gate Room", () => {
     assert.deepEqual(selected, ["copypass"]);
   });
 
+  it("does not recommend a Crews Council for a tiny single-pass wording change", () => {
+    const result = evaluateXPassGate({
+      title: "FAQ wording cleanup",
+      changed_files: ["docs/faq.md"],
+    });
+
+    assert.equal(result.crews_council.needed, false);
+    assert.equal(result.crews_council.status, "not_needed");
+    assert.equal(result.crews_council.lite_check.needed, true);
+    assert.equal(result.crews_council.lite_check.mode, "anti_rubber_stamp");
+    assert.ok(result.crews_council.lite_check.questions.length >= 4);
+    assert.equal(result.receipt.crews_council.needed, false);
+  });
+
   it("returns advisory xpass_needed when selected checks have no receipts yet", () => {
     const result = evaluateXPassGate({
       mode: "advisory",
@@ -277,6 +291,49 @@ describe("PinballWake XPass Gate Room", () => {
       "legalpass",
       "sloppass",
     ]);
+  });
+
+  it("recommends a Crews Council for broad public launch and compliance judgement", () => {
+    const result = evaluateXPassGate({
+      title: "Launch pricing and compliance readiness decision",
+      context: "Need a go/no-go judgement before this public enterprise page ships.",
+      changed_files: [
+        "docs/enterprisepass-product-brief.md",
+        "docs/legal/pricing-claims.md",
+        "src/pages/Enterprise.tsx",
+      ],
+    });
+
+    assert.equal(result.crews_council.needed, true);
+    assert.equal(result.crews_council.status, "recommended");
+    assert.equal(result.crews_council.suggested_template, "Council");
+    assert.equal(result.crews_council.suggested_tool, "start_crew_run");
+    assert.match(result.crews_council.reasons.join("\n"), /judgement|launch|decision/i);
+    assert.equal(result.receipt.crews_council.needed, true);
+  });
+
+  it("recommends a Crews Council when pass evidence is mixed", () => {
+    const result = evaluateXPassGate({
+      target: { type: "pr", id: 548, sha: "abc123" },
+      changed_files: ["docs/pricing.md", "docs/legal/terms.md"],
+      pass_results: [
+        { check: "CopyPass", status: "passed", run_id: "copy-1", target_sha: "abc123" },
+        { check: "LegalPass", status: "failed", run_id: "legal-1", target_sha: "abc123" },
+      ],
+    });
+
+    assert.equal(result.crews_council.needed, true);
+    assert.match(result.crews_council.reasons.join("\n"), /mixed/i);
+  });
+
+  it("dogfoods Crews surfaces by recommending a Crews Council", () => {
+    const result = evaluateXPassGate({
+      title: "Improve Crews composer council handoff",
+      changed_files: ["src/pages/admin/crews/CrewComposer.tsx"],
+    });
+
+    assert.equal(result.crews_council.needed, true);
+    assert.match(result.crews_council.reasons.join("\n"), /Crews|Council/);
   });
 
   it("routes current accessibility and AI security terms from external standards to the right checks", () => {


### PR DESCRIPTION
## Summary\n- add a deterministic Crews Council recommendation to the XPass gate receipt\n- add Council Lite anti-rubber-stamp questions for material work without forcing a full multi-agent run\n- add Launchpad Council induction so launch/risk/mixed-proof work prompts start_crew_run before final readiness\n- add BrainMap induction visibility for Council Lite / Crews Council, keeping Council as a Crews mode/template rather than a new CouncilPass product\n\n## Tests\n- node --test scripts\\pinballwake-launchpad-room.test.mjs scripts\\pinballwake-xpass-gate-room.test.mjs scripts\\UnClick-brainmap.test.mjs\n- npm run brainmap:check\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launch readiness and proof-receipt semantics for operators; recommendations are advisory but can gate Launchpad “ready” until council proof is recorded.
> 
> **Overview**
> **XPass** now attaches a deterministic **Crews Council** recommendation (`not_needed` / `consider` / `recommended`) and **Council Lite** anti-rubber-stamp questions to gate output and receipts, driven by heuristics such as judgement language, broad multi-pass selection, mixed pass evidence, and high-risk public/legal/security overlap—without introducing a separate CouncilPass product.
> 
> **Launchpad** consumes that signal via **Council induction**: material work can add a `prompt_crews_council` setup step and `start_crew_run` guidance until a completed council run is recorded; the master heartbeat and wizard proof expectations were updated accordingly.
> 
> **Docs and Brainmap** were extended (PRDs plus regenerated artifacts) with a new seat-induction step and inventory entry for Crews Council Induction at `/admin/pinballwake`, with matching tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535d607f5e536f611d1a8ae3f1e1cf5157349b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->