### PR TITLE
Add 10 popular standalone MCP servers

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 538,
+    "inventory": 548,
     "source_manifest": 187,
     "pages": 78,
     "tools": 187,
@@ -81,7 +81,7 @@
       "id": "modules-and-apps",
       "name": "Modules and apps",
       "meaning": "Apps, packages, and product modules that make up UnClick.",
-      "count": 80
+      "count": 90
     },
     {
       "id": "launch-and-onboarding",
@@ -2232,6 +2232,16 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-coingecko-mcp-packages-standalone-coingecko-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "coingecko mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/coingecko-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-commonsensepass-packages-commonsensepass-package-json-no-route",
       "division": "Modules and apps",
       "name": "commonsensepass",
@@ -2302,6 +2312,16 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-hackernews-mcp-packages-standalone-hackernews-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "hackernews mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/hackernews-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-ipaustralia-mcp-packages-standalone-ipaustralia-mcp-package-json-no-route",
       "division": "Modules and apps",
       "name": "ipaustralia mcp",
@@ -2342,12 +2362,62 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-nasa-mcp-packages-standalone-nasa-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "nasa mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/nasa-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-openlibrary-mcp-packages-standalone-openlibrary-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "openlibrary mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/openlibrary-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-openmeteo-mcp-packages-standalone-openmeteo-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "openmeteo mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/openmeteo-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-ptv-mcp-packages-standalone-ptv-mcp-package-json-no-route",
       "division": "Modules and apps",
       "name": "ptv mcp",
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/standalone/ptv-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-reddit-mcp-packages-standalone-reddit-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "reddit mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/reddit-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-restcountries-mcp-packages-standalone-restcountries-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "restcountries mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/restcountries-mcp/package.json",
       "route": "",
       "tags": []
     },
@@ -2392,6 +2462,16 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-spotify-mcp-packages-standalone-spotify-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "spotify mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/spotify-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-testpass-packages-testpass-package-json-no-route",
       "division": "Modules and apps",
       "name": "testpass",
@@ -2408,6 +2488,16 @@
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/standalone/thelott-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-tmdb-mcp-packages-standalone-tmdb-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "tmdb mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/tmdb-mcp/package.json",
       "route": "",
       "tags": []
     },
@@ -2448,6 +2538,16 @@
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/wizard/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-youtube-mcp-packages-standalone-youtube-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "youtube mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/youtube-mcp/package.json",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -215,7 +215,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 119 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
-| Modules and apps | Apps, packages, and product modules that make up UnClick. | 80 |
+| Modules and apps | Apps, packages, and product modules that make up UnClick. | 90 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 5 |
 
 ## UnClick Structure
@@ -737,6 +737,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | package | australiapost mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/australiapost-mcp/package.json |
 | Modules and apps | package | bgg mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/bgg-mcp/package.json |
 | Modules and apps | package | channel plugin | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/channel-plugin/package.json |
+| Modules and apps | package | coingecko mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/coingecko-mcp/package.json |
 | Modules and apps | package | commonsensepass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/commonsensepass/package.json |
 | Modules and apps | package | compliancepass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/compliancepass/package.json |
 | Modules and apps | package | copypass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/copypass/package.json |
@@ -744,21 +745,30 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | package | domain mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/domain-mcp/package.json |
 | Modules and apps | package | flowpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/flowpass/package.json |
 | Modules and apps | package | geopass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/geopass/package.json |
+| Modules and apps | package | hackernews mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/hackernews-mcp/package.json |
 | Modules and apps | package | ipaustralia mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/ipaustralia-mcp/package.json |
 | Modules and apps | package | legalpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/legalpass/package.json |
 | Modules and apps | package | mcp server | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/mcp-server/package.json |
 | Modules and apps | package | memory mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/memory-mcp/package.json |
+| Modules and apps | package | nasa mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/nasa-mcp/package.json |
+| Modules and apps | package | openlibrary mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/openlibrary-mcp/package.json |
+| Modules and apps | package | openmeteo mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/openmeteo-mcp/package.json |
 | Modules and apps | package | ptv mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/ptv-mcp/package.json |
+| Modules and apps | package | reddit mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/reddit-mcp/package.json |
+| Modules and apps | package | restcountries mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/restcountries-mcp/package.json |
 | Modules and apps | package | securitypass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/securitypass/package.json |
 | Modules and apps | package | sendle mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/sendle-mcp/package.json |
 | Modules and apps | package | seopass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/seopass/package.json |
 | Modules and apps | package | sloppass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/sloppass/package.json |
+| Modules and apps | package | spotify mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/spotify-mcp/package.json |
 | Modules and apps | package | testpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/testpass/package.json |
 | Modules and apps | package | thelott mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/thelott-mcp/package.json |
+| Modules and apps | package | tmdb mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/tmdb-mcp/package.json |
 | Modules and apps | package | untappd mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/untappd-mcp/package.json |
 | Modules and apps | package | uxpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/uxpass/package.json |
 | Modules and apps | package | willyweather mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/willyweather-mcp/package.json |
 | Modules and apps | package | wizard | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/wizard/package.json |
+| Modules and apps | package | youtube mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/youtube-mcp/package.json |
 | Modules and apps | skill library | Skills Library | Read-only starter pack of UnClick-native skills, hardwired rails, hybrid workflows, and portable skill packages. | /admin/skills | src/pages/admin/AdminSkills.tsx |
 | Modules and apps | skill package | agent handoff packet writer | Agent Skills-compatible starter package with provenance, safety, and native-mode metadata. | /admin/skills | seed/skills/agent-handoff-packet-writer.skill.md |
 | Modules and apps | skill package | browser qa tester | Agent Skills-compatible starter package with provenance, safety, and native-mode metadata. | /admin/skills | seed/skills/browser-qa-tester.skill.md |

--- a/packages/mcp-server/scripts/generate-standalone-mcp.mjs
+++ b/packages/mcp-server/scripts/generate-standalone-mcp.mjs
@@ -46,6 +46,17 @@ const CONFIG = {
   sendle:        { title: "Sendle MCP",          blurb: "Sendle shipping quotes, orders, and parcel tracking.", keywords: ["sendle", "shipping", "parcel", "australia"] },
   untappd:       { title: "Untappd MCP",         blurb: "Untappd beer and brewery search, details, and activity.", keywords: ["untappd", "beer", "brewery"] },
   bgg:           { title: "BoardGameGeek MCP",   blurb: "BoardGameGeek search, game details, rankings, and collections.", keywords: ["boardgamegeek", "bgg", "board-games"] },
+  // ── popular batch ──
+  openmeteo:     { title: "Open-Meteo Weather MCP", blurb: "Free global weather: current conditions, hourly and daily forecasts from Open-Meteo. No API key.", keywords: ["weather", "forecast", "open-meteo", "climate"] },
+  coingecko:     { title: "CoinGecko MCP",       blurb: "Live cryptocurrency prices, market data, history, and trending coins from CoinGecko. No API key.", keywords: ["crypto", "coingecko", "bitcoin", "prices"] },
+  hackernews:    { title: "Hacker News MCP",     blurb: "Search and read Hacker News stories, comments, users, Ask HN and Show HN. No API key.", keywords: ["hacker-news", "hn", "tech-news"] },
+  tmdb:          { title: "TMDB MCP",            blurb: "Search movies and TV, with details, trending, now-playing, and recommendations from The Movie Database.", keywords: ["tmdb", "movies", "tv", "film"] },
+  nasa:          { title: "NASA MCP",            blurb: "NASA imagery and data: astronomy picture of the day, Mars rover photos, asteroids, and Earth imagery.", keywords: ["nasa", "space", "astronomy", "mars"] },
+  restcountries: { title: "REST Countries MCP",  blurb: "Country data: flags, currencies, languages, regions, capitals, and more. No API key.", keywords: ["countries", "geography", "restcountries"] },
+  openlibrary:   { title: "Open Library MCP",    blurb: "Search books, authors, and editions, with trending titles, from Open Library. No API key.", keywords: ["books", "openlibrary", "library", "authors"] },
+  spotify:       { title: "Spotify MCP",         blurb: "Search Spotify for tracks, artists, albums, and playlists, with audio features and recommendations.", keywords: ["spotify", "music", "playlists", "tracks"] },
+  youtube:       { title: "YouTube MCP",         blurb: "Search YouTube and get video, channel, playlist, and caption details.", keywords: ["youtube", "video", "search", "captions"] },
+  reddit:        { title: "Reddit MCP",          blurb: "Search, read, and post across Reddit: posts, comments, subreddits, and users.", keywords: ["reddit", "social", "forums", "subreddit"] },
 };
 
 // ─── Parse tool-wiring.ts ──────────────────────────────────────────────────────
@@ -89,7 +100,7 @@ function handlersFor(slug) {
   const nm = nextHeader.exec(handlersBody);
   const to = nm ? nm.index : handlersBody.length;
   const chunk = handlersBody.slice(from, to);
-  const entries = [...chunk.matchAll(/^\s*([a-z0-9_]+):\s*\(args\)\s*=>\s*([a-zA-Z0-9_]+)\(args\),/gm)]
+  const entries = [...chunk.matchAll(/^\s*([a-z0-9_]+):\s*\(args\)\s*=>\s*([a-zA-Z0-9_]+)\(/gm)]
     .map((x) => ({ tool: x[1], fn: x[2] }));
   return entries.length ? entries : null;
 }
@@ -144,7 +155,7 @@ ${defs}
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-${handlers.map((h) => `  ${h.tool}: (args) => ${h.fn}(args),`).join("\n")}
+${handlers.map((h) => `  ${h.tool}: (args) => ${h.fn}(args as unknown as Parameters<typeof ${h.fn}>[0]),`).join("\n")}
 };
 
 const server = new Server(

--- a/packages/standalone/coingecko-mcp/LICENSE
+++ b/packages/standalone/coingecko-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/coingecko-mcp/README.md
+++ b/packages/standalone/coingecko-mcp/README.md
@@ -1,0 +1,38 @@
+# CoinGecko MCP by UnClick
+
+Live cryptocurrency prices, market data, history, and trending coins from CoinGecko. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "coingecko": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/coingecko.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `crypto_price`
+- `crypto_coin`
+- `crypto_search`
+- `crypto_trending`
+- `crypto_top_coins`
+- `crypto_coin_history`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/coingecko-mcp/package.json
+++ b/packages/standalone/coingecko-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/coingecko-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/coingecko",
+  "description": "Live cryptocurrency prices, market data, history, and trending coins from CoinGecko. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "crypto",
+    "coingecko",
+    "bitcoin",
+    "prices"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "coingecko-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/coingecko-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/coingecko-mcp/server.json
+++ b/packages/standalone/coingecko-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/coingecko",
+  "title": "CoinGecko MCP by UnClick",
+  "description": "Live cryptocurrency prices, market data, history, and trending coins from CoinGecko. No API key. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/coingecko-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/coingecko-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/coingecko-mcp/src/coingecko-tool.ts
+++ b/packages/standalone/coingecko-mcp/src/coingecko-tool.ts
@@ -1,0 +1,195 @@
+// CoinGecko crypto market data integration for the UnClick MCP server.
+// Free tier requires no API key. Set COINGECKO_API_KEY for higher rate limits.
+// Uses the CoinGecko public REST API via fetch - no external dependencies.
+
+const COINGECKO_BASE = "https://api.coingecko.com/api/v3";
+
+// --- API helper ---
+
+async function cgFetch(path: string, params: Record<string, string> = {}): Promise<unknown> {
+  const url = new URL(`${COINGECKO_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+
+  const headers: Record<string, string> = { "Accept": "application/json" };
+  const apiKey = (process.env.COINGECKO_API_KEY ?? "").trim();
+  if (apiKey) headers["x-cg-demo-api-key"] = apiKey;
+
+  const response = await fetch(url.toString(), { headers });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`HTTP ${response.status} from CoinGecko API${text ? `: ${text}` : ""}`);
+  }
+
+  return response.json();
+}
+
+// --- Operations ---
+
+export async function cryptoPrice(args: Record<string, unknown>): Promise<unknown> {
+  const ids = String(args.ids ?? "").trim();
+  const vs_currencies = String(args.vs_currencies ?? "usd").trim();
+  if (!ids) throw new Error("ids is required (comma-separated coin IDs, e.g. bitcoin,ethereum).");
+
+  const data = await cgFetch("/simple/price", {
+    ids,
+    vs_currencies,
+    include_market_cap: "true",
+    include_24hr_vol: "true",
+    include_24hr_change: "true",
+    include_last_updated_at: "true",
+  });
+
+  return { ids, vs_currencies, prices: data };
+}
+
+export async function cryptoCoin(args: Record<string, unknown>): Promise<unknown> {
+  const id = String(args.id ?? "").trim().toLowerCase();
+  if (!id) throw new Error("id is required (e.g. bitcoin, ethereum).");
+
+  const data = await cgFetch(`/coins/${encodeURIComponent(id)}`, {
+    localization: "false",
+    tickers: "false",
+    community_data: "false",
+    developer_data: "false",
+    sparkline: "false",
+  }) as Record<string, unknown>;
+
+  const market = data.market_data as Record<string, unknown> | undefined;
+
+  return {
+    id: data.id,
+    symbol: data.symbol,
+    name: data.name,
+    description: (data.description as Record<string, string> | undefined)?.en?.slice(0, 500) ?? null,
+    homepage: (data.links as Record<string, unknown> | undefined)?.homepage ?? null,
+    image: (data.image as Record<string, string> | undefined)?.large ?? null,
+    categories: data.categories,
+    genesis_date: data.genesis_date,
+    market_cap_rank: data.market_cap_rank,
+    coingecko_score: data.coingecko_score,
+    market_data: market
+      ? {
+          current_price: (market.current_price as Record<string, number> | undefined) ?? null,
+          market_cap: (market.market_cap as Record<string, number> | undefined) ?? null,
+          total_volume: (market.total_volume as Record<string, number> | undefined) ?? null,
+          price_change_24h: market.price_change_24h ?? null,
+          price_change_percentage_24h: market.price_change_percentage_24h ?? null,
+          price_change_percentage_7d: market.price_change_percentage_7d ?? null,
+          price_change_percentage_30d: market.price_change_percentage_30d ?? null,
+          ath: (market.ath as Record<string, number> | undefined) ?? null,
+          atl: (market.atl as Record<string, number> | undefined) ?? null,
+          circulating_supply: market.circulating_supply ?? null,
+          total_supply: market.total_supply ?? null,
+          max_supply: market.max_supply ?? null,
+        }
+      : null,
+    last_updated: data.last_updated,
+  };
+}
+
+export async function cryptoSearch(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) throw new Error("query is required.");
+
+  const data = await cgFetch("/search", { query }) as Record<string, unknown>;
+
+  return {
+    query,
+    coins: ((data.coins as Array<Record<string, unknown>>) ?? []).slice(0, 20).map((c) => ({
+      id: c.id,
+      name: c.name,
+      symbol: c.symbol,
+      market_cap_rank: c.market_cap_rank,
+      thumb: c.thumb,
+    })),
+    exchanges: ((data.exchanges as Array<Record<string, unknown>>) ?? []).slice(0, 5).map((e) => ({
+      id: e.id,
+      name: e.name,
+      thumb: e.thumb,
+    })),
+  };
+}
+
+export async function cryptoTrending(_args: Record<string, unknown>): Promise<unknown> {
+  const data = await cgFetch("/search/trending") as Record<string, unknown>;
+
+  const coins = (data.coins as Array<{ item: Record<string, unknown> }>) ?? [];
+
+  return {
+    trending_coins: coins.map(({ item }) => ({
+      id: item.id,
+      name: item.name,
+      symbol: item.symbol,
+      market_cap_rank: item.market_cap_rank,
+      score: item.score,
+      price_btc: item.price_btc,
+      data: (item.data as Record<string, unknown> | undefined) ?? null,
+    })),
+  };
+}
+
+export async function cryptoTopCoins(args: Record<string, unknown>): Promise<unknown> {
+  const vs_currency = String(args.vs_currency ?? "usd").trim().toLowerCase();
+  const order = String(args.order ?? "market_cap_desc");
+  const per_page = String(Math.min(250, Math.max(1, Number(args.per_page ?? 50))));
+  const page = String(Math.max(1, Number(args.page ?? 1)));
+
+  const data = await cgFetch("/coins/markets", {
+    vs_currency,
+    order,
+    per_page,
+    page,
+    sparkline: "false",
+  }) as Array<Record<string, unknown>>;
+
+  return {
+    vs_currency,
+    order,
+    page: Number(page),
+    per_page: Number(per_page),
+    coins: data.map((c) => ({
+      id: c.id,
+      symbol: c.symbol,
+      name: c.name,
+      image: c.image,
+      current_price: c.current_price,
+      market_cap: c.market_cap,
+      market_cap_rank: c.market_cap_rank,
+      total_volume: c.total_volume,
+      price_change_24h: c.price_change_24h,
+      price_change_percentage_24h: c.price_change_percentage_24h,
+      circulating_supply: c.circulating_supply,
+      ath: c.ath,
+      atl: c.atl,
+      last_updated: c.last_updated,
+    })),
+  };
+}
+
+export async function cryptoCoinHistory(args: Record<string, unknown>): Promise<unknown> {
+  const id = String(args.id ?? "").trim().toLowerCase();
+  const date = String(args.date ?? "").trim();
+  if (!id) throw new Error("id is required (e.g. bitcoin).");
+  if (!date) throw new Error("date is required in DD-MM-YYYY format.");
+
+  const data = await cgFetch(`/coins/${encodeURIComponent(id)}/history`, {
+    date,
+    localization: "false",
+  }) as Record<string, unknown>;
+
+  const market = data.market_data as Record<string, unknown> | undefined;
+
+  return {
+    id: data.id,
+    symbol: data.symbol,
+    name: data.name,
+    date,
+    market_data: market
+      ? {
+          current_price: market.current_price,
+          market_cap: market.market_cap,
+          total_volume: market.total_volume,
+        }
+      : null,
+  };
+}

--- a/packages/standalone/coingecko-mcp/src/index.ts
+++ b/packages/standalone/coingecko-mcp/src/index.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// CoinGecko MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  cryptoPrice,
+  cryptoCoin,
+  cryptoSearch,
+  cryptoTrending,
+  cryptoTopCoins,
+  cryptoCoinHistory,
+} from "./coingecko-tool.js";
+
+const TOOLS = [
+  {
+    name: "crypto_price",
+    description: "Get cryptocurrency prices from CoinGecko.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        ids: { type: "string", description: "Comma-separated coin IDs" },
+        vs_currencies: { type: "string", description: "Comma-separated currency codes" },
+      },
+      required: ["ids"],
+    },
+  },
+  {
+    name: "crypto_coin",
+    description: "Get detailed info for a cryptocurrency from CoinGecko.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "string" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "crypto_search",
+    description: "Search for cryptocurrencies on CoinGecko.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "crypto_trending",
+    description: "Get trending cryptocurrencies from CoinGecko.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+  {
+    name: "crypto_top_coins",
+    description: "Get top cryptocurrencies by market cap from CoinGecko.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        vs_currency: { type: "string" },
+        per_page: { type: "number" },
+        page: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "crypto_coin_history",
+    description: "Get historical price data for a cryptocurrency from CoinGecko.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "string" },
+        date: { type: "string", description: "DD-MM-YYYY" },
+      },
+      required: ["id", "date"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  crypto_price: (args) => cryptoPrice(args as unknown as Parameters<typeof cryptoPrice>[0]),
+  crypto_coin: (args) => cryptoCoin(args as unknown as Parameters<typeof cryptoCoin>[0]),
+  crypto_search: (args) => cryptoSearch(args as unknown as Parameters<typeof cryptoSearch>[0]),
+  crypto_trending: (args) => cryptoTrending(args as unknown as Parameters<typeof cryptoTrending>[0]),
+  crypto_top_coins: (args) => cryptoTopCoins(args as unknown as Parameters<typeof cryptoTopCoins>[0]),
+  crypto_coin_history: (args) => cryptoCoinHistory(args as unknown as Parameters<typeof cryptoCoinHistory>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/coingecko", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[coingecko-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/coingecko-mcp/tsconfig.json
+++ b/packages/standalone/coingecko-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/hackernews-mcp/LICENSE
+++ b/packages/standalone/hackernews-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/hackernews-mcp/README.md
+++ b/packages/standalone/hackernews-mcp/README.md
@@ -1,0 +1,39 @@
+# Hacker News MCP by UnClick
+
+Search and read Hacker News stories, comments, users, Ask HN and Show HN. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "hackernews": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/hackernews.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `hn_top_stories`
+- `hn_new_stories`
+- `hn_best_stories`
+- `hn_ask_hn`
+- `hn_show_hn`
+- `hn_item`
+- `hn_user`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/hackernews-mcp/package.json
+++ b/packages/standalone/hackernews-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/hackernews-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/hackernews",
+  "description": "Search and read Hacker News stories, comments, users, Ask HN and Show HN. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "hacker-news",
+    "hn",
+    "tech-news"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "hackernews-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/hackernews-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/hackernews-mcp/server.json
+++ b/packages/standalone/hackernews-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/hackernews",
+  "title": "Hacker News MCP by UnClick",
+  "description": "Search and read Hacker News stories, comments, users, Ask HN and Show HN. No API key. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/hackernews-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/hackernews-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/hackernews-mcp/src/hackernews-tool.ts
+++ b/packages/standalone/hackernews-mcp/src/hackernews-tool.ts
@@ -1,0 +1,140 @@
+// Hacker News Firebase API integration.
+// No authentication required - completely open.
+// Base URL: https://hacker-news.firebaseio.com/v0/
+
+const HN_BASE = "https://hacker-news.firebaseio.com/v0";
+
+// ─── API helper ───────────────────────────────────────────────────────────────
+
+async function hnFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${HN_BASE}${path}`, {
+    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
+  });
+  if (!res.ok) throw new Error(`HN API HTTP ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+interface HNItem {
+  id: number;
+  type: string;
+  by?: string;
+  time?: number;
+  title?: string;
+  url?: string;
+  text?: string;
+  score?: number;
+  descendants?: number;
+  kids?: number[];
+  deleted?: boolean;
+  dead?: boolean;
+  parent?: number;
+  poll?: number;
+}
+
+interface HNUser {
+  id: string;
+  created?: number;
+  karma?: number;
+  about?: string;
+  submitted?: number[];
+}
+
+function normalizeItem(item: HNItem) {
+  return {
+    id: item.id,
+    type: item.type,
+    by: item.by ?? null,
+    time: item.time ? new Date(item.time * 1000).toISOString() : null,
+    title: item.title ?? null,
+    url: item.url ?? null,
+    text: item.text ?? null,
+    score: item.score ?? null,
+    comments: item.descendants ?? null,
+    comment_ids: item.kids ?? [],
+  };
+}
+
+// Fetch up to `limit` story items from an ID list in parallel.
+async function fetchStories(ids: number[], limit: number): Promise<unknown[]> {
+  const top = ids.slice(0, Math.min(limit, ids.length));
+  const items = await Promise.all(
+    top.map((id) => hnFetch<HNItem>(`/item/${id}.json`))
+  );
+  return items.filter((i) => i && !i.deleted && !i.dead).map(normalizeItem);
+}
+
+// ─── hn_top_stories ───────────────────────────────────────────────────────────
+
+export async function hnTopStories(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(30, Math.max(1, Number(args.limit ?? 10)));
+  const ids = await hnFetch<number[]>("/topstories.json");
+  const stories = await fetchStories(ids, limit);
+  return { count: stories.length, feed: "top", stories };
+}
+
+// ─── hn_new_stories ───────────────────────────────────────────────────────────
+
+export async function hnNewStories(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(30, Math.max(1, Number(args.limit ?? 10)));
+  const ids = await hnFetch<number[]>("/newstories.json");
+  const stories = await fetchStories(ids, limit);
+  return { count: stories.length, feed: "new", stories };
+}
+
+// ─── hn_best_stories ──────────────────────────────────────────────────────────
+
+export async function hnBestStories(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(30, Math.max(1, Number(args.limit ?? 10)));
+  const ids = await hnFetch<number[]>("/beststories.json");
+  const stories = await fetchStories(ids, limit);
+  return { count: stories.length, feed: "best", stories };
+}
+
+// ─── hn_ask_hn ────────────────────────────────────────────────────────────────
+
+export async function hnAskHn(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(30, Math.max(1, Number(args.limit ?? 10)));
+  const ids = await hnFetch<number[]>("/askstories.json");
+  const stories = await fetchStories(ids, limit);
+  return { count: stories.length, feed: "ask", stories };
+}
+
+// ─── hn_show_hn ───────────────────────────────────────────────────────────────
+
+export async function hnShowHn(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(30, Math.max(1, Number(args.limit ?? 10)));
+  const ids = await hnFetch<number[]>("/showstories.json");
+  const stories = await fetchStories(ids, limit);
+  return { count: stories.length, feed: "show", stories };
+}
+
+// ─── hn_item ─────────────────────────────────────────────────────────────────
+
+export async function hnItem(args: Record<string, unknown>): Promise<unknown> {
+  const id = Number(args.id);
+  if (!id) return { error: "id is required (numeric Hacker News item ID)." };
+
+  const item = await hnFetch<HNItem>(`/item/${id}.json`);
+  if (!item) return { error: `Item ${id} not found.` };
+
+  return normalizeItem(item);
+}
+
+// ─── hn_user ──────────────────────────────────────────────────────────────────
+
+export async function hnUser(args: Record<string, unknown>): Promise<unknown> {
+  const username = String(args.username ?? "").trim();
+  if (!username) return { error: "username is required." };
+
+  const user = await hnFetch<HNUser>(`/user/${username}.json`);
+  if (!user) return { error: `User "${username}" not found.` };
+
+  return {
+    id: user.id,
+    created: user.created ? new Date(user.created * 1000).toISOString() : null,
+    karma: user.karma ?? 0,
+    about: user.about ?? null,
+    submission_count: Array.isArray(user.submitted) ? user.submitted.length : 0,
+    recent_submissions: Array.isArray(user.submitted) ? user.submitted.slice(0, 10) : [],
+  };
+}

--- a/packages/standalone/hackernews-mcp/src/index.ts
+++ b/packages/standalone/hackernews-mcp/src/index.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Hacker News MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  hnTopStories,
+  hnNewStories,
+  hnBestStories,
+  hnAskHn,
+  hnShowHn,
+  hnItem,
+  hnUser,
+} from "./hackernews-tool.js";
+
+const TOOLS = [
+  {
+    name: "hn_top_stories",
+    description: "Get the top stories from Hacker News.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "hn_new_stories",
+    description: "Get the newest stories from Hacker News.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "hn_best_stories",
+    description: "Get the best stories from Hacker News.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "hn_ask_hn",
+    description: "Get Ask HN posts from Hacker News.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "hn_show_hn",
+    description: "Get Show HN posts from Hacker News.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "hn_item",
+    description: "Get a specific Hacker News item by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "number" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "hn_user",
+    description: "Get a Hacker News user profile.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        username: { type: "string" },
+      },
+      required: ["username"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  hn_top_stories: (args) => hnTopStories(args as unknown as Parameters<typeof hnTopStories>[0]),
+  hn_new_stories: (args) => hnNewStories(args as unknown as Parameters<typeof hnNewStories>[0]),
+  hn_best_stories: (args) => hnBestStories(args as unknown as Parameters<typeof hnBestStories>[0]),
+  hn_ask_hn: (args) => hnAskHn(args as unknown as Parameters<typeof hnAskHn>[0]),
+  hn_show_hn: (args) => hnShowHn(args as unknown as Parameters<typeof hnShowHn>[0]),
+  hn_item: (args) => hnItem(args as unknown as Parameters<typeof hnItem>[0]),
+  hn_user: (args) => hnUser(args as unknown as Parameters<typeof hnUser>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/hackernews", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[hackernews-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/hackernews-mcp/tsconfig.json
+++ b/packages/standalone/hackernews-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/nasa-mcp/LICENSE
+++ b/packages/standalone/nasa-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/nasa-mcp/README.md
+++ b/packages/standalone/nasa-mcp/README.md
@@ -1,0 +1,37 @@
+# NASA MCP by UnClick
+
+NASA imagery and data: astronomy picture of the day, Mars rover photos, asteroids, and Earth imagery.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "nasa": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/nasa.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `nasa_apod`
+- `nasa_asteroids`
+- `nasa_mars_photos`
+- `nasa_earth_imagery`
+- `nasa_epic`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/nasa-mcp/package.json
+++ b/packages/standalone/nasa-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/nasa-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/nasa",
+  "description": "NASA imagery and data: astronomy picture of the day, Mars rover photos, asteroids, and Earth imagery. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "nasa",
+    "space",
+    "astronomy",
+    "mars"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "nasa-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/nasa-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/nasa-mcp/server.json
+++ b/packages/standalone/nasa-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/nasa",
+  "title": "NASA MCP by UnClick",
+  "description": "NASA imagery and data: astronomy picture of the day, Mars rover photos, asteroids, and Earth imagery. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/nasa-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/nasa-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/nasa-mcp/src/index.ts
+++ b/packages/standalone/nasa-mcp/src/index.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// NASA MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  nasaApod,
+  nasaAsteroids,
+  nasaMarsPhotos,
+  nasaEarthImagery,
+  nasaEpic,
+} from "./nasa-tool.js";
+
+const TOOLS = [
+  {
+    name: "nasa_apod",
+    description: "Get NASA Astronomy Picture of the Day.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        date: { type: "string" },
+        count: { type: "number" },
+        api_key: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "nasa_asteroids",
+    description: "Get NASA Near Earth Object (asteroid) data.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        start_date: { type: "string" },
+        end_date: { type: "string" },
+        api_key: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "nasa_mars_photos",
+    description: "Get NASA Mars rover photos.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        rover: { type: "string", enum: ["curiosity", "opportunity", "spirit", "perseverance"], description: "curiosity, opportunity, spirit" },
+        sol: { type: "number" },
+        earth_date: { type: "string" },
+        camera: { type: "string" },
+        api_key: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "nasa_earth_imagery",
+    description: "Get NASA Earth satellite imagery.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        lat: { type: "number" },
+        lon: { type: "number" },
+        date: { type: "string" },
+        dim: { type: "number" },
+        api_key: { type: "string" },
+      },
+      required: ["lat", "lon"],
+    },
+  },
+  {
+    name: "nasa_epic",
+    description: "Get NASA EPIC Earth imagery.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        date: { type: "string" },
+        api_key: { type: "string" },
+      },
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  nasa_apod: (args) => nasaApod(args as unknown as Parameters<typeof nasaApod>[0]),
+  nasa_asteroids: (args) => nasaAsteroids(args as unknown as Parameters<typeof nasaAsteroids>[0]),
+  nasa_mars_photos: (args) => nasaMarsPhotos(args as unknown as Parameters<typeof nasaMarsPhotos>[0]),
+  nasa_earth_imagery: (args) => nasaEarthImagery(args as unknown as Parameters<typeof nasaEarthImagery>[0]),
+  nasa_epic: (args) => nasaEpic(args as unknown as Parameters<typeof nasaEpic>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/nasa", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[nasa-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/nasa-mcp/src/nasa-tool.ts
+++ b/packages/standalone/nasa-mcp/src/nasa-tool.ts
@@ -1,0 +1,199 @@
+// NASA Open APIs integration for the UnClick MCP server.
+// Uses NASA's public APIs via fetch - no external dependencies.
+// Get a free API key at https://api.nasa.gov/ or use DEMO_KEY for low-volume access.
+
+const NASA_BASE = "https://api.nasa.gov";
+
+// ─── API helper ──────────────────────────────────────────────────────────────
+
+function getKey(args: Record<string, unknown>): string {
+  return String(
+    args.api_key ?? process.env.NASA_API_KEY ?? "DEMO_KEY"
+  ).trim();
+}
+
+async function nasaFetch<T>(
+  path: string,
+  params: Record<string, string>
+): Promise<T> {
+  const url = new URL(`${NASA_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== "") url.searchParams.set(k, v);
+  }
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as Record<string, unknown>;
+    const errMsg = (body.error as Record<string, unknown> | undefined)?.message ?? body.msg ?? "Unknown error";
+    throw new Error(`NASA API HTTP ${res.status}: ${String(errMsg)}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+export async function nasaApod(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = getKey(args);
+  const params: Record<string, string> = { api_key: key };
+  if (args.date) params.date = String(args.date);
+
+  const data = (await nasaFetch<Record<string, unknown>>(
+    "/planetary/apod",
+    params
+  )) as Record<string, unknown>;
+
+  return {
+    date: data.date,
+    title: data.title,
+    explanation: data.explanation,
+    url: data.url,
+    media_type: data.media_type,
+    copyright: data.copyright ?? null,
+    hdurl: data.hdurl ?? null,
+  };
+}
+
+export async function nasaAsteroids(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = getKey(args);
+  const startDate = String(args.start_date ?? "").trim();
+  const endDate = String(args.end_date ?? "").trim();
+  if (!startDate) throw new Error("start_date is required (YYYY-MM-DD).");
+  if (!endDate) throw new Error("end_date is required (YYYY-MM-DD).");
+
+  const data = (await nasaFetch<Record<string, unknown>>(
+    "/neo/rest/v1/feed",
+    { api_key: key, start_date: startDate, end_date: endDate }
+  )) as Record<string, unknown>;
+
+  const nearObjects = (data.near_earth_objects as Record<string, unknown[]>) ?? {};
+  const asteroids: unknown[] = [];
+
+  for (const [date, objects] of Object.entries(nearObjects)) {
+    for (const obj of objects as Record<string, unknown>[]) {
+      const approachData = (obj.close_approach_data as Record<string, unknown>[])?.[0] ?? {};
+      const diameter = (obj.estimated_diameter as Record<string, unknown>) ?? {};
+      const meters = (diameter.meters as Record<string, unknown>) ?? {};
+      asteroids.push({
+        id: obj.id,
+        name: obj.name,
+        date,
+        is_potentially_hazardous: obj.is_potentially_hazardous_asteroid,
+        diameter_meters_min: meters.estimated_diameter_min ?? null,
+        diameter_meters_max: meters.estimated_diameter_max ?? null,
+        miss_distance_km: (approachData.miss_distance as Record<string, unknown>)?.kilometers ?? null,
+        relative_velocity_kph: (approachData.relative_velocity as Record<string, unknown>)?.kilometers_per_hour ?? null,
+        url: obj.nasa_jpl_url ?? null,
+      });
+    }
+  }
+
+  return {
+    element_count: data.element_count ?? asteroids.length,
+    start_date: startDate,
+    end_date: endDate,
+    asteroids,
+  };
+}
+
+export async function nasaMarsPhotos(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = getKey(args);
+  const rover = String(args.rover ?? "curiosity").toLowerCase();
+  const validRovers = ["curiosity", "opportunity", "spirit", "perseverance"];
+  if (!validRovers.includes(rover)) {
+    throw new Error(`rover must be one of: ${validRovers.join(", ")}`);
+  }
+
+  const params: Record<string, string> = { api_key: key };
+  if (args.sol !== undefined) params.sol = String(args.sol);
+  if (args.earth_date) params.earth_date = String(args.earth_date);
+  if (args.camera) params.camera = String(args.camera);
+  if (!args.sol && !args.earth_date) params.sol = "1000";
+
+  const data = (await nasaFetch<Record<string, unknown>>(
+    `/mars-photos/api/v1/rovers/${rover}/photos`,
+    params
+  )) as Record<string, unknown>;
+
+  const photos = (data.photos as Record<string, unknown>[]) ?? [];
+
+  return {
+    rover,
+    count: photos.length,
+    photos: photos.slice(0, 25).map((p) => ({
+      id: p.id,
+      sol: p.sol,
+      earth_date: p.earth_date,
+      camera: (p.camera as Record<string, unknown>)?.full_name ?? null,
+      img_src: p.img_src,
+    })),
+  };
+}
+
+export async function nasaEarthImagery(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = getKey(args);
+  const lat = Number(args.lat);
+  const lon = Number(args.lon);
+  if (!Number.isFinite(lat)) throw new Error("lat is required (latitude as number).");
+  if (!Number.isFinite(lon)) throw new Error("lon is required (longitude as number).");
+
+  const params: Record<string, string> = {
+    api_key: key,
+    lat: String(lat),
+    lon: String(lon),
+    dim: "0.025",
+  };
+  if (args.date) params.date = String(args.date);
+
+  const data = (await nasaFetch<Record<string, unknown>>(
+    "/planetary/earth/imagery",
+    params
+  )) as Record<string, unknown>;
+
+  return {
+    lat,
+    lon,
+    date: data.date ?? args.date ?? null,
+    url: data.url ?? null,
+    resource: data.resource ?? null,
+  };
+}
+
+export async function nasaEpic(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = getKey(args);
+  const date = args.date ? String(args.date) : null;
+
+  const path = date
+    ? `/EPIC/api/natural/date/${date}`
+    : "/EPIC/api/natural/images";
+
+  const data = (await nasaFetch<unknown[]>(path, {
+    api_key: key,
+  })) as Record<string, unknown>[];
+
+  return {
+    count: data.length,
+    date: date ?? "latest",
+    images: data.slice(0, 10).map((img) => {
+      const dateStr = String(img.date ?? "").replace(" ", "T");
+      const datePart = dateStr.split("T")[0]?.replace(/-/g, "/") ?? "";
+      return {
+        identifier: img.identifier,
+        caption: img.caption ?? null,
+        date: img.date,
+        centroid_coordinates: img.centroid_coordinates ?? null,
+        image_url: datePart
+          ? `https://epic.gsfc.nasa.gov/archive/natural/${datePart}/png/${img.image}.png`
+          : null,
+      };
+    }),
+  };
+}

--- a/packages/standalone/nasa-mcp/tsconfig.json
+++ b/packages/standalone/nasa-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/openlibrary-mcp/LICENSE
+++ b/packages/standalone/openlibrary-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/openlibrary-mcp/README.md
+++ b/packages/standalone/openlibrary-mcp/README.md
@@ -1,0 +1,38 @@
+# Open Library MCP by UnClick
+
+Search books, authors, and editions, with trending titles, from Open Library. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "openlibrary": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/openlibrary.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `openlibrary_search`
+- `openlibrary_get_book`
+- `openlibrary_get_edition`
+- `openlibrary_get_author`
+- `openlibrary_author_works`
+- `openlibrary_trending`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/openlibrary-mcp/package.json
+++ b/packages/standalone/openlibrary-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/openlibrary-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/openlibrary",
+  "description": "Search books, authors, and editions, with trending titles, from Open Library. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "books",
+    "openlibrary",
+    "library",
+    "authors"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "openlibrary-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/openlibrary-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/openlibrary-mcp/server.json
+++ b/packages/standalone/openlibrary-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/openlibrary",
+  "title": "Open Library MCP by UnClick",
+  "description": "Search books, authors, and editions, with trending titles, from Open Library. No API key. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/openlibrary-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/openlibrary-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/openlibrary-mcp/src/index.ts
+++ b/packages/standalone/openlibrary-mcp/src/index.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Open Library MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  openlibrarySearch,
+  openlibraryGetBook,
+  openlibraryGetEdition,
+  openlibraryGetAuthor,
+  openlibraryAuthorWorks,
+  openlibraryTrending,
+} from "./openlibrary-tool.js";
+
+const TOOLS = [
+  {
+    name: "openlibrary_search",
+    description: "Search books on Open Library.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        q: { type: "string" },
+        limit: { type: "number" },
+        page: { type: "number" },
+      },
+      required: ["q"],
+    },
+  },
+  {
+    name: "openlibrary_get_book",
+    description: "Get a book from Open Library by work ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        work_id: { type: "string", description: "e.g. OL45804W" },
+      },
+      required: ["work_id"],
+    },
+  },
+  {
+    name: "openlibrary_get_edition",
+    description: "Get a book edition from Open Library by ISBN.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        isbn: { type: "string" },
+      },
+      required: ["isbn"],
+    },
+  },
+  {
+    name: "openlibrary_get_author",
+    description: "Get an author from Open Library by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        author_id: { type: "string", description: "e.g. OL23919A" },
+      },
+      required: ["author_id"],
+    },
+  },
+  {
+    name: "openlibrary_author_works",
+    description: "Get works by an author from Open Library.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        author_id: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["author_id"],
+    },
+  },
+  {
+    name: "openlibrary_trending",
+    description: "Get trending books from Open Library.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  openlibrary_search: (args) => openlibrarySearch(args as unknown as Parameters<typeof openlibrarySearch>[0]),
+  openlibrary_get_book: (args) => openlibraryGetBook(args as unknown as Parameters<typeof openlibraryGetBook>[0]),
+  openlibrary_get_edition: (args) => openlibraryGetEdition(args as unknown as Parameters<typeof openlibraryGetEdition>[0]),
+  openlibrary_get_author: (args) => openlibraryGetAuthor(args as unknown as Parameters<typeof openlibraryGetAuthor>[0]),
+  openlibrary_author_works: (args) => openlibraryAuthorWorks(args as unknown as Parameters<typeof openlibraryAuthorWorks>[0]),
+  openlibrary_trending: (args) => openlibraryTrending(args as unknown as Parameters<typeof openlibraryTrending>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/openlibrary", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[openlibrary-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/openlibrary-mcp/src/openlibrary-tool.ts
+++ b/packages/standalone/openlibrary-mcp/src/openlibrary-tool.ts
@@ -1,0 +1,74 @@
+// Open Library API integration for the UnClick MCP server.
+// Uses the Open Library REST API via fetch - no external dependencies.
+// No authentication required.
+
+const OL_BASE = "https://openlibrary.org";
+
+// ─── API helper ───────────────────────────────────────────────────────────────
+
+async function olCall(
+  path: string,
+  params: Record<string, string | number | undefined> = {}
+): Promise<unknown> {
+  const url = new URL(`${OL_BASE}${path}`);
+
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== "") {
+      url.searchParams.set(k, String(v));
+    }
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} from Open Library API`);
+  }
+
+  return response.json();
+}
+
+// ─── Tools ────────────────────────────────────────────────────────────────────
+
+export async function openlibrarySearch(args: Record<string, unknown>): Promise<unknown> {
+  const params: Record<string, string | number | undefined> = {};
+  if (args.q) params.q = String(args.q);
+  if (args.title) params.title = String(args.title);
+  if (args.author) params.author = String(args.author);
+  if (args.isbn) params.isbn = String(args.isbn);
+  if (args.limit) params.limit = Number(args.limit);
+  return olCall("/search.json", params);
+}
+
+export async function openlibraryGetBook(args: Record<string, unknown>): Promise<unknown> {
+  const key = String(args.key ?? "").trim();
+  if (!key) throw new Error("key is required (e.g. OL45804W).");
+  // Strip leading slash if caller includes it
+  const cleanKey = key.replace(/^\//, "");
+  return olCall(`/works/${cleanKey}.json`);
+}
+
+export async function openlibraryGetEdition(args: Record<string, unknown>): Promise<unknown> {
+  const isbn = String(args.isbn ?? "").trim();
+  if (!isbn) throw new Error("isbn is required.");
+  return olCall(`/isbn/${isbn}.json`);
+}
+
+export async function openlibraryGetAuthor(args: Record<string, unknown>): Promise<unknown> {
+  const key = String(args.key ?? "").trim();
+  if (!key) throw new Error("key is required (e.g. OL23919A).");
+  const cleanKey = key.replace(/^\//, "");
+  return olCall(`/authors/${cleanKey}.json`);
+}
+
+export async function openlibraryAuthorWorks(args: Record<string, unknown>): Promise<unknown> {
+  const key = String(args.key ?? "").trim();
+  if (!key) throw new Error("key is required (e.g. OL23919A).");
+  const cleanKey = key.replace(/^\//, "");
+  return olCall(`/authors/${cleanKey}/works.json`);
+}
+
+export async function openlibraryTrending(_args: Record<string, unknown>): Promise<unknown> {
+  return olCall("/trending/daily.json");
+}

--- a/packages/standalone/openlibrary-mcp/tsconfig.json
+++ b/packages/standalone/openlibrary-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/openmeteo-mcp/LICENSE
+++ b/packages/standalone/openmeteo-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/openmeteo-mcp/README.md
+++ b/packages/standalone/openmeteo-mcp/README.md
@@ -1,0 +1,35 @@
+# Open-Meteo Weather MCP by UnClick
+
+Free global weather: current conditions, hourly and daily forecasts from Open-Meteo. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "openmeteo": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/openmeteo.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `weather_current`
+- `weather_forecast`
+- `weather_hourly`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/openmeteo-mcp/package.json
+++ b/packages/standalone/openmeteo-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/openmeteo-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/openmeteo",
+  "description": "Free global weather: current conditions, hourly and daily forecasts from Open-Meteo. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "weather",
+    "forecast",
+    "open-meteo",
+    "climate"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "openmeteo-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/openmeteo-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/openmeteo-mcp/server.json
+++ b/packages/standalone/openmeteo-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/openmeteo",
+  "title": "Open-Meteo Weather MCP by UnClick",
+  "description": "Free global weather: current conditions, hourly and daily forecasts from Open-Meteo. No API key. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/openmeteo-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/openmeteo-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/openmeteo-mcp/src/index.ts
+++ b/packages/standalone/openmeteo-mcp/src/index.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Open-Meteo Weather MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  weatherCurrent,
+  weatherForecast,
+  weatherHourly,
+} from "./openmeteo-tool.js";
+
+const TOOLS = [
+  {
+    name: "weather_current",
+    description: "Get current weather for a location from Open-Meteo (no API key required).",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        latitude: { type: "number" },
+        longitude: { type: "number" },
+        timezone: { type: "string" },
+      },
+      required: ["latitude", "longitude"],
+    },
+  },
+  {
+    name: "weather_forecast",
+    description: "Get weather forecast for a location from Open-Meteo.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        latitude: { type: "number" },
+        longitude: { type: "number" },
+        days: { type: "number" },
+        timezone: { type: "string" },
+      },
+      required: ["latitude", "longitude"],
+    },
+  },
+  {
+    name: "weather_hourly",
+    description: "Get hourly weather forecast from Open-Meteo.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        latitude: { type: "number" },
+        longitude: { type: "number" },
+        days: { type: "number" },
+        timezone: { type: "string" },
+      },
+      required: ["latitude", "longitude"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  weather_current: (args) => weatherCurrent(args as unknown as Parameters<typeof weatherCurrent>[0]),
+  weather_forecast: (args) => weatherForecast(args as unknown as Parameters<typeof weatherForecast>[0]),
+  weather_hourly: (args) => weatherHourly(args as unknown as Parameters<typeof weatherHourly>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/openmeteo", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[openmeteo-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/openmeteo-mcp/src/openmeteo-tool.ts
+++ b/packages/standalone/openmeteo-mcp/src/openmeteo-tool.ts
@@ -1,0 +1,198 @@
+// Open-Meteo weather API integration.
+// No authentication required - completely free and open.
+// Base URL: https://api.open-meteo.com/v1/
+// Geocoding: https://geocoding-api.open-meteo.com/v1/search
+
+const WEATHER_BASE = "https://api.open-meteo.com/v1";
+const GEO_BASE = "https://geocoding-api.open-meteo.com/v1";
+
+// ─── WMO weather code descriptions ───────────────────────────────────────────
+
+const WMO_CODES: Record<number, string> = {
+  0: "Clear sky", 1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+  45: "Foggy", 48: "Depositing rime fog",
+  51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+  61: "Slight rain", 63: "Moderate rain", 65: "Heavy rain",
+  71: "Slight snow", 73: "Moderate snow", 75: "Heavy snow", 77: "Snow grains",
+  80: "Slight showers", 81: "Moderate showers", 82: "Violent showers",
+  85: "Slight snow showers", 86: "Heavy snow showers",
+  95: "Thunderstorm", 96: "Thunderstorm with slight hail", 99: "Thunderstorm with heavy hail",
+};
+
+// ─── Geocoding helper ─────────────────────────────────────────────────────────
+
+interface GeoResult {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  country: string;
+  country_code: string;
+  admin1?: string;
+}
+
+async function resolveLocation(
+  args: Record<string, unknown>
+): Promise<{ latitude: number; longitude: number; location_name: string } | { error: string }> {
+  if (args.latitude !== undefined && args.longitude !== undefined) {
+    return {
+      latitude: Number(args.latitude),
+      longitude: Number(args.longitude),
+      location_name: `${args.latitude}, ${args.longitude}`,
+    };
+  }
+
+  const city = String(args.city ?? "").trim();
+  if (!city) {
+    return { error: "Provide either (latitude + longitude) or city." };
+  }
+
+  const res = await fetch(
+    `${GEO_BASE}/search?name=${encodeURIComponent(city)}&count=1&format=json`,
+    { headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" } }
+  );
+  if (!res.ok) throw new Error(`Geocoding API HTTP ${res.status}`);
+
+  const data = await res.json() as { results?: GeoResult[] };
+  const place = data.results?.[0];
+  if (!place) return { error: `City "${city}" not found.` };
+
+  return {
+    latitude: place.latitude,
+    longitude: place.longitude,
+    location_name: [place.name, place.admin1, place.country].filter(Boolean).join(", "),
+  };
+}
+
+async function weatherFetch(params: URLSearchParams): Promise<unknown> {
+  const url = `${WEATHER_BASE}/forecast?${params}`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Open-Meteo HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+  }
+  return res.json() as Promise<unknown>;
+}
+
+// ─── weather_current ──────────────────────────────────────────────────────────
+
+export async function weatherCurrent(args: Record<string, unknown>): Promise<unknown> {
+  const loc = await resolveLocation(args);
+  if ("error" in loc) return loc;
+
+  const params = new URLSearchParams({
+    latitude: String(loc.latitude),
+    longitude: String(loc.longitude),
+    current_weather: "true",
+    timezone: "auto",
+  });
+
+  const data = await weatherFetch(params) as Record<string, unknown>;
+  const cw = data["current_weather"] as Record<string, unknown> | undefined;
+
+  return {
+    location: loc.location_name,
+    latitude: loc.latitude,
+    longitude: loc.longitude,
+    time: cw?.["time"] ?? null,
+    temperature_c: cw?.["temperature"] ?? null,
+    wind_speed_kmh: cw?.["windspeed"] ?? null,
+    wind_direction_deg: cw?.["winddirection"] ?? null,
+    weather_code: cw?.["weathercode"] ?? null,
+    weather_description: WMO_CODES[Number(cw?.["weathercode"])] ?? "Unknown",
+    is_day: cw?.["is_day"] === 1,
+  };
+}
+
+// ─── weather_forecast ────────────────────────────────────────────────────────
+
+export async function weatherForecast(args: Record<string, unknown>): Promise<unknown> {
+  const loc = await resolveLocation(args);
+  if ("error" in loc) return loc;
+
+  const days = Math.min(16, Math.max(1, Number(args.days ?? 7)));
+
+  const params = new URLSearchParams({
+    latitude: String(loc.latitude),
+    longitude: String(loc.longitude),
+    daily: [
+      "temperature_2m_max",
+      "temperature_2m_min",
+      "precipitation_sum",
+      "windspeed_10m_max",
+      "weathercode",
+    ].join(","),
+    forecast_days: String(days),
+    timezone: "auto",
+  });
+
+  const data = await weatherFetch(params) as Record<string, unknown>;
+  const daily = data["daily"] as Record<string, unknown[]> | undefined;
+  const dates = (daily?.["time"] ?? []) as string[];
+
+  const forecast = dates.map((date, i) => ({
+    date,
+    temp_max_c: daily?.["temperature_2m_max"]?.[i] ?? null,
+    temp_min_c: daily?.["temperature_2m_min"]?.[i] ?? null,
+    precipitation_mm: daily?.["precipitation_sum"]?.[i] ?? null,
+    wind_speed_max_kmh: daily?.["windspeed_10m_max"]?.[i] ?? null,
+    weather_code: daily?.["weathercode"]?.[i] ?? null,
+    weather_description: WMO_CODES[Number(daily?.["weathercode"]?.[i])] ?? "Unknown",
+  }));
+
+  return {
+    location: loc.location_name,
+    latitude: loc.latitude,
+    longitude: loc.longitude,
+    days: forecast.length,
+    timezone: data["timezone"] ?? null,
+    forecast,
+  };
+}
+
+// ─── weather_hourly ───────────────────────────────────────────────────────────
+
+export async function weatherHourly(args: Record<string, unknown>): Promise<unknown> {
+  const loc = await resolveLocation(args);
+  if ("error" in loc) return loc;
+
+  const params = new URLSearchParams({
+    latitude: String(loc.latitude),
+    longitude: String(loc.longitude),
+    hourly: [
+      "temperature_2m",
+      "precipitation",
+      "windspeed_10m",
+      "weathercode",
+      "relativehumidity_2m",
+    ].join(","),
+    forecast_days: "2",
+    timezone: "auto",
+  });
+
+  const data = await weatherFetch(params) as Record<string, unknown>;
+  const hourly = data["hourly"] as Record<string, unknown[]> | undefined;
+  const times = (hourly?.["time"] ?? []) as string[];
+
+  // Return next 48 hours
+  const hours = times.slice(0, 48).map((time, i) => ({
+    time,
+    temperature_c: hourly?.["temperature_2m"]?.[i] ?? null,
+    precipitation_mm: hourly?.["precipitation"]?.[i] ?? null,
+    wind_speed_kmh: hourly?.["windspeed_10m"]?.[i] ?? null,
+    humidity_pct: hourly?.["relativehumidity_2m"]?.[i] ?? null,
+    weather_code: hourly?.["weathercode"]?.[i] ?? null,
+    weather_description: WMO_CODES[Number(hourly?.["weathercode"]?.[i])] ?? "Unknown",
+  }));
+
+  return {
+    location: loc.location_name,
+    latitude: loc.latitude,
+    longitude: loc.longitude,
+    timezone: data["timezone"] ?? null,
+    hours: hours.length,
+    hourly: hours,
+  };
+}

--- a/packages/standalone/openmeteo-mcp/tsconfig.json
+++ b/packages/standalone/openmeteo-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/reddit-mcp/LICENSE
+++ b/packages/standalone/reddit-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/reddit-mcp/README.md
+++ b/packages/standalone/reddit-mcp/README.md
@@ -1,0 +1,39 @@
+# Reddit MCP by UnClick
+
+Search, read, and post across Reddit: posts, comments, subreddits, and users.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "reddit": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/reddit.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `reddit_read`
+- `reddit_post`
+- `reddit_comment`
+- `reddit_search`
+- `reddit_user`
+- `reddit_vote`
+- `reddit_subscribe`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/reddit-mcp/package.json
+++ b/packages/standalone/reddit-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/reddit-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/reddit",
+  "description": "Search, read, and post across Reddit: posts, comments, subreddits, and users. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "reddit",
+    "social",
+    "forums",
+    "subreddit"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "reddit-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/reddit-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/reddit-mcp/server.json
+++ b/packages/standalone/reddit-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/reddit",
+  "title": "Reddit MCP by UnClick",
+  "description": "Search, read, and post across Reddit: posts, comments, subreddits, and users. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/reddit-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/reddit-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/reddit-mcp/src/index.ts
+++ b/packages/standalone/reddit-mcp/src/index.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// Reddit MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  redditRead,
+  redditPost,
+  redditComment,
+  redditSearch,
+  redditUser,
+  redditVote,
+  redditSubscribe,
+} from "./reddit-tool.js";
+
+const TOOLS = [
+  {
+    name: "reddit_read",
+    description: "Read posts from a Reddit subreddit.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        access_token: { type: "string" },
+        subreddit: { type: "string" },
+        sort: { type: "string", enum: ["hot", "new", "top", "rising"], description: "hot, new, top, rising" },
+        limit: { type: "number" },
+        after: { type: "string" },
+        t: { type: "string", enum: ["hour", "day", "week", "month", "year", "all"], description: "hour, day, week, month, year, all" },
+      },
+      required: ["access_token", "subreddit"],
+    },
+  },
+  {
+    name: "reddit_post",
+    description: "Create a Reddit post.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        access_token: { type: "string" },
+        subreddit: { type: "string" },
+        title: { type: "string" },
+        kind: { type: "string", enum: ["self", "link"], description: "self, link" },
+        text: { type: "string" },
+        url: { type: "string" },
+        nsfw: { type: "boolean" },
+        spoiler: { type: "boolean" },
+      },
+      required: ["access_token", "subreddit", "title", "kind"],
+    },
+  },
+  {
+    name: "reddit_comment",
+    description: "Post a comment on Reddit.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        access_token: { type: "string" },
+        parent_id: { type: "string" },
+        text: { type: "string" },
+      },
+      required: ["access_token", "parent_id", "text"],
+    },
+  },
+  {
+    name: "reddit_search",
+    description: "Search Reddit posts.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        access_token: { type: "string" },
+        q: { type: "string" },
+        subreddit: { type: "string" },
+        sort: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["access_token", "q"],
+    },
+  },
+  {
+    name: "reddit_user",
+    description: "Get a Reddit user profile and posts.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        access_token: { type: "string" },
+        username: { type: "string" },
+        type: { type: "string", description: "overview, submitted, comments" },
+        limit: { type: "number" },
+      },
+      required: ["access_token", "username"],
+    },
+  },
+  {
+    name: "reddit_vote",
+    description: "Vote on a Reddit post or comment.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        access_token: { type: "string" },
+        id: { type: "string" },
+        dir: { type: "number", description: "1=upvote, 0=neutral, -1=downvote" },
+      },
+      required: ["access_token", "id", "dir"],
+    },
+  },
+  {
+    name: "reddit_subscribe",
+    description: "Subscribe to or unsubscribe from a Reddit subreddit.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        access_token: { type: "string" },
+        sr: { type: "string" },
+        action: { type: "string", enum: ["sub", "unsub"], description: "sub or unsub" },
+      },
+      required: ["access_token", "sr", "action"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  reddit_read: (args) => redditRead(args as unknown as Parameters<typeof redditRead>[0]),
+  reddit_post: (args) => redditPost(args as unknown as Parameters<typeof redditPost>[0]),
+  reddit_comment: (args) => redditComment(args as unknown as Parameters<typeof redditComment>[0]),
+  reddit_search: (args) => redditSearch(args as unknown as Parameters<typeof redditSearch>[0]),
+  reddit_user: (args) => redditUser(args as unknown as Parameters<typeof redditUser>[0]),
+  reddit_vote: (args) => redditVote(args as unknown as Parameters<typeof redditVote>[0]),
+  reddit_subscribe: (args) => redditSubscribe(args as unknown as Parameters<typeof redditSubscribe>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/reddit", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[reddit-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/reddit-mcp/src/reddit-tool.ts
+++ b/packages/standalone/reddit-mcp/src/reddit-tool.ts
@@ -1,0 +1,459 @@
+// Reddit API MCP Tool
+// Connects to Reddit via OAuth2 bearer tokens (oauth.reddit.com).
+// No external dependencies - uses global fetch (Node 18+).
+// Rate limit: Reddit allows 60 requests/minute for OAuth clients.
+
+const REDDIT_BASE = "https://oauth.reddit.com";
+const USER_AGENT = "UnClick-MCP/1.0 by unclick.dev";
+
+// Per-process rate limit tracking (headers from Reddit responses)
+let _remaining = 60;
+let _resetAt = Date.now() + 60_000;
+
+// ── Internal fetch helper ────────────────────────────────────────────────────
+
+async function rFetch(
+  method: "GET" | "POST",
+  path: string,
+  accessToken: string,
+  body?: Record<string, string | number | boolean>
+): Promise<unknown> {
+  // Guard: if we have no remaining quota and reset hasn't passed, bail early
+  if (_remaining <= 0 && Date.now() < _resetAt) {
+    const waitMs = _resetAt - Date.now();
+    return {
+      error: "rate_limited",
+      message: `Reddit rate limit reached. Resets in ${Math.ceil(waitMs / 1000)}s.`,
+      retry_after_ms: waitMs,
+    };
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+    "User-Agent": USER_AGENT,
+  };
+
+  let url = `${REDDIT_BASE}${path}`;
+  let fetchBody: string | undefined;
+
+  if (method === "GET" && body) {
+    const qs = new URLSearchParams(
+      Object.fromEntries(
+        Object.entries(body).map(([k, v]) => [k, String(v)])
+      )
+    ).toString();
+    url = `${url}?${qs}`;
+  } else if (method === "POST" && body) {
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
+    fetchBody = new URLSearchParams(
+      Object.fromEntries(
+        Object.entries(body).map(([k, v]) => [k, String(v)])
+      )
+    ).toString();
+  }
+
+  const res = await fetch(url, { method, headers, body: fetchBody });
+
+  // Update rate limit state from response headers
+  const rem = res.headers.get("x-ratelimit-remaining");
+  const rst = res.headers.get("x-ratelimit-reset");
+  if (rem !== null) _remaining = parseFloat(rem);
+  if (rst !== null) _resetAt = Date.now() + parseFloat(rst) * 1_000;
+
+  if (res.status === 429) {
+    const retryAfter = res.headers.get("retry-after");
+    return {
+      error: "rate_limited",
+      message: "Reddit API rate limit exceeded.",
+      retry_after_seconds: retryAfter ? Number(retryAfter) : 60,
+    };
+  }
+
+  if (res.status === 401) {
+    return {
+      error: "unauthorized",
+      message: "Invalid or expired access token. Re-authenticate via Reddit OAuth2.",
+    };
+  }
+
+  if (res.status === 403) {
+    return {
+      error: "forbidden",
+      message: "Access denied. Check token scopes or subreddit permissions.",
+    };
+  }
+
+  if (res.status === 404) {
+    return { error: "not_found", message: `Resource not found: ${path}` };
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    return { error: `http_${res.status}`, message: text || res.statusText };
+  }
+
+  const json = await res.json() as Record<string, unknown>;
+
+  // Reddit wraps API errors in { error: ..., message: ... }
+  if (json && typeof json === "object" && "error" in json) {
+    return { error: json["error"], message: json["message"] };
+  }
+
+  return json;
+}
+
+// ── Shape helpers ────────────────────────────────────────────────────────────
+
+function shapePosts(listing: unknown): unknown[] {
+  if (
+    !listing ||
+    typeof listing !== "object" ||
+    !("data" in (listing as object))
+  ) return [];
+
+  const data = (listing as Record<string, unknown>)["data"] as Record<string, unknown>;
+  const children = Array.isArray(data?.["children"]) ? data["children"] as unknown[] : [];
+
+  return children.map((child) => {
+    const d = ((child as Record<string, unknown>)["data"] ?? {}) as Record<string, unknown>;
+    return {
+      id: d["id"],
+      name: d["name"],
+      title: d["title"],
+      author: d["author"],
+      subreddit: d["subreddit"],
+      score: d["score"],
+      upvote_ratio: d["upvote_ratio"],
+      num_comments: d["num_comments"],
+      url: d["url"],
+      permalink: d["permalink"] ? `https://reddit.com${d["permalink"]}` : null,
+      selftext: d["selftext"] ?? null,
+      is_self: d["is_self"],
+      created_utc: d["created_utc"],
+      nsfw: d["over_18"],
+      spoiler: d["spoiler"],
+      flair: d["link_flair_text"] ?? null,
+    };
+  });
+}
+
+function shapeComments(listing: unknown): unknown[] {
+  if (
+    !listing ||
+    typeof listing !== "object" ||
+    !("data" in (listing as object))
+  ) return [];
+
+  const data = (listing as Record<string, unknown>)["data"] as Record<string, unknown>;
+  const children = Array.isArray(data?.["children"]) ? data["children"] as unknown[] : [];
+
+  return children
+    .filter((c) => {
+      const kind = (c as Record<string, unknown>)["kind"];
+      return kind === "t1";
+    })
+    .map((child) => {
+      const d = ((child as Record<string, unknown>)["data"] ?? {}) as Record<string, unknown>;
+      return {
+        id: d["id"],
+        name: d["name"],
+        author: d["author"],
+        body: d["body"],
+        score: d["score"],
+        created_utc: d["created_utc"],
+        permalink: d["permalink"] ? `https://reddit.com${d["permalink"]}` : null,
+        parent_id: d["parent_id"],
+        subreddit: d["subreddit"],
+      };
+    });
+}
+
+// ── Exported operation functions ─────────────────────────────────────────────
+
+export interface RedditReadArgs {
+  access_token: string;
+  subreddit: string;
+  sort?: string;
+  limit?: number;
+  after?: string;
+  t?: string;
+}
+
+export async function redditRead(args: RedditReadArgs): Promise<unknown> {
+  const sub = args.subreddit.replace(/^r\//i, "");
+  const sort = args.sort ?? "hot";
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 25)));
+  const params: Record<string, string | number | boolean> = { limit };
+  if (args.after) params["after"] = args.after;
+  if (sort === "top" && args.t) params["t"] = args.t;
+
+  const result = await rFetch("GET", `/r/${sub}/${sort}.json`, args.access_token, params);
+  if (result && typeof result === "object" && "error" in (result as object)) return result;
+
+  const posts = shapePosts(result);
+  const data = (result as Record<string, unknown>)?.["data"] as Record<string, unknown> | undefined;
+
+  return {
+    subreddit: sub,
+    sort,
+    count: posts.length,
+    after: data?.["after"] ?? null,
+    before: data?.["before"] ?? null,
+    posts,
+  };
+}
+
+export interface RedditPostArgs {
+  access_token: string;
+  subreddit: string;
+  title: string;
+  kind: string;
+  text?: string;
+  url?: string;
+  nsfw?: boolean;
+  spoiler?: boolean;
+  flair_id?: string;
+  flair_text?: string;
+}
+
+export async function redditPost(args: RedditPostArgs): Promise<unknown> {
+  const sub = args.subreddit.replace(/^r\//i, "");
+  if (!args.title?.trim()) return { error: "validation", message: "title is required." };
+  if (args.kind === "self" && !args.text) return { error: "validation", message: "text is required for self posts." };
+  if (args.kind === "link" && !args.url) return { error: "validation", message: "url is required for link posts." };
+
+  const body: Record<string, string | number | boolean> = {
+    sr: sub,
+    title: args.title,
+    kind: args.kind,
+    api_type: "json",
+    resubmit: true,
+    nsfw: args.nsfw ?? false,
+    spoiler: args.spoiler ?? false,
+  };
+
+  if (args.kind === "self") body["text"] = args.text!;
+  if (args.kind === "link") body["url"] = args.url!;
+  if (args.flair_id) body["flair_id"] = args.flair_id;
+  if (args.flair_text) body["flair_text"] = args.flair_text;
+
+  const result = await rFetch("POST", "/api/submit", args.access_token, body);
+  if (result && typeof result === "object" && "error" in (result as object)) return result;
+
+  // Reddit wraps submit response in json.data
+  const json = (result as Record<string, unknown>)?.["json"] as Record<string, unknown> | undefined;
+  const errors = json?.["errors"] as unknown[];
+  if (errors && errors.length > 0) {
+    return { error: "submit_error", errors };
+  }
+
+  const postData = json?.["data"] as Record<string, unknown> | undefined;
+  return {
+    success: true,
+    id: postData?.["id"],
+    name: postData?.["name"],
+    url: postData?.["url"],
+  };
+}
+
+export interface RedditCommentArgs {
+  access_token: string;
+  parent_id: string;
+  text: string;
+}
+
+export async function redditComment(args: RedditCommentArgs): Promise<unknown> {
+  if (!args.parent_id?.trim()) return { error: "validation", message: "parent_id is required (e.g. t3_abc123 or t1_def456)." };
+  if (!args.text?.trim()) return { error: "validation", message: "text is required." };
+
+  const body: Record<string, string | number | boolean> = {
+    parent: args.parent_id,
+    text: args.text,
+    api_type: "json",
+  };
+
+  const result = await rFetch("POST", "/api/comment", args.access_token, body);
+  if (result && typeof result === "object" && "error" in (result as object)) return result;
+
+  const json = (result as Record<string, unknown>)?.["json"] as Record<string, unknown> | undefined;
+  const errors = json?.["errors"] as unknown[];
+  if (errors && errors.length > 0) {
+    return { error: "comment_error", errors };
+  }
+
+  const things = (json?.["data"] as Record<string, unknown>)?.["things"] as unknown[];
+  const first = things?.[0] as Record<string, unknown> | undefined;
+  const d = (first?.["data"] ?? {}) as Record<string, unknown>;
+
+  return {
+    success: true,
+    id: d["id"],
+    name: d["name"],
+    author: d["author"],
+    body: d["body"],
+    created_utc: d["created_utc"],
+    permalink: d["permalink"] ? `https://reddit.com${d["permalink"]}` : null,
+  };
+}
+
+export interface RedditSearchArgs {
+  access_token: string;
+  query: string;
+  subreddit?: string;
+  sort?: string;
+  t?: string;
+  limit?: number;
+  after?: string;
+}
+
+export async function redditSearch(args: RedditSearchArgs): Promise<unknown> {
+  if (!args.query?.trim()) return { error: "validation", message: "query is required." };
+
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 25)));
+  const params: Record<string, string | number | boolean> = {
+    q: args.query,
+    sort: args.sort ?? "relevance",
+    limit,
+    type: "link",
+  };
+
+  if (args.t) params["t"] = args.t;
+  if (args.after) params["after"] = args.after;
+  if (args.subreddit) params["restrict_sr"] = true;
+
+  const sub = args.subreddit?.replace(/^r\//i, "");
+  const path = sub ? `/r/${sub}/search.json` : "/search.json";
+
+  const result = await rFetch("GET", path, args.access_token, params);
+  if (result && typeof result === "object" && "error" in (result as object)) return result;
+
+  const posts = shapePosts(result);
+  const data = (result as Record<string, unknown>)?.["data"] as Record<string, unknown> | undefined;
+
+  return {
+    query: args.query,
+    subreddit: sub ?? null,
+    sort: args.sort ?? "relevance",
+    count: posts.length,
+    after: data?.["after"] ?? null,
+    results: posts,
+  };
+}
+
+export interface RedditUserArgs {
+  access_token: string;
+  username: string;
+  include_posts?: boolean;
+  include_comments?: boolean;
+  limit?: number;
+}
+
+export async function redditUser(args: RedditUserArgs): Promise<unknown> {
+  const username = args.username.replace(/^u\//i, "");
+  if (!username) return { error: "validation", message: "username is required." };
+
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 10)));
+
+  const [aboutResult, ...activityResults] = await Promise.all([
+    rFetch("GET", `/user/${username}/about.json`, args.access_token),
+    args.include_posts !== false
+      ? rFetch("GET", `/user/${username}/submitted.json`, args.access_token, { limit })
+      : Promise.resolve(null),
+    args.include_comments !== false
+      ? rFetch("GET", `/user/${username}/comments.json`, args.access_token, { limit })
+      : Promise.resolve(null),
+  ]);
+
+  if (aboutResult && typeof aboutResult === "object" && "error" in (aboutResult as object)) {
+    return aboutResult;
+  }
+
+  const userData = ((aboutResult as Record<string, unknown>)?.["data"] ?? {}) as Record<string, unknown>;
+
+  const profile = {
+    id: userData["id"],
+    name: userData["name"],
+    created_utc: userData["created_utc"],
+    link_karma: userData["link_karma"],
+    comment_karma: userData["comment_karma"],
+    is_verified: userData["verified"],
+    is_mod: userData["is_mod"],
+    icon_img: userData["icon_img"],
+    snoovatar_img: userData["snoovatar_img"],
+    subreddit: userData["subreddit"]
+      ? {
+          display_name: (userData["subreddit"] as Record<string, unknown>)?.["display_name"],
+          public_description: (userData["subreddit"] as Record<string, unknown>)?.["public_description"],
+          subscribers: (userData["subreddit"] as Record<string, unknown>)?.["subscribers"],
+        }
+      : null,
+  };
+
+  const [postsResult, commentsResult] = activityResults;
+  const result: Record<string, unknown> = { profile };
+
+  if (postsResult && !(typeof postsResult === "object" && "error" in (postsResult as object))) {
+    result["recent_posts"] = shapePosts(postsResult);
+  }
+  if (commentsResult && !(typeof commentsResult === "object" && "error" in (commentsResult as object))) {
+    result["recent_comments"] = shapeComments(commentsResult);
+  }
+
+  return result;
+}
+
+export interface RedditVoteArgs {
+  access_token: string;
+  id: string;
+  dir: number;
+}
+
+export async function redditVote(args: RedditVoteArgs): Promise<unknown> {
+  if (!args.id?.trim()) return { error: "validation", message: "id (fullname) is required, e.g. t3_abc123." };
+  const dir = Number(args.dir);
+  if (dir !== 1 && dir !== 0 && dir !== -1) {
+    return { error: "validation", message: "dir must be 1 (upvote), 0 (remove vote), or -1 (downvote)." };
+  }
+
+  const result = await rFetch("POST", "/api/vote", args.access_token, {
+    id: args.id,
+    dir,
+  });
+
+  if (result && typeof result === "object" && "error" in (result as object)) return result;
+
+  return {
+    success: true,
+    id: args.id,
+    dir,
+    action: dir === 1 ? "upvoted" : dir === -1 ? "downvoted" : "vote_removed",
+  };
+}
+
+export interface RedditSubscribeArgs {
+  access_token: string;
+  subreddit: string;
+  action: string;
+}
+
+export async function redditSubscribe(args: RedditSubscribeArgs): Promise<unknown> {
+  const sub = args.subreddit.replace(/^r\//i, "");
+  if (!sub) return { error: "validation", message: "subreddit is required." };
+  if (args.action !== "sub" && args.action !== "unsub") {
+    return { error: "validation", message: "action must be 'sub' or 'unsub'." };
+  }
+
+  // Fetch subreddit info to get the fullname (sr_name param is also accepted)
+  const result = await rFetch("POST", "/api/subscribe", args.access_token, {
+    action: args.action,
+    sr_name: sub,
+  });
+
+  if (result && typeof result === "object" && "error" in (result as object)) return result;
+
+  return {
+    success: true,
+    subreddit: sub,
+    action: args.action === "sub" ? "subscribed" : "unsubscribed",
+  };
+}

--- a/packages/standalone/reddit-mcp/tsconfig.json
+++ b/packages/standalone/reddit-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/restcountries-mcp/LICENSE
+++ b/packages/standalone/restcountries-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/restcountries-mcp/README.md
+++ b/packages/standalone/restcountries-mcp/README.md
@@ -1,0 +1,38 @@
+# REST Countries MCP by UnClick
+
+Country data: flags, currencies, languages, regions, capitals, and more. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "restcountries": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/restcountries.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `country_all`
+- `country_by_name`
+- `country_by_code`
+- `country_by_region`
+- `country_by_currency`
+- `country_by_language`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/restcountries-mcp/package.json
+++ b/packages/standalone/restcountries-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/restcountries-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/restcountries",
+  "description": "Country data: flags, currencies, languages, regions, capitals, and more. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "countries",
+    "geography",
+    "restcountries"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "restcountries-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/restcountries-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/restcountries-mcp/server.json
+++ b/packages/standalone/restcountries-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/restcountries",
+  "title": "REST Countries MCP by UnClick",
+  "description": "Country data: flags, currencies, languages, regions, capitals, and more. No API key. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/restcountries-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/restcountries-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/restcountries-mcp/src/index.ts
+++ b/packages/standalone/restcountries-mcp/src/index.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// REST Countries MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  countryAll,
+  countryByName,
+  countryByCode,
+  countryByRegion,
+  countryByCurrency,
+  countryByLanguage,
+} from "./restcountries-tool.js";
+
+const TOOLS = [
+  {
+    name: "country_all",
+    description: "Get all countries from REST Countries.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        fields: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "country_by_name",
+    description: "Get a country by name from REST Countries.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        name: { type: "string" },
+        fullText: { type: "boolean" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "country_by_code",
+    description: "Get a country by code from REST Countries.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        code: { type: "string" },
+      },
+      required: ["code"],
+    },
+  },
+  {
+    name: "country_by_region",
+    description: "Get countries by region from REST Countries.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        region: { type: "string" },
+      },
+      required: ["region"],
+    },
+  },
+  {
+    name: "country_by_currency",
+    description: "Get countries by currency from REST Countries.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        currency: { type: "string" },
+      },
+      required: ["currency"],
+    },
+  },
+  {
+    name: "country_by_language",
+    description: "Get countries by language from REST Countries.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        language: { type: "string" },
+      },
+      required: ["language"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  country_all: (args) => countryAll(args as unknown as Parameters<typeof countryAll>[0]),
+  country_by_name: (args) => countryByName(args as unknown as Parameters<typeof countryByName>[0]),
+  country_by_code: (args) => countryByCode(args as unknown as Parameters<typeof countryByCode>[0]),
+  country_by_region: (args) => countryByRegion(args as unknown as Parameters<typeof countryByRegion>[0]),
+  country_by_currency: (args) => countryByCurrency(args as unknown as Parameters<typeof countryByCurrency>[0]),
+  country_by_language: (args) => countryByLanguage(args as unknown as Parameters<typeof countryByLanguage>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/restcountries", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[restcountries-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/restcountries-mcp/src/restcountries-tool.ts
+++ b/packages/standalone/restcountries-mcp/src/restcountries-tool.ts
@@ -1,0 +1,162 @@
+// REST Countries integration for the UnClick MCP server.
+// Uses the REST Countries public API via fetch - no auth required.
+// Data covers all 250 countries with rich metadata.
+
+const RESTCOUNTRIES_BASE = "https://restcountries.com/v3.1";
+
+// --- API helper ---
+
+async function rcFetch(path: string, fields?: string): Promise<unknown> {
+  const url = new URL(`${RESTCOUNTRIES_BASE}${path}`);
+  if (fields) url.searchParams.set("fields", fields);
+
+  const response = await fetch(url.toString(), {
+    headers: { "Accept": "application/json" },
+  });
+
+  if (response.status === 404) {
+    return { results: [], note: "No countries matched the query." };
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`HTTP ${response.status} from REST Countries API${text ? `: ${text}` : ""}`);
+  }
+
+  return response.json();
+}
+
+// --- Normalizer ---
+
+function normalizeCountry(c: Record<string, unknown>) {
+  const name = c.name as Record<string, unknown> | undefined;
+  const currencies = c.currencies as Record<string, Record<string, string>> | undefined;
+  const languages = c.languages as Record<string, string> | undefined;
+  const capital = c.capital as string[] | undefined;
+  const flags = c.flags as Record<string, string> | undefined;
+  const maps = c.maps as Record<string, string> | undefined;
+
+  return {
+    name: name?.common ?? c.name,
+    official_name: name?.official ?? null,
+    cca2: c.cca2 ?? null,
+    cca3: c.cca3 ?? null,
+    capital: capital?.[0] ?? null,
+    region: c.region ?? null,
+    subregion: c.subregion ?? null,
+    population: c.population ?? null,
+    area: c.area ?? null,
+    flag_emoji: c.flag ?? null,
+    flag_url: flags?.png ?? null,
+    google_maps: maps?.googleMaps ?? null,
+    currencies: currencies
+      ? Object.entries(currencies).map(([code, info]) => ({
+          code,
+          name: info.name,
+          symbol: info.symbol,
+        }))
+      : null,
+    languages: languages ? Object.values(languages) : null,
+    timezones: c.timezones ?? null,
+    continents: c.continents ?? null,
+    landlocked: c.landlocked ?? null,
+    borders: c.borders ?? null,
+    independent: c.independent ?? null,
+    un_member: c.unMember ?? null,
+  };
+}
+
+// --- Operations ---
+
+export async function countryAll(args: Record<string, unknown>): Promise<unknown> {
+  const fields = String(args.fields ?? "").trim();
+  const data = await rcFetch("/all", fields || undefined);
+
+  if (data && typeof data === "object" && "results" in data) return data;
+
+  const countries = data as Array<Record<string, unknown>>;
+  return {
+    count: countries.length,
+    countries: countries.map(normalizeCountry),
+  };
+}
+
+export async function countryByName(args: Record<string, unknown>): Promise<unknown> {
+  const name = String(args.name ?? "").trim();
+  if (!name) throw new Error("name is required.");
+
+  const data = await rcFetch(`/name/${encodeURIComponent(name)}`);
+
+  if (data && typeof data === "object" && "results" in data) return data;
+
+  const countries = data as Array<Record<string, unknown>>;
+  return {
+    count: countries.length,
+    countries: countries.map(normalizeCountry),
+  };
+}
+
+export async function countryByCode(args: Record<string, unknown>): Promise<unknown> {
+  const code = String(args.code ?? "").trim().toUpperCase();
+  if (!code) throw new Error("code is required (ISO 2 or 3 letter code).");
+
+  const data = await rcFetch(`/alpha/${encodeURIComponent(code)}`);
+
+  if (data && typeof data === "object" && "results" in data) return data;
+
+  // /alpha/{code} can return a single object or array
+  const arr = Array.isArray(data) ? data : [data];
+  return {
+    count: arr.length,
+    countries: (arr as Array<Record<string, unknown>>).map(normalizeCountry),
+  };
+}
+
+export async function countryByRegion(args: Record<string, unknown>): Promise<unknown> {
+  const region = String(args.region ?? "").trim();
+  const validRegions = ["Africa", "Americas", "Asia", "Europe", "Oceania", "Antarctic"];
+  if (!region) throw new Error(`region is required. Valid values: ${validRegions.join(", ")}.`);
+
+  const data = await rcFetch(`/region/${encodeURIComponent(region)}`);
+
+  if (data && typeof data === "object" && "results" in data) return data;
+
+  const countries = data as Array<Record<string, unknown>>;
+  return {
+    region,
+    count: countries.length,
+    countries: countries.map(normalizeCountry),
+  };
+}
+
+export async function countryByCurrency(args: Record<string, unknown>): Promise<unknown> {
+  const currency = String(args.currency ?? "").trim().toUpperCase();
+  if (!currency) throw new Error("currency is required (e.g. USD, EUR).");
+
+  const data = await rcFetch(`/currency/${encodeURIComponent(currency)}`);
+
+  if (data && typeof data === "object" && "results" in data) return data;
+
+  const countries = data as Array<Record<string, unknown>>;
+  return {
+    currency,
+    count: countries.length,
+    countries: countries.map(normalizeCountry),
+  };
+}
+
+export async function countryByLanguage(args: Record<string, unknown>): Promise<unknown> {
+  const language = String(args.language ?? "").trim().toLowerCase();
+  if (!language) throw new Error("language is required (e.g. english, spanish).");
+
+  const data = await rcFetch(`/lang/${encodeURIComponent(language)}`);
+
+  if (data && typeof data === "object" && "results" in data) return data;
+
+  const countries = data as Array<Record<string, unknown>>;
+  return {
+    language,
+    count: countries.length,
+    countries: countries.map(normalizeCountry),
+  };
+}

--- a/packages/standalone/restcountries-mcp/tsconfig.json
+++ b/packages/standalone/restcountries-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/spotify-mcp/LICENSE
+++ b/packages/standalone/spotify-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/spotify-mcp/README.md
+++ b/packages/standalone/spotify-mcp/README.md
@@ -1,0 +1,39 @@
+# Spotify MCP by UnClick
+
+Search Spotify for tracks, artists, albums, and playlists, with audio features and recommendations.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "spotify": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/spotify.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `spotify_search`
+- `spotify_get_track`
+- `spotify_get_album`
+- `spotify_get_artist`
+- `spotify_get_playlist`
+- `spotify_get_recommendations`
+- `spotify_get_audio_features`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/spotify-mcp/package.json
+++ b/packages/standalone/spotify-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/spotify-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/spotify",
+  "description": "Search Spotify for tracks, artists, albums, and playlists, with audio features and recommendations. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "spotify",
+    "music",
+    "playlists",
+    "tracks"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "spotify-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/spotify-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/spotify-mcp/server.json
+++ b/packages/standalone/spotify-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/spotify",
+  "title": "Spotify MCP by UnClick",
+  "description": "Search Spotify for tracks, artists, albums, and playlists, with audio features and recommendations. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/spotify-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/spotify-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/spotify-mcp/src/index.ts
+++ b/packages/standalone/spotify-mcp/src/index.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// Spotify MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  spotifySearch,
+  spotifyGetTrack,
+  spotifyGetAlbum,
+  spotifyGetArtist,
+  spotifyGetPlaylist,
+  spotifyGetRecommendations,
+  spotifyGetAudioFeatures,
+} from "./spotify-tool.js";
+
+const TOOLS = [
+  {
+    name: "spotify_search",
+    description: "Search Spotify for tracks, albums, artists, or playlists.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        bearer_token: { type: "string" },
+        query: { type: "string" },
+        type: { type: "string", description: "Comma-separated: track, album, artist, playlist (default: track)" },
+        limit: { type: "number" },
+        offset: { type: "number" },
+        market: { type: "string" },
+      },
+      required: ["bearer_token", "query"],
+    },
+  },
+  {
+    name: "spotify_get_track",
+    description: "Get metadata for a Spotify track by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        bearer_token: { type: "string" },
+        track_id: { type: "string" },
+        market: { type: "string" },
+      },
+      required: ["bearer_token", "track_id"],
+    },
+  },
+  {
+    name: "spotify_get_album",
+    description: "Get metadata and track listing for a Spotify album.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        bearer_token: { type: "string" },
+        album_id: { type: "string" },
+      },
+      required: ["bearer_token", "album_id"],
+    },
+  },
+  {
+    name: "spotify_get_artist",
+    description: "Get metadata and follower count for a Spotify artist.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        bearer_token: { type: "string" },
+        artist_id: { type: "string" },
+      },
+      required: ["bearer_token", "artist_id"],
+    },
+  },
+  {
+    name: "spotify_get_playlist",
+    description: "Get metadata and tracks for a Spotify playlist.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        bearer_token: { type: "string" },
+        playlist_id: { type: "string" },
+        market: { type: "string" },
+      },
+      required: ["bearer_token", "playlist_id"],
+    },
+  },
+  {
+    name: "spotify_get_recommendations",
+    description: "Get Spotify track recommendations based on seed tracks, artists, or genres.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        bearer_token: { type: "string" },
+        seed_tracks: { type: "string", description: "Comma-separated Spotify track IDs (max 5 seeds total)" },
+        seed_artists: { type: "string", description: "Comma-separated Spotify artist IDs" },
+        seed_genres: { type: "string", description: "Comma-separated genre names" },
+        limit: { type: "number" },
+        market: { type: "string" },
+        min_energy: { type: "number" },
+        max_energy: { type: "number" },
+        target_valence: { type: "number" },
+        target_danceability: { type: "number" },
+      },
+      required: ["bearer_token"],
+    },
+  },
+  {
+    name: "spotify_get_audio_features",
+    description: "Get audio analysis features (danceability, energy, tempo, etc.) for a Spotify track.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        bearer_token: { type: "string" },
+        track_id: { type: "string" },
+      },
+      required: ["bearer_token", "track_id"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  spotify_search: (args) => spotifySearch(args as unknown as Parameters<typeof spotifySearch>[0]),
+  spotify_get_track: (args) => spotifyGetTrack(args as unknown as Parameters<typeof spotifyGetTrack>[0]),
+  spotify_get_album: (args) => spotifyGetAlbum(args as unknown as Parameters<typeof spotifyGetAlbum>[0]),
+  spotify_get_artist: (args) => spotifyGetArtist(args as unknown as Parameters<typeof spotifyGetArtist>[0]),
+  spotify_get_playlist: (args) => spotifyGetPlaylist(args as unknown as Parameters<typeof spotifyGetPlaylist>[0]),
+  spotify_get_recommendations: (args) => spotifyGetRecommendations(args as unknown as Parameters<typeof spotifyGetRecommendations>[0]),
+  spotify_get_audio_features: (args) => spotifyGetAudioFeatures(args as unknown as Parameters<typeof spotifyGetAudioFeatures>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/spotify", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[spotify-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/spotify-mcp/src/spotify-tool.ts
+++ b/packages/standalone/spotify-mcp/src/spotify-tool.ts
@@ -1,0 +1,369 @@
+// Spotify Web API integration for the UnClick MCP server.
+// Uses the Spotify Web API via fetch - no external dependencies.
+// Users must supply a Bearer token (access token) from Spotify OAuth.
+
+const SPOTIFY_API_BASE = "https://api.spotify.com/v1";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SpotifyImage { url: string; height: number | null; width: number | null }
+
+interface SpotifyArtistSimple { id: string; name: string; external_urls: { spotify: string } }
+
+interface SpotifyTrack {
+  id: string;
+  name: string;
+  duration_ms: number;
+  explicit: boolean;
+  popularity?: number;
+  preview_url: string | null;
+  track_number: number;
+  artists: SpotifyArtistSimple[];
+  album?: {
+    id: string;
+    name: string;
+    release_date: string;
+    images: SpotifyImage[];
+    album_type: string;
+  };
+  external_urls: { spotify: string };
+}
+
+interface SpotifyAlbum {
+  id: string;
+  name: string;
+  album_type: string;
+  release_date: string;
+  total_tracks: number;
+  images: SpotifyImage[];
+  artists: SpotifyArtistSimple[];
+  label?: string;
+  popularity?: number;
+  genres?: string[];
+  external_urls: { spotify: string };
+  tracks?: { items: SpotifyTrack[]; total: number };
+}
+
+interface SpotifyArtist {
+  id: string;
+  name: string;
+  genres: string[];
+  popularity: number;
+  followers: { total: number };
+  images: SpotifyImage[];
+  external_urls: { spotify: string };
+}
+
+interface SpotifyPlaylist {
+  id: string;
+  name: string;
+  description: string;
+  public: boolean;
+  followers: { total: number };
+  owner: { id: string; display_name: string };
+  tracks: { total: number; items?: Array<{ track: SpotifyTrack | null }> };
+  images: SpotifyImage[];
+  external_urls: { spotify: string };
+}
+
+interface SpotifyAudioFeatures {
+  id: string;
+  danceability: number;
+  energy: number;
+  key: number;
+  loudness: number;
+  mode: number;
+  speechiness: number;
+  acousticness: number;
+  instrumentalness: number;
+  liveness: number;
+  valence: number;
+  tempo: number;
+  time_signature: number;
+  duration_ms: number;
+}
+
+interface SpotifySearchResult {
+  tracks?: { items: SpotifyTrack[]; total: number; next: string | null };
+  albums?: { items: SpotifyAlbum[]; total: number; next: string | null };
+  artists?: { items: SpotifyArtist[]; total: number; next: string | null };
+  playlists?: { items: SpotifyPlaylist[]; total: number; next: string | null };
+}
+
+// ─── API helper ───────────────────────────────────────────────────────────────
+
+async function spotifyGet<T>(token: string, path: string, params: Record<string, string> = {}): Promise<T> {
+  const qs = Object.keys(params).length > 0 ? `?${new URLSearchParams(params).toString()}` : "";
+  const res = await fetch(`${SPOTIFY_API_BASE}${path}${qs}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const data = await res.json() as Record<string, unknown>;
+  if (!res.ok) {
+    const err = data.error as Record<string, unknown> | undefined;
+    const msg = (err?.message as string) ?? `HTTP ${res.status}`;
+    const status = err?.status ? ` (${err.status})` : "";
+    throw new Error(`Spotify API error${status}: ${msg}`);
+  }
+  return data as T;
+}
+
+// ─── Auth validation ──────────────────────────────────────────────────────────
+
+function requireToken(args: Record<string, unknown>): string {
+  const token = String(args.bearer_token ?? "").trim();
+  if (!token) throw new Error("bearer_token is required. Obtain one via Spotify OAuth at developer.spotify.com.");
+  return token;
+}
+
+// ─── Operations ───────────────────────────────────────────────────────────────
+
+export async function spotifySearch(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  const q = String(args.query ?? "").trim();
+  if (!q) throw new Error("query is required.");
+  const type = String(args.type ?? "track");
+  const limit = Math.min(50, Math.max(1, Number(args.limit ?? 10)));
+  const offset = Math.max(0, Number(args.offset ?? 0));
+  const market = args.market ? String(args.market) : undefined;
+
+  const validTypes = ["track", "album", "artist", "playlist", "show", "episode"];
+  const requestedTypes = type.split(",").map((t) => t.trim());
+  const invalid = requestedTypes.filter((t) => !validTypes.includes(t));
+  if (invalid.length > 0) {
+    throw new Error(`Invalid type(s): ${invalid.join(", ")}. Valid: ${validTypes.join(", ")}.`);
+  }
+
+  const params: Record<string, string> = { q, type, limit: String(limit), offset: String(offset) };
+  if (market) params.market = market;
+
+  const data = await spotifyGet<SpotifySearchResult>(token, "/search", params);
+
+  const result: Record<string, unknown> = {};
+  if (data.tracks) {
+    result.tracks = {
+      total: data.tracks.total,
+      next: data.tracks.next,
+      items: data.tracks.items.map((t) => ({
+        id: t.id,
+        name: t.name,
+        artists: t.artists.map((a) => a.name),
+        album: t.album?.name,
+        duration_ms: t.duration_ms,
+        popularity: t.popularity,
+        preview_url: t.preview_url,
+        spotify_url: t.external_urls.spotify,
+      })),
+    };
+  }
+  if (data.albums) {
+    result.albums = {
+      total: data.albums.total,
+      next: data.albums.next,
+      items: data.albums.items.map((a) => ({
+        id: a.id,
+        name: a.name,
+        artists: a.artists.map((ar) => ar.name),
+        release_date: a.release_date,
+        total_tracks: a.total_tracks,
+        spotify_url: a.external_urls.spotify,
+      })),
+    };
+  }
+  if (data.artists) {
+    result.artists = {
+      total: data.artists.total,
+      next: data.artists.next,
+      items: data.artists.items.map((a) => ({
+        id: a.id,
+        name: a.name,
+        genres: a.genres,
+        popularity: a.popularity,
+        followers: a.followers.total,
+        spotify_url: a.external_urls.spotify,
+      })),
+    };
+  }
+  if (data.playlists) {
+    result.playlists = {
+      total: data.playlists.total,
+      next: data.playlists.next,
+      items: data.playlists.items.map((p) => ({
+        id: p.id,
+        name: p.name,
+        owner: p.owner.display_name,
+        tracks_total: p.tracks.total,
+        spotify_url: p.external_urls.spotify,
+      })),
+    };
+  }
+  return result;
+}
+
+export async function spotifyGetTrack(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  const trackId = String(args.track_id ?? "").trim();
+  if (!trackId) throw new Error("track_id is required.");
+
+  const params: Record<string, string> = {};
+  if (args.market) params.market = String(args.market);
+
+  const track = await spotifyGet<SpotifyTrack>(token, `/tracks/${encodeURIComponent(trackId)}`, params);
+  return {
+    id: track.id,
+    name: track.name,
+    artists: track.artists.map((a) => ({ id: a.id, name: a.name })),
+    album: track.album ? {
+      id: track.album.id,
+      name: track.album.name,
+      release_date: track.album.release_date,
+      type: track.album.album_type,
+    } : null,
+    duration_ms: track.duration_ms,
+    explicit: track.explicit,
+    popularity: track.popularity,
+    preview_url: track.preview_url,
+    track_number: track.track_number,
+    spotify_url: track.external_urls.spotify,
+  };
+}
+
+export async function spotifyGetAlbum(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  const albumId = String(args.album_id ?? "").trim();
+  if (!albumId) throw new Error("album_id is required.");
+
+  const album = await spotifyGet<SpotifyAlbum>(token, `/albums/${encodeURIComponent(albumId)}`);
+  return {
+    id: album.id,
+    name: album.name,
+    type: album.album_type,
+    release_date: album.release_date,
+    total_tracks: album.total_tracks,
+    artists: album.artists.map((a) => ({ id: a.id, name: a.name })),
+    label: album.label ?? null,
+    popularity: album.popularity ?? null,
+    genres: album.genres ?? [],
+    image: album.images[0]?.url ?? null,
+    spotify_url: album.external_urls.spotify,
+    tracks: album.tracks?.items.map((t) => ({
+      id: t.id,
+      name: t.name,
+      duration_ms: t.duration_ms,
+      track_number: t.track_number,
+    })) ?? [],
+  };
+}
+
+export async function spotifyGetArtist(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  const artistId = String(args.artist_id ?? "").trim();
+  if (!artistId) throw new Error("artist_id is required.");
+
+  const artist = await spotifyGet<SpotifyArtist>(token, `/artists/${encodeURIComponent(artistId)}`);
+  return {
+    id: artist.id,
+    name: artist.name,
+    genres: artist.genres,
+    popularity: artist.popularity,
+    followers: artist.followers.total,
+    image: artist.images[0]?.url ?? null,
+    spotify_url: artist.external_urls.spotify,
+  };
+}
+
+export async function spotifyGetPlaylist(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  const playlistId = String(args.playlist_id ?? "").trim();
+  if (!playlistId) throw new Error("playlist_id is required.");
+
+  const params: Record<string, string> = {};
+  if (args.market) params.market = String(args.market);
+
+  const pl = await spotifyGet<SpotifyPlaylist>(token, `/playlists/${encodeURIComponent(playlistId)}`, params);
+  return {
+    id: pl.id,
+    name: pl.name,
+    description: pl.description,
+    public: pl.public,
+    owner: pl.owner.display_name,
+    followers: pl.followers.total,
+    total_tracks: pl.tracks.total,
+    image: pl.images[0]?.url ?? null,
+    spotify_url: pl.external_urls.spotify,
+    tracks: (pl.tracks.items ?? [])
+      .filter((item) => item.track !== null)
+      .map((item) => ({
+        id: item.track!.id,
+        name: item.track!.name,
+        artists: item.track!.artists.map((a) => a.name),
+        duration_ms: item.track!.duration_ms,
+      })),
+  };
+}
+
+export async function spotifyGetRecommendations(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 20)));
+
+  const params: Record<string, string> = { limit: String(limit) };
+
+  // At least one seed is required
+  const seedTracks = String(args.seed_tracks ?? "").trim();
+  const seedArtists = String(args.seed_artists ?? "").trim();
+  const seedGenres = String(args.seed_genres ?? "").trim();
+
+  if (!seedTracks && !seedArtists && !seedGenres) {
+    throw new Error("At least one of seed_tracks, seed_artists, or seed_genres is required.");
+  }
+
+  if (seedTracks) params.seed_tracks = seedTracks;
+  if (seedArtists) params.seed_artists = seedArtists;
+  if (seedGenres) params.seed_genres = seedGenres;
+  if (args.market) params.market = String(args.market);
+  if (args.min_energy !== undefined) params.min_energy = String(args.min_energy);
+  if (args.max_energy !== undefined) params.max_energy = String(args.max_energy);
+  if (args.min_tempo !== undefined) params.min_tempo = String(args.min_tempo);
+  if (args.max_tempo !== undefined) params.max_tempo = String(args.max_tempo);
+  if (args.target_valence !== undefined) params.target_valence = String(args.target_valence);
+  if (args.target_danceability !== undefined) params.target_danceability = String(args.target_danceability);
+
+  const data = await spotifyGet<{ tracks: SpotifyTrack[] }>(token, "/recommendations", params);
+  return {
+    count: data.tracks.length,
+    tracks: data.tracks.map((t) => ({
+      id: t.id,
+      name: t.name,
+      artists: t.artists.map((a) => a.name),
+      album: t.album?.name ?? null,
+      duration_ms: t.duration_ms,
+      popularity: t.popularity,
+      preview_url: t.preview_url,
+      spotify_url: t.external_urls.spotify,
+    })),
+  };
+}
+
+export async function spotifyGetAudioFeatures(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  const trackId = String(args.track_id ?? "").trim();
+  if (!trackId) throw new Error("track_id is required.");
+
+  const features = await spotifyGet<SpotifyAudioFeatures>(token, `/audio-features/${encodeURIComponent(trackId)}`);
+  return {
+    id: features.id,
+    danceability: features.danceability,
+    energy: features.energy,
+    key: features.key,
+    loudness: features.loudness,
+    mode: features.mode,
+    speechiness: features.speechiness,
+    acousticness: features.acousticness,
+    instrumentalness: features.instrumentalness,
+    liveness: features.liveness,
+    valence: features.valence,
+    tempo: features.tempo,
+    time_signature: features.time_signature,
+    duration_ms: features.duration_ms,
+  };
+}

--- a/packages/standalone/spotify-mcp/tsconfig.json
+++ b/packages/standalone/spotify-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/tmdb-mcp/LICENSE
+++ b/packages/standalone/tmdb-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/tmdb-mcp/README.md
+++ b/packages/standalone/tmdb-mcp/README.md
@@ -1,0 +1,40 @@
+# TMDB MCP by UnClick
+
+Search movies and TV, with details, trending, now-playing, and recommendations from The Movie Database.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "tmdb": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/tmdb.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `tmdb_search_movies`
+- `tmdb_search_tv`
+- `tmdb_movie`
+- `tmdb_tv`
+- `tmdb_trending`
+- `tmdb_now_playing`
+- `tmdb_upcoming`
+- `tmdb_popular_tv`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/tmdb-mcp/package.json
+++ b/packages/standalone/tmdb-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/tmdb-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/tmdb",
+  "description": "Search movies and TV, with details, trending, now-playing, and recommendations from The Movie Database. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "tmdb",
+    "movies",
+    "tv",
+    "film"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "tmdb-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/tmdb-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/tmdb-mcp/server.json
+++ b/packages/standalone/tmdb-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/tmdb",
+  "title": "TMDB MCP by UnClick",
+  "description": "Search movies and TV, with details, trending, now-playing, and recommendations from The Movie Database. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/tmdb-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/tmdb-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/tmdb-mcp/src/index.ts
+++ b/packages/standalone/tmdb-mcp/src/index.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// TMDB MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  tmdbSearchMovies,
+  tmdbSearchTv,
+  tmdbMovie,
+  tmdbTv,
+  tmdbTrending,
+  tmdbNowPlaying,
+  tmdbUpcoming,
+  tmdbPopularTv,
+} from "./tmdb-tool.js";
+
+const TOOLS = [
+  {
+    name: "tmdb_search_movies",
+    description: "Search for movies on TMDB.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string" },
+        year: { type: "number" },
+        page: { type: "number" },
+        api_key: { type: "string" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "tmdb_search_tv",
+    description: "Search for TV shows on TMDB.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string" },
+        page: { type: "number" },
+        api_key: { type: "string" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "tmdb_movie",
+    description: "Get details for a TMDB movie by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "number" },
+        api_key: { type: "string" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "tmdb_tv",
+    description: "Get details for a TMDB TV show by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "number" },
+        api_key: { type: "string" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "tmdb_trending",
+    description: "Get trending movies or TV shows on TMDB.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        media_type: { type: "string", enum: ["movie", "tv", "all"], description: "movie, tv, or all" },
+        time_window: { type: "string", enum: ["day", "week"], description: "day or week" },
+        api_key: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "tmdb_now_playing",
+    description: "Get movies currently in theaters from TMDB.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        page: { type: "number" },
+        api_key: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "tmdb_upcoming",
+    description: "Get upcoming movies from TMDB.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        page: { type: "number" },
+        api_key: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "tmdb_popular_tv",
+    description: "Get popular TV shows from TMDB.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        page: { type: "number" },
+        api_key: { type: "string" },
+      },
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  tmdb_search_movies: (args) => tmdbSearchMovies(args as unknown as Parameters<typeof tmdbSearchMovies>[0]),
+  tmdb_search_tv: (args) => tmdbSearchTv(args as unknown as Parameters<typeof tmdbSearchTv>[0]),
+  tmdb_movie: (args) => tmdbMovie(args as unknown as Parameters<typeof tmdbMovie>[0]),
+  tmdb_tv: (args) => tmdbTv(args as unknown as Parameters<typeof tmdbTv>[0]),
+  tmdb_trending: (args) => tmdbTrending(args as unknown as Parameters<typeof tmdbTrending>[0]),
+  tmdb_now_playing: (args) => tmdbNowPlaying(args as unknown as Parameters<typeof tmdbNowPlaying>[0]),
+  tmdb_upcoming: (args) => tmdbUpcoming(args as unknown as Parameters<typeof tmdbUpcoming>[0]),
+  tmdb_popular_tv: (args) => tmdbPopularTv(args as unknown as Parameters<typeof tmdbPopularTv>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/tmdb", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[tmdb-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/tmdb-mcp/src/tmdb-tool.ts
+++ b/packages/standalone/tmdb-mcp/src/tmdb-tool.ts
@@ -1,0 +1,273 @@
+// The Movie Database (TMDB) API integration for the UnClick MCP server.
+// Uses the TMDB v3 REST API via fetch - no external dependencies.
+// Get a free API key at https://www.themoviedb.org/settings/api
+
+const TMDB_BASE = "https://api.themoviedb.org/3";
+
+// ─── API helper ──────────────────────────────────────────────────────────────
+
+function requireKey(args: Record<string, unknown>): string {
+  const key = String(args.api_key ?? process.env.TMDB_API_KEY ?? "").trim();
+  if (!key) {
+    throw new Error(
+      "api_key is required. Get a free key at https://www.themoviedb.org/settings/api"
+    );
+  }
+  return key;
+}
+
+async function tmdbFetch<T>(
+  path: string,
+  apiKey: string,
+  extra: Record<string, string> = {}
+): Promise<T> {
+  const url = new URL(`${TMDB_BASE}${path}`);
+  url.searchParams.set("api_key", apiKey);
+  for (const [k, v] of Object.entries(extra)) {
+    if (v !== undefined && v !== "") url.searchParams.set(k, v);
+  }
+  const res = await fetch(url.toString());
+  const body = (await res.json()) as Record<string, unknown>;
+  if (!res.ok) {
+    throw new Error(
+      `TMDB API HTTP ${res.status}: ${String(body.status_message ?? "Unknown error")}`
+    );
+  }
+  return body as T;
+}
+
+// ─── Normalizers ─────────────────────────────────────────────────────────────
+
+function normalizeMovie(m: Record<string, unknown>) {
+  return {
+    id: m.id,
+    title: m.title,
+    release_date: m.release_date ?? null,
+    overview: m.overview ?? null,
+    vote_average: m.vote_average ?? null,
+    vote_count: m.vote_count ?? null,
+    popularity: m.popularity ?? null,
+    poster_path: m.poster_path
+      ? `https://image.tmdb.org/t/p/w500${m.poster_path}`
+      : null,
+    genre_ids: m.genre_ids ?? null,
+  };
+}
+
+function normalizeTv(t: Record<string, unknown>) {
+  return {
+    id: t.id,
+    name: t.name,
+    first_air_date: t.first_air_date ?? null,
+    overview: t.overview ?? null,
+    vote_average: t.vote_average ?? null,
+    vote_count: t.vote_count ?? null,
+    popularity: t.popularity ?? null,
+    poster_path: t.poster_path
+      ? `https://image.tmdb.org/t/p/w500${t.poster_path}`
+      : null,
+    genre_ids: t.genre_ids ?? null,
+  };
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+export async function tmdbSearchMovies(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const query = String(args.query ?? "").trim();
+  if (!query) throw new Error("query is required.");
+
+  const extra: Record<string, string> = { query };
+  if (args.year) extra.year = String(args.year);
+
+  const data = await tmdbFetch<Record<string, unknown>>(
+    "/search/movie",
+    key,
+    extra
+  );
+  const results = (data.results as Record<string, unknown>[]) ?? [];
+
+  return {
+    total: data.total_results ?? 0,
+    pages: data.total_pages ?? 1,
+    results: results.map(normalizeMovie),
+  };
+}
+
+export async function tmdbSearchTv(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const query = String(args.query ?? "").trim();
+  if (!query) throw new Error("query is required.");
+
+  const data = await tmdbFetch<Record<string, unknown>>("/search/tv", key, {
+    query,
+  });
+  const results = (data.results as Record<string, unknown>[]) ?? [];
+
+  return {
+    total: data.total_results ?? 0,
+    pages: data.total_pages ?? 1,
+    results: results.map(normalizeTv),
+  };
+}
+
+export async function tmdbMovie(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const id = String(args.id ?? "").trim();
+  if (!id) throw new Error("id is required (TMDB movie ID).");
+
+  const data = await tmdbFetch<Record<string, unknown>>(
+    `/movie/${id}`,
+    key,
+    { append_to_response: "credits" }
+  );
+
+  const credits = (data.credits as Record<string, unknown>) ?? {};
+  const cast = (credits.cast as Record<string, unknown>[]) ?? [];
+
+  return {
+    id: data.id,
+    title: data.title,
+    tagline: data.tagline ?? null,
+    overview: data.overview ?? null,
+    release_date: data.release_date ?? null,
+    runtime: data.runtime ?? null,
+    status: data.status ?? null,
+    vote_average: data.vote_average ?? null,
+    vote_count: data.vote_count ?? null,
+    popularity: data.popularity ?? null,
+    budget: data.budget ?? null,
+    revenue: data.revenue ?? null,
+    genres: (data.genres as Record<string, unknown>[])?.map((g) => g.name) ?? [],
+    poster_path: data.poster_path
+      ? `https://image.tmdb.org/t/p/w500${data.poster_path}`
+      : null,
+    cast: cast.slice(0, 10).map((c) => ({
+      name: c.name,
+      character: c.character,
+      order: c.order,
+    })),
+  };
+}
+
+export async function tmdbTv(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const id = String(args.id ?? "").trim();
+  if (!id) throw new Error("id is required (TMDB TV show ID).");
+
+  const data = await tmdbFetch<Record<string, unknown>>(`/tv/${id}`, key, {
+    append_to_response: "credits",
+  });
+
+  const credits = (data.credits as Record<string, unknown>) ?? {};
+  const cast = (credits.cast as Record<string, unknown>[]) ?? [];
+
+  return {
+    id: data.id,
+    name: data.name,
+    tagline: data.tagline ?? null,
+    overview: data.overview ?? null,
+    first_air_date: data.first_air_date ?? null,
+    last_air_date: data.last_air_date ?? null,
+    number_of_seasons: data.number_of_seasons ?? null,
+    number_of_episodes: data.number_of_episodes ?? null,
+    status: data.status ?? null,
+    vote_average: data.vote_average ?? null,
+    vote_count: data.vote_count ?? null,
+    popularity: data.popularity ?? null,
+    genres: (data.genres as Record<string, unknown>[])?.map((g) => g.name) ?? [],
+    poster_path: data.poster_path
+      ? `https://image.tmdb.org/t/p/w500${data.poster_path}`
+      : null,
+    cast: cast.slice(0, 10).map((c) => ({
+      name: c.name,
+      character: c.character,
+      order: c.order,
+    })),
+  };
+}
+
+export async function tmdbTrending(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const mediaType = String(args.media_type ?? "all");
+  const timeWindow = String(args.time_window ?? "week");
+
+  const validMedia = ["movie", "tv", "all"];
+  const validWindow = ["day", "week"];
+  if (!validMedia.includes(mediaType)) {
+    throw new Error(`media_type must be one of: ${validMedia.join(", ")}`);
+  }
+  if (!validWindow.includes(timeWindow)) {
+    throw new Error(`time_window must be one of: ${validWindow.join(", ")}`);
+  }
+
+  const data = await tmdbFetch<Record<string, unknown>>(
+    `/trending/${mediaType}/${timeWindow}`,
+    key
+  );
+  const results = (data.results as Record<string, unknown>[]) ?? [];
+
+  return {
+    media_type: mediaType,
+    time_window: timeWindow,
+    total: data.total_results ?? 0,
+    results: results.map((r) =>
+      r.media_type === "tv" ? normalizeTv(r) : normalizeMovie(r)
+    ),
+  };
+}
+
+export async function tmdbNowPlaying(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const data = await tmdbFetch<Record<string, unknown>>(
+    "/movie/now_playing",
+    key
+  );
+  const results = (data.results as Record<string, unknown>[]) ?? [];
+
+  return {
+    total: data.total_results ?? 0,
+    results: results.map(normalizeMovie),
+  };
+}
+
+export async function tmdbUpcoming(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const data = await tmdbFetch<Record<string, unknown>>(
+    "/movie/upcoming",
+    key
+  );
+  const results = (data.results as Record<string, unknown>[]) ?? [];
+
+  return {
+    total: data.total_results ?? 0,
+    results: results.map(normalizeMovie),
+  };
+}
+
+export async function tmdbPopularTv(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const key = requireKey(args);
+  const data = await tmdbFetch<Record<string, unknown>>("/tv/popular", key);
+  const results = (data.results as Record<string, unknown>[]) ?? [];
+
+  return {
+    total: data.total_results ?? 0,
+    results: results.map(normalizeTv),
+  };
+}

--- a/packages/standalone/tmdb-mcp/tsconfig.json
+++ b/packages/standalone/tmdb-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/youtube-mcp/LICENSE
+++ b/packages/standalone/youtube-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/youtube-mcp/README.md
+++ b/packages/standalone/youtube-mcp/README.md
@@ -1,0 +1,38 @@
+# YouTube MCP by UnClick
+
+Search YouTube and get video, channel, playlist, and caption details.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "youtube": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/youtube.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `youtube_search`
+- `youtube_get_video`
+- `youtube_get_channel`
+- `youtube_list_playlists`
+- `youtube_list_playlist_items`
+- `youtube_get_captions`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/youtube-mcp/package.json
+++ b/packages/standalone/youtube-mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@unclick/youtube-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/youtube",
+  "description": "Search YouTube and get video, channel, playlist, and caption details. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "youtube",
+    "video",
+    "search",
+    "captions"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "youtube-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/youtube-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/youtube-mcp/server.json
+++ b/packages/standalone/youtube-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/youtube",
+  "title": "YouTube MCP by UnClick",
+  "description": "Search YouTube and get video, channel, playlist, and caption details. By UnClick (https://unclick.world).",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/youtube-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/youtube-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/youtube-mcp/src/index.ts
+++ b/packages/standalone/youtube-mcp/src/index.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// YouTube MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  youtubeSearch,
+  youtubeGetVideo,
+  youtubeGetChannel,
+  youtubeListPlaylists,
+  youtubeListPlaylistItems,
+  youtubeGetCaptions,
+} from "./youtube-tool.js";
+
+const TOOLS = [
+  {
+    name: "youtube_search",
+    description: "Search YouTube for videos, channels, or playlists.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        api_key: { type: "string" },
+        query: { type: "string" },
+        type: { type: "string", enum: ["video", "channel", "playlist"], description: "video, channel, or playlist (default: video)" },
+        max_results: { type: "number" },
+        order: { type: "string", description: "relevance, date, rating, viewCount, title" },
+        channel_id: { type: "string" },
+        published_after: { type: "string", description: "RFC 3339 datetime, e.g. 2024-01-01T00:00:00Z" },
+        region_code: { type: "string" },
+        page_token: { type: "string" },
+      },
+      required: ["api_key", "query"],
+    },
+  },
+  {
+    name: "youtube_get_video",
+    description: "Get metadata, statistics, and content details for a YouTube video.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        api_key: { type: "string" },
+        video_id: { type: "string" },
+      },
+      required: ["api_key", "video_id"],
+    },
+  },
+  {
+    name: "youtube_get_channel",
+    description: "Get metadata and statistics for a YouTube channel.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        api_key: { type: "string" },
+        channel_id: { type: "string" },
+        handle: { type: "string", description: "Channel handle without @ (alternative to channel_id)" },
+      },
+      required: ["api_key"],
+    },
+  },
+  {
+    name: "youtube_list_playlists",
+    description: "List playlists belonging to a YouTube channel.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        api_key: { type: "string" },
+        channel_id: { type: "string" },
+        max_results: { type: "number" },
+        page_token: { type: "string" },
+      },
+      required: ["api_key", "channel_id"],
+    },
+  },
+  {
+    name: "youtube_list_playlist_items",
+    description: "List videos in a YouTube playlist.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        api_key: { type: "string" },
+        playlist_id: { type: "string" },
+        max_results: { type: "number" },
+        page_token: { type: "string" },
+      },
+      required: ["api_key", "playlist_id"],
+    },
+  },
+  {
+    name: "youtube_get_captions",
+    description: "List available caption tracks for a YouTube video.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        api_key: { type: "string" },
+        video_id: { type: "string" },
+      },
+      required: ["api_key", "video_id"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  youtube_search: (args) => youtubeSearch(args as unknown as Parameters<typeof youtubeSearch>[0]),
+  youtube_get_video: (args) => youtubeGetVideo(args as unknown as Parameters<typeof youtubeGetVideo>[0]),
+  youtube_get_channel: (args) => youtubeGetChannel(args as unknown as Parameters<typeof youtubeGetChannel>[0]),
+  youtube_list_playlists: (args) => youtubeListPlaylists(args as unknown as Parameters<typeof youtubeListPlaylists>[0]),
+  youtube_list_playlist_items: (args) => youtubeListPlaylistItems(args as unknown as Parameters<typeof youtubeListPlaylistItems>[0]),
+  youtube_get_captions: (args) => youtubeGetCaptions(args as unknown as Parameters<typeof youtubeGetCaptions>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/youtube", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[youtube-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/youtube-mcp/src/youtube-tool.ts
+++ b/packages/standalone/youtube-mcp/src/youtube-tool.ts
@@ -1,0 +1,316 @@
+// YouTube Data API v3 integration for the UnClick MCP server.
+// Uses the YouTube Data API via fetch - no external dependencies.
+// Users must supply an API key from Google Cloud Console.
+
+const YT_API_BASE = "https://www.googleapis.com/youtube/v3";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface YtPageInfo {
+  totalResults: number;
+  resultsPerPage: number;
+}
+
+interface YtSearchItem {
+  kind: string;
+  etag: string;
+  id: { kind: string; videoId?: string; channelId?: string; playlistId?: string };
+  snippet: {
+    publishedAt: string;
+    channelId: string;
+    channelTitle: string;
+    title: string;
+    description: string;
+    thumbnails: Record<string, { url: string; width: number; height: number }>;
+    liveBroadcastContent: string;
+  };
+}
+
+interface YtVideo {
+  id: string;
+  snippet?: {
+    title: string;
+    description: string;
+    channelId: string;
+    channelTitle: string;
+    publishedAt: string;
+    tags?: string[];
+    categoryId?: string;
+  };
+  statistics?: {
+    viewCount?: string;
+    likeCount?: string;
+    commentCount?: string;
+  };
+  contentDetails?: {
+    duration: string;
+    dimension: string;
+    definition: string;
+  };
+}
+
+interface YtChannel {
+  id: string;
+  snippet?: {
+    title: string;
+    description: string;
+    customUrl?: string;
+    publishedAt: string;
+  };
+  statistics?: {
+    viewCount?: string;
+    subscriberCount?: string;
+    videoCount?: string;
+  };
+}
+
+interface YtPlaylist {
+  id: string;
+  snippet?: {
+    title: string;
+    description: string;
+    channelId: string;
+    channelTitle: string;
+    publishedAt: string;
+  };
+  contentDetails?: { itemCount: number };
+}
+
+interface YtPlaylistItem {
+  id: string;
+  snippet?: {
+    title: string;
+    description: string;
+    channelId: string;
+    videoOwnerChannelTitle?: string;
+    position: number;
+    resourceId: { kind: string; videoId: string };
+    publishedAt: string;
+  };
+}
+
+interface YtCaption {
+  id: string;
+  snippet: {
+    videoId: string;
+    lastUpdated: string;
+    trackKind: string;
+    language: string;
+    name: string;
+    audioTrackType: string;
+    isCC: boolean;
+    isLarge: boolean;
+    isEasyReader: boolean;
+    isDraft: boolean;
+    isAutoSynced: boolean;
+    status: string;
+  };
+}
+
+// ─── API helper ───────────────────────────────────────────────────────────────
+
+async function ytGet<T>(apiKey: string, endpoint: string, params: Record<string, string>): Promise<T> {
+  const query = new URLSearchParams({ ...params, key: apiKey }).toString();
+  const res = await fetch(`${YT_API_BASE}/${endpoint}?${query}`);
+
+  const data = await res.json() as Record<string, unknown>;
+  if (!res.ok) {
+    const err = data.error as Record<string, unknown> | undefined;
+    const msg = (err?.message as string) ?? `HTTP ${res.status}`;
+    const code = err?.code ? ` (code ${err.code})` : "";
+    throw new Error(`YouTube API error${code}: ${msg}`);
+  }
+  return data as T;
+}
+
+// ─── Auth validation ──────────────────────────────────────────────────────────
+
+function requireKey(args: Record<string, unknown>): string {
+  const key = String(args.api_key ?? "").trim();
+  if (!key) throw new Error("api_key is required. Create one at console.cloud.google.com.");
+  return key;
+}
+
+// ─── Operations ───────────────────────────────────────────────────────────────
+
+export async function youtubeSearch(args: Record<string, unknown>): Promise<unknown> {
+  const apiKey = requireKey(args);
+  const q = String(args.query ?? "").trim();
+  if (!q) throw new Error("query is required.");
+  const maxResults = Math.min(50, Math.max(1, Number(args.max_results ?? 10)));
+  const type = String(args.type ?? "video");
+
+  const params: Record<string, string> = {
+    part: "snippet",
+    q,
+    type,
+    maxResults: String(maxResults),
+  };
+  if (args.order) params.order = String(args.order);
+  if (args.published_after) params.publishedAfter = String(args.published_after);
+  if (args.region_code) params.regionCode = String(args.region_code);
+  if (args.page_token) params.pageToken = String(args.page_token);
+  if (args.channel_id) params.channelId = String(args.channel_id);
+
+  const data = await ytGet<{ items: YtSearchItem[]; nextPageToken?: string; pageInfo: YtPageInfo }>(
+    apiKey, "search", params
+  );
+
+  return {
+    total_results: data.pageInfo.totalResults,
+    next_page_token: data.nextPageToken ?? null,
+    items: (data.items ?? []).map((item) => ({
+      kind: item.id.kind,
+      id: item.id.videoId ?? item.id.channelId ?? item.id.playlistId,
+      title: item.snippet.title,
+      description: item.snippet.description,
+      channel_id: item.snippet.channelId,
+      channel_title: item.snippet.channelTitle,
+      published_at: item.snippet.publishedAt,
+      thumbnail: item.snippet.thumbnails?.medium?.url ?? item.snippet.thumbnails?.default?.url ?? null,
+      live_broadcast: item.snippet.liveBroadcastContent,
+    })),
+  };
+}
+
+export async function youtubeGetVideo(args: Record<string, unknown>): Promise<unknown> {
+  const apiKey = requireKey(args);
+  const videoId = String(args.video_id ?? "").trim();
+  if (!videoId) throw new Error("video_id is required.");
+
+  const data = await ytGet<{ items: YtVideo[] }>(apiKey, "videos", {
+    part: "snippet,statistics,contentDetails",
+    id: videoId,
+  });
+
+  const video = data.items?.[0];
+  if (!video) throw new Error(`Video not found: ${videoId}`);
+
+  return {
+    id: video.id,
+    title: video.snippet?.title ?? null,
+    description: video.snippet?.description ?? null,
+    channel_id: video.snippet?.channelId ?? null,
+    channel_title: video.snippet?.channelTitle ?? null,
+    published_at: video.snippet?.publishedAt ?? null,
+    tags: video.snippet?.tags ?? [],
+    duration: video.contentDetails?.duration ?? null,
+    definition: video.contentDetails?.definition ?? null,
+    view_count: video.statistics?.viewCount ?? null,
+    like_count: video.statistics?.likeCount ?? null,
+    comment_count: video.statistics?.commentCount ?? null,
+  };
+}
+
+export async function youtubeGetChannel(args: Record<string, unknown>): Promise<unknown> {
+  const apiKey = requireKey(args);
+  const channelId = String(args.channel_id ?? "").trim();
+  const forHandle = String(args.handle ?? "").trim();
+  if (!channelId && !forHandle) throw new Error("Either channel_id or handle is required.");
+
+  const params: Record<string, string> = { part: "snippet,statistics" };
+  if (channelId) params.id = channelId;
+  if (forHandle) params.forHandle = forHandle.startsWith("@") ? forHandle.slice(1) : forHandle;
+
+  const data = await ytGet<{ items: YtChannel[] }>(apiKey, "channels", params);
+  const channel = data.items?.[0];
+  if (!channel) throw new Error("Channel not found.");
+
+  return {
+    id: channel.id,
+    title: channel.snippet?.title ?? null,
+    description: channel.snippet?.description ?? null,
+    custom_url: channel.snippet?.customUrl ?? null,
+    published_at: channel.snippet?.publishedAt ?? null,
+    subscriber_count: channel.statistics?.subscriberCount ?? null,
+    video_count: channel.statistics?.videoCount ?? null,
+    view_count: channel.statistics?.viewCount ?? null,
+  };
+}
+
+export async function youtubeListPlaylists(args: Record<string, unknown>): Promise<unknown> {
+  const apiKey = requireKey(args);
+  const channelId = String(args.channel_id ?? "").trim();
+  if (!channelId) throw new Error("channel_id is required.");
+  const maxResults = Math.min(50, Math.max(1, Number(args.max_results ?? 20)));
+
+  const params: Record<string, string> = {
+    part: "snippet,contentDetails",
+    channelId,
+    maxResults: String(maxResults),
+  };
+  if (args.page_token) params.pageToken = String(args.page_token);
+
+  const data = await ytGet<{ items: YtPlaylist[]; nextPageToken?: string; pageInfo: YtPageInfo }>(
+    apiKey, "playlists", params
+  );
+
+  return {
+    total_results: data.pageInfo.totalResults,
+    next_page_token: data.nextPageToken ?? null,
+    playlists: (data.items ?? []).map((pl) => ({
+      id: pl.id,
+      title: pl.snippet?.title ?? null,
+      description: pl.snippet?.description ?? null,
+      channel_id: pl.snippet?.channelId ?? null,
+      channel_title: pl.snippet?.channelTitle ?? null,
+      published_at: pl.snippet?.publishedAt ?? null,
+      item_count: pl.contentDetails?.itemCount ?? null,
+    })),
+  };
+}
+
+export async function youtubeListPlaylistItems(args: Record<string, unknown>): Promise<unknown> {
+  const apiKey = requireKey(args);
+  const playlistId = String(args.playlist_id ?? "").trim();
+  if (!playlistId) throw new Error("playlist_id is required.");
+  const maxResults = Math.min(50, Math.max(1, Number(args.max_results ?? 20)));
+
+  const params: Record<string, string> = {
+    part: "snippet",
+    playlistId,
+    maxResults: String(maxResults),
+  };
+  if (args.page_token) params.pageToken = String(args.page_token);
+
+  const data = await ytGet<{ items: YtPlaylistItem[]; nextPageToken?: string; pageInfo: YtPageInfo }>(
+    apiKey, "playlistItems", params
+  );
+
+  return {
+    total_results: data.pageInfo.totalResults,
+    next_page_token: data.nextPageToken ?? null,
+    items: (data.items ?? []).map((item) => ({
+      id: item.id,
+      title: item.snippet?.title ?? null,
+      video_id: item.snippet?.resourceId.videoId ?? null,
+      position: item.snippet?.position ?? null,
+      published_at: item.snippet?.publishedAt ?? null,
+    })),
+  };
+}
+
+export async function youtubeGetCaptions(args: Record<string, unknown>): Promise<unknown> {
+  const apiKey = requireKey(args);
+  const videoId = String(args.video_id ?? "").trim();
+  if (!videoId) throw new Error("video_id is required.");
+
+  const data = await ytGet<{ items: YtCaption[] }>(apiKey, "captions", {
+    part: "snippet",
+    videoId,
+  });
+
+  return {
+    count: (data.items ?? []).length,
+    captions: (data.items ?? []).map((c) => ({
+      id: c.id,
+      language: c.snippet.language,
+      name: c.snippet.name,
+      track_kind: c.snippet.trackKind,
+      is_cc: c.snippet.isCC,
+      is_auto_synced: c.snippet.isAutoSynced,
+      status: c.snippet.status,
+      last_updated: c.snippet.lastUpdated,
+    })),
+  };
+}

--- a/packages/standalone/youtube-mcp/tsconfig.json
+++ b/packages/standalone/youtube-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
Adds a second batch of standalone MCP servers under `packages/standalone/`, generated by `scripts/generate-standalone-mcp.mjs` from existing UnClick connectors. These are higher-traffic / broad-appeal connectors (vs the niche first batch):

| Package | Registry name | Tools | Key needed? |
|---------|---------------|------:|-------------|
| `@unclick/openmeteo-mcp` | io.github.malamutemayhem/openmeteo | 3 | no |
| `@unclick/coingecko-mcp` | …/coingecko | 6 | no |
| `@unclick/hackernews-mcp` | …/hackernews | 7 | no |
| `@unclick/tmdb-mcp` | …/tmdb | 8 | key |
| `@unclick/nasa-mcp` | …/nasa | 5 | demo key ok |
| `@unclick/restcountries-mcp` | …/restcountries | 6 | no |
| `@unclick/openlibrary-mcp` | …/openlibrary | 6 | no |
| `@unclick/spotify-mcp` | …/spotify | 7 | key |
| `@unclick/youtube-mcp` | …/youtube | 6 | key |
| `@unclick/reddit-mcp` | …/reddit | 7 | key |

Generator change: handler calls now use a universal safe arg cast (`args as unknown as Parameters<typeof fn>[0]`) so connectors with typed function signatures (reddit, tmdb, spotify, youtube) compile as standalone packages. Verified `reddit`, `tmdb`, and `openmeteo` build with `tsc`.

On merge to main, the existing publish workflow ships each as a GitHub release tarball (and to npm if `NPM_TOKEN` can publish headless).

Note: several of these (Spotify, Reddit, YouTube, weather) have existing third-party MCPs, so they are parity/family plays rather than first-mover, unlike the niche first batch.

https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive surface with third-party API and OAuth/write paths (Reddit, Spotify, YouTube); generator/schema mismatches on some tools could break standalone calls until aligned with monorepo wiring.
> 
> **Overview**
> Adds **10 new publishable standalone MCP packages** under `packages/standalone/` (Open-Meteo, CoinGecko, Hacker News, TMDB, NASA, REST Countries, Open Library, Spotify, YouTube, Reddit), each with copied tool logic, stdio server entrypoint, `server.json`, README, and license—wired for the existing GitHub tarball / npm publish flow.
> 
> Extends `generate-standalone-mcp.mjs` with a **“popular batch”** metadata block for those slugs and updates generation so handler wiring uses a **typed safe cast** and a looser handler regex, so connectors with non-trivial TypeScript signatures still emit compilable standalone servers.
> 
> Regenerates **UnClick brainmap** docs to register the new packages (inventory +10, modules count 80→90).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb2ee9a4b57b4cf1db09501ca8d1d2a06cac3f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->