### PR TITLE
Wire tool-index brain into live unclick_search (intent routing for all 803 tools)

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -13,6 +13,7 @@ import { crewsStartRun } from "./crews-tool.js";
 import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
 import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
+import { searchToolIndex } from "./memory/tool-awareness.js";
 import { emitSignal } from "./signals/emit.js";
 import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
 import { getCommonSensePassProtocol } from "./commonsensepass-protocol.js";
@@ -2250,26 +2251,38 @@ export function createServer(): Server {
 
       // ── Meta tools ──────────────────────────────────────────────
       if (name === "unclick_search") {
-        const results = searchTools(
-          String(args.query ?? ""),
-          args.category as string | undefined
-        );
-        if (results.length === 0) {
+        const query = String(args.query ?? "");
+        const results = searchTools(query, args.category as string | undefined);
+        // Also search the full integration surface (803+ tools) with intent/alias
+        // routing, so "next train" finds ptv_search, "bitcoin price" finds crypto.
+        const toolHits = query ? searchToolIndex(query, 10) : [];
+
+        if (results.length === 0 && toolHits.length === 0) {
           return {
             content: [
               {
                 type: "text",
-                text: `No tools found matching "${args.query}". Try unclick_browse to see all available tools.`,
+                text: `No tools found matching "${query}". Try unclick_browse to see all available tools.`,
               },
             ],
           };
         }
-        const text = results.map(formatToolSummary).join("\n\n---\n\n");
+
+        const sections: string[] = [];
+        if (toolHits.length > 0) {
+          const lines = toolHits
+            .map((h) => `- **${h.name}** (${h.app}) -- ${h.description}`)
+            .join("\n");
+          sections.push(`Integration tools (call directly by name, or via unclick_call):\n${lines}`);
+        }
+        if (results.length > 0) {
+          sections.push(`Built-in catalog tools:\n\n${results.map(formatToolSummary).join("\n\n---\n\n")}`);
+        }
         return {
           content: [
             {
               type: "text",
-              text: `Found ${results.length} tool(s) matching "${args.query}":\n\n${text}`,
+              text: `Found ${toolHits.length + results.length} tool(s) matching "${query}":\n\n${sections.join("\n\n")}`,
             },
           ],
         };


### PR DESCRIPTION
Switches the tool-discovery brain on for real.

`unclick_search` previously searched only the ~21 built-in `CATALOG` utilities, so an agent searching "ptv", "train", "stripe", or "weather" found **nothing** — even though those 803 integration tools are advertised and callable. It now **also** runs `searchToolIndex` (intent + alias routing) over the full integration surface and lists those hits first.

Result, live via `unclick_search`:
- "next train" → `ptv_search`, `ptv_departures`
- "bitcoin price" → `crypto_price`
- "send a slack message" → `slack_action`
- "create a github issue" → `github_action`

Built-in catalog utilities still appear below the integration hits. Typecheck clean; capability/server-manifest/advertised-tools suites pass.

This completes the discovery loop: self-updating index (merged) → boot capability map (merged) → **live `unclick_search` routing (this PR)**.

https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-handler change to an internal meta tool; read-only search with no auth or data-path changes.
> 
> **Overview**
> **`unclick_search`** now searches the full integration tool index (intent/alias routing via `searchToolIndex`), not only the small built-in `CATALOG`. Agents can discover tools like PTV, crypto, Slack, or GitHub from natural-language queries that previously returned no matches.
> 
> Responses list **integration tools** first (name, app, description, callable by name or `unclick_call`), then **built-in catalog** hits. Empty results and match counts reflect both sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461a0aefbaea1d27139d1ef02db89f78cf669f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->