### PR TITLE
docs(fleet): prefer local-minimal cloud-first proof

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,30 @@ Use this as the short start ritual before any edit, branch, or PR action:
 3. Confirm the files you want are not already owned by another active PR or worker.
 4. Claim one small chip, post status in Fishbowl, and default to a draft PR first when risk is unclear.
 
+## Local-minimal / cloud-first mode
+
+Local worker seats must not create approval fatigue. Default to narrow local proof, then push and let GitHub Actions, Vercel, and QueuePush run the broad checks.
+
+Allowed local work:
+
+- Read repo files.
+- Make narrow edits inside the current worktree.
+- Run focused tests for touched files or packages.
+- Check `git status`, `git diff`, `git log`, and PR/check status.
+- Commit, push, and open or update one scoped branch.
+
+Do not run broad local sweeps by default:
+
+- No full repo dogfood loops.
+- No repeated full build/test loops.
+- No browser/Vite cache dogtests unless the user asked for UI proof.
+- No AppData, Temp, global filesystem, or outside-repo temp work unless explicitly required.
+- No parallel local builder work unless Chris assigned it.
+
+If temporary files are needed, put them under `.codex-tmp/<job-name>` in the current worktree and clean them before finishing.
+
+If a local command needs approval, ask once only. Include the exact reason, why cloud checks cannot do it, exact files or folders touched, and expected duration. If approval is not granted, report `BLOCKER: APPROVAL_NEEDED` with the progress so far and the exact cloud alternative.
+
 ## Monorepo structure
 
 ```


### PR DESCRIPTION
Adds the Local-minimal / cloud-first operating rule to AGENTS.md so local worker seats stop creating approval fatigue and push broad checks to GitHub Actions, Vercel, and QueuePush.

Proof run locally:
- git diff --check
- npm run brainmap:check

Notes:
- Docs-only change.
- Extracted from the older dogfood PR without taking its stale dogfood conflicts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to agent workflow guidance with no application, auth, or infrastructure changes.
> 
> **Overview**
> **Adds a new "Local-minimal / cloud-first mode" section to `AGENTS.md`**, placed after "Before you touch code" and before "Monorepo structure."
> 
> The section tells local fleet workers to keep on-machine work narrow (reads, scoped edits, focused tests, git/PR status) and to **defer broad verification to GitHub Actions, Vercel, and QueuePush** so local seats do not trigger repeated approval prompts. It lists **disallowed default local sweeps** (full dogfood, repeated full build/test, UI cache dogtests without request, AppData/Temp/out-of-repo work, parallel builder work unless assigned).
> 
> It also standardizes **temp files** under `.codex-tmp/<job-name>` in the worktree with cleanup before finish, and a **single approval ask** with required rationale; if denied, workers must report `BLOCKER: APPROVAL_NEEDED` and name the cloud alternative.
> 
> No runtime or product code changes—fleet operating documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2db9400390a7ff2963cc5d06ca3e1ef50b92b521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->