### PR TITLE
Harden PTV to L4 (timeout + 429 + colocated test) — the reference connector

### DIFF
--- a/packages/mcp-server/src/ptv-tool.test.ts
+++ b/packages/mcp-server/src/ptv-tool.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ptvSearch, ptvDepartures } from "./ptv-tool.js";
+
+// Colocated PTV connector tests. Exercise the L2 (resilience) and L4 (source
+// stamp + memory defaults) behaviours so PTV is the reference for the depth ladder.
+
+describe("ptv connector resilience (L2)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("surfaces a clean rate-limit error on HTTP 429", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: false,
+      status: 429,
+      headers: { get: (h: string) => (h === "Retry-After" ? "30" : null) },
+      text: async () => "rate limited",
+    })));
+    await expect(ptvSearch({ search_term: "Richmond" })).rejects.toThrow(/rate limit reached \(HTTP 429\).*retry after 30s/i);
+  });
+
+  it("surfaces a clean timeout error when the request aborts", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    }));
+    await expect(ptvSearch({ search_term: "Richmond" })).rejects.toThrow(/timed out/i);
+  });
+
+  it("wraps generic network failures with a clear message", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("ENOTFOUND"); }));
+    await expect(ptvSearch({ search_term: "Richmond" })).rejects.toThrow(/network error: ENOTFOUND/i);
+  });
+});
+
+describe("ptv source stamping + memory defaults (L4)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("stamps source, attribution, freshness, and next steps on search", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ stops: [] }) })));
+    const result = await ptvSearch({ search_term: "Brighton Beach" }) as Record<string, any>;
+    expect(result.unclick_meta).toMatchObject({
+      source: "PTV Timetable API v3",
+      next_steps: ["Use a returned stop_id with ptv_departures."],
+    });
+    expect(result.unclick_meta.attribution).toMatch(/Public Transport Victoria/);
+    expect(typeof result.unclick_meta.fetched_at).toBe("string");
+  });
+
+  it("uses env home-stop defaults and records which defaults it used", async () => {
+    vi.stubEnv("PTV_HOME_STOP_ID", "1071");
+    vi.stubEnv("PTV_HOME_ROUTE_TYPE", "0");
+    const fetchMock = vi.fn(async (..._a: unknown[]) => ({ ok: true, status: 200, json: async () => ({ departures: [] }) }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await ptvDepartures({}) as Record<string, any>;
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/v3/departures/route_type/0/stop/1071");
+    expect(result.unclick_meta.defaults_used).toEqual(
+      expect.arrayContaining(["PTV_HOME_STOP_ID", "PTV_HOME_ROUTE_TYPE"]),
+    );
+  });
+
+  it("explicit args override env defaults (and are not flagged as defaults)", async () => {
+    vi.stubEnv("PTV_HOME_STOP_ID", "1071");
+    const fetchMock = vi.fn(async (..._a: unknown[]) => ({ ok: true, status: 200, json: async () => ({ departures: [] }) }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await ptvDepartures({ stop_id: "9999", route_type: 0 }) as Record<string, any>;
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/stop/9999");
+    expect(result.unclick_meta.defaults_used).not.toContain("PTV_HOME_STOP_ID");
+  });
+});

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -29,11 +29,30 @@ function buildPtvUrl(path: string, params: Record<string, string>): string {
   return `${PTV_BASE}${path}?${querystring}&signature=${signature}`;
 }
 
+const PTV_TIMEOUT_MS = Number(process.env.PTV_TIMEOUT_MS) || 10000;
+
 async function ptvFetch(path: string, params: Record<string, string> = {}): Promise<unknown> {
   const url = buildPtvUrl(path, params);
-  const res = await fetch(url, {
-    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PTV_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.io)" },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+    }
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) {
+    const retryAfter = res.headers.get("Retry-After");
+    throw new Error(`PTV API rate limit reached (HTTP 429)${retryAfter ? `, retry after ${retryAfter}s` : ""}.`);
+  }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`PTV API HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);


### PR DESCRIPTION
Takes PTV from L1 → L4 on the connector depth ladder, making it the first genuine top-tier connector and the copyable template for the other ~160.

PTV already had the higher-level features (memory defaults at L3, source/freshness/next_step stamping at L4) but the ladder capped it at **L1** because it lacked the L2 basics. This adds them:
- **Request timeout** via `AbortController` (`PTV_TIMEOUT_MS`, default 10s) — no more hanging on a slow PTV API
- **Clean 429 handling** (surfaces `Retry-After`) and wrapped network/timeout error messages
- **Colocated `ptv-tool.test.ts`** (6 tests) covering timeout, 429, network error, source stamping, env memory defaults, and arg-overrides-env

After this, PTV satisfies L1→L2→L3→L4: calls API → reliable (errors + timeout + test) → memory-aware (home-stop defaults) → proactive (source stamp + next steps). tsc clean; 6/6 tests pass.

Note: the depth-ladder scorer that will grade this as L4 is in open PR #1198; PTV's signals (timeout/test/stamp/memory) are all present here, so it grades L4 once that lands.

https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to PTV HTTP client resilience and new unit tests; no auth, data model, or cross-connector behavior changes beyond clearer external API errors.
> 
> **Overview**
> Hardens the PTV MCP connector’s shared **`ptvFetch`** path so outbound timetable calls fail predictably instead of hanging or surfacing raw fetch errors.
> 
> **`ptvFetch`** now aborts after **`PTV_TIMEOUT_MS`** (default 10s), maps **`AbortError`** and other failures to explicit timeout/network messages, and treats **HTTP 429** as a dedicated rate-limit error that includes **`Retry-After`** when present. All PTV tools that use **`ptvFetch`** inherit this behavior.
> 
> Adds colocated **`ptv-tool.test.ts`** (six Vitest cases) that stub **`fetch`** / env to lock in timeout, 429, network errors, **`unclick_meta`** stamping on search, and home-stop env defaults vs explicit args on departures—serving as the reference pattern for connector depth (L2/L4).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f008a0e2fe9172e318cd4e429fb8d58a8c2a596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->