### PR TITLE
chore(dogfood): update public receipt

### DIFF
--- a/public/dogfood/latest.json
+++ b/public/dogfood/latest.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-05-28T11:40:19.980Z",
-  "lastRunAt": "2026-05-28T11:40:19.980Z",
-  "status": "pending",
-  "source": "dogfood receipt dry run",
+  "generatedAt": "2026-05-28T12:34:54.682Z",
+  "lastRunAt": "2026-05-28T12:34:54.682Z",
+  "status": "passing",
+  "source": "nightly dogfood workflow",
   "headline": "We dogfood UnClick on UnClick.",
   "target": "UnClick public and agent-facing product surfaces",
   "nextAutomation": "Nightly dogfood receipts refresh this board with live checks, scheduled XPass package proof, and scheduled public-safe boundary proof.",
@@ -136,22 +136,32 @@
     {
       "id": "testpass",
       "name": "TestPass",
-      "status": "pending",
-      "summary": "Dry-run receipt builder validated the TestPass result shape.",
-      "evidence": "Dry run only. Live workflow calls /api/testpass-run with source=scheduled.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "dry_run_only",
-      "nextProof": "Run the dogfood report without --dry-run and with a TestPass token before marking this passing."
+      "status": "passing",
+      "summary": "Scheduled TestPass completed with 17 checks and 0 failures.",
+      "evidence": "Run 693eb80d-1dc3-4b8e-847b-f3c56b156d5e checked https://unclick.world/api/mcp.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "693eb80d-1dc3-4b8e-847b-f3c56b156d5e",
+      "targetUrl": "https://unclick.world/api/mcp",
+      "proof": {
+        "kind": "testpass_run",
+        "runId": "693eb80d-1dc3-4b8e-847b-f3c56b156d5e",
+        "targetUrl": "https://unclick.world/api/mcp"
+      }
     },
     {
       "id": "uxpass",
       "name": "UXPass",
-      "status": "pending",
-      "summary": "Dry-run receipt builder validated the UXPass result shape.",
-      "evidence": "Dry run only. Live workflow calls /api/uxpass-run against the public URL.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "dry_run_only",
-      "nextProof": "Run the dogfood report without --dry-run and with a UXPass token before marking this passing."
+      "status": "passing",
+      "summary": "Scheduled UXPass completed with UX score 100.",
+      "evidence": "Run 6bb265c5-c163-4d15-a046-cef5b381461f checked https://unclick.world.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "6bb265c5-c163-4d15-a046-cef5b381461f",
+      "targetUrl": "https://unclick.world",
+      "proof": {
+        "kind": "uxpass_run",
+        "runId": "6bb265c5-c163-4d15-a046-cef5b381461f",
+        "targetUrl": "https://unclick.world"
+      }
     },
     {
       "id": "securitypass",
@@ -159,7 +169,7 @@
       "status": "passing",
       "summary": "Safe recurring proof verified SecurityPass remains deny-by-default before active probes.",
       "evidence": "Static proof checked the runner scope gate plus scanner wrapper safety settings; no active probes were run.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
       "proof": {
         "kind": "securitypass_safe_static_proof",
         "files": {
@@ -208,32 +218,55 @@
     {
       "id": "sloppass",
       "name": "SlopPass",
-      "status": "pending",
-      "summary": "Package-backed quality review exists, but the public dogfood receipt has not run it yet.",
-      "evidence": "SlopPass has a package runner, verdict pack, and dogfood tests; public status stays pending until a scheduled receipt exists.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/sloppass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed SlopPass.",
+      "evidence": "Receipt xpass-package-sweep-8ad0c460f00e0271 ran npm run test --workspace=@unclick/sloppass; cross-checked by TestPass, CommonSensePass, CopyPass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-package-sweep-8ad0c460f00e0271",
       "targetUrl": "packages/sloppass",
-      "nextProof": "Add a recurring SlopPass public receipt before marking this passing."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-8ad0c460f00e0271",
+        "packageId": "sloppass",
+        "targetUrl": "packages/sloppass",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "false-DONE and proof-claim sanity",
+            "status": "passing"
+          },
+          {
+            "id": "copypass",
+            "name": "CopyPass",
+            "role": "plain-English claims and wording boundary",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "seopass",
       "name": "SEOPass",
-      "status": "pending",
-      "summary": "Dry-run receipt builder validated the SEOPass result shape.",
-      "evidence": "Dry run only. Live workflow fetches public HTML, robots.txt, sitemap.xml, and llms.txt.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "dry_run_only",
-      "runId": "seopass-dry-run-shape",
+      "status": "passing",
+      "summary": "SEOPass read-only dogfood completed with SEO health score 91.",
+      "evidence": "Run seopass-dogfood-20260528123504 checked public HTML, robots.txt, sitemap.xml, and llms.txt for https://unclick.world.",
+      "checkedAt": "2026-05-28T12:35:04.135Z",
+      "runId": "seopass-dogfood-20260528123504",
       "targetUrl": "https://unclick.world",
       "proof": {
         "kind": "seopass_run",
-        "runId": "seopass-dry-run-shape",
+        "runId": "seopass-dogfood-20260528123504",
         "targetUrl": "https://unclick.world",
+        "score": 91,
         "sourceUrls": [
           "https://unclick.world",
           "https://unclick.world/robots.txt",
@@ -241,112 +274,267 @@
           "https://unclick.world/llms.txt"
         ]
       },
-      "nextProof": "Run the dogfood report without --dry-run so SEOPass can fetch the public SEO surfaces before marking it passing."
+      "nextProof": "Schedule this receipt and wire it to the shared GEOPass baseline."
     },
     {
       "id": "copypass",
       "name": "CopyPass",
-      "status": "pending",
-      "summary": "Package-backed copy quality review exists, but the public dogfood receipt has not run it yet.",
-      "evidence": "CopyPass has deterministic review tooling and CopyRoom boundary checks; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/copypass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed CopyPass.",
+      "evidence": "Receipt xpass-package-sweep-8ad0c460f00e0271 ran npm run test --workspace=@unclick/copypass; cross-checked by SlopPass, LegalPass, CommonSensePass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-package-sweep-8ad0c460f00e0271",
       "targetUrl": "packages/copypass",
-      "nextProof": "Add a recurring CopyPass receipt with CopyRoom/source-copy proof."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-8ad0c460f00e0271",
+        "packageId": "copypass",
+        "targetUrl": "packages/copypass",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "sloppass",
+            "name": "SlopPass",
+            "role": "anti-slop quality review",
+            "status": "passing"
+          },
+          {
+            "id": "legalpass",
+            "name": "LegalPass",
+            "role": "claims and guidance-only boundary",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "legalpass",
       "name": "LegalPass",
-      "status": "pending",
-      "summary": "Package-backed policy and claims guidance exists, but the public dogfood receipt has not run it yet.",
-      "evidence": "LegalPass has guidance tooling, pack schema, and public proof boundaries; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/legalpass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed LegalPass.",
+      "evidence": "Receipt xpass-package-sweep-8ad0c460f00e0271 ran npm run test --workspace=@unclick/legalpass; cross-checked by CopyPass, SecurityPass, CommonSensePass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-package-sweep-8ad0c460f00e0271",
       "targetUrl": "packages/legalpass",
-      "nextProof": "Add a recurring LegalPass receipt that stays guidance-only, not legal certification."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-8ad0c460f00e0271",
+        "packageId": "legalpass",
+        "targetUrl": "packages/legalpass",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "copypass",
+            "name": "CopyPass",
+            "role": "public wording and claims clarity",
+            "status": "passing"
+          },
+          {
+            "id": "securitypass",
+            "name": "SecurityPass",
+            "role": "safe local package proof only",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "certification-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "commonsensepass",
       "name": "CommonSensePass",
-      "status": "pending",
-      "summary": "Worker sanity checks exist, but the public dogfood receipt has not run them yet.",
-      "evidence": "CommonSensePass is routed for proof, queue, claim, false-DONE, and merge-ready sanity; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/commonsensepass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed CommonSensePass.",
+      "evidence": "Receipt xpass-package-sweep-8ad0c460f00e0271 ran npm run test --workspace=@unclick/commonsensepass; cross-checked by TestPass, SlopPass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-package-sweep-8ad0c460f00e0271",
       "targetUrl": "packages/commonsensepass",
-      "nextProof": "Add a recurring CommonSensePass proof receipt for worker claims and queue health."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-8ad0c460f00e0271",
+        "packageId": "commonsensepass",
+        "targetUrl": "packages/commonsensepass",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "sloppass",
+            "name": "SlopPass",
+            "role": "anti-slop claim review",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "flowpass",
       "name": "FlowPass",
-      "status": "pending",
-      "summary": "Package-backed journey checks exist, but the public dogfood receipt has not run them yet.",
-      "evidence": "FlowPass has journey fixtures for onboarding, checkout, handoff, forms, and success/failure states; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/flowpass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed FlowPass.",
+      "evidence": "Receipt xpass-package-sweep-8ad0c460f00e0271 ran npm run test --workspace=@unclick/flowpass; cross-checked by UXPass, TestPass, CommonSensePass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-package-sweep-8ad0c460f00e0271",
       "targetUrl": "packages/flowpass",
-      "nextProof": "Add a recurring FlowPass receipt for one public journey target."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-8ad0c460f00e0271",
+        "packageId": "flowpass",
+        "targetUrl": "packages/flowpass",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "uxpass",
+            "name": "UXPass",
+            "role": "route and UX sweep overlap",
+            "status": "passing"
+          },
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "geopass",
       "name": "GEOPass",
-      "status": "pending",
-      "summary": "Package-backed answer-engine readiness checks exist, but the public dogfood receipt has not run them yet.",
-      "evidence": "GEOPass has AI answer-engine readiness scanning for llms.txt, schema, bots, and metadata; public status stays pending until scheduled proof exists.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "package_ready_needs_scheduled_receipt",
-      "proof": {
-        "kind": "package_ready",
-        "targetUrl": "packages/geopass"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass package sweep passed GEOPass.",
+      "evidence": "Receipt xpass-package-sweep-8ad0c460f00e0271 ran npm run test --workspace=@unclick/geopass; cross-checked by TestPass, SEOPass, CommonSensePass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-package-sweep-8ad0c460f00e0271",
       "targetUrl": "packages/geopass",
-      "nextProof": "Add a recurring GEOPass answer-engine readiness receipt."
+      "proof": {
+        "kind": "xpass_package_sweep",
+        "runId": "xpass-package-sweep-8ad0c460f00e0271",
+        "packageId": "geopass",
+        "targetUrl": "packages/geopass",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-package-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "package tests must pass before public proof is trusted",
+            "status": "passing"
+          },
+          {
+            "id": "seopass",
+            "name": "SEOPass",
+            "role": "search-indexing overlap for crawlable answer sources",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "rotatepass",
       "name": "RotatePass",
-      "status": "pending",
-      "summary": "Credential lifecycle boundaries are documented and guarded, but no live credential rotation runs in public dogfood.",
-      "evidence": "RotatePass stays boundary-only until a safe local receipt can prove redaction and lifecycle behavior without touching real secrets.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "boundary_needs_runner",
-      "proof": {
-        "kind": "boundary",
-        "targetUrl": "docs/rotatepass-local-phase0.md"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass boundary sweep passed RotatePass.",
+      "evidence": "Receipt xpass-boundary-sweep-5b2f73743e349bcb ran node --test scripts/rotatepass-redaction-guard.test.mjs; cross-checked by SecurityPass, LegalPass, CommonSensePass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-boundary-sweep-5b2f73743e349bcb",
       "targetUrl": "docs/rotatepass-local-phase0.md",
-      "nextProof": "Add a safe local RotatePass receipt that proves lifecycle handling without exposing secrets."
+      "proof": {
+        "kind": "xpass_boundary_sweep",
+        "runId": "xpass-boundary-sweep-5b2f73743e349bcb",
+        "productId": "rotatepass",
+        "targetUrl": "docs/rotatepass-local-phase0.md",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-boundary-sweep.json",
+        "reviewers": [
+          {
+            "id": "securitypass",
+            "name": "SecurityPass",
+            "role": "safe local security and secret-boundary proof",
+            "status": "passing"
+          },
+          {
+            "id": "legalpass",
+            "name": "LegalPass",
+            "role": "safe guidance and non-certification wording",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "proof-claim sanity and false-DONE guard",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "wakepass",
       "name": "WakePass",
-      "status": "pending",
-      "summary": "Wake and stale-work visibility exists, but the public dogfood receipt has not run a public-safe stale-work check yet.",
-      "evidence": "WakePass powers dispatch, stale ACK, heartbeat, and reclaim visibility; public status stays pending until a public-safe receipt exists.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
-      "reasonCode": "boundary_needs_runner",
-      "proof": {
-        "kind": "boundary",
-        "targetUrl": "docs/prd/wakepass.md"
-      },
+      "status": "passing",
+      "summary": "Scheduled XPass boundary sweep passed WakePass.",
+      "evidence": "Receipt xpass-boundary-sweep-5b2f73743e349bcb ran node --test scripts/event-wake-router.test.mjs scripts/pinballwake-ack-ledger-room.test.mjs scripts/pinballwake-stale-room.test.mjs scripts/worker-liveness-watchdog.test.mjs; cross-checked by TestPass, CommonSensePass, FlowPass.",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
+      "runId": "xpass-boundary-sweep-5b2f73743e349bcb",
       "targetUrl": "docs/prd/wakepass.md",
-      "nextProof": "Add a public-safe WakePass receipt for stale scheduled work and reclaim visibility."
+      "proof": {
+        "kind": "xpass_boundary_sweep",
+        "runId": "xpass-boundary-sweep-5b2f73743e349bcb",
+        "productId": "wakepass",
+        "targetUrl": "docs/prd/wakepass.md",
+        "targetSha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
+        "receiptPath": "public/dogfood/xpass-boundary-sweep.json",
+        "reviewers": [
+          {
+            "id": "testpass",
+            "name": "TestPass",
+            "role": "automation and MCP smoke trust gate",
+            "status": "passing"
+          },
+          {
+            "id": "commonsensepass",
+            "name": "CommonSensePass",
+            "role": "stale-work and false-DONE sanity",
+            "status": "passing"
+          },
+          {
+            "id": "flowpass",
+            "name": "FlowPass",
+            "role": "handoff and recovery-path overlap",
+            "status": "passing"
+          }
+        ]
+      }
     },
     {
       "id": "compliancepass",
@@ -354,7 +542,7 @@
       "status": "passing",
       "summary": "CompliancePass scanned 27 readiness checks and scored 99.3/100.",
       "evidence": "See /enterprise/latest.json for the evidence-backed readiness report.",
-      "checkedAt": "2026-05-28T11:40:19.980Z",
+      "checkedAt": "2026-05-28T12:34:54.682Z",
       "reasonCode": "public_receipt_complete",
       "score": 99.3,
       "band": "green",
@@ -368,10 +556,10 @@
   "trend": [
     {
       "date": "2026-05-28",
-      "passing": 2,
+      "passing": 13,
       "failing": 0,
       "blocked": 0,
-      "pending": 11
+      "pending": 0
     }
   ],
   "lastActionableFailure": {

--- a/public/dogfood/uxpass-site-sweep.json
+++ b/public/dogfood/uxpass-site-sweep.json
@@ -2,10 +2,10 @@
   "kind": "uxpass_site_sweep_receipt",
   "check": "uxpass",
   "name": "UXPass",
-  "generated_at": "2026-05-27T18:16:58.806Z",
-  "run_id": "uxpass-site-sweep-8d444e83ea3bf574",
-  "status": "blocked",
-  "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+  "generated_at": "2026-05-28T12:35:04.622Z",
+  "run_id": "uxpass-site-sweep-ef2db80c6f989426",
+  "status": "passing",
+  "target_sha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
   "min_score": 80,
   "allowed_origins": [
     "https://unclick.world",
@@ -31,15 +31,15 @@
         "origin": "https://unclick.world",
         "path": "/"
       },
-      "status": "blocked",
-      "run_id": null,
-      "ux_score": null,
-      "summary": "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      "status": "passing",
+      "run_id": "f30e905d-d433-4e14-8abe-8991b2946410",
+      "ux_score": 100,
+      "summary": "UXPass completed with score 100.",
       "proof": {
-        "kind": "safe_fallback_receipt",
-        "reason": "missing_credential",
+        "kind": "uxpass_run",
+        "runId": "f30e905d-d433-4e14-8abe-8991b2946410",
         "targetUrl": "https://unclick.world/",
-        "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8"
+        "target_sha": "ca602ea4028d620d9fb2c06787550406ea5a3df0"
       },
       "evidence": {
         "viewports": [
@@ -47,7 +47,7 @@
             "name": "desktop",
             "width": 1440,
             "height": 1000,
-            "capture_status": "skipped_missing_credential",
+            "capture_status": "api_receipt",
             "screenshot_url": null,
             "console_issues": [],
             "layout_issues": []
@@ -56,7 +56,7 @@
             "name": "mobile",
             "width": 390,
             "height": 844,
-            "capture_status": "skipped_missing_credential",
+            "capture_status": "api_receipt",
             "screenshot_url": null,
             "console_issues": [],
             "layout_issues": []
@@ -73,15 +73,15 @@
         "origin": "https://unclick.world",
         "path": "/dashboard"
       },
-      "status": "blocked",
-      "run_id": null,
-      "ux_score": null,
-      "summary": "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      "status": "passing",
+      "run_id": "424a8960-3fad-4675-9523-6bee565c3642",
+      "ux_score": 100,
+      "summary": "UXPass completed with score 100.",
       "proof": {
-        "kind": "safe_fallback_receipt",
-        "reason": "missing_credential",
+        "kind": "uxpass_run",
+        "runId": "424a8960-3fad-4675-9523-6bee565c3642",
         "targetUrl": "https://unclick.world/dashboard",
-        "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8"
+        "target_sha": "ca602ea4028d620d9fb2c06787550406ea5a3df0"
       },
       "evidence": {
         "viewports": [
@@ -89,7 +89,7 @@
             "name": "desktop",
             "width": 1440,
             "height": 1000,
-            "capture_status": "skipped_missing_credential",
+            "capture_status": "api_receipt",
             "screenshot_url": null,
             "console_issues": [],
             "layout_issues": []
@@ -98,7 +98,7 @@
             "name": "mobile",
             "width": 390,
             "height": 844,
-            "capture_status": "skipped_missing_credential",
+            "capture_status": "api_receipt",
             "screenshot_url": null,
             "console_issues": [],
             "layout_issues": []
@@ -115,15 +115,15 @@
         "origin": "https://unclick.world",
         "path": "/admin/you"
       },
-      "status": "blocked",
-      "run_id": null,
-      "ux_score": null,
-      "summary": "Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
+      "status": "passing",
+      "run_id": "80bfc60d-7dae-4e2b-9639-1d21771424f5",
+      "ux_score": 100,
+      "summary": "UXPass completed with score 100.",
       "proof": {
-        "kind": "safe_fallback_receipt",
-        "reason": "missing_credential",
+        "kind": "uxpass_run",
+        "runId": "80bfc60d-7dae-4e2b-9639-1d21771424f5",
         "targetUrl": "https://unclick.world/admin/you",
-        "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8"
+        "target_sha": "ca602ea4028d620d9fb2c06787550406ea5a3df0"
       },
       "evidence": {
         "viewports": [
@@ -131,7 +131,7 @@
             "name": "desktop",
             "width": 1440,
             "height": 1000,
-            "capture_status": "skipped_missing_credential",
+            "capture_status": "api_receipt",
             "screenshot_url": null,
             "console_issues": [],
             "layout_issues": []
@@ -140,7 +140,7 @@
             "name": "mobile",
             "width": 390,
             "height": 844,
-            "capture_status": "skipped_missing_credential",
+            "capture_status": "api_receipt",
             "screenshot_url": null,
             "console_issues": [],
             "layout_issues": []
@@ -151,20 +151,16 @@
       }
     }
   ],
-  "action_needed": [
-    "https://unclick.world/: Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
-    "https://unclick.world/dashboard: Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET.",
-    "https://unclick.world/admin/you: Missing UXPASS_SITE_SWEEP_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET."
-  ],
-  "summary": "UXPass site sweep could not run because no token was available.",
+  "action_needed": [],
+  "summary": "UXPass site sweep passing across 3 URL(s).",
   "xpass_gate_result": {
     "check": "uxpass",
     "name": "UXPass",
-    "status": "blocked",
-    "run_id": "uxpass-site-sweep-8d444e83ea3bf574",
-    "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+    "status": "passed",
+    "run_id": "uxpass-site-sweep-ef2db80c6f989426",
+    "target_sha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
     "url": "https://unclick.world",
-    "summary": "UXPass site sweep could not run because no token was available.",
-    "generated_at": "2026-05-27T18:16:58.806Z"
+    "summary": "UXPass site sweep passing across 3 URL(s).",
+    "generated_at": "2026-05-28T12:35:04.622Z"
   }
 }

--- a/public/dogfood/xpass-boundary-sweep.json
+++ b/public/dogfood/xpass-boundary-sweep.json
@@ -1,10 +1,10 @@
 {
   "kind": "xpass_boundary_sweep_receipt_v1",
-  "generated_at": "2026-05-28T11:40:19.953Z",
-  "checked_at": "2026-05-28T11:40:19.953Z",
-  "run_id": "xpass-boundary-sweep-755f48c8fcf229e7",
-  "source": "local xpass boundary sweep",
-  "target_sha": null,
+  "generated_at": "2026-05-28T12:34:53.494Z",
+  "checked_at": "2026-05-28T12:34:53.494Z",
+  "run_id": "xpass-boundary-sweep-5b2f73743e349bcb",
+  "source": "nightly dogfood workflow",
+  "target_sha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
   "package_sweep_path": "public/dogfood/xpass-package-sweep.json",
   "package_sweep_status": "fresh",
   "status": "passing",
@@ -18,14 +18,14 @@
       "role": "safe credential lifecycle and redaction proof",
       "target_url": "docs/rotatepass-local-phase0.md",
       "status": "passing",
-      "checked_at": "2026-05-28T11:40:19.953Z",
+      "checked_at": "2026-05-28T12:34:53.494Z",
       "command": [
         "node",
         "--test",
         "scripts/rotatepass-redaction-guard.test.mjs"
       ],
       "exit_code": 0,
-      "duration_ms": 0,
+      "duration_ms": 105,
       "summary": "RotatePass public-safe boundary tests passed.",
       "failure_hint": null,
       "proof": {
@@ -45,7 +45,7 @@
       "role": "public-safe wake, stale work, ACK, and liveness proof",
       "target_url": "docs/prd/wakepass.md",
       "status": "passing",
-      "checked_at": "2026-05-28T11:40:19.953Z",
+      "checked_at": "2026-05-28T12:34:53.494Z",
       "command": [
         "node",
         "--test",
@@ -55,7 +55,7 @@
         "scripts/worker-liveness-watchdog.test.mjs"
       ],
       "exit_code": 0,
-      "duration_ms": 0,
+      "duration_ms": 1020,
       "summary": "WakePass public-safe boundary tests passed.",
       "failure_hint": null,
       "proof": {

--- a/public/dogfood/xpass-package-sweep.json
+++ b/public/dogfood/xpass-package-sweep.json
@@ -1,13 +1,40 @@
 {
   "kind": "xpass_package_sweep_receipt_v1",
-  "generated_at": "2026-05-27T18:16:34.133Z",
-  "checked_at": "2026-05-27T18:16:34.133Z",
-  "run_id": "xpass-package-sweep-f4b3e91c0e94f4fb",
+  "generated_at": "2026-05-28T12:34:36.863Z",
+  "checked_at": "2026-05-28T12:34:36.863Z",
+  "run_id": "xpass-package-sweep-8ad0c460f00e0271",
   "source": "nightly dogfood workflow",
-  "target_sha": "82e080a2764f1b69d889e19d4a5e912df28b12b8",
+  "target_sha": "ca602ea4028d620d9fb2c06787550406ea5a3df0",
   "status": "passing",
-  "summary": "XPass package sweep passing across 10 package(s).",
+  "scope": "full",
+  "summary": "XPass package sweep passing across all 10 package(s).",
   "package_count": 10,
+  "expected_package_count": 10,
+  "selected_package_ids": [
+    "testpass",
+    "uxpass",
+    "securitypass",
+    "sloppass",
+    "seopass",
+    "copypass",
+    "legalpass",
+    "commonsensepass",
+    "flowpass",
+    "geopass"
+  ],
+  "expected_package_ids": [
+    "testpass",
+    "uxpass",
+    "securitypass",
+    "sloppass",
+    "seopass",
+    "copypass",
+    "legalpass",
+    "commonsensepass",
+    "flowpass",
+    "geopass"
+  ],
+  "unknown_package_ids": [],
   "packages": [
     {
       "id": "testpass",
@@ -17,7 +44,7 @@
       "stage": "live_gate",
       "role": "merge proof and MCP smoke gate",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -25,7 +52,7 @@
         "--workspace=@unclick/testpass"
       ],
       "exit_code": 0,
-      "duration_ms": 6858,
+      "duration_ms": 6199,
       "summary": "TestPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -47,7 +74,7 @@
       "stage": "live_dogfood",
       "role": "public UX and route sweep gate",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -55,7 +82,7 @@
         "--workspace=@unclick/uxpass"
       ],
       "exit_code": 0,
-      "duration_ms": 1330,
+      "duration_ms": 1423,
       "summary": "UXPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -77,7 +104,7 @@
       "stage": "scope_gated",
       "role": "safe local security package proof only",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -85,7 +112,7 @@
         "--workspace=@unclick/securitypass"
       ],
       "exit_code": 0,
-      "duration_ms": 1507,
+      "duration_ms": 1386,
       "summary": "SecurityPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -107,7 +134,7 @@
       "stage": "package_ready",
       "role": "AI-code quality and anti-slop review",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -115,7 +142,7 @@
         "--workspace=@unclick/sloppass"
       ],
       "exit_code": 0,
-      "duration_ms": 1400,
+      "duration_ms": 1250,
       "summary": "SlopPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -137,7 +164,7 @@
       "stage": "package_ready",
       "role": "crawler, canonical, robots, sitemap, and metadata proof",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -145,7 +172,7 @@
         "--workspace=@unclick/seopass"
       ],
       "exit_code": 0,
-      "duration_ms": 872,
+      "duration_ms": 951,
       "summary": "SEOPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -167,7 +194,7 @@
       "stage": "package_ready",
       "role": "copy quality, claims, and source-copy boundary proof",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -175,7 +202,7 @@
         "--workspace=@unclick/copypass"
       ],
       "exit_code": 0,
-      "duration_ms": 1173,
+      "duration_ms": 1081,
       "summary": "CopyPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -197,7 +224,7 @@
       "stage": "package_ready",
       "role": "guidance-only policy and claims proof",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -205,7 +232,7 @@
         "--workspace=@unclick/legalpass"
       ],
       "exit_code": 0,
-      "duration_ms": 1369,
+      "duration_ms": 1271,
       "summary": "LegalPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -227,7 +254,7 @@
       "stage": "live_gate",
       "role": "false-DONE, claim sanity, and proof honesty gate",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -235,7 +262,7 @@
         "--workspace=@unclick/commonsensepass"
       ],
       "exit_code": 0,
-      "duration_ms": 1149,
+      "duration_ms": 1066,
       "summary": "CommonSensePass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -257,7 +284,7 @@
       "stage": "package_ready",
       "role": "journey and handoff proof",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -265,7 +292,7 @@
         "--workspace=@unclick/flowpass"
       ],
       "exit_code": 0,
-      "duration_ms": 920,
+      "duration_ms": 1146,
       "summary": "FlowPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -287,7 +314,7 @@
       "stage": "package_ready",
       "role": "answer-engine readiness and AI-discovery proof",
       "status": "passing",
-      "checked_at": "2026-05-27T18:16:34.133Z",
+      "checked_at": "2026-05-28T12:34:36.863Z",
       "command": [
         "npm",
         "run",
@@ -295,7 +322,7 @@
         "--workspace=@unclick/geopass"
       ],
       "exit_code": 0,
-      "duration_ms": 856,
+      "duration_ms": 801,
       "summary": "GEOPass package tests passed.",
       "failure_hint": null,
       "proof": {
@@ -311,6 +338,90 @@
     }
   ],
   "cross_pass_matrix": [
+    {
+      "target_id": "testpass",
+      "target_name": "TestPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "proof honesty and false-DONE gate coverage",
+          "status": "passing"
+        },
+        {
+          "id": "securitypass",
+          "name": "SecurityPass",
+          "role": "MCP and safe local security boundary review",
+          "status": "passing"
+        },
+        {
+          "id": "sloppass",
+          "name": "SlopPass",
+          "role": "fixture quality and failure-message review",
+          "status": "passing"
+        }
+      ],
+      "summary": "TestPass was cross-checked by CommonSensePass, SecurityPass, SlopPass."
+    },
+    {
+      "target_id": "uxpass",
+      "target_name": "UXPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "package tests must pass before public UX proof is trusted",
+          "status": "passing"
+        },
+        {
+          "id": "flowpass",
+          "name": "FlowPass",
+          "role": "route, journey, and handoff overlap",
+          "status": "passing"
+        },
+        {
+          "id": "copypass",
+          "name": "CopyPass",
+          "role": "interface copy and public wording clarity",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "proof-claim sanity",
+          "status": "passing"
+        }
+      ],
+      "summary": "UXPass was cross-checked by TestPass, FlowPass, CopyPass, CommonSensePass."
+    },
+    {
+      "target_id": "securitypass",
+      "target_name": "SecurityPass",
+      "status": "passing",
+      "reviewers": [
+        {
+          "id": "testpass",
+          "name": "TestPass",
+          "role": "package tests must pass before security proof is trusted",
+          "status": "passing"
+        },
+        {
+          "id": "commonsensepass",
+          "name": "CommonSensePass",
+          "role": "scope-gate and proof-claim sanity",
+          "status": "passing"
+        },
+        {
+          "id": "legalpass",
+          "name": "LegalPass",
+          "role": "safe guidance boundary and non-certification wording",
+          "status": "passing"
+        }
+      ],
+      "summary": "SecurityPass was cross-checked by TestPass, CommonSensePass, LegalPass."
+    },
     {
       "target_id": "sloppass",
       "target_name": "SlopPass",


### PR DESCRIPTION
Automated public dogfood receipt refresh from workflow run https://github.com/malamutemayhem/unclick/actions/runs/26574923933. Receipt proof: status passing, 13 passing, 0 failing, 0 blocked, 0 pending; UXPass site sweep passed 3/3 URLs with score 100.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is limited to generated public dogfood JSON; it does not change runtime code, auth, or deployment behavior.
> 
> **Overview**
> Refreshes **public dogfood receipt JSON** after the nightly workflow (replacing a dry-run / pending snapshot). **`latest.json`** moves to **passing** with source **nightly dogfood workflow**, **13 passing / 0 pending**, and per-check rows now cite real run IDs and proof kinds (live TestPass/UXPass, SEOPass dogfood score 91, XPass package/boundary sweeps, etc.) instead of `dry_run_only` or package-ready placeholders.
> 
> **`uxpass-site-sweep.json`** flips from **blocked** (missing token) to **passing** on `/`, `/dashboard`, and `/admin/you` with UX score 100. **`xpass-package-sweep.json`** and **`xpass-boundary-sweep.json`** get new run IDs, `target_sha` `ca602ea…`, full-scope package metadata, timings, and expanded cross-pass matrices.
> 
> No application or workflow logic changes in the diff—only committed artifacts under `public/dogfood/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d66afb6fffc80b03805d5306fd2fb21e0d4febd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->