### PR TITLE
Add master benchmark prompt with copy buttons to Benchmarks page

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7317,8 +7317,8 @@
     },
     {
       "source": "src/pages/admin/AdminBenchmarks.tsx",
-      "hash": "2ba65d4943e0",
-      "bytes": 20931
+      "hash": "a22439f75761",
+      "bytes": 24203
     },
     {
       "source": "src/pages/admin/Fishbowl.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -59,7 +59,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 4dadebd9c4aa | 22681 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3a9b7643c7fc | 13854 |
-| src/pages/admin/AdminBenchmarks.tsx | 2ba65d4943e0 | 20931 |
+| src/pages/admin/AdminBenchmarks.tsx | a22439f75761 | 24203 |
 | src/pages/admin/Fishbowl.tsx | 525cfc33fcdc | 33809 |
 | src/pages/admin/AdminBrainmap.tsx | c764ced96836 | 26511 |
 | src/pages/admin/AdminCodebase.tsx | ff33937fdf7b | 8044 |

--- a/src/lib/benchmarkPrompt.ts
+++ b/src/lib/benchmarkPrompt.ts
@@ -1,0 +1,57 @@
+/**
+ * The master benchmark prompt - a starting reference, editable as things
+ * evolve. Paste the SAME prompt into a fresh "Code" session for each of the
+ * four contestants (Claude/Codex, each with and without UnClick). The only
+ * thing that changes between sessions is whether UnClick is connected.
+ *
+ * Kept here as a constant so the Admin Benchmarks page can show it with a
+ * copy button. The grading answer key is deliberately NOT in this file or
+ * the prompt, so the agent under test cannot read the answers.
+ */
+
+export const MASTER_PROMPT = `You are taking the UnClick Capability Benchmark v1. Treat this as a timed capability test. Work through every task in order.
+
+Rules:
+- Use any tools, memory, or capabilities available to you. If you have persistent memory or external tools, use them. If you have none, do your best with what you have.
+- Answer each task with its number (for example "C1:"). Be concise.
+- For TOOL tasks, actually perform the action and report the real result, and name the tool you used. If you cannot perform it, write "cannot perform - no tool".
+- For REASONING and KNOWLEDGE tasks, answer from your own thinking. Do not look these up.
+- At the very end, output a section titled "TOOLS/MEMORY USED:" listing what you used, or "none".
+
+=== CODING ===
+C1. Write a function is_palindrome(s) that returns true if s reads the same forwards and backwards, ignoring case, spaces, and punctuation. Show its output for "A man, a plan, a canal: Panama" and for "hello world".
+C2. Write a function second_largest(nums) that returns the second-largest UNIQUE number in a list, or null if there is not one. Show its output for [4, 1, 4, 3, 2] and for [5, 5].
+
+=== REASONING (answer from your own thinking, no tools) ===
+R1. A bat and a ball cost $1.10 in total. The bat costs $1.00 more than the ball. How much does the ball cost?
+R2. If 5 machines take 5 minutes to make 5 widgets, how long do 100 machines take to make 100 widgets?
+R3. Two coins add up to 30 cents, and one of them is not a nickel. What are the two coins?
+
+=== KNOWLEDGE (answer from your own thinking, no tools) ===
+K1. What is the chemical symbol for gold, and its atomic number?
+K2. Who wrote "Pride and Prejudice", and in what year was it first published?
+K3. What is the capital city of Australia?
+
+=== TOOL USE (actually perform these and name the tool) ===
+T1. Report the current date and time in Sydney, Australia right now.
+T2. Report the current weather in Sydney, Australia right now (conditions and temperature).
+T3. Convert 100 US dollars to Australian dollars at today's real exchange rate, and state the rate you used.
+
+=== MEMORY (seed step) ===
+M0. Remember these three facts for a later, separate session. If you have persistent memory, store them now and confirm you have saved them:
+   - My product launch date is 14 September 2026.
+   - My co-founder's name is Priya Nair.
+   - My favourite test city is Wollongong.
+
+End of benchmark. Output your answers now, then the "TOOLS/MEMORY USED:" section.`;
+
+/**
+ * Run this in a SEPARATE, fresh session (after the master prompt session is
+ * closed) to score the Memory category. A plain model will have forgotten;
+ * an UnClick-equipped one should recall via its memory.
+ */
+export const MEMORY_RECALL_PROMPT = `This is a memory recall check for the UnClick Capability Benchmark v1. Do not guess from this message. If you have persistent memory, load it first. Answer these about me:
+MR1. What is my product launch date?
+MR2. What is my co-founder's name?
+MR3. What is my favourite test city?
+If you do not know an answer, write "unknown". Then output "TOOLS/MEMORY USED:" listing what you used, or "none".`;

--- a/src/pages/admin/AdminBenchmarks.tsx
+++ b/src/pages/admin/AdminBenchmarks.tsx
@@ -26,7 +26,11 @@ import {
   BookOpen,
   Wrench,
   Database,
+  Copy,
+  Check,
+  ListChecks,
 } from "lucide-react";
+import { MASTER_PROMPT, MEMORY_RECALL_PROMPT } from "@/lib/benchmarkPrompt";
 import {
   CONTESTANT_LABEL,
   ORIGIN_LABEL,
@@ -170,6 +174,68 @@ function EmptyCard({ label }: { label: string }) {
     <div className="rounded-xl border border-dashed border-white/[0.08] bg-white/[0.01] p-5">
       <p className="text-xs text-[#555] capitalize">{label}</p>
       <p className="mt-2 text-sm text-[#444]">No score recorded</p>
+    </div>
+  );
+}
+
+function CopyableBlock({ label, text }: { label: string; text: string }) {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  }
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-black/30">
+      <div className="flex items-center justify-between gap-2 border-b border-white/[0.06] px-3 py-2">
+        <span className="text-[11px] font-medium text-[#999]">{label}</span>
+        <button
+          onClick={copy}
+          className="flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.04] px-2.5 py-1 text-[11px] text-[#aaa] transition-colors hover:bg-white/[0.08] hover:text-white"
+        >
+          {copied ? <Check className="h-3 w-3 text-emerald-300" /> : <Copy className="h-3 w-3" />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap px-3 py-3 text-[11px] leading-relaxed text-[#bbb]">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+function HowToRun() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-5">
+      <button onClick={() => setOpen((v) => !v)} className="flex w-full items-center gap-2 text-left">
+        <ListChecks className="h-4 w-4" style={{ color: TEAL }} />
+        <span className="text-sm font-semibold text-white">How to run a benchmark</span>
+        <span className="ml-auto text-[11px] text-[#666]">{open ? "Hide" : "Show"}</span>
+      </button>
+
+      {open && (
+        <div className="mt-4 space-y-4">
+          <ol className="space-y-1.5 text-xs leading-relaxed text-[#aaa]">
+            <li>1. Open a fresh <span className="text-[#ddd]">Code</span> session (Claude Code or Codex CLI). Not Chat, not a fleet session.</li>
+            <li>2. Run the same <span className="text-[#ddd]">master prompt</span> below in all four: Claude alone, Claude + UnClick, Codex alone, Codex + UnClick. The only difference between sessions is whether UnClick is connected.</li>
+            <li>3. For the Memory score, close the session and run the <span className="text-[#ddd]">recall prompt</span> in a brand-new session.</li>
+            <li>4. Grade each category out of 100 against your private answer key, then record the run (helper: <code className="text-[#888]">scripts/benchmark-record.mjs</code>, or ask your agent to record it).</li>
+          </ol>
+
+          <CopyableBlock label="Master prompt (paste into each of the four sessions)" text={MASTER_PROMPT} />
+          <CopyableBlock label="Memory recall prompt (run in a separate fresh session)" text={MEMORY_RECALL_PROMPT} />
+
+          <p className="text-[11px] leading-relaxed text-[#666]">
+            This is a starting reference. Edit it as the benchmark evolves. Keep the answer key private so
+            the agent under test cannot read it.
+          </p>
+        </div>
+      )}
     </div>
   );
 }
@@ -471,6 +537,10 @@ export default function AdminBenchmarks() {
           UnClick attached. The score is out of 100 (higher is better). The green number shows how many
           points UnClick adds. Watch the dated history below to see progress over time.
         </p>
+      </div>
+
+      <div className="mb-6">
+        <HowToRun />
       </div>
 
       {suite && categories.length > 0 && (


### PR DESCRIPTION
## What this adds

A reusable **"How to run a benchmark"** panel on `/admin/benchmarks` (admin-gated, so it stays private). It's a collapsible card with:

- **Step-by-step instructions** (use a fresh **Code** session, run the same prompt across all four contestants, do the memory recall in a separate session, grade and record).
- A **copy button** for the **master prompt** (pasted identically into all four contestant sessions).
- A **copy button** for the separate **memory-recall prompt** (run in a fresh session to score the Memory category).

## Why

The master prompt is the fair-control mechanism Chris asked for: the same prompt every session, with the only variable being whether UnClick is connected. Keeping it in the admin means it's a private, editable starting reference that can evolve.

## Details

- `src/lib/benchmarkPrompt.ts`: `MASTER_PROMPT` + `MEMORY_RECALL_PROMPT`. Covers all five categories (coding, reasoning, knowledge, tool use, memory) and tells the agent to use any tools/memory available, so UnClick runs take full advantage while raw runs simply cannot. The grading **answer key is deliberately kept out of the prompt** so the agent under test cannot read it.
- `src/pages/admin/AdminBenchmarks.tsx`: `HowToRun` + `CopyableBlock` components.

## Proof

- `npx tsc --noEmit` clean
- `npm run build` succeeds
- `npm run brainmap:check` passes (regenerated)
- `npm run lint` passes (one pre-existing non-blocking fetch-on-mount warning)

Follow-up to #1179. No database changes.

https://claude.ai/code/session_01WdM3JDBxwM5u9vAe4BgZ69

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdM3JDBxwM5u9vAe4BgZ69)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only UI and static prompt strings; no auth, API, or data-model changes.
> 
> **Overview**
> Adds a collapsible **How to run a benchmark** section on the admin Benchmarks page so operators can follow a fixed workflow and copy the exact prompts used across the four contestant sessions.
> 
> New `benchmarkPrompt.ts` holds **`MASTER_PROMPT`** (full v1 capability exam: coding, reasoning, knowledge, tool use, and memory seed) and **`MEMORY_RECALL_PROMPT`** for a separate session. The grading answer key stays out of the repo/prompt on purpose.
> 
> The page wires **`CopyableBlock`** (clipboard + preview) for both prompts and short steps (fresh Code session, same prompt for Claude/Codex ± UnClick, recall in a new session, grade/record). Brainmap metadata is regenerated for the touched admin file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 585cc0e01fe005320f7efb621252c0fd82129d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->