### PR TITLE
Route tool failures into bug reports

### DIFF
--- a/api/report-bug.ts
+++ b/api/report-bug.ts
@@ -85,6 +85,21 @@ function classifySeverity(errorMessage: string, requestPayload?: unknown): strin
   return "medium";
 }
 
+function normalizeAgentContext(agentContext: unknown): string | null {
+  if (!agentContext) return null;
+  if (typeof agentContext === "string") return agentContext;
+  try {
+    return JSON.stringify(agentContext);
+  } catch {
+    return String(agentContext);
+  }
+}
+
+function normalizeSeverity(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  return ["critical", "high", "medium", "low"].includes(value) ? value : fallback;
+}
+
 // ---------------------------------------------------------------------------
 // Email notification via Resend
 // ---------------------------------------------------------------------------
@@ -160,7 +175,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const { tool_name, error_message, request_payload, expected_behavior, agent_context } =
+  const { tool_name, error_message, request_payload, expected_behavior, agent_context, notify, severity: requested_severity } =
     req.body ?? {};
 
   if (!tool_name || !error_message) {
@@ -174,7 +189,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const rawApiKey = authHeader || bodyApiKey;
   const apiKeyHash = rawApiKey ? sha256hex(rawApiKey) : null;
 
-  const severity = classifySeverity(String(error_message), request_payload);
+  const severity = normalizeSeverity(requested_severity, classifySeverity(String(error_message), request_payload));
+  const normalizedAgentContext = normalizeAgentContext(agent_context);
 
   // ---------------------------------------------------------------------------
   // Supabase write
@@ -204,7 +220,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       error_message: String(error_message),
       request_payload: request_payload ?? null,
       expected_behavior: expected_behavior ? String(expected_behavior) : null,
-      agent_context: agent_context ? String(agent_context) : null,
+      agent_context: normalizedAgentContext,
       severity,
       status: "open",
       api_key_hash: apiKeyHash,
@@ -218,14 +234,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   // Await the email so Vercel doesn't terminate before the request completes
-  await sendBugEmail({
-    tool_name: String(tool_name),
-    error_message: String(error_message),
-    severity,
-    expected_behavior: expected_behavior ? String(expected_behavior) : undefined,
-    agent_context: agent_context ? String(agent_context) : undefined,
-    created_at: data.created_at ?? new Date().toISOString(),
-  });
+  if (notify !== false) {
+    await sendBugEmail({
+      tool_name: String(tool_name),
+      error_message: String(error_message),
+      severity,
+      expected_behavior: expected_behavior ? String(expected_behavior) : undefined,
+      agent_context: normalizedAgentContext ?? undefined,
+      created_at: data.created_at ?? new Date().toISOString(),
+    });
+  }
 
   return res.status(201).json({
     ...data,

--- a/apps/api/src/routes/report-bug.ts
+++ b/apps/api/src/routes/report-bug.ts
@@ -63,6 +63,7 @@ const ReportBugSchema = z.object({
   expected_behavior: z.string().max(2000).optional(),
   severity: z.enum(SEVERITY_VALUES).optional(),
   agent_context: z.record(z.unknown()).optional(),
+  notify: z.boolean().optional().default(true),
 });
 
 // ---------------------------------------------------------------------------
@@ -146,14 +147,16 @@ export function createReportBugRouter(db: Db) {
     const createdAt = (report.createdAt as Date).toISOString();
 
     // Fire-and-forget email - don't block the response
-    sendBugEmail({
-      tool_name: report.toolName,
-      error_message: report.errorMessage,
-      severity,
-      expected_behavior: report.expectedBehavior,
-      agent_context: report.agentContext,
-      created_at: createdAt,
-    });
+    if (body.notify !== false) {
+      sendBugEmail({
+        tool_name: report.toolName,
+        error_message: report.errorMessage,
+        severity,
+        expected_behavior: report.expectedBehavior,
+        agent_context: report.agentContext,
+        created_at: createdAt,
+      });
+    }
 
     return created(c, {
       report_id: report.id,

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7617,8 +7617,8 @@
     },
     {
       "source": "src/pages/admin/AdminSettings.tsx",
-      "hash": "ede6df5d0e86",
-      "bytes": 38095
+      "hash": "cce2a4ca6248",
+      "bytes": 40580
     },
     {
       "source": "src/pages/MemorySetupGuide.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -77,7 +77,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminModeration.tsx | c81500ffb43d | 880 |
 | src/pages/admin/AdminOrchestrator.tsx | 4741f71afba9 | 94705 |
 | src/pages/admin/AdminPinballWake.tsx | 1b09a0b4c1b4 | 21751 |
-| src/pages/admin/AdminSettings.tsx | ede6df5d0e86 | 38095 |
+| src/pages/admin/AdminSettings.tsx | cce2a4ca6248 | 40580 |
 | src/pages/MemorySetupGuide.tsx | 79f83645f7c9 | 10264 |
 | src/pages/admin/signals/SignalsSettings.tsx | 791cd433a5b0 | 9837 |
 | src/pages/admin/signals/SignalsCatalog.tsx | 7baa82ac0d7f | 10835 |

--- a/packages/mcp-server/src/__tests__/tool-failure-class.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-failure-class.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyFailure } from "../tool-failure-class.js";
+
+describe("classifyFailure", () => {
+  it("flags upstream API errors as owner-actionable", () => {
+    const c = classifyFailure("weather_current: HTTP 503 service unavailable");
+    expect(c.failureClass).toBe("upstream");
+    expect(c.ownerActionable).toBe(true);
+  });
+
+  it("flags our own exceptions as tool_bug (critical)", () => {
+    const c = classifyFailure("foo_tool: Cannot read properties of undefined (reading 'id')");
+    expect(c.failureClass).toBe("tool_bug");
+    expect(c.ownerActionable).toBe(true);
+    expect(c.severity).toBe("critical");
+  });
+
+  it("treats auth problems as user-side config", () => {
+    const c = classifyFailure("stripe_charges: HTTP 401 unauthorized");
+    expect(c.failureClass).toBe("auth_config");
+    expect(c.ownerActionable).toBe(false);
+  });
+
+  it("treats timeouts and rate limits as transient", () => {
+    expect(classifyFailure("x: request timed out").failureClass).toBe("transient");
+    expect(classifyFailure("y: 429 rate limit exceeded").failureClass).toBe("transient");
+  });
+
+  it("treats missing args as usage", () => {
+    const c = classifyFailure("ptv_departures: stop_id is required.");
+    expect(c.failureClass).toBe("usage");
+    expect(c.ownerActionable).toBe(false);
+  });
+
+  it("defaults unknown failures to owner-actionable so nothing is missed", () => {
+    const c = classifyFailure("weird_tool: something went sideways");
+    expect(c.failureClass).toBe("unknown");
+    expect(c.ownerActionable).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/__tests__/tool-failure-report.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-failure-report.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildToolFailureBugReport,
+  shouldAutoReportFailure,
+} from "../tool-failure-report.js";
+import type { FailureClassification } from "../tool-failure-class.js";
+
+const toolBug: FailureClassification = {
+  failureClass: "tool_bug",
+  ownerActionable: true,
+  severity: "critical",
+};
+
+const usage: FailureClassification = {
+  failureClass: "usage",
+  ownerActionable: false,
+  severity: "action_needed",
+};
+
+describe("tool failure bug reporter", () => {
+  it("builds dashboard-only bug reports for owner-actionable failures", () => {
+    const report = buildToolFailureBugReport(
+      "ptv_search",
+      "ptv_search: Cannot read properties of undefined",
+      toolBug,
+      { query: "Brighton Beach", api_key: "secret" },
+    );
+
+    expect(report).toMatchObject({
+      tool_name: "ptv_search",
+      severity: "critical",
+      notify: false,
+    });
+    expect(report.request_payload).toMatchObject({
+      failure_class: "tool_bug",
+      owner_actionable: true,
+      args: {
+        query: "Brighton Beach",
+        api_key: "[redacted]",
+      },
+    });
+  });
+
+  it("does not auto-report user-side usage failures", () => {
+    expect(shouldAutoReportFailure("ptv_departures", "stop_id is required", usage, 1_000)).toBe(false);
+  });
+
+  it("throttles duplicate owner-actionable reports", () => {
+    expect(shouldAutoReportFailure("x", "same failure", toolBug, 1_000)).toBe(true);
+    expect(shouldAutoReportFailure("x", "same failure", toolBug, 1_001)).toBe(false);
+    expect(shouldAutoReportFailure("x", "same failure", toolBug, 16 * 60 * 1_000)).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -14,6 +14,7 @@ import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
 import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
 import { searchToolIndex } from "./memory/tool-awareness.js";
+import { classifyFailure } from "./tool-failure-class.js";
 import { emitSignal } from "./signals/emit.js";
 import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
 import { getCommonSensePassProtocol } from "./commonsensepass-protocol.js";
@@ -183,14 +184,19 @@ function signalToolFailure(toolName: string, result: unknown, args?: unknown): v
   const apiKeyHash = currentApiKeyHash();
   const summary = failureSummary(toolName, result);
   if (!apiKeyHash || !summary) return;
+  const cls = classifyFailure(summary);
   void emitSignal({
     apiKeyHash,
     tool: toolName,
     action: "failed",
-    severity: "action_needed",
+    severity: cls.severity,
     summary: summary.slice(0, 500),
     deepLink: signalDeepLink(toolName),
-    payload: signalPayload(toolName, args),
+    payload: {
+      ...signalPayload(toolName, args),
+      failure_class: cls.failureClass,
+      owner_actionable: cls.ownerActionable,
+    },
   });
 }
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -15,6 +15,7 @@ import { MEMORY_HANDLERS } from "./memory/handlers.js";
 import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
 import { searchToolIndex } from "./memory/tool-awareness.js";
 import { classifyFailure } from "./tool-failure-class.js";
+import { reportToolFailureBug } from "./tool-failure-report.js";
 import { emitSignal } from "./signals/emit.js";
 import { getHeartbeatProtocol } from "./heartbeat-protocol.js";
 import { getCommonSensePassProtocol } from "./commonsensepass-protocol.js";
@@ -185,13 +186,14 @@ function signalToolFailure(toolName: string, result: unknown, args?: unknown): v
   const summary = failureSummary(toolName, result);
   if (!apiKeyHash || !summary) return;
   const cls = classifyFailure(summary);
+  reportToolFailureBug(toolName, summary, cls, args);
   void emitSignal({
     apiKeyHash,
     tool: toolName,
     action: "failed",
     severity: cls.severity,
     summary: summary.slice(0, 500),
-    deepLink: signalDeepLink(toolName),
+    deepLink: cls.ownerActionable ? "/admin/settings#bugs" : signalDeepLink(toolName),
     payload: {
       ...signalPayload(toolName, args),
       failure_class: cls.failureClass,
@@ -2379,6 +2381,7 @@ export function createServer(): Server {
           if (memHandler) {
             recordToolCall(op);
             const result = await memHandler(params);
+            signalToolFailure(endpointId, result, params);
             return {
               content: [{ type: "text", text: memoryToolText(op, result) }],
             };
@@ -2389,6 +2392,7 @@ export function createServer(): Server {
         const localHandler = LOCAL_CATALOG_HANDLERS[endpointId];
         if (localHandler) {
           const result = await localHandler(params);
+          signalToolFailure(endpointId, result, params);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           };
@@ -2524,15 +2528,22 @@ export function createServer(): Server {
         message = String(err);
       }
       const apiKeyHash = currentApiKeyHash();
+      const summary = `${name}: ${message}`;
       if (apiKeyHash) {
+        const cls = classifyFailure(summary);
+        reportToolFailureBug(name, summary, cls, args);
         void emitSignal({
           apiKeyHash,
           tool: name,
           action: "exception",
-          severity: "action_needed",
-          summary: `${name}: ${message}`.slice(0, 500),
-          deepLink: signalDeepLink(name),
-          payload: signalPayload(name, args),
+          severity: cls.severity,
+          summary: summary.slice(0, 500),
+          deepLink: cls.ownerActionable ? "/admin/settings#bugs" : signalDeepLink(name),
+          payload: {
+            ...signalPayload(name, args),
+            failure_class: cls.failureClass,
+            owner_actionable: cls.ownerActionable,
+          },
         });
       }
       return {

--- a/packages/mcp-server/src/tool-failure-class.ts
+++ b/packages/mcp-server/src/tool-failure-class.ts
@@ -1,0 +1,53 @@
+// tool-failure-class.ts
+// Classifies a tool failure so the bug pipeline can tell apart problems UnClick
+// must fix (tool_bug, upstream, unknown) from user/transient issues (auth_config,
+// usage, transient). Drives severity on the emitted signal and lets the admin
+// "bugs" view filter for owner-actionable failures.
+
+export type FailureClass =
+  | "tool_bug"      // our wrapper is broken (exceptions, bad parsing, schema/impl drift)
+  | "upstream"      // the third-party API failed (5xx, unavailable)
+  | "auth_config"   // missing or invalid credentials / config
+  | "usage"         // caller supplied bad or missing arguments
+  | "transient"     // timeout, network blip, rate limit
+  | "unknown";
+
+export interface FailureClassification {
+  failureClass: FailureClass;
+  /** True when this is UnClick's problem to fix or monitor (surface to the owner). */
+  ownerActionable: boolean;
+  severity: "info" | "warning" | "action_needed" | "critical";
+}
+
+export function classifyFailure(summary: string): FailureClassification {
+  const s = summary.toLowerCase();
+
+  // transient first: timeouts, network, rate limits
+  if (/\b(timeout|timed out|etimedout|econnreset|econnrefused|enotfound|network|fetch failed|429)\b/.test(s) || /rate.?limit/.test(s)) {
+    return { failureClass: "transient", ownerActionable: false, severity: "info" };
+  }
+
+  // auth / config: missing or invalid credentials
+  if (/\b(unauthori[sz]ed|forbidden|401|403|invalid (api )?key|invalid token)\b/.test(s) ||
+      /\b(api[_ ]?key|access[_ ]?token|secret|credentials?)\b.*\b(required|missing|not set|invalid)\b/.test(s) ||
+      /\b(env(ironment)? var|not set)\b/.test(s)) {
+    return { failureClass: "auth_config", ownerActionable: false, severity: "action_needed" };
+  }
+
+  // upstream: the external API is down or erroring server-side
+  if (/\b(500|502|503|504|bad gateway|service unavailable|upstream|server error)\b/.test(s)) {
+    return { failureClass: "upstream", ownerActionable: true, severity: "warning" };
+  }
+
+  // tool_bug: signs our own code broke
+  if (/cannot read|undefined is not|is not a function|typeerror|unexpected token|cannot convert|reading '|is not iterable/.test(s)) {
+    return { failureClass: "tool_bug", ownerActionable: true, severity: "critical" };
+  }
+
+  // usage: bad or missing arguments (caller side; schema/impl drift is caught pre-ship)
+  if (/\b(required|invalid|must be|expected|unknown (param|argument|field)|bad request|400)\b/.test(s)) {
+    return { failureClass: "usage", ownerActionable: false, severity: "action_needed" };
+  }
+
+  return { failureClass: "unknown", ownerActionable: true, severity: "warning" };
+}

--- a/packages/mcp-server/src/tool-failure-class.ts
+++ b/packages/mcp-server/src/tool-failure-class.ts
@@ -16,7 +16,8 @@ export interface FailureClassification {
   failureClass: FailureClass;
   /** True when this is UnClick's problem to fix or monitor (surface to the owner). */
   ownerActionable: boolean;
-  severity: "info" | "warning" | "action_needed" | "critical";
+  /** Matches the signal system's severity enum. */
+  severity: "info" | "action_needed" | "critical";
 }
 
 export function classifyFailure(summary: string): FailureClassification {
@@ -36,7 +37,7 @@ export function classifyFailure(summary: string): FailureClassification {
 
   // upstream: the external API is down or erroring server-side
   if (/\b(500|502|503|504|bad gateway|service unavailable|upstream|server error)\b/.test(s)) {
-    return { failureClass: "upstream", ownerActionable: true, severity: "warning" };
+    return { failureClass: "upstream", ownerActionable: true, severity: "action_needed" };
   }
 
   // tool_bug: signs our own code broke
@@ -49,5 +50,5 @@ export function classifyFailure(summary: string): FailureClassification {
     return { failureClass: "usage", ownerActionable: false, severity: "action_needed" };
   }
 
-  return { failureClass: "unknown", ownerActionable: true, severity: "warning" };
+  return { failureClass: "unknown", ownerActionable: true, severity: "action_needed" };
 }

--- a/packages/mcp-server/src/tool-failure-report.ts
+++ b/packages/mcp-server/src/tool-failure-report.ts
@@ -1,0 +1,77 @@
+import { createClient } from "./client.js";
+import type { FailureClassification } from "./tool-failure-class.js";
+
+type BugSeverity = "low" | "medium" | "high" | "critical";
+
+const REPORT_THROTTLE_MS = 15 * 60 * 1000;
+const recentReports = new Map<string, number>();
+
+function bugSeverity(cls: FailureClassification): BugSeverity {
+  if (cls.severity === "critical") return "critical";
+  if (cls.failureClass === "upstream") return "high";
+  if (cls.failureClass === "unknown") return "medium";
+  return "medium";
+}
+
+function compactArgs(args: unknown): Record<string, unknown> {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return {};
+  const record = args as Record<string, unknown>;
+  const compact: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (/key|token|secret|password|credential/i.test(key)) {
+      compact[key] = "[redacted]";
+    } else if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
+      compact[key] = value;
+    } else {
+      compact[key] = "[complex]";
+    }
+  }
+  return compact;
+}
+
+export function shouldAutoReportFailure(toolName: string, summary: string, cls: FailureClassification, now = Date.now()): boolean {
+  if (!cls.ownerActionable) return false;
+  const key = `${toolName}:${cls.failureClass}:${summary.slice(0, 240)}`;
+  const last = recentReports.get(key) ?? 0;
+  if (last > 0 && now - last < REPORT_THROTTLE_MS) return false;
+  recentReports.set(key, now);
+  return true;
+}
+
+export function buildToolFailureBugReport(
+  toolName: string,
+  summary: string,
+  cls: FailureClassification,
+  args?: unknown,
+): Record<string, unknown> {
+  return {
+    tool_name: toolName,
+    error_message: summary.slice(0, 4000),
+    request_payload: {
+      source: "mcp-server:auto-tool-failure",
+      failure_class: cls.failureClass,
+      owner_actionable: cls.ownerActionable,
+      args: compactArgs(args),
+    },
+    expected_behavior: "Tool call should complete successfully or return a clean, actionable user-facing error.",
+    severity: bugSeverity(cls),
+    agent_context: {
+      source: "mcp-server",
+      auto_reported: true,
+      notification_channel: "dashboard-log-only",
+    },
+    notify: false,
+  };
+}
+
+export function reportToolFailureBug(toolName: string, summary: string, cls: FailureClassification, args?: unknown): void {
+  if (!shouldAutoReportFailure(toolName, summary, cls)) return;
+  try {
+    const client = createClient();
+    void client.call("POST", "/v1/report-bug", buildToolFailureBugReport(toolName, summary, cls, args)).catch(() => {
+      // Fire-and-forget. The signal path still records the failure if bug intake is unavailable.
+    });
+  } catch {
+    // Never let bug reporting affect the user's tool result.
+  }
+}

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -69,6 +69,16 @@ interface GeneratedConfigResponse {
   generated_at: string;
 }
 
+interface BugReport {
+  id: string;
+  tool_name: string;
+  error_message: string;
+  severity: "low" | "medium" | "high" | "critical" | string;
+  status: string;
+  created_at: string;
+  updated_at?: string | null;
+}
+
 function getStoredPlatform(): Platform {
   try {
     const v = localStorage.getItem(PLATFORM_STORAGE);
@@ -120,6 +130,8 @@ export default function AdminSettings() {
   const [generating, setGenerating] = useState(false);
 
   const [howToCheckOpen, setHowToCheckOpen] = useState(false);
+  const [bugReports, setBugReports] = useState<BugReport[]>([]);
+  const [bugReportsError, setBugReportsError] = useState<string | null>(null);
 
   const [deleteOpen, setDeleteOpen]   = useState(false);
   const [deleteTyped, setDeleteTyped] = useState("");
@@ -173,10 +185,11 @@ export default function AdminSettings() {
     (async () => {
       const authHeader = { Authorization: `Bearer ${effectiveToken}` };
       try {
-        const [connRes, settingsRes, bcRes] = await Promise.all([
+        const [connRes, settingsRes, bcRes, bugsRes] = await Promise.all([
           fetch("/api/memory-admin?action=admin_check_connection", { headers: authHeader }),
           fetch("/api/memory-admin?action=tenant_settings_get", { headers: authHeader }),
           fetch("/api/memory-admin?action=business_context"),
+          fetch("/api/memory-admin?action=admin_bug_reports&limit=5", { headers: authHeader }),
         ]);
         if (!cancelled && connRes.ok) {
           setConnection((await connRes.json()) as ConnectionStatus);
@@ -195,6 +208,16 @@ export default function AdminSettings() {
         if (!cancelled && bcRes.ok) {
           const body = (await bcRes.json()) as { data: BusinessContextEntry[] };
           setBusinessContext(body.data ?? []);
+        }
+        if (!cancelled) {
+          if (bugsRes.ok) {
+            const body = (await bugsRes.json()) as { data?: BugReport[] };
+            setBugReports(body.data ?? []);
+            setBugReportsError(null);
+          } else {
+            const body = (await bugsRes.json().catch(() => ({}))) as { error?: string };
+            setBugReportsError(body.error ?? `Bug log request failed (${bugsRes.status})`);
+          }
         }
       } catch (err) {
         if (!cancelled) {
@@ -807,29 +830,61 @@ export default function AdminSettings() {
         </section>
 
         {/* SUPPORT */}
-        <section className="rounded-xl border border-white/[0.06] bg-[#111111] p-6">
-          <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
-            <Bug className="h-4 w-4 text-white/40" />
-            Support
-          </h2>
-          <p className="mt-1 text-xs text-white/60">Found something off? Let us know.</p>
+        <section id="bugs" className="rounded-xl border border-[#E2B93B]/20 bg-[#111111] p-6">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+                <Bug className="h-4 w-4 text-[#E2B93B]" />
+                Bugs
+              </h2>
+              <p className="mt-1 text-xs text-white/60">
+                Tool failures that need UnClick attention are filed here automatically.
+              </p>
+            </div>
+            <Link
+              to="/admin/signals"
+              className="rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:border-[#61C1C4]/40 hover:text-white"
+            >
+              Open signals
+            </Link>
+          </div>
+
+          {bugReportsError ? (
+            <p className="mt-4 rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+              {bugReportsError}
+            </p>
+          ) : bugReports.length === 0 ? (
+            <p className="mt-4 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-xs text-white/50">
+              No bug reports logged for this account yet.
+            </p>
+          ) : (
+            <div className="mt-4 divide-y divide-white/[0.06] overflow-hidden rounded-lg border border-white/[0.06]">
+              {bugReports.map((report) => (
+                <div key={report.id} className="bg-white/[0.02] px-3 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-xs font-semibold text-white/90">{report.tool_name}</p>
+                      <p className="mt-1 break-words text-xs text-white/55">{report.error_message}</p>
+                    </div>
+                    <span className="shrink-0 rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-2 py-0.5 text-[11px] font-semibold text-[#E2B93B]">
+                      {report.severity}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-white/35">
+                    <span>{report.status}</span>
+                    <span>{formatRelative(report.created_at)}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="mt-4 flex flex-wrap gap-2">
-            <a
-              href="https://github.com/anthropics/claude-code/issues/new"
-              target="_blank"
-              rel="noreferrer"
+            <Link
+              to="/admin/signals"
               className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:border-[#61C1C4]/40 hover:text-white"
             >
-              Report a bug
-            </a>
-            <a
-              href="https://github.com/anthropics/claude-code/issues"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:border-[#61C1C4]/40 hover:text-white"
-            >
-              View submitted bugs
-            </a>
+              View live log
+            </Link>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- classify MCP tool failures as tool_bug, upstream, auth_config, usage, transient, or unknown
- auto-file owner-actionable failures into bug_reports with notify:false so they stay dashboard/log only
- keep mc_signals emission for every captured failure and link owner-actionable signals to /admin/settings#bugs
- add a Bugs panel on Admin Settings showing the latest scoped bug reports

## Verification
- npm run test --workspace=@unclick/mcp-server
- npm run test --workspace=apps/api
- npm run build
- npm run test:brainmap
- npx tsc --noEmit
- npx eslint api/report-bug.ts apps/api/src/routes/report-bug.ts packages/mcp-server/src/server.ts packages/mcp-server/src/tool-failure-class.ts packages/mcp-server/src/tool-failure-report.ts packages/mcp-server/src/__tests__/tool-failure-report.test.ts src/pages/admin/AdminSettings.tsx

Note: full npm run lint still fails on pre-existing errors in packages/mcp-server/src/flowpass-runtime.ts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP failure handling and dual bug-report endpoints (persistence + optional email); misclassification could spam the dashboard or miss real incidents, but `notify: false` limits email noise.
> 
> **Overview**
> **MCP tool failures** are now classified (`tool_bug`, `upstream`, `auth_config`, `usage`, `transient`, `unknown`) and **owner-actionable** ones are auto-filed to `POST /v1/report-bug` with **`notify: false`** (dashboard-only, throttled ~15m). Signals still fire on failures, with severity from classification and owner-actionable deep links to **`/admin/settings#bugs`**. Failure signaling also runs on memory/local catalog tool paths and on handler exceptions.
> 
> **Bug intake** on both Vercel and Hono accepts optional **`severity`** and **`notify`** (skip email when `notify === false`), and normalizes **`agent_context`** (object or string).
> 
> **Admin Settings** replaces generic support links with a **Bugs** section (`#bugs`) that loads recent scoped bug reports via `admin_bug_reports`.
> 
> New unit tests cover classification, report building, and auto-report throttling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc2f235fb2d74a614c6f850e1e437b7c29a8186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->