### PR TITLE
ci: workflow hygiene — finish action bumps + tier-2 auto-merge containment

### DIFF
--- a/.github/workflows/autonomous-runner.yml
+++ b/.github/workflows/autonomous-runner.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Restore execute canary daily cap
         id: canary-cap
         if: ${{ github.event_name == 'schedule' && vars.AUTONOMOUS_RUNNER_SCHEDULED_EXECUTE_CANARY == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .pinballwake/canary-daily-cap
           key: autopilot-execute-canary-${{ steps.canary-day.outputs.day }}
@@ -281,7 +281,7 @@ jobs:
 
       - name: Save execute canary daily cap
         if: ${{ steps.runner-plan.outputs.canary_execute == 'true' && success() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .pinballwake/canary-daily-cap
           key: autopilot-execute-canary-${{ steps.canary-day.outputs.day }}

--- a/.github/workflows/dirty-branch-hygiene.yml
+++ b/.github/workflows/dirty-branch-hygiene.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/openhands-test-mode.yml
+++ b/.github/workflows/openhands-test-mode.yml
@@ -22,10 +22,10 @@ jobs:
       OPENHANDS_TEST_MODE: "1"
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/tier2-auto-merge-queue-check.yml
+++ b/.github/workflows/tier2-auto-merge-queue-check.yml
@@ -23,10 +23,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TIER2_AUTOMERGE_PR_LIMIT: "30"
-          TIER2_AUTOMERGE_EXECUTE: "true"
+          TIER2_AUTOMERGE_EXECUTE: "false"
           TIER2_AUTOMERGE_ALLOW_UNREVIEWED_LOW_RISK: "true"
           TIER2_AUTOMERGE_ALLOW_REVIEW_PROOF_COMMENTS: "true"
           TIER2_AUTOMERGE_MAX_MERGES: "1"
-          TIER2_AUTOMERGE_OPTIONAL_PENDING_CHECKS: "Cursor Bugbot"
           TIER2_AUTOMERGE_HYDRATE_POTENTIAL_CANDIDATES: "true"
         run: node scripts/tier2-auto-merge-queue-check.mjs

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8035,8 +8035,8 @@
     },
     {
       "source": ".github/workflows/tier2-auto-merge-queue-check.yml",
-      "hash": "f26a538f2ee9",
-      "bytes": 896
+      "hash": "5abfca8c42dc",
+      "bytes": 830
     }
   ]
 }

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7976,7 +7976,7 @@
     },
     {
       "source": ".github/workflows/autonomous-runner.yml",
-      "hash": "a1280cfec46b",
+      "hash": "a8c83efde889",
       "bytes": 15338
     },
     {
@@ -7986,7 +7986,7 @@
     },
     {
       "source": ".github/workflows/dirty-branch-hygiene.yml",
-      "hash": "9d192a7da041",
+      "hash": "3df7d09eebc7",
       "bytes": 2190
     },
     {
@@ -8006,7 +8006,7 @@
     },
     {
       "source": ".github/workflows/openhands-test-mode.yml",
-      "hash": "3bd5d5f48573",
+      "hash": "9aaef5273976",
       "bytes": 1137
     },
     {

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -188,13 +188,13 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/ebay-tool.ts | 10dffe36315f | 7595 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
-| .github/workflows/autonomous-runner.yml | a1280cfec46b | 15338 |
+| .github/workflows/autonomous-runner.yml | a8c83efde889 | 15338 |
 | .github/workflows/claude.yml | e8fc79a85b6c | 1085 |
-| .github/workflows/dirty-branch-hygiene.yml | 9d192a7da041 | 2190 |
+| .github/workflows/dirty-branch-hygiene.yml | 3df7d09eebc7 | 2190 |
 | .github/workflows/dogfood-report.yml | 65897c4393aa | 6605 |
 | .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
-| .github/workflows/openhands-test-mode.yml | 3bd5d5f48573 | 1137 |
+| .github/workflows/openhands-test-mode.yml | 9aaef5273976 | 1137 |
 | .github/workflows/publish-channel-package.yml | 5c9197848ca9 | 8046 |
 | .github/workflows/publish-mcp-package.yml | 9ab3fed97fef | 5749 |
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -201,7 +201,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
 | .github/workflows/testpass-pr-check.yml | bca601f0a1c2 | 20251 |
 | .github/workflows/testpass-scheduled-smoke.yml | 46f9a65b1dbb | 1673 |
-| .github/workflows/tier2-auto-merge-queue-check.yml | f26a538f2ee9 | 896 |
+| .github/workflows/tier2-auto-merge-queue-check.yml | 5abfca8c42dc | 830 |
 
 ## Division Index
 


### PR DESCRIPTION
## What this does

CI/workflow hygiene pass. Two parts, both workflow-only:

### 1. Finish the GitHub Actions version bumps
Main was already on `actions/checkout@v6` + `actions/setup-node@v6` almost everywhere; this cleans up the remaining stragglers:
- `dirty-branch-hygiene.yml`: `checkout@v4` -> `v6`, `setup-node@v4` -> `v6`
- `openhands-test-mode.yml`: `checkout@v4` -> `v6`, `setup-node@v4` -> `v6`
- `autonomous-runner.yml`: `cache/restore@v4` + `cache/save@v4` -> `v5`

Satisfies and supersedes Dependabot **#960**, **#961**, **#1048** (they auto-close once this lands).

### 2. Tier-2 auto-merge containment (supersedes #1018)
In `tier2-auto-merge-queue-check.yml`:
- `TIER2_AUTOMERGE_EXECUTE: "false"` — the 10-minute cron now reports in dry-run only and will not merge PRs without real review.
- Removed `TIER2_AUTOMERGE_OPTIONAL_PENDING_CHECKS: "Cursor Bugbot"` — Bugbot is discontinued.

Re-enable `EXECUTE` later only behind the hardened v1 rail (app token, counted approval, ledger writes, Boardroom close trail) described in #1018.

The brainmap is regenerated to match the changed workflow content hashes (the CI stale guard tracks them).

## Risk
Low. Workflow-only, no app logic. `checkout@v6` / `cache@v5` need runner v2.327.1+, which GitHub-hosted runners exceed. `setup-node@v6` limits auto-caching to npm; this repo uses npm. The containment change only makes auto-merge *safer* (stops unattended merges).

Part of the cloud-repo merge-coordination + ring-fence pass.

https://claude.ai/code/session_01LtAec6MBm6LcsLkcKKgbA4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; tier-2 containment reduces merge automation risk rather than expanding it.
> 
> **Overview**
> **Workflow hygiene only:** bumps remaining GitHub Actions to match the rest of the repo (`checkout`/`setup-node` **v6** in dirty-branch and OpenHands test workflows; **cache restore/save v5** in autonomous-runner) and refreshes generated brainmap hashes so CI stale guards stay aligned.
> 
> **Tier-2 auto-merge containment:** the scheduled queue job now runs with **`TIER2_AUTOMERGE_EXECUTE: "false"`** so the ~10-minute cron evaluates the queue in **dry-run** and will not merge PRs unattended. **`TIER2_AUTOMERGE_OPTIONAL_PENDING_CHECKS`** for Cursor Bugbot is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2088ef3672b43a7d8c7f19518d869debf8123acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->