### PR TITLE
feat(autopilotiq): Phase 0 foundation (supersedes #1144/#1145/#1146)

### DIFF
--- a/api/autopilotiq-circuit-breakers.test.ts
+++ b/api/autopilotiq-circuit-breakers.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOPILOTIQ_COMPONENTS,
+  CIRCUIT_BREAK_REASONS,
+  DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+  DEFAULT_CIRCUIT_BREAKER_LIMITS,
+  evaluateCircuitBreaker,
+  isComponentAllowed,
+  isComponentPaused,
+  isSelfImprovementKilled,
+  recordCircuitBreak,
+  type AutopilotIQComponent,
+  type AutopilotIQSafetyConfig,
+  type CircuitBreakerLimits,
+  type CircuitBreakRecord,
+} from "./lib/autopilotiq-circuit-breakers";
+
+describe("evaluateCircuitBreaker (Layer 1)", () => {
+  it("allows when no resource has been used and defaults apply", () => {
+    const v = evaluateCircuitBreaker({});
+    expect(v.allow).toBe(true);
+    expect(v.breached).toBeNull();
+    expect(v.detail).toContain("within all configured limits");
+  });
+
+  it("allows when usage is exactly at the limit (strict > triggers breach)", () => {
+    const limits: CircuitBreakerLimits = { max_actions: 8 };
+    expect(evaluateCircuitBreaker({ actions: 8 }, limits).allow).toBe(true);
+    expect(evaluateCircuitBreaker({ actions: 9 }, limits).allow).toBe(false);
+  });
+
+  it("treats an undefined limit as uncapped for that resource", () => {
+    const limits: CircuitBreakerLimits = { max_actions: 8 }; // tokens uncapped
+    const v = evaluateCircuitBreaker({ actions: 1, tokens: 1_000_000 }, limits);
+    expect(v.allow).toBe(true);
+  });
+
+  it("breaches circuit_break_actions with a clear detail line", () => {
+    const v = evaluateCircuitBreaker({ actions: 12 }, { max_actions: 8 });
+    expect(v.allow).toBe(false);
+    expect(v.breached).toBe("circuit_break_actions");
+    expect(v.detail).toContain("actions=12");
+    expect(v.detail).toContain("limit=8");
+  });
+
+  it("breaches circuit_break_tokens when tokens exceed the cap", () => {
+    const v = evaluateCircuitBreaker({ tokens: 300_000 }, { max_tokens: 200_000 });
+    expect(v.breached).toBe("circuit_break_tokens");
+  });
+
+  it("breaches circuit_break_cost when usd exceeds the cap", () => {
+    const v = evaluateCircuitBreaker({ usd: 1.25 }, { max_usd: 1.0 });
+    expect(v.breached).toBe("circuit_break_cost");
+    expect(v.detail).toContain("usd=1.25");
+  });
+
+  it("breaches circuit_break_time when wall_ms exceeds the cap", () => {
+    const v = evaluateCircuitBreaker({ wall_ms: 600_000 }, { max_wall_ms: 5 * 60_000 });
+    expect(v.breached).toBe("circuit_break_time");
+  });
+
+  it("breaches circuit_break_retries when retries exceed the cap", () => {
+    const v = evaluateCircuitBreaker({ retries: 4 }, { max_retries: 3 });
+    expect(v.breached).toBe("circuit_break_retries");
+  });
+
+  it("returns the first deterministic breach when multiple limits are exceeded", () => {
+    // actions is checked first (actions > tokens > cost > time > retries)
+    const v = evaluateCircuitBreaker(
+      { actions: 99, tokens: 9_999_999, usd: 99 },
+      { max_actions: 8, max_tokens: 200_000, max_usd: 1.0 },
+    );
+    expect(v.breached).toBe("circuit_break_actions");
+  });
+
+  it("uses DEFAULT_CIRCUIT_BREAKER_LIMITS when no limits are provided", () => {
+    const v = evaluateCircuitBreaker({ actions: 9 });
+    expect(v.breached).toBe("circuit_break_actions");
+    expect(v.limits).toBe(DEFAULT_CIRCUIT_BREAKER_LIMITS);
+  });
+
+  it("every reason in CIRCUIT_BREAK_REASONS can be produced by some breach", () => {
+    const breachedReasons = new Set<string>();
+    breachedReasons.add(evaluateCircuitBreaker({ actions: 99 }, { max_actions: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ tokens: 99 }, { max_tokens: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ usd: 99 }, { max_usd: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ wall_ms: 99 }, { max_wall_ms: 1 }).breached!);
+    breachedReasons.add(evaluateCircuitBreaker({ retries: 99 }, { max_retries: 1 }).breached!);
+    for (const reason of CIRCUIT_BREAK_REASONS) {
+      expect(breachedReasons.has(reason)).toBe(true);
+    }
+  });
+});
+
+describe("isSelfImprovementKilled (Layer 3)", () => {
+  it("defaults to false", () => {
+    expect(isSelfImprovementKilled()).toBe(false);
+    expect(isSelfImprovementKilled(DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG)).toBe(false);
+  });
+
+  it("returns true when the flag is set", () => {
+    expect(isSelfImprovementKilled({ self_improvement_kill: true })).toBe(true);
+  });
+});
+
+describe("isComponentPaused (Layer 2)", () => {
+  it("defaults to not paused", () => {
+    for (const component of AUTOPILOTIQ_COMPONENTS) {
+      expect(isComponentPaused(component)).toBe(false);
+    }
+  });
+
+  it("returns true only for the named paused components", () => {
+    const config: AutopilotIQSafetyConfig = {
+      paused_components: ["seat_intelligence", "creative_evolution"],
+    };
+    expect(isComponentPaused("seat_intelligence", config)).toBe(true);
+    expect(isComponentPaused("creative_evolution", config)).toBe(true);
+    expect(isComponentPaused("autopilotiq_tuner", config)).toBe(false);
+  });
+
+  it("the global kill switch trumps the per-component list", () => {
+    const config: AutopilotIQSafetyConfig = {
+      self_improvement_kill: true,
+      paused_components: [], // explicitly empty
+    };
+    for (const component of AUTOPILOTIQ_COMPONENTS) {
+      expect(isComponentPaused(component, config)).toBe(true);
+    }
+  });
+});
+
+describe("isComponentAllowed (compound)", () => {
+  it("reports allowed=true with reason='ok' under default config", () => {
+    expect(isComponentAllowed("autopilotiq_tuner")).toEqual({ allowed: true, reason: "ok" });
+  });
+
+  it("reports reason='kill_switch' when the global kill is engaged", () => {
+    const v = isComponentAllowed("autopilotiq_tuner", { self_improvement_kill: true });
+    expect(v).toEqual({ allowed: false, reason: "kill_switch" });
+  });
+
+  it("reports reason='component_paused' when only that component is paused", () => {
+    const v = isComponentAllowed("retry_tuner", {
+      self_improvement_kill: false,
+      paused_components: ["retry_tuner"],
+    });
+    expect(v).toEqual({ allowed: false, reason: "component_paused" });
+  });
+
+  it("kill_switch is reported instead of component_paused when both apply", () => {
+    const v = isComponentAllowed("retry_tuner", {
+      self_improvement_kill: true,
+      paused_components: ["retry_tuner"],
+    });
+    expect(v.reason).toBe("kill_switch");
+  });
+});
+
+describe("recordCircuitBreak", () => {
+  it("returns null and never calls the recorder when the verdict allows", async () => {
+    let called = 0;
+    const record = await recordCircuitBreak({
+      jobId: "job-1",
+      verdict: evaluateCircuitBreaker({ actions: 1 }, { max_actions: 8 }),
+      recorder: () => {
+        called += 1;
+      },
+    });
+    expect(record).toBeNull();
+    expect(called).toBe(0);
+  });
+
+  it("builds a record with the Slice 0a adapter shape on breach", async () => {
+    const verdict = evaluateCircuitBreaker(
+      { actions: 99, tokens: 1234, usd: 5.5, wall_ms: 12_000, retries: 2 },
+      { max_actions: 8 },
+    );
+    const record = await recordCircuitBreak({
+      jobId: "job-cb-1",
+      parentJobId: "epic-1",
+      attemptN: 3,
+      receiptId: "receipt-x",
+      routeTaken: { seat: "builder", model: "openai/gpt-oss-120b:free", tool_set: ["edit"] },
+      verdict,
+    });
+
+    expect(record).not.toBeNull();
+    const r = record as CircuitBreakRecord;
+    expect(r.jobId).toBe("job-cb-1");
+    expect(r.parentJobId).toBe("epic-1");
+    expect(r.taskType).toBe("circuit_break");
+    expect(r.attemptN).toBe(3);
+    expect(r.outcome).toBe("fail");
+    expect(r.outcomeReason).toBe("policy_block");
+    expect(r.break_reason).toBe("circuit_break_actions");
+    expect(r.break_detail).toContain("actions=99");
+    expect(r.routeTaken).toEqual({
+      seat: "builder",
+      model: "openai/gpt-oss-120b:free",
+      prompt_version: "circuit_break:circuit_break_actions",
+      tool_set: ["edit"],
+    });
+    expect(r.costSignal).toEqual({ tokens: 1234, wall_ms: 12_000, usd: 5.5, retries: 2 });
+    expect(r.receiptId).toBe("receipt-x");
+  });
+
+  it("calls the injected recorder exactly once per breach with the same record", async () => {
+    const seen: CircuitBreakRecord[] = [];
+    const verdict = evaluateCircuitBreaker({ usd: 2 }, { max_usd: 1 });
+    const record = await recordCircuitBreak({
+      jobId: "job-cb-2",
+      verdict,
+      recorder: (rec) => {
+        seen.push(rec);
+      },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe(record);
+    expect(seen[0].break_reason).toBe("circuit_break_cost");
+  });
+
+  it("returns the record even when no recorder is provided", async () => {
+    const verdict = evaluateCircuitBreaker({ retries: 5 }, { max_retries: 3 });
+    const record = await recordCircuitBreak({ jobId: "job-cb-3", verdict });
+    expect(record?.break_reason).toBe("circuit_break_retries");
+  });
+});

--- a/api/autopilotiq-outcome-ledger.test.ts
+++ b/api/autopilotiq-outcome-ledger.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOPILOT_OUTCOME_REASONS,
+  AUTOPILOT_OUTCOMES,
+  buildAutopilotOutcomeRow,
+  type AutopilotOutcomeInput,
+} from "./lib/autopilotiq-outcome-ledger";
+
+const now = new Date("2026-05-28T00:00:00.000Z");
+
+function baseInput(overrides: Partial<AutopilotOutcomeInput> = {}): AutopilotOutcomeInput {
+  return {
+    apiKeyHash: "hash_abc",
+    jobId: "job-123",
+    taskType: "coding",
+    outcome: "success",
+    outcomeReason: "proof_landed",
+    now,
+    ...overrides,
+  };
+}
+
+describe("autopilotiq outcome ledger", () => {
+  it("builds an immutable per-attempt row with route, cost, and defaults", () => {
+    const row = buildAutopilotOutcomeRow(
+      baseInput({
+        parentJobId: "epic-1",
+        attemptN: 2,
+        actorAgentId: "runner-seat",
+        routeTaken: {
+          seat: "builder",
+          model: "openai/gpt-oss-120b:free",
+          prompt_version: "v3",
+          tool_set: ["edit", "bash"],
+        },
+        costSignal: { tokens: 1200, wall_ms: 8400, usd: 0.0, retries: 1 },
+        xpassVerdict: "PASS",
+        confidence: "hard_gate",
+        humanTouch: "approved",
+        receiptId: "receipt-9",
+        closedAt: "2026-05-28T00:01:00.000Z",
+        inputs: { brief: "ship the slice", owned_files: ["api/x.ts"] },
+      }),
+    );
+
+    expect(row).toMatchObject({
+      api_key_hash: "hash_abc",
+      job_id: "job-123",
+      parent_job_id: "epic-1",
+      attempt_n: 2,
+      task_type: "coding",
+      actor_agent_id: "runner-seat",
+      xpass_verdict: "PASS",
+      outcome: "success",
+      outcome_reason: "proof_landed",
+      confidence: "hard_gate",
+      human_touch: "approved",
+      receipt_id: "receipt-9",
+      created_at: "2026-05-28T00:00:00.000Z",
+      closed_at: "2026-05-28T00:01:00.000Z",
+    });
+    expect(row.route_taken).toEqual({
+      seat: "builder",
+      model: "openai/gpt-oss-120b:free",
+      prompt_version: "v3",
+      tool_set: ["edit", "bash"],
+    });
+    expect(row.cost_signal).toEqual({ tokens: 1200, wall_ms: 8400, usd: 0, retries: 1 });
+    expect(row.inputs_hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("applies safe defaults when optional fields are omitted", () => {
+    const row = buildAutopilotOutcomeRow(baseInput({ outcome: "hold", outcomeReason: "awaiting_proof" }));
+    expect(row.attempt_n).toBe(1);
+    expect(row.actor_agent_id).toBe("autopilot");
+    expect(row.parent_job_id).toBeNull();
+    expect(row.receipt_id).toBeNull();
+    expect(row.closed_at).toBeNull();
+    expect(row.xpass_verdict).toBe("none");
+    expect(row.confidence).toBe("silence");
+    expect(row.human_touch).toBe("auto");
+    expect(row.route_taken).toEqual({ seat: null, model: null, prompt_version: null, tool_set: null });
+    expect(row.cost_signal).toEqual({ tokens: null, wall_ms: null, usd: null, retries: null });
+  });
+
+  it("hashes inputs deterministically and never stores them raw", () => {
+    const a = buildAutopilotOutcomeRow(baseInput({ inputs: { a: 1, b: 2 } }));
+    const b = buildAutopilotOutcomeRow(baseInput({ inputs: { b: 2, a: 1 } }));
+    const c = buildAutopilotOutcomeRow(baseInput({ inputs: { a: 1, b: 3 } }));
+    // Order-independent (stable) hash; different content => different hash.
+    expect(a.inputs_hash).toBe(b.inputs_hash);
+    expect(a.inputs_hash).not.toBe(c.inputs_hash);
+    // The raw input values must not appear anywhere on the row.
+    expect(JSON.stringify(a)).not.toContain('"a":1');
+    expect("inputs" in (a as Record<string, unknown>)).toBe(false);
+  });
+
+  it("derives a stable idempotency key within the same time bucket", () => {
+    const row1 = buildAutopilotOutcomeRow(baseInput({ inputs: { x: 1 } }));
+    const row2 = buildAutopilotOutcomeRow(baseInput({ inputs: { x: 1 } }));
+    expect(row1.idempotency_key).toBe(row2.idempotency_key);
+    expect(row1.idempotency_key).toContain("job-123:1:success:proof_landed:");
+    const otherAttempt = buildAutopilotOutcomeRow(baseInput({ attemptN: 2, inputs: { x: 1 } }));
+    expect(otherAttempt.idempotency_key).not.toBe(row1.idempotency_key);
+  });
+
+  it("rejects values outside the closed taxonomies", () => {
+    expect(() => buildAutopilotOutcomeRow(baseInput({ outcome: "maybe" }))).toThrow(/outcome/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ outcomeReason: "vibes" }))).toThrow(
+      /outcome_reason/,
+    );
+    expect(() => buildAutopilotOutcomeRow(baseInput({ confidence: "medium" }))).toThrow(/confidence/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ humanTouch: "ignored" }))).toThrow(/human_touch/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ xpassVerdict: "MAYBE" }))).toThrow(/xpass_verdict/);
+  });
+
+  it("refuses secret-shaped inputs and route fields before writing", () => {
+    expect(() => buildAutopilotOutcomeRow(baseInput({ inputs: { api_key: "uc_deadbeefdeadbeef" } }))).toThrow(
+      /sensitive key/,
+    );
+    expect(() =>
+      buildAutopilotOutcomeRow(baseInput({ inputs: { note: "Authorization: Bearer abc.def.ghi" } })),
+    ).toThrow(/sensitive text/);
+    expect(() =>
+      buildAutopilotOutcomeRow(
+        baseInput({ routeTaken: { seat: "builder", token: "sk-abcdef0123456789" } as never }),
+      ),
+    ).toThrow(/sensitive key/);
+  });
+
+  it("validates required fields and attempt_n", () => {
+    expect(() => buildAutopilotOutcomeRow(baseInput({ jobId: "" }))).toThrow(/job_id required/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ taskType: "" }))).toThrow(/task_type required/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ apiKeyHash: "" }))).toThrow(/api_key_hash required/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ attemptN: 0 }))).toThrow(/attempt_n/);
+    expect(() => buildAutopilotOutcomeRow(baseInput({ attemptN: 1.5 }))).toThrow(/attempt_n/);
+  });
+
+  it("exposes closed taxonomies as frozen-shaped constants", () => {
+    expect(AUTOPILOT_OUTCOMES).toContain("success");
+    expect(AUTOPILOT_OUTCOMES).toContain("fail");
+    expect(AUTOPILOT_OUTCOMES).toContain("hold");
+    expect(AUTOPILOT_OUTCOME_REASONS).toContain("xpass_fail");
+    expect(AUTOPILOT_OUTCOME_REASONS).toContain("budget_exceeded");
+    expect(AUTOPILOT_OUTCOME_REASONS).toContain("policy_block");
+    // Every reason is unique.
+    expect(new Set(AUTOPILOT_OUTCOME_REASONS).size).toBe(AUTOPILOT_OUTCOME_REASONS.length);
+  });
+});

--- a/api/autopilotiq-probe-set.test.ts
+++ b/api/autopilotiq-probe-set.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROBE_CHECK_KINDS,
+  PROBE_SET_V0,
+  PROBE_TASK_TYPES,
+  aggregateProbeResults,
+  checkProbeDrift,
+  checkScoreboardHonesty,
+  runProbeSuite,
+  scoreProbe,
+  type Probe,
+  type ProbeOutcomeRecord,
+  type ProbeResult,
+} from "./lib/autopilotiq-probe-set";
+
+function probe(overrides: Partial<Probe> & Pick<Probe, "expected" | "check_kind">): Probe {
+  return {
+    id: overrides.id ?? "probe.test.example",
+    task_type: overrides.task_type ?? "format",
+    prompt: overrides.prompt ?? "test prompt",
+    description: overrides.description ?? "test description",
+    expected: overrides.expected,
+    check_kind: overrides.check_kind,
+  };
+}
+
+describe("autopilotiq probe set v0 - data integrity", () => {
+  it("exposes a non-empty, frozen probe set with unique ids and valid taxonomies", () => {
+    expect(PROBE_SET_V0.length).toBeGreaterThanOrEqual(6);
+    const ids = PROBE_SET_V0.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const p of PROBE_SET_V0) {
+      expect(PROBE_TASK_TYPES).toContain(p.task_type);
+      expect(PROBE_CHECK_KINDS).toContain(p.check_kind);
+      expect(p.prompt.length).toBeGreaterThan(0);
+      expect(p.expected.length).toBeGreaterThan(0);
+      expect(p.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("scoreProbe", () => {
+  it("equals: exact match passes, others fail with a reason", () => {
+    const p = probe({ expected: "yes", check_kind: "equals" });
+    expect(scoreProbe(p, "yes")).toEqual({ pass: true, reason: "exact match" });
+    expect(scoreProbe(p, "Yes").pass).toBe(false);
+    expect(scoreProbe(p, "no").reason).toContain("expected 'yes'");
+  });
+
+  it("equals_trimmed: ignores surrounding whitespace", () => {
+    const p = probe({ expected: "foo_bar_baz", check_kind: "equals_trimmed" });
+    expect(scoreProbe(p, "  foo_bar_baz\n").pass).toBe(true);
+    expect(scoreProbe(p, "foo bar baz").pass).toBe(false);
+  });
+
+  it("includes: substring presence", () => {
+    const p = probe({ expected: "needle", check_kind: "includes" });
+    expect(scoreProbe(p, "a haystack needle inside").pass).toBe(true);
+    expect(scoreProbe(p, "a haystack").pass).toBe(false);
+  });
+
+  it("regex: pattern match against actual", () => {
+    const p = probe({ expected: "^\\d{4}-\\d{2}-\\d{2}$", check_kind: "regex" });
+    expect(scoreProbe(p, "2026-05-28").pass).toBe(true);
+    expect(scoreProbe(p, "May 28, 2026").pass).toBe(false);
+  });
+
+  it("regex: invalid pattern fails cleanly without throwing", () => {
+    const p = probe({ expected: "[unterminated", check_kind: "regex" });
+    const result = scoreProbe(p, "anything");
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("invalid regex");
+  });
+
+  it("json_equal: order-independent equality on parsed JSON", () => {
+    const p = probe({ expected: '[1,2,3]', check_kind: "json_equal" });
+    expect(scoreProbe(p, "[1,2,3]").pass).toBe(true);
+    expect(scoreProbe(p, "[ 1, 2, 3 ]").pass).toBe(true);
+    expect(scoreProbe(p, "[3,2,1]").pass).toBe(false);
+
+    const obj = probe({ expected: '{"a":1,"b":2}', check_kind: "json_equal" });
+    expect(scoreProbe(obj, '{"b":2,"a":1}').pass).toBe(true);
+    expect(scoreProbe(obj, "not json").pass).toBe(false);
+  });
+
+  it("length_at_least: minimum character count", () => {
+    const p = probe({ expected: "10", check_kind: "length_at_least" });
+    expect(scoreProbe(p, "1234567890").pass).toBe(true);
+    expect(scoreProbe(p, "short").pass).toBe(false);
+  });
+});
+
+describe("aggregateProbeResults", () => {
+  function res(overrides: Partial<ProbeResult>): ProbeResult {
+    return {
+      probe_id: overrides.probe_id ?? "p",
+      task_type: overrides.task_type ?? "format",
+      pass: overrides.pass ?? true,
+      reason: overrides.reason ?? "",
+      actual: overrides.actual ?? "",
+      wall_ms: overrides.wall_ms ?? 0,
+      started_at: overrides.started_at ?? "2026-05-28T00:00:00.000Z",
+      finished_at: overrides.finished_at ?? "2026-05-28T00:00:00.000Z",
+    };
+  }
+
+  it("computes pass_rate and a per-task-type breakdown", () => {
+    const results = [
+      res({ probe_id: "a", task_type: "json_extract", pass: true }),
+      res({ probe_id: "b", task_type: "json_extract", pass: false }),
+      res({ probe_id: "c", task_type: "regex_match", pass: true }),
+      res({ probe_id: "d", task_type: "regex_match", pass: true }),
+    ];
+    const board = aggregateProbeResults(results, {
+      suiteRunId: "run-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+    });
+    expect(board.total).toBe(4);
+    expect(board.passed).toBe(3);
+    expect(board.failed).toBe(1);
+    expect(board.pass_rate).toBeCloseTo(0.75, 5);
+    expect(board.by_task_type.json_extract).toEqual({ total: 2, passed: 1, pass_rate: 0.5 });
+    expect(board.by_task_type.regex_match).toEqual({ total: 2, passed: 2, pass_rate: 1 });
+    expect(board.suite_run_id).toBe("run-1");
+  });
+
+  it("returns pass_rate=0 (not NaN) for an empty result set", () => {
+    const board = aggregateProbeResults([], {
+      suiteRunId: "run-empty",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+    });
+    expect(board.total).toBe(0);
+    expect(board.pass_rate).toBe(0);
+    expect(board.by_task_type).toEqual({});
+  });
+});
+
+describe("checkProbeDrift", () => {
+  it("classifies stable when |delta| < threshold", () => {
+    const r = checkProbeDrift({ baseline_pass_rate: 0.8, current_pass_rate: 0.82, threshold: 0.05 });
+    expect(r.verdict).toBe("stable");
+    expect(r.delta).toBeCloseTo(0.02, 5);
+  });
+
+  it("classifies drifting_up when delta exceeds threshold positive", () => {
+    const r = checkProbeDrift({ baseline_pass_rate: 0.6, current_pass_rate: 0.8, threshold: 0.05 });
+    expect(r.verdict).toBe("drifting_up");
+  });
+
+  it("classifies drifting_down when delta exceeds threshold negative", () => {
+    const r = checkProbeDrift({ baseline_pass_rate: 0.9, current_pass_rate: 0.7, threshold: 0.05 });
+    expect(r.verdict).toBe("drifting_down");
+  });
+});
+
+describe("checkScoreboardHonesty (catches lying scoreboard)", () => {
+  it("flags an 'improving' claim against flat probes as dishonest", () => {
+    const v = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: 0.8,
+      current_pass_rate: 0.81,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(false);
+    expect(v.observed_verdict).toBe("stable");
+    expect(v.reason).toContain("contradicts observed");
+  });
+
+  it("flags an 'improving' claim against a real drop as dishonest", () => {
+    const v = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: 0.9,
+      current_pass_rate: 0.7,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(false);
+    expect(v.observed_verdict).toBe("drifting_down");
+  });
+
+  it("accepts an honest 'improving' claim when probes actually drift up", () => {
+    const v = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: 0.6,
+      current_pass_rate: 0.8,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(true);
+    expect(v.observed_verdict).toBe("drifting_up");
+  });
+
+  it("accepts an honest 'stable' claim", () => {
+    const v = checkScoreboardHonesty({
+      claim: "stable",
+      baseline_pass_rate: 0.8,
+      current_pass_rate: 0.79,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(true);
+    expect(v.observed_verdict).toBe("stable");
+  });
+
+  it("flags a 'stable' claim when probes are actually degrading", () => {
+    const v = checkScoreboardHonesty({
+      claim: "stable",
+      baseline_pass_rate: 0.9,
+      current_pass_rate: 0.6,
+      threshold: 0.05,
+    });
+    expect(v.honest).toBe(false);
+    expect(v.observed_verdict).toBe("drifting_down");
+  });
+});
+
+describe("runProbeSuite (end-to-end harness)", () => {
+  it("runs the suite with an oracle executor and yields a green scoreboard", async () => {
+    let tick = 0;
+    const out = await runProbeSuite({
+      executor: (p) => p.expected, // oracle: always return the expected answer
+      suiteRunId: "run-oracle",
+      now: () => new Date(Date.parse("2026-05-28T00:00:00.000Z") + ++tick * 5),
+    });
+    expect(out.scoreboard.total).toBe(PROBE_SET_V0.length);
+    expect(out.scoreboard.passed).toBe(PROBE_SET_V0.length);
+    expect(out.scoreboard.pass_rate).toBe(1);
+    for (const result of out.results) {
+      expect(result.pass).toBe(true);
+      expect(result.wall_ms).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("runs the suite with a degenerate executor and yields a red scoreboard", async () => {
+    const out = await runProbeSuite({
+      executor: () => "definitely wrong",
+      suiteRunId: "run-bad",
+    });
+    expect(out.scoreboard.passed).toBe(0);
+    expect(out.scoreboard.pass_rate).toBe(0);
+    expect(out.results.every((r) => !r.pass)).toBe(true);
+  });
+
+  it("captures executor failures cleanly without throwing", async () => {
+    const out = await runProbeSuite({
+      executor: () => {
+        throw new Error("executor offline");
+      },
+    });
+    expect(out.scoreboard.failed).toBe(PROBE_SET_V0.length);
+    expect(out.results[0].reason).toContain("executor threw");
+  });
+
+  it("emits ProbeOutcomeRecord shaped for the Slice 0a recorder", async () => {
+    const records: ProbeOutcomeRecord[] = [];
+    await runProbeSuite({
+      executor: (p) => p.expected,
+      recorder: (record) => {
+        records.push(record);
+      },
+      suiteRunId: "run-record",
+      routeTaken: { seat: "builder", model: "openai/gpt-oss-120b:free", tool_set: ["edit"] },
+    });
+    expect(records).toHaveLength(PROBE_SET_V0.length);
+    const first = records[0];
+    expect(first.taskType).toBe("probe");
+    expect(first.parentJobId).toBe("run-record");
+    expect(first.outcome).toBe("success");
+    expect(first.outcomeReason).toBe("clean_pass");
+    expect(first.attemptN).toBe(1);
+    expect(first.routeTaken.prompt_version).toMatch(/^probe:/);
+    expect(first.routeTaken.seat).toBe("builder");
+    expect(first.routeTaken.tool_set).toEqual(["edit"]);
+    expect(first.costSignal.wall_ms).toBeGreaterThanOrEqual(0);
+    expect(first.prompt_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(first.expected_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(first.actual_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect("prompt" in (first as Record<string, unknown>)).toBe(false);
+    expect("expected" in (first as Record<string, unknown>)).toBe(false);
+    expect("actual" in (first as Record<string, unknown>)).toBe(false);
+  });
+
+  it("emits outcomeReason='wrong_route' for a failed probe via the recorder", async () => {
+    const records: ProbeOutcomeRecord[] = [];
+    await runProbeSuite({
+      executor: () => "definitely wrong",
+      recorder: (record) => {
+        records.push(record);
+      },
+    });
+    expect(records.every((r) => r.outcome === "fail")).toBe(true);
+    expect(records.every((r) => r.outcomeReason === "wrong_route")).toBe(true);
+  });
+
+  it("integrates with the honesty check: oracle vs degenerate runs map to claims", async () => {
+    const oracle = await runProbeSuite({ executor: (p) => p.expected });
+    const degenerate = await runProbeSuite({ executor: () => "wrong" });
+
+    // Pretend the prior baseline was the degenerate run; the oracle run is a
+    // real improvement, so an "improving" claim should be honest.
+    const honest = checkScoreboardHonesty({
+      claim: "improving",
+      baseline_pass_rate: degenerate.scoreboard.pass_rate,
+      current_pass_rate: oracle.scoreboard.pass_rate,
+      threshold: 0.05,
+    });
+    expect(honest.honest).toBe(true);
+    expect(honest.observed_verdict).toBe("drifting_up");
+
+    // Conversely: baseline was the oracle, but we now ship the degenerate run
+    // and try to claim "stable"; the honesty check must reject that lie.
+    const dishonest = checkScoreboardHonesty({
+      claim: "stable",
+      baseline_pass_rate: oracle.scoreboard.pass_rate,
+      current_pass_rate: degenerate.scoreboard.pass_rate,
+      threshold: 0.05,
+    });
+    expect(dishonest.honest).toBe(false);
+    expect(dishonest.observed_verdict).toBe("drifting_down");
+  });
+});

--- a/api/lib/autopilotiq-circuit-breakers.ts
+++ b/api/lib/autopilotiq-circuit-breakers.ts
@@ -1,0 +1,273 @@
+// AutopilotIQ circuit breakers + kill switches (Phase 0, Slice 0c) - safety
+// scaffolding, capture-only.
+//
+// Three layers of safety, built BEFORE anything acts (the spec is explicit:
+// build in Phase 0, never retrofit):
+//   1. Per-job circuit breaker - hard ceilings on actions/cost/tokens/wall/
+//      retries with CLOSED reason codes (circuit_break_*).
+//   2. Component pause flags - a readable per-component paused model, default
+//      safe and explicit.
+//   3. Global self-improvement kill switch - one boolean halts every
+//      autonomous self-improvement path.
+//
+// Pure / config-driven. Additive: nothing in this slice halts live production
+// jobs; later phases call these. The breach recorder is dependency-injected,
+// so this slice does not couple to Slice 0a's outcome ledger (PR #1144) and
+// stays independently mergeable. Natural production wiring once 0a lands is a
+// thin adapter that forwards CircuitBreakRecord to recordAutopilotOutcome.
+
+export const CIRCUIT_BREAK_REASONS = [
+  "circuit_break_actions",
+  "circuit_break_tokens",
+  "circuit_break_cost",
+  "circuit_break_time",
+  "circuit_break_retries",
+] as const;
+export type CircuitBreakReason = (typeof CIRCUIT_BREAK_REASONS)[number];
+
+export const AUTOPILOTIQ_COMPONENTS = [
+  "autopilotiq_tuner",
+  "seat_intelligence",
+  "creative_evolution",
+  "retry_tuner",
+  "shadow_learner",
+  "gated_learner",
+] as const;
+export type AutopilotIQComponent = (typeof AUTOPILOTIQ_COMPONENTS)[number];
+
+// Layer 1 inputs ---------------------------------------------------------
+
+export interface CircuitBreakerLimits {
+  // Each limit is optional; when undefined the corresponding resource is
+  // uncapped for this evaluation. Hard ceilings: usage > limit triggers a
+  // breach.
+  max_actions?: number;
+  max_tokens?: number;
+  max_usd?: number;
+  max_wall_ms?: number;
+  max_retries?: number;
+}
+
+export interface CircuitBreakerUsage {
+  actions?: number;
+  tokens?: number;
+  usd?: number;
+  wall_ms?: number;
+  retries?: number;
+}
+
+export interface CircuitBreakerVerdict {
+  allow: boolean;
+  breached: CircuitBreakReason | null;
+  detail: string;
+  limits: CircuitBreakerLimits;
+  usage: CircuitBreakerUsage;
+}
+
+// Conservative defaults. These are explicit and easy to tune; they intentionally
+// favour halting on uncertainty over continuing past safety budgets.
+export const DEFAULT_CIRCUIT_BREAKER_LIMITS: CircuitBreakerLimits = Object.freeze({
+  max_actions: 8,
+  max_tokens: 200_000,
+  max_usd: 1.0,
+  max_wall_ms: 5 * 60_000,
+  max_retries: 3,
+});
+
+// Layer 2 + 3 config ----------------------------------------------------
+
+export interface AutopilotIQSafetyConfig {
+  // Global kill switch. When true, every autonomous self-improvement path is
+  // considered halted regardless of per-component pause flags.
+  self_improvement_kill?: boolean;
+  // Per-component pauses. Default: empty (no components paused).
+  paused_components?: readonly AutopilotIQComponent[];
+}
+
+export const DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG: AutopilotIQSafetyConfig = Object.freeze({
+  self_improvement_kill: false,
+  paused_components: [],
+});
+
+// ----------------------------------------------------------------------
+// Layer 1: per-job circuit breaker
+// ----------------------------------------------------------------------
+
+/**
+ * Evaluate hard ceilings for a single job's resource usage. Pure - no I/O.
+ * Returns the first deterministic breach (order: actions, tokens, cost, time,
+ * retries) so callers see the most economically obvious cap first. A limit of
+ * `undefined` means uncapped for that resource; usage of `undefined` counts as
+ * zero. Breach when `usage > limit` (strict): equality is still allowed.
+ */
+export function evaluateCircuitBreaker(
+  usage: CircuitBreakerUsage,
+  limits: CircuitBreakerLimits = DEFAULT_CIRCUIT_BREAKER_LIMITS,
+): CircuitBreakerVerdict {
+  const checks: Array<{
+    used: number;
+    limit: number | undefined;
+    reason: CircuitBreakReason;
+    label: string;
+  }> = [
+    { used: usage.actions ?? 0, limit: limits.max_actions, reason: "circuit_break_actions", label: "actions" },
+    { used: usage.tokens ?? 0, limit: limits.max_tokens, reason: "circuit_break_tokens", label: "tokens" },
+    { used: usage.usd ?? 0, limit: limits.max_usd, reason: "circuit_break_cost", label: "usd" },
+    { used: usage.wall_ms ?? 0, limit: limits.max_wall_ms, reason: "circuit_break_time", label: "wall_ms" },
+    { used: usage.retries ?? 0, limit: limits.max_retries, reason: "circuit_break_retries", label: "retries" },
+  ];
+
+  for (const check of checks) {
+    if (typeof check.limit !== "number") continue;
+    if (check.used > check.limit) {
+      return {
+        allow: false,
+        breached: check.reason,
+        detail: `${check.label}=${check.used} > limit=${check.limit}`,
+        limits,
+        usage,
+      };
+    }
+  }
+
+  return {
+    allow: true,
+    breached: null,
+    detail: "within all configured limits",
+    limits,
+    usage,
+  };
+}
+
+// ----------------------------------------------------------------------
+// Layer 2 + 3: component pause / global kill
+// ----------------------------------------------------------------------
+
+/**
+ * True when the global self-improvement kill switch is engaged. Pure read.
+ */
+export function isSelfImprovementKilled(
+  config: AutopilotIQSafetyConfig = DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+): boolean {
+  return Boolean(config.self_improvement_kill);
+}
+
+/**
+ * True when a specific component is paused. The global kill switch trumps
+ * everything (any component is paused when the kill is engaged); otherwise
+ * `paused_components` decides.
+ */
+export function isComponentPaused(
+  name: AutopilotIQComponent,
+  config: AutopilotIQSafetyConfig = DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+): boolean {
+  if (isSelfImprovementKilled(config)) return true;
+  const paused = config.paused_components ?? [];
+  return paused.includes(name);
+}
+
+export interface ComponentAllowance {
+  allowed: boolean;
+  reason: "ok" | "kill_switch" | "component_paused";
+}
+
+/**
+ * Compound check: returns allowed=false with the precise reason. Use this on
+ * any code path that's about to invoke an AutopilotIQ component so the cause
+ * of a halt is always explicit.
+ */
+export function isComponentAllowed(
+  name: AutopilotIQComponent,
+  config: AutopilotIQSafetyConfig = DEFAULT_AUTOPILOTIQ_SAFETY_CONFIG,
+): ComponentAllowance {
+  if (isSelfImprovementKilled(config)) return { allowed: false, reason: "kill_switch" };
+  const paused = config.paused_components ?? [];
+  if (paused.includes(name)) return { allowed: false, reason: "component_paused" };
+  return { allowed: true, reason: "ok" };
+}
+
+// ----------------------------------------------------------------------
+// Breach record (Slice 0a adapter shape)
+// ----------------------------------------------------------------------
+
+// Field names mirror the camelCase input of Slice 0a's recordAutopilotOutcome
+// (api/lib/autopilotiq-outcome-ledger.ts in PR #1144) so a one-line adapter
+// can forward these once 0a lands. outcomeReason="policy_block" is the
+// natural fit in 0a's closed taxonomy.
+export interface CircuitBreakRecord {
+  jobId: string;
+  parentJobId: string | null;
+  taskType: "circuit_break";
+  attemptN: number;
+  outcome: "fail";
+  outcomeReason: "policy_block";
+  routeTaken: {
+    seat: string | null;
+    model: string | null;
+    prompt_version: string;
+    tool_set: string[] | null;
+  };
+  costSignal: {
+    tokens: number | null;
+    wall_ms: number | null;
+    usd: number | null;
+    retries: number | null;
+  };
+  receiptId: string | null;
+  break_reason: CircuitBreakReason;
+  break_detail: string;
+}
+
+export type CircuitBreakRecorder = (record: CircuitBreakRecord) => Promise<void> | void;
+
+export interface RecordCircuitBreakInput {
+  jobId: string;
+  parentJobId?: string | null;
+  attemptN?: number;
+  verdict: CircuitBreakerVerdict;
+  recorder?: CircuitBreakRecorder;
+  receiptId?: string | null;
+  routeTaken?: Partial<CircuitBreakRecord["routeTaken"]>;
+}
+
+/**
+ * Build a circuit-break record and emit it through an optional recorder.
+ * Returns `null` when the verdict is allow-true (no breach to record) and the
+ * built record otherwise. Capture-only: the caller decides whether to also
+ * halt the job; this helper just preserves the breach as evidence.
+ */
+export async function recordCircuitBreak(
+  input: RecordCircuitBreakInput,
+): Promise<CircuitBreakRecord | null> {
+  if (input.verdict.allow || input.verdict.breached === null) return null;
+
+  const route = input.routeTaken ?? {};
+  const record: CircuitBreakRecord = {
+    jobId: input.jobId,
+    parentJobId: input.parentJobId ?? null,
+    taskType: "circuit_break",
+    attemptN: input.attemptN ?? 1,
+    outcome: "fail",
+    outcomeReason: "policy_block",
+    routeTaken: {
+      seat: route.seat ?? null,
+      model: route.model ?? null,
+      prompt_version: route.prompt_version ?? `circuit_break:${input.verdict.breached}`,
+      tool_set: route.tool_set ?? null,
+    },
+    costSignal: {
+      tokens: input.verdict.usage.tokens ?? null,
+      wall_ms: input.verdict.usage.wall_ms ?? null,
+      usd: input.verdict.usage.usd ?? null,
+      retries: input.verdict.usage.retries ?? null,
+    },
+    receiptId: input.receiptId ?? null,
+    break_reason: input.verdict.breached,
+    break_detail: input.verdict.detail,
+  };
+
+  if (input.recorder) {
+    await Promise.resolve(input.recorder(record));
+  }
+  return record;
+}

--- a/api/lib/autopilotiq-outcome-ledger.ts
+++ b/api/lib/autopilotiq-outcome-ledger.ts
@@ -1,0 +1,330 @@
+// AutopilotIQ outcome ledger (Phase 0, Slice 0a) - capture only.
+//
+// Immutable per-attempt record of what AutoPilot tried and how it ended. This
+// module is the data-capture foundation for the AutopilotIQ learning layer
+// (Boardroom 9e131baf). It is ADDITIVE: nothing in this slice reads these rows
+// to change routing, scoring, or behaviour. Later phases read the ledger; they
+// must not rewrite history.
+//
+// Safety: raw inputs are never stored (only a stable inputs_hash), and
+// secret/credential-shaped fields are refused before any row is built.
+
+import { createHash } from "crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const AUTOPILOT_OUTCOMES = ["success", "fail", "hold"] as const;
+export type AutopilotOutcome = (typeof AUTOPILOT_OUTCOMES)[number];
+
+// Closed outcome-reason taxonomy. Grouped by the outcome it usually explains,
+// but the DB does not couple them - any listed reason is valid for any outcome.
+export const AUTOPILOT_OUTCOME_REASONS = [
+  // success
+  "clean_pass",
+  "proof_landed",
+  "recovered",
+  // hold
+  "awaiting_proof",
+  "awaiting_review",
+  "gated_hold",
+  // fail
+  "xpass_fail",
+  "tool_error",
+  "model_refusal",
+  "budget_exceeded",
+  "user_revert",
+  "timeout",
+  "policy_block",
+  "rate_limit",
+  "missing_proof",
+  "duplicate_claim",
+  "stale_owner",
+  "wrong_route",
+  "unknown_error",
+] as const;
+export type AutopilotOutcomeReason = (typeof AUTOPILOT_OUTCOME_REASONS)[number];
+
+export const AUTOPILOT_CONFIDENCE_LEVELS = ["hard_gate", "soft_gate", "silence"] as const;
+export type AutopilotConfidence = (typeof AUTOPILOT_CONFIDENCE_LEVELS)[number];
+
+export const AUTOPILOT_HUMAN_TOUCH_STATES = ["auto", "edited", "reverted", "approved"] as const;
+export type AutopilotHumanTouch = (typeof AUTOPILOT_HUMAN_TOUCH_STATES)[number];
+
+export const AUTOPILOT_XPASS_VERDICTS = [
+  "PASS",
+  "BLOCKER",
+  "HOLD",
+  "SUPPRESS",
+  "ROUTE",
+  "none",
+] as const;
+export type AutopilotXpassVerdict = (typeof AUTOPILOT_XPASS_VERDICTS)[number];
+
+export interface AutopilotRouteTaken {
+  seat?: string | null;
+  model?: string | null;
+  prompt_version?: string | null;
+  tool_set?: string[] | null;
+}
+
+export interface AutopilotCostSignal {
+  tokens?: number | null;
+  wall_ms?: number | null;
+  usd?: number | null;
+  retries?: number | null;
+}
+
+export interface AutopilotOutcomeInput {
+  apiKeyHash: string;
+  jobId: string;
+  parentJobId?: string | null;
+  attemptN?: number;
+  taskType: string;
+  actorAgentId?: string | null;
+  routeTaken?: AutopilotRouteTaken;
+  // Raw inputs are hashed into inputs_hash and then discarded - never stored.
+  inputs?: Record<string, unknown>;
+  xpassVerdict?: AutopilotXpassVerdict | string;
+  outcome: AutopilotOutcome | string;
+  outcomeReason: AutopilotOutcomeReason | string;
+  confidence?: AutopilotConfidence | string;
+  costSignal?: AutopilotCostSignal;
+  humanTouch?: AutopilotHumanTouch | string;
+  receiptId?: string | null;
+  closedAt?: Date | string | null;
+  now?: Date;
+}
+
+export interface AutopilotOutcomeRow {
+  api_key_hash: string;
+  job_id: string;
+  parent_job_id: string | null;
+  attempt_n: number;
+  task_type: string;
+  actor_agent_id: string;
+  route_taken: AutopilotRouteTaken;
+  inputs_hash: string;
+  xpass_verdict: AutopilotXpassVerdict;
+  outcome: AutopilotOutcome;
+  outcome_reason: AutopilotOutcomeReason;
+  confidence: AutopilotConfidence;
+  cost_signal: AutopilotCostSignal;
+  human_touch: AutopilotHumanTouch;
+  receipt_id: string | null;
+  idempotency_key: string;
+  created_at: string;
+  closed_at: string | null;
+}
+
+const OUTCOME_SET = new Set<string>(AUTOPILOT_OUTCOMES);
+const OUTCOME_REASON_SET = new Set<string>(AUTOPILOT_OUTCOME_REASONS);
+const CONFIDENCE_SET = new Set<string>(AUTOPILOT_CONFIDENCE_LEVELS);
+const HUMAN_TOUCH_SET = new Set<string>(AUTOPILOT_HUMAN_TOUCH_STATES);
+const XPASS_VERDICT_SET = new Set<string>(AUTOPILOT_XPASS_VERDICTS);
+
+const SENSITIVE_KEY_RE = /(api[_-]?key|secret|token|password|credential|authorization|cookie)/i;
+const SENSITIVE_TEXT_RE =
+  /(authorization:\s*bearer\s+\S+|uc_[a-f0-9]{16,}|sk-[a-z0-9_-]{12,}|gh[pousr]_[a-z0-9_]{20,})/i;
+
+function compact(value: unknown, max = 500): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fiveSecondBucket(date: Date): string {
+  return String(Math.floor(date.getTime() / 5000));
+}
+
+// Reject secret-shaped keys/text and strip unsupported value types. Used on the
+// inputs (before hashing) and on route_taken so nothing sensitive is captured.
+function sanitizeUnknown(key: string, value: unknown): unknown {
+  if (SENSITIVE_KEY_RE.test(key)) {
+    throw new Error(`Autopilot outcome payload contains sensitive key: ${key}`);
+  }
+  if (typeof value === "string") {
+    const text = compact(value);
+    if (SENSITIVE_TEXT_RE.test(text)) {
+      throw new Error(`Autopilot outcome payload contains sensitive text in: ${key}`);
+    }
+    return text;
+  }
+  if (value == null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeUnknown(key, item));
+  }
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
+        childKey,
+        sanitizeUnknown(childKey, childValue),
+      ]),
+    );
+  }
+  return undefined;
+}
+
+function sanitizeRecord(record: Record<string, unknown> = {}): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (SENSITIVE_KEY_RE.test(key)) {
+      throw new Error(`Autopilot outcome payload contains sensitive key: ${key}`);
+    }
+    const safe = sanitizeUnknown(key, value);
+    if (safe !== undefined) sanitized[key] = safe;
+  }
+  return sanitized;
+}
+
+function normalizeEnum(value: string, set: Set<string>, label: string): string {
+  if (!set.has(value)) throw new Error(`Unsupported autopilot ${label}: ${value}`);
+  return value;
+}
+
+function normalizeRouteTaken(route: AutopilotRouteTaken = {}): AutopilotRouteTaken {
+  const sanitized = sanitizeRecord(route as Record<string, unknown>);
+  const toolSet = Array.isArray(sanitized.tool_set)
+    ? (sanitized.tool_set as unknown[]).map((item) => compact(item, 160)).filter(Boolean)
+    : null;
+  return {
+    seat: sanitized.seat != null ? compact(sanitized.seat, 128) : null,
+    model: sanitized.model != null ? compact(sanitized.model, 128) : null,
+    prompt_version: sanitized.prompt_version != null ? compact(sanitized.prompt_version, 64) : null,
+    tool_set: toolSet,
+  };
+}
+
+function normalizeCostSignal(cost: AutopilotCostSignal = {}): AutopilotCostSignal {
+  const num = (value: unknown): number | null =>
+    typeof value === "number" && Number.isFinite(value) ? value : null;
+  return {
+    tokens: num(cost.tokens),
+    wall_ms: num(cost.wall_ms),
+    usd: num(cost.usd),
+    retries: num(cost.retries),
+  };
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+/**
+ * Build an immutable outcome-ledger row from an AutoPilot attempt. Pure: no I/O.
+ * Validates closed taxonomies, refuses secret-shaped inputs, hashes the inputs
+ * (never stores them raw), and derives a deterministic idempotency key.
+ */
+export function buildAutopilotOutcomeRow(input: AutopilotOutcomeInput): AutopilotOutcomeRow {
+  const now = input.now ?? new Date();
+  if (!input.apiKeyHash) throw new Error("api_key_hash required");
+
+  const jobId = compact(input.jobId, 160);
+  if (!jobId) throw new Error("job_id required");
+  const taskType = compact(input.taskType, 120);
+  if (!taskType) throw new Error("task_type required");
+
+  const attemptN = input.attemptN ?? 1;
+  if (!Number.isInteger(attemptN) || attemptN < 1) {
+    throw new Error(`attempt_n must be an integer >= 1, got: ${input.attemptN}`);
+  }
+
+  const outcome = normalizeEnum(compact(input.outcome, 32), OUTCOME_SET, "outcome") as AutopilotOutcome;
+  const outcomeReason = normalizeEnum(
+    compact(input.outcomeReason, 48),
+    OUTCOME_REASON_SET,
+    "outcome_reason",
+  ) as AutopilotOutcomeReason;
+  const confidence = normalizeEnum(
+    compact(input.confidence ?? "silence", 32),
+    CONFIDENCE_SET,
+    "confidence",
+  ) as AutopilotConfidence;
+  const humanTouch = normalizeEnum(
+    compact(input.humanTouch ?? "auto", 32),
+    HUMAN_TOUCH_SET,
+    "human_touch",
+  ) as AutopilotHumanTouch;
+  const xpassVerdict = normalizeEnum(
+    compact(input.xpassVerdict ?? "none", 16),
+    XPASS_VERDICT_SET,
+    "xpass_verdict",
+  ) as AutopilotXpassVerdict;
+
+  const routeTaken = normalizeRouteTaken(input.routeTaken);
+  const costSignal = normalizeCostSignal(input.costSignal);
+
+  // Inputs are sanitized (secrets refused), hashed, then discarded.
+  const inputsHash = sha256(stableJson(sanitizeRecord(input.inputs ?? {})));
+
+  const actorAgentId = compact(input.actorAgentId ?? "autopilot", 128) || "autopilot";
+  const parentJobId = input.parentJobId != null ? compact(input.parentJobId, 160) || null : null;
+  const receiptId = input.receiptId != null ? compact(input.receiptId, 160) || null : null;
+
+  const idempotencyKey = [
+    jobId,
+    String(attemptN),
+    outcome,
+    outcomeReason,
+    inputsHash,
+    fiveSecondBucket(now),
+  ].join(":");
+
+  return {
+    api_key_hash: input.apiKeyHash,
+    job_id: jobId,
+    parent_job_id: parentJobId,
+    attempt_n: attemptN,
+    task_type: taskType,
+    actor_agent_id: actorAgentId,
+    route_taken: routeTaken,
+    inputs_hash: inputsHash,
+    xpass_verdict: xpassVerdict,
+    outcome,
+    outcome_reason: outcomeReason,
+    confidence,
+    cost_signal: costSignal,
+    human_touch: humanTouch,
+    receipt_id: receiptId,
+    idempotency_key: idempotencyKey,
+    created_at: now.toISOString(),
+    closed_at: toIso(input.closedAt),
+  };
+}
+
+/**
+ * Persist one outcome row. Capture-only: this writes to the ledger and returns;
+ * no caller in this slice reads it back to influence routing or behaviour.
+ */
+export async function recordAutopilotOutcome(
+  supabase: SupabaseClient,
+  input: AutopilotOutcomeInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const row = buildAutopilotOutcomeRow(input);
+    const { error } = await supabase
+      .from("mc_autopilot_outcomes")
+      .upsert(row, { onConflict: "api_key_hash,idempotency_key", ignoreDuplicates: true });
+    if (error) throw error;
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}

--- a/api/lib/autopilotiq-probe-set.ts
+++ b/api/lib/autopilotiq-probe-set.ts
@@ -1,0 +1,500 @@
+// AutopilotIQ probe set (Phase 0, Slice 0b) - capture only, scoreboard honesty anchor.
+//
+// A small set of DETERMINISTIC known-answer probes plus a pure scorer, an
+// aggregate scoreboard, and a drift / scoreboard-honesty check. The point: if a
+// future scoreboard claims "improving" while probe pass-rate is flat or down,
+// scoreboard honesty fails. Capture-only and additive - no nightly schedule is
+// wired by this slice; the recorder is dependency-injected so this module does
+// not depend on Slice 0a (the outcome ledger), and stays independently
+// testable. Natural production wiring: pass an adapter that calls
+// recordAutopilotOutcome(supabase, ...) from autopilotiq-outcome-ledger.ts.
+
+import { createHash } from "crypto";
+
+export const PROBE_CHECK_KINDS = [
+  "equals",
+  "equals_trimmed",
+  "includes",
+  "regex",
+  "json_equal",
+  "length_at_least",
+] as const;
+export type ProbeCheckKind = (typeof PROBE_CHECK_KINDS)[number];
+
+export const PROBE_TASK_TYPES = [
+  "json_extract",
+  "string_transform",
+  "regex_match",
+  "count",
+  "sort",
+  "format",
+] as const;
+export type ProbeTaskType = (typeof PROBE_TASK_TYPES)[number];
+
+export interface Probe {
+  id: string;
+  task_type: ProbeTaskType;
+  prompt: string;
+  expected: string;
+  check_kind: ProbeCheckKind;
+  description: string;
+}
+
+export interface ProbeResult {
+  probe_id: string;
+  task_type: string;
+  pass: boolean;
+  reason: string;
+  actual: string;
+  wall_ms: number;
+  started_at: string;
+  finished_at: string;
+}
+
+export interface ProbeTaskTypeScoreboard {
+  total: number;
+  passed: number;
+  pass_rate: number;
+}
+
+export interface ProbeScoreboard {
+  total: number;
+  passed: number;
+  failed: number;
+  pass_rate: number;
+  by_task_type: Record<string, ProbeTaskTypeScoreboard>;
+  generated_at: string;
+  suite_run_id: string;
+}
+
+export type ProbeDriftVerdict = "stable" | "drifting_up" | "drifting_down";
+
+export interface ProbeDriftReport {
+  baseline_pass_rate: number;
+  current_pass_rate: number;
+  delta: number;
+  threshold: number;
+  verdict: ProbeDriftVerdict;
+}
+
+export type ScoreboardClaim = "improving" | "stable" | "degrading";
+
+export interface ScoreboardHonestyVerdict {
+  honest: boolean;
+  claim: ScoreboardClaim;
+  observed_verdict: ProbeDriftVerdict;
+  delta: number;
+  threshold: number;
+  reason: string;
+}
+
+// Capture record emitted per probe attempt. Field names mirror the camelCase
+// input of the Slice 0a recorder (recordAutopilotOutcome) so a thin adapter can
+// pass these through once 0a merges, without coupling this slice to 0a's table.
+export interface ProbeOutcomeRecord {
+  jobId: string; // stable per-probe id (e.g. probe.json_extract.user_email_v1)
+  parentJobId: string; // suite_run_id - groups all probes from one suite run
+  taskType: "probe";
+  attemptN: number;
+  outcome: "success" | "fail";
+  outcomeReason: string; // structural; adapter maps to slice 0a's closed taxonomy
+  routeTaken: {
+    seat?: string | null;
+    model?: string | null;
+    prompt_version: string; // "probe:<task_type>:<probe_id_suffix>"
+    tool_set?: string[] | null;
+  };
+  costSignal: {
+    wall_ms: number;
+  };
+  receiptId: string | null;
+  prompt_hash: string;
+  expected_hash: string;
+  actual_hash: string;
+}
+
+export type ProbeExecutor = (probe: Probe) => Promise<string> | string;
+export type ProbeRecorder = (record: ProbeOutcomeRecord) => Promise<void> | void;
+
+// ----------------------------------------------------------------------------
+// Probe set v0
+// ----------------------------------------------------------------------------
+
+// Deterministic, language-agnostic probes. Each is a tiny, fixed task whose
+// correct answer never changes - that is the honesty anchor: if pass-rate
+// against this set drifts, the lane is changing in ways the scoreboard cannot
+// hide. Extend by adding more entries; do not edit existing ids.
+export const PROBE_SET_V0: readonly Probe[] = Object.freeze([
+  {
+    id: "probe.json_extract.user_email_v1",
+    task_type: "json_extract",
+    prompt: 'From {"name":"Ada","email":"ada@example.com","age":36}, output only the value of the "email" field.',
+    expected: "ada@example.com",
+    check_kind: "equals_trimmed",
+    description: "JSON field extraction; trivial but anchors follow-instruction fidelity.",
+  },
+  {
+    id: "probe.string.kebab_to_snake_v1",
+    task_type: "string_transform",
+    prompt: "Convert 'foo-bar-baz' to snake_case by replacing each '-' with '_'. Output only the result.",
+    expected: "foo_bar_baz",
+    check_kind: "equals_trimmed",
+    description: "Deterministic string transform; probes literal-output discipline.",
+  },
+  {
+    id: "probe.regex.uuid_present_v1",
+    task_type: "regex_match",
+    prompt:
+      "Does 'session 550e8400-e29b-41d4-a716-446655440000 was started' contain a UUID? Answer exactly 'yes' or 'no'.",
+    expected: "yes",
+    check_kind: "equals_trimmed",
+    description: "Detection task with a one-word constrained answer.",
+  },
+  {
+    id: "probe.count.unique_words_v1",
+    task_type: "count",
+    prompt:
+      "Count the unique whitespace-separated lowercase tokens in 'the quick brown the lazy quick'. Output only the integer.",
+    expected: "4",
+    check_kind: "equals_trimmed",
+    description: "Cardinality / counting task with a single-integer answer.",
+  },
+  {
+    id: "probe.sort.ascending_json_v1",
+    task_type: "sort",
+    prompt:
+      "Sort [3,1,4,1,5,9,2,6,5,3,5] in ascending order and output the result as a JSON array on a single line.",
+    expected: "[1,1,2,3,3,4,5,5,5,6,9]",
+    check_kind: "json_equal",
+    description: "Multi-element sort with stable JSON output.",
+  },
+  {
+    id: "probe.format.iso_date_v1",
+    task_type: "format",
+    prompt: "Convert the ISO-8601 timestamp '2026-05-28T14:30:00Z' to a YYYY-MM-DD date string. Output only the date.",
+    expected: "2026-05-28",
+    check_kind: "equals_trimmed",
+    description: "Formatting a known timestamp to a date string.",
+  },
+]);
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function truncate(value: string, max = 120): string {
+  return value.length > max ? `${value.slice(0, max - 3)}...` : value;
+}
+
+// ----------------------------------------------------------------------------
+// Scoring
+// ----------------------------------------------------------------------------
+
+/**
+ * Score one probe attempt. Pure: no I/O. Returns pass + a short reason that
+ * explains a fail without leaking the full prompt.
+ */
+export function scoreProbe(
+  probe: Probe,
+  actual: string,
+): { pass: boolean; reason: string } {
+  switch (probe.check_kind) {
+    case "equals": {
+      const pass = actual === probe.expected;
+      return {
+        pass,
+        reason: pass
+          ? "exact match"
+          : `expected '${truncate(probe.expected)}' got '${truncate(actual)}'`,
+      };
+    }
+    case "equals_trimmed": {
+      const a = (actual ?? "").trim();
+      const e = probe.expected.trim();
+      const pass = a === e;
+      return {
+        pass,
+        reason: pass
+          ? "exact match (trimmed)"
+          : `expected '${truncate(e)}' got '${truncate(a)}'`,
+      };
+    }
+    case "includes": {
+      const pass = String(actual ?? "").includes(probe.expected);
+      return {
+        pass,
+        reason: pass ? "substring present" : `'${truncate(probe.expected)}' not found in actual`,
+      };
+    }
+    case "regex": {
+      let re: RegExp;
+      try {
+        re = new RegExp(probe.expected);
+      } catch (err) {
+        return { pass: false, reason: `invalid regex in probe expected: ${(err as Error).message}` };
+      }
+      const pass = re.test(String(actual ?? ""));
+      return {
+        pass,
+        reason: pass ? "regex matched" : `regex '${truncate(probe.expected)}' did not match actual`,
+      };
+    }
+    case "json_equal": {
+      let expectedParsed: unknown;
+      let actualParsed: unknown;
+      try {
+        expectedParsed = JSON.parse(probe.expected);
+      } catch (err) {
+        return { pass: false, reason: `invalid JSON in probe expected: ${(err as Error).message}` };
+      }
+      try {
+        actualParsed = JSON.parse(String(actual ?? ""));
+      } catch (err) {
+        return { pass: false, reason: `actual is not valid JSON: ${(err as Error).message}` };
+      }
+      const pass = stableJson(expectedParsed) === stableJson(actualParsed);
+      return {
+        pass,
+        reason: pass
+          ? "JSON shapes equal"
+          : `expected JSON '${truncate(stableJson(expectedParsed))}' got '${truncate(stableJson(actualParsed))}'`,
+      };
+    }
+    case "length_at_least": {
+      const min = Number.parseInt(probe.expected, 10);
+      if (!Number.isFinite(min)) {
+        return { pass: false, reason: `invalid length threshold in probe expected: ${probe.expected}` };
+      }
+      const pass = String(actual ?? "").length >= min;
+      return {
+        pass,
+        reason: pass ? `length>=${min}` : `expected length>=${min}, got length=${String(actual ?? "").length}`,
+      };
+    }
+    default: {
+      const exhaustive: never = probe.check_kind;
+      return { pass: false, reason: `unsupported check_kind: ${String(exhaustive)}` };
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Aggregate
+// ----------------------------------------------------------------------------
+
+/**
+ * Aggregate probe results into a scoreboard. pass_rate is `passed/total`
+ * (NaN-free: 0 when total is 0). by_task_type lets callers see which capability
+ * is degrading even when the overall rate is flat.
+ */
+export function aggregateProbeResults(
+  results: ProbeResult[],
+  options: { suiteRunId: string; generatedAt: string },
+): ProbeScoreboard {
+  const total = results.length;
+  const passed = results.filter((result) => result.pass).length;
+  const failed = total - passed;
+  const passRate = total === 0 ? 0 : passed / total;
+
+  const byTaskType: Record<string, ProbeTaskTypeScoreboard> = {};
+  for (const result of results) {
+    const bucket = byTaskType[result.task_type] ?? { total: 0, passed: 0, pass_rate: 0 };
+    bucket.total += 1;
+    if (result.pass) bucket.passed += 1;
+    bucket.pass_rate = bucket.total === 0 ? 0 : bucket.passed / bucket.total;
+    byTaskType[result.task_type] = bucket;
+  }
+
+  return {
+    total,
+    passed,
+    failed,
+    pass_rate: passRate,
+    by_task_type: byTaskType,
+    generated_at: options.generatedAt,
+    suite_run_id: options.suiteRunId,
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Drift + scoreboard honesty
+// ----------------------------------------------------------------------------
+
+/**
+ * Compare a current pass-rate to a baseline. Verdict is "stable" when |delta|
+ * < threshold; otherwise "drifting_up" or "drifting_down". Threshold defaults
+ * to 0.05 (5 percentage points) - tune per probe-set size.
+ */
+export function checkProbeDrift(input: {
+  current_pass_rate: number;
+  baseline_pass_rate: number;
+  threshold?: number;
+}): ProbeDriftReport {
+  const threshold = input.threshold ?? 0.05;
+  const delta = input.current_pass_rate - input.baseline_pass_rate;
+  let verdict: ProbeDriftVerdict;
+  if (Math.abs(delta) < threshold) verdict = "stable";
+  else if (delta > 0) verdict = "drifting_up";
+  else verdict = "drifting_down";
+  return {
+    baseline_pass_rate: input.baseline_pass_rate,
+    current_pass_rate: input.current_pass_rate,
+    delta,
+    threshold,
+    verdict,
+  };
+}
+
+/**
+ * Catch a lying scoreboard. A claim of "improving" is honest only if the probe
+ * set is drifting up; "degrading" only if drifting down; "stable" only if the
+ * |delta| is below threshold. Anything else means the scoreboard's narrative
+ * does not match the probe-anchored truth.
+ */
+export function checkScoreboardHonesty(input: {
+  claim: ScoreboardClaim;
+  current_pass_rate: number;
+  baseline_pass_rate: number;
+  threshold?: number;
+}): ScoreboardHonestyVerdict {
+  const drift = checkProbeDrift({
+    current_pass_rate: input.current_pass_rate,
+    baseline_pass_rate: input.baseline_pass_rate,
+    threshold: input.threshold,
+  });
+  const expectedFor: Record<ScoreboardClaim, ProbeDriftVerdict> = {
+    improving: "drifting_up",
+    stable: "stable",
+    degrading: "drifting_down",
+  };
+  const honest = drift.verdict === expectedFor[input.claim];
+  const reason = honest
+    ? `claim '${input.claim}' matches observed '${drift.verdict}' (delta=${drift.delta.toFixed(3)})`
+    : `claim '${input.claim}' contradicts observed '${drift.verdict}' (delta=${drift.delta.toFixed(3)}, threshold=${drift.threshold})`;
+  return {
+    honest,
+    claim: input.claim,
+    observed_verdict: drift.verdict,
+    delta: drift.delta,
+    threshold: drift.threshold,
+    reason,
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Harness
+// ----------------------------------------------------------------------------
+
+export interface RunProbeSuiteInput {
+  probes?: readonly Probe[];
+  executor: ProbeExecutor;
+  recorder?: ProbeRecorder;
+  suiteRunId?: string;
+  routeTaken?: Pick<ProbeOutcomeRecord["routeTaken"], "seat" | "model" | "tool_set">;
+  now?: () => Date;
+}
+
+export interface RunProbeSuiteOutput {
+  scoreboard: ProbeScoreboard;
+  results: ProbeResult[];
+}
+
+/**
+ * Run a probe suite end-to-end with an injected executor. For each probe:
+ *   1. call executor(probe) and measure wall_ms,
+ *   2. score actual vs expected,
+ *   3. optionally emit a ProbeOutcomeRecord via the injected recorder.
+ *
+ * Capture-only: this function never reads the recorder's output back to alter
+ * behaviour. Probe-set choice does not influence the scorer. The recorder is
+ * optional so the harness is fully usable without persistence (e.g. in CI or
+ * a local smoke run).
+ */
+export async function runProbeSuite(input: RunProbeSuiteInput): Promise<RunProbeSuiteOutput> {
+  const probes = input.probes ?? PROBE_SET_V0;
+  const now = input.now ?? (() => new Date());
+  const suiteRunId = input.suiteRunId ?? `probe-suite-${now().toISOString()}`;
+  const route = input.routeTaken ?? {};
+  const results: ProbeResult[] = [];
+
+  for (const probe of probes) {
+    const startedAt = now();
+    let actual: string;
+    let executorError: Error | null = null;
+    try {
+      const value = await Promise.resolve(input.executor(probe));
+      actual = String(value ?? "");
+    } catch (err) {
+      executorError = err as Error;
+      actual = "";
+    }
+    const finishedAt = now();
+    const wallMs = finishedAt.getTime() - startedAt.getTime();
+
+    let pass: boolean;
+    let reason: string;
+    if (executorError) {
+      pass = false;
+      reason = `executor threw: ${executorError.message}`;
+    } else {
+      const scored = scoreProbe(probe, actual);
+      pass = scored.pass;
+      reason = scored.reason;
+    }
+
+    results.push({
+      probe_id: probe.id,
+      task_type: probe.task_type,
+      pass,
+      reason,
+      actual,
+      wall_ms: wallMs,
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+    });
+
+    if (input.recorder) {
+      const record: ProbeOutcomeRecord = {
+        jobId: probe.id,
+        parentJobId: suiteRunId,
+        taskType: "probe",
+        attemptN: 1,
+        outcome: pass ? "success" : "fail",
+        outcomeReason: pass ? "clean_pass" : executorError ? "tool_error" : "wrong_route",
+        routeTaken: {
+          seat: route.seat ?? null,
+          model: route.model ?? null,
+          prompt_version: `probe:${probe.task_type}:${probe.id}`,
+          tool_set: route.tool_set ?? null,
+        },
+        costSignal: { wall_ms: wallMs },
+        receiptId: null,
+        prompt_hash: sha256(probe.prompt),
+        expected_hash: sha256(probe.expected),
+        actual_hash: sha256(actual),
+      };
+      await Promise.resolve(input.recorder(record));
+    }
+  }
+
+  const scoreboard = aggregateProbeResults(results, {
+    suiteRunId,
+    generatedAt: now().toISOString(),
+  });
+  return { scoreboard, results };
+}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 526,
+    "inventory": 529,
     "source_manifest": 189,
     "pages": 81,
     "tools": 187,
@@ -63,7 +63,7 @@
       "id": "automations",
       "name": "Automations",
       "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
-      "count": 118
+      "count": 121
     },
     {
       "id": "ledgers-and-proof",
@@ -558,6 +558,36 @@
       "kind": "autopilot module",
       "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
       "source": "api/lib/autopilot-control-ledger.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilotiq-circuit-breakers-api-lib-autopilotiq-circuit-breakers-ts-no-route",
+      "division": "Automations",
+      "name": "autopilotiq circuit breakers",
+      "kind": "autopilot module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/autopilotiq-circuit-breakers.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilotiq-outcome-ledger-api-lib-autopilotiq-outcome-ledger-ts-no-route",
+      "division": "Automations",
+      "name": "autopilotiq outcome ledger",
+      "kind": "autopilot module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/autopilotiq-outcome-ledger.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-autopilot-module-autopilotiq-probe-set-api-lib-autopilotiq-probe-set-ts-no-route",
+      "division": "Automations",
+      "name": "autopilotiq probe set",
+      "kind": "autopilot module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/autopilotiq-probe-set.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -214,7 +214,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
-| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 118 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 121 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 66 |
@@ -575,6 +575,9 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Signals Settings | Admin surface for Signals Settings. | /admin/signals/settings | src/pages/admin/signals/SignalsSettings.tsx |
 | Admin surfaces | admin page | Test Pass Catalog | Admin surface for Test Pass Catalog. | /admin/testpass | src/pages/admin/testpass/TestPassCatalog.tsx |
 | Automations | autopilot module | autopilot control ledger | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilot-control-ledger.ts |
+| Automations | autopilot module | autopilotiq circuit breakers | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilotiq-circuit-breakers.ts |
+| Automations | autopilot module | autopilotiq outcome ledger | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilotiq-outcome-ledger.ts |
+| Automations | autopilot module | autopilotiq probe set | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/autopilotiq-probe-set.ts |
 | Automations | autopilot module | autopilotkit liveness | autopilotkit liveness shared frontend logic. | - | scripts/lib/autopilotkit-liveness.mjs |
 | Automations | autopilot module | pinballwake autopilot master loop | pinballwake autopilot master loop UnClick module. | - | scripts/pinballwake-autopilot-master-loop.mjs |
 | Automations | autopilot module | pinballwake autopilot triage | pinballwake autopilot triage UnClick module. | - | scripts/pinballwake-autopilot-triage.mjs |

--- a/supabase/migrations/20260528000000_autopilotiq_outcome_ledger.sql
+++ b/supabase/migrations/20260528000000_autopilotiq_outcome_ledger.sql
@@ -1,0 +1,85 @@
+-- AutopilotIQ outcome ledger (Phase 0, Slice 0a) - capture only.
+-- Immutable per-attempt record of what AutoPilot tried and how it ended.
+-- Additive: nothing reads this table to change routing or behaviour yet.
+-- Tenant-scoped and append-only. Raw inputs are never stored (only inputs_hash);
+-- secrets/credentials are refused by the recorder helper before any write.
+
+CREATE TABLE IF NOT EXISTS mc_autopilot_outcomes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_hash text NOT NULL,
+  job_id text NOT NULL,
+  parent_job_id text,
+  attempt_n integer NOT NULL DEFAULT 1 CHECK (attempt_n >= 1),
+  task_type text NOT NULL,
+  actor_agent_id text NOT NULL,
+  -- route_taken: { seat, model, prompt_version, tool_set }
+  route_taken jsonb NOT NULL DEFAULT '{}'::jsonb,
+  inputs_hash text NOT NULL,
+  xpass_verdict text NOT NULL DEFAULT 'none'
+    CHECK (xpass_verdict IN ('PASS', 'BLOCKER', 'HOLD', 'SUPPRESS', 'ROUTE', 'none')),
+  outcome text NOT NULL
+    CHECK (outcome IN ('success', 'fail', 'hold')),
+  outcome_reason text NOT NULL
+    CHECK (outcome_reason IN (
+      'clean_pass',
+      'proof_landed',
+      'recovered',
+      'awaiting_proof',
+      'awaiting_review',
+      'gated_hold',
+      'xpass_fail',
+      'tool_error',
+      'model_refusal',
+      'budget_exceeded',
+      'user_revert',
+      'timeout',
+      'policy_block',
+      'rate_limit',
+      'missing_proof',
+      'duplicate_claim',
+      'stale_owner',
+      'wrong_route',
+      'unknown_error'
+    )),
+  confidence text NOT NULL DEFAULT 'silence'
+    CHECK (confidence IN ('hard_gate', 'soft_gate', 'silence')),
+  -- cost_signal: { tokens, wall_ms, usd, retries }
+  cost_signal jsonb NOT NULL DEFAULT '{}'::jsonb,
+  human_touch text NOT NULL DEFAULT 'auto'
+    CHECK (human_touch IN ('auto', 'edited', 'reverted', 'approved')),
+  receipt_id text,
+  idempotency_key text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  closed_at timestamptz,
+  seq bigserial UNIQUE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_idempotency
+  ON mc_autopilot_outcomes(api_key_hash, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_job
+  ON mc_autopilot_outcomes(api_key_hash, job_id, attempt_n DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_task_type
+  ON mc_autopilot_outcomes(api_key_hash, task_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_autopilot_outcomes_outcome
+  ON mc_autopilot_outcomes(api_key_hash, outcome, outcome_reason, created_at DESC);
+
+ALTER TABLE mc_autopilot_outcomes ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'mc_autopilot_outcomes'
+      AND policyname = 'mc_autopilot_outcomes_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_autopilot_outcomes_service_role_all"
+      ON mc_autopilot_outcomes FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Lands AutopilotIQ Phase 0 as one coherent foundation, replacing the three stale capture-only drafts #1144 / #1145 / #1146 (each was far behind main on divergent history). Chris approved landing all three including the database table.

## What it adds (all additive, all verified safe)
- **`api/lib/autopilotiq-outcome-ledger.ts`** + migration `supabase/migrations/20260528000000_autopilotiq_outcome_ledger.sql` — records autopilot outcomes. The migration creates a brand-new table `mc_autopilot_outcomes` (`CREATE TABLE IF NOT EXISTS`, 4 indexes, RLS enabled, service_role-only policy). Purely additive/idempotent; the table does not currently exist in the live project, no existing object is touched.
- **`api/lib/autopilotiq-probe-set.ts`** — deterministic known-answer honesty probes + scorer.
- **`api/lib/autopilotiq-circuit-breakers.ts`** — hard per-job ceilings (actions/tokens/cost/time/retries), per-component pause flags, and a global self-improvement kill switch.

## Decoupling
Each module is imported **only by its own test** and dependency-injects its recorder — no shipped call-site invokes them yet. This is intentional Phase 0 groundwork (built before anything acts), so it ships as inert foundation with **zero runtime behaviour change** today.

## Verification
- `npx vitest run api/autopilotiq-*.test.ts` → **56/56 pass** against current main.
- `npm run brainmap:check` → clean (regenerated for the 3 new tracked modules).

## On merge
`apply-migrations.yml` will apply the additive migration to the production Supabase project (approved). Re-running is idempotent.

Supersedes #1144, #1145, #1146.

https://claude.ai/code/session_01LtAec6MBm6LcsLkcKKgbA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtAec6MBm6LcsLkcKKgbA4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive libraries and a new table with no production call sites; migration is idempotent and RLS-limited to service_role, so merge risk is low aside from applying the new schema in prod.
> 
> **Overview**
> Adds **AutopilotIQ Phase 0** as capture-only foundation: three `api/lib` modules, Vitest coverage (56 tests), an idempotent Supabase migration for `mc_autopilot_outcomes`, and regenerated brainmap docs. Nothing in shipped routes imports these yet—**no runtime behavior change** until later wiring.
> 
> **Outcome ledger** (`autopilotiq-outcome-ledger.ts` + `20260528000000_autopilotiq_outcome_ledger.sql`): builds tenant-scoped per-attempt rows with closed taxonomies, `inputs_hash` only (no raw inputs), secret-shaped payload rejection, idempotent upsert on `(api_key_hash, idempotency_key)`, RLS + service_role policy.
> 
> **Probe set** (`autopilotiq-probe-set.ts`): frozen `PROBE_SET_V0`, pure scoring, scoreboard aggregation, drift vs baseline, and **scoreboard honesty** checks so “improving/stable” claims must match probe pass-rate movement; optional injected recorder (hashed prompt/expected/actual).
> 
> **Circuit breakers** (`autopilotiq-circuit-breakers.ts`): per-job limits (actions/tokens/USD/wall/retries), per-component pause list, global self-improvement kill switch, and optional breach records shaped for the ledger adapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2221c02e25157ca78db0a2d7cf4d939786efc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->