### PR TITLE
docs: record required CI check unstick path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+## Required CI Checks
+
+The main merge rail is GitHub ruleset `16788514`. It requires the `Website (root package)` and `MCP server package` checks from `.github/workflows/ci.yml`.
+
+Those jobs intentionally run on every pull request. If GitHub leaves either required check in `Expected` after a narrow change, do not bypass the rule. First confirm `.github/workflows/ci.yml` still has an unfiltered `pull_request` trigger. If the workflow is unfiltered, push an empty trigger commit to the pull request branch so GitHub re-evaluates the required checks:
+
+```bash
+git commit --allow-empty -m "chore: trigger required checks"
+git push
+```
+
+If a workflow path filter is reintroduced later, it must include every path that can affect either required job, including `api/**`, `.github/workflows/ci.yml`, `package.json`, `package-lock.json`, `packages/**`, `scripts/**`, and `src/**`.


### PR DESCRIPTION
Boardroom Job: e1a51d36-6b0e-4d03-80d0-b3452e04d273

## Summary
- Confirms the current merge rail source: ruleset 16788514 requires the CI jobs from `.github/workflows/ci.yml`.
- Documents the safe empty-trigger commit unstick when GitHub leaves a required check in `Expected` even though the workflow is unfiltered.
- Lists the paths that must be included if workflow path filters are reintroduced later.

## Proof
- Verified `.github/workflows/ci.yml` has an unfiltered `pull_request` trigger.
- Verified GitHub ruleset 16788514 requires only `Website (root package)` and `MCP server package`.
- Docs-only change; no runtime tests required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or workflow behavior impact.
> 
> **Overview**
> Adds **`CONTRIBUTING.md`** so contributors know how merge gating works and how to recover when GitHub stalls required checks.
> 
> It states that ruleset **16788514** requires **`Website (root package)`** and **`MCP server package`** from **`.github/workflows/ci.yml`**, that those jobs are meant to run on every PR, and that you should not bypass the rule if a check stays in **Expected**. The doc tells you to confirm the workflow still has an unfiltered **`pull_request`** trigger, then use an empty commit (`chore: trigger required checks`) to force re-evaluation.
> 
> It also notes that if path filters return to CI, they must cover paths that can affect those jobs (`api/**`, workflow file, lockfiles, `packages/**`, `scripts/**`, `src/**`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f9953883f7fd12af33d343d990b58f17a02dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->