### PR TITLE
feat(sloppass): detect stale overwrite risk

### DIFF
--- a/packages/sloppass/README.md
+++ b/packages/sloppass/README.md
@@ -10,6 +10,7 @@ This package is a deliberately small promptfoo-derived engine. It keeps the usef
 - report surface
 - a small provider set
 - unified-diff input with file and line evidence
+- optional 3-way git context for stale-checkout overwrite detection
 - markdown build-fix prompts an agent can paste back into its work loop
 - supply-chain and security-bypass review triggers for generated code that added dependency, package-hook, or transport-risk surface
 

--- a/packages/sloppass/src/__tests__/schema.test.ts
+++ b/packages/sloppass/src/__tests__/schema.test.ts
@@ -13,7 +13,7 @@ describe("SlopPass run schema", () => {
     expect(parsed.target.label).toBe("source sample");
   });
 
-  it("keeps the six PRD categories as built-in checks", () => {
+  it("keeps the seven PRD categories as built-in checks", () => {
     expect(DEFAULT_CHECKS).toEqual([
       "grounding_api_reality",
       "logic_plausibility",
@@ -21,6 +21,7 @@ describe("SlopPass run schema", () => {
       "test_proof_theatre",
       "slopocalypse_failure_mode",
       "maintenance_change_risk",
+      "vcs_integration_risk",
     ]);
   });
 
@@ -40,7 +41,27 @@ describe("SlopPass run schema", () => {
     expect(parsed.provider).toBe("http");
   });
 
-  it("rejects a run without files or diff", () => {
+  it("accepts git_context as a review source", () => {
+    const parsed = SlopPassRunInputSchema.parse({
+      target: { kind: "pr", label: "PR 123", ref: "123" },
+      git_context: {
+        base_sha: "base",
+        head_sha: "head",
+        files: {
+          "src/example.ts": {
+            base_blob: "export const before = true;",
+            main_blob: "export const current = true;",
+            pr_head_blob: "export const before = true;",
+          },
+        },
+      },
+      checks: ["vcs_integration_risk"],
+    });
+
+    expect(parsed.git_context?.files["src/example.ts"].main_blob).toContain("current");
+  });
+
+  it("rejects a run without files, diff, or git_context", () => {
     expect(() =>
       SlopPassRunInputSchema.parse({
         target: { kind: "files", label: "empty" },
@@ -117,5 +138,48 @@ describe("SlopPass run schema", () => {
 
     expect(parsed.verdict).toBe("warn");
     expect(parsed.scope.provider).toBe("provided-source");
+  });
+
+  it("validates cross-branch evidence on findings", () => {
+    const parsed = SlopPassResultSchema.parse({
+      target: { kind: "pr", label: "PR 123", ref: "123" },
+      scope: {
+        checks_attempted: ["vcs_integration_risk"],
+        files_reviewed: ["src/example.ts"],
+        provider: "http",
+      },
+      verdict: "fail",
+      findings: [
+        {
+          title: "Current main lines are missing from the PR head",
+          category: "vcs_integration_risk",
+          severity: "critical",
+          why_it_matters: "A clean textual merge can still erase current main work.",
+          evidence: "src/example.ts:2 exists in current main but not in the PR head.",
+          suggested_fix: "Rebase current main and preserve the missing line.",
+          file: "src/example.ts",
+          line: 2,
+          cross_branch_evidence: {
+            base_sha: "base",
+            head_sha: "head",
+            file: "src/example.ts",
+            line_range: [2, 2],
+          },
+        },
+      ],
+      not_checked: [],
+      summary: {
+        posture: "Scoped static review completed.",
+        counts_by_severity: { critical: 1, high: 0, medium: 0, low: 0, info: 0 },
+        coverage_note: "Only provided source files were inspected.",
+      },
+      disclaimer: {
+        headline: "Scoped review only",
+        body: "Human review is still required.",
+        compact: "Scoped review only.",
+      },
+    });
+
+    expect(parsed.findings[0].cross_branch_evidence?.line_range).toEqual([2, 2]);
   });
 });

--- a/packages/sloppass/src/__tests__/stale-overwrite.test.ts
+++ b/packages/sloppass/src/__tests__/stale-overwrite.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { detectStaleOverwrites } from "../lenses/stale-overwrite.js";
+import { runSlopPass } from "../runner/index.js";
+
+const contextFor = (overrides: {
+  base_blob?: string;
+  main_blob?: string;
+  pr_head_blob?: string;
+} = {}) => ({
+  base_sha: "base-sha",
+  head_sha: "head-sha",
+  files: {
+    "src/routes.ts": {
+      base_blob: [
+        "export const routes = [",
+        "  '/admin',",
+        "];",
+      ].join("\n"),
+      main_blob: [
+        "export const routes = [",
+        "  '/admin',",
+        "  '/jobsmith',",
+        "  '/draftroom',",
+        "];",
+      ].join("\n"),
+      pr_head_blob: [
+        "export const routes = [",
+        "  '/admin',",
+        "];",
+      ].join("\n"),
+      ...overrides,
+    },
+  },
+});
+
+describe("stale-overwrite lens", () => {
+  it("does not report when the PR head preserves current main lines", () => {
+    const findings = detectStaleOverwrites(
+      contextFor({
+        pr_head_blob: [
+          "export const routes = [",
+          "  '/admin',",
+          "  '/jobsmith',",
+          "  '/draftroom',",
+          "];",
+        ].join("\n"),
+      }),
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it("reports main-only lines missing from the PR head", () => {
+    const findings = detectStaleOverwrites(contextFor());
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      category: "vcs_integration_risk",
+      severity: "critical",
+      file: "src/routes.ts",
+      line: 3,
+      cross_branch_evidence: {
+        base_sha: "base-sha",
+        head_sha: "head-sha",
+        file: "src/routes.ts",
+        line_range: [3, 4],
+      },
+    });
+    expect(findings[0].evidence).toContain("'/jobsmith'");
+    expect(findings[0].evidence).toContain("'/draftroom'");
+  });
+
+  it("emits not_checked when git_context is absent", async () => {
+    const result = await runSlopPass({
+      target: { kind: "files", label: "plain source", files: ["src/plain.ts"] },
+      files: [{ path: "src/plain.ts", content: "export const ok = true;" }],
+      checks: ["vcs_integration_risk"],
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(result.scope.checks_attempted).toEqual([]);
+    expect(result.verdict).toBe("unknown");
+    expect(result.not_checked).toContainEqual({
+      label: "stale-overwrite-detector",
+      reason: "git_context not provided in SlopPassRunInput.",
+    });
+  });
+
+  it("runs through SlopPass with git_context and returns a blocking finding", async () => {
+    const result = await runSlopPass({
+      target: { kind: "pr", label: "PR 123", ref: "123" },
+      git_context: contextFor(),
+      checks: ["vcs_integration_risk"],
+    });
+
+    expect(result.scope.files_reviewed).toEqual(["src/routes.ts"]);
+    expect(result.findings).toHaveLength(1);
+    expect(result.verdict).toBe("fail");
+    expect(result.summary.counts_by_severity.critical).toBe(1);
+  });
+});

--- a/packages/sloppass/src/__tests__/verdict-pack.test.ts
+++ b/packages/sloppass/src/__tests__/verdict-pack.test.ts
@@ -99,6 +99,21 @@ describe("SlopPass verdict pack", () => {
     expect(pack.scope.provider).toBe("provided-source");
   });
 
+  it("does not turn a git-context-only request green when only source was provided", () => {
+    const pack = createProvidedSourceSlopPassReport({
+      target: { kind: "files", label: "stale overwrite", files: ["src/routes.ts"] },
+      files: [{ path: "src/routes.ts", content: "export const ok = true;" }],
+      checks: ["vcs_integration_risk"],
+    });
+
+    expect(pack.scope.checks_attempted).toEqual([]);
+    expect(pack.verdict).toBe("unknown");
+    expect(pack.not_checked).toContainEqual({
+      label: "stale-overwrite-detector",
+      reason: "git_context not provided for this provided-source run.",
+    });
+  });
+
   it("keeps secret-looking provided-source evidence redacted", () => {
     const pack = createProvidedSourceSlopPassReport({
       target: { kind: "files", label: "secret source", files: ["src/config.ts"] },

--- a/packages/sloppass/src/categories.ts
+++ b/packages/sloppass/src/categories.ts
@@ -7,6 +7,7 @@ export const SLOPPASS_CATEGORIES: Record<SlopPassCategory, string> = {
   test_proof_theatre: "Test and proof theatre",
   slopocalypse_failure_mode: "Karpathy-style slopocalypse failure modes",
   maintenance_change_risk: "Maintenance and change-risk signals",
+  vcs_integration_risk: "Version-control integration risk",
 };
 
 export const DEFAULT_CHECKS = Object.keys(SLOPPASS_CATEGORIES) as SlopPassCategory[];

--- a/packages/sloppass/src/index.ts
+++ b/packages/sloppass/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./categories.js";
 export * from "./disclaimer.js";
 export * from "./diff.js";
+export * from "./lenses/stale-overwrite.js";
 export * from "./reporter.js";
 export * from "./runner/index.js";
 export * from "./schema.js";

--- a/packages/sloppass/src/lenses/stale-overwrite.ts
+++ b/packages/sloppass/src/lenses/stale-overwrite.ts
@@ -1,0 +1,85 @@
+import type { SlopPassFinding, SlopPassGitContext } from "../types.js";
+
+interface LineEntry {
+  number: number;
+  text: string;
+  key: string;
+}
+
+function splitLines(blob: string): LineEntry[] {
+  return blob.replace(/\r\n/g, "\n").split("\n").map((text, index) => ({
+    number: index + 1,
+    text,
+    key: text.trim(),
+  }));
+}
+
+function comparableLineSet(blob: string): Set<string> {
+  return new Set(
+    splitLines(blob)
+      .map((line) => line.key)
+      .filter(Boolean),
+  );
+}
+
+function groupContiguous(lines: LineEntry[]): LineEntry[][] {
+  const groups: LineEntry[][] = [];
+  for (const line of lines) {
+    const current = groups[groups.length - 1];
+    const previous = current?.[current.length - 1];
+    if (current && previous && line.number === previous.number + 1) {
+      current.push(line);
+    } else {
+      groups.push([line]);
+    }
+  }
+  return groups;
+}
+
+function evidenceSnippet(lines: LineEntry[]): string {
+  const shown = lines.slice(0, 8).map((line) => line.text.trimEnd());
+  const suffix = lines.length > shown.length ? `\n... plus ${lines.length - shown.length} more line(s)` : "";
+  return `${shown.join("\n")}${suffix}`;
+}
+
+export function detectStaleOverwrites(gitContext: SlopPassGitContext): SlopPassFinding[] {
+  const findings: SlopPassFinding[] = [];
+
+  for (const [file, blobs] of Object.entries(gitContext.files)) {
+    const baseLines = comparableLineSet(blobs.base_blob);
+    const prHeadLines = comparableLineSet(blobs.pr_head_blob);
+    const missingMainOnlyLines = splitLines(blobs.main_blob).filter(
+      (line) => line.key && !baseLines.has(line.key) && !prHeadLines.has(line.key),
+    );
+
+    for (const group of groupContiguous(missingMainOnlyLines)) {
+      const first = group[0];
+      const last = group[group.length - 1];
+      const range = `${first.number}${first.number === last.number ? "" : `-${last.number}`}`;
+      const snippet = evidenceSnippet(group);
+
+      findings.push({
+        title: "Current main lines are missing from the PR head",
+        category: "vcs_integration_risk",
+        severity: "critical",
+        why_it_matters:
+          "The PR appears to start from an older file version and would drop lines that landed on main after the PR base. A clean textual merge can still erase current work.",
+        evidence: `${file}:${range} exists in current main but not in the PR base or PR head:\n${snippet}`,
+        suggested_fix:
+          "Rebase or merge current main, preserve these lines intentionally, then rerun SlopPass with fresh git_context.",
+        confidence_note:
+          "Deterministic 3-way line comparison. It catches missing main-only lines but still needs human review for intentional rewrites.",
+        file,
+        line: first.number,
+        cross_branch_evidence: {
+          base_sha: gitContext.base_sha,
+          head_sha: gitContext.head_sha,
+          file,
+          line_range: [first.number, last.number],
+        },
+      });
+    }
+  }
+
+  return findings;
+}

--- a/packages/sloppass/src/runner/index.ts
+++ b/packages/sloppass/src/runner/index.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CHECKS } from "../categories.js";
 import { SLOPPASS_DISCLAIMER } from "../disclaimer.js";
 import { sourceFilesFromUnifiedDiff } from "../diff.js";
+import { detectStaleOverwrites } from "../lenses/stale-overwrite.js";
 import { SlopPassRunInputSchema, type SlopPassRunInput } from "../schema.js";
 import type { SlopPassResult, SlopPassSeverity } from "../types.js";
 import { detectSlopSignals } from "./detectors.js";
@@ -20,6 +21,14 @@ function reviewableFiles(files: NonNullable<SlopPassRunInput["files"]> | undefin
 function sourceFilesFor(parsed: ReturnType<typeof SlopPassRunInputSchema.parse>) {
   const files = reviewableFiles(parsed.files);
   if (files.length > 0) return files;
+  if (parsed.git_context) {
+    return Object.entries(parsed.git_context.files)
+      .filter(([, blobs]) => blobs.pr_head_blob.trim().length > 0)
+      .map(([path, blobs]) => ({
+        path,
+        content: blobs.pr_head_blob,
+      }));
+  }
   return sourceFilesFromUnifiedDiff(parsed.diff ?? "");
 }
 
@@ -30,16 +39,25 @@ function uniquePaths(files: Array<{ path: string }>): string[] {
 export async function runSlopPass(input: SlopPassRunInput): Promise<SlopPassResult> {
   const parsed = SlopPassRunInputSchema.parse(input);
   const checks = parsed.checks ?? DEFAULT_CHECKS;
+  const wantsStaleOverwrite = checks.includes("vcs_integration_risk");
+  const sourceChecks = checks.filter((check) => check !== "vcs_integration_risk");
+  const attemptedChecks = checks.filter((check) =>
+    check !== "vcs_integration_risk" || Boolean(parsed.git_context)
+  );
   const files = sourceFilesFor(parsed);
   if (files.length === 0) {
     throw new Error("SlopPass could not find any added source lines in the provided diff.");
   }
   const provider = getProvider(parsed.provider);
-  const providerFindings = await provider.evaluate(files, checks);
+  const providerFindings = await provider.evaluate(files, sourceChecks);
   const heuristicFindings = detectSlopSignals(files).filter((finding) =>
-    checks.includes(finding.category)
+    sourceChecks.includes(finding.category)
   );
-  const findings = [...providerFindings, ...heuristicFindings];
+  const staleOverwriteFindings =
+    parsed.git_context && wantsStaleOverwrite
+      ? detectStaleOverwrites(parsed.git_context)
+      : [];
+  const findings = [...providerFindings, ...heuristicFindings, ...staleOverwriteFindings];
   const counts = emptyCounts();
   for (const finding of findings) counts[finding.severity]++;
 
@@ -48,22 +66,31 @@ export async function runSlopPass(input: SlopPassRunInput): Promise<SlopPassResu
     label: category,
     reason: "Check was not requested for this scoped run.",
   }));
+  if (wantsStaleOverwrite && !parsed.git_context) {
+    notChecked.push({
+      label: "stale-overwrite-detector",
+      reason: "git_context not provided in SlopPassRunInput.",
+    });
+  }
 
   const hasSerious = SEVERITIES.slice(0, 3).some((severity) => counts[severity] > 0);
+  const noAttemptedChecks = attemptedChecks.length === 0;
   return {
     target: parsed.target,
     scope: {
-      checks_attempted: checks,
+      checks_attempted: attemptedChecks,
       files_reviewed: uniquePaths(files),
       provider: provider.id,
     },
-    verdict: toSlopPassVerdict(counts),
+    verdict: noAttemptedChecks ? "unknown" : toSlopPassVerdict(counts),
     findings,
     not_checked: notChecked,
     summary: {
-      posture: hasSerious
-        ? "SlopPass found evidence-backed risks in the inspected scope."
-        : "SlopPass found no major slop signals in the inspected scope.",
+      posture: noAttemptedChecks
+        ? "SlopPass did not run the requested check because required context was missing."
+        : hasSerious
+          ? "SlopPass found evidence-backed risks in the inspected scope."
+          : "SlopPass found no major slop signals in the inspected scope.",
       counts_by_severity: counts,
       coverage_note:
         "This result only covers the target, diff or files, and checks listed in the scope. Unknown runtime paths stay unknown.",

--- a/packages/sloppass/src/schema.ts
+++ b/packages/sloppass/src/schema.ts
@@ -15,6 +15,7 @@ export const SlopPassCategorySchema = z.enum([
   "test_proof_theatre",
   "slopocalypse_failure_mode",
   "maintenance_change_risk",
+  "vcs_integration_risk",
 ]);
 
 export const SlopPassTargetSchema = z.object({
@@ -40,6 +41,18 @@ export const SlopPassFindingSchema = z.object({
   confidence_note: z.string().optional(),
   file: z.string().optional(),
   line: z.number().int().positive().optional(),
+  cross_branch_evidence: z
+    .object({
+      base_sha: z.string().min(1),
+      head_sha: z.string().min(1),
+      overwritten_commits: z.array(z.string().min(1)).optional(),
+      file: z.string().min(1),
+      line_range: z.tuple([
+        z.number().int().positive(),
+        z.number().int().positive(),
+      ]),
+    })
+    .optional(),
 });
 
 export const SlopPassVerdictSchema = z.enum(["pass", "warn", "fail", "unknown"]);
@@ -67,6 +80,18 @@ export const SlopPassDisclaimerSchema = z.object({
   compact: z.string().min(1),
 });
 
+export const SlopPassGitContextSchema = z.object({
+  base_sha: z.string().min(1),
+  head_sha: z.string().min(1),
+  files: z.record(
+    z.object({
+      base_blob: z.string().max(SLOPPASS_LIMITS.maxFileBytes),
+      main_blob: z.string().max(SLOPPASS_LIMITS.maxFileBytes),
+      pr_head_blob: z.string().max(SLOPPASS_LIMITS.maxFileBytes),
+    }),
+  ),
+});
+
 export const SlopPassResultSchema = z.object({
   target: SlopPassTargetSchema,
   scope: SlopPassScopeSchema,
@@ -82,16 +107,18 @@ export const SlopPassRunInputSchema = z
     target: SlopPassTargetSchema,
     files: z.array(SlopPassSourceFileSchema).max(SLOPPASS_LIMITS.maxFiles).optional(),
     diff: z.string().max(SLOPPASS_LIMITS.maxDiffBytes).optional(),
+    git_context: SlopPassGitContextSchema.optional(),
     checks: z.array(SlopPassCategorySchema).min(1).optional(),
     provider: z.enum(["openai", "anthropic", "google", "ollama", "http"]).default("http"),
   })
   .superRefine((value, ctx) => {
     if (value.files?.some((file) => file.content.trim().length > 0)) return;
     if (typeof value.diff === "string" && value.diff.trim()) return;
+    if (Object.keys(value.git_context?.files ?? {}).length > 0) return;
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["files"],
-      message: "SlopPass requires at least one source file or a unified diff.",
+      message: "SlopPass requires at least one source file, unified diff, or git_context file.",
     });
   });
 

--- a/packages/sloppass/src/types.ts
+++ b/packages/sloppass/src/types.ts
@@ -3,6 +3,7 @@ import type {
   SlopPassCategorySchema,
   SlopPassDisclaimerSchema,
   SlopPassFindingSchema,
+  SlopPassGitContextSchema,
   SlopPassNotCheckedSchema,
   SlopPassResultSchema,
   SlopPassScopeSchema,
@@ -20,6 +21,7 @@ export type SlopPassTarget = z.output<typeof SlopPassTargetSchema>;
 export type SlopPassSourceFile = z.output<typeof SlopPassSourceFileSchema>;
 export type SlopPassScope = z.output<typeof SlopPassScopeSchema>;
 export type SlopPassFinding = z.output<typeof SlopPassFindingSchema>;
+export type SlopPassGitContext = z.output<typeof SlopPassGitContextSchema>;
 export type SlopPassNotChecked = z.output<typeof SlopPassNotCheckedSchema>;
 export type SlopPassSummary = z.output<typeof SlopPassSummarySchema>;
 export type SlopPassDisclaimer = z.output<typeof SlopPassDisclaimerSchema>;

--- a/packages/sloppass/src/verdict-pack.ts
+++ b/packages/sloppass/src/verdict-pack.ts
@@ -89,6 +89,10 @@ function createNotChecked(checks: SlopPassCategory[], reason: string) {
   }));
 }
 
+function sourceOnlyChecks(checks: SlopPassCategory[]): SlopPassCategory[] {
+  return checks.filter((check) => check !== "vcs_integration_risk");
+}
+
 function uniquePaths(files: Array<{ path: string }>): string[] {
   return Array.from(new Set(files.map((file) => file.path)));
 }
@@ -191,30 +195,40 @@ export function createProvidedSourceSlopPassReport(
   input: CreateProvidedSourceSlopPassReportInput,
 ): SlopPassVerdictPack {
   const checks = parseChecks(input.checks);
+  const attemptedChecks = sourceOnlyChecks(checks);
   const parsed = SlopPassRunInputSchema.parse({ target: input.target, files: input.files, checks });
   const files = (parsed.files ?? [])
     .filter((file) => file.content.trim().length > 0)
     .map((file) => SlopPassSourceFileSchema.parse(file));
   const findings = detectSlopSmells(files).filter((finding) =>
-    checks.includes(finding.category),
+    attemptedChecks.includes(finding.category),
   );
   const counts = countFindings(findings);
+  const noAttemptedChecks = attemptedChecks.length === 0;
+  const notChecked = createNotChecked(
+    checks,
+    "Check was not requested for this provided-source run.",
+  );
+  if (checks.includes("vcs_integration_risk")) {
+    notChecked.push({
+      label: "stale-overwrite-detector",
+      reason: "git_context not provided for this provided-source run.",
+    });
+  }
   const result = SlopPassResultSchema.parse({
     target: SlopPassTargetSchema.parse(input.target),
     scope: {
-      checks_attempted: checks,
+      checks_attempted: attemptedChecks,
       files_reviewed: uniquePaths(files),
       provider: "provided-source",
     },
-    verdict: toSlopPassVerdict(counts),
+    verdict: noAttemptedChecks ? "unknown" : toSlopPassVerdict(counts),
     findings,
-    not_checked: createNotChecked(
-      checks,
-      "Check was not requested for this provided-source run.",
-    ),
+    not_checked: notChecked,
     summary: {
-      posture:
-        findings.length > 0
+      posture: noAttemptedChecks
+        ? "SlopPass did not run the requested check because required context was missing."
+        : findings.length > 0
           ? "SlopPass found deterministic slop signals in the inspected source."
           : "SlopPass found no deterministic slop signals in the inspected source.",
       counts_by_severity: counts,


### PR DESCRIPTION
## What changed

- Added `vcs_integration_risk` as a SlopPass category.
- Added optional `git_context` input with base, current main, and PR head blobs.
- Added `cross_branch_evidence` on findings for stale-overwrite proof.
- Added `detectStaleOverwrites`, a deterministic 3-way line lens.
- Wired the lens into `runSlopPass` and preserved honest `not_checked` output when `git_context` is missing.
- Added focused tests for schema, runner behavior, direct lens behavior, and provided-source honesty.

## Scope

This is the package-only v1 lens from the handoff memo. The GitHub Action and octokit PR wiring are intentionally left for a separate v2 PR.

## Proof

- `git diff --check` passed.
- `npm run test --workspace=@unclick/sloppass -- --runInBand` was attempted locally, but this clean worktree does not have dependencies installed, so `vitest` was unavailable. Cloud checks should run the normal install path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the sloppass package with schema, runner, and test updates; no auth, production, or CI integration in this PR.
> 
> **Overview**
> Adds **version-control integration risk** to SlopPass: a new `vcs_integration_risk` category, optional **`git_context`** (base / current main / PR head blobs per file), and **`cross_branch_evidence`** on findings so stale-checkout overwrites are provable across branches.
> 
> A deterministic **`detectStaleOverwrites`** lens flags lines that exist on current main but not on the PR base or head—catching merges that look clean but drop post-base main work. The runner and provided-source verdict path wire this in and return **`unknown`** with an explicit **`not_checked`** entry when `vcs_integration_risk` is requested without `git_context`, instead of implying a green pass.
> 
> Package-only scope; GitHub Action / octokit wiring is left for a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e1128e39b7c39ab87920a9fb6b9dd7b367165a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->