### PR TITLE
[codex] add FidelityPass not-applicable scope

### DIFF
--- a/docs/prd/xpass-closure-board.md
+++ b/docs/prd/xpass-closure-board.md
@@ -26,7 +26,7 @@ This does not mean every expensive runner executes every time. The lightweight c
 | UXPass | Yes | ~ | Real package and runner exist, with visual audit work, viewport support, and dogfood fixtures. Still not enough to guarantee every mediocre UI becomes polished. | Finish annotated reports, stronger visual hierarchy checks, mobile and desktop evidence, and scheduled proof that does not clog the queue. |
 | SecurityPass | Yes | ~ | Real package and guardrails exist. Public dogfood is intentionally scope-gated until safe recurring proof exists. | Add deny-by-default recurring runner proof and make security receipts visible without exposing secrets. |
 | CopyPass | Yes | ~ | Real copy-quality package exists. It checks wording, claims, tone, clarity, and product copy risk. | Add recurring or on-demand live receipt surface and keep it separate from exact-copy fidelity. |
-| FidelityPass | Yes | ✗ | Official XPass/QC wrapper over CopyRoom, but not a separate completed engine yet. | Implement wrapper behavior over CopyRoom receipts, including `N/A` when no 1:1 copy is in scope. Do not duplicate CopyRoom. |
+| FidelityPass | Yes | ✓ | Official XPass/QC wrapper over CopyRoom/FidelityCopy receipts. It can verify exact-copy proof, suppress prose-only proof, and return explicit `N/A` when no 1:1 copy is in scope. | Keep it as a wrapper only. Do not duplicate CopyRoom. |
 | CopyRoom | Adjacent | ~ | Official exact-copy room. It is the office photocopier workers must use for 1:1 copying, transcription, mirroring, or preservation. | Reinforce worker usage and require a CopyRoom receipt whenever exact copying is requested. |
 | LegalPass | Yes | ~ | Package and guardrail library exist, but much of the deeper execution is still guidance or fixture-led. | Turn legal and policy checks into scoped receipts with clear "not legal advice" boundaries. |
 | SlopPass | Yes | ~ | Official AI/code quality product. Package, tests, product brief, and XPass selector wiring exist. | Finish live PR diff integration and make SlopPass the only public code-quality name. No QualityPass fork. |
@@ -78,7 +78,7 @@ This keeps the XPass range agile. The checklist does not just judge the product.
 
 ## Next Closure Order
 
-1. Finish FidelityPass wrapper over CopyRoom receipts, including `N/A`.
+1. Done: FidelityPass wrapper over CopyRoom receipts, including explicit `N/A`.
 2. Restore or expose CommonSensePass as a worker-available tool and enforce it before trusted status claims.
 3. Wire SlopPass into PR diff and code-quality receipts.
 4. Add recurring receipts for CopyPass, SecurityPass, LegalPass, SEOPass, FlowPass, and CompliancePass.

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1097,7 +1097,7 @@
       },
       {
         "name": "fidelitypass_verify_copy",
-        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
+        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes, or return N/A when no exact 1:1 copy is in scope. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
       }
     ]
   },

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -29,6 +29,7 @@ describe("runtime tool schema validation", () => {
     { name: "commonsensepass_protocol", args: { bogus_field: "should reject" } },
     { name: "commonsensepass_check", args: { claim: "quiet", context: { now_ms: 1 }, bogus_field: "should reject" } },
     { name: "commonsensepass_rules", args: { include_fixtures: false, bogus_field: "should reject" } },
+    { name: "fidelitypass_verify_copy", args: { copy_scope: "not_applicable", bogus_field: "should reject" } },
     { name: "list_expressroom_drafts", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
     {
       name: "ack_handoff",
@@ -125,6 +126,20 @@ describe("runtime tool schema validation", () => {
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("commonsensepass_rules", {
       include_fixtures: false,
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("fidelitypass_verify_copy", {
+      copy_scope: "not_applicable",
+      scope_reason: "No exact copy is in scope for this target.",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("fidelitypass_verify_copy", {
+      copy_scope: "exact_copy",
+      copyroom_source_packet: {
+        source_id: "source-1",
+        source_pointer: "copyroom://source-1",
+        text: "Exact source",
+      },
+      output_text: "Exact source",
+      mode: "text_exact",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("list_expressroom_drafts", {
       agent_id: "strict-probe",

--- a/packages/mcp-server/src/fidelitycopy-tool.test.ts
+++ b/packages/mcp-server/src/fidelitycopy-tool.test.ts
@@ -174,6 +174,44 @@ describe("fidelitycopy-tool", () => {
     expect(result.action_needed?.[0]).toContain("source_text/source_base64");
   });
 
+  it("returns N/A when no exact copy is in scope", async () => {
+    const result = (await fidelitypassVerifyCopy({
+      exact_copy_required: false,
+      scope_reason: "This is copy-quality review, not a 1:1 copy or transcription task.",
+      provenance_ref: "boardroom://todo/fidelitypass-na",
+    })) as {
+      verdict?: string;
+      receipt?: { kind?: string; status?: string; verdict?: string; reason?: string; action_needed?: string[] };
+      action_needed?: string[];
+    };
+
+    expect(result.verdict).toBe("N/A");
+    expect(result.receipt?.kind).toBe("fidelitypass_scope_receipt_v1");
+    expect(result.receipt?.status).toBe("not_applicable");
+    expect(result.receipt?.verdict).toBe("N/A");
+    expect(result.receipt?.reason).toContain("copy-quality review");
+    expect(result.action_needed).toEqual([]);
+  });
+
+  it("accepts copy_scope=not_applicable as the explicit XPass wrapper skip", async () => {
+    const result = (await fidelitypassVerifyCopy({
+      copy_scope: "not_applicable",
+    })) as { verdict?: string; receipt?: { checked_scope?: string; reason?: string } };
+
+    expect(result.verdict).toBe("N/A");
+    expect(result.receipt?.checked_scope).toBe("no_exact_copy");
+    expect(result.receipt?.reason).toContain("No exact 1:1 copy");
+  });
+
+  it("rejects contradictory FidelityPass scope hints", async () => {
+    const result = (await fidelitypassVerifyCopy({
+      copy_scope: "exact_copy",
+      exact_copy_required: false,
+    })) as { error?: string };
+
+    expect(result.error).toContain("scope conflict");
+  });
+
   it("rejects malformed base64 instead of creating a fake byte receipt", async () => {
     const result = (await fidelitycopyCopy({
       source_base64: "not valid base64",

--- a/packages/mcp-server/src/fidelitycopy-tool.ts
+++ b/packages/mcp-server/src/fidelitycopy-tool.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 type FidelityCopyMode = "raw_bytes" | "text_exact" | "json_canonical" | "approved_transform";
-type FidelityCopyVerdict = "PASS" | "BLOCKER" | "HOLD" | "ROUTE" | "SUPPRESS";
+type FidelityCopyVerdict = "PASS" | "BLOCKER" | "HOLD" | "ROUTE" | "SUPPRESS" | "N/A";
 
 interface Payload {
   kind: "text" | "base64";
@@ -48,9 +48,23 @@ interface FidelityCopyReceipt {
   action_needed: string[];
 }
 
+interface FidelityPassNotApplicableReceipt {
+  kind: "fidelitypass_scope_receipt_v1";
+  status: "not_applicable";
+  verdict: "N/A";
+  checked_scope: "no_exact_copy";
+  reason: string;
+  action_needed: string[];
+  tool_version: string;
+  timestamp: string;
+  provenance_ref: string;
+}
+
 const TOOL_VERSION = "fidelitycopy-v1";
 const DEFAULT_SOURCE_REF = "fidelitycopy://inline-source";
 const DEFAULT_OUTPUT_REF = "fidelitycopy://inline-output";
+const DEFAULT_NOT_APPLICABLE_REASON =
+  "No exact 1:1 copy, transcription, mirroring, or preservation is in scope for this target.";
 
 export async function fidelitycopyCopy(args: Record<string, unknown>): Promise<unknown> {
   const mode = parseMode(args.mode);
@@ -73,6 +87,17 @@ export async function fidelitycopyCopy(args: Record<string, unknown>): Promise<u
 }
 
 export async function fidelitypassVerifyCopy(args: Record<string, unknown>): Promise<unknown> {
+  const scope = parseFidelityPassScope(args);
+  if ("error" in scope) return { error: scope.error };
+  if (scope.notApplicable) {
+    const receipt = buildNotApplicableReceipt(args);
+    return {
+      verdict: "N/A",
+      receipt,
+      action_needed: receipt.action_needed,
+    };
+  }
+
   const receiptPayload = parseReceipt(args.receipt_payload ?? args.receipt);
   const mode = parseMode(args.mode) ?? modeFromReceipt(receiptPayload);
   if (!mode) return { error: "mode must be one of: raw_bytes, text_exact, json_canonical, approved_transform" };
@@ -109,6 +134,41 @@ export async function fidelitypassVerifyCopy(args: Record<string, unknown>): Pro
   }
 
   return { verdict: receipt.verdict, receipt };
+}
+
+function parseFidelityPassScope(args: Record<string, unknown>): { notApplicable: boolean } | { error: string } {
+  const copyScope = readString(args.copy_scope);
+  const exactCopyRequired = args.exact_copy_required;
+
+  if (copyScope !== null && copyScope !== "" && copyScope !== "exact_copy" && copyScope !== "not_applicable") {
+    return { error: "copy_scope must be exact_copy or not_applicable" };
+  }
+  if (exactCopyRequired !== undefined && exactCopyRequired !== null && typeof exactCopyRequired !== "boolean") {
+    return { error: "exact_copy_required must be a boolean" };
+  }
+  if (copyScope === "exact_copy" && exactCopyRequired === false) {
+    return { error: "FidelityPass scope conflict: copy_scope=exact_copy cannot be combined with exact_copy_required=false." };
+  }
+  if (copyScope === "not_applicable" && exactCopyRequired === true) {
+    return { error: "FidelityPass scope conflict: copy_scope=not_applicable cannot be combined with exact_copy_required=true." };
+  }
+
+  return { notApplicable: copyScope === "not_applicable" || exactCopyRequired === false };
+}
+
+function buildNotApplicableReceipt(args: Record<string, unknown>): FidelityPassNotApplicableReceipt {
+  const reason = readString(args.scope_reason)?.trim() || DEFAULT_NOT_APPLICABLE_REASON;
+  return {
+    kind: "fidelitypass_scope_receipt_v1",
+    status: "not_applicable",
+    verdict: "N/A",
+    checked_scope: "no_exact_copy",
+    reason,
+    action_needed: [],
+    tool_version: TOOL_VERSION,
+    timestamp: new Date().toISOString(),
+    provenance_ref: readString(args.provenance_ref) || "mcp://fidelitypass/not-applicable",
+  };
 }
 
 function createCopyOutput(

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1111,7 +1111,7 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       },
       {
         "name": "fidelitypass_verify_copy",
-        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
+        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes, or return N/A when no exact 1:1 copy is in scope. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
       }
     ]
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12839,11 +12839,24 @@ export const ADDITIONAL_TOOLS = [
   {
     name: "fidelitypass_verify_copy",
     description:
-      "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes. Missing bytes, stale metadata, or prose-only AI proof cannot PASS.",
+      "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes, or return N/A when no exact 1:1 copy is in scope. Missing bytes, stale metadata, or prose-only AI proof cannot PASS.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
+        exact_copy_required: {
+          type: "boolean",
+          description: "Set false only when the target has no exact 1:1 copy, transcription, mirroring, or preservation scope. Returns N/A.",
+        },
+        copy_scope: {
+          type: "string",
+          enum: ["exact_copy", "not_applicable"],
+          description: "Explicit FidelityPass scope. Use not_applicable to record the XPass N/A row when no exact copy is in scope.",
+        },
+        scope_reason: {
+          type: "string",
+          description: "Reason why FidelityPass is N/A for this target. Used only when exact_copy_required=false or copy_scope=not_applicable.",
+        },
         source_text: { type: "string", description: "Exact source text to verify. Mutually exclusive with source_base64." },
         source_base64: { type: "string", description: "Exact source bytes as base64. Mutually exclusive with source_text." },
         copyroom_source_packet: {


### PR DESCRIPTION
## Summary
- adds an explicit `N/A` path to `fidelitypass_verify_copy` when no exact 1:1 copy is in scope
- keeps exact-copy verification strict: source/output bytes or CopyRoom packets are still required for PASS, and prose-only proof remains suppressed
- updates the XPass closure board and generated tool discovery description

## Local proof
- `npx vitest run --root packages/mcp-server src/fidelitycopy-tool.test.ts src/__tests__/tool-schema-validation.test.ts src/__tests__/advertised-tools-schema.test.ts`
- `npm run build --workspace=@unclick/mcp-server`
- `node scripts/generate-tool-index.mjs --check`
- `npx eslint packages/mcp-server/src/fidelitycopy-tool.ts packages/mcp-server/src/fidelitycopy-tool.test.ts`
- `npm run test --workspace=@unclick/mcp-server`
- `node scripts/UnClick-brainmap.mjs --check`
- `git diff --check`
- `npm run build`

Boardroom job: 18b54a7e-2bc6-4720-97d8-07dcaf4d80c4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded MCP tool and receipt change with tests; no change to auth, payments, or existing PASS/BLOCKER byte checks.
> 
> **Overview**
> Adds an explicit **N/A** outcome to `fidelitypass_verify_copy` when a target has no exact 1:1 copy, transcription, mirroring, or preservation work—via `copy_scope: "not_applicable"` or `exact_copy_required: false`, optional `scope_reason`, and a `fidelitypass_scope_receipt_v1` receipt instead of byte verification.
> 
> **Exact-copy behavior stays strict:** callers still need source/output bytes or CopyRoom packets for PASS; prose-only proof is still **SUPPRESS**; conflicting scope flags return a scope conflict error.
> 
> Docs and generated tool metadata mark **FidelityPass** complete on the XPass closure board; schema validation and unit tests cover the new arguments and N/A paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf90949622c433ff01c182a22de9c4506247d728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->