### PR TITLE
[codex] Flag TestPass fail-to-pass overrides

### DIFF
--- a/api/lib/testpass-edit-guard.ts
+++ b/api/lib/testpass-edit-guard.ts
@@ -1,0 +1,63 @@
+export interface TestPassEditItemRow {
+  id: string;
+  run_id: string;
+  check_id?: string | null;
+  title?: string | null;
+  verdict?: string | null;
+}
+
+export interface TestPassOverrideSignal {
+  api_key_hash: string;
+  tool: "testpass";
+  action: "fail_to_pass_override";
+  severity: "action_needed";
+  summary: string;
+  deep_link: string;
+  payload: {
+    source: "testpass_edit_item";
+    anomaly: true;
+    auto_merge_gate: "hold";
+    run_id: string;
+    item_id: string;
+    check_id: string | null;
+    title: string | null;
+    previous_verdict: "fail";
+    new_verdict: "check";
+    actor_user_id: string;
+    notes: string;
+  };
+}
+
+export function isTestPassFailToPassOverride(previousVerdict: unknown, nextDbVerdict: string): boolean {
+  return String(previousVerdict ?? "").toLowerCase() === "fail" && nextDbVerdict === "check";
+}
+
+export function buildTestPassFailToPassOverrideSignal(input: {
+  apiKeyHash: string;
+  actorUserId: string;
+  runId: string;
+  item: TestPassEditItemRow;
+  notes: string;
+}): TestPassOverrideSignal {
+  return {
+    api_key_hash: input.apiKeyHash,
+    tool: "testpass",
+    action: "fail_to_pass_override",
+    severity: "action_needed",
+    summary: `TestPass fail-to-pass override requested for run ${input.runId}.`,
+    deep_link: `/admin/testpass/runs/${input.runId}`,
+    payload: {
+      source: "testpass_edit_item",
+      anomaly: true,
+      auto_merge_gate: "hold",
+      run_id: input.runId,
+      item_id: input.item.id,
+      check_id: input.item.check_id ?? null,
+      title: input.item.title ?? null,
+      previous_verdict: "fail",
+      new_verdict: "check",
+      actor_user_id: input.actorUserId,
+      notes: input.notes,
+    },
+  };
+}

--- a/api/testpass-edit-guard.test.ts
+++ b/api/testpass-edit-guard.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTestPassFailToPassOverrideSignal,
+  isTestPassFailToPassOverride,
+} from "./lib/testpass-edit-guard";
+
+describe("TestPass edit override guard", () => {
+  it("detects only fail to pass verdict overrides", () => {
+    expect(isTestPassFailToPassOverride("fail", "check")).toBe(true);
+    expect(isTestPassFailToPassOverride("FAIL", "check")).toBe(true);
+    expect(isTestPassFailToPassOverride("fail", "other")).toBe(false);
+    expect(isTestPassFailToPassOverride("check", "check")).toBe(false);
+    expect(isTestPassFailToPassOverride(null, "check")).toBe(false);
+  });
+
+  it("builds an action_needed signal with the required justification", () => {
+    const signal = buildTestPassFailToPassOverrideSignal({
+      apiKeyHash: "hash-1",
+      actorUserId: "user-1",
+      runId: "run-1",
+      item: {
+        id: "item-1",
+        run_id: "run-1",
+        check_id: "TP-001",
+        title: "Proof must be real",
+        verdict: "fail",
+      },
+      notes: "Human reviewed the fresh proof",
+    });
+
+    expect(signal).toMatchObject({
+      api_key_hash: "hash-1",
+      tool: "testpass",
+      action: "fail_to_pass_override",
+      severity: "action_needed",
+      deep_link: "/admin/testpass/runs/run-1",
+      payload: {
+        source: "testpass_edit_item",
+        anomaly: true,
+        auto_merge_gate: "hold",
+        run_id: "run-1",
+        item_id: "item-1",
+        check_id: "TP-001",
+        previous_verdict: "fail",
+        new_verdict: "check",
+        actor_user_id: "user-1",
+        notes: "Human reviewed the fresh proof",
+      },
+    });
+  });
+});

--- a/api/testpass.ts
+++ b/api/testpass.ts
@@ -29,6 +29,12 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import * as crypto from "node:crypto";
 import {
+  buildTestPassFailToPassOverrideSignal,
+  isTestPassFailToPassOverride,
+  type TestPassEditItemRow,
+  type TestPassOverrideSignal,
+} from "./lib/testpass-edit-guard.js";
+import {
   computeVerdictSummary,
   createEvidence,
   createRun,
@@ -122,6 +128,41 @@ async function resolveActorUserId(
     return getActorUserIdFromApiKey(supabaseUrl, serviceKey, token);
   }
   return getActorUserId(supabaseUrl, token);
+}
+
+async function resolveApiKeyHashForSignal(
+  supabaseUrl: string,
+  serviceKey: string,
+  token: string,
+  actorUserId: string,
+): Promise<string | null> {
+  if (token.startsWith("uc_")) return sha256hex(token);
+
+  const r = await fetch(
+    `${supabaseUrl}/rest/v1/api_keys?user_id=eq.${encodeURIComponent(actorUserId)}&is_active=eq.true&select=key_hash&limit=1`,
+    { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } },
+  );
+  if (!r.ok) return null;
+  const rows = (await r.json()) as Array<{ key_hash: string | null }>;
+  return rows[0]?.key_hash ?? null;
+}
+
+async function insertTestPassOverrideSignal(
+  supabaseUrl: string,
+  serviceKey: string,
+  signal: TestPassOverrideSignal,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const r = await fetch(`${supabaseUrl}/rest/v1/mc_signals`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+    },
+    body: JSON.stringify(signal),
+  });
+  if (r.ok) return { ok: true };
+  return { ok: false, error: await r.text() };
 }
 
 interface TestPassPackRow {
@@ -584,6 +625,39 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const ownerRows = (await ownerCheck.json()) as Array<{ id: string }>;
     if (!ownerRows[0]) return json(res, 404, { error: "Run not found" });
 
+    const itemBeforeRes = await fetch(
+      `${supabaseUrl}/rest/v1/testpass_items?id=eq.${encodeURIComponent(body.item_id)}&run_id=eq.${encodeURIComponent(body.run_id)}&select=id,run_id,check_id,title,verdict&limit=1`,
+      { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } },
+    );
+    if (!itemBeforeRes.ok) {
+      const text = await itemBeforeRes.text();
+      return json(res, 500, { error: `edit_item item lookup failed: ${text}` });
+    }
+    const itemBeforeRows = (await itemBeforeRes.json()) as TestPassEditItemRow[];
+    const itemBefore = itemBeforeRows[0];
+    if (!itemBefore) return json(res, 404, { error: "Item not found" });
+
+    let overrideSignal: TestPassOverrideSignal | null = null;
+    if (isTestPassFailToPassOverride(itemBefore.verdict, dbVerdict)) {
+      const apiKeyHash = await resolveApiKeyHashForSignal(supabaseUrl, serviceKey, token, actorUserId);
+      if (!apiKeyHash) {
+        return json(res, 409, {
+          error: "fail-to-pass overrides require an auditable mc_signals key",
+        });
+      }
+      overrideSignal = buildTestPassFailToPassOverrideSignal({
+        apiKeyHash,
+        actorUserId,
+        runId: body.run_id,
+        item: itemBefore,
+        notes,
+      });
+      const signalInsert = await insertTestPassOverrideSignal(supabaseUrl, serviceKey, overrideSignal);
+      if (!signalInsert.ok) {
+        return json(res, 500, { error: `fail-to-pass override signal failed: ${signalInsert.error}` });
+      }
+    }
+
     const patch: Record<string, unknown> = { verdict: dbVerdict, on_fail_comment: notes };
 
     const upd = await fetch(
@@ -609,7 +683,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const summary = await computeVerdictSummary(config, body.run_id);
     const isDone = summary.pending === 0;
     await updateRunStatus(config, body.run_id, isDone ? (summary.fail > 0 ? "failed" : "complete") : "running", summary);
-    return json(res, 200, { item, summary });
+    return json(res, 200, {
+      item,
+      summary,
+      override_guard: overrideSignal
+        ? { fail_to_pass: true, signal_action: overrideSignal.action, signal_inserted: true }
+        : { fail_to_pass: false },
+    });
   }
 
   if (req.method === "POST" && action === "heal") {

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 525,
+    "inventory": 526,
     "source_manifest": 190,
     "pages": 82,
     "tools": 187,
@@ -51,7 +51,7 @@
       "id": "passes-and-gates",
       "name": "Passes and gates",
       "meaning": "Quality, proof, safety, and fidelity checks.",
-      "count": 15
+      "count": 16
     },
     {
       "id": "wrappers-and-protocols",
@@ -2548,6 +2548,16 @@
       "kind": "pass",
       "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
       "source": "api/lib/testpass-boundary.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-pass-testpass-edit-guard-api-lib-testpass-edit-guard-ts-no-route",
+      "division": "Passes and gates",
+      "name": "testpass edit guard",
+      "kind": "pass",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/testpass-edit-guard.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -213,7 +213,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Tools | MCP and gateway capabilities available to seats. | 187 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
-| Passes and gates | Quality, proof, safety, and fidelity checks. | 15 |
+| Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 118 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
@@ -776,6 +776,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Passes and gates | pass | testpass | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/testpass.ts |
 | Passes and gates | pass | testpass background handoff | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/testpass-background-handoff.ts |
 | Passes and gates | pass | testpass boundary | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/testpass-boundary.ts |
+| Passes and gates | pass | testpass edit guard | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/testpass-edit-guard.ts |
 | Passes and gates | pass | testpass pr comment | testpass pr comment UnClick module. | - | scripts/testpass-pr-comment.mjs |
 | Passes and gates | pass | testpass pr target | testpass pr target UnClick module. | - | scripts/testpass-pr-target.mjs |
 | Passes and gates | pass | testpass run | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/testpass-run.ts |

--- a/packages/mcp-server/src/__tests__/testpass-tool.test.ts
+++ b/packages/mcp-server/src/__tests__/testpass-tool.test.ts
@@ -144,6 +144,11 @@ describe("TestPass MCP tool", () => {
     expect(tool?.inputSchema.required).toContain("notes");
   });
 
+  it("warns agents that fail-to-pass edits are signal flagged", () => {
+    const tool = ADDITIONAL_TOOLS.find((candidate) => candidate.name === "testpass_edit_item");
+    expect(tool?.description).toContain("Fail-to-pass edits are flagged in mc_signals");
+  });
+
   it("advertises the research-brief MCP affordances", () => {
     const toolNames = ADDITIONAL_TOOLS.map((tool) => tool.name);
     expect(toolNames).toEqual(expect.arrayContaining([

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12172,7 +12172,7 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "testpass_edit_item",
-    description: "Override the verdict and optional notes for a single check item in a TestPass run.",
+    description: "Override the verdict and notes for a single check item in a TestPass run. Fail-to-pass edits are flagged in mc_signals.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,


### PR DESCRIPTION
## Summary
- Detects TestPass manual fail-to-pass item edits before the verdict patch is applied.
- Requires an auditable tenant key for that risky path and inserts an action_needed mc_signals anomaly with the reviewer notes.
- Advertises the MCP tool behavior so agents know fail-to-pass edits are flagged.

## Why
Unattended agents should not be able to quietly turn a failing TestPass item into a passing one. The edit path already required notes, but it did not raise an anomaly for the highest-risk transition.

## Validation
- git diff --cached --check
- no banned arrow or em-dash characters in touched files
- node --experimental-strip-types smoke for the new guard helper
- npx vitest targeted run attempted, blocked by missing local clean-worktree dependencies, so GitHub checks are the broad proof

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quality-gate and merge-hold signaling for manual verdict overrides; incorrect detection or signal failures could block legitimate edits or miss risky ones.
> 
> **Overview**
> **TestPass manual edits** that move a check item from **fail** to **pass** (`check` in the DB) are now treated as high-risk: the API loads the item **before** patching, and for that transition only it **must** resolve an auditable `api_key_hash`, **inserts** an `action_needed` **`mc_signals`** row (`fail_to_pass_override`, anomaly + `auto_merge_gate: hold`, reviewer notes), then applies the verdict update. Missing a key returns **409**; signal insert failure returns **500** and blocks the edit. The **`edit_item`** response adds **`override_guard`** so callers know whether a signal was recorded.
> 
> Shared logic lives in **`api/lib/testpass-edit-guard.ts`** with unit tests; the MCP **`testpass_edit_item`** description warns agents that fail-to-pass edits are flagged. Brainmap inventory counts were regenerated to include the new pass helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef866fa28afc4f14583078e321433adc992609f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->