### PR TITLE
feat(fishbowl): reconcile merged PR todos

### DIFF
--- a/api/fishbowl-pr-merge-reconcile.test.ts
+++ b/api/fishbowl-pr-merge-reconcile.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFishbowlPrMergeProofComment,
+  buildFishbowlPrMergeVerifierAgentId,
+  extractFishbowlTodoIdsFromText,
+  hasFishbowlPrMergeProofComment,
+  parseFishbowlMergedPullRequest,
+} from "./lib/fishbowl-pr-merge-reconcile";
+
+const todoId = "55e85295-ad6d-42fc-bead-2743abf5e4ec";
+
+describe("Fishbowl PR merge reconciliation helpers", () => {
+  it("extracts linked todo ids from close words and admin links", () => {
+    const ids = extractFishbowlTodoIdsFromText(
+      [
+        `Closes ${todoId}`,
+        `Proof: /admin/jobs#todo-${todoId}`,
+        `Boardroom todo ${todoId}`,
+      ].join("\n"),
+    );
+
+    expect(ids).toEqual([todoId]);
+  });
+
+  it("normalizes GitHub pull_request.closed payloads", () => {
+    const parsed = parseFishbowlMergedPullRequest({
+      action: "closed",
+      repository: { full_name: "malamutemayhem/unclick" },
+      pull_request: {
+        number: 1169,
+        html_url: "https://github.com/malamutemayhem/unclick/pull/1169",
+        title: "Ship stale overwrite detector",
+        body: `Closes ${todoId}`,
+        merged: true,
+        merged_at: "2026-05-29T01:23:45Z",
+        merge_commit_sha: "5db60a2f9bd0a6461c839ff5a756b8b66123abcd",
+      },
+    });
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.pr).toMatchObject({
+      number: 1169,
+      repositoryFullName: "malamutemayhem/unclick",
+      merged: true,
+      mergeCommitSha: "5db60a2f9bd0a6461c839ff5a756b8b66123abcd",
+      linkedTodoIds: [todoId],
+    });
+  });
+
+  it("keeps unmerged pull requests visible without pretending they are done", () => {
+    const parsed = parseFishbowlMergedPullRequest({
+      pull_request: {
+        number: 1170,
+        body: `Closes ${todoId}`,
+        merged: false,
+        merge_commit_sha: "abc1234",
+      },
+    });
+
+    expect(parsed.pr?.merged).toBe(false);
+    expect(parsed.pr?.linkedTodoIds).toEqual([todoId]);
+  });
+
+  it("builds independent verifier ids within the Boardroom agent id limit", () => {
+    expect(buildFishbowlPrMergeVerifierAgentId("codex-builder")).toBe("codex-builder-github-merge-proof");
+    expect(buildFishbowlPrMergeVerifierAgentId("x".repeat(140))).toHaveLength(128);
+  });
+
+  it("builds proof comments that satisfy the close gate and dedupe cleanly", () => {
+    const pr = parseFishbowlMergedPullRequest({
+      repository_full_name: "malamutemayhem/unclick",
+      pr_number: 1169,
+      pr_url: "https://github.com/malamutemayhem/unclick/pull/1169",
+      merged: true,
+      merged_at: "2026-05-29T01:23:45Z",
+      merge_commit_sha: "5db60a2f9bd0a6461c839ff5a756b8b66123abcd",
+      linked_todo_ids: [todoId],
+    }).pr;
+
+    expect(pr).not.toBeNull();
+    const text = buildFishbowlPrMergeProofComment({ pr: pr!, todoId });
+    expect(text).toContain("PASS: PR #1169 merged");
+    expect(text).toContain("merge commit 5db60a2f9bd0a6461c839ff5a756b8b66123abcd");
+    expect(hasFishbowlPrMergeProofComment([{ text }], pr!)).toBe(true);
+  });
+});

--- a/api/lib/fishbowl-pr-merge-reconcile.ts
+++ b/api/lib/fishbowl-pr-merge-reconcile.ts
@@ -1,0 +1,160 @@
+export interface FishbowlMergedPullRequest {
+  number: number | null;
+  url: string | null;
+  title: string | null;
+  body: string | null;
+  merged: boolean;
+  mergedAt: string | null;
+  mergeCommitSha: string | null;
+  repositoryFullName: string | null;
+  comments: string[];
+  linkedTodoIds: string[];
+}
+
+export interface FishbowlPrMergeParseResult {
+  pr: FishbowlMergedPullRequest | null;
+  error?: string;
+}
+
+export interface FishbowlPrMergeProofInput {
+  pr: FishbowlMergedPullRequest;
+  todoId: string;
+}
+
+const UUID_SOURCE = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const TODO_ID_RE = new RegExp(`^${UUID_SOURCE}$`, "i");
+const ADMIN_TODO_LINK_RE = new RegExp(`(?:/admin/jobs#todo-|#todo-)(${UUID_SOURCE})`, "gi");
+const CLOSE_TODO_RE = new RegExp(
+  `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+(?:boardroom\\s+|fishbowl\\s+|todo\\s+|job\\s+)?(${UUID_SOURCE})\\b`,
+  "gi",
+);
+const NAMED_TODO_RE = new RegExp(
+  `\\b(?:boardroom\\s+todo|fishbowl\\s+todo|todo|job)\\s*[:#-]?\\s*(${UUID_SOURCE})\\b`,
+  "gi",
+);
+const SHA_RE = /^[a-f0-9]{7,40}$/i;
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) return Number(value.trim());
+  return null;
+}
+
+function readCommentTexts(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (typeof item === "string") return item.trim();
+      const row = readObject(item);
+      return readString(row?.body) ?? readString(row?.text) ?? "";
+    })
+    .filter(Boolean);
+}
+
+function uniqueTodoIds(ids: string[]): string[] {
+  return [...new Set(ids.map((id) => id.toLowerCase()).filter((id) => TODO_ID_RE.test(id)))];
+}
+
+export function extractFishbowlTodoIdsFromText(text: string): string[] {
+  const ids: string[] = [];
+  for (const pattern of [ADMIN_TODO_LINK_RE, CLOSE_TODO_RE, NAMED_TODO_RE]) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      ids.push(match[1]);
+    }
+  }
+  return uniqueTodoIds(ids);
+}
+
+export function parseFishbowlMergedPullRequest(rawBody: Record<string, unknown>): FishbowlPrMergeParseResult {
+  const pullRequest = readObject(rawBody.pull_request) ?? readObject(rawBody.pr) ?? rawBody;
+  const repository = readObject(rawBody.repository);
+  const repositoryFullName =
+    readString(repository?.full_name) ??
+    readString(rawBody.repository_full_name) ??
+    readString(rawBody.repo) ??
+    null;
+  const comments = [
+    ...readCommentTexts(rawBody.comments),
+    ...readCommentTexts(rawBody.issue_comments),
+    ...readCommentTexts(rawBody.review_comments),
+  ];
+  const explicitLinkedTodoIds = Array.isArray(rawBody.linked_todo_ids)
+    ? rawBody.linked_todo_ids.map((id) => readString(id)).filter(Boolean) as string[]
+    : [];
+
+  const mergeCommitSha =
+    readString(pullRequest.merge_commit_sha) ??
+    readString(rawBody.merge_commit_sha) ??
+    readString(rawBody.merge_commit) ??
+    null;
+  const mergedAt = readString(pullRequest.merged_at) ?? readString(rawBody.merged_at) ?? null;
+  const merged = pullRequest.merged === true || rawBody.merged === true || Boolean(mergedAt);
+
+  const pr: FishbowlMergedPullRequest = {
+    number: readNumber(pullRequest.number) ?? readNumber(rawBody.pr_number) ?? null,
+    url: readString(pullRequest.html_url) ?? readString(rawBody.pr_url) ?? readString(rawBody.html_url) ?? null,
+    title: readString(pullRequest.title) ?? readString(rawBody.title) ?? null,
+    body: readString(pullRequest.body) ?? readString(rawBody.body) ?? null,
+    merged,
+    mergedAt,
+    mergeCommitSha: mergeCommitSha && SHA_RE.test(mergeCommitSha) ? mergeCommitSha : null,
+    repositoryFullName,
+    comments,
+    linkedTodoIds: [],
+  };
+
+  const linkedText = [pr.title, pr.body, ...comments].filter(Boolean).join("\n");
+  pr.linkedTodoIds = uniqueTodoIds([
+    ...extractFishbowlTodoIdsFromText(linkedText),
+    ...explicitLinkedTodoIds,
+  ]);
+
+  if (!pr.number && !pr.url) {
+    return { pr: null, error: "pull_request number or url required" };
+  }
+  return { pr };
+}
+
+export function buildFishbowlPrMergeVerifierAgentId(agentId: string): string {
+  const suffix = "-github-merge-proof";
+  const base = agentId.trim() || "github-action-fishbowl-autoclose";
+  if (base.length + suffix.length <= 128) return `${base}${suffix}`;
+  return `${base.slice(0, 128 - suffix.length)}${suffix}`;
+}
+
+export function buildFishbowlPrMergeProofComment(input: FishbowlPrMergeProofInput): string {
+  const prLabel = input.pr.number ? `PR #${input.pr.number}` : "GitHub PR";
+  const proofLines = [
+    `PASS: ${prLabel} merged and links to Boardroom todo ${input.todoId}.`,
+    input.pr.url ? `proof: ${input.pr.url}` : null,
+    input.pr.mergeCommitSha ? `merge commit ${input.pr.mergeCommitSha}` : null,
+    input.pr.repositoryFullName ? `repository: ${input.pr.repositoryFullName}` : null,
+    input.pr.mergedAt ? `merged_at: ${input.pr.mergedAt}` : null,
+    "source: fishbowl-pr-merge-reconcile",
+  ];
+  return proofLines.filter(Boolean).join("\n");
+}
+
+export function hasFishbowlPrMergeProofComment(
+  comments: Array<{ text?: string | null }>,
+  pr: FishbowlMergedPullRequest,
+): boolean {
+  const prUrl = pr.url?.toLowerCase() ?? "";
+  const sha = pr.mergeCommitSha?.toLowerCase() ?? "";
+  return comments.some((comment) => {
+    const text = String(comment.text ?? "").toLowerCase();
+    if (!text.includes("source: fishbowl-pr-merge-reconcile")) return false;
+    if (prUrl && text.includes(prUrl)) return true;
+    if (sha && text.includes(sha)) return true;
+    return false;
+  });
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -150,6 +150,12 @@ import {
   buildFishbowlTodoHandoffDispatchRow,
   planFishbowlTodoHandoff,
 } from "./lib/fishbowl-todo-handoff.js";
+import {
+  buildFishbowlPrMergeProofComment,
+  buildFishbowlPrMergeVerifierAgentId,
+  hasFishbowlPrMergeProofComment,
+  parseFishbowlMergedPullRequest,
+} from "./lib/fishbowl-pr-merge-reconcile.js";
 import { classifyTodoActionability } from "./lib/fishbowl-todo-actionability.js";
 import {
   planFishbowlPostLedgerEvent,
@@ -9392,7 +9398,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       // ─── Fishbowl Todos + Ideas v1 ────────────────────────────────────────
       //
-      // All thirteen handlers below share the same shape:
+      // These handlers share the same shape:
       //   1. Require POST.
       //   2. Resolve api_key_hash.
       //   3. Validate agent_id (<= 128 chars).
@@ -9410,6 +9416,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       case "fishbowl_create_todo":
       case "fishbowl_update_todo":
       case "fishbowl_complete_todo":
+      case "fishbowl_reconcile_merged_pr":
       case "fishbowl_drop_todo":
       case "fishbowl_delete_todo":
       case "fishbowl_list_todos":
@@ -9488,6 +9495,192 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const DONE_TODO_ARCHIVE_WINDOW_MS = 12 * 60 * 60 * 1000;
 
         // ── Todos ──────────────────────────────────────────────────────────
+
+        if (action === "fishbowl_reconcile_merged_pr") {
+          const parsed = parseFishbowlMergedPullRequest(body);
+          if (parsed.error || !parsed.pr) {
+            return res.status(400).json({
+              error: parsed.error ?? "pull_request payload required",
+              how_to_fix:
+                "Send a GitHub pull_request payload, or { pr_number, pr_url, merged, merged_at, merge_commit_sha }.",
+            });
+          }
+
+          const pr = parsed.pr;
+          if (!pr.merged) {
+            return res.status(200).json({
+              closed: 0,
+              skipped: [{ reason: "pull_request_not_merged" }],
+              pr: { number: pr.number, url: pr.url },
+            });
+          }
+          if (!pr.mergeCommitSha) {
+            return res.status(409).json({
+              error: "merge_commit_sha required",
+              how_to_fix: "Pass the merged PR merge_commit_sha so the todo gets durable Git proof.",
+            });
+          }
+          if (pr.linkedTodoIds.length === 0) {
+            return res.status(200).json({
+              closed: 0,
+              skipped: [{ reason: "no_linked_todos" }],
+              pr: { number: pr.number, url: pr.url, merge_commit_sha: pr.mergeCommitSha },
+            });
+          }
+
+          const { data: todoRows, error: todoErr } = await supabase
+            .from("mc_fishbowl_todos")
+            .select("id,title,description,status,created_by_agent_id,assigned_to_agent_id,priority")
+            .eq("api_key_hash", apiKeyHash)
+            .in("id", pr.linkedTodoIds);
+          if (todoErr) throw todoErr;
+
+          const todosById = new Map((todoRows ?? []).map((todo) => [String(todo.id), todo]));
+          const foundTodoIds = (todoRows ?? []).map((todo) => String(todo.id));
+          let commentsByTodoId = new Map<string, Array<{ author_agent_id: string | null; text: string | null; created_at: string | null }>>();
+          if (foundTodoIds.length > 0) {
+            const { data: comments, error: commentErr } = await supabase
+              .from("mc_fishbowl_comments")
+              .select("target_id,author_agent_id,text,created_at")
+              .eq("api_key_hash", apiKeyHash)
+              .eq("target_kind", "todo")
+              .in("target_id", foundTodoIds)
+              .order("created_at", { ascending: true });
+            if (commentErr) throw commentErr;
+            commentsByTodoId = (comments ?? []).reduce<typeof commentsByTodoId>((acc, comment) => {
+              const targetId = String(comment.target_id);
+              acc.set(targetId, [
+                ...(acc.get(targetId) ?? []),
+                {
+                  author_agent_id: typeof comment.author_agent_id === "string" ? comment.author_agent_id : null,
+                  text: typeof comment.text === "string" ? comment.text : null,
+                  created_at: typeof comment.created_at === "string" ? comment.created_at : null,
+                },
+              ]);
+              return acc;
+            }, new Map());
+          }
+
+          const nowIso = new Date().toISOString();
+          const proofAgentId = buildFishbowlPrMergeVerifierAgentId(agentId);
+          const closed: Array<{ todo_id: string; title: string | null; merge_commit_sha: string }> = [];
+          const skipped: Array<{ todo_id?: string; reason: string; code?: string; how_to_fix?: string }> = [];
+
+          for (const todoId of pr.linkedTodoIds) {
+            const beforeTodo = todosById.get(todoId);
+            if (!beforeTodo) {
+              skipped.push({ todo_id: todoId, reason: "todo_not_found" });
+              continue;
+            }
+
+            const status = String(beforeTodo.status ?? "");
+            if (status === "done") {
+              skipped.push({ todo_id: todoId, reason: "already_done" });
+              continue;
+            }
+            if (status === "dropped") {
+              skipped.push({ todo_id: todoId, reason: "todo_dropped" });
+              continue;
+            }
+
+            const existingComments = commentsByTodoId.get(todoId) ?? [];
+            let gateComments = existingComments;
+            if (!hasFishbowlPrMergeProofComment(existingComments, pr)) {
+              const proofText = buildFishbowlPrMergeProofComment({ pr, todoId });
+              const { error: proofErr } = await supabase.from("mc_fishbowl_comments").insert({
+                api_key_hash: apiKeyHash,
+                target_kind: "todo",
+                target_id: todoId,
+                author_agent_id: proofAgentId,
+                text: proofText,
+              });
+              if (proofErr) throw proofErr;
+              gateComments = [
+                ...existingComments,
+                {
+                  author_agent_id: proofAgentId,
+                  text: proofText,
+                  created_at: nowIso,
+                },
+              ];
+              commentsByTodoId.set(todoId, gateComments);
+            }
+
+            const completionGate = evaluateFishbowlCompletionPolicy({
+              todo: {
+                id: String(beforeTodo.id),
+                title: typeof beforeTodo.title === "string" ? beforeTodo.title : null,
+                description: typeof beforeTodo.description === "string" ? beforeTodo.description : null,
+                created_by_agent_id:
+                  typeof beforeTodo.created_by_agent_id === "string" ? beforeTodo.created_by_agent_id : null,
+              },
+              comments: gateComments,
+              closerAgentId: agentId,
+            });
+            if (!completionGate.allowed) {
+              skipped.push({
+                todo_id: todoId,
+                reason: "completion_gate_failed",
+                code: completionGate.code,
+                how_to_fix: completionGate.how_to_fix,
+              });
+              continue;
+            }
+
+            const { data: updatedTodo, error: updateErr } = await supabase
+              .from("mc_fishbowl_todos")
+              .update({ status: "done", completed_at: nowIso, updated_at: nowIso })
+              .eq("api_key_hash", apiKeyHash)
+              .eq("id", todoId)
+              .in("status", ["open", "in_progress"])
+              .select("*")
+              .maybeSingle();
+            if (updateErr) throw updateErr;
+            if (!updatedTodo) {
+              skipped.push({ todo_id: todoId, reason: "todo_changed_before_close" });
+              continue;
+            }
+
+            await recordAutopilotEvents(
+              supabase,
+              apiKeyHash,
+              planTodoLedgerEvents({
+                todoId: updatedTodo.id,
+                actorAgentId: agentId,
+                before: beforeTodo,
+                after: updatedTodo,
+              }),
+            );
+
+            void postFishbowlEvent(
+              supabase,
+              apiKeyHash,
+              agentId,
+              "todo-completed",
+              `Todo done: ${updatedTodo.title}`,
+            );
+            closed.push({
+              todo_id: String(updatedTodo.id),
+              title: typeof updatedTodo.title === "string" ? updatedTodo.title : null,
+              merge_commit_sha: pr.mergeCommitSha,
+            });
+          }
+
+          return res.status(200).json({
+            closed: closed.length,
+            closed_todos: closed,
+            skipped,
+            linked_todo_ids: pr.linkedTodoIds,
+            pr: {
+              number: pr.number,
+              url: pr.url,
+              repository_full_name: pr.repositoryFullName,
+              merged_at: pr.mergedAt,
+              merge_commit_sha: pr.mergeCommitSha,
+            },
+            proof_agent_id: proofAgentId,
+          });
+        }
 
         if (action === "fishbowl_create_todo") {
           const titleRes = validateTitle(body.title);


### PR DESCRIPTION
## Summary
- add a tenant-scoped fishbowl_reconcile_merged_pr action for merged GitHub PR payloads
- parse Boardroom todo links from Closes <todo-id>, todo references, and /admin/jobs#todo-<id> links
- add merge commit proof with an independent verifier identity, then close only if the existing Fishbowl completion gate allows it
- add focused helper coverage for parsing, proof comments, dedupe, and unmerged PR holds

## Proof
- git diff --check passed
- no em dash scan on touched files found no matches
- Node helper smoke assertions passed with experimental strip types
- Vitest attempted locally but this clean worktree has no installed dependencies; PR checks are the broad proof path

## Notes
- No workflow files touched. This gives GitHub Actions or a webhook a real API action to call without changing CI config in this slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates todo status and comments via a new API path tied to external PR payloads; behavior is gated on merge SHA and completion policy but incorrect linking or policy bypass would be impactful.
> 
> **Overview**
> Adds **`fishbowl_reconcile_merged_pr`**, a tenant-scoped Fishbowl API action that accepts GitHub-style merged PR payloads (webhook or simplified fields), discovers linked Boardroom todo UUIDs from PR text (`Closes`, named todos, `/admin/jobs#todo-` links), and optionally completes those todos after merge.
> 
> New helpers in **`fishbowl-pr-merge-reconcile`** normalize payloads, require a valid **merge commit SHA** for merged PRs, post a deduped **merge-proof** todo comment under a separate **verifier agent id**, then run the existing **`evaluateFishbowlCompletionPolicy`** before marking todos **done** (with ledger events and feed posts). Unmerged PRs, missing links, and gate failures return structured **skipped** results instead of closing.
> 
> Vitest coverage exercises parsing, unmerged holds, verifier id length limits, and proof comment dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd688cf6dc4585c314169d13772c78a9e066579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->