### PR TITLE
Add memory-aware PTV defaults

### DIFF
--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -2615,7 +2615,7 @@
       },
       {
         "name": "ptv_departures",
-        "description": "Get PTV departures for a stop."
+        "description": "Get PTV departures for a stop. In full UnClick, stop_id can be filled from saved Memory defaults."
       },
       {
         "name": "ptv_disruptions",

--- a/packages/mcp-server/scripts/generate-tool-index.mjs
+++ b/packages/mcp-server/scripts/generate-tool-index.mjs
@@ -99,4 +99,4 @@ function main() {
   console.log(`${index.length} apps, ${toolCount} tools indexed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) main();

--- a/packages/mcp-server/src/__tests__/capability-briefing.test.ts
+++ b/packages/mcp-server/src/__tests__/capability-briefing.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { buildCapabilityBriefing, searchToolIndex } from "../memory/tool-awareness.js";
 import { TOOL_INDEX } from "../memory/tool-index.generated.js";
-import { ptvSearch } from "../ptv-tool.js";
+import { ptvDepartures, ptvSearch } from "../ptv-tool.js";
 
 describe("generated tool index", () => {
   it("is populated with apps and tools", () => {
@@ -43,7 +43,10 @@ describe("inward capability briefing", () => {
 });
 
 describe("ptv_search schema/impl alignment", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
 
   it("errors on the advertised arg name when nothing is provided", async () => {
     const res = await ptvSearch({});
@@ -63,5 +66,26 @@ describe("ptv_search schema/impl alignment", () => {
     vi.stubGlobal("fetch", fetchMock);
     await ptvSearch({ query: "Flinders Street" });
     expect(String(fetchMock.mock.calls[0][0])).toContain("Flinders%20Street");
+  });
+
+  it("uses env defaults for standalone departures and stamps source metadata", async () => {
+    vi.stubEnv("PTV_HOME_STOP_ID", "12345");
+    vi.stubEnv("PTV_HOME_ROUTE_TYPE", "0");
+    const fetchMock = vi.fn(async (..._args: unknown[]) => ({
+      ok: true,
+      json: async () => ({ departures: [] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await ptvDepartures({});
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/v3/departures/route_type/0/stop/12345");
+    expect(result).toMatchObject({
+      departures: [],
+      unclick_meta: {
+        source: "PTV Timetable API v3",
+        defaults_used: ["PTV_HOME_STOP_ID", "PTV_HOME_ROUTE_TYPE"],
+      },
+    });
   });
 });

--- a/packages/mcp-server/src/__tests__/tool-memory-defaults.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-memory-defaults.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyToolMemoryDefaults,
+  extractPtvDefaultsFromMemoryRows,
+} from "../tool-memory-defaults.js";
+
+describe("PTV memory defaults", () => {
+  it("extracts a saved home stop from memory text", () => {
+    const defaults = extractPtvDefaultsFromMemoryRows([
+      {
+        source: "fact",
+        content: "PTV home station stop_id 12345 route_type 0 direction_id 9",
+      },
+    ]);
+
+    expect(defaults).toEqual({
+      stop_id: "12345",
+      route_type: 0,
+      direction_id: "9",
+    });
+  });
+
+  it("applies business-context defaults when ptv_departures has no stop_id", async () => {
+    const result = await applyToolMemoryDefaults("ptv_departures", {}, {
+      backend: {
+        async getBusinessContext() {
+          return [
+            {
+              category: "connector_defaults",
+              key: "ptv",
+              value: {
+                stop_id: 12345,
+                route_type: 0,
+                max_results: 3,
+              },
+            },
+          ];
+        },
+        async searchMemory() {
+          return [];
+        },
+      },
+    });
+
+    expect(result.args).toMatchObject({
+      stop_id: "12345",
+      route_type: 0,
+      max_results: 3,
+      __unclick_memory_defaults: ["memory.stop_id", "memory.route_type", "memory.max_results"],
+    });
+  });
+
+  it("does not override explicit PTV args", async () => {
+    const result = await applyToolMemoryDefaults("ptv_departures", { stop_id: 999 }, {
+      backend: {
+        async getBusinessContext() {
+          return [
+            { category: "connector_defaults", key: "ptv", value: { stop_id: 12345 } },
+          ];
+        },
+        async searchMemory() {
+          return [];
+        },
+      },
+    });
+
+    expect(result.args).toEqual({ stop_id: 999 });
+    expect(result.applied).toEqual([]);
+  });
+});

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -2629,7 +2629,7 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       },
       {
         "name": "ptv_departures",
-        "description": "Get PTV departures for a stop."
+        "description": "Get PTV departures for a stop. In full UnClick, stop_id can be filled from saved Memory defaults."
       },
       {
         "name": "ptv_disruptions",

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -6,6 +6,8 @@
 import { createHmac } from "node:crypto";
 
 const PTV_BASE = "https://timetableapi.ptv.vic.gov.au";
+const PTV_ATTRIBUTION =
+  "Source: Licensed from Public Transport Victoria under a Creative Commons Attribution 4.0 International Licence.";
 
 // ─── Signature helper ─────────────────────────────────────────────────────────
 
@@ -39,6 +41,35 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
   return res.json() as Promise<unknown>;
 }
 
+function stringArg(args: Record<string, unknown>, key: string, envKey?: string): string {
+  const value = args[key] ?? (envKey ? process.env[envKey] : undefined);
+  return String(value ?? "").trim();
+}
+
+function numberArg(args: Record<string, unknown>, key: string, envKey: string, fallback: number): number {
+  const value = args[key] ?? process.env[envKey];
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function addPtvMeta(result: unknown, tool: string, defaultsUsed: string[]): unknown {
+  const meta = {
+    source: "PTV Timetable API v3",
+    attribution: PTV_ATTRIBUTION,
+    fetched_at: new Date().toISOString(),
+    defaults_used: defaultsUsed,
+    next_steps:
+      tool === "ptv_search"
+        ? ["Use a returned stop_id with ptv_departures."]
+        : ["Use ptv_disruptions to check service disruptions for the same route type."],
+  };
+
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return { ...(result as Record<string, unknown>), unclick_meta: meta };
+  }
+  return { data: result, unclick_meta: meta };
+}
+
 // Route type codes
 // 0 = Train (metro), 1 = Tram, 2 = Bus, 3 = Vline (regional train), 4 = Night Bus
 
@@ -50,26 +81,46 @@ export async function ptvSearch(args: Record<string, unknown>): Promise<unknown>
   const query = String(args.search_term ?? args.query ?? "").trim();
   if (!query) return { error: "search_term is required." };
 
-  return ptvFetch(`/v3/search/${encodeURIComponent(query)}`);
+  const result = await ptvFetch(`/v3/search/${encodeURIComponent(query)}`);
+  return addPtvMeta(result, "ptv_search", []);
 }
 
 // ─── ptv_departures ───────────────────────────────────────────────────────────
 // GET /v3/departures/route_type/{route_type}/stop/{stop_id}
 
 export async function ptvDepartures(args: Record<string, unknown>): Promise<unknown> {
-  const stopId = String(args.stop_id ?? "").trim();
+  const stopId = stringArg(args, "stop_id", "PTV_HOME_STOP_ID");
   if (!stopId) return { error: "stop_id is required." };
 
-  const routeType = Number(args.route_type ?? 0);
+  const defaultsUsed = Array.isArray(args.__unclick_memory_defaults)
+    ? args.__unclick_memory_defaults.filter((value): value is string => typeof value === "string")
+    : [];
+  if (args.stop_id === undefined && process.env.PTV_HOME_STOP_ID) defaultsUsed.push("PTV_HOME_STOP_ID");
+
+  const routeType = numberArg(args, "route_type", "PTV_HOME_ROUTE_TYPE", 0);
+  if (args.route_type === undefined && process.env.PTV_HOME_ROUTE_TYPE) defaultsUsed.push("PTV_HOME_ROUTE_TYPE");
   const params: Record<string, string> = {};
 
-  if (args.max_results) params["max_results"] = String(Math.min(20, Number(args.max_results)));
-  if (args.route_id) params["route_id"] = String(args.route_id);
-  if (args.direction_id) params["direction_id"] = String(args.direction_id);
+  const maxResults = numberArg(args, "max_results", "PTV_DEFAULT_MAX_RESULTS", 5);
+  if (maxResults > 0) params["max_results"] = String(Math.min(20, maxResults));
+
+  const routeId = stringArg(args, "route_id", "PTV_HOME_ROUTE_ID");
+  if (routeId) {
+    params["route_id"] = routeId;
+    if (args.route_id === undefined && process.env.PTV_HOME_ROUTE_ID) defaultsUsed.push("PTV_HOME_ROUTE_ID");
+  }
+
+  const directionId = stringArg(args, "direction_id", "PTV_HOME_DIRECTION_ID");
+  if (directionId) {
+    params["direction_id"] = directionId;
+    if (args.direction_id === undefined && process.env.PTV_HOME_DIRECTION_ID) defaultsUsed.push("PTV_HOME_DIRECTION_ID");
+  }
+
   if (args.look_backwards === true) params["look_backwards"] = "true";
   if (args.include_cancelled === true) params["include_cancelled"] = "true";
 
-  return ptvFetch(`/v3/departures/route_type/${routeType}/stop/${stopId}`, params);
+  const result = await ptvFetch(`/v3/departures/route_type/${routeType}/stop/${stopId}`, params);
+  return addPtvMeta(result, "ptv_departures", defaultsUsed);
 }
 
 // ─── ptv_disruptions ──────────────────────────────────────────────────────────

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -14,6 +14,7 @@ import { LOCAL_CATALOG_HANDLERS } from "./local-catalog-handlers.js";
 import { MEMORY_HANDLERS } from "./memory/handlers.js";
 import { markContextLoaded, recordToolCall } from "./memory/session-state.js";
 import { searchToolIndex } from "./memory/tool-awareness.js";
+import { applyToolMemoryDefaults } from "./tool-memory-defaults.js";
 import { classifyFailure } from "./tool-failure-class.js";
 import { reportToolFailureBug } from "./tool-failure-report.js";
 import { emitSignal } from "./signals/emit.js";
@@ -2415,8 +2416,9 @@ export function createServer(): Server {
         const handlerKey = endpointId.replace(/\./g, "_");
         const additionalHandler = ADDITIONAL_HANDLERS[handlerKey];
         if (additionalHandler) {
-          const result = await additionalHandler(params);
-          signalToolFailure(handlerKey, result, params);
+          const { args: handlerArgs } = await applyToolMemoryDefaults(handlerKey, params);
+          const result = await additionalHandler(handlerArgs);
+          signalToolFailure(handlerKey, result, handlerArgs);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           };
@@ -2495,8 +2497,9 @@ export function createServer(): Server {
       // ── Additional tools (third-party integrations) ───────────────
       const additionalHandler = ADDITIONAL_HANDLERS[name];
       if (additionalHandler) {
-        const result = await additionalHandler(args);
-        signalToolFailure(name, result, args);
+        const { args: handlerArgs } = await applyToolMemoryDefaults(name, args);
+        const result = await additionalHandler(handlerArgs);
+        signalToolFailure(name, result, handlerArgs);
         return {
           content: [
             {

--- a/packages/mcp-server/src/tool-memory-defaults.ts
+++ b/packages/mcp-server/src/tool-memory-defaults.ts
@@ -1,0 +1,149 @@
+import { getBackend } from "./memory/db.js";
+import type { MemoryBackend } from "./memory/types.js";
+
+type DefaultableBackend = Pick<MemoryBackend, "getBusinessContext" | "searchMemory">;
+
+export interface ToolMemoryDefaultsResult {
+  args: Record<string, unknown>;
+  applied: string[];
+}
+
+interface PtvDefaults {
+  stop_id?: string;
+  route_type?: number;
+  route_id?: string;
+  direction_id?: string;
+  max_results?: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function parseJsonish(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizePtvDefaults(value: unknown): PtvDefaults | null {
+  const raw = parseJsonish(value);
+  const row = asRecord(raw);
+  if (!row) return null;
+
+  const stop = row.stop_id ?? row.stopId ?? row.home_stop_id ?? row.homeStopId;
+  if (stop === undefined || stop === null || String(stop).trim() === "") return null;
+
+  const defaults: PtvDefaults = { stop_id: String(stop).trim() };
+  const routeType = Number(row.route_type ?? row.routeType ?? 0);
+  if (Number.isFinite(routeType)) defaults.route_type = routeType;
+
+  const routeId = row.route_id ?? row.routeId;
+  if (routeId !== undefined && routeId !== null && String(routeId).trim()) defaults.route_id = String(routeId).trim();
+
+  const directionId = row.direction_id ?? row.directionId;
+  if (directionId !== undefined && directionId !== null && String(directionId).trim()) defaults.direction_id = String(directionId).trim();
+
+  const maxResults = Number(row.max_results ?? row.maxResults);
+  if (Number.isFinite(maxResults) && maxResults > 0) defaults.max_results = maxResults;
+
+  return defaults;
+}
+
+function extractNumber(text: string, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = text.match(new RegExp(`${escaped}\\s*(?:=|:|is)?\\s*(\\d+)`, "i"));
+    if (match?.[1]) return Number(match[1]);
+  }
+  return undefined;
+}
+
+function extractString(text: string, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = text.match(new RegExp(`${escaped}\\s*(?:=|:|is)?\\s*([A-Za-z0-9_-]+)`, "i"));
+    if (match?.[1]) return match[1];
+  }
+  return undefined;
+}
+
+export function extractPtvDefaultsFromMemoryRows(rows: unknown[]): PtvDefaults | null {
+  for (const row of rows) {
+    const record = asRecord(row);
+    const text =
+      typeof row === "string"
+        ? row
+        : typeof record?.content === "string"
+          ? record.content
+          : typeof record?.fact === "string"
+            ? record.fact
+            : typeof record?.summary === "string"
+              ? record.summary
+              : "";
+    if (!/ptv|public transport|train|station/i.test(text)) continue;
+
+    const stopId = extractString(text, ["ptv_home_stop_id", "home_stop_id", "stop_id", "stop id"]);
+    if (!stopId) continue;
+
+    const defaults: PtvDefaults = { stop_id: stopId };
+    const routeType = extractNumber(text, ["route_type", "route type"]);
+    if (routeType !== undefined) defaults.route_type = routeType;
+
+    const routeId = extractString(text, ["route_id", "route id"]);
+    if (routeId) defaults.route_id = routeId;
+
+    const directionId = extractString(text, ["direction_id", "direction id"]);
+    if (directionId) defaults.direction_id = directionId;
+
+    return defaults;
+  }
+  return null;
+}
+
+async function loadPtvDefaults(backend: DefaultableBackend): Promise<PtvDefaults | null> {
+  const businessContext = await backend.getBusinessContext().catch(() => []);
+  for (const row of businessContext) {
+    const record = asRecord(row);
+    if (!record) continue;
+    const category = String(record.category ?? "").toLowerCase();
+    const key = String(record.key ?? "").toLowerCase();
+    if (!["connector_defaults", "tool_defaults", "ptv"].includes(category)) continue;
+    if (!["ptv", "ptv_home_station", "ptv_departures", "home_station"].includes(key)) continue;
+
+    const defaults = normalizePtvDefaults(record.value);
+    if (defaults) return defaults;
+  }
+
+  const memoryRows = await backend.searchMemory("PTV home station stop_id route_type", 5).catch(() => []);
+  return extractPtvDefaultsFromMemoryRows(Array.isArray(memoryRows) ? memoryRows : []);
+}
+
+export async function applyToolMemoryDefaults(
+  toolName: string,
+  args: Record<string, unknown>,
+  options: { backend?: DefaultableBackend } = {}
+): Promise<ToolMemoryDefaultsResult> {
+  if (toolName !== "ptv_departures" || args.stop_id !== undefined) {
+    return { args, applied: [] };
+  }
+
+  const backend = options.backend ?? await getBackend();
+  const defaults = await loadPtvDefaults(backend);
+  if (!defaults?.stop_id) return { args, applied: [] };
+
+  const nextArgs: Record<string, unknown> = { ...args };
+  const applied: string[] = [];
+  for (const [key, value] of Object.entries(defaults)) {
+    if (nextArgs[key] !== undefined || value === undefined) continue;
+    nextArgs[key] = value;
+    applied.push(`memory.${key}`);
+  }
+  if (applied.length > 0) nextArgs.__unclick_memory_defaults = applied;
+  return { args: nextArgs, applied };
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -1858,18 +1858,20 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "ptv_departures",
-    description: "Get PTV departures for a stop.",
+    description: "Get PTV departures for a stop. In full UnClick, stop_id can be filled from saved Memory defaults.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        route_type: { type: "number", description: "0=train,1=tram,2=bus,3=vline,4=night" },
-        stop_id: { type: "number" },
+        route_type: { type: "number", description: "0=train, 1=tram, 2=bus, 3=vline, 4=night. Defaults to train." },
+        stop_id: { type: "number", description: "PTV stop ID. Optional when a saved UnClick Memory default exists." },
         route_id: { type: "number" },
-        max_results: { type: "number" },
+        direction_id: { type: "number" },
+        max_results: { type: "number", description: "Defaults to 5, maximum 20." },
+        look_backwards: { type: "boolean" },
+        include_cancelled: { type: "boolean" },
         api_key: { type: "string" },
       },
-      required: ["route_type", "stop_id"],
     },
   },
   {

--- a/packages/standalone/ptv-mcp/src/index.ts
+++ b/packages/standalone/ptv-mcp/src/index.ts
@@ -35,18 +35,20 @@ const TOOLS = [
   },
   {
     name: "ptv_departures",
-    description: "Get PTV departures for a stop.",
+    description: "Get PTV departures for a stop. In full UnClick, stop_id can be filled from saved Memory defaults.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        route_type: { type: "number", description: "0=train,1=tram,2=bus,3=vline,4=night" },
-        stop_id: { type: "number" },
+        route_type: { type: "number", description: "0=train, 1=tram, 2=bus, 3=vline, 4=night. Defaults to train." },
+        stop_id: { type: "number", description: "PTV stop ID. Optional when a saved UnClick Memory default exists." },
         route_id: { type: "number" },
-        max_results: { type: "number" },
+        direction_id: { type: "number" },
+        max_results: { type: "number", description: "Defaults to 5, maximum 20." },
+        look_backwards: { type: "boolean" },
+        include_cancelled: { type: "boolean" },
         api_key: { type: "string" },
       },
-      required: ["route_type", "stop_id"],
     },
   },
   {

--- a/packages/standalone/ptv-mcp/src/ptv-tool.ts
+++ b/packages/standalone/ptv-mcp/src/ptv-tool.ts
@@ -6,6 +6,8 @@
 import { createHmac } from "node:crypto";
 
 const PTV_BASE = "https://timetableapi.ptv.vic.gov.au";
+const PTV_ATTRIBUTION =
+  "Source: Licensed from Public Transport Victoria under a Creative Commons Attribution 4.0 International Licence.";
 
 // ─── Signature helper ─────────────────────────────────────────────────────────
 
@@ -39,6 +41,35 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
   return res.json() as Promise<unknown>;
 }
 
+function stringArg(args: Record<string, unknown>, key: string, envKey?: string): string {
+  const value = args[key] ?? (envKey ? process.env[envKey] : undefined);
+  return String(value ?? "").trim();
+}
+
+function numberArg(args: Record<string, unknown>, key: string, envKey: string, fallback: number): number {
+  const value = args[key] ?? process.env[envKey];
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function addPtvMeta(result: unknown, tool: string, defaultsUsed: string[]): unknown {
+  const meta = {
+    source: "PTV Timetable API v3",
+    attribution: PTV_ATTRIBUTION,
+    fetched_at: new Date().toISOString(),
+    defaults_used: defaultsUsed,
+    next_steps:
+      tool === "ptv_search"
+        ? ["Use a returned stop_id with ptv_departures."]
+        : ["Use ptv_disruptions to check service disruptions for the same route type."],
+  };
+
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return { ...(result as Record<string, unknown>), unclick_meta: meta };
+  }
+  return { data: result, unclick_meta: meta };
+}
+
 // Route type codes
 // 0 = Train (metro), 1 = Tram, 2 = Bus, 3 = Vline (regional train), 4 = Night Bus
 
@@ -50,26 +81,46 @@ export async function ptvSearch(args: Record<string, unknown>): Promise<unknown>
   const query = String(args.search_term ?? args.query ?? "").trim();
   if (!query) return { error: "search_term is required." };
 
-  return ptvFetch(`/v3/search/${encodeURIComponent(query)}`);
+  const result = await ptvFetch(`/v3/search/${encodeURIComponent(query)}`);
+  return addPtvMeta(result, "ptv_search", []);
 }
 
 // ─── ptv_departures ───────────────────────────────────────────────────────────
 // GET /v3/departures/route_type/{route_type}/stop/{stop_id}
 
 export async function ptvDepartures(args: Record<string, unknown>): Promise<unknown> {
-  const stopId = String(args.stop_id ?? "").trim();
+  const stopId = stringArg(args, "stop_id", "PTV_HOME_STOP_ID");
   if (!stopId) return { error: "stop_id is required." };
 
-  const routeType = Number(args.route_type ?? 0);
+  const defaultsUsed = Array.isArray(args.__unclick_memory_defaults)
+    ? args.__unclick_memory_defaults.filter((value): value is string => typeof value === "string")
+    : [];
+  if (args.stop_id === undefined && process.env.PTV_HOME_STOP_ID) defaultsUsed.push("PTV_HOME_STOP_ID");
+
+  const routeType = numberArg(args, "route_type", "PTV_HOME_ROUTE_TYPE", 0);
+  if (args.route_type === undefined && process.env.PTV_HOME_ROUTE_TYPE) defaultsUsed.push("PTV_HOME_ROUTE_TYPE");
   const params: Record<string, string> = {};
 
-  if (args.max_results) params["max_results"] = String(Math.min(20, Number(args.max_results)));
-  if (args.route_id) params["route_id"] = String(args.route_id);
-  if (args.direction_id) params["direction_id"] = String(args.direction_id);
+  const maxResults = numberArg(args, "max_results", "PTV_DEFAULT_MAX_RESULTS", 5);
+  if (maxResults > 0) params["max_results"] = String(Math.min(20, maxResults));
+
+  const routeId = stringArg(args, "route_id", "PTV_HOME_ROUTE_ID");
+  if (routeId) {
+    params["route_id"] = routeId;
+    if (args.route_id === undefined && process.env.PTV_HOME_ROUTE_ID) defaultsUsed.push("PTV_HOME_ROUTE_ID");
+  }
+
+  const directionId = stringArg(args, "direction_id", "PTV_HOME_DIRECTION_ID");
+  if (directionId) {
+    params["direction_id"] = directionId;
+    if (args.direction_id === undefined && process.env.PTV_HOME_DIRECTION_ID) defaultsUsed.push("PTV_HOME_DIRECTION_ID");
+  }
+
   if (args.look_backwards === true) params["look_backwards"] = "true";
   if (args.include_cancelled === true) params["include_cancelled"] = "true";
 
-  return ptvFetch(`/v3/departures/route_type/${routeType}/stop/${stopId}`, params);
+  const result = await ptvFetch(`/v3/departures/route_type/${routeType}/stop/${stopId}`, params);
+  return addPtvMeta(result, "ptv_departures", defaultsUsed);
 }
 
 // ─── ptv_disruptions ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- let full UnClick fill ptv_departures defaults from Memory/business context
- let standalone PTV use env defaults for home stop/route settings
- add source/freshness metadata and next-step hints to PTV responses
- refresh the generated tool index and PTV standalone output

## Verification
- npx tsc -p packages/mcp-server/tsconfig.json --noEmit
- npm run test:brainmap
- node packages/mcp-server/scripts/check-standalone-registry.mjs
- npm run test --workspace=@unclick/mcp-server
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to PTV tooling and optional default injection; explicit args are not overridden, with tests covering merge behavior.
> 
> **Overview**
> Adds **memory-aware defaults** for `ptv_departures` in full UnClick: a new `tool-memory-defaults` layer loads home stop/route settings from business context or memory search, merges them only when `stop_id` is omitted, and the MCP server applies this before additional tool handlers run.
> 
> **PTV tool behavior** is expanded in both the main and standalone packages: `ptv_departures` can fall back to env vars (`PTV_HOME_*`, etc.), required schema fields are relaxed, and responses gain `unclick_meta` (source, attribution, fetch time, which defaults were used, next-step hints). Tool catalog text and the generated tool index note Memory-filled `stop_id`.
> 
> Tests cover memory extraction/merge, env-based departures metadata, and the tool-index generator’s main guard is fixed for cross-platform paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a136a8796778177c6873776450a0ceebe9418cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->