### PR TITLE
fix(memory): bound backend cache with LRU

### DIFF
--- a/packages/mcp-server/src/__tests__/memory-backend-cache.test.ts
+++ b/packages/mcp-server/src/__tests__/memory-backend-cache.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createBoundedMemoryBackendCache,
+  parseBackendCacheMaxTenants,
+} from "../memory/db.js";
+
+describe("bounded MCP memory backend cache", () => {
+  it("uses a generous bounded default and clamps unsafe env input", () => {
+    const previous = process.env.UNCLICK_MEMORY_BACKEND_CACHE_MAX_TENANTS;
+    delete process.env.UNCLICK_MEMORY_BACKEND_CACHE_MAX_TENANTS;
+    try {
+      expect(parseBackendCacheMaxTenants()).toBe(1024);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.UNCLICK_MEMORY_BACKEND_CACHE_MAX_TENANTS;
+      } else {
+        process.env.UNCLICK_MEMORY_BACKEND_CACHE_MAX_TENANTS = previous;
+      }
+    }
+    expect(parseBackendCacheMaxTenants("")).toBe(1024);
+    expect(parseBackendCacheMaxTenants("0")).toBe(1024);
+    expect(parseBackendCacheMaxTenants("not-a-number")).toBe(1024);
+    expect(parseBackendCacheMaxTenants("3")).toBe(3);
+    expect(parseBackendCacheMaxTenants("250000")).toBe(100000);
+  });
+
+  it("records hits, misses, and LRU evictions without exposing tenant keys", () => {
+    const cache = createBoundedMemoryBackendCache<string>(2);
+
+    cache.set("tenant-a", "backend-a");
+    cache.set("tenant-b", "backend-b");
+    expect(cache.get("tenant-a")).toBe("backend-a");
+
+    cache.set("tenant-c", "backend-c");
+
+    expect(cache.get("tenant-b")).toBeNull();
+    expect(cache.get("tenant-a")).toBe("backend-a");
+    expect(cache.get("tenant-c")).toBe("backend-c");
+    expect(cache.metrics()).toEqual({
+      hits: 3,
+      misses: 1,
+      evictions: 1,
+      size: 2,
+      maxSize: 2,
+    });
+    expect(JSON.stringify(cache.metrics())).not.toContain("tenant-");
+  });
+
+  it("refreshes recency when an existing key is replaced", () => {
+    const cache = createBoundedMemoryBackendCache<string>(2);
+
+    cache.set("tenant-a", "backend-a1");
+    cache.set("tenant-b", "backend-b");
+    cache.set("tenant-a", "backend-a2");
+    cache.set("tenant-c", "backend-c");
+
+    expect(cache.get("tenant-a")).toBe("backend-a2");
+    expect(cache.get("tenant-b")).toBeNull();
+    expect(cache.get("tenant-c")).toBe("backend-c");
+  });
+});

--- a/packages/mcp-server/src/memory/db.ts
+++ b/packages/mcp-server/src/memory/db.ts
@@ -41,6 +41,74 @@ interface ByodConfig {
   service_role_key: string;
 }
 
+export interface BackendCacheMetrics {
+  hits: number;
+  misses: number;
+  evictions: number;
+  size: number;
+  maxSize: number;
+}
+
+export interface BoundedMemoryBackendCache<T> {
+  get(key: string): T | null;
+  set(key: string, value: T): void;
+  metrics(): BackendCacheMetrics;
+}
+
+const DEFAULT_BACKEND_CACHE_MAX_TENANTS = 1024;
+const MAX_BACKEND_CACHE_MAX_TENANTS = 100000;
+
+export function parseBackendCacheMaxTenants(raw = process.env.UNCLICK_MEMORY_BACKEND_CACHE_MAX_TENANTS): number {
+  if (raw == null || raw === "") return DEFAULT_BACKEND_CACHE_MAX_TENANTS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) return DEFAULT_BACKEND_CACHE_MAX_TENANTS;
+  return Math.min(parsed, MAX_BACKEND_CACHE_MAX_TENANTS);
+}
+
+export function createBoundedMemoryBackendCache<T>(
+  maxSize = parseBackendCacheMaxTenants(),
+): BoundedMemoryBackendCache<T> {
+  const entries = new Map<string, T>();
+  let hits = 0;
+  let misses = 0;
+  let evictions = 0;
+
+  return {
+    get(key: string): T | null {
+      if (!entries.has(key)) {
+        misses += 1;
+        return null;
+      }
+      const value = entries.get(key) as T;
+      entries.delete(key);
+      entries.set(key, value);
+      hits += 1;
+      return value;
+    },
+    set(key: string, value: T): void {
+      if (entries.has(key)) {
+        entries.delete(key);
+      }
+      entries.set(key, value);
+      while (entries.size > maxSize) {
+        const oldestKey = entries.keys().next().value;
+        if (typeof oldestKey !== "string") break;
+        entries.delete(oldestKey);
+        evictions += 1;
+      }
+    },
+    metrics(): BackendCacheMetrics {
+      return {
+        hits,
+        misses,
+        evictions,
+        size: entries.size,
+        maxSize,
+      };
+    },
+  };
+}
+
 async function fetchByodConfig(apiKey: string): Promise<ByodConfig | null> {
   try {
     const res = await fetch(`${MEMORY_API_BASE}/api/memory-admin?action=config`, {
@@ -65,10 +133,11 @@ async function fetchByodConfig(apiKey: string): Promise<ByodConfig | null> {
 // Per-tenant backend cache. Keyed so different api_keys never share a backend.
 // In serverless this lives only for the lifetime of a warm instance, which is
 // the right scope. In long-lived standalone use, the cache key is constant.
-//
-// TODO(phase-1+): bound this with an LRU if a single warm instance ever serves
-// thousands of tenants. For Phase 1 the unbounded map is fine.
-const backendCache = new Map<string, MemoryBackend>();
+const backendCache = createBoundedMemoryBackendCache<MemoryBackend>();
+
+export function getBackendCacheMetrics(): BackendCacheMetrics {
+  return backendCache.metrics();
+}
 
 function instanceKey(): string {
   const hash = process.env.UNCLICK_API_KEY_HASH;

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -6,7 +6,7 @@
  * params object. Used by both direct MCP tools and the unclick_call meta-tool.
  */
 
-import { getBackend } from "./db.js";
+import { getBackend, getBackendCacheMetrics } from "./db.js";
 import {
   buildToolGuidance,
   classifyTools,
@@ -776,7 +776,15 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
 
   async memory_status() {
     const db = await getBackend();
-    return db.getMemoryStatus();
+    const status = await db.getMemoryStatus();
+    const statusObject =
+      status && typeof status === "object" && !Array.isArray(status)
+        ? status as Record<string, unknown>
+        : { status };
+    return {
+      ...statusObject,
+      backend_cache: getBackendCacheMetrics(),
+    };
   },
 
   async invalidate_fact(args) {


### PR DESCRIPTION
## Summary
- replace the unbounded per-tenant MCP memory backend Map with a bounded LRU cache
- default the cap to 1024 tenants and allow tuning with UNCLICK_MEMORY_BACKEND_CACHE_MAX_TENANTS
- expose safe backend_cache metrics on memory_status: hits, misses, evictions, size, maxSize
- add focused cache tests for env parsing, LRU eviction, recency refresh, and tenant-key redaction

## Proof
- git diff --check passed
- no em dash scan on touched files found no matches
- Node helper smoke assertions passed with experimental strip types
- Vitest attempted locally but this clean worktree has no installed dependencies; PR checks are the broad proof path

## Notes
- No package files touched. No new dependency added; this uses Map insertion order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eviction can force backend rebuilds on busy warm instances; behavior change is intentional for memory safety but affects multi-tenant serverless caching.
> 
> **Overview**
> Replaces the **unbounded** per-tenant MCP memory backend `Map` with a **bounded LRU** implemented via `Map` insertion order in `db.ts`, addressing the prior TODO about warm instances serving many tenants.
> 
> **Capacity** defaults to **1024** tenants and is tunable with `UNCLICK_MEMORY_BACKEND_CACHE_MAX_TENANTS` (invalid or out-of-range values clamp to safe defaults, max **100000**). **`memory_status`** now includes a `backend_cache` object with **hits, misses, evictions, size, and maxSize** only—no tenant identifiers in metrics.
> 
> Adds **Vitest** coverage for env parsing, LRU eviction, recency refresh on `set`, and metrics JSON redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadf825680c8e7ff9042c686a30761fe49a4fadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->