### PR TITLE
Plant flags: publish standalone MCPs to the official MCP registry (discoverability)

### DIFF
--- a/.github/workflows/publish-standalone-mcps.yml
+++ b/.github/workflows/publish-standalone-mcps.yml
@@ -1,13 +1,18 @@
 name: Publish standalone MCPs
 
-# Publishes the standalone niche MCP servers in packages/standalone/*-mcp two ways:
+# Publishes the standalone niche MCP servers in packages/standalone/*-mcp three ways:
 #   1. GitHub release tarballs (always; npm-free, GITHUB_TOKEN only).
 #   2. npm packages (only if the NPM_TOKEN secret is set; skipped otherwise).
-# Both are idempotent: a version already published is skipped, so re-runs are safe.
+#   3. The official MCP registry (registry.modelcontextprotocol.io) via GitHub
+#      OIDC, so they are discoverable in the MCP directories. Runs only after
+#      npm publish, since the registry validates the npm package.
+# All idempotent: an already-published version is skipped, so re-runs are safe.
 #
-# Runs automatically when packages/standalone/** lands on main. To publish to npm,
-# add repo secret NPM_TOKEN (a granular automation token with write access to the
-# @unclick scope). No secret = tarball-only, still fully working.
+# Runs automatically when packages/standalone/** lands on main.
+#
+# IMPORTANT for npm + registry: NPM_TOKEN must be able to publish headlessly,
+# i.e. a granular token with "Bypass 2FA" enabled (or an automation token).
+# A token that still requires a 2FA OTP will fail in CI (tarballs still publish).
 
 on:
   push:
@@ -36,6 +41,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Build, pack, and (if NPM_TOKEN set) publish to npm
+        id: pub
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -62,7 +68,7 @@ jobs:
                   echo "npm: $name@$version already published, skipping"
                 else
                   # Non-fatal: a token/2FA problem must not block the tarball path.
-                  if npm publish --access public; then
+                  if npm publish --access public --provenance; then
                     echo "npm: published $name@$version"
                   else
                     echo "::warning::npm publish failed for $name@$version (token/2FA?). Tarball still published."
@@ -75,6 +81,8 @@ jobs:
             echo "::endgroup::"
           done
           echo "Packed tarballs:"; ls -1 ../release-artifacts/*.tgz
+          # Registry publish is only meaningful once the npm packages exist.
+          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then echo "registry_eligible=true" >> "$GITHUB_OUTPUT"; fi
 
       - name: Upload tarballs to rolling GitHub release
         run: |
@@ -92,3 +100,30 @@ jobs:
           done
           gh release edit "$ROLLING_TAG" --title "$title" --notes "$notes"
           echo "Published tarballs to release ${ROLLING_TAG}."
+
+      - name: Publish to the official MCP registry (GitHub OIDC)
+        # Lands each standalone in registry.modelcontextprotocol.io so it is
+        # discoverable in the MCP directories. Uses GitHub OIDC for the
+        # io.github.malamutemayhem/* namespace (no token needed for the registry).
+        # Runs only after npm publish, since the registry validates the npm package.
+        if: ${{ steps.pub.outputs.registry_eligible == 'true' }}
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher; then
+            echo "::warning::could not download mcp-publisher; skipping registry publish"; exit 0
+          fi
+          sudo mv mcp-publisher /usr/local/bin/mcp-publisher
+          if ! mcp-publisher login github-oidc; then
+            echo "::warning::mcp-publisher OIDC login failed; skipping registry publish"; exit 0
+          fi
+          published=0
+          for dir in packages/standalone/*-mcp; do
+            [ -d "$dir" ] || continue
+            if ( cd "$dir" && mcp-publisher publish ); then
+              published=$((published+1)); echo "registry: published $dir"
+            else
+              echo "::warning::registry publish failed for $dir"
+            fi
+          done
+          echo "Registry publish attempted; $published succeeded."

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8197,8 +8197,8 @@
     },
     {
       "source": ".github/workflows/publish-standalone-mcps.yml",
-      "hash": "397d720ec57d",
-      "bytes": 4007
+      "hash": "af5014743384",
+      "bytes": 5953
     },
     {
       "source": ".github/workflows/review-enforcement-warning.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -193,7 +193,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/openhands-test-mode.yml | 9aaef5273976 | 1137 |
 | .github/workflows/publish-channel-package.yml | 5c9197848ca9 | 8046 |
 | .github/workflows/publish-mcp-package.yml | c029877aab11 | 6427 |
-| .github/workflows/publish-standalone-mcps.yml | 397d720ec57d | 4007 |
+| .github/workflows/publish-standalone-mcps.yml | af5014743384 | 5953 |
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
 | .github/workflows/scheduled-build-self-test.yml | 1362b535ff33 | 1024 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |


### PR DESCRIPTION
Completes the "plant the flags" pipeline so the standalone MCPs become discoverable, not just downloadable.

Adds a third publish target to the standalone workflow:
1. GitHub release tarballs (unchanged)
2. npm (unchanged, gated on NPM_TOKEN) — now with `--provenance`
3. **NEW: the official MCP registry** (`registry.modelcontextprotocol.io`) via `mcp-publisher` + GitHub OIDC, under the `io.github.malamutemayhem/*` namespace. This is what lists them in the MCP directories so AIs/users actually find them. Gated on npm publish (the registry validates the npm package) and `continue-on-error` so it can never block the tarball path.

**One human step still required to actually plant them:** `NPM_TOKEN` must be able to publish headlessly — a granular token with **"Bypass 2FA" enabled** (or an automation token). The current token had 2FA-bypass off, which is why npm has been skipping. Once the token can publish, a merge/run pushes all standalones to npm + the registry.

https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automated npm publishing and a new external registry integration; failures are mostly isolated from tarballs, but a misconfigured NPM_TOKEN or OIDC setup could still affect discoverability or publish outcomes.
> 
> **Overview**
> Extends the **standalone MCP publish** workflow with a **third distribution path**: after npm (when `NPM_TOKEN` is set), it runs **`mcp-publisher`** against **`registry.modelcontextprotocol.io`** using **GitHub OIDC**, so packages under `io.github.malamutemayhem/*` can show up in MCP directories. That step is **`continue-on-error`**, only runs when npm is eligible, and warns instead of failing the job if download, OIDC login, or per-package publish fails—**tarball releases stay the primary safe path**.
> 
> npm publishes now use **`--provenance`**, and workflow comments call out that **`NPM_TOKEN` must publish headlessly** (automation token or granular token with **Bypass 2FA**). The build/publish step is **`id: pub`** and sets **`registry_eligible`** when a token is present.
> 
> Generated **brainmap** metadata for `.github/workflows/publish-standalone-mcps.yml` is refreshed to match the larger workflow file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b690d2811a4f0e956b70e608b0ab18241b6c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->