### PR TITLE
Harden standalone MCP registry publishing

### DIFF
--- a/.github/workflows/publish-standalone-mcps.yml
+++ b/.github/workflows/publish-standalone-mcps.yml
@@ -48,6 +48,8 @@ jobs:
           set -euo pipefail
           mkdir -p ../release-artifacts
           rm -f ../release-artifacts/*.tgz || true
+          npm_ready_file="$GITHUB_WORKSPACE/../release-artifacts/npm-ready-packages.txt"
+          : > "$npm_ready_file"
           npm_published=0; npm_skipped=0
           for dir in packages/standalone/*-mcp; do
             [ -d "$dir" ] || continue
@@ -64,14 +66,24 @@ jobs:
               cp "$GITHUB_WORKSPACE/../release-artifacts/$packed" "$GITHUB_WORKSPACE/../release-artifacts/$slug.tgz"
               # 2) npm publish, only when a token is present and version is new
               if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+                npm_ready=false
                 if npm view "$name@$version" version >/dev/null 2>&1; then
                   echo "npm: $name@$version already published, skipping"
+                  npm_ready=true
                 else
                   # Non-fatal: a token/2FA problem must not block the tarball path.
                   if npm publish --access public --provenance; then
                     echo "npm: published $name@$version"
+                    npm_ready=true
                   else
                     echo "::warning::npm publish failed for $name@$version (token/2FA?). Tarball still published."
+                  fi
+                fi
+                if [ "$npm_ready" = true ]; then
+                  if npm view "$name@$version" version >/dev/null 2>&1; then
+                    echo "$dir" >> "$npm_ready_file"
+                  else
+                    echo "::warning::npm did not confirm $name@$version yet; skipping registry publish for this package"
                   fi
                 fi
               else
@@ -82,7 +94,12 @@ jobs:
           done
           echo "Packed tarballs:"; ls -1 ../release-artifacts/*.tgz
           # Registry publish is only meaningful once the npm packages exist.
-          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then echo "registry_eligible=true" >> "$GITHUB_OUTPUT"; fi
+          if [ -s "$npm_ready_file" ]; then
+            echo "registry_eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "registry_eligible=false" >> "$GITHUB_OUTPUT"
+            echo "No npm-confirmed packages; skipping registry publish."
+          fi
 
       - name: Upload tarballs to rolling GitHub release
         run: |
@@ -118,12 +135,20 @@ jobs:
             echo "::warning::mcp-publisher OIDC login failed; skipping registry publish"; exit 0
           fi
           published=0
-          for dir in packages/standalone/*-mcp; do
-            [ -d "$dir" ] || continue
+          ready_file="../release-artifacts/npm-ready-packages.txt"
+          while IFS= read -r dir; do
+            [ -n "$dir" ] || continue
+            [ -d "$dir" ] || { echo "::warning::registry package directory missing: $dir"; continue; }
+            name=$(node -p "require('./$dir/package.json').name")
+            version=$(node -p "require('./$dir/package.json').version")
+            if ! npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "::warning::registry skipped for $dir because $name@$version is not visible on npm"
+              continue
+            fi
             if ( cd "$dir" && mcp-publisher publish ); then
               published=$((published+1)); echo "registry: published $dir"
             else
               echo "::warning::registry publish failed for $dir"
             fi
-          done
+          done < "$ready_file"
           echo "Registry publish attempted; $published succeeded."

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8317,8 +8317,8 @@
     },
     {
       "source": ".github/workflows/publish-standalone-mcps.yml",
-      "hash": "af5014743384",
-      "bytes": 5953
+      "hash": "ddd200e03a08",
+      "bytes": 7228
     },
     {
       "source": ".github/workflows/review-enforcement-warning.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -193,7 +193,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/openhands-test-mode.yml | 9aaef5273976 | 1137 |
 | .github/workflows/publish-channel-package.yml | 5c9197848ca9 | 8046 |
 | .github/workflows/publish-mcp-package.yml | c029877aab11 | 6427 |
-| .github/workflows/publish-standalone-mcps.yml | af5014743384 | 5953 |
+| .github/workflows/publish-standalone-mcps.yml | ddd200e03a08 | 7228 |
 | .github/workflows/review-enforcement-warning.yml | 64b27fdddfe8 | 548 |
 | .github/workflows/scheduled-build-self-test.yml | 1362b535ff33 | 1024 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -22,7 +22,7 @@
     "build": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && tsc",
     "dev": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && tsx --test src/memory/__tests__/typed-links.test.ts src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts src/memory/__tests__/response-bounds.test.ts src/memory/__tests__/load-memory-invalidation.test.ts src/memory/__tests__/snapshot-taxonomy.test.ts src/memory/__tests__/local-backend.test.ts && vitest run && node scripts/generate-tool-index.mjs --check",
+    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && tsx --test src/memory/__tests__/typed-links.test.ts src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts src/memory/__tests__/response-bounds.test.ts src/memory/__tests__/load-memory-invalidation.test.ts src/memory/__tests__/snapshot-taxonomy.test.ts src/memory/__tests__/local-backend.test.ts && vitest run && node scripts/generate-tool-index.mjs --check && node scripts/check-standalone-registry.mjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/mcp-server/scripts/check-standalone-registry.mjs
+++ b/packages/mcp-server/scripts/check-standalone-registry.mjs
@@ -1,0 +1,55 @@
+// Validates generated standalone MCP registry manifests before CI publishes them.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STANDALONE_ROOT = path.resolve(__dirname, "../../standalone");
+const MAX_DESCRIPTION_LENGTH = 100;
+
+const failures = [];
+
+for (const entry of fs.readdirSync(STANDALONE_ROOT, { withFileTypes: true })) {
+  if (!entry.isDirectory() || !entry.name.endsWith("-mcp")) continue;
+
+  const dir = path.join(STANDALONE_ROOT, entry.name);
+  const serverPath = path.join(dir, "server.json");
+  const packagePath = path.join(dir, "package.json");
+
+  if (!fs.existsSync(serverPath)) {
+    failures.push(`${entry.name}: missing server.json`);
+    continue;
+  }
+  if (!fs.existsSync(packagePath)) {
+    failures.push(`${entry.name}: missing package.json`);
+    continue;
+  }
+
+  const server = JSON.parse(fs.readFileSync(serverPath, "utf8"));
+  const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  const description = String(server.description ?? "");
+
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    failures.push(`${entry.name}: server.json description is ${description.length} chars, max ${MAX_DESCRIPTION_LENGTH}`);
+  }
+
+  const npmPackage = server.packages?.find((item) => item?.registryType === "npm");
+  if (!npmPackage) {
+    failures.push(`${entry.name}: server.json missing npm package entry`);
+  } else if (npmPackage.identifier !== pkg.name) {
+    failures.push(`${entry.name}: server.json npm identifier ${npmPackage.identifier} does not match package.json ${pkg.name}`);
+  }
+
+  if (pkg.mcpName !== server.name) {
+    failures.push(`${entry.name}: package.json mcpName ${pkg.mcpName} does not match server.json ${server.name}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Standalone registry validation failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Standalone registry manifests are valid.");

--- a/packages/mcp-server/scripts/generate-standalone-mcp.mjs
+++ b/packages/mcp-server/scripts/generate-standalone-mcp.mjs
@@ -31,6 +31,7 @@ const NAMESPACE = "io.github.malamutemayhem";        // verified registry namesp
 const VERSION = "0.1.0";
 const FUNNEL = "By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world";
 const ICON = "https://unclick.world/favicon.png";
+const MAX_REGISTRY_DESCRIPTION = 100;
 
 // ─── The top-10 must-have standalones (open niches, we are first) ──────────────
 // keywords feed the registry/README so the server is found for its own term.
@@ -125,6 +126,22 @@ function write(file, content) {
   fs.writeFileSync(file, content);
 }
 
+function trimRegistryDescription(cfg) {
+  const title = cfg.title.replace(/\s+MCP$/i, "");
+  const keywordText = cfg.keywords.slice(0, 3).join(", ");
+  const candidates = [
+    `${cfg.blurb} By UnClick.`,
+    `${title} tools for ${keywordText} by UnClick.`,
+    `${title} MCP by UnClick.`,
+  ].map((text) => text.replace(/\s+/g, " ").trim());
+
+  const fit = candidates.find((text) => text.length <= MAX_REGISTRY_DESCRIPTION);
+  if (fit) return fit;
+
+  const fallback = candidates.at(-1) ?? "Standalone MCP by UnClick.";
+  return fallback.slice(0, MAX_REGISTRY_DESCRIPTION - 3).replace(/\s+\S*$/, "") + "...";
+}
+
 function generate(slug) {
   const cfg = CONFIG[slug];
   if (!cfg) throw new Error(`no config for slug: ${slug}`);
@@ -144,6 +161,7 @@ function generate(slug) {
   const outDir = path.join(OUT_ROOT, `${slug}-mcp`);
   const regName = `${NAMESPACE}/${slug}`;
   const pkgName = `@unclick/${slug}-mcp`;
+  const registryDescription = trimRegistryDescription(cfg);
 
   // index.ts — a minimal MCP stdio server exposing just this connector
   const index = `#!/usr/bin/env node
@@ -235,7 +253,7 @@ main().catch((err) => {
     $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     name: regName,
     title: `${cfg.title} by UnClick`,
-    description: `${cfg.blurb} By UnClick (https://unclick.world).`,
+    description: registryDescription,
     version: VERSION,
     websiteUrl: "https://unclick.world",
     icons: [{ src: ICON, mimeType: "image/png", sizes: ["512x512"] }],

--- a/packages/standalone/amber-mcp/server.json
+++ b/packages/standalone/amber-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/amber",
   "title": "Amber Electric MCP by UnClick",
-  "description": "Real-time Australian electricity spot prices and renewables data from Amber Electric. By UnClick (https://unclick.world).",
+  "description": "Real-time Australian electricity spot prices and renewables data from Amber Electric. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/amber-mcp/src/index.ts
+++ b/packages/standalone/amber-mcp/src/index.ts
@@ -56,9 +56,9 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  amber_sites: (args) => getAmberSites(args),
-  amber_current_price: (args) => getAmberCurrentPrice(args),
-  amber_forecast: (args) => getAmberForecast(args),
+  amber_sites: (args) => getAmberSites(args as unknown as Parameters<typeof getAmberSites>[0]),
+  amber_current_price: (args) => getAmberCurrentPrice(args as unknown as Parameters<typeof getAmberCurrentPrice>[0]),
+  amber_forecast: (args) => getAmberForecast(args as unknown as Parameters<typeof getAmberForecast>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/australiapost-mcp/server.json
+++ b/packages/standalone/australiapost-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/australiapost",
   "title": "Australia Post MCP by UnClick",
-  "description": "Australia Post parcel tracking, postcode lookup, and delivery times. By UnClick (https://unclick.world).",
+  "description": "Australia Post parcel tracking, postcode lookup, and delivery times. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/australiapost-mcp/src/index.ts
+++ b/packages/standalone/australiapost-mcp/src/index.ts
@@ -62,9 +62,9 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  auspost_track_parcel: (args) => trackAuspostParcel(args),
-  auspost_get_postcode: (args) => getAuspostPostcode(args),
-  auspost_delivery_times: (args) => getAuspostDeliveryTimes(args),
+  auspost_track_parcel: (args) => trackAuspostParcel(args as unknown as Parameters<typeof trackAuspostParcel>[0]),
+  auspost_get_postcode: (args) => getAuspostPostcode(args as unknown as Parameters<typeof getAuspostPostcode>[0]),
+  auspost_delivery_times: (args) => getAuspostDeliveryTimes(args as unknown as Parameters<typeof getAuspostDeliveryTimes>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/bgg-mcp/server.json
+++ b/packages/standalone/bgg-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/bgg",
   "title": "BoardGameGeek MCP by UnClick",
-  "description": "BoardGameGeek search, game details, rankings, and collections. By UnClick (https://unclick.world).",
+  "description": "BoardGameGeek search, game details, rankings, and collections. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/bgg-mcp/src/index.ts
+++ b/packages/standalone/bgg-mcp/src/index.ts
@@ -85,11 +85,11 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  bgg_search: (args) => bggSearch(args),
-  bgg_game_details: (args) => bggGameDetails(args),
-  bgg_user_collection: (args) => bggUserCollection(args),
-  bgg_top_games: (args) => bggTopGames(args),
-  bgg_game_reviews: (args) => bggGameReviews(args),
+  bgg_search: (args) => bggSearch(args as unknown as Parameters<typeof bggSearch>[0]),
+  bgg_game_details: (args) => bggGameDetails(args as unknown as Parameters<typeof bggGameDetails>[0]),
+  bgg_user_collection: (args) => bggUserCollection(args as unknown as Parameters<typeof bggUserCollection>[0]),
+  bgg_top_games: (args) => bggTopGames(args as unknown as Parameters<typeof bggTopGames>[0]),
+  bgg_game_reviews: (args) => bggGameReviews(args as unknown as Parameters<typeof bggGameReviews>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/coingecko-mcp/server.json
+++ b/packages/standalone/coingecko-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/coingecko",
   "title": "CoinGecko MCP by UnClick",
-  "description": "Live cryptocurrency prices, market data, history, and trending coins from CoinGecko. No API key. By UnClick (https://unclick.world).",
+  "description": "CoinGecko tools for crypto, coingecko, bitcoin by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/domain-mcp/server.json
+++ b/packages/standalone/domain-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/domain",
   "title": "Domain MCP by UnClick",
-  "description": "Australian property listings, prices, and suburb stats from Domain. By UnClick (https://unclick.world).",
+  "description": "Australian property listings, prices, and suburb stats from Domain. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/domain-mcp/src/index.ts
+++ b/packages/standalone/domain-mcp/src/index.ts
@@ -70,9 +70,9 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  domain_search_listings: (args) => searchDomainListings(args),
-  domain_get_property: (args) => getDomainProperty(args),
-  domain_suburb_stats: (args) => getDomainSuburbStats(args),
+  domain_search_listings: (args) => searchDomainListings(args as unknown as Parameters<typeof searchDomainListings>[0]),
+  domain_get_property: (args) => getDomainProperty(args as unknown as Parameters<typeof getDomainProperty>[0]),
+  domain_suburb_stats: (args) => getDomainSuburbStats(args as unknown as Parameters<typeof getDomainSuburbStats>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/espn-mcp/server.json
+++ b/packages/standalone/espn-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/espn",
   "title": "ESPN Sports MCP by UnClick",
-  "description": "Live scores, news, and team info across NFL, NBA, MLB, NHL, and soccer from ESPN. No API key. By UnClick (https://unclick.world).",
+  "description": "ESPN Sports tools for sports, scores, espn by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/exchangerate-mcp/server.json
+++ b/packages/standalone/exchangerate-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/exchangerate",
   "title": "Exchange Rates MCP by UnClick",
-  "description": "Currency conversion plus latest and historical exchange rates. By UnClick (https://unclick.world).",
+  "description": "Currency conversion plus latest and historical exchange rates. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/genius-mcp/server.json
+++ b/packages/standalone/genius-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/genius",
   "title": "Genius Lyrics MCP by UnClick",
-  "description": "Search songs and artists and get song and artist detail from Genius. By UnClick (https://unclick.world).",
+  "description": "Search songs and artists and get song and artist detail from Genius. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/hackernews-mcp/server.json
+++ b/packages/standalone/hackernews-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/hackernews",
   "title": "Hacker News MCP by UnClick",
-  "description": "Search and read Hacker News stories, comments, users, Ask HN and Show HN. No API key. By UnClick (https://unclick.world).",
+  "description": "Search and read Hacker News stories, comments, users, Ask HN and Show HN. No API key. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/igdb-mcp/server.json
+++ b/packages/standalone/igdb-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/igdb",
   "title": "IGDB Games MCP by UnClick",
-  "description": "Video game database: search games, companies, genres, and platforms via IGDB. By UnClick (https://unclick.world).",
+  "description": "Video game database: search games, companies, genres, and platforms via IGDB. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/ipaustralia-mcp/server.json
+++ b/packages/standalone/ipaustralia-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/ipaustralia",
   "title": "IP Australia MCP by UnClick",
-  "description": "Australian trademark and patent search via IP Australia. By UnClick (https://unclick.world).",
+  "description": "Australian trademark and patent search via IP Australia. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/ipaustralia-mcp/src/index.ts
+++ b/packages/standalone/ipaustralia-mcp/src/index.ts
@@ -63,9 +63,9 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  search_trademarks: (args) => searchTrademarks(args),
-  get_trademark_details: (args) => getTrademarkDetails(args),
-  search_patents: (args) => searchPatents(args),
+  search_trademarks: (args) => searchTrademarks(args as unknown as Parameters<typeof searchTrademarks>[0]),
+  get_trademark_details: (args) => getTrademarkDetails(args as unknown as Parameters<typeof getTrademarkDetails>[0]),
+  search_patents: (args) => searchPatents(args as unknown as Parameters<typeof searchPatents>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/lastfm-mcp/server.json
+++ b/packages/standalone/lastfm-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/lastfm",
   "title": "Last.fm MCP by UnClick",
-  "description": "Music charts, artist info, similar artists, and top tracks from Last.fm. By UnClick (https://unclick.world).",
+  "description": "Music charts, artist info, similar artists, and top tracks from Last.fm. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/meal-mcp/server.json
+++ b/packages/standalone/meal-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/meal",
   "title": "Recipes MCP by UnClick",
-  "description": "Search recipes by name, ingredient, category, or area, with full instructions, from TheMealDB. No API key. By UnClick (https://unclick.world).",
+  "description": "Recipes tools for recipes, meals, cooking by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/musicbrainz-mcp/server.json
+++ b/packages/standalone/musicbrainz-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/musicbrainz",
   "title": "MusicBrainz MCP by UnClick",
-  "description": "Open music metadata: artists, releases, and recordings from MusicBrainz. No API key. By UnClick (https://unclick.world).",
+  "description": "Open music metadata: artists, releases, and recordings from MusicBrainz. No API key. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/nasa-mcp/server.json
+++ b/packages/standalone/nasa-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/nasa",
   "title": "NASA MCP by UnClick",
-  "description": "NASA imagery and data: astronomy picture of the day, Mars rover photos, asteroids, and Earth imagery. By UnClick (https://unclick.world).",
+  "description": "NASA tools for nasa, space, astronomy by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/omdb-mcp/server.json
+++ b/packages/standalone/omdb-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/omdb",
   "title": "OMDb Movies MCP by UnClick",
-  "description": "Search movies and shows and get details by title or IMDb ID from the Open Movie Database. By UnClick (https://unclick.world).",
+  "description": "OMDb Movies tools for movies, omdb, imdb by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/openaq-mcp/server.json
+++ b/packages/standalone/openaq-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/openaq",
   "title": "OpenAQ Air Quality MCP by UnClick",
-  "description": "Global air quality measurements by location and country from OpenAQ. No API key. By UnClick (https://unclick.world).",
+  "description": "Global air quality measurements by location and country from OpenAQ. No API key. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/openlibrary-mcp/server.json
+++ b/packages/standalone/openlibrary-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/openlibrary",
   "title": "Open Library MCP by UnClick",
-  "description": "Search books, authors, and editions, with trending titles, from Open Library. No API key. By UnClick (https://unclick.world).",
+  "description": "Open Library tools for books, openlibrary, library by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/openmeteo-mcp/server.json
+++ b/packages/standalone/openmeteo-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/openmeteo",
   "title": "Open-Meteo Weather MCP by UnClick",
-  "description": "Free global weather: current conditions, hourly and daily forecasts from Open-Meteo. No API key. By UnClick (https://unclick.world).",
+  "description": "Open-Meteo Weather tools for weather, forecast, open-meteo by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/ptv-mcp/server.json
+++ b/packages/standalone/ptv-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/ptv",
   "title": "PTV MCP by UnClick",
-  "description": "Melbourne / Victoria public transport timetables, departures, and disruptions (PTV). By UnClick (https://unclick.world).",
+  "description": "Melbourne / Victoria public transport timetables, departures, and disruptions (PTV). By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/rawg-mcp/server.json
+++ b/packages/standalone/rawg-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/rawg",
   "title": "RAWG Games MCP by UnClick",
-  "description": "Search video games with detail, screenshots, genres, and upcoming releases from RAWG. By UnClick (https://unclick.world).",
+  "description": "Search video games with detail, screenshots, genres, and upcoming releases from RAWG. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/reddit-mcp/server.json
+++ b/packages/standalone/reddit-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/reddit",
   "title": "Reddit MCP by UnClick",
-  "description": "Search, read, and post across Reddit: posts, comments, subreddits, and users. By UnClick (https://unclick.world).",
+  "description": "Search, read, and post across Reddit: posts, comments, subreddits, and users. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/restcountries-mcp/server.json
+++ b/packages/standalone/restcountries-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/restcountries",
   "title": "REST Countries MCP by UnClick",
-  "description": "Country data: flags, currencies, languages, regions, capitals, and more. No API key. By UnClick (https://unclick.world).",
+  "description": "Country data: flags, currencies, languages, regions, capitals, and more. No API key. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/sendle-mcp/server.json
+++ b/packages/standalone/sendle-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/sendle",
   "title": "Sendle MCP by UnClick",
-  "description": "Sendle shipping quotes, orders, and parcel tracking. By UnClick (https://unclick.world).",
+  "description": "Sendle shipping quotes, orders, and parcel tracking. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/sendle-mcp/src/index.ts
+++ b/packages/standalone/sendle-mcp/src/index.ts
@@ -69,9 +69,9 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  sendle_get_quote: (args) => getSendleQuote(args),
-  sendle_create_order: (args) => createSendleOrder(args),
-  sendle_track_parcel: (args) => trackSendleParcel(args),
+  sendle_get_quote: (args) => getSendleQuote(args as unknown as Parameters<typeof getSendleQuote>[0]),
+  sendle_create_order: (args) => createSendleOrder(args as unknown as Parameters<typeof createSendleOrder>[0]),
+  sendle_track_parcel: (args) => trackSendleParcel(args as unknown as Parameters<typeof trackSendleParcel>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/spotify-mcp/server.json
+++ b/packages/standalone/spotify-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/spotify",
   "title": "Spotify MCP by UnClick",
-  "description": "Search Spotify for tracks, artists, albums, and playlists, with audio features and recommendations. By UnClick (https://unclick.world).",
+  "description": "Spotify tools for spotify, music, playlists by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/thelott-mcp/server.json
+++ b/packages/standalone/thelott-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/thelott",
   "title": "The Lott MCP by UnClick",
-  "description": "Australian lottery results and jackpots from The Lott. By UnClick (https://unclick.world).",
+  "description": "Australian lottery results and jackpots from The Lott. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/thelott-mcp/src/index.ts
+++ b/packages/standalone/thelott-mcp/src/index.ts
@@ -41,8 +41,8 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  lott_results: (args) => getLottResults(args),
-  lott_jackpots: (args) => getLottJackpots(args),
+  lott_results: (args) => getLottResults(args as unknown as Parameters<typeof getLottResults>[0]),
+  lott_jackpots: (args) => getLottJackpots(args as unknown as Parameters<typeof getLottJackpots>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/tmdb-mcp/server.json
+++ b/packages/standalone/tmdb-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/tmdb",
   "title": "TMDB MCP by UnClick",
-  "description": "Search movies and TV, with details, trending, now-playing, and recommendations from The Movie Database. By UnClick (https://unclick.world).",
+  "description": "TMDB tools for tmdb, movies, tv by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/trivia-mcp/server.json
+++ b/packages/standalone/trivia-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/trivia",
   "title": "Trivia MCP by UnClick",
-  "description": "Trivia questions across categories and difficulties from the Open Trivia Database. No API key. By UnClick (https://unclick.world).",
+  "description": "Trivia tools for trivia, quiz, questions by UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/untappd-mcp/server.json
+++ b/packages/standalone/untappd-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/untappd",
   "title": "Untappd MCP by UnClick",
-  "description": "Untappd beer and brewery search, details, and activity. By UnClick (https://unclick.world).",
+  "description": "Untappd beer and brewery search, details, and activity. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/untappd-mcp/src/index.ts
+++ b/packages/standalone/untappd-mcp/src/index.ts
@@ -90,11 +90,11 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  untappd_search_beer: (args) => untappdSearchBeer(args),
-  untappd_get_beer: (args) => untappdGetBeer(args),
-  untappd_get_brewery: (args) => untappdGetBrewery(args),
-  untappd_search_brewery: (args) => untappdSearchBrewery(args),
-  untappd_beer_activities: (args) => untappdBeerActivities(args),
+  untappd_search_beer: (args) => untappdSearchBeer(args as unknown as Parameters<typeof untappdSearchBeer>[0]),
+  untappd_get_beer: (args) => untappdGetBeer(args as unknown as Parameters<typeof untappdGetBeer>[0]),
+  untappd_get_brewery: (args) => untappdGetBrewery(args as unknown as Parameters<typeof untappdGetBrewery>[0]),
+  untappd_search_brewery: (args) => untappdSearchBrewery(args as unknown as Parameters<typeof untappdSearchBrewery>[0]),
+  untappd_beer_activities: (args) => untappdBeerActivities(args as unknown as Parameters<typeof untappdBeerActivities>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/usgs-mcp/server.json
+++ b/packages/standalone/usgs-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/usgs",
   "title": "USGS Earthquakes MCP by UnClick",
-  "description": "Recent earthquakes worldwide and by region, with detail, from USGS. No API key. By UnClick (https://unclick.world).",
+  "description": "Recent earthquakes worldwide and by region, with detail, from USGS. No API key. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/willyweather-mcp/server.json
+++ b/packages/standalone/willyweather-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/willyweather",
   "title": "WillyWeather MCP by UnClick",
-  "description": "Australian weather, surf, and tide forecasts from WillyWeather. By UnClick (https://unclick.world).",
+  "description": "Australian weather, surf, and tide forecasts from WillyWeather. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [

--- a/packages/standalone/willyweather-mcp/src/index.ts
+++ b/packages/standalone/willyweather-mcp/src/index.ts
@@ -63,9 +63,9 @@ const TOOLS = [
 ];
 
 const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-  willyweather_forecast: (args) => getWillyweatherForecast(args),
-  willyweather_surf: (args) => getWillyweatherSurf(args),
-  willyweather_tide: (args) => getWillyweatherTide(args),
+  willyweather_forecast: (args) => getWillyweatherForecast(args as unknown as Parameters<typeof getWillyweatherForecast>[0]),
+  willyweather_surf: (args) => getWillyweatherSurf(args as unknown as Parameters<typeof getWillyweatherSurf>[0]),
+  willyweather_tide: (args) => getWillyweatherTide(args as unknown as Parameters<typeof getWillyweatherTide>[0]),
 };
 
 const server = new Server(

--- a/packages/standalone/youtube-mcp/server.json
+++ b/packages/standalone/youtube-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/youtube",
   "title": "YouTube MCP by UnClick",
-  "description": "Search YouTube and get video, channel, playlist, and caption details. By UnClick (https://unclick.world).",
+  "description": "Search YouTube and get video, channel, playlist, and caption details. By UnClick.",
   "version": "0.1.0",
   "websiteUrl": "https://unclick.world",
   "icons": [


### PR DESCRIPTION
## Summary
- cap generated standalone registry descriptions so MCP registry validation passes
- add a standalone registry manifest validator to the MCP package test gate
- only attempt official registry publish for packages npm confirms are live

## Verification
- npx tsc -p packages/mcp-server/tsconfig.json --noEmit
- npm run test:brainmap
- node packages/mcp-server/scripts/check-standalone-registry.mjs
- npm run test --workspace=@unclick/mcp-server
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect release/CI and generated metadata for standalone MCPs, not runtime auth or core app logic; publish failures degrade gracefully with warnings.
> 
> **Overview**
> Hardens **standalone MCP** release and registry publishing so CI only promotes packages that npm actually exposes, and manifests meet registry limits.
> 
> The **publish-standalone-mcps** workflow now writes `npm-ready-packages.txt` after each package is confirmed on npm (`npm view`), sets `registry_eligible` only when that list is non-empty, and runs **mcp-publisher** only for those dirs (with a second npm visibility check). Tarball/GitHub release behavior is unchanged when npm fails.
> 
> **Generator + manifests:** `generate-standalone-mcp.mjs` adds `trimRegistryDescription` (100-char cap); generated `server.json` descriptions are shortened (some use keyword-style text). A new **`check-standalone-registry.mjs`** runs in `@unclick/mcp-server` `test` to enforce description length, npm identifier ↔ `package.json` name, and `mcpName` ↔ `server.json` name.
> 
> Several standalone **`index.ts`** handlers gain typed casts to connector argument types. Brainmap docs reflect the workflow file hash/size update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5fe4ebf73f5c7d6a668c8da330d1714d4b947ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->