### PR TITLE
fix(admin): keep jobs visible when profile claim stalls

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7298,8 +7298,8 @@
     },
     {
       "source": "src/pages/admin/AdminJobs.tsx",
-      "hash": "d4782e020bb5",
-      "bytes": 59940
+      "hash": "ea5ff201abd2",
+      "bytes": 60846
     },
     {
       "source": "src/pages/admin/AdminJobsmith.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -68,7 +68,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/crews/CrewsSettings.tsx | 9a2037783312 | 889 |
 | src/pages/admin/crews/CrewsCatalog.tsx | 089b6c00af2e | 5949 |
 | src/pages/admin/AdminDashboard.tsx | 437a146a3d78 | 5259 |
-| src/pages/admin/AdminJobs.tsx | d4782e020bb5 | 59940 |
+| src/pages/admin/AdminJobs.tsx | ea5ff201abd2 | 60846 |
 | src/pages/admin/AdminJobsmith.tsx | 34ba72c04cb2 | 54660 |
 | src/pages/admin/AdminKeychain.tsx | 0c355d737922 | 77124 |
 | src/pages/admin/AdminMemory.tsx | f001b0a54b31 | 9731 |

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,12 +3,37 @@ import { createClient } from "@supabase/supabase-js";
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
+type SupabaseAuthLock = <R>(
+  name: string,
+  acquireTimeout: number,
+  fn: () => Promise<R>,
+) => Promise<R>;
+
+let browserAuthLockTail = Promise.resolve();
+
+const browserLocalAuthLock: SupabaseAuthLock = async (_name, _acquireTimeout, fn) => {
+  const run = browserAuthLockTail.then(fn, fn);
+  browserAuthLockTail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+};
+
 // Fall back to harmless placeholders so the module doesn't throw at load time
 // on preview deploys that don't have the env vars set. Any runtime call will
 // still fail, but it'll fail where it can be caught instead of blanking the app.
 export const supabase = createClient(
   supabaseUrl || "https://placeholder.supabase.co",
   supabaseAnonKey || "placeholder-anon-key",
+  {
+    auth: {
+      // The admin app is a single-page control room. A local queue avoids the
+      // browser Web Locks path that can leave gotrue auth locked after React
+      // Strict Mode remounts, while still serialising auth calls in this tab.
+      lock: browserLocalAuthLock,
+    },
+  },
 );
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -225,4 +225,29 @@ describe("AdminJobs", () => {
     expect(JOBS_REFRESH_INTERVAL_MS).toBe(60_000);
     expect(screen.getByText("Refreshes every 60s")).toBeInTheDocument();
   });
+
+  it("loads jobs with a safe read identity when the admin profile claim fails", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("fishbowl_admin_claim")) {
+        return Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ error: "claim unavailable" }),
+        } as Response);
+      }
+      if (url.includes("fishbowl_list_todos")) {
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          agent_id: "admin-jobs-ui",
+          include_description: true,
+        });
+        return jsonResponse({ todos: currentJobs });
+      }
+      return jsonResponse({});
+    });
+
+    render(React.createElement(AdminJobs));
+
+    expect(await screen.findByText("Alpha ready job")).toBeInTheDocument();
+    expect(screen.getByText("Jobs are visible, but posting comments is waiting for the admin profile.")).toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -90,6 +90,7 @@ const JOBS_REFRESH_LABEL = `${Math.round(JOBS_REFRESH_INTERVAL_MS / 1000)}s`;
 // `before_created_at` cursor until exhausted.
 const COMPLETED_INITIAL_VISIBLE = 50;
 const COMPLETED_PAGE_SIZE = 100;
+const ADMIN_JOBS_READ_AGENT_ID = "admin-jobs-ui";
 const EMPTY_MANUAL_ORDER: ManualOrder = {
   active: [],
   next: [],
@@ -1188,14 +1189,22 @@ export default function AdminJobs() {
   const [loading, setLoading] = useState(false);
   const [firstLoadDone, setFirstLoadDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [profileClaimError, setProfileClaimError] = useState<string | null>(null);
   const [pollSeq, setPollSeq] = useState(0);
   const [manualOrder, setManualOrder] = useState<ManualOrder>(() => loadManualOrder());
   const [sectionPrefs, setSectionPrefs] = useState<SectionPreferences>(() => loadSectionPreferences());
   const [searchQuery, setSearchQuery] = useState("");
+  const jobsReadAgentId = humanAgentId ?? (token ? ADMIN_JOBS_READ_AGENT_ID : null);
 
   useEffect(() => {
-    if (!token) return;
+    if (!token) {
+      setHumanAgentId(null);
+      setProfileClaimError(null);
+      return;
+    }
     let cancelled = false;
+    setHumanAgentId(null);
+    setProfileClaimError(null);
 
     async function claim() {
       try {
@@ -1206,12 +1215,19 @@ export default function AdminJobs() {
         });
         const body = (await res.json().catch(() => ({}))) as {
           profile?: FishbowlProfile;
+          error?: string;
         };
         if (!cancelled && res.ok && body.profile) {
           setHumanAgentId(body.profile.agent_id);
+          setProfileClaimError(null);
+        } else if (!cancelled) {
+          setProfileClaimError(body.error ?? "Admin profile claim failed");
         }
       } catch {
-        if (!cancelled) setHumanAgentId(null);
+        if (!cancelled) {
+          setHumanAgentId(null);
+          setProfileClaimError("Admin profile claim failed");
+        }
       }
     }
 
@@ -1222,7 +1238,7 @@ export default function AdminJobs() {
   }, [authHeader, token]);
 
   useEffect(() => {
-    if (!humanAgentId) return;
+    if (!jobsReadAgentId) return;
     let cancelled = false;
 
     async function loadJobs() {
@@ -1232,7 +1248,7 @@ export default function AdminJobs() {
           method: "POST",
           headers: { ...authHeader, "Content-Type": "application/json" },
           body: JSON.stringify({
-            agent_id: humanAgentId,
+            agent_id: jobsReadAgentId,
             include_description: true,
             limit: 200,
           }),
@@ -1265,7 +1281,7 @@ export default function AdminJobs() {
       cancelled = true;
       clearInterval(id);
     };
-  }, [authHeader, humanAgentId]);
+  }, [authHeader, jobsReadAgentId]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1357,7 +1373,7 @@ export default function AdminJobs() {
   // the visible count on the client via SectionPreferences. When server
   // cursor support lands, this becomes a paged loop.
   const fetchCompletedBatch = useCallback(async () => {
-    if (!humanAgentId) return;
+    if (!jobsReadAgentId) return;
     setCompletedHistoryLoading(true);
     try {
       const requestLimit = 200;
@@ -1365,7 +1381,7 @@ export default function AdminJobs() {
         method: "POST",
         headers: { ...authHeader, "Content-Type": "application/json" },
         body: JSON.stringify({
-          agent_id: humanAgentId,
+          agent_id: jobsReadAgentId,
           include_description: true,
           status: "done",
           limit: requestLimit,
@@ -1386,19 +1402,19 @@ export default function AdminJobs() {
     } finally {
       setCompletedHistoryLoading(false);
     }
-  }, [authHeader, humanAgentId]);
+  }, [authHeader, jobsReadAgentId]);
 
   // Auto-load the first batch as soon as the agent id is known. Replaces the
   // old "Show completed history" first-click gate; users now see the last
   // 50 completed without any extra action.
   useEffect(() => {
-    if (!humanAgentId) return;
+    if (!jobsReadAgentId) return;
     if (completedHistoryLoaded || completedHistoryLoading) return;
     void fetchCompletedBatch();
-  }, [humanAgentId, completedHistoryLoaded, completedHistoryLoading, fetchCompletedBatch]);
+  }, [jobsReadAgentId, completedHistoryLoaded, completedHistoryLoading, fetchCompletedBatch]);
 
   const loadCompletedHistory = async () => {
-    if (!humanAgentId || completedHistoryLoading) return;
+    if (!jobsReadAgentId || completedHistoryLoading) return;
     if (!completedHistoryLoaded) {
       // Edge case: button clicked before the auto-load finished.
       await fetchCompletedBatch();
@@ -1466,6 +1482,12 @@ export default function AdminJobs() {
       {error && (
         <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
           {error}
+        </div>
+      )}
+
+      {profileClaimError && firstLoadDone && (
+        <div className="rounded-lg border border-[#E2B93B]/25 bg-[#E2B93B]/10 px-4 py-3 text-sm text-[#F6D773]">
+          Jobs are visible, but posting comments is waiting for the admin profile.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Boardroom Job: e7742286-e4be-4f01-a624-0601f79fc272

Fixes the Jobs admin 0/0/0 failure mode from the missing-jobs reconciliation pass:

- adds a browser-local Supabase auth lock queue so the admin app does not rely on the browser Web Locks path that can stall after React Strict Mode remounts
- lets `/admin/jobs` read the Jobs board with a safe non-human read identity when the human admin profile claim fails or stalls
- leaves posting/commenting gated on the real human profile, with a visible warning instead of a silent empty board
- adds a regression test proving Jobs still render when `fishbowl_admin_claim` fails
- refreshes BrainMap generated artifacts

## Proof

- `npm exec vitest run src/pages/admin/AdminJobs.test.tsx` passed, 7 tests
- `npm run build` passed
- `npm run brainmap:check` passed after regenerating BrainMap
- `git diff --check` passed

Cursor Bugbot/Bugbot is ignored per UnClick standing rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to admin Jobs UI, Supabase client auth locking, and read-only fallback identity; comment posting stays on the human profile.
> 
> **Overview**
> Fixes the **Jobs** admin board showing **0/0/0** when the human Fishbowl profile claim fails or auth stalls.
> 
> **Supabase** now uses a **tab-local auth lock queue** instead of the browser Web Locks path that could leave GoTrue locked after React Strict Mode remounts.
> 
> **`/admin/jobs`** loads todos with a fallback read identity (`admin-jobs-ui`) whenever a session token exists but `fishbowl_admin_claim` does not succeed; list polling and completed-history fetches use that same read id. **Comments** still require the real human `agent_id`, and a **warning banner** explains that gap after the first load. A **Vitest** case asserts jobs still render when the claim API fails; BrainMap generated docs were refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa98ad524aa6e7609529090a9f0a946a4e69798b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->