### PR TITLE
Classify tool failures (bug pipeline foundation)

### DIFF
--- a/packages/mcp-server/src/__tests__/tool-failure-class.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-failure-class.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyFailure } from "../tool-failure-class.js";
+
+describe("classifyFailure", () => {
+  it("flags upstream API errors as owner-actionable", () => {
+    const c = classifyFailure("weather_current: HTTP 503 service unavailable");
+    expect(c.failureClass).toBe("upstream");
+    expect(c.ownerActionable).toBe(true);
+  });
+
+  it("flags our own exceptions as tool_bug (critical)", () => {
+    const c = classifyFailure("foo_tool: Cannot read properties of undefined (reading 'id')");
+    expect(c.failureClass).toBe("tool_bug");
+    expect(c.ownerActionable).toBe(true);
+    expect(c.severity).toBe("critical");
+  });
+
+  it("treats auth problems as user-side config", () => {
+    const c = classifyFailure("stripe_charges: HTTP 401 unauthorized");
+    expect(c.failureClass).toBe("auth_config");
+    expect(c.ownerActionable).toBe(false);
+  });
+
+  it("treats timeouts and rate limits as transient", () => {
+    expect(classifyFailure("x: request timed out").failureClass).toBe("transient");
+    expect(classifyFailure("y: 429 rate limit exceeded").failureClass).toBe("transient");
+  });
+
+  it("treats missing args as usage", () => {
+    const c = classifyFailure("ptv_departures: stop_id is required.");
+    expect(c.failureClass).toBe("usage");
+    expect(c.ownerActionable).toBe(false);
+  });
+
+  it("defaults unknown failures to owner-actionable so nothing is missed", () => {
+    const c = classifyFailure("weird_tool: something went sideways");
+    expect(c.failureClass).toBe("unknown");
+    expect(c.ownerActionable).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -14,6 +14,7 @@ import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
 import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
 import { searchToolIndex } from "./memory/tool-awareness.js";
+import { classifyFailure } from "./tool-failure-class.js";
 import { emitSignal } from "./signals/emit.js";
 import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
 import { getCommonSensePassProtocol } from "./commonsensepass-protocol.js";
@@ -183,14 +184,19 @@ function signalToolFailure(toolName: string, result: unknown, args?: unknown): v
   const apiKeyHash = currentApiKeyHash();
   const summary = failureSummary(toolName, result);
   if (!apiKeyHash || !summary) return;
+  const cls = classifyFailure(summary);
   void emitSignal({
     apiKeyHash,
     tool: toolName,
     action: "failed",
-    severity: "action_needed",
+    severity: cls.severity,
     summary: summary.slice(0, 500),
     deepLink: signalDeepLink(toolName),
-    payload: signalPayload(toolName, args),
+    payload: {
+      ...signalPayload(toolName, args),
+      failure_class: cls.failureClass,
+      owner_actionable: cls.ownerActionable,
+    },
   });
 }
 

--- a/packages/mcp-server/src/tool-failure-class.ts
+++ b/packages/mcp-server/src/tool-failure-class.ts
@@ -1,0 +1,53 @@
+// tool-failure-class.ts
+// Classifies a tool failure so the bug pipeline can tell apart problems UnClick
+// must fix (tool_bug, upstream, unknown) from user/transient issues (auth_config,
+// usage, transient). Drives severity on the emitted signal and lets the admin
+// "bugs" view filter for owner-actionable failures.
+
+export type FailureClass =
+  | "tool_bug"      // our wrapper is broken (exceptions, bad parsing, schema/impl drift)
+  | "upstream"      // the third-party API failed (5xx, unavailable)
+  | "auth_config"   // missing or invalid credentials / config
+  | "usage"         // caller supplied bad or missing arguments
+  | "transient"     // timeout, network blip, rate limit
+  | "unknown";
+
+export interface FailureClassification {
+  failureClass: FailureClass;
+  /** True when this is UnClick's problem to fix or monitor (surface to the owner). */
+  ownerActionable: boolean;
+  severity: "info" | "warning" | "action_needed" | "critical";
+}
+
+export function classifyFailure(summary: string): FailureClassification {
+  const s = summary.toLowerCase();
+
+  // transient first: timeouts, network, rate limits
+  if (/\b(timeout|timed out|etimedout|econnreset|econnrefused|enotfound|network|fetch failed|429)\b/.test(s) || /rate.?limit/.test(s)) {
+    return { failureClass: "transient", ownerActionable: false, severity: "info" };
+  }
+
+  // auth / config: missing or invalid credentials
+  if (/\b(unauthori[sz]ed|forbidden|401|403|invalid (api )?key|invalid token)\b/.test(s) ||
+      /\b(api[_ ]?key|access[_ ]?token|secret|credentials?)\b.*\b(required|missing|not set|invalid)\b/.test(s) ||
+      /\b(env(ironment)? var|not set)\b/.test(s)) {
+    return { failureClass: "auth_config", ownerActionable: false, severity: "action_needed" };
+  }
+
+  // upstream: the external API is down or erroring server-side
+  if (/\b(500|502|503|504|bad gateway|service unavailable|upstream|server error)\b/.test(s)) {
+    return { failureClass: "upstream", ownerActionable: true, severity: "warning" };
+  }
+
+  // tool_bug: signs our own code broke
+  if (/cannot read|undefined is not|is not a function|typeerror|unexpected token|cannot convert|reading '|is not iterable/.test(s)) {
+    return { failureClass: "tool_bug", ownerActionable: true, severity: "critical" };
+  }
+
+  // usage: bad or missing arguments (caller side; schema/impl drift is caught pre-ship)
+  if (/\b(required|invalid|must be|expected|unknown (param|argument|field)|bad request|400)\b/.test(s)) {
+    return { failureClass: "usage", ownerActionable: false, severity: "action_needed" };
+  }
+
+  return { failureClass: "unknown", ownerActionable: true, severity: "warning" };
+}

--- a/packages/mcp-server/src/tool-failure-class.ts
+++ b/packages/mcp-server/src/tool-failure-class.ts
@@ -16,7 +16,8 @@ export interface FailureClassification {
   failureClass: FailureClass;
   /** True when this is UnClick's problem to fix or monitor (surface to the owner). */
   ownerActionable: boolean;
-  severity: "info" | "warning" | "action_needed" | "critical";
+  /** Matches the signal system's severity enum. */
+  severity: "info" | "action_needed" | "critical";
 }
 
 export function classifyFailure(summary: string): FailureClassification {
@@ -36,7 +37,7 @@ export function classifyFailure(summary: string): FailureClassification {
 
   // upstream: the external API is down or erroring server-side
   if (/\b(500|502|503|504|bad gateway|service unavailable|upstream|server error)\b/.test(s)) {
-    return { failureClass: "upstream", ownerActionable: true, severity: "warning" };
+    return { failureClass: "upstream", ownerActionable: true, severity: "action_needed" };
   }
 
   // tool_bug: signs our own code broke
@@ -49,5 +50,5 @@ export function classifyFailure(summary: string): FailureClassification {
     return { failureClass: "usage", ownerActionable: false, severity: "action_needed" };
   }
 
-  return { failureClass: "unknown", ownerActionable: true, severity: "warning" };
+  return { failureClass: "unknown", ownerActionable: true, severity: "action_needed" };
 }


### PR DESCRIPTION
Foundation for the system-wide bug pipeline.

Every tool failure is already signalled on all dispatch paths via `signalToolFailure`. This adds `classifyFailure` so each failure is tagged:
- **tool_bug** (our wrapper broke — exceptions/parsing) — critical, owner-actionable
- **upstream** (third-party API 5xx) — owner-actionable
- **unknown** — owner-actionable (so nothing slips through)
- **auth_config** / **usage** / **transient** — user-side or transient, not owner bugs

The classification + an `owner_actionable` flag + a meaningful severity are attached to the emitted signal payload (no DB change), so the admin "bugs" view can filter for the failures UnClick must actually fix vs user/transient noise.

tsc clean; classifier unit-tested (6 cases). Next steps: route owner-actionable failures into the Yellow Admin Bugs area + alerting.

https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss)_