### PR TITLE
Add Benchmarks admin page: the UnClick report card

### DIFF
--- a/api/benchmarks.test.ts
+++ b/api/benchmarks.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateRecordRun,
+  computeOverallFromCategories,
+  deriveEngineParts,
+  CONTESTANTS,
+} from "./benchmarks";
+
+const CATS = [
+  { key: "coding", weight: 20 },
+  { key: "tool_use", weight: 25 },
+  { key: "memory", weight: 25 },
+  { key: "reasoning", weight: 15 },
+  { key: "knowledge", weight: 15 },
+];
+
+describe("deriveEngineParts", () => {
+  it("splits engine and unclick flag for every contestant", () => {
+    expect(deriveEngineParts("codex_raw")).toEqual({ engine: "codex", usesUnclick: false });
+    expect(deriveEngineParts("claude_unclick")).toEqual({ engine: "claude", usesUnclick: true });
+    expect(CONTESTANTS).toHaveLength(4);
+  });
+});
+
+describe("computeOverallFromCategories", () => {
+  it("returns a 0-100 score", () => {
+    const perfect = Object.fromEntries(CATS.map((c) => [c.key, { score: 100, max: 100 }]));
+    expect(computeOverallFromCategories(perfect, CATS)).toBe(100);
+  });
+
+  it("returns 0 with no weight", () => {
+    expect(computeOverallFromCategories({}, [])).toBe(0);
+  });
+});
+
+describe("validateRecordRun", () => {
+  const valid = {
+    suite_slug: "unclick-capability-v1",
+    run_label: "May baseline",
+    results: [
+      { contestant: "claude_raw", category_scores: { coding: { score: 80, max: 100 } } },
+      { contestant: "claude_unclick", category_scores: { coding: { score: 80, max: 100 } } },
+    ],
+  };
+
+  it("accepts a well-formed payload", () => {
+    const out = validateRecordRun(valid);
+    expect(out.ok).toBe(true);
+  });
+
+  it("rejects a missing suite_slug", () => {
+    const out = validateRecordRun({ ...valid, suite_slug: "" });
+    expect(out.ok).toBe(false);
+  });
+
+  it("rejects an empty results array", () => {
+    const out = validateRecordRun({ ...valid, results: [] });
+    expect(out.ok).toBe(false);
+  });
+
+  it("rejects an unknown contestant", () => {
+    const out = validateRecordRun({
+      ...valid,
+      results: [{ contestant: "gpt5_raw", category_scores: {} }],
+    });
+    expect(out.ok).toBe(false);
+  });
+
+  it("rejects a duplicate contestant", () => {
+    const out = validateRecordRun({
+      ...valid,
+      results: [
+        { contestant: "claude_raw", category_scores: { coding: { score: 1, max: 1 } } },
+        { contestant: "claude_raw", category_scores: { coding: { score: 1, max: 1 } } },
+      ],
+    });
+    expect(out.ok).toBe(false);
+  });
+
+  it("rejects non-numeric category scores", () => {
+    const out = validateRecordRun({
+      ...valid,
+      results: [{ contestant: "codex_raw", category_scores: { coding: { score: "high", max: 100 } } }],
+    });
+    expect(out.ok).toBe(false);
+  });
+
+  it("rejects a bad source", () => {
+    const out = validateRecordRun({ ...valid, source: "magic" });
+    expect(out.ok).toBe(false);
+  });
+});

--- a/api/benchmarks.ts
+++ b/api/benchmarks.ts
@@ -1,0 +1,315 @@
+/**
+ * UnClick Benchmarks - Vercel serverless function.
+ *
+ * Server-controlled, admin-only. Reads the benchmark scoreboard and records
+ * new runs. Browser clients never touch the tables directly; this endpoint
+ * uses the service role and gates on ADMIN_EMAILS.
+ *
+ * Routes (via ?action=):
+ *   GET  /api/benchmarks?action=overview      -> active suite + latest run + history
+ *   GET  /api/benchmarks?action=run&id=<uuid> -> one run with its results
+ *   POST /api/benchmarks?action=record_run    -> insert a run + its results
+ *   POST /api/benchmarks?action=delete_run     -> { id } delete a run (e.g. the sample)
+ *
+ * The record_run payload contract is documented in docs/benchmarks.md.
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+
+// ── Contestant + category helpers (kept small and self-contained so the ────
+// serverless bundle stays simple; the richer display logic lives in
+// src/lib/benchmarks.ts and is unit-tested there too).
+
+export const CONTESTANTS = ["codex_raw", "claude_raw", "codex_unclick", "claude_unclick"] as const;
+export type Contestant = (typeof CONTESTANTS)[number];
+
+export function deriveEngineParts(contestant: Contestant): {
+  engine: "codex" | "claude";
+  usesUnclick: boolean;
+} {
+  return {
+    engine: contestant.startsWith("codex") ? "codex" : "claude",
+    usesUnclick: contestant.endsWith("unclick"),
+  };
+}
+
+export interface SuiteCategory {
+  key: string;
+  weight: number;
+}
+
+export interface CategoryScore {
+  score: number;
+  max: number;
+}
+
+/** Turn weighted per-category scores into a 0-100 number. Mirrors src/lib. */
+export function computeOverallFromCategories(
+  categoryScores: Record<string, CategoryScore>,
+  categories: SuiteCategory[],
+): number {
+  const totalWeight = categories.reduce((s, c) => s + (c.weight || 0), 0);
+  if (totalWeight <= 0) return 0;
+  let weighted = 0;
+  for (const cat of categories) {
+    const cs = categoryScores[cat.key];
+    if (!cs || !(cs.max > 0)) continue;
+    const fraction = Math.max(0, Math.min(1, cs.score / cs.max));
+    weighted += fraction * cat.weight;
+  }
+  return Math.round((weighted / totalWeight) * 100 * 100) / 100;
+}
+
+export interface RecordRunInput {
+  suite_slug: string;
+  run_label: string;
+  run_date?: string;
+  source?: "manual" | "script" | "auto";
+  notes?: string;
+  results: Array<{
+    contestant: Contestant;
+    category_scores: Record<string, CategoryScore>;
+    overall_score?: number;
+    tasks_total?: number;
+    tasks_passed?: number;
+    evidence?: Record<string, unknown>;
+  }>;
+}
+
+type ValidationResult =
+  | { ok: true; value: RecordRunInput }
+  | { ok: false; error: string };
+
+/** Validate the record_run body. Pure, so it is easy to unit-test. */
+export function validateRecordRun(body: unknown): ValidationResult {
+  if (!body || typeof body !== "object") return { ok: false, error: "Body must be an object." };
+  const b = body as Record<string, unknown>;
+
+  if (typeof b.suite_slug !== "string" || !b.suite_slug.trim()) {
+    return { ok: false, error: "suite_slug is required." };
+  }
+  if (typeof b.run_label !== "string") {
+    return { ok: false, error: "run_label must be a string." };
+  }
+  if (!Array.isArray(b.results) || b.results.length === 0) {
+    return { ok: false, error: "results must be a non-empty array." };
+  }
+  if (b.run_date !== undefined && typeof b.run_date !== "string") {
+    return { ok: false, error: "run_date must be a date string (YYYY-MM-DD)." };
+  }
+  if (b.source !== undefined && !["manual", "script", "auto"].includes(b.source as string)) {
+    return { ok: false, error: "source must be manual, script, or auto." };
+  }
+
+  const seen = new Set<string>();
+  for (const raw of b.results) {
+    if (!raw || typeof raw !== "object") return { ok: false, error: "Each result must be an object." };
+    const r = raw as Record<string, unknown>;
+    if (!CONTESTANTS.includes(r.contestant as Contestant)) {
+      return { ok: false, error: `Unknown contestant: ${String(r.contestant)}.` };
+    }
+    if (seen.has(r.contestant as string)) {
+      return { ok: false, error: `Duplicate contestant: ${String(r.contestant)}.` };
+    }
+    seen.add(r.contestant as string);
+    if (!r.category_scores || typeof r.category_scores !== "object") {
+      return { ok: false, error: `category_scores is required for ${String(r.contestant)}.` };
+    }
+    for (const [key, cs] of Object.entries(r.category_scores as Record<string, unknown>)) {
+      const c = cs as Record<string, unknown>;
+      if (typeof c?.score !== "number" || typeof c?.max !== "number") {
+        return { ok: false, error: `category_scores.${key} needs numeric score and max.` };
+      }
+    }
+  }
+
+  return { ok: true, value: b as unknown as RecordRunInput };
+}
+
+// ── Auth ───────────────────────────────────────────────────────────────────
+
+function bearerFrom(req: VercelRequest): string | null {
+  const header = req.headers.authorization;
+  if (!header || typeof header !== "string") return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+function adminEmails(): string[] {
+  return (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/** Verify a Supabase session JWT and return the email, or null. */
+async function resolveAdminEmail(
+  req: VercelRequest,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+): Promise<string | null> {
+  const token = bearerFrom(req);
+  if (!token || token.startsWith("uc_") || token.startsWith("agt_")) return null;
+  try {
+    const scoped = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data, error } = await scoped.auth.getUser(token);
+    if (error || !data?.user?.email) return null;
+    const email = data.user.email.toLowerCase();
+    return adminEmails().includes(email) ? email : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  if (req.method === "OPTIONS") return res.status(204).end();
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(500).json({ error: "Database service unavailable" });
+  }
+
+  const adminEmail = await resolveAdminEmail(req, supabaseUrl, serviceRoleKey);
+  if (!adminEmail) return res.status(403).json({ error: "Admin access required" });
+
+  const db = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const action = String(req.query.action ?? "");
+
+  try {
+    if (req.method === "GET" && action === "overview") return await overview(db, res);
+    if (req.method === "GET" && action === "run") return await runDetail(db, res, String(req.query.id ?? ""));
+    if (req.method === "POST" && action === "record_run") return await recordRun(db, res, req.body, adminEmail);
+    if (req.method === "POST" && action === "delete_run") return await deleteRun(db, res, req.body);
+    return res.status(400).json({ error: "Unknown action" });
+  } catch (err) {
+    return res.status(500).json({ error: err instanceof Error ? err.message : "Internal error" });
+  }
+}
+
+// ── Action implementations ───────────────────────────────────────────────────
+
+type Db = ReturnType<typeof createClient>;
+
+async function overview(db: Db, res: VercelResponse) {
+  const { data: suite } = await db
+    .from("benchmark_suites")
+    .select("*")
+    .eq("is_active", true)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!suite) return res.status(200).json({ suite: null, latest: null, history: [] });
+
+  const { data: runs } = await db
+    .from("benchmark_runs")
+    .select("*")
+    .eq("suite_id", suite.id)
+    .order("run_date", { ascending: false })
+    .order("created_at", { ascending: false });
+
+  const runList = runs ?? [];
+  const runIds = runList.map((r) => r.id);
+
+  const { data: allResults } = runIds.length
+    ? await db.from("benchmark_results").select("*").in("run_id", runIds)
+    : { data: [] as Record<string, unknown>[] };
+
+  const byRun = new Map<string, Record<string, unknown>[]>();
+  for (const r of allResults ?? []) {
+    const list = byRun.get(r.run_id as string) ?? [];
+    list.push(r);
+    byRun.set(r.run_id as string, list);
+  }
+
+  const history = runList.map((run) => ({ ...run, results: byRun.get(run.id) ?? [] }));
+  const latest = history.find((r) => r.status === "complete") ?? history[0] ?? null;
+
+  return res.status(200).json({ suite, latest, history });
+}
+
+async function runDetail(db: Db, res: VercelResponse, id: string) {
+  if (!id) return res.status(400).json({ error: "id is required" });
+  const { data: run } = await db.from("benchmark_runs").select("*").eq("id", id).maybeSingle();
+  if (!run) return res.status(404).json({ error: "Run not found" });
+  const { data: results } = await db.from("benchmark_results").select("*").eq("run_id", id);
+  return res.status(200).json({ run: { ...run, results: results ?? [] } });
+}
+
+async function recordRun(db: Db, res: VercelResponse, body: unknown, adminEmail: string) {
+  const validation = validateRecordRun(body);
+  if (!validation.ok) return res.status(400).json({ error: validation.error });
+  const input = validation.value;
+
+  const { data: suite } = await db
+    .from("benchmark_suites")
+    .select("id, categories")
+    .eq("slug", input.suite_slug)
+    .maybeSingle();
+  if (!suite) return res.status(404).json({ error: `Suite not found: ${input.suite_slug}` });
+
+  const categories = (suite.categories as SuiteCategory[]) ?? [];
+
+  const { data: run, error: runErr } = await db
+    .from("benchmark_runs")
+    .insert({
+      suite_id: suite.id,
+      run_label: input.run_label,
+      run_date: input.run_date ?? new Date().toISOString().slice(0, 10),
+      status: "complete",
+      source: input.source ?? "manual",
+      notes: input.notes ?? `Recorded by ${adminEmail}`,
+    })
+    .select("*")
+    .single();
+  if (runErr || !run) return res.status(500).json({ error: runErr?.message ?? "Failed to create run" });
+
+  const rows = input.results.map((r) => {
+    const { engine, usesUnclick } = deriveEngineParts(r.contestant);
+    const overall =
+      typeof r.overall_score === "number"
+        ? r.overall_score
+        : computeOverallFromCategories(r.category_scores, categories);
+    return {
+      run_id: run.id,
+      contestant: r.contestant,
+      engine,
+      uses_unclick: usesUnclick,
+      overall_score: overall,
+      tasks_total: r.tasks_total ?? 0,
+      tasks_passed: r.tasks_passed ?? 0,
+      category_scores: r.category_scores,
+      evidence: r.evidence ?? {},
+    };
+  });
+
+  const { error: resErr } = await db.from("benchmark_results").insert(rows);
+  if (resErr) {
+    // Roll back the orphan run so a failed record does not litter history.
+    await db.from("benchmark_runs").delete().eq("id", run.id);
+    return res.status(500).json({ error: resErr.message });
+  }
+
+  return res.status(201).json({ run: { ...run, results: rows } });
+}
+
+async function deleteRun(db: Db, res: VercelResponse, body: unknown) {
+  const id = (body as { id?: string } | null)?.id;
+  if (!id) return res.status(400).json({ error: "id is required" });
+  const { error } = await db.from("benchmark_runs").delete().eq("id", id);
+  if (error) return res.status(500).json({ error: error.message });
+  return res.status(200).json({ ok: true });
+}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,9 +9,9 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 526,
-    "source_manifest": 189,
-    "pages": 81,
+    "inventory": 527,
+    "source_manifest": 186,
+    "pages": 78,
     "tools": 187,
     "rooms": 23,
     "workers": 8
@@ -21,13 +21,13 @@
       "id": "admin-surfaces",
       "name": "Admin surfaces",
       "meaning": "Private operator views and internal control panels.",
-      "count": 46
+      "count": 47
     },
     {
       "id": "public-surfaces",
       "name": "Public surfaces",
       "meaning": "Public product, docs, marketplace, and user-facing routes.",
-      "count": 35
+      "count": 31
     },
     {
       "id": "tools",
@@ -81,7 +81,7 @@
       "id": "modules-and-apps",
       "name": "Modules and apps",
       "meaning": "Apps, packages, and product modules that make up UnClick.",
-      "count": 66
+      "count": 70
     },
     {
       "id": "launch-and-onboarding",
@@ -139,6 +139,16 @@
       "meaning": "Admin surface for Admin Ecosystem Pages.",
       "source": "src/pages/admin/AdminEcosystemPages.tsx",
       "route": "/admin/autopilot",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-benchmarks-src-pages-admin-adminbenchmarks-tsx-admin-benchmarks",
+      "division": "Admin surfaces",
+      "name": "Admin Benchmarks",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Benchmarks.",
+      "source": "src/pages/admin/AdminBenchmarks.tsx",
+      "route": "/admin/benchmarks",
       "tags": []
     },
     {
@@ -1922,6 +1932,46 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-component-arena-home-src-pages-arena-arenahome-tsx-no-route",
+      "division": "Modules and apps",
+      "name": "Arena Home",
+      "kind": "component",
+      "meaning": "Arena page for Arena Home.",
+      "source": "src/pages/arena/ArenaHome.tsx",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-component-arena-leaderboard-src-pages-arena-arenaleaderboard-tsx-no-route",
+      "division": "Modules and apps",
+      "name": "Arena Leaderboard",
+      "kind": "component",
+      "meaning": "Arena page for Arena Leaderboard.",
+      "source": "src/pages/arena/ArenaLeaderboard.tsx",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-component-arena-problem-src-pages-arena-arenaproblem-tsx-no-route",
+      "division": "Modules and apps",
+      "name": "Arena Problem",
+      "kind": "component",
+      "meaning": "Arena page for Arena Problem.",
+      "source": "src/pages/arena/ArenaProblem.tsx",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-component-arena-submit-problem-src-pages-arena-arenasubmitproblem-tsx-no-route",
+      "division": "Modules and apps",
+      "name": "Arena Submit Problem",
+      "kind": "component",
+      "meaning": "Arena page for Arena Submit Problem.",
+      "source": "src/pages/arena/ArenaSubmitProblem.tsx",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-component-backstage-pass-src-pages-backstagepass-tsx-no-route",
       "division": "Modules and apps",
       "name": "Backstage Pass",
@@ -2659,46 +2709,6 @@
       "meaning": "Verifies ACKs, stale handoffs, and worker wake requests before motion claims.",
       "source": "docs/pinballwake-igniteonly-api.md",
       "route": "",
-      "tags": []
-    },
-    {
-      "id": "public-surfaces-public-page-arena-home-src-pages-arena-arenahome-tsx-arena",
-      "division": "Public surfaces",
-      "name": "Arena Home",
-      "kind": "public page",
-      "meaning": "Arena page for Arena Home.",
-      "source": "src/pages/arena/ArenaHome.tsx",
-      "route": "/arena",
-      "tags": []
-    },
-    {
-      "id": "public-surfaces-public-page-arena-leaderboard-src-pages-arena-arenaleaderboard-tsx-arena-leaderboard",
-      "division": "Public surfaces",
-      "name": "Arena Leaderboard",
-      "kind": "public page",
-      "meaning": "Arena page for Arena Leaderboard.",
-      "source": "src/pages/arena/ArenaLeaderboard.tsx",
-      "route": "/arena/leaderboard",
-      "tags": []
-    },
-    {
-      "id": "public-surfaces-public-page-arena-problem-src-pages-arena-arenaproblem-tsx-arena-id",
-      "division": "Public surfaces",
-      "name": "Arena Problem",
-      "kind": "public page",
-      "meaning": "Arena page for Arena Problem.",
-      "source": "src/pages/arena/ArenaProblem.tsx",
-      "route": "/arena/:id",
-      "tags": []
-    },
-    {
-      "id": "public-surfaces-public-page-arena-submit-problem-src-pages-arena-arenasubmitproblem-tsx-arena-submit",
-      "division": "Public surfaces",
-      "name": "Arena Submit Problem",
-      "kind": "public page",
-      "meaning": "Arena page for Arena Submit Problem.",
-      "source": "src/pages/arena/ArenaSubmitProblem.tsx",
-      "route": "/arena/submit",
       "tags": []
     },
     {
@@ -5402,6 +5412,12 @@
       "src/pages/admin/AdminEcosystemPages.tsx"
     ],
     [
+      "/admin/benchmarks",
+      "Admin Benchmarks",
+      "Admin surface for Admin Benchmarks.",
+      "src/pages/admin/AdminBenchmarks.tsx"
+    ],
+    [
       "/admin/billing",
       "Admin Billing",
       "Admin surface for Admin Ecosystem Pages.",
@@ -5634,30 +5650,6 @@
       "Admin Shell",
       "Admin surface for Admin Shell.",
       "src/pages/admin/AdminShell.tsx"
-    ],
-    [
-      "/arena/:id",
-      "Arena Problem",
-      "Arena page for Arena Problem.",
-      "src/pages/arena/ArenaProblem.tsx"
-    ],
-    [
-      "/arena/leaderboard",
-      "Arena Leaderboard",
-      "Arena page for Arena Leaderboard.",
-      "src/pages/arena/ArenaLeaderboard.tsx"
-    ],
-    [
-      "/arena/submit",
-      "Arena Submit Problem",
-      "Arena page for Arena Submit Problem.",
-      "src/pages/arena/ArenaSubmitProblem.tsx"
-    ],
-    [
-      "/arena",
-      "Arena Home",
-      "Arena page for Arena Home.",
-      "src/pages/arena/ArenaHome.tsx"
     ],
     [
       "/auth/callback",
@@ -7140,13 +7132,13 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "1aa898894c02",
-      "bytes": 13811
+      "hash": "26405e588808",
+      "bytes": 14258
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
-      "hash": "1509360c4bfa",
-      "bytes": 19341
+      "hash": "a5993008255d",
+      "bytes": 19438
     },
     {
       "source": "src/pages/admin/AdminSkills.tsx",
@@ -7324,6 +7316,11 @@
       "bytes": 13854
     },
     {
+      "source": "src/pages/admin/AdminBenchmarks.tsx",
+      "hash": "2ba65d4943e0",
+      "bytes": 20931
+    },
+    {
       "source": "src/pages/admin/Fishbowl.tsx",
       "hash": "525cfc33fcdc",
       "bytes": 33809
@@ -7472,26 +7469,6 @@
       "source": "src/pages/admin/AdminYou.tsx",
       "hash": "394d65c7aabb",
       "bytes": 37346
-    },
-    {
-      "source": "src/pages/arena/ArenaProblem.tsx",
-      "hash": "11869f637abe",
-      "bytes": 15032
-    },
-    {
-      "source": "src/pages/arena/ArenaLeaderboard.tsx",
-      "hash": "af62b63a8204",
-      "bytes": 5299
-    },
-    {
-      "source": "src/pages/arena/ArenaSubmitProblem.tsx",
-      "hash": "06f3f416155c",
-      "bytes": 6899
-    },
-    {
-      "source": "src/pages/arena/ArenaHome.tsx",
-      "hash": "7674a937b45c",
-      "bytes": 10180
     },
     {
       "source": "src/pages/AuthCallback.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,8 +22,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | a8f64d0da135 | 4873 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | 1aa898894c02 | 13811 |
-| src/pages/admin/AdminShell.tsx | 1509360c4bfa | 19341 |
+| src/App.tsx | 26405e588808 | 14258 |
+| src/pages/admin/AdminShell.tsx | a5993008255d | 19438 |
 | src/pages/admin/AdminSkills.tsx | 4b5e69217a39 | 14848 |
 | src/lib/skillLibrary.ts | 7d69323f9491 | 10487 |
 | src/lib/skillLibrarySeeds.ts | 51ca658707f8 | 652 |
@@ -59,6 +59,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 4dadebd9c4aa | 22681 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3a9b7643c7fc | 13854 |
+| src/pages/admin/AdminBenchmarks.tsx | 2ba65d4943e0 | 20931 |
 | src/pages/admin/Fishbowl.tsx | 525cfc33fcdc | 33809 |
 | src/pages/admin/AdminBrainmap.tsx | c764ced96836 | 26511 |
 | src/pages/admin/AdminCodebase.tsx | ff33937fdf7b | 8044 |
@@ -89,10 +90,6 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminTools.tsx | 8544965a0043 | 8530 |
 | src/pages/admin/AdminUsers.tsx | 701e7da2f201 | 863 |
 | src/pages/admin/AdminYou.tsx | 394d65c7aabb | 37346 |
-| src/pages/arena/ArenaProblem.tsx | 11869f637abe | 15032 |
-| src/pages/arena/ArenaLeaderboard.tsx | af62b63a8204 | 5299 |
-| src/pages/arena/ArenaSubmitProblem.tsx | 06f3f416155c | 6899 |
-| src/pages/arena/ArenaHome.tsx | 7674a937b45c | 10180 |
 | src/pages/AuthCallback.tsx | 41644ade9f97 | 5284 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
 | src/pages/Connect.tsx | ebf2c68ad6c3 | 29590 |
@@ -207,8 +204,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 
 | Division | Meaning | Items |
 | --- | --- | --- |
-| Admin surfaces | Private operator views and internal control panels. | 46 |
-| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 35 |
+| Admin surfaces | Private operator views and internal control panels. | 47 |
+| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 31 |
 | Tools | MCP and gateway capabilities available to seats. | 187 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
@@ -217,7 +214,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 118 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
-| Modules and apps | Apps, packages, and product modules that make up UnClick. | 66 |
+| Modules and apps | Apps, packages, and product modules that make up UnClick. | 70 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 5 |
 
 ## UnClick Structure
@@ -258,6 +255,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /admin/audit-log | Admin Audit Log | Internal audit trail for sensitive admin actions. | src/pages/admin/AdminAuditLog.tsx |
 | /admin/autopilot/expressbuild | Admin Express Build | Admin surface for Admin Express Build. | src/pages/admin/AdminExpressBuild.tsx |
 | /admin/autopilot | Admin Autopilot | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
+| /admin/benchmarks | Admin Benchmarks | Admin surface for Admin Benchmarks. | src/pages/admin/AdminBenchmarks.tsx |
 | /admin/billing | Admin Billing | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
 | /admin/boardroom | Fishbowl | Boardroom discussion surface for worker coordination. | src/pages/admin/Fishbowl.tsx |
 | /admin/brainmap | Admin Brainmap | Generated ecosystem map that teaches seats what UnClick is. | src/pages/admin/AdminBrainmap.tsx |
@@ -297,10 +295,6 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /admin/workers | Admin Workers | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
 | /admin/you | Admin You | Personal account, identity, and access panel. | src/pages/admin/AdminYou.tsx |
 | /admin | Admin Shell | Admin surface for Admin Shell. | src/pages/admin/AdminShell.tsx |
-| /arena/:id | Arena Problem | Arena page for Arena Problem. | src/pages/arena/ArenaProblem.tsx |
-| /arena/leaderboard | Arena Leaderboard | Arena page for Arena Leaderboard. | src/pages/arena/ArenaLeaderboard.tsx |
-| /arena/submit | Arena Submit Problem | Arena page for Arena Submit Problem. | src/pages/arena/ArenaSubmitProblem.tsx |
-| /arena | Arena Home | Arena page for Arena Home. | src/pages/arena/ArenaHome.tsx |
 | /auth/callback | Auth Callback | User-facing page for Auth Callback. | src/pages/AuthCallback.tsx |
 | /auth/verify-mfa | Verify Mfa | User-facing page for Verify Mfa. | src/pages/VerifyMfa.tsx |
 | /connect/:platform | Connect | User-facing page for Connect. | src/pages/Connect.tsx |
@@ -533,6 +527,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Admin Analytics | Internal analytics view for platform signals and usage. | /admin/analytics | src/pages/admin/AdminAnalytics.tsx |
 | Admin surfaces | admin page | Admin Audit Log | Internal audit trail for sensitive admin actions. | /admin/audit-log | src/pages/admin/AdminAuditLog.tsx |
 | Admin surfaces | admin page | Admin Autopilot | Admin surface for Admin Ecosystem Pages. | /admin/autopilot | src/pages/admin/AdminEcosystemPages.tsx |
+| Admin surfaces | admin page | Admin Benchmarks | Admin surface for Admin Benchmarks. | /admin/benchmarks | src/pages/admin/AdminBenchmarks.tsx |
 | Admin surfaces | admin page | Admin Billing | Admin surface for Admin Ecosystem Pages. | /admin/billing | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin Brainmap | Generated ecosystem map that teaches seats what UnClick is. | /admin/brainmap | src/pages/admin/AdminBrainmap.tsx |
 | Admin surfaces | admin page | Admin Checks | Admin surface for Admin Ecosystem Pages. | /admin/checks | src/pages/admin/AdminEcosystemPages.tsx |
@@ -711,6 +706,10 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | app | JobSmith | CV, cover-letter, job application, and rules/checklist engine. | /admin/jobsmith | apps/jobsmith/package.json |
 | Modules and apps | automation module | AutoPilotKit | Internal automation bolt-on for proof-first work motion. | - | AUTOPILOT.md |
 | Modules and apps | component | Admin Settings | Account and admin configuration. | - | src/pages/AdminSettings.tsx |
+| Modules and apps | component | Arena Home | Arena page for Arena Home. | - | src/pages/arena/ArenaHome.tsx |
+| Modules and apps | component | Arena Leaderboard | Arena page for Arena Leaderboard. | - | src/pages/arena/ArenaLeaderboard.tsx |
+| Modules and apps | component | Arena Problem | Arena page for Arena Problem. | - | src/pages/arena/ArenaProblem.tsx |
+| Modules and apps | component | Arena Submit Problem | Arena page for Arena Submit Problem. | - | src/pages/arena/ArenaSubmitProblem.tsx |
 | Modules and apps | component | Backstage Pass | User-facing page for Backstage Pass. | - | src/pages/BackstagePass.tsx |
 | Modules and apps | component | Brain Map | Legacy Memory Brain Map component kept distinct from ecosystem Brainmap. | - | src/pages/admin/BrainMap.tsx |
 | Modules and apps | component | Build Desk | Build and project work surface. | - | src/pages/BuildDesk.tsx |
@@ -785,10 +784,6 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Passes and gates | pass | uxpass site sweep | uxpass site sweep UnClick module. | - | scripts/uxpass-site-sweep.mjs |
 | Passes and gates | pass | uxpass visual audit | uxpass visual audit UnClick module. | - | scripts/uxpass-visual-audit.mjs |
 | Passes and gates | wake gate | WakePass | Verifies ACKs, stale handoffs, and worker wake requests before motion claims. | - | docs/pinballwake-igniteonly-api.md |
-| Public surfaces | public page | Arena Home | Arena page for Arena Home. | /arena | src/pages/arena/ArenaHome.tsx |
-| Public surfaces | public page | Arena Leaderboard | Arena page for Arena Leaderboard. | /arena/leaderboard | src/pages/arena/ArenaLeaderboard.tsx |
-| Public surfaces | public page | Arena Problem | Arena page for Arena Problem. | /arena/:id | src/pages/arena/ArenaProblem.tsx |
-| Public surfaces | public page | Arena Submit Problem | Arena page for Arena Submit Problem. | /arena/submit | src/pages/arena/ArenaSubmitProblem.tsx |
 | Public surfaces | public page | Auth Callback | User-facing page for Auth Callback. | /auth/callback | src/pages/AuthCallback.tsx |
 | Public surfaces | public page | Connect | User-facing page for Connect. | /connect/:platform | src/pages/Connect.tsx |
 | Public surfaces | public page | Crews | Public Crews explanation and entry point. | /crews | src/pages/Crews.tsx |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,124 @@
+# UnClick Benchmarks
+
+**Purpose:** prove, with dated evidence, that UnClick makes an AI agent
+better. The Benchmarks admin page is the scoreboard investors and the team
+look at to answer one question: is UnClick earning its place, or is it
+clutter?
+
+This is the "report card" phase. It stores and displays results and gives
+you an idiot-proof view of progress over time. A later phase can add an
+automated harness that runs the contestants by itself and posts results to
+the same scoreboard with no rework.
+
+## The idea in one minute
+
+A **suite** is an exam made of weighted categories. A **run** is one sitting
+of that exam on a date. Each run has four **contestants**:
+
+| Contestant key   | Meaning           |
+|------------------|-------------------|
+| `codex_raw`      | Codex on its own  |
+| `claude_raw`     | Claude on its own |
+| `codex_unclick`  | Codex + UnClick   |
+| `claude_unclick` | Claude + UnClick  |
+
+Every contestant gets a score out of 100. The **UnClick lift** is how many
+points UnClick adds for an engine (`unclick - raw`). It is computed at read
+time, never stored.
+
+## Why the categories are weighted the way they are
+
+The starter suite (`unclick-capability-v1`) covers five categories. Tool use
+and memory carry the most weight because they are what UnClick uniquely
+provides. A pure coding test would mostly grade the base model and show
+little UnClick lift, which would undersell the product.
+
+| Category    | Weight | UnClick strength? | What it is |
+|-------------|:------:|:-----------------:|------------|
+| Coding      |   20   |                   | Famous public style (HumanEval / SWE-bench): write/fix code that passes hidden tests |
+| Reasoning   |   15   |                   | Famous public style (GSM8K / BIG-Bench): multi-step logic and word problems |
+| Knowledge   |   15   |                   | Famous public style (MMLU): broad factual exam |
+| Tool use    |   25   |        yes        | Mix (GAIA / tau-bench + UnClick tasks): actually call real tools to get something done |
+| Memory      |   25   |        yes        | Custom UnClick test: recall something across a fresh, later session |
+
+Weights sum to 100, so a run's overall score is a clean 0-100 number. Each
+category carries an `origin` (`famous`, `mixed`, or `custom`) and a `basis`
+string, which the page renders in plain English so anyone can see at a
+glance what the exam actually measures.
+
+## Where things live
+
+| Piece            | File |
+|------------------|------|
+| Database schema  | `supabase/migrations/20260529100000_benchmarks_schema.sql` |
+| Scoring + lift maths | `src/lib/benchmarks.ts` (unit-tested in `benchmarks.test.ts`) |
+| API (admin-gated) | `api/benchmarks.ts` (helpers tested in `benchmarks.test.ts`) |
+| The report card UI | `src/pages/admin/AdminBenchmarks.tsx` (`/admin/benchmarks`) |
+| Recording helper | `scripts/benchmark-record.mjs` |
+
+The tables are server-controlled: only `/api/benchmarks` (service role,
+gated on `ADMIN_EMAILS`) reads and writes them.
+
+## How to record a run
+
+Build a JSON file in this shape and post it. `overall_score` is optional;
+if omitted it is computed from `category_scores` and the suite weights.
+
+```json
+{
+  "suite_slug": "unclick-capability-v1",
+  "run_label": "June 2026 baseline",
+  "run_date": "2026-06-01",
+  "source": "manual",
+  "notes": "First real run after the memory upgrade.",
+  "results": [
+    {
+      "contestant": "claude_raw",
+      "category_scores": {
+        "coding":    { "score": 80, "max": 100 },
+        "reasoning": { "score": 78, "max": 100 },
+        "knowledge": { "score": 70, "max": 100 },
+        "tool_use":  { "score": 20, "max": 100 },
+        "memory":    { "score": 15, "max": 100 }
+      },
+      "tasks_total": 100,
+      "tasks_passed": 47,
+      "evidence": { "model": "claude-opus-4-8", "transcript_url": "..." }
+    }
+    // ...repeat for claude_unclick, codex_raw, codex_unclick
+  ]
+}
+```
+
+Post it with the helper (needs an admin session token):
+
+```bash
+node scripts/benchmark-record.mjs ./my-run.json \
+  --base https://unclick.world \
+  --token "$ADMIN_ACCESS_TOKEN"
+```
+
+The seed migration adds one **sample run** so the page is not empty. It is
+clearly badged "Sample data" and can be removed from the page with one
+click once a real run exists.
+
+## Each test should help close the loop
+
+The point is not just a number; it is to find where agents fail and feed
+that back into UnClick. When a run is recorded:
+
+- Put the failing-task detail in each result's `evidence` (transcript link,
+  which tasks failed, why).
+- The categories with the lowest UnClick lift are the next thing to improve
+  (e.g. if tool-use lift is small, the catalog or tool descriptions need
+  work; if memory lift is small, recall quality needs work).
+- This pairs with `.github/workflows/continuous-improvement-watch.yml`: a
+  declining or flat score across dated runs is a signal to open improvement
+  work, the same way the fleet reacts to other signals.
+
+## What "100" means
+
+100 = aced every task, including the hardest. Nobody is expected to hit 100
+soon, so the number climbing across dated runs is the progress signal. The
+report shows both the absolute score and the UnClick lift so you can read
+"how good is it" and "how much is UnClick helping" at the same time.

--- a/scripts/benchmark-record.mjs
+++ b/scripts/benchmark-record.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+ * benchmark-record.mjs - post a benchmark run to the UnClick scoreboard.
+ *
+ * Usage:
+ *   node scripts/benchmark-record.mjs <run.json> [--base <url>] [--token <jwt>]
+ *
+ * - <run.json> is a file in the record_run shape (see docs/benchmarks.md).
+ * - --base   defaults to $UNCLICK_BASE_URL or https://unclick.world
+ * - --token  defaults to $UNCLICK_ADMIN_TOKEN (a Supabase admin session JWT)
+ *
+ * This is the bridge for the "report card first" phase: you (or a future
+ * automated harness) produce the JSON, this posts it. Same endpoint the UI
+ * reads from, so nothing changes when execution is automated later.
+ */
+
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const args = { file: null, base: null, token: null };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === "--base") args.base = rest[++i];
+    else if (a === "--token") args.token = rest[++i];
+    else if (!a.startsWith("--")) args.file = a;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const base = args.base || process.env.UNCLICK_BASE_URL || "https://unclick.world";
+  const token = args.token || process.env.UNCLICK_ADMIN_TOKEN;
+
+  if (!args.file) {
+    console.error("Usage: node scripts/benchmark-record.mjs <run.json> [--base <url>] [--token <jwt>]");
+    process.exit(1);
+  }
+  if (!token) {
+    console.error("Missing admin token. Pass --token or set UNCLICK_ADMIN_TOKEN.");
+    process.exit(1);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(await readFile(args.file, "utf8"));
+  } catch (err) {
+    console.error(`Could not read or parse ${args.file}: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (!payload.source) payload.source = "script";
+
+  const url = `${base.replace(/\/$/, "")}/api/benchmarks?action=record_run`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(payload),
+  });
+
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    console.error(`Failed (${res.status}): ${body.error ?? "unknown error"}`);
+    process.exit(1);
+  }
+
+  const runId = body.run?.id ?? "(unknown)";
+  console.log(`Recorded run ${runId} (${payload.results?.length ?? 0} contestants).`);
+  console.log(`View it at ${base.replace(/\/$/, "")}/admin/benchmarks`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,12 @@ import DocsPage from "./pages/Docs.tsx";
 import LinkInBioPage from "./pages/tools/LinkInBio.tsx";
 import SchedulingPage from "./pages/tools/Scheduling.tsx";
 import SolvePage from "./pages/tools/Solve.tsx";
-import ArenaHome from "./pages/arena/ArenaHome.tsx";
-import ArenaProblem from "./pages/arena/ArenaProblem.tsx";
-import ArenaLeaderboard from "./pages/arena/ArenaLeaderboard.tsx";
-import ArenaSubmitProblem from "./pages/arena/ArenaSubmitProblem.tsx";
+// Arena is hidden for now (not deleted). Its pages, components, and API
+// remain in the codebase; only the public routes are turned off below.
+// import ArenaHome from "./pages/arena/ArenaHome.tsx";
+// import ArenaProblem from "./pages/arena/ArenaProblem.tsx";
+// import ArenaLeaderboard from "./pages/arena/ArenaLeaderboard.tsx";
+// import ArenaSubmitProblem from "./pages/arena/ArenaSubmitProblem.tsx";
 import FAQPage from "./pages/FAQPage.tsx";
 import ConnectPage from "./pages/Connect.tsx";
 import DevelopersPage from "./pages/Developers.tsx";
@@ -77,6 +79,7 @@ import AdminAuditLog from "./pages/admin/AdminAuditLog.tsx";
 import AdminBrainmap from "./pages/admin/AdminBrainmap.tsx";
 import AdminJobs from "./pages/admin/AdminJobs.tsx";
 import AdminJobsmith from "./pages/admin/AdminJobsmith.tsx";
+import AdminBenchmarks from "./pages/admin/AdminBenchmarks.tsx";
 import AdminExpressBuild from "./pages/admin/AdminExpressBuild.tsx";
 import {
   AdminAutopilot,
@@ -120,11 +123,12 @@ const App = () => (
           <Route path="/tools/link-in-bio" element={<LinkInBioPage />} />
           <Route path="/tools/scheduling" element={<SchedulingPage />} />
           <Route path="/tools/solve" element={<SolvePage />} />
-          {/* Arena - AI agent problem board with 6 viral features */}
-          <Route path="/arena" element={<ArenaHome />} />
-          <Route path="/arena/leaderboard" element={<ArenaLeaderboard />} />
-          <Route path="/arena/submit" element={<ArenaSubmitProblem />} />
-          <Route path="/arena/:id" element={<ArenaProblem />} />
+          {/* Arena - hidden for now (not deleted). Routes redirect home so the
+              pages are not reachable; components and API are retained. */}
+          <Route path="/arena" element={<Navigate to="/" replace />} />
+          <Route path="/arena/leaderboard" element={<Navigate to="/" replace />} />
+          <Route path="/arena/submit" element={<Navigate to="/" replace />} />
+          <Route path="/arena/:id" element={<Navigate to="/" replace />} />
           <Route path="/developers" element={<DevelopersPage />} />
           <Route path="/developers/docs" element={<DeveloperDocsPage />} />
           <Route path="/developers/submit" element={<DeveloperSubmitPage />} />
@@ -205,6 +209,7 @@ const App = () => (
             <Route path="moderation"     element={<RequireAdmin><AdminModeration /></RequireAdmin>} />
             <Route path="audit-log"      element={<RequireAdmin><AdminAuditLog /></RequireAdmin>} />
             <Route path="brainmap"       element={<RequireAdmin><AdminBrainmap /></RequireAdmin>} />
+            <Route path="benchmarks"     element={<RequireAdmin><AdminBenchmarks /></RequireAdmin>} />
             <Route path="signals"          element={<SignalsCatalog />} />
             <Route path="signals/settings" element={<SignalsSettings />} />
             <Route path="boardroom"        element={<Fishbowl />} />

--- a/src/lib/benchmarks.test.ts
+++ b/src/lib/benchmarks.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeOverall,
+  contestantParts,
+  engineLifts,
+  averageLift,
+  formatLift,
+  round2,
+  type BenchmarkRun,
+  type SuiteCategory,
+} from "./benchmarks";
+
+const CATEGORIES: SuiteCategory[] = [
+  { key: "coding", label: "Coding", weight: 20 },
+  { key: "reasoning", label: "Reasoning", weight: 15 },
+  { key: "knowledge", label: "Knowledge", weight: 15 },
+  { key: "tool_use", label: "Tool use", weight: 25, unclick_strength: true },
+  { key: "memory", label: "Memory", weight: 25, unclick_strength: true },
+];
+
+describe("contestantParts", () => {
+  it("derives engine and unclick flag from the contestant key", () => {
+    expect(contestantParts("codex_raw")).toEqual({ engine: "codex", usesUnclick: false });
+    expect(contestantParts("claude_unclick")).toEqual({ engine: "claude", usesUnclick: true });
+  });
+});
+
+describe("computeOverall", () => {
+  it("returns 100 when every category is perfect", () => {
+    const scores = Object.fromEntries(
+      CATEGORIES.map((c) => [c.key, { score: 100, max: 100 }]),
+    );
+    expect(computeOverall(scores, CATEGORIES)).toBe(100);
+  });
+
+  it("returns 0 when nothing is passed", () => {
+    const scores = Object.fromEntries(CATEGORIES.map((c) => [c.key, { score: 0, max: 100 }]));
+    expect(computeOverall(scores, CATEGORIES)).toBe(0);
+  });
+
+  it("weights tool_use and memory heavily (UnClick strengths)", () => {
+    // Perfect on the two heavy categories only (50 of 100 weight).
+    const scores = {
+      coding: { score: 0, max: 100 },
+      reasoning: { score: 0, max: 100 },
+      knowledge: { score: 0, max: 100 },
+      tool_use: { score: 100, max: 100 },
+      memory: { score: 100, max: 100 },
+    };
+    expect(computeOverall(scores, CATEGORIES)).toBe(50);
+  });
+
+  it("matches the hand-computed seed sample for claude_raw", () => {
+    const scores = {
+      coding: { score: 80, max: 100 },
+      reasoning: { score: 78, max: 100 },
+      knowledge: { score: 70, max: 100 },
+      tool_use: { score: 20, max: 100 },
+      memory: { score: 15, max: 100 },
+    };
+    expect(computeOverall(scores, CATEGORIES)).toBe(46.95);
+  });
+
+  it("ignores categories with no max and never exceeds 100", () => {
+    const scores = {
+      coding: { score: 999, max: 100 }, // over-perfect is clamped
+      tool_use: { score: 50, max: 0 }, // zero max is skipped
+    };
+    const overall = computeOverall(scores, CATEGORIES);
+    expect(overall).toBeLessThanOrEqual(100);
+    expect(overall).toBeGreaterThan(0);
+  });
+
+  it("normalises onto 0-100 even when weights do not sum to 100", () => {
+    const cats: SuiteCategory[] = [
+      { key: "a", label: "A", weight: 1 },
+      { key: "b", label: "B", weight: 1 },
+    ];
+    const scores = { a: { score: 100, max: 100 }, b: { score: 0, max: 100 } };
+    expect(computeOverall(scores, cats)).toBe(50);
+  });
+});
+
+function makeRun(overrides: Partial<Record<string, number>> = {}): BenchmarkRun {
+  const s = {
+    claude_raw: 47,
+    claude_unclick: 83,
+    codex_raw: 45,
+    codex_unclick: 80,
+    ...overrides,
+  };
+  return {
+    id: "run-1",
+    suite_id: "suite-1",
+    run_label: "test",
+    run_date: "2026-05-29",
+    status: "complete",
+    source: "manual",
+    notes: "",
+    results: [
+      { contestant: "claude_raw", engine: "claude", uses_unclick: false, overall_score: s.claude_raw!, tasks_total: 100, tasks_passed: 47, category_scores: {} },
+      { contestant: "claude_unclick", engine: "claude", uses_unclick: true, overall_score: s.claude_unclick!, tasks_total: 100, tasks_passed: 83, category_scores: {} },
+      { contestant: "codex_raw", engine: "codex", uses_unclick: false, overall_score: s.codex_raw!, tasks_total: 100, tasks_passed: 45, category_scores: {} },
+      { contestant: "codex_unclick", engine: "codex", uses_unclick: true, overall_score: s.codex_unclick!, tasks_total: 100, tasks_passed: 80, category_scores: {} },
+    ],
+  };
+}
+
+describe("engineLifts / averageLift", () => {
+  it("computes the per-engine UnClick lift", () => {
+    const lifts = engineLifts(makeRun());
+    const claude = lifts.find((l) => l.engine === "claude")!;
+    const codex = lifts.find((l) => l.engine === "codex")!;
+    expect(claude.lift).toBe(36);
+    expect(codex.lift).toBe(35);
+  });
+
+  it("averages the lift across engines", () => {
+    expect(averageLift(makeRun())).toBe(35.5);
+  });
+
+  it("returns null lift when a side is missing", () => {
+    const run = makeRun();
+    run.results = run.results.filter((r) => r.contestant !== "claude_unclick");
+    const claude = engineLifts(run).find((l) => l.engine === "claude")!;
+    expect(claude.lift).toBeNull();
+  });
+});
+
+describe("formatLift", () => {
+  it("adds an explicit plus sign for gains", () => {
+    expect(formatLift(14)).toBe("+14");
+    expect(formatLift(-3)).toBe("-3");
+    expect(formatLift(null)).toBe("n/a");
+  });
+});
+
+describe("round2", () => {
+  it("rounds to two decimals", () => {
+    expect(round2(46.954)).toBe(46.95);
+  });
+});

--- a/src/lib/benchmarks.ts
+++ b/src/lib/benchmarks.ts
@@ -1,0 +1,180 @@
+/**
+ * Benchmarks - shared types and pure scoring helpers.
+ *
+ * Plain English: a benchmark "suite" is an exam made of weighted
+ * categories. A "run" is one sitting of that exam on a date. Each run has
+ * four contestants. This module turns per-category scores into a single
+ * score out of 100, and works out how many points UnClick adds (the lift).
+ *
+ * Everything here is pure (no network, no React) so it is easy to test and
+ * can be reused by the API and any future automated harness.
+ */
+
+export const CONTESTANTS = [
+  "codex_raw",
+  "claude_raw",
+  "codex_unclick",
+  "claude_unclick",
+] as const;
+
+export type Contestant = (typeof CONTESTANTS)[number];
+
+export type Engine = "codex" | "claude";
+
+/** A human label for each contestant, for idiot-proof display. */
+export const CONTESTANT_LABEL: Record<Contestant, string> = {
+  codex_raw: "Codex alone",
+  claude_raw: "Claude alone",
+  codex_unclick: "Codex + UnClick",
+  claude_unclick: "Claude + UnClick",
+};
+
+/** Engine + whether UnClick is attached, derived from the contestant key. */
+export function contestantParts(c: Contestant): { engine: Engine; usesUnclick: boolean } {
+  return {
+    engine: c.startsWith("codex") ? "codex" : "claude",
+    usesUnclick: c.endsWith("unclick"),
+  };
+}
+
+export interface SuiteCategory {
+  key: string;
+  label: string;
+  weight: number;
+  description?: string;
+  /** True for categories where UnClick is expected to help (tool use, memory). */
+  unclick_strength?: boolean;
+  /** Where the tasks come from, for the "what is this test" explainer. */
+  origin?: "famous" | "custom" | "mixed";
+  /** Plain-English provenance, e.g. "HumanEval / SWE-bench style". */
+  basis?: string;
+}
+
+/** Friendly label + colour hint for a category's origin. */
+export const ORIGIN_LABEL: Record<NonNullable<SuiteCategory["origin"]>, string> = {
+  famous: "Based on a famous public benchmark",
+  custom: "Custom UnClick test",
+  mixed: "Mix of public benchmark + custom",
+};
+
+export interface BenchmarkSuite {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  version: string;
+  categories: SuiteCategory[];
+  max_score: number;
+}
+
+/** One category's raw score within a result: points out of a max. */
+export interface CategoryScore {
+  score: number;
+  max: number;
+}
+
+export type CategoryScores = Record<string, CategoryScore>;
+
+export interface BenchmarkResult {
+  contestant: Contestant;
+  engine: Engine;
+  uses_unclick: boolean;
+  overall_score: number;
+  tasks_total: number;
+  tasks_passed: number;
+  category_scores: CategoryScores;
+  evidence?: Record<string, unknown>;
+}
+
+export interface BenchmarkRun {
+  id: string;
+  suite_id: string;
+  run_label: string;
+  run_date: string;
+  status: "draft" | "complete";
+  source: "manual" | "script" | "auto" | "seed_sample";
+  notes: string;
+  results: BenchmarkResult[];
+}
+
+/** Clamp a number into [min, max]. */
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+/** Round to two decimals (scores are stored as numeric(5,2)). */
+export function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Turn per-category scores into one score out of 100.
+ *
+ * For each category we take the fraction passed (score / max), multiply by
+ * the category weight, and sum. When the weights sum to 100 the result is a
+ * clean 0-100 number. If weights sum to something else we normalise so the
+ * result is still on a 0-100 scale and never misleads.
+ */
+export function computeOverall(
+  categoryScores: CategoryScores,
+  categories: SuiteCategory[],
+): number {
+  const totalWeight = categories.reduce((sum, c) => sum + (c.weight || 0), 0);
+  if (totalWeight <= 0) return 0;
+
+  let weighted = 0;
+  for (const cat of categories) {
+    const cs = categoryScores[cat.key];
+    if (!cs || cs.max <= 0) continue;
+    const fraction = clamp(cs.score / cs.max, 0, 1);
+    weighted += fraction * cat.weight;
+  }
+  // Normalise onto 0-100 regardless of how the weights were set.
+  return round2((weighted / totalWeight) * 100);
+}
+
+/** Find a result for a contestant in a run, or undefined. */
+export function resultFor(run: BenchmarkRun, contestant: Contestant): BenchmarkResult | undefined {
+  return run.results.find((r) => r.contestant === contestant);
+}
+
+export interface EngineLift {
+  engine: Engine;
+  rawScore: number | null;
+  unclickScore: number | null;
+  /** Points UnClick adds (unclick - raw). Null if either side is missing. */
+  lift: number | null;
+}
+
+/**
+ * Work out, per engine, how many points UnClick adds. This is the headline
+ * "UnClick lift" the report leans on.
+ */
+export function engineLifts(run: BenchmarkRun): EngineLift[] {
+  const engines: Engine[] = ["claude", "codex"];
+  return engines.map((engine) => {
+    const raw = run.results.find((r) => r.engine === engine && !r.uses_unclick);
+    const unclick = run.results.find((r) => r.engine === engine && r.uses_unclick);
+    const rawScore = raw ? raw.overall_score : null;
+    const unclickScore = unclick ? unclick.overall_score : null;
+    const lift =
+      rawScore !== null && unclickScore !== null ? round2(unclickScore - rawScore) : null;
+    return { engine, rawScore, unclickScore, lift };
+  });
+}
+
+/** The average UnClick lift across engines, for a single headline number. */
+export function averageLift(run: BenchmarkRun): number | null {
+  const lifts = engineLifts(run)
+    .map((e) => e.lift)
+    .filter((l): l is number => l !== null);
+  if (lifts.length === 0) return null;
+  return round2(lifts.reduce((s, l) => s + l, 0) / lifts.length);
+}
+
+/** Format a lift with an explicit sign, e.g. "+14" or "-3". */
+export function formatLift(lift: number | null): string {
+  if (lift === null) return "n/a";
+  const rounded = Math.round(lift);
+  return rounded >= 0 ? `+${rounded}` : `${rounded}`;
+}

--- a/src/pages/admin/AdminBenchmarks.tsx
+++ b/src/pages/admin/AdminBenchmarks.tsx
@@ -1,0 +1,579 @@
+/**
+ * AdminBenchmarks - the benchmark report card at /admin/benchmarks
+ *
+ * Admin-only. Answers one question in plain English: is UnClick making
+ * agents better? It shows the latest contest between four contestants
+ * (Codex and Claude, each with and without UnClick), the points UnClick
+ * adds, a per-category breakdown, and a dated history so progress over
+ * time is obvious at a glance.
+ *
+ * Data comes from /api/benchmarks (admin-gated, service-role). The scoring
+ * and "lift" maths live in src/lib/benchmarks.ts.
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useSession } from "@/lib/auth";
+import {
+  Loader2,
+  Lock,
+  RefreshCw,
+  Trophy,
+  Sparkles,
+  Trash2,
+  Code2,
+  Brain,
+  BookOpen,
+  Wrench,
+  Database,
+} from "lucide-react";
+import {
+  CONTESTANT_LABEL,
+  ORIGIN_LABEL,
+  engineLifts,
+  formatLift,
+  resultFor,
+  type BenchmarkRun,
+  type BenchmarkResult,
+  type BenchmarkSuite,
+  type SuiteCategory,
+  type Contestant,
+  type Engine,
+} from "@/lib/benchmarks";
+
+const YELLOW = "#E2B93B";
+const TEAL = "#61C1C4";
+
+const CATEGORY_ICON: Record<string, typeof Code2> = {
+  coding: Code2,
+  reasoning: Brain,
+  knowledge: BookOpen,
+  tool_use: Wrench,
+  memory: Database,
+};
+
+// ── Row coercion: Supabase returns numeric columns as strings, so we ────────
+// normalise the raw API rows into the typed shapes the lib expects.
+
+interface RawRun {
+  id: string;
+  suite_id: string;
+  run_label: string;
+  run_date: string;
+  status: string;
+  source: string;
+  notes: string;
+  results?: RawResult[];
+}
+interface RawResult {
+  contestant: string;
+  engine: string;
+  uses_unclick: boolean;
+  overall_score: number | string;
+  tasks_total: number | string;
+  tasks_passed: number | string;
+  category_scores: Record<string, { score: number | string; max: number | string }>;
+  evidence?: Record<string, unknown>;
+}
+
+function toResult(r: RawResult): BenchmarkResult {
+  const cats: Record<string, { score: number; max: number }> = {};
+  for (const [k, v] of Object.entries(r.category_scores ?? {})) {
+    cats[k] = { score: Number(v.score), max: Number(v.max) };
+  }
+  return {
+    contestant: r.contestant as Contestant,
+    engine: r.engine as Engine,
+    uses_unclick: Boolean(r.uses_unclick),
+    overall_score: Number(r.overall_score),
+    tasks_total: Number(r.tasks_total),
+    tasks_passed: Number(r.tasks_passed),
+    category_scores: cats,
+    evidence: r.evidence ?? {},
+  };
+}
+
+function toRun(r: RawRun): BenchmarkRun {
+  return {
+    id: r.id,
+    suite_id: r.suite_id,
+    run_label: r.run_label,
+    run_date: r.run_date,
+    status: (r.status as BenchmarkRun["status"]) ?? "complete",
+    source: (r.source as BenchmarkRun["source"]) ?? "manual",
+    notes: r.notes ?? "",
+    results: (r.results ?? []).map(toResult),
+  };
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+// ── Small presentational pieces ──────────────────────────────────────────────
+
+function ScoreCardInner({ result, lift }: { result: BenchmarkResult; lift: number | null }) {
+  const accent = result.uses_unclick ? TEAL : "#888";
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-5">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-medium text-[#aaa]">{CONTESTANT_LABEL[result.contestant]}</p>
+        {result.uses_unclick && lift !== null && (
+          <span className="rounded-full bg-emerald-400/10 px-2 py-0.5 text-[11px] font-semibold text-emerald-300">
+            {formatLift(lift)} with UnClick
+          </span>
+        )}
+      </div>
+      <div className="mt-2 flex items-baseline gap-1">
+        <span className="text-4xl font-semibold tabular-nums" style={{ color: accent }}>
+          {Math.round(result.overall_score)}
+        </span>
+        <span className="text-sm text-[#666]">/100</span>
+      </div>
+      {result.tasks_total > 0 && (
+        <p className="mt-1 text-[11px] text-[#666]">
+          {result.tasks_passed} of {result.tasks_total} tasks passed
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ContestantPair({
+  run,
+  engine,
+}: {
+  run: BenchmarkRun;
+  engine: Engine;
+}) {
+  const raw = run.results.find((r) => r.engine === engine && !r.uses_unclick);
+  const unclick = run.results.find((r) => r.engine === engine && r.uses_unclick);
+  const lift =
+    raw && unclick ? Math.round(unclick.overall_score - raw.overall_score) : null;
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {raw ? <ScoreCardInner result={raw} lift={null} /> : <EmptyCard label={`${engine} alone`} />}
+      {unclick ? (
+        <ScoreCardInner result={unclick} lift={lift} />
+      ) : (
+        <EmptyCard label={`${engine} + UnClick`} />
+      )}
+    </div>
+  );
+}
+
+function EmptyCard({ label }: { label: string }) {
+  return (
+    <div className="rounded-xl border border-dashed border-white/[0.08] bg-white/[0.01] p-5">
+      <p className="text-xs text-[#555] capitalize">{label}</p>
+      <p className="mt-2 text-sm text-[#444]">No score recorded</p>
+    </div>
+  );
+}
+
+const ORIGIN_COLOR: Record<string, string> = {
+  famous: TEAL,
+  custom: YELLOW,
+  mixed: "#9b8cff",
+};
+
+function WhatsInTheExam({ suite, categories }: { suite: BenchmarkSuite; categories: SuiteCategory[] }) {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-5">
+      <p className="text-sm font-semibold text-white">What is in the exam</p>
+      <p className="mt-1 text-xs leading-relaxed text-[#888]">
+        {suite.description ||
+          "A mix of well-known public benchmark styles plus custom UnClick tasks."}
+      </p>
+      <ul className="mt-4 space-y-3">
+        {categories.map((cat) => {
+          const Icon = CATEGORY_ICON[cat.key] ?? Sparkles;
+          const origin = cat.origin ?? "custom";
+          const color = ORIGIN_COLOR[origin] ?? "#888";
+          return (
+            <li key={cat.key} className="flex gap-3">
+              <span
+                className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
+                style={{ background: `${color}1a`, color }}
+              >
+                <Icon className="h-4 w-4" />
+              </span>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium text-[#ddd]">{cat.label}</span>
+                  <span className="text-[11px] text-[#666]">worth {cat.weight} of 100</span>
+                  {cat.unclick_strength && (
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[10px] font-medium"
+                      style={{ background: `${TEAL}1a`, color: TEAL }}
+                    >
+                      UnClick strength
+                    </span>
+                  )}
+                </div>
+                <p className="mt-0.5 text-xs leading-relaxed text-[#999]">{cat.description}</p>
+                <p className="mt-1 text-[11px]" style={{ color }}>
+                  {ORIGIN_LABEL[origin]}
+                  {cat.basis ? ` (${cat.basis})` : ""}
+                </p>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="mt-4 flex flex-wrap gap-3 border-t border-white/[0.06] pt-3 text-[11px] text-[#777]">
+        <span className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full" style={{ background: TEAL }} /> Famous public benchmark
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full" style={{ background: "#9b8cff" }} /> Mix
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full" style={{ background: YELLOW }} /> Custom UnClick test
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CategoryBreakdown({ run, categories }: { run: BenchmarkRun; categories: SuiteCategory[] }) {
+  function frac(result: BenchmarkResult | undefined, key: string): number {
+    if (!result) return 0;
+    const cs = result.category_scores[key];
+    if (!cs || cs.max <= 0) return 0;
+    return Math.max(0, Math.min(1, cs.score / cs.max)) * 100;
+  }
+
+  const lanes: { contestant: Contestant; color: string }[] = [
+    { contestant: "claude_raw", color: "#888" },
+    { contestant: "claude_unclick", color: TEAL },
+    { contestant: "codex_raw", color: "#888" },
+    { contestant: "codex_unclick", color: "#9b8cff" },
+  ];
+
+  return (
+    <div className="space-y-4">
+      {categories.map((cat) => {
+        const Icon = CATEGORY_ICON[cat.key] ?? Sparkles;
+        return (
+          <div key={cat.key} className="rounded-xl border border-white/[0.06] bg-[#111111] p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Icon className="h-4 w-4 text-[#888]" />
+              <span className="text-sm font-medium text-[#ddd]">{cat.label}</span>
+              {cat.unclick_strength && (
+                <span
+                  className="rounded-full px-2 py-0.5 text-[10px] font-medium"
+                  style={{ background: `${TEAL}1a`, color: TEAL }}
+                >
+                  UnClick strength
+                </span>
+              )}
+              <span className="ml-auto text-[11px] text-[#555]">weight {cat.weight}</span>
+            </div>
+            <div className="space-y-1.5">
+              {lanes.map(({ contestant, color }) => {
+                const pct = frac(resultFor(run, contestant), cat.key);
+                return (
+                  <div key={contestant} className="flex items-center gap-2">
+                    <span className="w-32 shrink-0 text-[11px] text-[#777]">
+                      {CONTESTANT_LABEL[contestant]}
+                    </span>
+                    <div className="h-2 flex-1 overflow-hidden rounded-full bg-white/[0.04]">
+                      <div
+                        className="h-full rounded-full"
+                        style={{ width: `${pct}%`, background: color }}
+                      />
+                    </div>
+                    <span className="w-8 shrink-0 text-right text-[11px] tabular-nums text-[#888]">
+                      {Math.round(pct)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function HistoryTable({ runs }: { runs: BenchmarkRun[] }) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-white/[0.06] bg-[#111111]">
+      <table className="w-full text-left text-xs">
+        <thead className="text-[#666]">
+          <tr className="border-b border-white/[0.06]">
+            <th className="px-4 py-3 font-medium">Date</th>
+            <th className="px-4 py-3 font-medium">Run</th>
+            <th className="px-4 py-3 font-medium">Claude</th>
+            <th className="px-4 py-3 font-medium">Codex</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => {
+            const lifts = engineLifts(run);
+            const claude = lifts.find((l) => l.engine === "claude");
+            const codex = lifts.find((l) => l.engine === "codex");
+            return (
+              <tr key={run.id} className="border-b border-white/[0.04] last:border-0">
+                <td className="px-4 py-3 text-[#aaa] tabular-nums">{formatDate(run.run_date)}</td>
+                <td className="px-4 py-3 text-[#888]">
+                  {run.run_label || "(untitled)"}
+                  {run.source === "seed_sample" && (
+                    <span className="ml-2 rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] text-[#777]">
+                      sample
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <LiftCell raw={claude?.rawScore ?? null} unclick={claude?.unclickScore ?? null} lift={claude?.lift ?? null} />
+                </td>
+                <td className="px-4 py-3">
+                  <LiftCell raw={codex?.rawScore ?? null} unclick={codex?.unclickScore ?? null} lift={codex?.lift ?? null} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function LiftCell({ raw, unclick, lift }: { raw: number | null; unclick: number | null; lift: number | null }) {
+  if (raw === null && unclick === null) return <span className="text-[#555]">-</span>;
+  return (
+    <span className="tabular-nums text-[#aaa]">
+      {raw === null ? "-" : Math.round(raw)}
+      <span className="text-[#555]"> &rarr; </span>
+      <span style={{ color: TEAL }}>{unclick === null ? "-" : Math.round(unclick)}</span>
+      {lift !== null && (
+        <span className={`ml-1.5 ${lift >= 0 ? "text-emerald-300" : "text-red-300"}`}>
+          ({formatLift(lift)})
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function AdminBenchmarks() {
+  const { session } = useSession();
+  const navigate = useNavigate();
+
+  const [adminVerified, setAdminVerified] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [suite, setSuite] = useState<BenchmarkSuite | null>(null);
+  const [latest, setLatest] = useState<BenchmarkRun | null>(null);
+  const [history, setHistory] = useState<BenchmarkRun[]>([]);
+
+  const load = useCallback(async () => {
+    if (!session) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch("/api/benchmarks?action=overview", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (r.status === 403) {
+        setAdminVerified(false);
+        navigate("/admin/you", { replace: true });
+        return;
+      }
+      setAdminVerified(true);
+      const body = await r.json();
+      if (!r.ok) throw new Error(body.error ?? "Failed to load benchmarks");
+      setSuite(
+        body.suite
+          ? { ...body.suite, categories: (body.suite.categories as SuiteCategory[]) ?? [] }
+          : null,
+      );
+      setLatest(body.latest ? toRun(body.latest) : null);
+      setHistory((body.history ?? []).map(toRun));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }, [session, navigate]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function removeSample(runId: string) {
+    if (!session) return;
+    await fetch("/api/benchmarks?action=delete_run", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id: runId }),
+    });
+    load();
+  }
+
+  if (adminVerified === false) {
+    return (
+      <div className="flex items-center gap-2 py-12 text-[#666]">
+        <Lock className="h-4 w-4" />
+        <span className="text-sm">Admin access required</span>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-12 text-[#666]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span className="text-sm">Loading benchmarks...</span>
+      </div>
+    );
+  }
+
+  const categories = suite?.categories ?? [];
+  const lifts = latest ? engineLifts(latest) : [];
+  const claudeLift = lifts.find((l) => l.engine === "claude")?.lift ?? null;
+  const codexLift = lifts.find((l) => l.engine === "codex")?.lift ?? null;
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Trophy className="h-5 w-5" style={{ color: YELLOW }} />
+            <h1 className="text-2xl font-semibold text-white">Benchmarks</h1>
+          </div>
+          <p className="mt-1 text-sm text-[#888]">Is UnClick making agents better? This is the scoreboard.</p>
+        </div>
+        <button
+          onClick={load}
+          className="flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-xs text-[#888] transition-colors hover:bg-white/[0.08] hover:text-white"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+      </div>
+
+      {/* What you're looking at */}
+      <div className="mb-6 rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 text-xs leading-relaxed text-[#999]">
+        <p className="font-medium text-[#ccc]">What you are looking at</p>
+        <p className="mt-1">
+          We give the same exam to four contestants: Codex and Claude, each on their own and again with
+          UnClick attached. The score is out of 100 (higher is better). The green number shows how many
+          points UnClick adds. Watch the dated history below to see progress over time.
+        </p>
+      </div>
+
+      {suite && categories.length > 0 && (
+        <div className="mb-6">
+          <WhatsInTheExam suite={suite} categories={categories} />
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-6 rounded-xl border border-red-400/20 bg-red-400/5 p-4 text-xs text-red-300">
+          {error}
+        </div>
+      )}
+
+      {!suite && (
+        <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-8 text-center">
+          <p className="text-sm text-[#888]">No benchmark suite is set up yet.</p>
+        </div>
+      )}
+
+      {suite && !latest && (
+        <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-8 text-center">
+          <p className="text-sm text-[#888]">No runs recorded yet for {suite.title}.</p>
+          <p className="mt-1 text-xs text-[#666]">
+            Record one with the helper in <code className="text-[#888]">scripts/benchmark-record.mjs</code>.
+          </p>
+        </div>
+      )}
+
+      {suite && latest && (
+        <>
+          {/* Latest contest */}
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold text-white">Latest contest</h2>
+            <span className="text-xs text-[#666]">
+              {latest.run_label || "(untitled)"} &middot; {formatDate(latest.run_date)}
+            </span>
+            {latest.source === "seed_sample" && (
+              <>
+                <span className="rounded-full bg-[#E2B93B]/10 px-2 py-0.5 text-[10px] font-medium" style={{ color: YELLOW }}>
+                  Sample data
+                </span>
+                <button
+                  onClick={() => removeSample(latest.id)}
+                  className="flex items-center gap-1 text-[11px] text-[#666] hover:text-red-300"
+                >
+                  <Trash2 className="h-3 w-3" /> Remove sample
+                </button>
+              </>
+            )}
+          </div>
+
+          {/* Headline takeaway */}
+          {(claudeLift !== null || codexLift !== null) && (
+            <p className="mb-5 text-sm text-[#bbb]">
+              On this exam, UnClick added{" "}
+              {claudeLift !== null && (
+                <>
+                  <span className="font-semibold text-emerald-300">{formatLift(claudeLift)}</span> to Claude
+                </>
+              )}
+              {claudeLift !== null && codexLift !== null && " and "}
+              {codexLift !== null && (
+                <>
+                  <span className="font-semibold text-emerald-300">{formatLift(codexLift)}</span> to Codex
+                </>
+              )}
+              .
+            </p>
+          )}
+
+          <div className="mb-8 grid gap-4 lg:grid-cols-2">
+            <div>
+              <p className="mb-2 text-[11px] uppercase tracking-wide text-[#666]">Claude</p>
+              <ContestantPair run={latest} engine="claude" />
+            </div>
+            <div>
+              <p className="mb-2 text-[11px] uppercase tracking-wide text-[#666]">Codex</p>
+              <ContestantPair run={latest} engine="codex" />
+            </div>
+          </div>
+
+          {/* Category breakdown */}
+          {categories.length > 0 && (
+            <>
+              <h2 className="mb-3 text-sm font-semibold text-white">Where the points come from</h2>
+              <div className="mb-8">
+                <CategoryBreakdown run={latest} categories={categories} />
+              </div>
+            </>
+          )}
+
+          {/* History */}
+          <h2 className="mb-3 text-sm font-semibold text-white">History (newest first)</h2>
+          <HistoryTable runs={history} />
+        </>
+      )}
+
+      <div className="mt-6 text-[11px] text-[#555]">
+        <Link to="/admin/checks" className="hover:text-[#888]">
+          XPass quality gates
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -60,6 +60,7 @@ import {
   FileStack,
   FileCode2,
   SlidersHorizontal,
+  Trophy,
 } from "lucide-react";
 
 function SurfaceLink({ path, label, icon: Icon, onClick, badge }: {
@@ -161,6 +162,7 @@ const ADMIN_SUBMENU = [
   { path: "/admin/moderation",    label: "Marketplace Moderation", icon: ShieldCheck },
   { path: "/admin/audit-log",     label: "Audit Log",             icon: ScrollText  },
   { path: "/admin/brainmap",      label: "Ecosystem Brainmap",    icon: Sparkles    },
+  { path: "/admin/benchmarks",    label: "Benchmarks",            icon: Trophy      },
 ] as const;
 
 function AdminSubmenu({ onLinkClick }: { onLinkClick?: () => void }) {

--- a/supabase/migrations/20260529100000_benchmarks_schema.sql
+++ b/supabase/migrations/20260529100000_benchmarks_schema.sql
@@ -1,0 +1,152 @@
+-- Benchmarks: measure whether UnClick makes an agent better.
+--
+-- The story this schema tells, in plain English:
+--   suite   = a named, versioned set of categories and weights (the exam).
+--   run     = one sitting of that exam on a given date (the contest).
+--   result  = one contestant's scores within a run. Four contestants per
+--             run: codex_raw, claude_raw, codex_unclick, claude_unclick.
+--
+-- "UnClick lift" (how many points UnClick adds) is computed at read time
+-- from the raw vs unclick results of the same engine; it is not stored.
+--
+-- These tables are server-controlled: the /api/benchmarks endpoint reads
+-- and writes with the service role and gates on ADMIN_EMAILS. Browser
+-- clients never touch them directly, so anon/authenticated are denied at
+-- the grant layer (matches the data-api service-only convention).
+
+create table if not exists benchmark_suites (
+  id           uuid primary key default gen_random_uuid(),
+  slug         text not null unique,
+  title        text not null,
+  description  text not null default '',
+  version      text not null default '1.0.0',
+  -- categories: [{ key, label, weight, description, unclick_strength }]
+  -- weights are expected to sum to 100 so a run's overall score is 0-100.
+  categories   jsonb not null default '[]',
+  max_score    integer not null default 100,
+  is_active    boolean not null default true,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+create table if not exists benchmark_runs (
+  id           uuid primary key default gen_random_uuid(),
+  suite_id     uuid not null references benchmark_suites(id) on delete cascade,
+  run_label    text not null default '',
+  run_date     date not null default current_date,
+  status       text not null default 'complete' check (status in ('draft','complete')),
+  -- source tells the UI how to badge the row:
+  --   manual      = a human recorded it
+  --   script      = the benchmark-record helper posted it
+  --   auto        = a future automated harness produced it
+  --   seed_sample = illustrative seed data, safe to delete
+  source       text not null default 'manual'
+                 check (source in ('manual','script','auto','seed_sample')),
+  notes        text not null default '',
+  created_at   timestamptz not null default now()
+);
+
+create table if not exists benchmark_results (
+  id              uuid primary key default gen_random_uuid(),
+  run_id          uuid not null references benchmark_runs(id) on delete cascade,
+  contestant      text not null
+                    check (contestant in ('codex_raw','claude_raw','codex_unclick','claude_unclick')),
+  engine          text not null check (engine in ('codex','claude')),
+  uses_unclick    boolean not null default false,
+  overall_score   numeric(5,2) not null default 0,
+  tasks_total     integer not null default 0,
+  tasks_passed    integer not null default 0,
+  -- category_scores: { <category_key>: { score, max } }
+  category_scores jsonb not null default '{}',
+  -- evidence: free-form { notes, transcript_url, model, harness_version, ... }
+  evidence        jsonb not null default '{}',
+  created_at      timestamptz not null default now(),
+  unique (run_id, contestant)
+);
+
+-- Indexes for the common read paths (latest run, history, run detail).
+create index if not exists benchmark_runs_suite_idx    on benchmark_runs(suite_id);
+create index if not exists benchmark_runs_date_idx      on benchmark_runs(run_date desc);
+create index if not exists benchmark_results_run_idx     on benchmark_results(run_id);
+
+-- Auto-update updated_at on suites.
+create or replace function benchmark_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists benchmark_suites_updated_at on benchmark_suites;
+create trigger benchmark_suites_updated_at
+  before update on benchmark_suites
+  for each row execute function benchmark_set_updated_at();
+
+-- RLS: enabled, but no anon/authenticated policies. Access is service-only.
+alter table benchmark_suites  enable row level security;
+alter table benchmark_runs    enable row level security;
+alter table benchmark_results enable row level security;
+
+revoke all on table benchmark_suites  from anon, authenticated;
+revoke all on table benchmark_runs    from anon, authenticated;
+revoke all on table benchmark_results from anon, authenticated;
+
+grant all on table benchmark_suites  to service_role;
+grant all on table benchmark_runs    to service_role;
+grant all on table benchmark_results to service_role;
+
+-- ── Seed: the starter suite (real, needed by the API) ──────────────────────
+-- Broad coverage across five categories, with tool_use and memory weighted
+-- highest because that is where UnClick is expected to lift the score.
+insert into benchmark_suites (slug, title, description, version, categories, max_score, is_active)
+values (
+  'unclick-capability-v1',
+  'UnClick Capability Benchmark v1',
+  'Measures an agent across coding, reasoning, knowledge, tool use, and cross-session memory. Tool use and memory are weighted highest because they are what UnClick uniquely provides.',
+  '1.0.0',
+  '[
+    {"key":"coding","label":"Coding","weight":20,"unclick_strength":false,"origin":"famous","basis":"HumanEval / SWE-bench style","description":"Write and fix real code; an answer only counts if it passes hidden tests."},
+    {"key":"reasoning","label":"Reasoning","weight":15,"unclick_strength":false,"origin":"famous","basis":"GSM8K / BIG-Bench style","description":"Multi-step logic and word problems where you must show the right steps, not just guess."},
+    {"key":"knowledge","label":"Knowledge","weight":15,"unclick_strength":false,"origin":"famous","basis":"MMLU style","description":"Broad factual questions across many subjects, like a general knowledge exam."},
+    {"key":"tool_use","label":"Tool use","weight":25,"unclick_strength":true,"origin":"mixed","basis":"GAIA / tau-bench style, UnClick tasks","description":"Actually get something done by calling real tools (send an email, look up data, hit an API), not just describe it."},
+    {"key":"memory","label":"Memory","weight":25,"unclick_strength":true,"origin":"custom","basis":"Custom UnClick cross-session test","description":"Tell the agent something in one session, then ask for it in a later, fresh session. A plain model forgets; UnClick should remember."}
+  ]'::jsonb,
+  100,
+  true
+)
+on conflict (slug) do nothing;
+
+-- ── Seed: one clearly-labelled sample run so the page renders something ─────
+-- These numbers are illustrative only. Delete this run from the Benchmarks
+-- page once a real run is recorded. Its source is 'seed_sample' so the UI
+-- shows a "Sample data" badge.
+do $$
+declare
+  v_suite uuid;
+  v_run   uuid;
+begin
+  select id into v_suite from benchmark_suites where slug = 'unclick-capability-v1';
+  if v_suite is null then return; end if;
+
+  -- Only seed the sample once.
+  if exists (select 1 from benchmark_runs where suite_id = v_suite and source = 'seed_sample') then
+    return;
+  end if;
+
+  insert into benchmark_runs (suite_id, run_label, run_date, status, source, notes)
+  values (v_suite, 'Sample run (illustrative only)', current_date, 'complete', 'seed_sample',
+          'Seed data so the page is not empty. Safe to delete once a real run exists.')
+  returning id into v_run;
+
+  insert into benchmark_results
+    (run_id, contestant, engine, uses_unclick, overall_score, tasks_total, tasks_passed, category_scores) values
+    (v_run, 'claude_raw',     'claude', false, 46.95, 100, 47,
+       '{"coding":{"score":80,"max":100},"reasoning":{"score":78,"max":100},"knowledge":{"score":70,"max":100},"tool_use":{"score":20,"max":100},"memory":{"score":15,"max":100}}'::jsonb),
+    (v_run, 'claude_unclick', 'claude', true,  83.15, 100, 83,
+       '{"coding":{"score":80,"max":100},"reasoning":{"score":78,"max":100},"knowledge":{"score":78,"max":100},"tool_use":{"score":85,"max":100},"memory":{"score":90,"max":100}}'::jsonb),
+    (v_run, 'codex_raw',      'codex',  false, 44.60, 100, 45,
+       '{"coding":{"score":82,"max":100},"reasoning":{"score":72,"max":100},"knowledge":{"score":66,"max":100},"tool_use":{"score":18,"max":100},"memory":{"score":12,"max":100}}'::jsonb),
+    (v_run, 'codex_unclick',  'codex',  true,  80.25, 100, 80,
+       '{"coding":{"score":82,"max":100},"reasoning":{"score":74,"max":100},"knowledge":{"score":75,"max":100},"tool_use":{"score":80,"max":100},"memory":{"score":86,"max":100}}'::jsonb);
+end $$;


### PR DESCRIPTION
## What this is

A dated, idiot-proof **Benchmarks** scoreboard in the admin (Yellow) section that answers one question: **is UnClick making agents better?**

Four contestants per run, scored out of 100, with the **UnClick lift** (points UnClick adds) shown alongside:

| Contestant | Meaning |
|---|---|
| `codex_raw` | Codex on its own |
| `claude_raw` | Claude on its own |
| `codex_unclick` | Codex + UnClick |
| `claude_unclick` | Claude + UnClick |

This is the **"report card first"** phase agreed with Chris: it stores and displays results via a defined record format. A future automated harness can post to the **same** endpoint with no rework.

## What landed

- **DB migration** (`supabase/migrations/20260529100000_benchmarks_schema.sql`): `benchmark_suites` / `benchmark_runs` / `benchmark_results` with service-only RLS + grants. Seeds the `unclick-capability-v1` suite and one clearly-badged **sample run** so the page renders immediately (one-click removable).
- **Scoring lib** (`src/lib/benchmarks.ts`): pure score + lift maths, fully unit-tested.
- **API** (`api/benchmarks.ts`): admin-gated via `ADMIN_EMAILS`, service-role; reads the scoreboard and records runs. Helpers unit-tested.
- **Report card UI** (`src/pages/admin/AdminBenchmarks.tsx`): latest contest, per-category bars, a plain-English **"what is in the exam"** explainer (shows whether each category is a famous public benchmark, a mix, or a custom UnClick test), and a dated **history** so progress over time is obvious.
- **Helper + docs** (`scripts/benchmark-record.mjs`, `docs/benchmarks.md`): how to record a run + the JSON contract.
- **Wiring**: `/admin/benchmarks` route + Benchmarks nav item.
- **Arena hidden** (not deleted): routes redirect home; pages, components, and API retained.

## Why the categories are weighted this way

Coding (20), Reasoning (15), Knowledge (15), **Tool use (25)**, **Memory (25)**. Tool use and memory carry the most weight because they are what UnClick uniquely provides; a pure coding test would mostly grade the base model and show little UnClick lift.

## Proof

- `npx tsc --noEmit` clean
- `vitest` 22 tests pass (scoring lib + API helpers)
- `npm run build` succeeds
- `npm run brainmap:check` passes (regenerated)
- `npm run lint` passes (one non-blocking warning: the idiomatic fetch-on-mount effect)

## Not in this PR (follow-ups)

- The DB migration is **not** applied to production by this PR. The new tables need a yes before touching the live Supabase project.
- Phase 2: the automated harness that drives Codex/Claude in both modes and posts results.
- Residual `/arena` links in a few pages (Pricing, FAQ, etc.) now redirect home; a tidy-up of those links can follow.

https://claude.ai/code/session_01WdM3JDBxwM5u9vAe4BgZ69

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdM3JDBxwM5u9vAe4BgZ69)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New service-role API writes benchmark data behind admin JWT checks; production needs the migration applied deliberately. Arena is only route-hidden, not removed.
> 
> **Overview**
> Adds an **admin Benchmarks scoreboard** at `/admin/benchmarks` to compare Codex/Claude with and without UnClick, show per-category scores, **UnClick lift**, and run history.
> 
> **Backend & data:** New Supabase tables (`benchmark_suites`, `benchmark_runs`, `benchmark_results`) with service-role-only access, seed suite `unclick-capability-v1`, and an illustrative **sample run**. **`/api/benchmarks`** (overview, run detail, `record_run`, `delete_run`) is gated on `ADMIN_EMAILS` and uses the service role. Shared scoring/validation in `src/lib/benchmarks.ts` and `api/benchmarks.ts`, plus `scripts/benchmark-record.mjs` and `docs/benchmarks.md`.
> 
> **UI & nav:** New `AdminBenchmarks` page, route behind `RequireAdmin`, and a Benchmarks item in the admin submenu. Brainmap artifacts regenerated for the new surface.
> 
> **Product tweak:** Public **Arena** routes now redirect home; arena code stays in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 248f01d84910e52d4fad20e9abec6c5386ed1b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->