### PR TITLE
Add batch 4 standalone MCPs

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 560,
+    "inventory": 572,
     "source_manifest": 187,
     "pages": 78,
     "tools": 187,
@@ -81,7 +81,7 @@
       "id": "modules-and-apps",
       "name": "Modules and apps",
       "meaning": "Apps, packages, and product modules that make up UnClick.",
-      "count": 102
+      "count": 114
     },
     {
       "id": "launch-and-onboarding",
@@ -2192,6 +2192,16 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-abn-mcp-packages-standalone-abn-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "abn mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/abn-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-amber-mcp-packages-standalone-amber-mcp-package-json-no-route",
       "division": "Modules and apps",
       "name": "amber mcp",
@@ -2228,6 +2238,16 @@
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/channel-plugin/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-chessdotcom-mcp-packages-standalone-chessdotcom-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "chessdotcom mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/chessdotcom-mcp/package.json",
       "route": "",
       "tags": []
     },
@@ -2282,6 +2302,16 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-deezer-mcp-packages-standalone-deezer-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "deezer mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/deezer-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-domain-mcp-packages-standalone-domain-mcp-package-json-no-route",
       "division": "Modules and apps",
       "name": "domain mcp",
@@ -2318,6 +2348,26 @@
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/flowpass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-fpl-mcp-packages-standalone-fpl-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "fpl mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/fpl-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-gdelt-mcp-packages-standalone-gdelt-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "gdelt mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/gdelt-mcp/package.json",
       "route": "",
       "tags": []
     },
@@ -2362,6 +2412,16 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-ipapi-mcp-packages-standalone-ipapi-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "ipapi mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/ipapi-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-ipaustralia-mcp-packages-standalone-ipaustralia-mcp-package-json-no-route",
       "division": "Modules and apps",
       "name": "ipaustralia mcp",
@@ -2388,6 +2448,16 @@
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/legalpass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-lichess-mcp-packages-standalone-lichess-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "lichess mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/lichess-mcp/package.json",
       "route": "",
       "tags": []
     },
@@ -2462,6 +2532,26 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-openf1-mcp-packages-standalone-openf1-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "openf1 mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/openf1-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-openfoodfacts-mcp-packages-standalone-openfoodfacts-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "openfoodfacts mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/openfoodfacts-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-openlibrary-mcp-packages-standalone-openlibrary-mcp-package-json-no-route",
       "division": "Modules and apps",
       "name": "openlibrary mcp",
@@ -2488,6 +2578,16 @@
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/standalone/ptv-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-radiobrowser-mcp-packages-standalone-radiobrowser-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "radiobrowser mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/radiobrowser-mcp/package.json",
       "route": "",
       "tags": []
     },
@@ -2552,12 +2652,32 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-package-sleeper-mcp-packages-standalone-sleeper-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "sleeper mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/sleeper-mcp/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-package-sloppass-packages-sloppass-package-json-no-route",
       "division": "Modules and apps",
       "name": "sloppass",
       "kind": "package",
       "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
       "source": "packages/sloppass/package.json",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-package-speedrun-mcp-packages-standalone-speedrun-mcp-package-json-no-route",
+      "division": "Modules and apps",
+      "name": "speedrun mcp",
+      "kind": "package",
+      "meaning": "Shared package used by UnClick tools, MCP, or worker lanes.",
+      "source": "packages/standalone/speedrun-mcp/package.json",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -215,7 +215,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 119 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
-| Modules and apps | Apps, packages, and product modules that make up UnClick. | 102 |
+| Modules and apps | Apps, packages, and product modules that make up UnClick. | 114 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 5 |
 
 ## UnClick Structure
@@ -733,26 +733,33 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | component | Storage Bar | Memory admin panel for Storage Bar. | - | src/pages/admin/memory/StorageBar.tsx |
 | Modules and apps | component | Todos | Admin surface for Todos. | - | src/pages/admin/fishbowl/Todos.tsx |
 | Modules and apps | component | Un Click Tools | Tool page for Un Click Tools. | - | src/pages/admin/tools/UnClickTools.tsx |
+| Modules and apps | package | abn mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/abn-mcp/package.json |
 | Modules and apps | package | amber mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/amber-mcp/package.json |
 | Modules and apps | package | australiapost mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/australiapost-mcp/package.json |
 | Modules and apps | package | bgg mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/bgg-mcp/package.json |
 | Modules and apps | package | channel plugin | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/channel-plugin/package.json |
+| Modules and apps | package | chessdotcom mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/chessdotcom-mcp/package.json |
 | Modules and apps | package | coingecko mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/coingecko-mcp/package.json |
 | Modules and apps | package | commonsensepass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/commonsensepass/package.json |
 | Modules and apps | package | compliancepass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/compliancepass/package.json |
 | Modules and apps | package | copypass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/copypass/package.json |
 | Modules and apps | package | core | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/core/package.json |
+| Modules and apps | package | deezer mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/deezer-mcp/package.json |
 | Modules and apps | package | domain mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/domain-mcp/package.json |
 | Modules and apps | package | espn mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/espn-mcp/package.json |
 | Modules and apps | package | exchangerate mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/exchangerate-mcp/package.json |
 | Modules and apps | package | flowpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/flowpass/package.json |
+| Modules and apps | package | fpl mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/fpl-mcp/package.json |
+| Modules and apps | package | gdelt mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/gdelt-mcp/package.json |
 | Modules and apps | package | genius mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/genius-mcp/package.json |
 | Modules and apps | package | geopass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/geopass/package.json |
 | Modules and apps | package | hackernews mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/hackernews-mcp/package.json |
 | Modules and apps | package | igdb mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/igdb-mcp/package.json |
+| Modules and apps | package | ipapi mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/ipapi-mcp/package.json |
 | Modules and apps | package | ipaustralia mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/ipaustralia-mcp/package.json |
 | Modules and apps | package | lastfm mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/lastfm-mcp/package.json |
 | Modules and apps | package | legalpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/legalpass/package.json |
+| Modules and apps | package | lichess mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/lichess-mcp/package.json |
 | Modules and apps | package | mcp server | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/mcp-server/package.json |
 | Modules and apps | package | meal mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/meal-mcp/package.json |
 | Modules and apps | package | memory mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/memory-mcp/package.json |
@@ -760,16 +767,21 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | package | nasa mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/nasa-mcp/package.json |
 | Modules and apps | package | omdb mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/omdb-mcp/package.json |
 | Modules and apps | package | openaq mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/openaq-mcp/package.json |
+| Modules and apps | package | openf1 mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/openf1-mcp/package.json |
+| Modules and apps | package | openfoodfacts mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/openfoodfacts-mcp/package.json |
 | Modules and apps | package | openlibrary mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/openlibrary-mcp/package.json |
 | Modules and apps | package | openmeteo mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/openmeteo-mcp/package.json |
 | Modules and apps | package | ptv mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/ptv-mcp/package.json |
+| Modules and apps | package | radiobrowser mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/radiobrowser-mcp/package.json |
 | Modules and apps | package | rawg mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/rawg-mcp/package.json |
 | Modules and apps | package | reddit mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/reddit-mcp/package.json |
 | Modules and apps | package | restcountries mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/restcountries-mcp/package.json |
 | Modules and apps | package | securitypass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/securitypass/package.json |
 | Modules and apps | package | sendle mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/sendle-mcp/package.json |
 | Modules and apps | package | seopass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/seopass/package.json |
+| Modules and apps | package | sleeper mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/sleeper-mcp/package.json |
 | Modules and apps | package | sloppass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/sloppass/package.json |
+| Modules and apps | package | speedrun mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/speedrun-mcp/package.json |
 | Modules and apps | package | spotify mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/spotify-mcp/package.json |
 | Modules and apps | package | testpass | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/testpass/package.json |
 | Modules and apps | package | thelott mcp | Shared package used by UnClick tools, MCP, or worker lanes. | - | packages/standalone/thelott-mcp/package.json |

--- a/packages/mcp-server/scripts/generate-standalone-mcp.mjs
+++ b/packages/mcp-server/scripts/generate-standalone-mcp.mjs
@@ -71,6 +71,19 @@ const CONFIG = {
   rawg:          { title: "RAWG Games MCP",      blurb: "Search video games with detail, screenshots, genres, and upcoming releases from RAWG.", keywords: ["games", "rawg", "video-games"] },
   igdb:          { title: "IGDB Games MCP",      blurb: "Video game database: search games, companies, genres, and platforms via IGDB.", keywords: ["games", "igdb", "video-games"] },
   genius:        { title: "Genius Lyrics MCP",   blurb: "Search songs and artists and get song and artist detail from Genius.", keywords: ["genius", "lyrics", "songs", "music"] },
+  // -- batch 4 --
+  abn:           { title: "ABN Lookup MCP",       blurb: "Australian Business Number lookup and business name search.", keywords: ["abn", "business", "australia"] },
+  chessdotcom:   { title: "Chess.com MCP",        blurb: "Chess.com player profiles, stats, games, puzzles, and leaderboards. No API key.", keywords: ["chess", "chess.com", "games"] },
+  openf1:        { title: "OpenF1 MCP",           blurb: "Formula 1 sessions, drivers, positions, laps, pit stops, car data, radio, and weather.", keywords: ["formula-1", "f1", "racing"] },
+  openfoodfacts: { title: "Open Food Facts MCP",  blurb: "Search food products, ingredients, nutrition, brands, and categories. No API key.", keywords: ["food", "nutrition", "open-food-facts"] },
+  lichess:       { title: "Lichess MCP",          blurb: "Lichess player profiles, games, daily puzzle, top players, and tournaments.", keywords: ["lichess", "chess", "games"] },
+  radiobrowser:  { title: "Radio Browser MCP",    blurb: "Search internet radio stations by country, tag, popularity, and votes. No API key.", keywords: ["radio", "stations", "music"] },
+  speedrun:      { title: "Speedrun.com MCP",     blurb: "Speedrun.com games, leaderboards, runs, and users. No API key.", keywords: ["speedrun", "games", "leaderboards"] },
+  ipapi:         { title: "IP Geolocation MCP",   blurb: "IP address geolocation and batch lookup with country, city, region, ISP, and timezone.", keywords: ["ip", "geolocation", "network"] },
+  fpl:           { title: "Fantasy Premier League MCP", blurb: "Fantasy Premier League teams, fixtures, players, standings, and league data.", keywords: ["fpl", "football", "fantasy"] },
+  deezer:        { title: "Deezer MCP",           blurb: "Search Deezer tracks, artists, albums, playlists, charts, and podcasts. No API key.", keywords: ["deezer", "music", "podcasts"] },
+  gdelt:         { title: "GDELT News MCP",       blurb: "Global news search, events, tone, themes, and geographic signals from GDELT.", keywords: ["gdelt", "news", "events"] },
+  sleeper:       { title: "Sleeper Fantasy MCP",  blurb: "Sleeper fantasy football users, leagues, rosters, drafts, players, and matchups.", keywords: ["sleeper", "fantasy", "football"] },
 };
 
 // ─── Parse tool-wiring.ts ──────────────────────────────────────────────────────

--- a/packages/standalone/abn-mcp/LICENSE
+++ b/packages/standalone/abn-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/abn-mcp/README.md
+++ b/packages/standalone/abn-mcp/README.md
@@ -1,0 +1,34 @@
+# ABN Lookup MCP by UnClick
+
+Australian Business Number lookup and business name search.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "abn": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/abn.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `abn_lookup`
+- `abn_search`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/abn-mcp/package.json
+++ b/packages/standalone/abn-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/abn-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/abn",
+  "description": "Australian Business Number lookup and business name search. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "abn",
+    "business",
+    "australia"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "abn-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/abn-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/abn-mcp/server.json
+++ b/packages/standalone/abn-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/abn",
+  "title": "ABN Lookup MCP by UnClick",
+  "description": "Australian Business Number lookup and business name search. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/abn-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/abn-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/abn-mcp/src/abn-tool.ts
+++ b/packages/standalone/abn-mcp/src/abn-tool.ts
@@ -1,0 +1,102 @@
+// Australian Business Registry (ABN Lookup) integration.
+// Uses the free ABR JSONP API - no authentication required.
+// Base URL: https://abr.business.gov.au/json/
+
+const ABN_BASE = "https://abr.business.gov.au/json";
+
+// ─── JSONP helper ─────────────────────────────────────────────────────────────
+
+async function fetchJsonp(url: string): Promise<unknown> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
+  });
+  if (!res.ok) {
+    throw new Error(`ABR API HTTP ${res.status}`);
+  }
+  const text = await res.text();
+  // Strip JSONP wrapper: callback({...}) or callback([...])
+  const match = text.match(/^[a-zA-Z_$][a-zA-Z0-9_$]*\s*\(([\s\S]*)\)\s*;?\s*$/);
+  if (!match) {
+    throw new Error("Unexpected ABR API response format (not JSONP).");
+  }
+  return JSON.parse(match[1]) as unknown;
+}
+
+// ─── abn_lookup ───────────────────────────────────────────────────────────────
+// GET /AbnDetails.aspx?abn={abn}&callback=callback
+// Returns entity name, type, ABN status, GST status, main business location.
+
+export async function abnLookup(args: Record<string, unknown>): Promise<unknown> {
+  const abn = String(args.abn ?? "").trim().replace(/\s/g, "");
+  if (!abn) return { error: "abn is required (11-digit Australian Business Number)." };
+
+  const url = `${ABN_BASE}/AbnDetails.aspx?abn=${encodeURIComponent(abn)}&callback=callback`;
+  const data = await fetchJsonp(url) as Record<string, unknown>;
+
+  if (data["Message"]) {
+    const msg = String(data["Message"]);
+    if (msg && msg.toLowerCase() !== "no record found") {
+      return { error: msg };
+    }
+  }
+
+  if (!data["Abn"]) {
+    return { error: "No business found for that ABN.", abn };
+  }
+
+  return {
+    abn: data["Abn"],
+    entity_name: data["EntityName"] ?? null,
+    entity_type_code: data["EntityTypeCode"] ?? null,
+    entity_type: data["EntityTypeName"] ?? null,
+    abn_status: data["AbnStatus"] ?? null,
+    abn_status_effective_from: data["AbnStatusEffectiveFrom"] ?? null,
+    gst_registered_from: data["Gst"] ?? null,
+    gst_status: data["Gst"] ? "Registered" : "Not registered",
+    acn: data["Acn"] || null,
+    address_state: data["AddressState"] ?? null,
+    address_postcode: data["AddressPostcode"] ?? null,
+    business_names: Array.isArray(data["BusinessName"])
+      ? (data["BusinessName"] as Array<Record<string, unknown>>).map(
+          (b) => ({ name: b["OrganisationName"], effective_from: b["EffectiveFrom"] })
+        )
+      : [],
+  };
+}
+
+// ─── abn_search ───────────────────────────────────────────────────────────────
+// GET /Search.aspx?name={name}&callback=callback
+// Returns list of matching businesses with ABNs.
+
+export async function abnSearch(args: Record<string, unknown>): Promise<unknown> {
+  const name = String(args.name ?? "").trim();
+  if (!name) return { error: "name is required." };
+
+  const params = new URLSearchParams({ name, callback: "callback" });
+  if (args.postcode) params.set("postcode", String(args.postcode));
+
+  const url = `${ABN_BASE}/Search.aspx?${params}`;
+  const data = await fetchJsonp(url) as Record<string, unknown>;
+
+  if (data["Message"]) {
+    const msg = String(data["Message"]);
+    if (msg) return { error: msg };
+  }
+
+  const names = Array.isArray(data["Names"]) ? data["Names"] as Array<Record<string, unknown>> : [];
+
+  return {
+    query: name,
+    count: names.length,
+    results: names.map((n) => ({
+      abn: n["Abn"],
+      name: n["Name"],
+      name_type: n["NameType"],
+      abn_status: n["AbnStatus"],
+      is_current: n["IsCurrent"],
+      state: n["State"] ?? null,
+      postcode: n["Postcode"] ?? null,
+      score: n["Score"] ?? null,
+    })),
+  };
+}

--- a/packages/standalone/abn-mcp/src/index.ts
+++ b/packages/standalone/abn-mcp/src/index.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// ABN Lookup MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  abnLookup,
+  abnSearch,
+} from "./abn-tool.js";
+
+const TOOLS = [
+  {
+    name: "abn_lookup",
+    description: "Look up an Australian Business Number (ABN).",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        abn: { type: "string" },
+        api_key: { type: "string" },
+      },
+      required: ["abn"],
+    },
+  },
+  {
+    name: "abn_search",
+    description: "Search for Australian businesses by name.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        name: { type: "string" },
+        api_key: { type: "string" },
+      },
+      required: ["name"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  abn_lookup: (args) => abnLookup(args as unknown as Parameters<typeof abnLookup>[0]),
+  abn_search: (args) => abnSearch(args as unknown as Parameters<typeof abnSearch>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/abn", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[abn-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/abn-mcp/tsconfig.json
+++ b/packages/standalone/abn-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/chessdotcom-mcp/LICENSE
+++ b/packages/standalone/chessdotcom-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/chessdotcom-mcp/README.md
+++ b/packages/standalone/chessdotcom-mcp/README.md
@@ -1,0 +1,37 @@
+# Chess.com MCP by UnClick
+
+Chess.com player profiles, stats, games, puzzles, and leaderboards. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "chessdotcom": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/chessdotcom.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `chess_player`
+- `chess_player_stats`
+- `chess_player_games`
+- `chess_puzzles_random`
+- `chess_leaderboards`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/chessdotcom-mcp/package.json
+++ b/packages/standalone/chessdotcom-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/chessdotcom-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/chessdotcom",
+  "description": "Chess.com player profiles, stats, games, puzzles, and leaderboards. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "chess",
+    "chess.com",
+    "games"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "chessdotcom-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/chessdotcom-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/chessdotcom-mcp/server.json
+++ b/packages/standalone/chessdotcom-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/chessdotcom",
+  "title": "Chess.com MCP by UnClick",
+  "description": "Chess.com player profiles, stats, games, puzzles, and leaderboards. No API key. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/chessdotcom-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/chessdotcom-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/chessdotcom-mcp/src/chessdotcom-tool.ts
+++ b/packages/standalone/chessdotcom-mcp/src/chessdotcom-tool.ts
@@ -1,0 +1,221 @@
+// Chess.com Public API integration for the UnClick MCP server.
+// Uses the Chess.com Published-Data API via fetch - no external dependencies, no API key required.
+// Documentation: https://www.chess.com/news/view/published-data-api
+
+const CHESS_BASE = "https://api.chess.com/pub";
+
+// ─── API helper ──────────────────────────────────────────────────────────────
+
+async function chessFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${CHESS_BASE}${path}`, {
+    headers: {
+      "User-Agent": "UnClick MCP Server",
+      Accept: "application/json",
+    },
+  });
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error(
+        `Not found (HTTP 404). Check the username or resource exists.`
+      );
+    }
+    throw new Error(`Chess.com API HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+export async function chessPlayer(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const username = String(args.username ?? "").trim().toLowerCase();
+  if (!username) throw new Error("username is required.");
+
+  const data = (await chessFetch<Record<string, unknown>>(
+    `/player/${username}`
+  )) as Record<string, unknown>;
+
+  return {
+    username: data.username,
+    name: data.name ?? null,
+    title: data.title ?? null,
+    country: data.country ?? null,
+    location: data.location ?? null,
+    joined: data.joined ? new Date(Number(data.joined) * 1000).toISOString() : null,
+    last_online: data.last_online
+      ? new Date(Number(data.last_online) * 1000).toISOString()
+      : null,
+    followers: data.followers ?? 0,
+    is_streamer: data.is_streamer ?? false,
+    verified: data.verified ?? false,
+    url: data.url ?? null,
+    avatar: data.avatar ?? null,
+  };
+}
+
+export async function chessPlayerStats(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const username = String(args.username ?? "").trim().toLowerCase();
+  if (!username) throw new Error("username is required.");
+
+  const data = (await chessFetch<Record<string, unknown>>(
+    `/player/${username}/stats`
+  )) as Record<string, unknown>;
+
+  const extractRating = (gameType: unknown) => {
+    if (!gameType || typeof gameType !== "object") return null;
+    const gt = gameType as Record<string, unknown>;
+    const last = (gt.last as Record<string, unknown>) ?? {};
+    const best = (gt.best as Record<string, unknown>) ?? {};
+    const record = (gt.record as Record<string, unknown>) ?? {};
+    return {
+      rating: last.rating ?? null,
+      best_rating: best.rating ?? null,
+      wins: record.win ?? 0,
+      losses: record.loss ?? 0,
+      draws: record.draw ?? 0,
+    };
+  };
+
+  return {
+    username,
+    chess_rapid: extractRating(data.chess_rapid),
+    chess_blitz: extractRating(data.chess_blitz),
+    chess_bullet: extractRating(data.chess_bullet),
+    chess_daily: extractRating(data.chess_daily),
+    tactics: data.tactics
+      ? {
+          highest: (data.tactics as Record<string, unknown>).highest ?? null,
+          lowest: (data.tactics as Record<string, unknown>).lowest ?? null,
+        }
+      : null,
+    puzzle_rush: data.puzzle_rush ?? null,
+  };
+}
+
+export async function chessPlayerGames(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const username = String(args.username ?? "").trim().toLowerCase();
+  if (!username) throw new Error("username is required.");
+  const year = String(args.year ?? "").trim();
+  const month = String(args.month ?? "").trim().padStart(2, "0");
+  if (!year) throw new Error("year is required (e.g. 2024).");
+  if (!args.month) throw new Error("month is required (e.g. 1 for January).");
+
+  const data = (await chessFetch<Record<string, unknown>>(
+    `/player/${username}/games/${year}/${month}`
+  )) as Record<string, unknown>;
+
+  const games = (data.games as Record<string, unknown>[]) ?? [];
+
+  return {
+    username,
+    year,
+    month,
+    count: games.length,
+    games: games.slice(-20).map((g) => ({
+      url: g.url,
+      pgn_first_move: g.pgn
+        ? String(g.pgn).split("\n").filter((l: string) => !l.startsWith("[")).join(" ").trim().slice(0, 100)
+        : null,
+      time_class: g.time_class,
+      time_control: g.time_control,
+      rated: g.rated,
+      white: {
+        username: (g.white as Record<string, unknown>)?.username,
+        result: (g.white as Record<string, unknown>)?.result,
+        rating: (g.white as Record<string, unknown>)?.rating,
+      },
+      black: {
+        username: (g.black as Record<string, unknown>)?.username,
+        result: (g.black as Record<string, unknown>)?.result,
+        rating: (g.black as Record<string, unknown>)?.rating,
+      },
+      end_time: g.end_time
+        ? new Date(Number(g.end_time) * 1000).toISOString()
+        : null,
+    })),
+  };
+}
+
+export async function chessPuzzlesRandom(
+  _args: Record<string, unknown>
+): Promise<unknown> {
+  const data = (await chessFetch<Record<string, unknown>>(
+    "/puzzle/random"
+  )) as Record<string, unknown>;
+
+  return {
+    title: data.title ?? null,
+    url: data.url ?? null,
+    publish_time: data.publish_time
+      ? new Date(Number(data.publish_time) * 1000).toISOString()
+      : null,
+    fen: data.fen ?? null,
+    pgn: data.pgn ?? null,
+    image: data.image ?? null,
+  };
+}
+
+export async function chessLeaderboards(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const data = (await chessFetch<Record<string, unknown>>(
+    "/leaderboards"
+  )) as Record<string, unknown>;
+
+  const gameType = args.game_type ? String(args.game_type) : null;
+  const validTypes = [
+    "live_rapid",
+    "live_blitz",
+    "live_bullet",
+    "live_bughouse",
+    "live_blitz960",
+    "live_threecheck",
+    "live_crazyhouse",
+    "live_kingofthehill",
+    "tactics",
+    "lessons",
+    "puzzle_rush",
+    "daily",
+    "daily960",
+  ];
+
+  if (gameType) {
+    if (!validTypes.includes(gameType)) {
+      throw new Error(
+        `game_type must be one of: ${validTypes.join(", ")}`
+      );
+    }
+    const board = (data[gameType] as Record<string, unknown>[]) ?? [];
+    return {
+      game_type: gameType,
+      count: board.length,
+      players: board.slice(0, 20).map((p) => ({
+        rank: p.rank,
+        username: p.username,
+        score: p.score,
+        title: p.title ?? null,
+        country: p.country ?? null,
+      })),
+    };
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const type of ["live_rapid", "live_blitz", "live_bullet", "daily"]) {
+    const board = (data[type] as Record<string, unknown>[]) ?? [];
+    result[type] = board.slice(0, 5).map((p) => ({
+      rank: p.rank,
+      username: p.username,
+      score: p.score,
+      title: p.title ?? null,
+    }));
+  }
+  return {
+    note: "Showing top 5 for rapid, blitz, bullet, and daily. Pass game_type for a full leaderboard.",
+    leaderboards: result,
+  };
+}

--- a/packages/standalone/chessdotcom-mcp/src/index.ts
+++ b/packages/standalone/chessdotcom-mcp/src/index.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Chess.com MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  chessPlayer,
+  chessPlayerStats,
+  chessPlayerGames,
+  chessPuzzlesRandom,
+  chessLeaderboards,
+} from "./chessdotcom-tool.js";
+
+const TOOLS = [
+  {
+    name: "chess_player",
+    description: "Get a Chess.com player profile.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        username: { type: "string" },
+      },
+      required: ["username"],
+    },
+  },
+  {
+    name: "chess_player_stats",
+    description: "Get Chess.com player statistics.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        username: { type: "string" },
+      },
+      required: ["username"],
+    },
+  },
+  {
+    name: "chess_player_games",
+    description: "Get recent games for a Chess.com player.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        username: { type: "string" },
+        year: { type: "number" },
+        month: { type: "number" },
+      },
+      required: ["username"],
+    },
+  },
+  {
+    name: "chess_puzzles_random",
+    description: "Get a random chess puzzle from Chess.com.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+  {
+    name: "chess_leaderboards",
+    description: "Get Chess.com leaderboards.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  chess_player: (args) => chessPlayer(args as unknown as Parameters<typeof chessPlayer>[0]),
+  chess_player_stats: (args) => chessPlayerStats(args as unknown as Parameters<typeof chessPlayerStats>[0]),
+  chess_player_games: (args) => chessPlayerGames(args as unknown as Parameters<typeof chessPlayerGames>[0]),
+  chess_puzzles_random: (args) => chessPuzzlesRandom(args as unknown as Parameters<typeof chessPuzzlesRandom>[0]),
+  chess_leaderboards: (args) => chessLeaderboards(args as unknown as Parameters<typeof chessLeaderboards>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/chessdotcom", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[chessdotcom-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/chessdotcom-mcp/tsconfig.json
+++ b/packages/standalone/chessdotcom-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/deezer-mcp/LICENSE
+++ b/packages/standalone/deezer-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/deezer-mcp/README.md
+++ b/packages/standalone/deezer-mcp/README.md
@@ -1,0 +1,38 @@
+# Deezer MCP by UnClick
+
+Search Deezer tracks, artists, albums, playlists, charts, and podcasts. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "deezer": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/deezer.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `deezer_search`
+- `deezer_get_artist`
+- `deezer_get_album`
+- `deezer_get_track`
+- `deezer_chart`
+- `deezer_search_playlist`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/deezer-mcp/package.json
+++ b/packages/standalone/deezer-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/deezer-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/deezer",
+  "description": "Search Deezer tracks, artists, albums, playlists, charts, and podcasts. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "deezer",
+    "music",
+    "podcasts"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "deezer-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/deezer-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/deezer-mcp/server.json
+++ b/packages/standalone/deezer-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/deezer",
+  "title": "Deezer MCP by UnClick",
+  "description": "Search Deezer tracks, artists, albums, playlists, charts, and podcasts. No API key. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/deezer-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/deezer-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/deezer-mcp/src/deezer-tool.ts
+++ b/packages/standalone/deezer-mcp/src/deezer-tool.ts
@@ -1,0 +1,236 @@
+// Deezer music API.
+// No API key required for basic search (public endpoints).
+// Base URL: https://api.deezer.com/
+
+const DEEZER_BASE = "https://api.deezer.com";
+
+async function deezerFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${DEEZER_BASE}${path}`, {
+    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
+  });
+  if (!res.ok) throw new Error(`Deezer API HTTP ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+interface DeezerTrack {
+  id: number;
+  title: string;
+  duration: number;
+  rank?: number;
+  preview?: string;
+  link?: string;
+  artist?: { id: number; name: string; picture?: string; link?: string };
+  album?: { id: number; title: string; cover?: string };
+}
+
+interface DeezerArtist {
+  id: number;
+  name: string;
+  nb_fan?: number;
+  nb_album?: number;
+  picture?: string;
+  picture_medium?: string;
+  link?: string;
+  radio?: boolean;
+}
+
+interface DeezerAlbum {
+  id: number;
+  title: string;
+  release_date?: string;
+  nb_tracks?: number;
+  duration?: number;
+  fans?: number;
+  cover?: string;
+  cover_medium?: string;
+  link?: string;
+  artist?: DeezerArtist;
+  tracks?: { data: DeezerTrack[] };
+  genres?: { data: Array<{ id: number; name: string }> };
+}
+
+interface DeezerSearchResponse {
+  data: DeezerTrack[];
+  total: number;
+  next?: string;
+}
+
+function normalizeTrack(t: DeezerTrack) {
+  return {
+    id: t.id,
+    title: t.title,
+    duration_seconds: t.duration,
+    duration_formatted: formatDuration(t.duration),
+    rank: t.rank ?? null,
+    preview_url: t.preview ?? null,
+    link: t.link ?? null,
+    artist: t.artist ? { id: t.artist.id, name: t.artist.name, link: t.artist.link ?? null } : null,
+    album: t.album ? { id: t.album.id, title: t.album.title, cover: t.album.cover ?? null } : null,
+  };
+}
+
+// ─── search_deezer ────────────────────────────────────────────────────────────
+
+export async function searchDeezer(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required." };
+
+  const limit = Math.min(50, Math.max(1, Number(args.limit ?? 10)));
+  const data = await deezerFetch<DeezerSearchResponse>(`/search?q=${encodeURIComponent(query)}&limit=${limit}`);
+
+  return {
+    query,
+    total: data.total,
+    returned: data.data.length,
+    tracks: data.data.map(normalizeTrack),
+  };
+}
+
+// ─── get_deezer_artist ────────────────────────────────────────────────────────
+
+export async function getDeezerArtist(args: Record<string, unknown>): Promise<unknown> {
+  const id = String(args.id ?? "").trim();
+  if (!id) return { error: "id is required (Deezer artist ID)." };
+
+  const artist = await deezerFetch<DeezerArtist>(`/artist/${encodeURIComponent(id)}`);
+
+  return {
+    id: artist.id,
+    name: artist.name,
+    fans: artist.nb_fan ?? null,
+    album_count: artist.nb_album ?? null,
+    picture: artist.picture_medium ?? artist.picture ?? null,
+    link: artist.link ?? null,
+    has_radio: artist.radio ?? null,
+  };
+}
+
+// ─── get_deezer_album ─────────────────────────────────────────────────────────
+
+export async function getDeezerAlbum(args: Record<string, unknown>): Promise<unknown> {
+  const id = String(args.id ?? "").trim();
+  if (!id) return { error: "id is required (Deezer album ID)." };
+
+  const album = await deezerFetch<DeezerAlbum>(`/album/${encodeURIComponent(id)}`);
+
+  return {
+    id: album.id,
+    title: album.title,
+    artist: album.artist ? { id: album.artist.id, name: album.artist.name } : null,
+    release_date: album.release_date ?? null,
+    track_count: album.nb_tracks ?? null,
+    duration_seconds: album.duration ?? null,
+    duration_formatted: album.duration ? formatDuration(album.duration) : null,
+    fans: album.fans ?? null,
+    cover: album.cover_medium ?? album.cover ?? null,
+    link: album.link ?? null,
+    genres: album.genres?.data.map((g) => g.name) ?? [],
+    tracklist: album.tracks?.data.map((t) => ({
+      id: t.id,
+      title: t.title,
+      duration_seconds: t.duration,
+      duration_formatted: formatDuration(t.duration),
+      preview_url: t.preview ?? null,
+    })) ?? [],
+  };
+}
+
+// ─── get_deezer_track ─────────────────────────────────────────────────────────
+
+export async function getDeezerTrack(args: Record<string, unknown>): Promise<unknown> {
+  const id = String(args.id ?? "").trim();
+  if (!id) return { error: "id is required (Deezer track ID)." };
+
+  interface FullTrack extends DeezerTrack {
+    bpm?: number;
+    gain?: number;
+    isrc?: string;
+    available_countries?: string[];
+  }
+
+  const track = await deezerFetch<FullTrack>(`/track/${encodeURIComponent(id)}`);
+
+  return {
+    ...normalizeTrack(track),
+    bpm: track.bpm ?? null,
+    isrc: track.isrc ?? null,
+    available_countries: track.available_countries ?? null,
+    note: track.preview ? "preview_url is a 30-second MP3 sample, freely accessible." : "No preview available for this track.",
+  };
+}
+
+// ─── get_deezer_chart ─────────────────────────────────────────────────────────
+
+interface DeezerChartResponse {
+  tracks: { data: DeezerTrack[] };
+}
+
+export async function getDeezerChart(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(50, Math.max(1, Number(args.limit ?? 10)));
+  const data = await deezerFetch<DeezerChartResponse>(`/chart/0/tracks?limit=${limit}`);
+
+  return {
+    chart: "Global Top Tracks",
+    count: data.tracks.data.length,
+    tracks: data.tracks.data.map((t, i) => ({
+      ...normalizeTrack(t),
+      rank: i + 1,
+    })),
+  };
+}
+
+// ─── search_deezer_playlist ───────────────────────────────────────────────────
+
+interface DeezerPlaylist {
+  id: number;
+  title: string;
+  nb_tracks?: number;
+  duration?: number;
+  fans?: number;
+  public?: boolean;
+  picture?: string;
+  picture_medium?: string;
+  link?: string;
+  user?: { id: number; name: string };
+}
+
+interface DeezerPlaylistSearchResponse {
+  data: DeezerPlaylist[];
+  total: number;
+}
+
+export async function searchDeezerPlaylist(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required." };
+
+  const limit = Math.min(25, Math.max(1, Number(args.limit ?? 10)));
+  const data = await deezerFetch<DeezerPlaylistSearchResponse>(`/search/playlist?q=${encodeURIComponent(query)}&limit=${limit}`);
+
+  return {
+    query,
+    total: data.total,
+    returned: data.data.length,
+    playlists: data.data.map((p) => ({
+      id: p.id,
+      title: p.title,
+      track_count: p.nb_tracks ?? null,
+      duration_seconds: p.duration ?? null,
+      duration_formatted: p.duration ? formatDuration(p.duration) : null,
+      fans: p.fans ?? null,
+      public: p.public ?? null,
+      cover: p.picture_medium ?? p.picture ?? null,
+      link: p.link ?? null,
+      created_by: p.user ? { id: p.user.id, name: p.user.name } : null,
+    })),
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}

--- a/packages/standalone/deezer-mcp/src/index.ts
+++ b/packages/standalone/deezer-mcp/src/index.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Deezer MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  searchDeezer,
+  getDeezerArtist,
+  getDeezerAlbum,
+  getDeezerTrack,
+  getDeezerChart,
+  searchDeezerPlaylist,
+} from "./deezer-tool.js";
+
+const TOOLS = [
+  {
+    name: "deezer_search",
+    description: "Search Deezer for tracks, artists, or albums.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        q: { type: "string" },
+        type: { type: "string", description: "track, artist, album, playlist" },
+        limit: { type: "number" },
+      },
+      required: ["q"],
+    },
+  },
+  {
+    name: "deezer_get_artist",
+    description: "Get a Deezer artist by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "number" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "deezer_get_album",
+    description: "Get a Deezer album by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "number" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "deezer_get_track",
+    description: "Get a Deezer track by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        id: { type: "number" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "deezer_chart",
+    description: "Get Deezer chart (top tracks/albums/artists).",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        type: { type: "string", description: "tracks, albums, artists, playlists" },
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "deezer_search_playlist",
+    description: "Search for Deezer playlists.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        q: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["q"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  deezer_search: (args) => searchDeezer(args as unknown as Parameters<typeof searchDeezer>[0]),
+  deezer_get_artist: (args) => getDeezerArtist(args as unknown as Parameters<typeof getDeezerArtist>[0]),
+  deezer_get_album: (args) => getDeezerAlbum(args as unknown as Parameters<typeof getDeezerAlbum>[0]),
+  deezer_get_track: (args) => getDeezerTrack(args as unknown as Parameters<typeof getDeezerTrack>[0]),
+  deezer_chart: (args) => getDeezerChart(args as unknown as Parameters<typeof getDeezerChart>[0]),
+  deezer_search_playlist: (args) => searchDeezerPlaylist(args as unknown as Parameters<typeof searchDeezerPlaylist>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/deezer", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[deezer-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/deezer-mcp/tsconfig.json
+++ b/packages/standalone/deezer-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/fpl-mcp/LICENSE
+++ b/packages/standalone/fpl-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/fpl-mcp/README.md
+++ b/packages/standalone/fpl-mcp/README.md
@@ -1,0 +1,39 @@
+# Fantasy Premier League MCP by UnClick
+
+Fantasy Premier League teams, fixtures, players, standings, and league data.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "fpl": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/fpl.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `fpl_bootstrap`
+- `fpl_player`
+- `fpl_gameweek`
+- `fpl_fixtures`
+- `fpl_my_team`
+- `fpl_manager`
+- `fpl_leagues_classic`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/fpl-mcp/package.json
+++ b/packages/standalone/fpl-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/fpl-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/fpl",
+  "description": "Fantasy Premier League teams, fixtures, players, standings, and league data. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "fpl",
+    "football",
+    "fantasy"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "fpl-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/fpl-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/fpl-mcp/server.json
+++ b/packages/standalone/fpl-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/fpl",
+  "title": "Fantasy Premier League MCP by UnClick",
+  "description": "Fantasy Premier League teams, fixtures, players, standings, and league data. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/fpl-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/fpl-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/fpl-mcp/src/fpl-tool.ts
+++ b/packages/standalone/fpl-mcp/src/fpl-tool.ts
@@ -1,0 +1,249 @@
+// Fantasy Premier League (FPL) API integration for the UnClick MCP server.
+// Uses the FPL public API via fetch - no external dependencies, no API key required.
+// Documentation: https://fantasy.premierleague.com/api/
+
+const FPL_BASE = "https://fantasy.premierleague.com/api";
+
+// ─── API helper ──────────────────────────────────────────────────────────────
+
+async function fplFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${FPL_BASE}${path}`, {
+    headers: {
+      "User-Agent": "UnClick MCP Server",
+      Accept: "application/json",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`FPL API HTTP ${res.status} for ${path}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+export async function fplBootstrap(
+  _args: Record<string, unknown>
+): Promise<unknown> {
+  const data = (await fplFetch<Record<string, unknown>>(
+    "/bootstrap-static/"
+  )) as Record<string, unknown>;
+
+  const players = (data.elements as Record<string, unknown>[]) ?? [];
+  const teams = (data.teams as Record<string, unknown>[]) ?? [];
+  const events = (data.events as Record<string, unknown>[]) ?? [];
+
+  const currentGw = events.find((e) => e.is_current === true);
+  const nextGw = events.find((e) => e.is_next === true);
+
+  return {
+    total_players: players.length,
+    total_teams: teams.length,
+    current_gameweek: currentGw
+      ? { id: currentGw.id, name: currentGw.name, deadline_time: currentGw.deadline_time }
+      : null,
+    next_gameweek: nextGw
+      ? { id: nextGw.id, name: nextGw.name, deadline_time: nextGw.deadline_time }
+      : null,
+    teams: teams.map((t) => ({
+      id: t.id,
+      name: t.name,
+      short_name: t.short_name,
+      strength: t.strength,
+    })),
+    top_players: players
+      .sort(
+        (a, b) =>
+          Number(b.total_points ?? 0) - Number(a.total_points ?? 0)
+      )
+      .slice(0, 20)
+      .map((p) => ({
+        id: p.id,
+        web_name: p.web_name,
+        first_name: p.first_name,
+        second_name: p.second_name,
+        team_id: p.team,
+        position: p.element_type,
+        total_points: p.total_points,
+        now_cost: p.now_cost,
+        selected_by_percent: p.selected_by_percent,
+        form: p.form,
+        status: p.status,
+      })),
+  };
+}
+
+export async function fplPlayer(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const id = String(args.id ?? "").trim();
+  if (!id) throw new Error("id is required (player element ID from fpl_bootstrap).");
+
+  const data = (await fplFetch<Record<string, unknown>>(
+    `/element-summary/${id}/`
+  )) as Record<string, unknown>;
+
+  const history = (data.history as Record<string, unknown>[]) ?? [];
+  const fixtures = (data.fixtures as Record<string, unknown>[]) ?? [];
+
+  return {
+    player_id: id,
+    season_stats: history.slice(-5).map((h) => ({
+      round: h.round,
+      opponent_team: h.opponent_team,
+      total_points: h.total_points,
+      minutes: h.minutes,
+      goals_scored: h.goals_scored,
+      assists: h.assists,
+      clean_sheets: h.clean_sheets,
+      bonus: h.bonus,
+      bps: h.bps,
+    })),
+    upcoming_fixtures: fixtures.slice(0, 5).map((f) => ({
+      event: f.event,
+      difficulty: f.difficulty,
+      kickoff_time: f.kickoff_time,
+      is_home: f.is_home,
+      team_h: f.team_h,
+      team_a: f.team_a,
+    })),
+  };
+}
+
+export async function fplGameweek(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const gw = String(args.gw ?? "").trim();
+  if (!gw) throw new Error("gw is required (gameweek number).");
+
+  const data = (await fplFetch<Record<string, unknown>>(
+    `/event/${gw}/live/`
+  )) as Record<string, unknown>;
+
+  const elements = (data.elements as Record<string, unknown>[]) ?? [];
+
+  return {
+    gameweek: Number(gw),
+    count: elements.length,
+    player_scores: elements.slice(0, 50).map((e) => {
+      const stats = (e.stats as Record<string, unknown>) ?? {};
+      return {
+        player_id: e.id,
+        total_points: stats.total_points,
+        minutes: stats.minutes,
+        goals_scored: stats.goals_scored,
+        assists: stats.assists,
+        bonus: stats.bonus,
+        clean_sheets: stats.clean_sheets,
+      };
+    }),
+  };
+}
+
+export async function fplFixtures(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const path = args.gw ? `/fixtures/?event=${args.gw}` : "/fixtures/";
+  const data = (await fplFetch<Record<string, unknown>[]>(path)) as Record<
+    string,
+    unknown
+  >[];
+
+  return {
+    count: data.length,
+    fixtures: data.slice(0, 50).map((f) => ({
+      id: f.id,
+      event: f.event,
+      kickoff_time: f.kickoff_time,
+      team_h: f.team_h,
+      team_a: f.team_a,
+      team_h_score: f.team_h_score ?? null,
+      team_a_score: f.team_a_score ?? null,
+      started: f.started,
+      finished: f.finished,
+    })),
+  };
+}
+
+export async function fplMyTeam(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const teamId = String(args.team_id ?? "").trim();
+  const gw = String(args.gw ?? "").trim();
+  if (!teamId) throw new Error("team_id is required.");
+  if (!gw) throw new Error("gw is required (gameweek number).");
+
+  const data = (await fplFetch<Record<string, unknown>>(
+    `/entry/${teamId}/event/${gw}/picks/`
+  )) as Record<string, unknown>;
+
+  const picks = (data.picks as Record<string, unknown>[]) ?? [];
+
+  return {
+    team_id: teamId,
+    gameweek: Number(gw),
+    active_chip: data.active_chip ?? null,
+    picks: picks.map((p) => ({
+      element: p.element,
+      position: p.position,
+      multiplier: p.multiplier,
+      is_captain: p.is_captain,
+      is_vice_captain: p.is_vice_captain,
+    })),
+  };
+}
+
+export async function fplManager(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const teamId = String(args.team_id ?? "").trim();
+  if (!teamId) throw new Error("team_id is required.");
+
+  const data = (await fplFetch<Record<string, unknown>>(
+    `/entry/${teamId}/`
+  )) as Record<string, unknown>;
+
+  return {
+    team_id: teamId,
+    manager_name: `${data.player_first_name ?? ""} ${data.player_last_name ?? ""}`.trim(),
+    team_name: data.name,
+    overall_rank: data.summary_overall_rank ?? null,
+    overall_points: data.summary_overall_points ?? null,
+    last_deadline_bank: data.last_deadline_bank ?? null,
+    last_deadline_value: data.last_deadline_value ?? null,
+    started_event: data.started_event ?? null,
+    favourite_team: data.favourite_team ?? null,
+  };
+}
+
+export async function fplLeaguesClassic(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const leagueId = String(args.league_id ?? "").trim();
+  if (!leagueId) throw new Error("league_id is required.");
+  const page = Math.max(1, Number(args.page ?? 1));
+
+  const data = (await fplFetch<Record<string, unknown>>(
+    `/leagues-classic/${leagueId}/standings/?page_standings=${page}`
+  )) as Record<string, unknown>;
+
+  const league = (data.league as Record<string, unknown>) ?? {};
+  const standings = (data.standings as Record<string, unknown>) ?? {};
+  const results = (standings.results as Record<string, unknown>[]) ?? [];
+
+  return {
+    league_id: leagueId,
+    league_name: league.name ?? null,
+    page,
+    has_next: standings.has_next ?? false,
+    count: results.length,
+    standings: results.map((r) => ({
+      rank: r.rank,
+      last_rank: r.last_rank,
+      team_name: r.entry_name,
+      manager_name: r.player_name,
+      entry_id: r.entry,
+      total: r.total,
+      event_total: r.event_total,
+    })),
+  };
+}

--- a/packages/standalone/fpl-mcp/src/index.ts
+++ b/packages/standalone/fpl-mcp/src/index.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Fantasy Premier League MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  fplBootstrap,
+  fplPlayer,
+  fplGameweek,
+  fplFixtures,
+  fplMyTeam,
+  fplManager,
+  fplLeaguesClassic,
+} from "./fpl-tool.js";
+
+const TOOLS = [
+  {
+    name: "fpl_bootstrap",
+    description: "Get Fantasy Premier League bootstrap data (players, teams, etc.).",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+  {
+    name: "fpl_player",
+    description: "Get FPL player details and history.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        player_id: { type: "number" },
+      },
+      required: ["player_id"],
+    },
+  },
+  {
+    name: "fpl_gameweek",
+    description: "Get FPL gameweek details.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        gameweek: { type: "number" },
+      },
+      required: ["gameweek"],
+    },
+  },
+  {
+    name: "fpl_fixtures",
+    description: "Get FPL fixtures, optionally for a gameweek.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        gameweek: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "fpl_my_team",
+    description: "Get an FPL manager's team for a gameweek.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        manager_id: { type: "number" },
+        gameweek: { type: "number" },
+        api_key: { type: "string" },
+      },
+      required: ["manager_id", "gameweek"],
+    },
+  },
+  {
+    name: "fpl_manager",
+    description: "Get an FPL manager profile.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        manager_id: { type: "number" },
+      },
+      required: ["manager_id"],
+    },
+  },
+  {
+    name: "fpl_leagues_classic",
+    description: "Get FPL classic league standings.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        league_id: { type: "number" },
+        page: { type: "number" },
+      },
+      required: ["league_id"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  fpl_bootstrap: (args) => fplBootstrap(args as unknown as Parameters<typeof fplBootstrap>[0]),
+  fpl_player: (args) => fplPlayer(args as unknown as Parameters<typeof fplPlayer>[0]),
+  fpl_gameweek: (args) => fplGameweek(args as unknown as Parameters<typeof fplGameweek>[0]),
+  fpl_fixtures: (args) => fplFixtures(args as unknown as Parameters<typeof fplFixtures>[0]),
+  fpl_my_team: (args) => fplMyTeam(args as unknown as Parameters<typeof fplMyTeam>[0]),
+  fpl_manager: (args) => fplManager(args as unknown as Parameters<typeof fplManager>[0]),
+  fpl_leagues_classic: (args) => fplLeaguesClassic(args as unknown as Parameters<typeof fplLeaguesClassic>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/fpl", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[fpl-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/fpl-mcp/tsconfig.json
+++ b/packages/standalone/fpl-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/gdelt-mcp/LICENSE
+++ b/packages/standalone/gdelt-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/gdelt-mcp/README.md
+++ b/packages/standalone/gdelt-mcp/README.md
@@ -1,0 +1,36 @@
+# GDELT News MCP by UnClick
+
+Global news search, events, tone, themes, and geographic signals from GDELT.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "gdelt": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/gdelt.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `gdelt_news_search`
+- `gdelt_tone_analysis`
+- `gdelt_geo_events`
+- `gdelt_trending`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/gdelt-mcp/package.json
+++ b/packages/standalone/gdelt-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/gdelt-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/gdelt",
+  "description": "Global news search, events, tone, themes, and geographic signals from GDELT. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "gdelt",
+    "news",
+    "events"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "gdelt-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/gdelt-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/gdelt-mcp/server.json
+++ b/packages/standalone/gdelt-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/gdelt",
+  "title": "GDELT News MCP by UnClick",
+  "description": "Global news search, events, tone, themes, and geographic signals from GDELT. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/gdelt-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/gdelt-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/gdelt-mcp/src/gdelt-tool.ts
+++ b/packages/standalone/gdelt-mcp/src/gdelt-tool.ts
@@ -1,0 +1,233 @@
+// GDELT Project integration - global news intelligence, no auth required.
+// Docs: https://www.gdeltproject.org/
+// DOC API: https://api.gdeltproject.org/api/v2/doc/doc
+// GEO API: https://api.gdeltproject.org/api/v2/geo/geo
+// Updated every 15 minutes. Covers all broadcast, print, and web news globally.
+
+const GDELT_DOC = "https://api.gdeltproject.org/api/v2/doc/doc";
+const GDELT_GEO = "https://api.gdeltproject.org/api/v2/geo/geo";
+
+// ─── API helpers ──────────────────────────────────────────────────────────────
+
+async function gdeltFetch(base: string, params: URLSearchParams): Promise<unknown> {
+  const url = `${base}?${params}`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
+  });
+  if (!res.ok) throw new Error(`GDELT API HTTP ${res.status}`);
+  return res.json() as Promise<unknown>;
+}
+
+interface GdeltArticle {
+  url?: string;
+  url_mobile?: string;
+  title?: string;
+  seendate?: string;
+  socialimage?: string;
+  domain?: string;
+  language?: string;
+  sourcecountry?: string;
+}
+
+interface GdeltTimelineEntry {
+  date?: string;
+  value?: number;
+  normvalue?: number;
+}
+
+interface GdeltGeoFeature {
+  type?: string;
+  geometry?: { type?: string; coordinates?: [number, number] };
+  properties?: {
+    name?: string;
+    countrycode?: string;
+    adm1code?: string;
+    latitude?: string;
+    longitude?: string;
+    featureid?: string;
+    count?: number;
+    tone?: number;
+  };
+}
+
+// ─── gdelt_news_search ────────────────────────────────────────────────────────
+
+export async function gdeltNewsSearch(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required." };
+
+  const maxrecords = Math.min(250, Math.max(1, Number(args.maxrecords ?? 25)));
+  const params = new URLSearchParams({
+    query,
+    mode: "artlist",
+    format: "json",
+    maxrecords: String(maxrecords),
+  });
+
+  if (args.startdatetime) params.set("startdatetime", String(args.startdatetime));
+  if (args.enddatetime) params.set("enddatetime", String(args.enddatetime));
+  if (args.sourcelang) params.set("sourcelang", String(args.sourcelang));
+  if (args.sourcecountry) params.set("sourcecountry", String(args.sourcecountry));
+
+  const data = await gdeltFetch(GDELT_DOC, params) as { articles?: GdeltArticle[] };
+  const articles = data?.articles ?? [];
+
+  return {
+    query,
+    count: articles.length,
+    articles: articles.map((a) => ({
+      title: a.title ?? null,
+      url: a.url ?? null,
+      domain: a.domain ?? null,
+      date: a.seendate ?? null,
+      language: a.language ?? null,
+      country: a.sourcecountry ?? null,
+      image: a.socialimage ?? null,
+    })),
+  };
+}
+
+// ─── gdelt_tone_analysis ──────────────────────────────────────────────────────
+// Uses timelinetone mode - returns average tone score over time.
+// Negative values = negative sentiment; positive = positive sentiment.
+
+export async function gdeltToneAnalysis(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required." };
+
+  const params = new URLSearchParams({
+    query,
+    mode: "timelinetone",
+    format: "json",
+  });
+
+  if (args.timespan) params.set("timespan", String(args.timespan));
+  if (args.sourcelang) params.set("sourcelang", String(args.sourcelang));
+  if (args.sourcecountry) params.set("sourcecountry", String(args.sourcecountry));
+
+  const data = await gdeltFetch(GDELT_DOC, params) as {
+    timeline?: Array<{ data?: GdeltTimelineEntry[] }>;
+  };
+
+  const timelineArr = data?.timeline ?? [];
+  const entries: GdeltTimelineEntry[] = timelineArr.flatMap((t) => t?.data ?? []);
+
+  if (entries.length === 0) {
+    return { query, timeline: [], summary: null };
+  }
+
+  const values = entries.map((e) => e.value ?? 0).filter((v) => !isNaN(v));
+  const avg = values.length > 0 ? values.reduce((a, b) => a + b, 0) / values.length : 0;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const latest = entries[entries.length - 1];
+
+  return {
+    query,
+    summary: {
+      average_tone: Math.round(avg * 100) / 100,
+      min_tone: Math.round(min * 100) / 100,
+      max_tone: Math.round(max * 100) / 100,
+      latest_tone: Math.round((latest?.value ?? 0) * 100) / 100,
+      latest_date: latest?.date ?? null,
+      interpretation:
+        avg < -2 ? "strongly negative" :
+        avg < -0.5 ? "slightly negative" :
+        avg < 0.5 ? "neutral" :
+        avg < 2 ? "slightly positive" : "strongly positive",
+    },
+    timeline: entries.slice(-30).map((e) => ({
+      date: e.date ?? null,
+      tone: Math.round((e.value ?? 0) * 100) / 100,
+    })),
+  };
+}
+
+// ─── gdelt_geo_events ─────────────────────────────────────────────────────────
+// Uses the GDELT GEO API - returns geographic event clusters with article counts and tone.
+
+export async function gdeltGeoEvents(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required." };
+
+  const maxpoints = Math.min(250, Math.max(1, Number(args.maxpoints ?? 50)));
+  const params = new URLSearchParams({
+    query,
+    format: "json",
+    maxpoints: String(maxpoints),
+  });
+
+  if (args.timespan) params.set("timespan", String(args.timespan));
+
+  const data = await gdeltFetch(GDELT_GEO, params) as { features?: GdeltGeoFeature[] };
+  const features = data?.features ?? [];
+
+  return {
+    query,
+    count: features.length,
+    events: features.map((f) => ({
+      name: f.properties?.name ?? null,
+      country: f.properties?.countrycode ?? null,
+      coordinates: f.geometry?.coordinates
+        ? { lat: f.geometry.coordinates[1], lng: f.geometry.coordinates[0] }
+        : null,
+      article_count: f.properties?.count ?? 0,
+      tone: f.properties?.tone != null
+        ? Math.round(f.properties.tone * 100) / 100
+        : null,
+    })).sort((a, b) => (b.article_count ?? 0) - (a.article_count ?? 0)),
+  };
+}
+
+// ─── gdelt_trending ───────────────────────────────────────────────────────────
+// Uses timelinevol mode - returns article volume over time for a query.
+// Shows whether a topic is surging, stable, or fading in the news cycle.
+
+export async function gdeltTrending(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required." };
+
+  const params = new URLSearchParams({
+    query,
+    mode: "timelinevol",
+    format: "json",
+  });
+
+  if (args.timespan) params.set("timespan", String(args.timespan));
+  if (args.sourcelang) params.set("sourcelang", String(args.sourcelang));
+
+  const data = await gdeltFetch(GDELT_DOC, params) as {
+    timeline?: Array<{ data?: GdeltTimelineEntry[] }>;
+  };
+
+  const timelineArr = data?.timeline ?? [];
+  const entries: GdeltTimelineEntry[] = timelineArr.flatMap((t) => t?.data ?? []);
+
+  if (entries.length === 0) {
+    return { query, trend: "no data", timeline: [] };
+  }
+
+  const values = entries.map((e) => e.normvalue ?? e.value ?? 0);
+  const recent = values.slice(-5);
+  const older = values.slice(0, Math.max(1, values.length - 5));
+  const recentAvg = recent.reduce((a, b) => a + b, 0) / recent.length;
+  const olderAvg = older.reduce((a, b) => a + b, 0) / older.length;
+
+  const trend =
+    olderAvg === 0 ? "emerging" :
+    recentAvg > olderAvg * 1.5 ? "surging" :
+    recentAvg > olderAvg * 1.1 ? "rising" :
+    recentAvg < olderAvg * 0.5 ? "fading" :
+    recentAvg < olderAvg * 0.9 ? "declining" : "stable";
+
+  return {
+    query,
+    trend,
+    recent_avg_volume: Math.round(recentAvg * 1000) / 1000,
+    older_avg_volume: Math.round(olderAvg * 1000) / 1000,
+    timeline: entries.map((e) => ({
+      date: e.date ?? null,
+      volume: Math.round((e.normvalue ?? e.value ?? 0) * 1000) / 1000,
+    })),
+  };
+}

--- a/packages/standalone/gdelt-mcp/src/index.ts
+++ b/packages/standalone/gdelt-mcp/src/index.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// GDELT News MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  gdeltNewsSearch,
+  gdeltToneAnalysis,
+  gdeltGeoEvents,
+  gdeltTrending,
+} from "./gdelt-tool.js";
+
+const TOOLS = [
+  {
+    name: "gdelt_news_search",
+    description: "Search global news via the GDELT Project. Returns article titles, URLs, sources, dates, countries, and languages. No API key required.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string", description: "Search query (keywords, phrases, or operators)" },
+        maxrecords: { type: "number", description: "Max articles to return (default 25, max 250)" },
+        startdatetime: { type: "string", description: "Start datetime YYYYMMDDHHMMSS (UTC)" },
+        enddatetime: { type: "string", description: "End datetime YYYYMMDDHHMMSS (UTC)" },
+        sourcelang: { type: "string", description: "Filter by source language (e.g. 'english', 'spanish')" },
+        sourcecountry: { type: "string", description: "Filter by source country code (e.g. 'US', 'GB', 'AU')" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "gdelt_tone_analysis",
+    description: "Analyse the sentiment and tone of global news coverage for a topic over time. Returns average tone scores (negative = negative coverage, positive = positive), trend summary, and timeline. Great for brand monitoring or tracking public sentiment.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string", description: "Topic or keyword to analyse" },
+        timespan: { type: "string", description: "Time window (e.g. '24h', '7d', '1month')" },
+        sourcelang: { type: "string", description: "Filter by source language" },
+        sourcecountry: { type: "string", description: "Filter by source country code" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "gdelt_geo_events",
+    description: "Get geographic distribution of news events for a topic from the GDELT GEO API. Returns event clusters with location, article count, and tone score.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string", description: "Topic or keyword to map" },
+        maxpoints: { type: "number", description: "Max location clusters to return (default 50, max 250)" },
+        timespan: { type: "string", description: "Time window (e.g. '24h', '7d')" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "gdelt_trending",
+    description: "Check whether a topic is trending in global news using GDELT article volume timelines. Returns a trend classification (surging, rising, stable, declining, fading) and volume data over time.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string", description: "Topic or keyword to check" },
+        timespan: { type: "string", description: "Time window (e.g. '24h', '7d', '1month')" },
+        sourcelang: { type: "string", description: "Filter by source language" },
+      },
+      required: ["query"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  gdelt_news_search: (args) => gdeltNewsSearch(args as unknown as Parameters<typeof gdeltNewsSearch>[0]),
+  gdelt_tone_analysis: (args) => gdeltToneAnalysis(args as unknown as Parameters<typeof gdeltToneAnalysis>[0]),
+  gdelt_geo_events: (args) => gdeltGeoEvents(args as unknown as Parameters<typeof gdeltGeoEvents>[0]),
+  gdelt_trending: (args) => gdeltTrending(args as unknown as Parameters<typeof gdeltTrending>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/gdelt", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[gdelt-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/gdelt-mcp/tsconfig.json
+++ b/packages/standalone/gdelt-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/ipapi-mcp/LICENSE
+++ b/packages/standalone/ipapi-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/ipapi-mcp/README.md
+++ b/packages/standalone/ipapi-mcp/README.md
@@ -1,0 +1,34 @@
+# IP Geolocation MCP by UnClick
+
+IP address geolocation and batch lookup with country, city, region, ISP, and timezone.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "ipapi": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/ipapi.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `ip_lookup`
+- `ip_batch`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/ipapi-mcp/package.json
+++ b/packages/standalone/ipapi-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/ipapi-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/ipapi",
+  "description": "IP address geolocation and batch lookup with country, city, region, ISP, and timezone. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "ip",
+    "geolocation",
+    "network"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "ipapi-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/ipapi-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/ipapi-mcp/server.json
+++ b/packages/standalone/ipapi-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/ipapi",
+  "title": "IP Geolocation MCP by UnClick",
+  "description": "IP address geolocation and batch lookup with country, city, region, ISP, and timezone. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/ipapi-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/ipapi-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/ipapi-mcp/src/index.ts
+++ b/packages/standalone/ipapi-mcp/src/index.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// IP Geolocation MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  ipLookup,
+  ipBatch,
+} from "./ipapi-tool.js";
+
+const TOOLS = [
+  {
+    name: "ip_lookup",
+    description: "Look up geolocation for an IP address.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        ip: { type: "string" },
+        api_key: { type: "string" },
+      },
+      required: ["ip"],
+    },
+  },
+  {
+    name: "ip_batch",
+    description: "Batch IP address geolocation lookup.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        ips: { type: "array", items: {}, description: "Array of IP address strings" },
+        api_key: { type: "string" },
+      },
+      required: ["ips"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  ip_lookup: (args) => ipLookup(args as unknown as Parameters<typeof ipLookup>[0]),
+  ip_batch: (args) => ipBatch(args as unknown as Parameters<typeof ipBatch>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/ipapi", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[ipapi-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/ipapi-mcp/src/ipapi-tool.ts
+++ b/packages/standalone/ipapi-mcp/src/ipapi-tool.ts
@@ -1,0 +1,93 @@
+// IP geolocation integration for the UnClick MCP server.
+// Uses the ip-api.com free tier via fetch - no auth required (100 req/min).
+// Returns country, region, city, lat/lon, ISP, timezone, and more.
+
+const IPAPI_BASE = "http://ip-api.com";
+
+// --- API helper ---
+
+async function ipapiGet(ip: string): Promise<Record<string, unknown>> {
+  const path = ip ? `/${encodeURIComponent(ip)}` : "/";
+  const url = `${IPAPI_BASE}/json${path}?fields=66846719`;
+
+  const response = await fetch(url, { headers: { "Accept": "application/json" } });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} from ip-api.com`);
+  }
+
+  const data = await response.json() as Record<string, unknown>;
+
+  if (data.status === "fail") {
+    throw new Error(`ip-api error: ${data.message ?? "Query failed"}`);
+  }
+
+  return data;
+}
+
+function normalizeIpData(data: Record<string, unknown>) {
+  return {
+    ip: data.query,
+    status: data.status,
+    country: data.country,
+    country_code: data.countryCode,
+    region: data.regionName,
+    region_code: data.region,
+    city: data.city,
+    zip: data.zip,
+    lat: data.lat,
+    lon: data.lon,
+    timezone: data.timezone,
+    isp: data.isp,
+    org: data.org,
+    as: data.as,
+    mobile: data.mobile,
+    proxy: data.proxy,
+    hosting: data.hosting,
+  };
+}
+
+// --- Operations ---
+
+export async function ipLookup(args: Record<string, unknown>): Promise<unknown> {
+  const ip = String(args.ip ?? "").trim();
+  // Empty ip will look up the caller's IP
+  const data = await ipapiGet(ip);
+  return normalizeIpData(data);
+}
+
+export async function ipBatch(args: Record<string, unknown>): Promise<unknown> {
+  const addresses = args.addresses;
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw new Error("addresses is required and must be a non-empty array of IP strings.");
+  }
+  if (addresses.length > 100) {
+    throw new Error("addresses array must contain 100 or fewer IPs per request.");
+  }
+
+  const body = addresses.map((a: unknown) => ({
+    query: String(a).trim(),
+    fields: "66846719",
+  }));
+
+  const response = await fetch(`${IPAPI_BASE}/batch`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Accept": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} from ip-api.com batch endpoint`);
+  }
+
+  const results = await response.json() as Array<Record<string, unknown>>;
+
+  return {
+    count: results.length,
+    results: results.map((r) => {
+      if (r.status === "fail") {
+        return { ip: r.query, error: r.message ?? "Query failed" };
+      }
+      return normalizeIpData(r);
+    }),
+  };
+}

--- a/packages/standalone/ipapi-mcp/tsconfig.json
+++ b/packages/standalone/ipapi-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/lichess-mcp/LICENSE
+++ b/packages/standalone/lichess-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/lichess-mcp/README.md
+++ b/packages/standalone/lichess-mcp/README.md
@@ -1,0 +1,37 @@
+# Lichess MCP by UnClick
+
+Lichess player profiles, games, daily puzzle, top players, and tournaments.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "lichess": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/lichess.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `lichess_user`
+- `lichess_user_games`
+- `lichess_puzzle_daily`
+- `lichess_top_players`
+- `lichess_tournament`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/lichess-mcp/package.json
+++ b/packages/standalone/lichess-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/lichess-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/lichess",
+  "description": "Lichess player profiles, games, daily puzzle, top players, and tournaments. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "lichess",
+    "chess",
+    "games"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "lichess-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/lichess-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/lichess-mcp/server.json
+++ b/packages/standalone/lichess-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/lichess",
+  "title": "Lichess MCP by UnClick",
+  "description": "Lichess player profiles, games, daily puzzle, top players, and tournaments. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/lichess-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/lichess-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/lichess-mcp/src/index.ts
+++ b/packages/standalone/lichess-mcp/src/index.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Lichess MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  lichessUser,
+  lichessUserGames,
+  lichessPuzzleDaily,
+  lichessTopPlayers,
+  lichessTournament,
+} from "./lichess-tool.js";
+
+const TOOLS = [
+  {
+    name: "lichess_user",
+    description: "Get a Lichess user profile.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        username: { type: "string" },
+      },
+      required: ["username"],
+    },
+  },
+  {
+    name: "lichess_user_games",
+    description: "Get games for a Lichess user.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        username: { type: "string" },
+        max: { type: "number" },
+        perfType: { type: "string" },
+        api_key: { type: "string" },
+      },
+      required: ["username"],
+    },
+  },
+  {
+    name: "lichess_puzzle_daily",
+    description: "Get the Lichess daily puzzle.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+  {
+    name: "lichess_top_players",
+    description: "Get top Lichess players for a game mode.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        perfType: { type: "string", enum: ["ultraBullet", "bullet", "blitz", "rapid", "classical", "chess960", "crazyhouse", "antichess", "atomic", "horde", "kingOfTheHill", "racingKings", "threeCheck"], description: "bullet, blitz, rapid, classical, etc." },
+        nb: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "lichess_tournament",
+    description: "Get details for a Lichess tournament.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        tournament_id: { type: "string" },
+      },
+      required: ["tournament_id"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  lichess_user: (args) => lichessUser(args as unknown as Parameters<typeof lichessUser>[0]),
+  lichess_user_games: (args) => lichessUserGames(args as unknown as Parameters<typeof lichessUserGames>[0]),
+  lichess_puzzle_daily: (args) => lichessPuzzleDaily(args as unknown as Parameters<typeof lichessPuzzleDaily>[0]),
+  lichess_top_players: (args) => lichessTopPlayers(args as unknown as Parameters<typeof lichessTopPlayers>[0]),
+  lichess_tournament: (args) => lichessTournament(args as unknown as Parameters<typeof lichessTournament>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/lichess", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[lichess-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/lichess-mcp/src/lichess-tool.ts
+++ b/packages/standalone/lichess-mcp/src/lichess-tool.ts
@@ -1,0 +1,251 @@
+// Lichess API integration for the UnClick MCP server.
+// Uses the Lichess public API via fetch - no external dependencies, no API key required.
+// Documentation: https://lichess.org/api
+
+const LICHESS_BASE = "https://lichess.org/api";
+
+// ─── API helper ──────────────────────────────────────────────────────────────
+
+async function lichessFetch<T>(
+  path: string,
+  params: Record<string, string> = {}
+): Promise<T> {
+  const url = new URL(`${LICHESS_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== "") url.searchParams.set(k, v);
+  }
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "UnClick MCP Server",
+    },
+  });
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("Not found (HTTP 404). Check the username or resource exists.");
+    }
+    const text = await res.text().catch(() => "");
+    throw new Error(`Lichess API HTTP ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+export async function lichessUser(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const username = String(args.username ?? "").trim().toLowerCase();
+  if (!username) throw new Error("username is required.");
+
+  const data = (await lichessFetch<Record<string, unknown>>(
+    `/user/${username}`
+  )) as Record<string, unknown>;
+
+  const perfs = (data.perfs as Record<string, unknown>) ?? {};
+  const ratings: Record<string, number | null> = {};
+  for (const [key, val] of Object.entries(perfs)) {
+    ratings[key] = (val as Record<string, unknown>).rating as number ?? null;
+  }
+
+  return {
+    id: data.id,
+    username: data.username,
+    title: data.title ?? null,
+    patron: data.patron ?? false,
+    created_at: data.createdAt
+      ? new Date(Number(data.createdAt)).toISOString()
+      : null,
+    seen_at: data.seenAt
+      ? new Date(Number(data.seenAt)).toISOString()
+      : null,
+    play_time_hours: data.playTime
+      ? Math.round(Number((data.playTime as Record<string, unknown>).total) / 3600)
+      : null,
+    game_count: data.count
+      ? (data.count as Record<string, unknown>).all
+      : null,
+    ratings,
+    online: data.online ?? false,
+  };
+}
+
+export async function lichessUserGames(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const username = String(args.username ?? "").trim().toLowerCase();
+  if (!username) throw new Error("username is required.");
+  const max = Math.min(50, Math.max(1, Number(args.max ?? 10)));
+
+  // Lichess returns NDJSON by default; request JSON
+  const url = new URL(`${LICHESS_BASE}/games/user/${username}`);
+  url.searchParams.set("max", String(max));
+  url.searchParams.set("pgnInJson", "false");
+  url.searchParams.set("clocks", "false");
+  url.searchParams.set("evals", "false");
+  url.searchParams.set("opening", "true");
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/x-ndjson",
+      "User-Agent": "UnClick MCP Server",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Lichess API HTTP ${res.status}`);
+  }
+
+  const text = await res.text();
+  const games = text
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter((g): g is Record<string, unknown> => g !== null);
+
+  return {
+    username,
+    count: games.length,
+    games: games.map((g) => {
+      const players = (g.players as Record<string, unknown>) ?? {};
+      const white = (players.white as Record<string, unknown>) ?? {};
+      const black = (players.black as Record<string, unknown>) ?? {};
+      return {
+        id: g.id,
+        rated: g.rated,
+        speed: g.speed,
+        status: g.status,
+        winner: g.winner ?? null,
+        created_at: g.createdAt
+          ? new Date(Number(g.createdAt)).toISOString()
+          : null,
+        white: {
+          user: (white.user as Record<string, unknown>)?.name ?? null,
+          rating: white.rating ?? null,
+          result: g.winner === "white" ? "win" : g.winner === "black" ? "loss" : "draw",
+        },
+        black: {
+          user: (black.user as Record<string, unknown>)?.name ?? null,
+          rating: black.rating ?? null,
+          result: g.winner === "black" ? "win" : g.winner === "white" ? "loss" : "draw",
+        },
+        opening: g.opening
+          ? (g.opening as Record<string, unknown>).name
+          : null,
+      };
+    }),
+  };
+}
+
+export async function lichessPuzzleDaily(
+  _args: Record<string, unknown>
+): Promise<unknown> {
+  const data = (await lichessFetch<Record<string, unknown>>(
+    "/puzzle/daily"
+  )) as Record<string, unknown>;
+
+  const puzzle = (data.puzzle as Record<string, unknown>) ?? {};
+  const game = (data.game as Record<string, unknown>) ?? {};
+
+  return {
+    id: puzzle.id,
+    rating: puzzle.rating ?? null,
+    plays: puzzle.plays ?? null,
+    themes: puzzle.themes ?? [],
+    solution: puzzle.solution ?? [],
+    fen: (game.pgn as string)?.split(" ").pop() ?? null,
+    pgn: game.pgn ?? null,
+    url: puzzle.id ? `https://lichess.org/training/${puzzle.id}` : null,
+  };
+}
+
+export async function lichessTopPlayers(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const perfType = String(args.perfType ?? "bullet");
+  const validTypes = [
+    "ultraBullet",
+    "bullet",
+    "blitz",
+    "rapid",
+    "classical",
+    "chess960",
+    "crazyhouse",
+    "antichess",
+    "atomic",
+    "horde",
+    "kingOfTheHill",
+    "racingKings",
+    "threeCheck",
+  ];
+  if (!validTypes.includes(perfType)) {
+    throw new Error(`perfType must be one of: ${validTypes.join(", ")}`);
+  }
+
+  const data = (await lichessFetch<Record<string, unknown>>(
+    `/player/top/10/${perfType}`
+  )) as Record<string, unknown>;
+
+  const users = (data.users as Record<string, unknown>[]) ?? [];
+
+  return {
+    perf_type: perfType,
+    count: users.length,
+    players: users.map((u) => {
+      const perfs = (u.perfs as Record<string, unknown>) ?? {};
+      const perf = (perfs[perfType] as Record<string, unknown>) ?? {};
+      return {
+        id: u.id,
+        username: u.username,
+        title: u.title ?? null,
+        patron: u.patron ?? false,
+        rating: perf.rating ?? null,
+        progress: perf.progress ?? null,
+      };
+    }),
+  };
+}
+
+export async function lichessTournament(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const id = String(args.id ?? "").trim();
+  if (!id) throw new Error("id is required (Lichess tournament ID).");
+
+  const data = (await lichessFetch<Record<string, unknown>>(
+    `/tournament/${id}`
+  )) as Record<string, unknown>;
+
+  const podium = (data.podium as Record<string, unknown>[]) ?? [];
+
+  return {
+    id: data.id,
+    full_name: data.fullName ?? data.id,
+    status: data.status ?? null,
+    starts_at: data.startsAt
+      ? new Date(Number(data.startsAt)).toISOString()
+      : null,
+    finished_at: data.finishesAt
+      ? new Date(Number(data.finishesAt)).toISOString()
+      : null,
+    nb_players: data.nbPlayers ?? null,
+    winner: podium[0]
+      ? {
+          username: (podium[0].player as Record<string, unknown>)?.name ?? null,
+          score: podium[0].score ?? null,
+        }
+      : null,
+    podium: podium.slice(0, 3).map((p) => ({
+      username: (p.player as Record<string, unknown>)?.name ?? null,
+      score: p.score ?? null,
+      nb: p.nb ?? null,
+    })),
+    url: `https://lichess.org/tournament/${id}`,
+  };
+}

--- a/packages/standalone/lichess-mcp/tsconfig.json
+++ b/packages/standalone/lichess-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/openf1-mcp/LICENSE
+++ b/packages/standalone/openf1-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/openf1-mcp/README.md
+++ b/packages/standalone/openf1-mcp/README.md
@@ -1,0 +1,40 @@
+# OpenF1 MCP by UnClick
+
+Formula 1 sessions, drivers, positions, laps, pit stops, car data, radio, and weather.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "openf1": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/openf1.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `f1_sessions`
+- `f1_drivers`
+- `f1_positions`
+- `f1_laps`
+- `f1_pit_stops`
+- `f1_car_data`
+- `f1_team_radio`
+- `f1_weather`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/openf1-mcp/package.json
+++ b/packages/standalone/openf1-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/openf1-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/openf1",
+  "description": "Formula 1 sessions, drivers, positions, laps, pit stops, car data, radio, and weather. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "formula-1",
+    "f1",
+    "racing"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "openf1-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/openf1-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/openf1-mcp/server.json
+++ b/packages/standalone/openf1-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/openf1",
+  "title": "OpenF1 MCP by UnClick",
+  "description": "Formula 1 sessions, drivers, positions, laps, pit stops, car data, radio, and weather. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/openf1-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/openf1-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/openf1-mcp/src/index.ts
+++ b/packages/standalone/openf1-mcp/src/index.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// OpenF1 MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  f1Sessions,
+  f1Drivers,
+  f1Positions,
+  f1Laps,
+  f1PitStops,
+  f1CarData,
+  f1TeamRadio,
+  f1Weather,
+} from "./openf1-tool.js";
+
+const TOOLS = [
+  {
+    name: "f1_sessions",
+    description: "Get Formula 1 sessions from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        year: { type: "number" },
+        session_type: { type: "string" },
+        country_name: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "f1_drivers",
+    description: "Get Formula 1 driver info from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_key: { type: "number" },
+        driver_number: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "f1_positions",
+    description: "Get Formula 1 position data from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_key: { type: "number" },
+        driver_number: { type: "number" },
+      },
+      required: ["session_key"],
+    },
+  },
+  {
+    name: "f1_laps",
+    description: "Get Formula 1 lap data from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_key: { type: "number" },
+        driver_number: { type: "number" },
+        lap_number: { type: "number" },
+      },
+      required: ["session_key"],
+    },
+  },
+  {
+    name: "f1_pit_stops",
+    description: "Get Formula 1 pit stop data from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_key: { type: "number" },
+        driver_number: { type: "number" },
+      },
+      required: ["session_key"],
+    },
+  },
+  {
+    name: "f1_car_data",
+    description: "Get Formula 1 car telemetry data from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_key: { type: "number" },
+        driver_number: { type: "number" },
+      },
+      required: ["session_key", "driver_number"],
+    },
+  },
+  {
+    name: "f1_team_radio",
+    description: "Get Formula 1 team radio messages from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_key: { type: "number" },
+        driver_number: { type: "number" },
+      },
+      required: ["session_key"],
+    },
+  },
+  {
+    name: "f1_weather",
+    description: "Get Formula 1 weather data from OpenF1.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        session_key: { type: "number" },
+      },
+      required: ["session_key"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  f1_sessions: (args) => f1Sessions(args as unknown as Parameters<typeof f1Sessions>[0]),
+  f1_drivers: (args) => f1Drivers(args as unknown as Parameters<typeof f1Drivers>[0]),
+  f1_positions: (args) => f1Positions(args as unknown as Parameters<typeof f1Positions>[0]),
+  f1_laps: (args) => f1Laps(args as unknown as Parameters<typeof f1Laps>[0]),
+  f1_pit_stops: (args) => f1PitStops(args as unknown as Parameters<typeof f1PitStops>[0]),
+  f1_car_data: (args) => f1CarData(args as unknown as Parameters<typeof f1CarData>[0]),
+  f1_team_radio: (args) => f1TeamRadio(args as unknown as Parameters<typeof f1TeamRadio>[0]),
+  f1_weather: (args) => f1Weather(args as unknown as Parameters<typeof f1Weather>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/openf1", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[openf1-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/openf1-mcp/src/openf1-tool.ts
+++ b/packages/standalone/openf1-mcp/src/openf1-tool.ts
@@ -1,0 +1,231 @@
+// OpenF1 Formula 1 API integration for the UnClick MCP server.
+// Uses the OpenF1 public API via fetch - no external dependencies, no API key required.
+// Documentation: https://openf1.org/
+
+const OPENF1_BASE = "https://api.openf1.org/v1";
+
+// ─── API helper ──────────────────────────────────────────────────────────────
+
+async function openf1Fetch<T>(
+  path: string,
+  params: Record<string, string | number>
+): Promise<T[]> {
+  const url = new URL(`${OPENF1_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== "") url.searchParams.set(k, String(v));
+  }
+  const res = await fetch(url.toString(), {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`OpenF1 API HTTP ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return res.json() as Promise<T[]>;
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+export async function f1Sessions(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const params: Record<string, string | number> = {};
+  if (args.year) params.year = Number(args.year);
+  if (args.country) params.country_name = String(args.country);
+  if (args.session_name) params.session_name = String(args.session_name);
+
+  const data = await openf1Fetch<Record<string, unknown>>("/sessions", params);
+
+  return {
+    count: data.length,
+    sessions: data.map((s) => ({
+      session_key: s.session_key,
+      session_name: s.session_name,
+      session_type: s.session_type,
+      date_start: s.date_start,
+      date_end: s.date_end,
+      year: s.year,
+      country_name: s.country_name,
+      circuit_short_name: s.circuit_short_name,
+      meeting_name: s.meeting_name,
+    })),
+  };
+}
+
+export async function f1Drivers(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const params: Record<string, string | number> = {};
+  if (args.session_key) params.session_key = Number(args.session_key);
+
+  const data = await openf1Fetch<Record<string, unknown>>("/drivers", params);
+
+  return {
+    count: data.length,
+    drivers: data.map((d) => ({
+      driver_number: d.driver_number,
+      full_name: d.full_name,
+      name_acronym: d.name_acronym,
+      team_name: d.team_name,
+      team_colour: d.team_colour ?? null,
+      country_code: d.country_code ?? null,
+      headshot_url: d.headshot_url ?? null,
+    })),
+  };
+}
+
+export async function f1Positions(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const sessionKey = args.session_key;
+  if (!sessionKey) throw new Error("session_key is required.");
+
+  const params: Record<string, string | number> = {
+    session_key: Number(sessionKey),
+  };
+  if (args.driver_number) params.driver_number = Number(args.driver_number);
+
+  const data = await openf1Fetch<Record<string, unknown>>("/position", params);
+
+  return {
+    count: data.length,
+    positions: data.slice(-50).map((p) => ({
+      driver_number: p.driver_number,
+      position: p.position,
+      date: p.date,
+    })),
+  };
+}
+
+export async function f1Laps(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const sessionKey = args.session_key;
+  if (!sessionKey) throw new Error("session_key is required.");
+
+  const params: Record<string, string | number> = {
+    session_key: Number(sessionKey),
+  };
+  if (args.driver_number) params.driver_number = Number(args.driver_number);
+  if (args.lap_number) params.lap_number = Number(args.lap_number);
+
+  const data = await openf1Fetch<Record<string, unknown>>("/laps", params);
+
+  return {
+    count: data.length,
+    laps: data.map((l) => ({
+      driver_number: l.driver_number,
+      lap_number: l.lap_number,
+      lap_duration: l.lap_duration ?? null,
+      is_pit_out_lap: l.is_pit_out_lap ?? false,
+      duration_sector_1: l.duration_sector_1 ?? null,
+      duration_sector_2: l.duration_sector_2 ?? null,
+      duration_sector_3: l.duration_sector_3 ?? null,
+    })),
+  };
+}
+
+export async function f1PitStops(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const sessionKey = args.session_key;
+  if (!sessionKey) throw new Error("session_key is required.");
+
+  const params: Record<string, string | number> = {
+    session_key: Number(sessionKey),
+  };
+  if (args.driver_number) params.driver_number = Number(args.driver_number);
+
+  const data = await openf1Fetch<Record<string, unknown>>("/pit", params);
+
+  return {
+    count: data.length,
+    pit_stops: data.map((p) => ({
+      driver_number: p.driver_number,
+      lap_number: p.lap_number,
+      pit_duration: p.pit_duration ?? null,
+      date: p.date,
+    })),
+  };
+}
+
+export async function f1CarData(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const sessionKey = args.session_key;
+  if (!sessionKey) throw new Error("session_key is required.");
+
+  const params: Record<string, string | number> = {
+    session_key: Number(sessionKey),
+  };
+  if (args.driver_number) params.driver_number = Number(args.driver_number);
+
+  const data = await openf1Fetch<Record<string, unknown>>("/car_data", params);
+  // Car data can be very large - return last 100 entries
+  const recent = data.slice(-100);
+
+  return {
+    count: recent.length,
+    note: "Returns last 100 telemetry entries. Use a specific driver_number to narrow results.",
+    telemetry: recent.map((c) => ({
+      driver_number: c.driver_number,
+      date: c.date,
+      speed: c.speed ?? null,
+      throttle: c.throttle ?? null,
+      brake: c.brake ?? null,
+      drs: c.drs ?? null,
+      gear: c.n_gear ?? null,
+      rpm: c.rpm ?? null,
+    })),
+  };
+}
+
+export async function f1TeamRadio(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const sessionKey = args.session_key;
+  if (!sessionKey) throw new Error("session_key is required.");
+
+  const params: Record<string, string | number> = {
+    session_key: Number(sessionKey),
+  };
+  if (args.driver_number) params.driver_number = Number(args.driver_number);
+
+  const data = await openf1Fetch<Record<string, unknown>>(
+    "/team_radio",
+    params
+  );
+
+  return {
+    count: data.length,
+    messages: data.map((r) => ({
+      driver_number: r.driver_number,
+      date: r.date,
+      recording_url: r.recording_url ?? null,
+    })),
+  };
+}
+
+export async function f1Weather(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const sessionKey = args.session_key;
+  if (!sessionKey) throw new Error("session_key is required.");
+
+  const data = await openf1Fetch<Record<string, unknown>>("/weather", {
+    session_key: Number(sessionKey),
+  });
+
+  return {
+    count: data.length,
+    weather: data.map((w) => ({
+      date: w.date,
+      air_temperature: w.air_temperature ?? null,
+      track_temperature: w.track_temperature ?? null,
+      humidity: w.humidity ?? null,
+      rainfall: w.rainfall ?? null,
+      wind_speed: w.wind_speed ?? null,
+      wind_direction: w.wind_direction ?? null,
+    })),
+  };
+}

--- a/packages/standalone/openf1-mcp/tsconfig.json
+++ b/packages/standalone/openf1-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/openfoodfacts-mcp/LICENSE
+++ b/packages/standalone/openfoodfacts-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/openfoodfacts-mcp/README.md
+++ b/packages/standalone/openfoodfacts-mcp/README.md
@@ -1,0 +1,35 @@
+# Open Food Facts MCP by UnClick
+
+Search food products, ingredients, nutrition, brands, and categories. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "openfoodfacts": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/openfoodfacts.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `food_search`
+- `food_get_product`
+- `food_by_category`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/openfoodfacts-mcp/package.json
+++ b/packages/standalone/openfoodfacts-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/openfoodfacts-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/openfoodfacts",
+  "description": "Search food products, ingredients, nutrition, brands, and categories. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "food",
+    "nutrition",
+    "open-food-facts"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "openfoodfacts-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/openfoodfacts-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/openfoodfacts-mcp/server.json
+++ b/packages/standalone/openfoodfacts-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/openfoodfacts",
+  "title": "Open Food Facts MCP by UnClick",
+  "description": "Search food products, ingredients, nutrition, brands, and categories. No API key. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/openfoodfacts-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/openfoodfacts-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/openfoodfacts-mcp/src/index.ts
+++ b/packages/standalone/openfoodfacts-mcp/src/index.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Open Food Facts MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  searchFoodProducts,
+  getFoodProduct,
+  getFoodByCategory,
+} from "./openfoodfacts-tool.js";
+
+const TOOLS = [
+  {
+    name: "food_search",
+    description: "Search for food products on Open Food Facts.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        query: { type: "string" },
+        page: { type: "number" },
+        page_size: { type: "number" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "food_get_product",
+    description: "Get a food product from Open Food Facts by barcode.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        barcode: { type: "string" },
+      },
+      required: ["barcode"],
+    },
+  },
+  {
+    name: "food_by_category",
+    description: "Get food products by category from Open Food Facts.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        category: { type: "string" },
+        page: { type: "number" },
+      },
+      required: ["category"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  food_search: (args) => searchFoodProducts(args as unknown as Parameters<typeof searchFoodProducts>[0]),
+  food_get_product: (args) => getFoodProduct(args as unknown as Parameters<typeof getFoodProduct>[0]),
+  food_by_category: (args) => getFoodByCategory(args as unknown as Parameters<typeof getFoodByCategory>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/openfoodfacts", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[openfoodfacts-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/openfoodfacts-mcp/src/openfoodfacts-tool.ts
+++ b/packages/standalone/openfoodfacts-mcp/src/openfoodfacts-tool.ts
@@ -1,0 +1,154 @@
+// ─── Open Food Facts Product Database ────────────────────────────────────────
+// Free, open-source food product database - no auth required.
+// Docs: https://wiki.openfoodfacts.org/API
+
+const OFF_BASE = "https://world.openfoodfacts.org";
+
+// ─── API helper ──────────────────────────────────────────────────────────────
+
+async function offFetch<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": "UnClick-MCP/1.0 (mcp@unclick.io)" },
+  });
+  if (!res.ok) {
+    throw new Error(`Open Food Facts API HTTP ${res.status}: ${url}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function mapProduct(p: Record<string, unknown>) {
+  return {
+    code:             p.code ?? p._id,
+    product_name:     p.product_name ?? p.product_name_en ?? null,
+    brands:           p.brands         ?? null,
+    categories:       p.categories     ?? null,
+    quantity:         p.quantity        ?? null,
+    image_url:        p.image_url       ?? null,
+    nutriscore_grade: p.nutriscore_grade ?? null,
+    ecoscore_grade:   p.ecoscore_grade  ?? null,
+    nova_group:       p.nova_group      ?? null,
+    ingredients_text: p.ingredients_text ?? null,
+    allergens:        p.allergens        ?? null,
+    labels:           p.labels           ?? null,
+    countries:        p.countries        ?? null,
+    nutriments: p.nutriments
+      ? {
+          energy_kcal_100g:   (p.nutriments as Record<string, unknown>)["energy-kcal_100g"] ?? null,
+          fat_100g:            (p.nutriments as Record<string, unknown>)["fat_100g"] ?? null,
+          saturated_fat_100g:  (p.nutriments as Record<string, unknown>)["saturated-fat_100g"] ?? null,
+          carbohydrates_100g:  (p.nutriments as Record<string, unknown>)["carbohydrates_100g"] ?? null,
+          sugars_100g:         (p.nutriments as Record<string, unknown>)["sugars_100g"] ?? null,
+          fiber_100g:          (p.nutriments as Record<string, unknown>)["fiber_100g"] ?? null,
+          proteins_100g:       (p.nutriments as Record<string, unknown>)["proteins_100g"] ?? null,
+          salt_100g:           (p.nutriments as Record<string, unknown>)["salt_100g"] ?? null,
+        }
+      : null,
+  };
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+export async function searchFoodProducts(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const query    = String(args.query ?? args.search_terms ?? "").trim();
+  if (!query) throw new Error("query is required.");
+
+  const page     = Math.max(1, Number(args.page ?? 1));
+  const pageSize = Math.min(50, Math.max(1, Number(args.page_size ?? 10)));
+
+  const url = new URL(`${OFF_BASE}/cgi/search.pl`);
+  url.searchParams.set("search_terms", query);
+  url.searchParams.set("json",         "1");
+  url.searchParams.set("page",         String(page));
+  url.searchParams.set("page_size",    String(pageSize));
+  url.searchParams.set("fields",
+    "code,product_name,brands,categories,quantity,image_url,nutriscore_grade,ecoscore_grade,nova_group,nutriments"
+  );
+
+  interface SearchResponse {
+    count:    number;
+    page:     number;
+    page_size: number;
+    products: Record<string, unknown>[];
+  }
+
+  const data = await offFetch<SearchResponse>(url.toString());
+
+  return {
+    query,
+    count:    data.count,
+    page,
+    page_size: pageSize,
+    products: (data.products ?? []).map(mapProduct),
+  };
+}
+
+export async function getFoodProduct(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const barcode = String(args.barcode ?? "").trim().replace(/[^0-9]/g, "");
+  if (!barcode) throw new Error("barcode is required (numeric EAN/UPC code).");
+
+  interface ProductResponse {
+    status:  number;
+    product: Record<string, unknown>;
+  }
+
+  const data = await offFetch<ProductResponse>(
+    `${OFF_BASE}/api/v2/product/${barcode}.json`
+  );
+
+  if (data.status !== 1 || !data.product) {
+    return { error: `Product with barcode ${barcode} not found.` };
+  }
+
+  return mapProduct({ ...data.product, code: barcode });
+}
+
+export async function getFoodByCategory(
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const category = String(args.category ?? "").trim().toLowerCase().replace(/\s+/g, "-");
+  if (!category) throw new Error("category is required (e.g. 'biscuits', 'dairy').");
+
+  const page     = Math.max(1, Number(args.page ?? 1));
+  const pageSize = Math.min(50, Math.max(1, Number(args.page_size ?? 10)));
+
+  const url = new URL(`${OFF_BASE}/category/${category}.json`);
+  url.searchParams.set("page",      String(page));
+  url.searchParams.set("page_size", String(pageSize));
+
+  interface CategoryResponse {
+    count:    number;
+    products: Record<string, unknown>[];
+  }
+
+  const data = await offFetch<CategoryResponse>(url.toString());
+
+  return {
+    category,
+    count:    data.count ?? 0,
+    page,
+    products: (data.products ?? []).slice(0, pageSize).map(mapProduct),
+  };
+}
+
+// ─── Public dispatcher ────────────────────────────────────────────────────────
+
+export async function openFoodFactsAction(
+  action: string,
+  args:   Record<string, unknown>
+): Promise<unknown> {
+  switch (action) {
+    case "search_food_products": return searchFoodProducts(args);
+    case "get_food_product":     return getFoodProduct(args);
+    case "get_food_by_category": return getFoodByCategory(args);
+    default:
+      return {
+        error:
+          `Unknown Open Food Facts action: "${action}". ` +
+          "Valid: search_food_products, get_food_product, get_food_by_category.",
+      };
+  }
+}

--- a/packages/standalone/openfoodfacts-mcp/tsconfig.json
+++ b/packages/standalone/openfoodfacts-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/radiobrowser-mcp/LICENSE
+++ b/packages/standalone/radiobrowser-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/radiobrowser-mcp/README.md
+++ b/packages/standalone/radiobrowser-mcp/README.md
@@ -1,0 +1,38 @@
+# Radio Browser MCP by UnClick
+
+Search internet radio stations by country, tag, popularity, and votes. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "radiobrowser": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/radiobrowser.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `radio_search`
+- `radio_by_country`
+- `radio_top_clicked`
+- `radio_top_voted`
+- `radio_by_tag`
+- `radio_countries`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/radiobrowser-mcp/package.json
+++ b/packages/standalone/radiobrowser-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/radiobrowser-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/radiobrowser",
+  "description": "Search internet radio stations by country, tag, popularity, and votes. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "radio",
+    "stations",
+    "music"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "radiobrowser-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/radiobrowser-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/radiobrowser-mcp/server.json
+++ b/packages/standalone/radiobrowser-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/radiobrowser",
+  "title": "Radio Browser MCP by UnClick",
+  "description": "Search internet radio stations by country, tag, popularity, and votes. No API key. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/radiobrowser-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/radiobrowser-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/radiobrowser-mcp/src/index.ts
+++ b/packages/standalone/radiobrowser-mcp/src/index.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Radio Browser MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  radioSearch,
+  radioByCountry,
+  radioTopClicked,
+  radioTopVoted,
+  radioByTag,
+  radioCountries,
+} from "./radiobrowser-tool.js";
+
+const TOOLS = [
+  {
+    name: "radio_search",
+    description: "Search for radio stations via Radio Browser.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        name: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "radio_by_country",
+    description: "Get radio stations by country.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        country: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["country"],
+    },
+  },
+  {
+    name: "radio_top_clicked",
+    description: "Get the most-clicked radio stations.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "radio_top_voted",
+    description: "Get the most-voted radio stations.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "radio_by_tag",
+    description: "Get radio stations by genre tag.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        tag: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["tag"],
+    },
+  },
+  {
+    name: "radio_countries",
+    description: "List all countries with radio stations.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  radio_search: (args) => radioSearch(args as unknown as Parameters<typeof radioSearch>[0]),
+  radio_by_country: (args) => radioByCountry(args as unknown as Parameters<typeof radioByCountry>[0]),
+  radio_top_clicked: (args) => radioTopClicked(args as unknown as Parameters<typeof radioTopClicked>[0]),
+  radio_top_voted: (args) => radioTopVoted(args as unknown as Parameters<typeof radioTopVoted>[0]),
+  radio_by_tag: (args) => radioByTag(args as unknown as Parameters<typeof radioByTag>[0]),
+  radio_countries: (args) => radioCountries(args as unknown as Parameters<typeof radioCountries>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/radiobrowser", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[radiobrowser-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/radiobrowser-mcp/src/radiobrowser-tool.ts
+++ b/packages/standalone/radiobrowser-mcp/src/radiobrowser-tool.ts
@@ -1,0 +1,174 @@
+// Radio Browser API integration - 50,000+ internet radio stations worldwide.
+// No authentication required - completely free and open.
+// Base URL: https://de1.api.radio-browser.info/json/
+
+const RADIO_BASE = "https://de1.api.radio-browser.info/json";
+
+// ─── API helper ───────────────────────────────────────────────────────────────
+
+async function radioFetch(path: string, params?: URLSearchParams): Promise<unknown> {
+  const url = params ? `${RADIO_BASE}${path}?${params}` : `${RADIO_BASE}${path}`;
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "UnClickMCP/1.0 (https://unclick.io)",
+      "Accept": "application/json",
+    },
+  });
+  if (!res.ok) throw new Error(`Radio Browser API HTTP ${res.status}`);
+  return res.json() as Promise<unknown>;
+}
+
+interface Station {
+  stationuuid: string;
+  name: string;
+  url: string;
+  url_resolved?: string;
+  homepage?: string;
+  favicon?: string;
+  country?: string;
+  countrycode?: string;
+  language?: string;
+  tags?: string;
+  codec?: string;
+  bitrate?: number;
+  votes?: number;
+  clickcount?: number;
+  lastchangetime?: string;
+}
+
+function normalizeStation(s: Station) {
+  return {
+    id: s.stationuuid,
+    name: s.name,
+    stream_url: s.url_resolved || s.url,
+    homepage: s.homepage || null,
+    favicon: s.favicon || null,
+    country: s.country || null,
+    country_code: s.countrycode || null,
+    language: s.language || null,
+    tags: s.tags ? s.tags.split(",").map((t) => t.trim()).filter(Boolean) : [],
+    codec: s.codec || null,
+    bitrate: s.bitrate || null,
+    votes: s.votes || 0,
+    click_count: s.clickcount || 0,
+  };
+}
+
+// ─── radio_search ─────────────────────────────────────────────────────────────
+// POST /stations/search
+
+export async function radioSearch(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 20)));
+  const params = new URLSearchParams({ limit: String(limit), hidebroken: "true" });
+
+  if (args.name) params.set("name", String(args.name));
+  if (args.country) params.set("country", String(args.country));
+  if (args.language) params.set("language", String(args.language));
+  if (args.tag) params.set("tag", String(args.tag));
+
+  if (!args.name && !args.country && !args.language && !args.tag) {
+    return { error: "At least one search filter is required: name, country, language, or tag." };
+  }
+
+  const data = await radioFetch("/stations/search", params) as Station[];
+  return {
+    count: data.length,
+    stations: data.map(normalizeStation),
+  };
+}
+
+// ─── radio_by_country ─────────────────────────────────────────────────────────
+// GET /stations/bycountry/{country}
+
+export async function radioByCountry(args: Record<string, unknown>): Promise<unknown> {
+  const country = String(args.country ?? "").trim();
+  if (!country) return { error: "country is required (e.g. 'Australia' or 'Germany')." };
+
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 30)));
+  const params = new URLSearchParams({ limit: String(limit), hidebroken: "true" });
+
+  const data = await radioFetch(
+    `/stations/bycountry/${encodeURIComponent(country)}`,
+    params
+  ) as Station[];
+
+  return {
+    country,
+    count: data.length,
+    stations: data.map(normalizeStation),
+  };
+}
+
+// ─── radio_top_clicked ────────────────────────────────────────────────────────
+// GET /stations/topclick
+
+export async function radioTopClicked(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 20)));
+  const params = new URLSearchParams({ limit: String(limit), hidebroken: "true" });
+
+  const data = await radioFetch("/stations/topclick", params) as Station[];
+  return {
+    count: data.length,
+    ranked_by: "click_count",
+    stations: data.map(normalizeStation),
+  };
+}
+
+// ─── radio_top_voted ──────────────────────────────────────────────────────────
+// GET /stations/topvote
+
+export async function radioTopVoted(args: Record<string, unknown>): Promise<unknown> {
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 20)));
+  const params = new URLSearchParams({ limit: String(limit), hidebroken: "true" });
+
+  const data = await radioFetch("/stations/topvote", params) as Station[];
+  return {
+    count: data.length,
+    ranked_by: "votes",
+    stations: data.map(normalizeStation),
+  };
+}
+
+// ─── radio_by_tag ─────────────────────────────────────────────────────────────
+// GET /stations/bytag/{tag}
+
+export async function radioByTag(args: Record<string, unknown>): Promise<unknown> {
+  const tag = String(args.tag ?? "").trim().toLowerCase();
+  if (!tag) return { error: "tag is required (e.g. 'jazz', 'classical', 'news')." };
+
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 30)));
+  const params = new URLSearchParams({ limit: String(limit), hidebroken: "true" });
+
+  const data = await radioFetch(
+    `/stations/bytag/${encodeURIComponent(tag)}`,
+    params
+  ) as Station[];
+
+  return {
+    tag,
+    count: data.length,
+    stations: data.map(normalizeStation),
+  };
+}
+
+// ─── radio_countries ──────────────────────────────────────────────────────────
+// GET /countries
+
+export async function radioCountries(_args: Record<string, unknown>): Promise<unknown> {
+  const data = await radioFetch("/countries") as Array<{
+    name: string;
+    stationcount: number;
+    iso_3166_1?: string;
+  }>;
+
+  const sorted = [...data].sort((a, b) => b.stationcount - a.stationcount);
+
+  return {
+    count: sorted.length,
+    countries: sorted.map((c) => ({
+      name: c.name,
+      station_count: c.stationcount,
+      code: c.iso_3166_1 ?? null,
+    })),
+  };
+}

--- a/packages/standalone/radiobrowser-mcp/tsconfig.json
+++ b/packages/standalone/radiobrowser-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/sleeper-mcp/LICENSE
+++ b/packages/standalone/sleeper-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/sleeper-mcp/README.md
+++ b/packages/standalone/sleeper-mcp/README.md
@@ -1,0 +1,38 @@
+# Sleeper Fantasy MCP by UnClick
+
+Sleeper fantasy football users, leagues, rosters, drafts, players, and matchups.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "sleeper": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/sleeper.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `sleeper_nfl_state`
+- `sleeper_players`
+- `sleeper_trending_players`
+- `sleeper_league`
+- `sleeper_league_rosters`
+- `sleeper_league_matchups`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/sleeper-mcp/package.json
+++ b/packages/standalone/sleeper-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/sleeper-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/sleeper",
+  "description": "Sleeper fantasy football users, leagues, rosters, drafts, players, and matchups. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "sleeper",
+    "fantasy",
+    "football"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "sleeper-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/sleeper-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/sleeper-mcp/server.json
+++ b/packages/standalone/sleeper-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/sleeper",
+  "title": "Sleeper Fantasy MCP by UnClick",
+  "description": "Sleeper fantasy football users, leagues, rosters, drafts, players, and matchups. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/sleeper-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/sleeper-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/sleeper-mcp/src/index.ts
+++ b/packages/standalone/sleeper-mcp/src/index.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Sleeper Fantasy MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  getNflState,
+  getSleeperPlayers,
+  getTrendingPlayers,
+  getSleeperLeague,
+  getLeagueRosters,
+  getLeagueMatchups,
+} from "./sleeper-tool.js";
+
+const TOOLS = [
+  {
+    name: "sleeper_nfl_state",
+    description: "Get the current NFL state from Sleeper.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+  {
+    name: "sleeper_players",
+    description: "Get all NFL players from Sleeper.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        sport: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "sleeper_trending_players",
+    description: "Get trending players on Sleeper.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        sport: { type: "string" },
+        type: { type: "string", enum: ["add", "drop"], description: "add or drop" },
+        lookback_hours: { type: "number" },
+        limit: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "sleeper_league",
+    description: "Get a Sleeper fantasy league by ID.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        league_id: { type: "string" },
+      },
+      required: ["league_id"],
+    },
+  },
+  {
+    name: "sleeper_league_rosters",
+    description: "Get rosters for a Sleeper fantasy league.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        league_id: { type: "string" },
+      },
+      required: ["league_id"],
+    },
+  },
+  {
+    name: "sleeper_league_matchups",
+    description: "Get matchups for a Sleeper fantasy league week.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        league_id: { type: "string" },
+        week: { type: "number" },
+      },
+      required: ["league_id", "week"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  sleeper_nfl_state: (args) => getNflState(args as unknown as Parameters<typeof getNflState>[0]),
+  sleeper_players: (args) => getSleeperPlayers(args as unknown as Parameters<typeof getSleeperPlayers>[0]),
+  sleeper_trending_players: (args) => getTrendingPlayers(args as unknown as Parameters<typeof getTrendingPlayers>[0]),
+  sleeper_league: (args) => getSleeperLeague(args as unknown as Parameters<typeof getSleeperLeague>[0]),
+  sleeper_league_rosters: (args) => getLeagueRosters(args as unknown as Parameters<typeof getLeagueRosters>[0]),
+  sleeper_league_matchups: (args) => getLeagueMatchups(args as unknown as Parameters<typeof getLeagueMatchups>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/sleeper", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[sleeper-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/sleeper-mcp/src/sleeper-tool.ts
+++ b/packages/standalone/sleeper-mcp/src/sleeper-tool.ts
@@ -1,0 +1,251 @@
+// Sleeper fantasy sports API.
+// No authentication required.
+// Base URL: https://api.sleeper.app/v1/
+
+const SLEEPER_BASE = "https://api.sleeper.app/v1";
+
+async function sleeperFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${SLEEPER_BASE}${path}`, {
+    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
+  });
+  if (!res.ok) throw new Error(`Sleeper API HTTP ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+// ─── get_nfl_state ────────────────────────────────────────────────────────────
+
+interface NflState {
+  week: number;
+  season_type: string;
+  season_start_date: string;
+  season: string;
+  previous_season: string;
+  leg: number;
+  league_season: string;
+  league_create_season: string;
+  display_week: number;
+}
+
+export async function getNflState(_args: Record<string, unknown>): Promise<unknown> {
+  const data = await sleeperFetch<NflState>("/state/nfl");
+  return {
+    current_week: data.week,
+    display_week: data.display_week,
+    season: data.season,
+    season_type: data.season_type,
+    season_start_date: data.season_start_date,
+    previous_season: data.previous_season,
+    leg: data.leg,
+  };
+}
+
+// ─── get_sleeper_players ──────────────────────────────────────────────────────
+
+interface SleeperPlayer {
+  player_id: string;
+  full_name?: string;
+  first_name?: string;
+  last_name?: string;
+  position?: string;
+  team?: string;
+  status?: string;
+  injury_status?: string;
+  age?: number;
+  years_exp?: number;
+  fantasy_positions?: string[];
+}
+
+export async function getSleeperPlayers(args: Record<string, unknown>): Promise<unknown> {
+  const confirmed = args.confirmed === true || String(args.confirmed) === "true";
+
+  if (!confirmed) {
+    return {
+      warning: "This endpoint returns a very large payload (5MB+) containing all NFL players. Pass confirmed: true to proceed.",
+      tip: "For trending players use get_trending_players instead, which is much smaller.",
+    };
+  }
+
+  const data = await sleeperFetch<Record<string, SleeperPlayer>>("/players/nfl");
+  const players = Object.values(data).filter((p) => p.full_name || (p.first_name && p.last_name));
+
+  return {
+    total_players: players.length,
+    note: "Full player list. Filter by position, team, or status as needed.",
+    players: players.slice(0, 200).map((p) => ({
+      id: p.player_id,
+      name: p.full_name ?? `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim(),
+      position: p.position ?? null,
+      team: p.team ?? null,
+      status: p.status ?? null,
+      injury_status: p.injury_status ?? null,
+      age: p.age ?? null,
+      years_exp: p.years_exp ?? null,
+    })),
+    truncated: players.length > 200,
+    truncated_message: players.length > 200 ? `Showing first 200 of ${players.length} players.` : null,
+  };
+}
+
+// ─── get_trending_players ─────────────────────────────────────────────────────
+
+interface TrendingPlayer {
+  player_id: string;
+  count: number;
+}
+
+export async function getTrendingPlayers(args: Record<string, unknown>): Promise<unknown> {
+  const type = String(args.type ?? "add").toLowerCase();
+  if (!["add", "drop"].includes(type)) {
+    return { error: 'type must be "add" or "drop".' };
+  }
+
+  const limit = Math.min(25, Math.max(1, Number(args.limit ?? 10)));
+  const data = await sleeperFetch<TrendingPlayer[]>(`/players/nfl/trending/${type}?limit=${limit}`);
+
+  return {
+    type,
+    limit,
+    count: data.length,
+    trending: data.map((p) => ({
+      player_id: p.player_id,
+      transaction_count: p.count,
+    })),
+    tip: "Use get_sleeper_players (confirmed: true) to look up player details by player_id.",
+  };
+}
+
+// ─── get_sleeper_league ───────────────────────────────────────────────────────
+
+interface SleeperLeague {
+  league_id: string;
+  name: string;
+  season: string;
+  season_type: string;
+  status: string;
+  sport: string;
+  total_rosters: number;
+  roster_positions: string[];
+  scoring_settings?: Record<string, number>;
+  settings?: Record<string, unknown>;
+  draft_id?: string;
+  avatar?: string;
+}
+
+export async function getSleeperLeague(args: Record<string, unknown>): Promise<unknown> {
+  const leagueId = String(args.league_id ?? "").trim();
+  if (!leagueId) return { error: "league_id is required." };
+
+  const data = await sleeperFetch<SleeperLeague>(`/league/${encodeURIComponent(leagueId)}`);
+
+  return {
+    league_id: data.league_id,
+    name: data.name,
+    season: data.season,
+    season_type: data.season_type,
+    status: data.status,
+    sport: data.sport,
+    total_rosters: data.total_rosters,
+    roster_positions: data.roster_positions,
+    draft_id: data.draft_id ?? null,
+    scoring_settings: data.scoring_settings ?? null,
+  };
+}
+
+// ─── get_league_rosters ───────────────────────────────────────────────────────
+
+interface SleeperRoster {
+  roster_id: number;
+  owner_id?: string;
+  league_id: string;
+  players?: string[];
+  starters?: string[];
+  reserve?: string[];
+  taxi?: string[];
+  settings?: {
+    wins?: number;
+    losses?: number;
+    ties?: number;
+    fpts?: number;
+    fpts_decimal?: number;
+    fpts_against?: number;
+    fpts_against_decimal?: number;
+    waiver_position?: number;
+    waiver_budget_used?: number;
+  };
+}
+
+export async function getLeagueRosters(args: Record<string, unknown>): Promise<unknown> {
+  const leagueId = String(args.league_id ?? "").trim();
+  if (!leagueId) return { error: "league_id is required." };
+
+  const data = await sleeperFetch<SleeperRoster[]>(`/league/${encodeURIComponent(leagueId)}/rosters`);
+
+  return {
+    league_id: leagueId,
+    roster_count: data.length,
+    rosters: data.map((r) => ({
+      roster_id: r.roster_id,
+      owner_id: r.owner_id ?? null,
+      player_count: r.players?.length ?? 0,
+      starters: r.starters ?? [],
+      bench: (r.players ?? []).filter((p) => !(r.starters ?? []).includes(p)),
+      reserve: r.reserve ?? [],
+      taxi: r.taxi ?? [],
+      record: r.settings
+        ? {
+            wins: r.settings.wins ?? 0,
+            losses: r.settings.losses ?? 0,
+            ties: r.settings.ties ?? 0,
+            points_for: ((r.settings.fpts ?? 0) + (r.settings.fpts_decimal ?? 0) / 100),
+            points_against: ((r.settings.fpts_against ?? 0) + (r.settings.fpts_against_decimal ?? 0) / 100),
+          }
+        : null,
+    })),
+  };
+}
+
+// ─── get_league_matchups ──────────────────────────────────────────────────────
+
+interface SleeperMatchup {
+  roster_id: number;
+  matchup_id: number;
+  players?: string[];
+  starters?: string[];
+  points: number;
+  players_points?: Record<string, number>;
+  custom_points?: number | null;
+}
+
+export async function getLeagueMatchups(args: Record<string, unknown>): Promise<unknown> {
+  const leagueId = String(args.league_id ?? "").trim();
+  const week = Number(args.week ?? 0);
+
+  if (!leagueId) return { error: "league_id is required." };
+  if (!week || isNaN(week)) return { error: "week is required (numeric week number)." };
+
+  const data = await sleeperFetch<SleeperMatchup[]>(`/league/${encodeURIComponent(leagueId)}/matchups/${week}`);
+
+  // Group by matchup_id
+  const grouped: Record<number, SleeperMatchup[]> = {};
+  for (const m of data) {
+    if (!grouped[m.matchup_id]) grouped[m.matchup_id] = [];
+    grouped[m.matchup_id].push(m);
+  }
+
+  const matchups = Object.entries(grouped).map(([matchupId, rosters]) => ({
+    matchup_id: Number(matchupId),
+    rosters: rosters.map((r) => ({
+      roster_id: r.roster_id,
+      points: r.points,
+      starters: r.starters ?? [],
+      player_count: r.players?.length ?? 0,
+    })),
+  }));
+
+  return {
+    league_id: leagueId,
+    week,
+    matchup_count: matchups.length,
+    matchups,
+  };
+}

--- a/packages/standalone/sleeper-mcp/tsconfig.json
+++ b/packages/standalone/sleeper-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/standalone/speedrun-mcp/LICENSE
+++ b/packages/standalone/speedrun-mcp/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright (c) 2026 UnClick / malamutemayhem
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/standalone/speedrun-mcp/README.md
+++ b/packages/standalone/speedrun-mcp/README.md
@@ -1,0 +1,37 @@
+# Speedrun.com MCP by UnClick
+
+Speedrun.com games, leaderboards, runs, and users. No API key.
+
+> By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+
+## Install
+
+Installs straight from GitHub, no npm account needed.
+
+```json
+{
+  "mcpServers": {
+    "speedrun": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/malamutemayhem/unclick/releases/download/standalone-mcps-latest/speedrun.tgz"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `speedrun_search_games`
+- `speedrun_get_game`
+- `speedrun_get_leaderboard`
+- `speedrun_list_runs`
+- `speedrun_get_user`
+
+## Want the rest?
+
+This is one connector. [UnClick](https://unclick.world) bundles 180+ tools plus
+persistent cross-session agent memory in a single install.
+
+## License
+
+Apache-2.0

--- a/packages/standalone/speedrun-mcp/package.json
+++ b/packages/standalone/speedrun-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unclick/speedrun-mcp",
+  "version": "0.1.0",
+  "mcpName": "io.github.malamutemayhem/speedrun",
+  "description": "Speedrun.com games, leaderboards, runs, and users. No API key. By UnClick (https://unclick.world).",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "unclick",
+    "speedrun",
+    "games",
+    "leaderboards"
+  ],
+  "author": "UnClick (https://unclick.world)",
+  "type": "module",
+  "bin": {
+    "speedrun-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "server.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "directory": "packages/standalone/speedrun-mcp"
+  },
+  "homepage": "https://unclick.world"
+}

--- a/packages/standalone/speedrun-mcp/server.json
+++ b/packages/standalone/speedrun-mcp/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.malamutemayhem/speedrun",
+  "title": "Speedrun.com MCP by UnClick",
+  "description": "Speedrun.com games, leaderboards, runs, and users. No API key. By UnClick.",
+  "version": "0.1.0",
+  "websiteUrl": "https://unclick.world",
+  "icons": [
+    {
+      "src": "https://unclick.world/favicon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/malamutemayhem/unclick.git",
+    "source": "github",
+    "subfolder": "packages/standalone/speedrun-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@unclick/speedrun-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/standalone/speedrun-mcp/src/index.ts
+++ b/packages/standalone/speedrun-mcp/src/index.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Speedrun.com MCP. Standalone MCP server by UnClick.
+// By UnClick. 180+ tools plus persistent agent memory in one install: https://unclick.world
+//
+// Generated from the UnClick connector by scripts/generate-standalone-mcp.mjs.
+// Edit the connector in the UnClick monorepo, not here.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  speedrunSearchGames,
+  speedrunGetGame,
+  speedrunGetLeaderboard,
+  speedrunListRuns,
+  speedrunGetUser,
+} from "./speedrun-tool.js";
+
+const TOOLS = [
+  {
+    name: "speedrun_search_games",
+    description: "Search for games on Speedrun.com by name. No API key required.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        name: { type: "string", description: "Game name to search" },
+        max: { type: "number", description: "Max results" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "speedrun_get_game",
+    description: "Get details of a game on Speedrun.com including categories and levels.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        game_id: { type: "string", description: "Speedrun.com game ID or abbreviation" },
+      },
+      required: ["game_id"],
+    },
+  },
+  {
+    name: "speedrun_get_leaderboard",
+    description: "Get the leaderboard for a Speedrun.com game category.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        game_id: { type: "string", description: "Game ID" },
+        category_id: { type: "string", description: "Category ID" },
+        top: { type: "number", description: "Only return top N places" },
+        platform: { type: "string" },
+        emulators: { type: "boolean" },
+        video_only: { type: "boolean" },
+      },
+      required: ["game_id", "category_id"],
+    },
+  },
+  {
+    name: "speedrun_list_runs",
+    description: "List speedruns with optional filters for game, category, user, or status.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        game: { type: "string", description: "Game ID" },
+        category: { type: "string" },
+        user: { type: "string", description: "User ID" },
+        status: { type: "string", enum: ["new", "verified", "rejected"], description: "new, verified, or rejected" },
+        orderby: { type: "string", enum: ["date", "submitted", "status", "game", "category", "level", "platform", "region", "emulated", "weblink"], description: "date, submitted, status, game, category, level, platform, region, emulated, or weblink" },
+        direction: { type: "string", enum: ["asc", "desc"], description: "asc or desc" },
+        max: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "speedrun_get_user",
+    description: "Get a Speedrun.com user profile by ID or username.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        user_id: { type: "string", description: "User ID or username" },
+      },
+      required: ["user_id"],
+    },
+  }
+];
+
+const HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  speedrun_search_games: (args) => speedrunSearchGames(args as unknown as Parameters<typeof speedrunSearchGames>[0]),
+  speedrun_get_game: (args) => speedrunGetGame(args as unknown as Parameters<typeof speedrunGetGame>[0]),
+  speedrun_get_leaderboard: (args) => speedrunGetLeaderboard(args as unknown as Parameters<typeof speedrunGetLeaderboard>[0]),
+  speedrun_list_runs: (args) => speedrunListRuns(args as unknown as Parameters<typeof speedrunListRuns>[0]),
+  speedrun_get_user: (args) => speedrunGetUser(args as unknown as Parameters<typeof speedrunGetUser>[0]),
+};
+
+const server = new Server(
+  { name: "io.github.malamutemayhem/speedrun", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const handler = HANDLERS[req.params.name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }], isError: true };
+  }
+  try {
+    const result = await handler((req.params.arguments ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[speedrun-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/standalone/speedrun-mcp/src/speedrun-tool.ts
+++ b/packages/standalone/speedrun-mcp/src/speedrun-tool.ts
@@ -1,0 +1,178 @@
+// Speedrun.com API - games, runs, and leaderboards.
+// Docs: https://github.com/speedruncomorg/api
+// Auth: None required for public data
+// Base: https://www.speedrun.com/api/v1
+
+const SPEEDRUN_BASE = "https://www.speedrun.com/api/v1";
+
+async function speedrunGet(
+  path: string,
+  params?: Record<string, string>
+): Promise<unknown> {
+  const url = new URL(`${SPEEDRUN_BASE}${path}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== "") url.searchParams.set(k, v);
+    }
+  }
+  const res = await fetch(url.toString(), {
+    headers: { Accept: "application/json" },
+  });
+  if (res.status === 404) throw new Error(`Speedrun.com: resource not found at ${path}.`);
+  if (res.status === 420) throw new Error("Speedrun.com rate limit exceeded. Please wait before retrying.");
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Speedrun.com HTTP ${res.status}: ${body || res.statusText}`);
+  }
+  return res.json() as Promise<unknown>;
+}
+
+// speedrun_search_games
+export async function speedrunSearchGames(args: Record<string, unknown>): Promise<unknown> {
+  try {
+    const name = String(args.name ?? "").trim();
+    if (!name) return { error: "name is required." };
+    const params: Record<string, string> = { name };
+    if (args.max) params.max = String(args.max);
+
+    const json = await speedrunGet("/games", params) as Record<string, unknown>;
+    const data = (json.data ?? []) as Array<Record<string, unknown>>;
+    return {
+      count: data.length,
+      games: data.map((g) => ({
+        id: g.id,
+        names: g.names,
+        abbreviation: g.abbreviation,
+        weblink: g.weblink,
+        released: g.released,
+        platforms: (g.platforms as string[] | undefined) ?? [],
+        regions: (g.regions as string[] | undefined) ?? [],
+      })),
+    };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// speedrun_get_game
+export async function speedrunGetGame(args: Record<string, unknown>): Promise<unknown> {
+  try {
+    const gameId = String(args.game_id ?? "").trim();
+    if (!gameId) return { error: "game_id is required (use speedrun_search_games to find an ID)." };
+
+    const json = await speedrunGet(`/games/${gameId}`, { embed: "categories,levels,platforms" }) as Record<string, unknown>;
+    const data = json.data as Record<string, unknown> | undefined;
+    if (!data) return { error: "Game not found." };
+    return {
+      id: data.id,
+      names: data.names,
+      abbreviation: data.abbreviation,
+      weblink: data.weblink,
+      released: data.released,
+      categories: (data.categories as Record<string, unknown>)?.data ?? [],
+      levels: (data.levels as Record<string, unknown>)?.data ?? [],
+      platforms: (data.platforms as Record<string, unknown>)?.data ?? [],
+    };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// speedrun_get_leaderboard
+export async function speedrunGetLeaderboard(args: Record<string, unknown>): Promise<unknown> {
+  try {
+    const gameId = String(args.game_id ?? "").trim();
+    if (!gameId) return { error: "game_id is required." };
+    const categoryId = String(args.category_id ?? "").trim();
+    if (!categoryId) return { error: "category_id is required." };
+
+    const params: Record<string, string> = { embed: "players" };
+    if (args.top) params.top = String(args.top);
+    if (args.platform) params.platform = String(args.platform);
+    if (args.region) params.region = String(args.region);
+    if (args.emulators !== undefined) params.emulators = String(args.emulators);
+    if (args.video_only !== undefined) params.video_only = String(args.video_only);
+
+    const json = await speedrunGet(`/leaderboards/${gameId}/category/${categoryId}`, params) as Record<string, unknown>;
+    const data = json.data as Record<string, unknown> | undefined;
+    const runs = (data?.runs ?? []) as Array<Record<string, unknown>>;
+    return {
+      game: data?.game,
+      category: data?.category,
+      weblink: data?.weblink,
+      count: runs.length,
+      runs: runs.map((r) => {
+        const run = r.run as Record<string, unknown>;
+        return {
+          place: r.place,
+          run_id: run?.id,
+          status: (run?.status as Record<string, unknown>)?.status,
+          times: run?.times,
+          date: run?.date,
+          weblink: run?.weblink,
+          players: run?.players,
+          videos: run?.videos,
+        };
+      }),
+    };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// speedrun_list_runs
+export async function speedrunListRuns(args: Record<string, unknown>): Promise<unknown> {
+  try {
+    const params: Record<string, string> = {};
+    if (args.game) params.game = String(args.game);
+    if (args.category) params.category = String(args.category);
+    if (args.user) params.user = String(args.user);
+    if (args.status) params.status = String(args.status);
+    if (args.orderby) params.orderby = String(args.orderby);
+    if (args.direction) params.direction = String(args.direction);
+    if (args.max) params.max = String(args.max);
+    if (!params.game && !params.user) return { error: "At least game or user is required." };
+
+    const json = await speedrunGet("/runs", params) as Record<string, unknown>;
+    const data = (json.data ?? []) as Array<Record<string, unknown>>;
+    return {
+      count: data.length,
+      runs: data.map((r) => ({
+        id: r.id,
+        game: r.game,
+        category: r.category,
+        status: (r.status as Record<string, unknown>)?.status,
+        times: r.times,
+        date: r.date,
+        weblink: r.weblink,
+        players: r.players,
+        videos: r.videos,
+      })),
+    };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// speedrun_get_user
+export async function speedrunGetUser(args: Record<string, unknown>): Promise<unknown> {
+  try {
+    const userId = String(args.user_id ?? "").trim();
+    if (!userId) return { error: "user_id is required (can be the username or ID)." };
+
+    const json = await speedrunGet(`/users/${userId}`) as Record<string, unknown>;
+    const data = json.data as Record<string, unknown> | undefined;
+    if (!data) return { error: "User not found." };
+    return {
+      id: data.id,
+      names: data.names,
+      weblink: data.weblink,
+      location: data.location,
+      signup: data.signup,
+      role: data.role,
+      links: data.links,
+    };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/standalone/speedrun-mcp/tsconfig.json
+++ b/packages/standalone/speedrun-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- add 12 more standalone UnClick MCP packages: abn, chessdotcom, openf1, openfoodfacts, lichess, radiobrowser, speedrun, ipapi, fpl, deezer, gdelt, sleeper
- update the standalone generator config and brainmap artifacts
- keep registry manifests inside the new validation limits

## Verification
- all 12 generated packages: npm install + npm run build
- npx tsc -p packages/mcp-server/tsconfig.json --noEmit
- npm run test:brainmap
- node packages/mcp-server/scripts/check-standalone-registry.mjs
- npm run test --workspace=@unclick/mcp-server
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive connector packages and generated docs only; no changes to core auth, billing, or monorepo runtime wiring beyond generator metadata.
> 
> **Overview**
> Adds **twelve new standalone MCP packages** under `packages/standalone/` (abn, chessdotcom, openf1, openfoodfacts, lichess, radiobrowser, speedrun, ipapi, fpl, deezer, gdelt, sleeper), each with the usual UnClick layout: tool implementations, stdio MCP entrypoint, `package.json`, `server.json`, README, and Apache-2.0 license.
> 
> **`generate-standalone-mcp.mjs`** gains a **batch 4** block in `CONFIG` so those slugs are included in the generator metadata (titles, blurbs, keywords).
> 
> **Brainmap artifacts** (`UnClick-brainmap.generated.json` / `.md`) are regenerated: inventory and “Modules and apps” counts rise by 12, with one row per new standalone package.
> 
> These servers are thin wrappers around public third-party HTTP APIs (mostly unauthenticated); install docs point at GitHub release tarballs via `npx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bddbd6698ed0ab915ca32ee0d54eb9553fee6413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->