### PR TITLE
Clarify benchmark how-to: 2x2 session matrix and two-part memory test

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7317,8 +7317,8 @@
     },
     {
       "source": "src/pages/admin/AdminBenchmarks.tsx",
-      "hash": "a22439f75761",
-      "bytes": 24203
+      "hash": "c870452753e8",
+      "bytes": 27046
     },
     {
       "source": "src/pages/admin/Fishbowl.tsx",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7317,8 +7317,8 @@
     },
     {
       "source": "src/pages/admin/AdminBenchmarks.tsx",
-      "hash": "c870452753e8",
-      "bytes": 27046
+      "hash": "69eb15aaf438",
+      "bytes": 25684
     },
     {
       "source": "src/pages/admin/Fishbowl.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -59,7 +59,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 4dadebd9c4aa | 22681 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3a9b7643c7fc | 13854 |
-| src/pages/admin/AdminBenchmarks.tsx | a22439f75761 | 24203 |
+| src/pages/admin/AdminBenchmarks.tsx | c870452753e8 | 27046 |
 | src/pages/admin/Fishbowl.tsx | 525cfc33fcdc | 33809 |
 | src/pages/admin/AdminBrainmap.tsx | c764ced96836 | 26511 |
 | src/pages/admin/AdminCodebase.tsx | ff33937fdf7b | 8044 |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -59,7 +59,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 4dadebd9c4aa | 22681 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3a9b7643c7fc | 13854 |
-| src/pages/admin/AdminBenchmarks.tsx | c870452753e8 | 27046 |
+| src/pages/admin/AdminBenchmarks.tsx | 69eb15aaf438 | 25684 |
 | src/pages/admin/Fishbowl.tsx | 525cfc33fcdc | 33809 |
 | src/pages/admin/AdminBrainmap.tsx | c764ced96836 | 26511 |
 | src/pages/admin/AdminCodebase.tsx | ff33937fdf7b | 8044 |

--- a/src/pages/admin/AdminBenchmarks.tsx
+++ b/src/pages/admin/AdminBenchmarks.tsx
@@ -209,7 +209,7 @@ function CopyableBlock({ label, text }: { label: string; text: string }) {
 }
 
 function HowToRun() {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   return (
     <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-5">
       <button onClick={() => setOpen((v) => !v)} className="flex w-full items-center gap-2 text-left">
@@ -219,20 +219,77 @@ function HowToRun() {
       </button>
 
       {open && (
-        <div className="mt-4 space-y-4">
-          <ol className="space-y-1.5 text-xs leading-relaxed text-[#aaa]">
-            <li>1. Open a fresh <span className="text-[#ddd]">Code</span> session (Claude Code or Codex CLI). Not Chat, not a fleet session.</li>
-            <li>2. Run the same <span className="text-[#ddd]">master prompt</span> below in all four: Claude alone, Claude + UnClick, Codex alone, Codex + UnClick. The only difference between sessions is whether UnClick is connected.</li>
-            <li>3. For the Memory score, close the session and run the <span className="text-[#ddd]">recall prompt</span> in a brand-new session.</li>
-            <li>4. Grade each category out of 100 against your private answer key, then record the run (helper: <code className="text-[#888]">scripts/benchmark-record.mjs</code>, or ask your agent to record it).</li>
-          </ol>
+        <div className="mt-4 space-y-5">
+          <p className="text-xs leading-relaxed text-[#aaa]">
+            You run the <span className="text-[#ddd]">same prompt</span> in{" "}
+            <span className="text-[#ddd]">four separate sessions</span>. The only thing that changes
+            between them is whether UnClick is connected. That is the whole experiment: change one
+            thing, watch the score move. (A different prompt for the UnClick runs would change two
+            things at once, so you could not tell what caused the difference.)
+          </p>
 
-          <CopyableBlock label="Master prompt (paste into each of the four sessions)" text={MASTER_PROMPT} />
-          <CopyableBlock label="Memory recall prompt (run in a separate fresh session)" text={MEMORY_RECALL_PROMPT} />
+          {/* The four sessions, as a clear 2-column matrix */}
+          <div>
+            <p className="mb-2 text-[11px] uppercase tracking-wide text-[#666]">The four sessions</p>
+            <div className="grid grid-cols-[auto_1fr_1fr] gap-2 text-xs">
+              <div />
+              <div className="rounded-md bg-white/[0.03] px-3 py-2 text-center font-medium text-[#999]">
+                Without UnClick
+              </div>
+              <div
+                className="rounded-md px-3 py-2 text-center font-medium"
+                style={{ background: `${TEAL}14`, color: TEAL }}
+              >
+                With UnClick
+              </div>
+
+              <div className="flex items-center px-1 font-medium text-[#999]">Claude</div>
+              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
+                Session 1<div className="text-[10px] text-[#666]">Claude alone</div>
+              </div>
+              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
+                Session 2<div className="text-[10px] text-[#666]">Claude + UnClick</div>
+              </div>
+
+              <div className="flex items-center px-1 font-medium text-[#999]">Codex</div>
+              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
+                Session 3<div className="text-[10px] text-[#666]">Codex alone</div>
+              </div>
+              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
+                Session 4<div className="text-[10px] text-[#666]">Codex + UnClick</div>
+              </div>
+            </div>
+            <p className="mt-2 text-[11px] text-[#666]">
+              All four sessions get the identical Prompt 1 below. Use a fresh <span className="text-[#999]">Code</span>{" "}
+              session each time (Claude Code or Codex CLI). Not Chat, not a fleet session.
+            </p>
+          </div>
+
+          {/* Why memory is a second part */}
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+            <p className="text-xs font-medium text-[#ccc]">Each session has two parts</p>
+            <ul className="mt-1.5 space-y-1 text-[11px] leading-relaxed text-[#999]">
+              <li>
+                <span className="text-[#ddd]">Part A - main test:</span> run Prompt 1. It also plants
+                three facts to remember.
+              </li>
+              <li>
+                <span className="text-[#ddd]">Part B - memory recall:</span> close that session, open a
+                brand-new one, and run Prompt 2. This is the only fair way to test memory that survives
+                between sessions. Inside one session even a plain model "remembers" what you just said,
+                so it would prove nothing. In the new session UnClick recalls the facts; a raw model
+                answers "unknown".
+              </li>
+            </ul>
+          </div>
+
+          <CopyableBlock label="Prompt 1 - Main test (run first, in each of the 4 sessions)" text={MASTER_PROMPT} />
+          <CopyableBlock label="Prompt 2 - Memory recall (run second, in a fresh session for each)" text={MEMORY_RECALL_PROMPT} />
 
           <p className="text-[11px] leading-relaxed text-[#666]">
-            This is a starting reference. Edit it as the benchmark evolves. Keep the answer key private so
-            the agent under test cannot read it.
+            Then grade each category out of 100 against your private answer key and record the run. This
+            is a starting reference - edit it as the benchmark evolves, and keep the answer key private
+            so the agent under test cannot read it.
           </p>
         </div>
       )}

--- a/src/pages/admin/AdminBenchmarks.tsx
+++ b/src/pages/admin/AdminBenchmarks.tsx
@@ -208,6 +208,42 @@ function CopyableBlock({ label, text }: { label: string; text: string }) {
   );
 }
 
+function RunColumn({ mode }: { mode: "off" | "on" }) {
+  const on = mode === "on";
+  const accent = on ? TEAL : "#888";
+  return (
+    <div
+      className="rounded-xl border p-4"
+      style={{
+        borderColor: on ? `${TEAL}33` : "rgba(255,255,255,0.06)",
+        background: on ? `${TEAL}0a` : "rgba(0,0,0,0.2)",
+      }}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <span className="h-2.5 w-2.5 rounded-full" style={{ background: accent }} />
+        <span className="text-sm font-semibold text-white">
+          {on ? "With UnClick" : "Without UnClick"}
+        </span>
+      </div>
+
+      <p className="mb-1.5 text-[11px] leading-relaxed text-[#999]">
+        Step 1. Open a fresh Code session with UnClick{" "}
+        <span className="font-semibold" style={{ color: accent }}>{on ? "ON" : "OFF"}</span>.
+      </p>
+      <p className="mb-1.5 text-[11px] leading-relaxed text-[#999]">
+        Step 2. Paste the main test, let it answer, grade it.
+      </p>
+      <CopyableBlock label="Main test (Prompt 1)" text={MASTER_PROMPT} />
+
+      <p className="mb-1.5 mt-3 text-[11px] leading-relaxed text-[#999]">
+        Step 3. Open a brand-new session (same UnClick {on ? "ON" : "OFF"}), paste the recall, grade the
+        memory answers.
+      </p>
+      <CopyableBlock label="Memory recall (Prompt 2)" text={MEMORY_RECALL_PROMPT} />
+    </div>
+  );
+}
+
 function HowToRun() {
   const [open, setOpen] = useState(true);
   return (
@@ -219,77 +255,30 @@ function HowToRun() {
       </button>
 
       {open && (
-        <div className="mt-4 space-y-5">
+        <div className="mt-4 space-y-4">
           <p className="text-xs leading-relaxed text-[#aaa]">
-            You run the <span className="text-[#ddd]">same prompt</span> in{" "}
-            <span className="text-[#ddd]">four separate sessions</span>. The only thing that changes
-            between them is whether UnClick is connected. That is the whole experiment: change one
-            thing, watch the score move. (A different prompt for the UnClick runs would change two
-            things at once, so you could not tell what caused the difference.)
+            Run the left column, then the right column. Do that once in{" "}
+            <span className="text-[#ddd]">Claude</span> and once in <span className="text-[#ddd]">Codex</span>{" "}
+            = your <span className="text-[#ddd]">four contestants</span>.
           </p>
 
-          {/* The four sessions, as a clear 2-column matrix */}
-          <div>
-            <p className="mb-2 text-[11px] uppercase tracking-wide text-[#666]">The four sessions</p>
-            <div className="grid grid-cols-[auto_1fr_1fr] gap-2 text-xs">
-              <div />
-              <div className="rounded-md bg-white/[0.03] px-3 py-2 text-center font-medium text-[#999]">
-                Without UnClick
-              </div>
-              <div
-                className="rounded-md px-3 py-2 text-center font-medium"
-                style={{ background: `${TEAL}14`, color: TEAL }}
-              >
-                With UnClick
-              </div>
-
-              <div className="flex items-center px-1 font-medium text-[#999]">Claude</div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
-                Session 1<div className="text-[10px] text-[#666]">Claude alone</div>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
-                Session 2<div className="text-[10px] text-[#666]">Claude + UnClick</div>
-              </div>
-
-              <div className="flex items-center px-1 font-medium text-[#999]">Codex</div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
-                Session 3<div className="text-[10px] text-[#666]">Codex alone</div>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-[#bbb]">
-                Session 4<div className="text-[10px] text-[#666]">Codex + UnClick</div>
-              </div>
-            </div>
-            <p className="mt-2 text-[11px] text-[#666]">
-              All four sessions get the identical Prompt 1 below. Use a fresh <span className="text-[#999]">Code</span>{" "}
-              session each time (Claude Code or Codex CLI). Not Chat, not a fleet session.
-            </p>
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 text-[11px] leading-relaxed text-[#999]">
+            <span className="text-[#ddd]">Note:</span> the prompt text is identical in both columns on
+            purpose. The only difference is whether UnClick is connected. The separate boxes just let you
+            work straight down one column. (Prompt 2 is in its own box because memory must be tested in a
+            brand-new session - inside one session even a plain model "remembers", so it would prove
+            nothing.)
           </div>
 
-          {/* Why memory is a second part */}
-          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
-            <p className="text-xs font-medium text-[#ccc]">Each session has two parts</p>
-            <ul className="mt-1.5 space-y-1 text-[11px] leading-relaxed text-[#999]">
-              <li>
-                <span className="text-[#ddd]">Part A - main test:</span> run Prompt 1. It also plants
-                three facts to remember.
-              </li>
-              <li>
-                <span className="text-[#ddd]">Part B - memory recall:</span> close that session, open a
-                brand-new one, and run Prompt 2. This is the only fair way to test memory that survives
-                between sessions. Inside one session even a plain model "remembers" what you just said,
-                so it would prove nothing. In the new session UnClick recalls the facts; a raw model
-                answers "unknown".
-              </li>
-            </ul>
+          <div className="grid gap-4 md:grid-cols-2">
+            <RunColumn mode="off" />
+            <RunColumn mode="on" />
           </div>
-
-          <CopyableBlock label="Prompt 1 - Main test (run first, in each of the 4 sessions)" text={MASTER_PROMPT} />
-          <CopyableBlock label="Prompt 2 - Memory recall (run second, in a fresh session for each)" text={MEMORY_RECALL_PROMPT} />
 
           <p className="text-[11px] leading-relaxed text-[#666]">
-            Then grade each category out of 100 against your private answer key and record the run. This
-            is a starting reference - edit it as the benchmark evolves, and keep the answer key private
-            so the agent under test cannot read it.
+            Grade each category out of 100 against your private answer key, then record the run. This is a
+            starting reference - edit it as the benchmark evolves, and keep the answer key private so the
+            agent under test cannot read it.
           </p>
         </div>
       )}


### PR DESCRIPTION
## What this does

Reworks the "How to run a benchmark" panel on `/admin/benchmarks` to remove two common points of confusion Chris flagged:

1. **Why one master prompt, not two** — added a plain-English note that the *same* prompt is reused across four sessions; the only variable is whether UnClick is connected (changing the prompt too would confound the result).
2. **The four sessions as a clear 2-column matrix** — Without UnClick vs With UnClick, by Claude and Codex, clearly titled.
3. **Why memory is a separate session** — a "two parts" box explaining Part A (main prompt, plants the facts) and Part B (recall in a fresh session, the only fair way to test cross-session memory). Prompts relabelled **Prompt 1 - Main test** and **Prompt 2 - Memory recall**.
4. Panel now defaults **open** so it's visible.

UI/text only. No data or schema changes.

## Proof
- `npx tsc --noEmit` clean
- `npm run build` succeeds
- `npm run brainmap:check` passes (regenerated)

Follow-up to #1179 / #1180.

https://claude.ai/code/session_01WdM3JDBxwM5u9vAe4BgZ69

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdM3JDBxwM5u9vAe4BgZ69)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and layout-only changes on an admin benchmarks page; no API, schema, or scoring logic changes.
> 
> **Overview**
> The **How to run a benchmark** panel on `AdminBenchmarks` is reworked so operators see the workflow up front: it **defaults to expanded**, replaces the numbered list with a short **2×2 framing** (run Without vs With UnClick, repeat for Claude and Codex), and adds a note that **prompt text is identical** across columns—only UnClick connectivity varies.
> 
> A new **`RunColumn`** component lays out each side as step-by-step copy plus **Prompt 1 (main test)** and **Prompt 2 (memory recall)** in separate copyable blocks, including why recall needs a **fresh session**. Grading/recording guidance is tightened at the bottom. Generated brainmap docs are refreshed to match the file hash/size change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca0f76df093074456bc23a15a4245c61e12d856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->