### PR TITLE
[codex] remove EnterprisePass duplicate from dogfood

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-28T11:13:42.236Z",
-  "lastRunAt": "2026-05-28T11:13:42.236Z",
+  "generatedAt": "2026-05-28T11:40:19.980Z",
+  "lastRunAt": "2026-05-28T11:40:19.980Z",
   "status": "pending",
   "source": "dogfood receipt dry run",
   "headline": "We dogfood UnClick on UnClick.",
@@ -130,15 +130,6 @@
       "automation": "Local deterministic scanner and public readiness receipt",
       "mentionProfile": "Low mention volume unless readiness evidence, claims, or docs drift.",
       "nextStep": "Keep report language conservative and link more XPass receipts as they mature."
-    },
-    {
-      "id": "enterprisepass",
-      "name": "EnterprisePass",
-      "stage": "guidance",
-      "label": "Guidance report",
-      "automation": "Receipt guard and readiness report boundary",
-      "mentionProfile": "Low mention volume while it remains a guidance layer, not certification.",
-      "nextStep": "Add low-risk readiness checks without claiming compliance certification."
     }
   ],
   "results": [
@@ -148,7 +139,7 @@
       "status": "pending",
       "summary": "Dry-run receipt builder validated the TestPass result shape.",
       "evidence": "Dry run only. Live workflow calls /api/testpass-run with source=scheduled.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "dry_run_only",
       "nextProof": "Run the dogfood report without --dry-run and with a TestPass token before marking this passing."
     },
@@ -158,7 +149,7 @@
       "status": "pending",
       "summary": "Dry-run receipt builder validated the UXPass result shape.",
       "evidence": "Dry run only. Live workflow calls /api/uxpass-run against the public URL.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "dry_run_only",
       "nextProof": "Run the dogfood report without --dry-run and with a UXPass token before marking this passing."
     },
@@ -168,7 +159,7 @@
       "status": "passing",
       "summary": "Safe recurring proof verified SecurityPass remains deny-by-default before active probes.",
       "evidence": "Static proof checked the runner scope gate plus scanner wrapper safety settings; no active probes were run.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "proof": {
         "kind": "securitypass_safe_static_proof",
         "files": {
@@ -220,7 +211,7 @@
       "status": "pending",
       "summary": "Package-backed quality review exists, but the public dogfood receipt has not run it yet.",
       "evidence": "SlopPass has a package runner, verdict pack, and dogfood tests; public status stays pending until a scheduled receipt exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -235,7 +226,7 @@
       "status": "pending",
       "summary": "Dry-run receipt builder validated the SEOPass result shape.",
       "evidence": "Dry run only. Live workflow fetches public HTML, robots.txt, sitemap.xml, and llms.txt.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "dry_run_only",
       "runId": "seopass-dry-run-shape",
       "targetUrl": "https://unclick.world",
@@ -258,7 +249,7 @@
       "status": "pending",
       "summary": "Package-backed copy quality review exists, but the public dogfood receipt has not run it yet.",
       "evidence": "CopyPass has deterministic review tooling and CopyRoom boundary checks; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -273,7 +264,7 @@
       "status": "pending",
       "summary": "Package-backed policy and claims guidance exists, but the public dogfood receipt has not run it yet.",
       "evidence": "LegalPass has guidance tooling, pack schema, and public proof boundaries; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -288,7 +279,7 @@
       "status": "pending",
       "summary": "Worker sanity checks exist, but the public dogfood receipt has not run them yet.",
       "evidence": "CommonSensePass is routed for proof, queue, claim, false-DONE, and merge-ready sanity; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -303,7 +294,7 @@
       "status": "pending",
       "summary": "Package-backed journey checks exist, but the public dogfood receipt has not run them yet.",
       "evidence": "FlowPass has journey fixtures for onboarding, checkout, handoff, forms, and success/failure states; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -318,7 +309,7 @@
       "status": "pending",
       "summary": "Package-backed answer-engine readiness checks exist, but the public dogfood receipt has not run them yet.",
       "evidence": "GEOPass has AI answer-engine readiness scanning for llms.txt, schema, bots, and metadata; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -333,7 +324,7 @@
       "status": "pending",
       "summary": "Credential lifecycle boundaries are documented and guarded, but no live credential rotation runs in public dogfood.",
       "evidence": "RotatePass stays boundary-only until a safe local receipt can prove redaction and lifecycle behavior without touching real secrets.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "boundary_needs_runner",
       "proof": {
         "kind": "boundary",
@@ -348,7 +339,7 @@
       "status": "pending",
       "summary": "Wake and stale-work visibility exists, but the public dogfood receipt has not run a public-safe stale-work check yet.",
       "evidence": "WakePass powers dispatch, stale ACK, heartbeat, and reclaim visibility; public status stays pending until a public-safe receipt exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "boundary_needs_runner",
       "proof": {
         "kind": "boundary",
@@ -363,7 +354,7 @@
       "status": "passing",
       "summary": "CompliancePass scanned 27 readiness checks and scored 99.3/100.",
       "evidence": "See /enterprise/latest.json for the evidence-backed readiness report.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "public_receipt_complete",
       "score": 99.3,
       "band": "green",
@@ -372,21 +363,6 @@
         "targetUrl": "/enterprise/latest.json",
         "checksTotal": 27
       }
-    },
-    {
-      "id": "enterprisepass",
-      "name": "EnterprisePass",
-      "status": "pending",
-      "summary": "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
-      "evidence": "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
-      "reasonCode": "boundary_needs_runner",
-      "proof": {
-        "kind": "boundary",
-        "targetUrl": "/enterprise/latest.json"
-      },
-      "targetUrl": "/enterprise/latest.json",
-      "nextProof": "Wire automated evidence checks before moving this beyond readiness guidance."
     }
   ],
   "trend": [
@@ -395,7 +371,7 @@
       "passing": 2,
       "failing": 0,
       "blocked": 0,
-      "pending": 12
+      "pending": 11
     }
   ],
   "lastActionableFailure": {

--- a/public/dogfood/xpass-boundary-sweep.json
+++ b/public/dogfood/xpass-boundary-sweep.json
@@ -1,0 +1,130 @@
+{
+  "kind": "xpass_boundary_sweep_receipt_v1",
+  "generated_at": "2026-05-28T11:40:19.953Z",
+  "checked_at": "2026-05-28T11:40:19.953Z",
+  "run_id": "xpass-boundary-sweep-755f48c8fcf229e7",
+  "source": "local xpass boundary sweep",
+  "target_sha": null,
+  "package_sweep_path": "public/dogfood/xpass-package-sweep.json",
+  "package_sweep_status": "fresh",
+  "status": "passing",
+  "summary": "XPass boundary sweep passing across 2 public-safe boundary product(s).",
+  "product_count": 2,
+  "products": [
+    {
+      "id": "rotatepass",
+      "name": "RotatePass",
+      "stage": "boundary",
+      "role": "safe credential lifecycle and redaction proof",
+      "target_url": "docs/rotatepass-local-phase0.md",
+      "status": "passing",
+      "checked_at": "2026-05-28T11:40:19.953Z",
+      "command": [
+        "node",
+        "--test",
+        "scripts/rotatepass-redaction-guard.test.mjs"
+      ],
+      "exit_code": 0,
+      "duration_ms": 0,
+      "summary": "RotatePass public-safe boundary tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "public_safe_boundary_test",
+        "command": [
+          "node",
+          "--test",
+          "scripts/rotatepass-redaction-guard.test.mjs"
+        ],
+        "targetUrl": "docs/rotatepass-local-phase0.md"
+      }
+    },
+    {
+      "id": "wakepass",
+      "name": "WakePass",
+      "stage": "live_gate",
+      "role": "public-safe wake, stale work, ACK, and liveness proof",
+      "target_url": "docs/prd/wakepass.md",
+      "status": "passing",
+      "checked_at": "2026-05-28T11:40:19.953Z",
+      "command": [
+        "node",
+        "--test",
+        "scripts/event-wake-router.test.mjs",
+        "scripts/pinballwake-ack-ledger-room.test.mjs",
+        "scripts/pinballwake-stale-room.test.mjs",
+        "scripts/worker-liveness-watchdog.test.mjs"
+      ],
+      "exit_code": 0,
+      "duration_ms": 0,
+      "summary": "WakePass public-safe boundary tests passed.",
+      "failure_hint": null,
+      "proof": {
+        "kind": "public_safe_boundary_test",
+        "command": [
+          "node",
+          "--test",
+          "scripts/event-wake-router.test.mjs",
+          "scripts/pinballwake-ack-ledger-room.test.mjs",
+          "scripts/pinballwake-stale-room.test.mjs",
+          "scripts/worker-liveness-watchdog.test.mjs"
+        ],
+        "targetUrl": "docs/prd/wakepass.md"
+      }
+    }
+  ],
+  "cross_pass_matrix": [
+    {
+      "target_id": "rotatepass",
+      "target_name": "RotatePass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "securitypass",
+          "name": "SecurityPass",
+          "role": "safe local security and secret-boundary proof",
+          "status": "passing"
+        },
+        {
+          "id": "legalpass",
+          "name": "LegalPass",
+          "role": "safe guidance and non-certification wording",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "proof-claim sanity and false-DONE guard",
+          "status": "passing"
+        }
+      ],
+      "summary": "RotatePass was cross-checked by SecurityPass, LegalPass, CommonSensePass."
+    },
+    {
+      "target_id": "wakepass",
+      "target_name": "WakePass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "automation and MCP smoke trust gate",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "stale-work and false-DONE sanity",
+          "status": "passing"
+        },
+        {
+          "id": "flowpass",
+          "name": "FlowPass",
+          "role": "handoff and recovery-path overlap",
+          "status": "passing"
+        }
+      ],
+      "summary": "WakePass was cross-checked by TestPass, CommonSensePass, FlowPass."
+    }
+  ],
+  "action_needed": []
+}

--- a/scripts/build-dogfood-report.mjs
+++ b/scripts/build-dogfood-report.mjs
@@ -163,15 +163,6 @@ const xpassIndex = [
     mentionProfile: "Low mention volume unless readiness evidence, claims, or docs drift.",
     nextStep: "Keep report language conservative and link more XPass receipts as they mature.",
   },
-  {
-    id: "enterprisepass",
-    name: "EnterprisePass",
-    stage: "guidance",
-    label: "Guidance report",
-    automation: "Receipt guard and readiness report boundary",
-    mentionProfile: "Low mention volume while it remains a guidance layer, not certification.",
-    nextStep: "Add low-risk readiness checks without claiming compliance certification.",
-  },
 ];
 
 function trimTrailingSlash(value) {
@@ -1147,14 +1138,6 @@ const results = [
     "Add a public-safe WakePass receipt for stale scheduled work and reclaim visibility.",
   ),
   await runCompliancePassReceipt(),
-  boundaryResult(
-    "enterprisepass",
-    "EnterprisePass",
-    "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
-    "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
-    "/enterprise/latest.json",
-    "Wire automated evidence checks before moving this beyond readiness guidance.",
-  ),
 ];
 
 const report = {

--- a/scripts/build-dogfood-report.test.mjs
+++ b/scripts/build-dogfood-report.test.mjs
@@ -87,13 +87,7 @@ test("dogfood receipt includes a safe SecurityPass proof without active probes",
     assert.equal(legalpass?.status, "pending");
     assert.equal(legalpass?.reasonCode, "package_ready_needs_scheduled_receipt");
     assert.equal(legalpass?.proof?.kind, "package_ready");
-    assert.equal(enterprisepass?.status, "pending");
-    assert.equal(enterprisepass?.reasonCode, "boundary_needs_runner");
-    assert.match(enterprisepass?.nextProof ?? "", /automated evidence checks/i);
-    assert.deepEqual(enterprisepass?.proof, {
-      kind: "boundary",
-      targetUrl: "/enterprise/latest.json",
-    });
+    assert.equal(enterprisepass, undefined);
     assert.equal(report.status, "pending");
     assert.match(report.statusLegend.blocked, /needs action|action is needed/i);
     assert.match(report.statusLegend.pending, /scheduled proof is not available yet/i);
@@ -189,7 +183,6 @@ test("dogfood receipt includes structured proof for live TestPass and UXPass run
       "rotatepass",
       "wakepass",
       "compliancepass",
-      "enterprisepass",
     ]);
 
     assert.equal(testpassRequest.body.source, "scheduled");

--- a/scripts/build-xpass-boundary-sweep.mjs
+++ b/scripts/build-xpass-boundary-sweep.mjs
@@ -42,15 +42,6 @@ export const BOUNDARY_PRODUCTS = [
       "scripts/worker-liveness-watchdog.test.mjs",
     ],
   },
-  {
-    id: "enterprisepass",
-    name: "EnterprisePass",
-    stage: "guidance",
-    role: "guidance-only readiness receipt guard",
-    target_url: "/enterprise/latest.json",
-    command: ["node", "--test", "scripts/enterprisepass-receipt-guard.test.mjs"],
-    actualCommand: [process.execPath, "--test", "scripts/enterprisepass-receipt-guard.test.mjs"],
-  },
 ];
 
 export const BOUNDARY_CROSS_PASS_MATRIX = [
@@ -68,15 +59,6 @@ export const BOUNDARY_CROSS_PASS_MATRIX = [
       { id: "testpass", role: "automation and MCP smoke trust gate" },
       { id: "commonsensepass", role: "stale-work and false-DONE sanity" },
       { id: "flowpass", role: "handoff and recovery-path overlap" },
-    ],
-  },
-  {
-    targetId: "enterprisepass",
-    reviewers: [
-      { id: "legalpass", role: "guidance-only and non-compliance-certification boundary" },
-      { id: "copypass", role: "public claim clarity" },
-      { id: "securitypass", role: "safe evidence-only boundary review" },
-      { id: "commonsensepass", role: "proof-claim sanity" },
     ],
   },
 ];

--- a/scripts/build-xpass-boundary-sweep.test.mjs
+++ b/scripts/build-xpass-boundary-sweep.test.mjs
@@ -47,7 +47,7 @@ test("XPass boundary sweep records public-safe boundary and cross-pass proof", a
 
     assert.equal(receipt.kind, "xpass_boundary_sweep_receipt_v1");
     assert.equal(receipt.status, "passing");
-    assert.equal(receipt.product_count, 3);
+    assert.equal(receipt.product_count, 2);
     assert.deepEqual(receipt.action_needed, []);
 
     const rotatepass = receipt.products.find((product) => product.id === "rotatepass");
@@ -58,7 +58,7 @@ test("XPass boundary sweep records public-safe boundary and cross-pass proof", a
     assert.equal(rotatepass?.proof.kind, "public_safe_boundary_test");
     assert.match(rotatepass?.summary ?? "", /public-safe boundary tests passed/i);
     assert.equal(wakepass?.status, "passing");
-    assert.equal(enterprisepass?.status, "passing");
+    assert.equal(enterprisepass, undefined);
 
     const rotatepassMatrix = receipt.cross_pass_matrix.find((row) => row.target_id === "rotatepass");
     assert.equal(rotatepassMatrix?.status, "passing");
@@ -132,8 +132,8 @@ test("XPass boundary sweep CLI writes a public-safe receipt", async () => {
 
     const receipt = JSON.parse(await fs.readFile(output, "utf8"));
     assert.equal(receipt.status, "passing");
-    assert.equal(receipt.products.length, 3);
-    assert.equal(receipt.cross_pass_matrix.length, 3);
+    assert.equal(receipt.products.length, 2);
+    assert.equal(receipt.cross_pass_matrix.length, 2);
     assert.equal(receipt.action_needed.length, 0);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });

--- a/src/__tests__/dogfood-report-proof-policy.test.ts
+++ b/src/__tests__/dogfood-report-proof-policy.test.ts
@@ -30,8 +30,7 @@ describe("Dogfood report proof policy", () => {
     expect(compliancepass?.summary).toMatch(/99\.3\/100/i);
     expect(copypass?.reasonCode).toBe("package_ready_needs_scheduled_receipt");
     expect(copypass?.proof?.kind).toBe("package_ready");
-    expect(enterprisepass?.reasonCode).toBe("boundary_needs_runner");
-    expect(enterprisepass?.proof?.kind).toBe("boundary");
+    expect(enterprisepass).toBeUndefined();
     expect(seopass?.proof?.kind).toBe("seopass_run");
     expect(seopass?.evidence).not.toMatch(/scaffold-only/i);
   });
@@ -45,7 +44,7 @@ describe("Dogfood report proof policy", () => {
     const enterprisepass = dogfoodReport.xpassIndex.find((entry) => entry.id === "enterprisepass");
     const seopass = dogfoodReport.xpassIndex.find((entry) => entry.id === "seopass");
 
-    expect(dogfoodReport.xpassIndex).toHaveLength(14);
+    expect(dogfoodReport.xpassIndex).toHaveLength(13);
     expect(testpass?.stage).toBe("live_gate");
     expect(testpass?.mentionProfile).toMatch(/protects merges/i);
     expect(compliancepass?.stage).toBe("live_dogfood");
@@ -55,7 +54,7 @@ describe("Dogfood report proof policy", () => {
     expect(commonsensepass?.stage).toBe("live_gate");
     expect(commonsensepass?.nextStep).toMatch(/worker-claim sanity/i);
     expect(wakepass?.stage).toBe("live_gate");
-    expect(enterprisepass?.stage).toBe("guidance");
+    expect(enterprisepass).toBeUndefined();
     expect(seopass?.stage).toBe("live_dogfood");
     expect(seopass?.automation).toMatch(/read-only SEO receipt/i);
   });

--- a/src/data/dogfoodReport.ts
+++ b/src/data/dogfoodReport.ts
@@ -96,8 +96,8 @@ export interface DogfoodReport {
 }
 
 export const dogfoodReport = {
-  "generatedAt": "2026-05-28T11:13:42.236Z",
-  "lastRunAt": "2026-05-28T11:13:42.236Z",
+  "generatedAt": "2026-05-28T11:40:19.980Z",
+  "lastRunAt": "2026-05-28T11:40:19.980Z",
   "status": "pending",
   "source": "dogfood receipt dry run",
   "headline": "We dogfood UnClick on UnClick.",
@@ -227,15 +227,6 @@ export const dogfoodReport = {
       "automation": "Local deterministic scanner and public readiness receipt",
       "mentionProfile": "Low mention volume unless readiness evidence, claims, or docs drift.",
       "nextStep": "Keep report language conservative and link more XPass receipts as they mature."
-    },
-    {
-      "id": "enterprisepass",
-      "name": "EnterprisePass",
-      "stage": "guidance",
-      "label": "Guidance report",
-      "automation": "Receipt guard and readiness report boundary",
-      "mentionProfile": "Low mention volume while it remains a guidance layer, not certification.",
-      "nextStep": "Add low-risk readiness checks without claiming compliance certification."
     }
   ],
   "results": [
@@ -245,7 +236,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Dry-run receipt builder validated the TestPass result shape.",
       "evidence": "Dry run only. Live workflow calls /api/testpass-run with source=scheduled.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "dry_run_only",
       "nextProof": "Run the dogfood report without --dry-run and with a TestPass token before marking this passing."
     },
@@ -255,7 +246,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Dry-run receipt builder validated the UXPass result shape.",
       "evidence": "Dry run only. Live workflow calls /api/uxpass-run against the public URL.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "dry_run_only",
       "nextProof": "Run the dogfood report without --dry-run and with a UXPass token before marking this passing."
     },
@@ -265,7 +256,7 @@ export const dogfoodReport = {
       "status": "passing",
       "summary": "Safe recurring proof verified SecurityPass remains deny-by-default before active probes.",
       "evidence": "Static proof checked the runner scope gate plus scanner wrapper safety settings; no active probes were run.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "proof": {
         "kind": "securitypass_safe_static_proof",
         "files": {
@@ -317,7 +308,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Package-backed quality review exists, but the public dogfood receipt has not run it yet.",
       "evidence": "SlopPass has a package runner, verdict pack, and dogfood tests; public status stays pending until a scheduled receipt exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -332,7 +323,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Dry-run receipt builder validated the SEOPass result shape.",
       "evidence": "Dry run only. Live workflow fetches public HTML, robots.txt, sitemap.xml, and llms.txt.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "dry_run_only",
       "runId": "seopass-dry-run-shape",
       "targetUrl": "https://unclick.world",
@@ -355,7 +346,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Package-backed copy quality review exists, but the public dogfood receipt has not run it yet.",
       "evidence": "CopyPass has deterministic review tooling and CopyRoom boundary checks; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -370,7 +361,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Package-backed policy and claims guidance exists, but the public dogfood receipt has not run it yet.",
       "evidence": "LegalPass has guidance tooling, pack schema, and public proof boundaries; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -385,7 +376,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Worker sanity checks exist, but the public dogfood receipt has not run them yet.",
       "evidence": "CommonSensePass is routed for proof, queue, claim, false-DONE, and merge-ready sanity; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -400,7 +391,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Package-backed journey checks exist, but the public dogfood receipt has not run them yet.",
       "evidence": "FlowPass has journey fixtures for onboarding, checkout, handoff, forms, and success/failure states; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -415,7 +406,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Package-backed answer-engine readiness checks exist, but the public dogfood receipt has not run them yet.",
       "evidence": "GEOPass has AI answer-engine readiness scanning for llms.txt, schema, bots, and metadata; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "package_ready_needs_scheduled_receipt",
       "proof": {
         "kind": "package_ready",
@@ -430,7 +421,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Credential lifecycle boundaries are documented and guarded, but no live credential rotation runs in public dogfood.",
       "evidence": "RotatePass stays boundary-only until a safe local receipt can prove redaction and lifecycle behavior without touching real secrets.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "boundary_needs_runner",
       "proof": {
         "kind": "boundary",
@@ -445,7 +436,7 @@ export const dogfoodReport = {
       "status": "pending",
       "summary": "Wake and stale-work visibility exists, but the public dogfood receipt has not run a public-safe stale-work check yet.",
       "evidence": "WakePass powers dispatch, stale ACK, heartbeat, and reclaim visibility; public status stays pending until a public-safe receipt exists.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "boundary_needs_runner",
       "proof": {
         "kind": "boundary",
@@ -460,7 +451,7 @@ export const dogfoodReport = {
       "status": "passing",
       "summary": "CompliancePass scanned 27 readiness checks and scored 99.3/100.",
       "evidence": "See /enterprise/latest.json for the evidence-backed readiness report.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
+      "checkedAt": "2026-05-28T11:40:19.980Z",
       "reasonCode": "public_receipt_complete",
       "score": 99.3,
       "band": "green",
@@ -469,21 +460,6 @@ export const dogfoodReport = {
         "targetUrl": "/enterprise/latest.json",
         "checksTotal": 27
       }
-    },
-    {
-      "id": "enterprisepass",
-      "name": "EnterprisePass",
-      "status": "pending",
-      "summary": "Seed enterprise-readiness report is published; automated evidence checks are not live yet.",
-      "evidence": "See /enterprise/latest.json for the readiness-report boundary and pending category map.",
-      "checkedAt": "2026-05-28T11:13:42.236Z",
-      "reasonCode": "boundary_needs_runner",
-      "proof": {
-        "kind": "boundary",
-        "targetUrl": "/enterprise/latest.json"
-      },
-      "targetUrl": "/enterprise/latest.json",
-      "nextProof": "Wire automated evidence checks before moving this beyond readiness guidance."
     }
   ],
   "trend": [
@@ -492,7 +468,7 @@ export const dogfoodReport = {
       "passing": 2,
       "failing": 0,
       "blocked": 0,
-      "pending": 12
+      "pending": 11
     }
   ],
   "lastActionableFailure": {


### PR DESCRIPTION
## Summary

- removes the old EnterprisePass duplicate from the dogfood board and XPass index so CompliancePass is the only public product row
- keeps EnterprisePass available only as a legacy alias in the CompliancePass receipt/docs path
- adds the public-safe XPass boundary sweep receipt with RotatePass and WakePass only

## Proof

- node --test scripts/build-dogfood-report.test.mjs scripts/build-xpass-boundary-sweep.test.mjs
- npx vitest run src/__tests__/dogfood-report-proof-policy.test.ts
- npm run brainmap:check
- git diff --check
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to public dogfood JSON, report builders, and tests; no runtime auth or production API behavior.
> 
> **Overview**
> **EnterprisePass** is removed as a separate dogfood/XPass product so **CompliancePass** is the only public readiness row on the board (still pointing at `/enterprise/latest.json`).
> 
> The dogfood report builder, fallback `dogfoodReport` data, and `public/dogfood/latest.json` drop **EnterprisePass** from `xpassIndex` and `results` (13 products, trend **pending** 12→11). The XPass boundary sweep now covers **RotatePass** and **WakePass** only—**EnterprisePass** is removed from `BOUNDARY_PRODUCTS`, the cross-pass matrix, and the new `public/dogfood/xpass-boundary-sweep.json` receipt. Tests are updated to expect no `enterprisepass` entries and boundary sweep counts of 2 instead of 3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5836b222ea69b27845ddfbb5cc3bfda26fbc2475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->