### PR TITLE
feat(copypass): add receipt envelope

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8327,8 +8327,8 @@
     },
     {
       "source": "packages/mcp-server/src/copypass-tool.ts",
-      "hash": "70d540c397a5",
-      "bytes": 31503
+      "hash": "3cbadbc448a0",
+      "bytes": 33377
     },
     {
       "source": "packages/mcp-server/src/crews-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -171,7 +171,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/commonsensepass-tool.ts | bad23b55ea01 | 1995 |
 | packages/mcp-server/src/compliancepass-tool.ts | 13242448457f | 3202 |
 | packages/mcp-server/src/convertkit-tool.ts | 2f77303a3441 | 8498 |
-| packages/mcp-server/src/copypass-tool.ts | 70d540c397a5 | 31503 |
+| packages/mcp-server/src/copypass-tool.ts | 3cbadbc448a0 | 33377 |
 | packages/mcp-server/src/crews-tool.ts | 111454c76c0a | 13547 |
 | packages/mcp-server/src/csuite-tool.ts | 0ab5af89bb49 | 70236 |
 | packages/mcp-server/src/datadog-tool.ts | 802b808614cd | 5556 |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -635,11 +635,11 @@
     "tools": [
       {
         "name": "copypass_run",
-        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, and optional CopyRoom exact-copy receipt."
+        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, a structured copypass_receipt_v1 proof envelope, and optional CopyRoom exact-copy receipt."
       },
       {
         "name": "copypass_status",
-        "description": "Fetch the current status, notes, deterministic findings, disclaimer, and CopyRoom receipt for a CopyPass run started in this MCP session."
+        "description": "Fetch the current status, notes, deterministic findings, disclaimer, copypass_receipt_v1 proof envelope, and CopyRoom receipt for a CopyPass run started in this MCP session."
       }
     ]
   },

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -49,6 +49,13 @@ describe("runtime tool schema validation", () => {
         bogus_field: "should reject",
       },
     },
+    {
+      name: "copypass_run",
+      args: {
+        copy_text: "Try UnClick with proof receipts.",
+        bogus_field: "should reject",
+      },
+    },
     { name: "stripe_customers", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     { name: "stripe_charges", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     {
@@ -144,6 +151,14 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("release_claim", {
       agent_id: "strict-probe",
       todo_id: "11111111-1111-4111-8111-111111111111",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("copypass_run", {
+      copy_text: "UnClick helps teams review AI work with shared context, public proof, and green checks.",
+      channel: "homepage_hero",
+      profile: "smoke",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("copypass_status", {
+      run_id: "copy-run-123",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_call", {
       endpoint_id: "memory.search_memory",

--- a/packages/mcp-server/src/copypass-tool.test.ts
+++ b/packages/mcp-server/src/copypass-tool.test.ts
@@ -42,6 +42,17 @@ describe("copypass-tool", () => {
       summary?: { counts_by_severity?: { high?: number; info?: number }; coverage_note?: string };
       verdict_summary?: { fail?: number };
       findings?: Array<{ check_id?: string }>;
+      receipt?: {
+        kind?: string;
+        pass?: string;
+        status?: string;
+        run_id?: string;
+        receipt_id?: string;
+        finding_count?: number;
+        action_needed?: string[];
+        evidence?: { source?: string; copyroom_receipt_attached?: boolean };
+        boundaries?: string[];
+      };
     };
 
     expect(run.status).toBe("complete");
@@ -55,6 +66,17 @@ describe("copypass-tool", () => {
     expect(run.verdict_summary?.fail).toBeGreaterThan(0);
     expect(run.findings?.map((finding) => finding.check_id)).toContain("unsupported-superiority");
     expect(run.run_id).toBeTruthy();
+    expect(run.receipt).toMatchObject({
+      kind: "copypass_receipt_v1",
+      pass: "copypass",
+      status: "FAIL",
+      run_id: run.run_id,
+      receipt_id: `copypass:${run.run_id}`,
+      finding_count: run.finding_count,
+      evidence: { source: "caller_provided_copy", copyroom_receipt_attached: false },
+    });
+    expect(run.receipt?.action_needed?.some((item) => item.includes("unsupported-superiority"))).toBe(true);
+    expect(run.receipt?.boundaries?.some((item) => item.includes("Legal, brand, or factual approval"))).toBe(true);
 
     const status = (await copypassStatus({
       run_id: run.run_id,
@@ -66,6 +88,7 @@ describe("copypass-tool", () => {
       summary?: { posture?: string };
       target?: { channel?: string };
       findings?: Array<{ check_id?: string }>;
+      receipt?: { kind?: string; status?: string; run_id?: string; receipt_id?: string };
     };
 
     expect(status.run_id).toBe(run.run_id);
@@ -75,6 +98,12 @@ describe("copypass-tool", () => {
     expect(status.summary?.posture).toContain("copy risks");
     expect(status.target?.channel).toBe("homepage_hero");
     expect(status.findings?.map((finding) => finding.check_id)).toContain("placeholder-copy");
+    expect(status.receipt).toMatchObject({
+      kind: "copypass_receipt_v1",
+      status: "FAIL",
+      run_id: run.run_id,
+      receipt_id: `copypass:${run.run_id}`,
+    });
   });
 
   it("detects MCP parity checks for tone fit and internal consistency", async () => {
@@ -114,6 +143,7 @@ describe("copypass-tool", () => {
       overall_score?: number;
       disclaimer?: { compact?: string };
       not_checked?: Array<{ label?: string }>;
+      receipt?: { status?: string; action_needed?: string[]; boundaries?: string[] };
     };
 
     expect(run.status).toBe("complete");
@@ -125,6 +155,9 @@ describe("copypass-tool", () => {
     expect(run.not_checked?.map((item) => item.label)).toContain(
       "Humaniser, template, or voice-profile rewrite",
     );
+    expect(run.receipt?.status).toBe("PASS");
+    expect(run.receipt?.action_needed).toEqual([]);
+    expect(run.receipt?.boundaries?.some((item) => item.includes("Detector-evasion guarantee"))).toBe(true);
   });
 
   it("flags detector-evasion claims in MCP runs", async () => {
@@ -251,6 +284,7 @@ describe("copypass-tool", () => {
         output_character_count?: number;
         newline_style?: string;
       };
+      receipt?: { evidence?: { source?: string; copyroom_receipt_attached?: boolean } };
     };
 
     expect(run.status).toBe("complete");
@@ -266,13 +300,21 @@ describe("copypass-tool", () => {
     expect(run.copyroom_receipt?.character_count).toBe(Array.from(sourceText).length);
     expect(run.copyroom_receipt?.output_character_count).toBe(run.copyroom_receipt?.character_count);
     expect(run.copyroom_receipt?.newline_style).toBe("crlf");
+    expect(run.receipt?.evidence).toMatchObject({
+      source: "copyroom_source_packet",
+      copyroom_receipt_attached: true,
+    });
 
     const status = (await copypassStatus({
       run_id: run.run_id,
-    })) as { copyroom_receipt?: { status?: string; source_sha256?: string; output_sha256?: string } };
+    })) as {
+      copyroom_receipt?: { status?: string; source_sha256?: string; output_sha256?: string };
+      receipt?: { evidence?: { copyroom_receipt_attached?: boolean } };
+    };
 
     expect(status.copyroom_receipt?.status).toBe("pass");
     expect(status.copyroom_receipt?.source_sha256).toBe(status.copyroom_receipt?.output_sha256);
+    expect(status.receipt?.evidence?.copyroom_receipt_attached).toBe(true);
   });
 
   it("blocks required CopyRoom receipt runs when the source packet is missing", async () => {

--- a/packages/mcp-server/src/copypass-tool.ts
+++ b/packages/mcp-server/src/copypass-tool.ts
@@ -132,6 +132,29 @@ interface CopyRunRecord {
   error?: string;
 }
 
+interface CopyPassReceipt {
+  kind: "copypass_receipt_v1";
+  pass: "copypass";
+  receipt_id: string;
+  run_id: string;
+  status: "PASS" | "WARN" | "FAIL";
+  profile: RunProfile;
+  checked_at: string;
+  completed_at: string;
+  target: CopyRunRecord["target"];
+  verdict: CopyPassRunVerdict;
+  overall_score: number;
+  finding_count: number;
+  checks_attempted: CopyPassCheckId[];
+  evidence: {
+    source: "caller_provided_copy" | "copyroom_source_packet";
+    copy_text_preview: string;
+    copyroom_receipt_attached: boolean;
+  };
+  boundaries: string[];
+  action_needed: string[];
+}
+
 const RUNS = new Map<string, CopyRunRecord>();
 
 const COPYPASS_DISCLAIMER = {
@@ -611,6 +634,39 @@ function summarizeCopyPass(findings: CopyFinding[]): CopyPassSummary {
   };
 }
 
+function toReceiptStatus(verdict: CopyPassRunVerdict): CopyPassReceipt["status"] {
+  if (verdict === "pass") return "PASS";
+  if (verdict === "warn") return "WARN";
+  return "FAIL";
+}
+
+function createCopyPassReceipt(run: CopyRunRecord): CopyPassReceipt {
+  return {
+    kind: "copypass_receipt_v1",
+    pass: "copypass",
+    receipt_id: `copypass:${run.id}`,
+    run_id: run.id,
+    status: toReceiptStatus(run.copypass_verdict),
+    profile: run.profile,
+    checked_at: run.completed_at ?? run.created_at,
+    completed_at: run.completed_at ?? run.created_at,
+    target: run.target,
+    verdict: run.copypass_verdict,
+    overall_score: run.overall_score,
+    finding_count: run.findings.length,
+    checks_attempted: run.checks_attempted,
+    evidence: {
+      source: run.copyroom_receipt ? "copyroom_source_packet" : "caller_provided_copy",
+      copy_text_preview: run.target.copy_text_preview,
+      copyroom_receipt_attached: Boolean(run.copyroom_receipt),
+    },
+    boundaries: run.not_checked.map((item) => `${item.label}: ${item.reason}`),
+    action_needed: run.findings.map((finding) =>
+      `${finding.severity.toUpperCase()}: ${finding.title} (${finding.check_id})`,
+    ),
+  };
+}
+
 function normalizeCopy(value: string): string {
   return value.toLocaleLowerCase("en-US").replace(/\s+/g, " ").trim();
 }
@@ -751,6 +807,7 @@ export async function copypassRun(args: Record<string, unknown>): Promise<unknow
     notes: completed.notes,
     preview: completed.target.copy_text_preview,
     copyroom_receipt: completed.copyroom_receipt ?? null,
+    receipt: createCopyPassReceipt(completed),
   };
 }
 
@@ -776,6 +833,7 @@ export async function copypassStatus(args: Record<string, unknown>): Promise<unk
     notes: run.notes,
     completed_at: run.completed_at,
     copyroom_receipt: run.copyroom_receipt ?? null,
+    receipt: createCopyPassReceipt(run),
   };
 }
 

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -649,11 +649,11 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "copypass_run",
-        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, and optional CopyRoom exact-copy receipt."
+        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, a structured copypass_receipt_v1 proof envelope, and optional CopyRoom exact-copy receipt."
       },
       {
         "name": "copypass_status",
-        "description": "Fetch the current status, notes, deterministic findings, disclaimer, and CopyRoom receipt for a CopyPass run started in this MCP session."
+        "description": "Fetch the current status, notes, deterministic findings, disclaimer, copypass_receipt_v1 proof envelope, and CopyRoom receipt for a CopyPass run started in this MCP session."
       }
     ]
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12748,7 +12748,7 @@ export const ADDITIONAL_TOOLS = [
   // ── copypass-tool.ts (copy quality QC with CopyRoom receipt support) ─────
   {
     name: "copypass_run",
-    description: "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, and optional CopyRoom exact-copy receipt.",
+    description: "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, a structured copypass_receipt_v1 proof envelope, and optional CopyRoom exact-copy receipt.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
@@ -12782,7 +12782,7 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "copypass_status",
-    description: "Fetch the current status, notes, deterministic findings, disclaimer, and CopyRoom receipt for a CopyPass run started in this MCP session.",
+    description: "Fetch the current status, notes, deterministic findings, disclaimer, copypass_receipt_v1 proof envelope, and CopyRoom receipt for a CopyPass run started in this MCP session.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,


### PR DESCRIPTION
## Summary
- add a first-class `copypass_receipt_v1` envelope to `copypass_run` and `copypass_status`
- include run id, target, PASS/WARN/FAIL status, evidence source, CopyRoom attachment flag, boundaries, and action-needed lines
- advertise the receipt surface in MCP tool descriptions and generated tool index

## Proof
- npm ci
- focused MCP CopyPass/schema tests passed
- CopyPass package tests passed
- MCP server build passed
- tool index check passed
- CopyPass package build passed
- ESLint on touched files passed
- git diff check passed
- full MCP server test suite passed
- root build passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API surface on CopyPass MCP tools with no auth or data-model changes; existing fields unchanged aside from a new `receipt` object.
> 
> **Overview**
> **CopyPass MCP responses now include a structured `copypass_receipt_v1` proof envelope** on both `copypass_run` and `copypass_status`, built from the completed run (PASS/WARN/FAIL, verdict, scores, evidence source, CopyRoom attachment, scope boundaries, and action-needed lines from findings).
> 
> Tool descriptions and generated indexes (`tool-index`, `memory/tool-index`, brainmap metadata) were updated to advertise the receipt. Tests cover receipt shape for fail/pass/CopyRoom paths, and `copypass_run` was added to strict schema validation probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f65caecf6cdd0b5eaa620408420c93c31fdaf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->