### PR TITLE
ci: api/lib extensionless-import guard (PR #1047 regression) + 2026-05-28 missing-jobs sub-lane manifest

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7063,11 +7063,15 @@
     ],
     [
       "test",
-      "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run"
+      "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension"
     ],
     [
       "test:api",
       "npm run test --workspace=apps/api"
+    ],
+    [
+      "test:api-lib-esm-extension",
+      "node --test scripts/api-lib-esm-extension-guard.test.mjs"
     ],
     [
       "test:brainmap",
@@ -7182,8 +7186,8 @@
     },
     {
       "source": "package.json",
-      "hash": "bbceabab4654",
-      "bytes": 6285
+      "hash": "82100008ad1b",
+      "bytes": 6417
     },
     {
       "source": "seed/skills/agent-handoff-packet-writer.skill.md",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -30,7 +30,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/ci.yml | ab3e717a4ae9 | 1663 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | .github/workflows/continuous-improvement-watch.yml | d121a434a464 | 2358 |
-| package.json | bbceabab4654 | 6285 |
+| package.json | 82100008ad1b | 6417 |
 | seed/skills/agent-handoff-packet-writer.skill.md | f9c498e48796 | 938 |
 | seed/skills/browser-qa-tester.skill.md | b57ce8b2e63a | 1115 |
 | seed/skills/builder-implementation-packet.skill.md | 1fcda17af905 | 1276 |
@@ -1144,8 +1144,9 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | build:dev | vite build --mode development |
 | compliancepass:report | npm run build --workspace=@unclick/compliancepass && node scripts/build-compliancepass-report.mjs |
 | lint | eslint . |
-| test | npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run |
+| test | npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension |
 | test:api | npm run test --workspace=apps/api |
+| test:api-lib-esm-extension | node --test scripts/api-lib-esm-extension-guard.test.mjs |
 | test:brainmap | node --test scripts/UnClick-brainmap.test.mjs |
 | test:compliancepass-receipt | node --test scripts/enterprisepass-receipt-guard.test.mjs |
 | test:continuous-improvement-watch | node --test scripts/pinballwake-continuous-improvement-watch.test.mjs |

--- a/docs/audit/2026-05-28-missing-jobs-cowork-lane.md
+++ b/docs/audit/2026-05-28-missing-jobs-cowork-lane.md
@@ -18,23 +18,23 @@ Source documents scanned (priority order):
 - `20260525 Heartbeat Diagnosis.md`
 - `20260525 Smart Timer Spec.md`
 
-## Filed jobs (this sub-lane)
+## Filed jobs (this sub-lane, first pass)
 
 | Boardroom ID | Priority | Title | Status this PR |
 |---|---|---|---|
 | `e80c682f-87b1-492d-864a-8181c92fd34a` | urgent | api/ extensionless-import guard: regression test catching prod ESM crash class (PR #1047 lesson) | **Closed by this PR** |
 | `80b5c54a-4642-4fda-8b5d-2c5a44cd1324` | high | /api/memory-admin sustained 401s: every-minute auth/secret mismatch from unclick.world | Filed, needs Vercel-log access (Chris) |
-| `e1a51d36-6b0e-4d03-80d0-b3452e04d273` | high | CI required-check path-filter audit: api/lib-only PRs sit "expected" forever and need empty trigger commit | Filed, needs branch-protection inspect (Chris) |
+| `e1a51d36-6b0e-4d03-80d0-b3452e04d273` | high | CI required-check path-filter audit: api/lib-only PRs sit "expected" forever and need empty trigger commit | Filed, option B docs shipped as PR #1165, option A still needs branch-protection inspect (Chris) |
 | `4826943a-b643-44bb-8aa6-a8fa4e7fde24` | high | Runner honesty slice: claim-only HOLD return must say hold/action explicitly (anti-false-DONE) | Filed, blocked on safe edit of minified runner file (per handover §32 caveat) |
 | `00e07cb5-8b8d-4da6-8442-40f435135c0a` | normal | Cursor Bugbot removal: still appears as non-required PR check despite being out of operating model | Filed, GitHub-App config change (Chris) |
 | `4fa1ee98-ddaf-4f5c-b6b9-7a3815ace329` | normal | Heartbeat monitor re-scope: strictly read-only path, strip wake/post tools before re-enable | Filed, tool-grant change (Chris) |
 | `a126a9fb-fa85-45cf-bde4-03a70694529f` | normal | Triage policy for 11 stale-freed jobs from 2026-05-26 14:00Z release burst | Filed, product decision (Chris) |
 
+Subsequent passes 2-4 filed 22 additional gap jobs (12 from older Context + comments + signals scan, 8 from folder scan, 2 from code-TODO scan). Full list in the sub-lane status comments on parent audit `d2bbcce8`.
+
 ## What this PR ships
 
-This PR ships the **only** safe-tier auto-mergeable item from the list above: the **api/ extensionless-import guard** regression test (todo `e80c682f`).
-
-The other six items are correctly filed in Boardroom with full context (source citation, evidence, acceptance criteria) but each requires either Chris approval (workflow/branch-protection/tool-grant changes, GitHub-App config, product triage decisions) or sub-lane discovery work that should not happen blind under the merge gates (minified runner edit per the handover's explicit caveat).
+This PR ships the **only** safe-tier auto-mergeable item from the first pass: the **api/ extensionless-import guard** regression test (todo `e80c682f`).
 
 ## The regression guard
 
@@ -42,7 +42,7 @@ The other six items are correctly filed in Boardroom with full context (source c
 
 Walks `api/lib/` recursively, parses every non-test `.ts` / `.tsx` / `.mts` / `.cts` / `.js` / `.mjs` / `.cjs` source file for relative imports (static, dynamic, type-only, re-exports), and fails CI if any specifier lacks an explicit recognised ESM extension (`.js`, `.mjs`, `.cjs`, `.json`).
 
-Wired into CI as a 3rd guard step in `.github/workflows/ci.yml`, alongside the existing RotatePass and CompliancePass guards.
+Wired into CI by chaining into the existing `npm test` script in `package.json`. The PR-author PAT lacks `workflow` scope to add a dedicated step to `.github/workflows/ci.yml` next to the existing RotatePass and CompliancePass guards; chaining into `npm test` gives the same effective coverage because the `Tests` step is already a required check in the `Website (root package)` CI job. A future PR with workflow scope can split it out for a cleaner failure name.
 
 Includes positive and negative control tests:
 - Positive: the exact extensionless line shape that crashed PR #1047's predecessor must fail.

--- a/docs/audit/2026-05-28-missing-jobs-cowork-lane.md
+++ b/docs/audit/2026-05-28-missing-jobs-cowork-lane.md
@@ -1,0 +1,64 @@
+# 2026-05-28 Missing Jobs Audit — Cowork sub-lane
+
+**Parent audit:** Boardroom todo `d2bbcce8-62a8-4a71-9b41-ccc6185173fd` — *Git sync audit: completed coding jobs need PR or commit proof*
+
+**Sub-lane owner:** Claude Cowork (`claude-cowork-creativelead`)
+**Started:** 2026-05-28T13:10Z
+**Sister lane:** `chatgpt-codex-missing-jobs-auditor` (GitHub PR packet lane, parent audit comment `e6c179fe` at 13:01Z)
+
+## Scope
+
+This lane covers action items raised in `C:\G\UnClick\Context` handover docs and recent context bundles that were never filed as official Boardroom jobs. It is **complementary** to the GitHub PR packet lane being worked by ChatGPT-Lenovo; no scope overlap is expected.
+
+Source documents scanned (priority order):
+
+- `20260527 UnClick Detailed Handover Notes.md` (3,240 lines)
+- `20260527 UnClick_Session_Handover.md` (746 lines)
+- `20260520-20260525 Context Bundle 09.md`
+- `20260525 Heartbeat Diagnosis.md`
+- `20260525 Smart Timer Spec.md`
+
+## Filed jobs (this sub-lane)
+
+| Boardroom ID | Priority | Title | Status this PR |
+|---|---|---|---|
+| `e80c682f-87b1-492d-864a-8181c92fd34a` | urgent | api/ extensionless-import guard: regression test catching prod ESM crash class (PR #1047 lesson) | **Closed by this PR** |
+| `80b5c54a-4642-4fda-8b5d-2c5a44cd1324` | high | /api/memory-admin sustained 401s: every-minute auth/secret mismatch from unclick.world | Filed, needs Vercel-log access (Chris) |
+| `e1a51d36-6b0e-4d03-80d0-b3452e04d273` | high | CI required-check path-filter audit: api/lib-only PRs sit "expected" forever and need empty trigger commit | Filed, needs branch-protection inspect (Chris) |
+| `4826943a-b643-44bb-8aa6-a8fa4e7fde24` | high | Runner honesty slice: claim-only HOLD return must say hold/action explicitly (anti-false-DONE) | Filed, blocked on safe edit of minified runner file (per handover §32 caveat) |
+| `00e07cb5-8b8d-4da6-8442-40f435135c0a` | normal | Cursor Bugbot removal: still appears as non-required PR check despite being out of operating model | Filed, GitHub-App config change (Chris) |
+| `4fa1ee98-ddaf-4f5c-b6b9-7a3815ace329` | normal | Heartbeat monitor re-scope: strictly read-only path, strip wake/post tools before re-enable | Filed, tool-grant change (Chris) |
+| `a126a9fb-fa85-45cf-bde4-03a70694529f` | normal | Triage policy for 11 stale-freed jobs from 2026-05-26 14:00Z release burst | Filed, product decision (Chris) |
+
+## What this PR ships
+
+This PR ships the **only** safe-tier auto-mergeable item from the list above: the **api/ extensionless-import guard** regression test (todo `e80c682f`).
+
+The other six items are correctly filed in Boardroom with full context (source citation, evidence, acceptance criteria) but each requires either Chris approval (workflow/branch-protection/tool-grant changes, GitHub-App config, product triage decisions) or sub-lane discovery work that should not happen blind under the merge gates (minified runner edit per the handover's explicit caveat).
+
+## The regression guard
+
+`scripts/api-lib-esm-extension-guard.test.mjs`
+
+Walks `api/lib/` recursively, parses every non-test `.ts` / `.tsx` / `.mts` / `.cts` / `.js` / `.mjs` / `.cjs` source file for relative imports (static, dynamic, type-only, re-exports), and fails CI if any specifier lacks an explicit recognised ESM extension (`.js`, `.mjs`, `.cjs`, `.json`).
+
+Wired into CI as a 3rd guard step in `.github/workflows/ci.yml`, alongside the existing RotatePass and CompliancePass guards.
+
+Includes positive and negative control tests:
+- Positive: the exact extensionless line shape that crashed PR #1047's predecessor must fail.
+- Negative: the fixed form (`./foo.js`) must pass.
+
+## Why not action the others in this PR
+
+Per the handover (`20260527 UnClick Detailed Handover Notes.md` §81 — Safety Surfaces):
+
+> Never touch these without explicit Chris approval: secrets, API keys, passwords, billing, DNS, production deploy settings, destructive data actions, force push, hard reset, GitHub rulesets, required check bypass, canary seed close, canary flags, workflow broad execute switch.
+
+- Path-filter widening requires changing the GitHub ruleset (`16788514`).
+- Bugbot removal requires GitHub App uninstall (external).
+- Heartbeat re-scope requires tool-grant change on the scheduled task.
+- Runner honesty slice requires editing the minified `pinballwake-autonomous-runner.mjs` — handover §32 says explicitly do NOT hand-edit blind.
+- 401 investigation requires Vercel log access not available to this seat.
+- Stale-freed-jobs triage is a product decision.
+
+Each of those is now a discrete Boardroom job with full context, so the next warm seat (or Chris) can action them with a clean ScopePack.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run",
+    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension",
     "compliancepass:report": "npm run build --workspace=@unclick/compliancepass && node scripts/build-compliancepass-report.mjs",
     "test:compliancepass-receipt": "node --test scripts/enterprisepass-receipt-guard.test.mjs",
     "test:enterprisepass-receipt": "node --test scripts/enterprisepass-receipt-guard.test.mjs",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:compliancepass-receipt": "node --test scripts/enterprisepass-receipt-guard.test.mjs",
     "test:enterprisepass-receipt": "node --test scripts/enterprisepass-receipt-guard.test.mjs",
     "test:rotatepass-redaction": "node --test scripts/rotatepass-redaction-guard.test.mjs",
+    "test:api-lib-esm-extension": "node --test scripts/api-lib-esm-extension-guard.test.mjs",
     "test:watch": "vitest",
     "test:api": "npm run test --workspace=apps/api",
     "review:dry-run": "node scripts/review-dry-run.mjs",

--- a/scripts/api-lib-esm-extension-guard.test.mjs
+++ b/scripts/api-lib-esm-extension-guard.test.mjs
@@ -1,0 +1,144 @@
+// Regression guard for the PR #1047 prod ESM crash class.
+//
+// In May 2026 a one-character omission — a relative import without the `.js`
+// extension in api/lib/fishbowl-todo-open-stale-release.ts — crashed the
+// Vercel function on every 15-minute cron tick with ERR_MODULE_NOT_FOUND.
+// vitest is lenient on extensionless relative imports, so local tests passed;
+// Vercel's nodenext ESM loader is strict, so prod broke. The api/ workspace
+// has no typecheck/build gate in CI that mirrors Vercel's ESM resolution.
+//
+// This guard fails CI if any TypeScript or JavaScript source file under
+// api/lib/ contains a relative import (static or dynamic, value or type-only,
+// import or re-export) whose specifier does not carry an explicit recognised
+// extension. Test files (`*.test.ts`) are excluded — they run under vitest,
+// not Vercel.
+//
+// If a future fix legitimately needs a non-`.js` extension (e.g. `.json`,
+// `.mjs`, `.cjs`), add it to ALLOWED_EXTENSIONS below with a comment
+// explaining why.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const scanRoot = path.join(repoRoot, "api", "lib");
+
+// Files of these extensions are scanned as source.
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"]);
+
+// Allowed extensions for relative import specifiers. `.js` is the canonical
+// target for `.ts` source under nodenext. Add new ones here with a note.
+const ALLOWED_EXTENSIONS = new Set([".js", ".mjs", ".cjs", ".json"]);
+
+// Test/spec files are not loaded by Vercel — they run under vitest in CI.
+function isTestFile(relativePath) {
+  return /\.test\.[mc]?[jt]sx?$/i.test(relativePath);
+}
+
+function walkSourceFiles(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "node_modules") continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkSourceFiles(fullPath, out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) continue;
+    const relativePath = path.relative(repoRoot, fullPath);
+    if (isTestFile(relativePath)) continue;
+    out.push({ fullPath, relativePath });
+  }
+  return out;
+}
+
+// Matches the relative-import shapes that compile to runtime imports:
+//   import ... from "./..." or '../...'
+//   import "./..."
+//   import type ... from "./..."
+//   export ... from "./..."
+//   export * from "./..."
+//   import("./...")  (dynamic)
+// Captures the specifier in group 2 (group 1 is the quote).
+const RELATIVE_IMPORT_PATTERNS = [
+  /\bfrom\s+(["'])(\.{1,2}\/[^"']+)\1/g,
+  /\bimport\s+(["'])(\.{1,2}\/[^"']+)\1/g,
+  /\bimport\s*\(\s*(["'])(\.{1,2}\/[^"']+)\1\s*\)/g,
+];
+
+function lineForOffset(content, offset) {
+  return content.slice(0, offset).split(/\r?\n/).length;
+}
+
+function findRelativeImports(content) {
+  const hits = [];
+  for (const pattern of RELATIVE_IMPORT_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of content.matchAll(pattern)) {
+      const specifier = match[2];
+      const offset = match.index ?? 0;
+      hits.push({ specifier, offset });
+    }
+  }
+  return hits;
+}
+
+function stripQueryAndFragment(specifier) {
+  return specifier.split("?")[0].split("#")[0];
+}
+
+function hasAllowedExtension(specifier) {
+  const ext = path.extname(stripQueryAndFragment(specifier)).toLowerCase();
+  return ALLOWED_EXTENSIONS.has(ext);
+}
+
+test("guard regex catches the historical .js-omission bug shape", () => {
+  // Positive control: this is exactly the line shape that crashed prod in #1047.
+  const sample = `import {
+  classifyTodoActionability,
+  type TodoActionability,
+} from "./fishbowl-todo-actionability";`;
+  const hits = findRelativeImports(sample);
+  assert.equal(hits.length, 1, "expected exactly one relative import");
+  assert.equal(hits[0].specifier, "./fishbowl-todo-actionability");
+  assert.equal(hasAllowedExtension(hits[0].specifier), false, "missing .js must be rejected");
+
+  // Negative control: the fixed form must pass.
+  const fixedSample = `import { x } from "./fishbowl-todo-actionability.js";`;
+  const fixedHits = findRelativeImports(fixedSample);
+  assert.equal(fixedHits.length, 1);
+  assert.equal(hasAllowedExtension(fixedHits[0].specifier), true);
+});
+
+test("api/lib relative imports all carry an explicit ESM extension", () => {
+  const files = walkSourceFiles(scanRoot);
+  assert.ok(files.length > 0, `expected source files under ${path.relative(repoRoot, scanRoot)}`);
+
+  const offenders = [];
+  for (const { fullPath, relativePath } of files) {
+    const content = fs.readFileSync(fullPath, "utf8");
+    for (const { specifier, offset } of findRelativeImports(content)) {
+      if (hasAllowedExtension(specifier)) continue;
+      const line = lineForOffset(content, offset);
+      offenders.push(`${relativePath}:${line} import "${specifier}" missing .js`);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    [
+      "Found relative imports in api/lib/ without an explicit .js extension.",
+      "Vercel's nodenext ESM loader will reject these at runtime with ERR_MODULE_NOT_FOUND",
+      "(see PR #1047). Add the .js extension to each specifier:",
+      ...offenders,
+    ].join("\n"),
+  );
+});


### PR DESCRIPTION
## What

Two changes from the 2026-05-28 **missing-jobs audit Cowork sub-lane** (parent Boardroom todo `d2bbcce8`, complementary to ChatGPT-Lenovo's GitHub PR packet lane):

1. **`scripts/api-lib-esm-extension-guard.test.mjs`** — Node test that fails CI if any source file under `api/lib/` has a relative import missing the `.js` ESM extension. This is the exact bug class that crashed prod in PR #1047 (one missing `.js` in `fishbowl-todo-open-stale-release.ts` → `ERR_MODULE_NOT_FOUND` on every 15-min Vercel cron tick). Vitest is lenient, Vercel's nodenext loader is strict, and the `api/` workspace has no typecheck gate that mirrors Vercel ESM. Now it does.
2. **`docs/audit/2026-05-28-missing-jobs-cowork-lane.md`** — manifest for the 7 Boardroom gap jobs filed under parent audit `d2bbcce8`, with status of each (1 closed by this PR, 6 filed-but-need-Chris-approval).

## How

Pattern matches the existing `scripts/rotatepass-redaction-guard.test.mjs` and `scripts/enterprisepass-receipt-guard.test.mjs` — `node:test` + `node:assert`, single `.mjs` file, wired into `package.json` as `test:api-lib-esm-extension`.

Chained into the existing `npm test` script (rather than added as a new `ci.yml` step) because the PR-author PAT lacks `workflow` scope. Coverage is equivalent: `Tests` is already a required step in the `Website (root package)` CI job, so the guard runs there. If a future PR gains workflow scope, splitting it into its own step alongside `RotatePass redaction guard` / `CompliancePass receipt guard` would give a cleaner failure name — non-blocking.

## Verification

- `npm run test:api-lib-esm-extension` passes locally against current `main`: 2 tests pass (positive control catches the historical extensionless shape, negative control accepts the fixed `.js` form, real scan of `api/lib/` finds zero offenders).
- Includes a **positive control** test that asserts the exact extensionless line shape from PR #1047 fails the guard regex — so the guard can never silently break.
- Includes a **negative control** test that the fixed `./foo.js` form passes — so the guard isn't over-strict.
- Dead-code addition only: the new file is a test, nothing in `api/`, `apps/`, or `packages/` imports it.

## Why now

From `20260527 UnClick_Session_Handover.md` §17 (lessons learned):

> The `.js` ESM crash: a one-character omission (extensionless relative import) passed all local vitest tests but **HARD-CRASHED the production watcher on every run for hours**. Root cause amplifier: the `api/` workspace has no typecheck/build gate in CI. We even saw the "extensionless-import warning" earlier and underweighted it. **LESSON: every relative import in non-test source MUST carry `.js`; add an ESM-resolution/typecheck gate; treat such warnings as potential prod-crashers.**

This PR is the "add an ESM-resolution gate" half of that lesson.

## Boardroom jobs

**Closes:** `e80c682f-87b1-492d-864a-8181c92fd34a` (urgent — *api/ extensionless-import guard*).

**Filed in the same sub-lane (full context in each Boardroom description, see docs file for the table):**

- `80b5c54a` high — /api/memory-admin sustained 401s
- `e1a51d36` high — CI required-check path-filter audit
- `4826943a` high — Runner honesty slice
- `00e07cb5` normal — Cursor Bugbot removal
- `4fa1ee98` normal — Heartbeat monitor re-scope
- `a126a9fb` normal — Triage policy for 11 stale-freed jobs

Each of those needs either Chris approval (workflow/branch-protection/tool-grant change, GitHub App config, product decision) or sub-lane work that violates the handover's explicit "do NOT hand-edit blind" caveats, so they're parked as full-context Boardroom jobs for the next warm seat.

## Coordination

Sister lane: `chatgpt-codex-missing-jobs-auditor` (working the GitHub PR packet lane — finding PR-specific action packets that exist as Boardroom messages or GitHub state but not as official Boardroom jobs). See parent audit comment `e6c179fe` (2026-05-28T13:01Z) and Cowork sub-lane claim comment `a8fe970c` (2026-05-28T13:04Z). No scope overlap expected.

🤖 Generated by Claude Cowork (Lenovo seat) for the 2026-05-28 missing-jobs audit. Parent audit: `d2bbcce8`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI guard and documentation; no runtime or api/lib source behavior changes in this diff.
> 
> **Overview**
> Adds a **CI regression guard** for extensionless relative imports under `api/lib/`, addressing the prod `ERR_MODULE_NOT_FOUND` class from PR #1047 that vitest did not catch but Vercel’s nodenext ESM loader does.
> 
> The new `scripts/api-lib-esm-extension-guard.test.mjs` walks non-test source files, flags relative `import`/`export`/`import()` specifiers without an allowed extension (`.js`, `.mjs`, `.cjs`, `.json`), and includes positive/negative controls tied to the historical bug shape. It is exposed as `npm run test:api-lib-esm-extension` and **chained into the root `npm test`** script so the existing required **Tests** CI step runs it (no separate workflow step in this PR).
> 
> Also adds **`docs/audit/2026-05-28-missing-jobs-cowork-lane.md`**, documenting the Cowork sub-lane audit: one urgent item closed by this guard, plus other gap jobs left for Chris or follow-up. Generated brainmap docs reflect the new script entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f93e0d3ff1a581541f890ee59a5d6a7782a4aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->