### PR TITLE
Shared connector-kit + Amber hardened to L4

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8212,8 +8212,8 @@
     },
     {
       "source": "packages/mcp-server/src/amber-tool.ts",
-      "hash": "6d020b798469",
-      "bytes": 4138
+      "hash": "06b9b05ffc91",
+      "bytes": 4840
     },
     {
       "source": "packages/mcp-server/src/anthropic-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -148,7 +148,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/algolia-tool.ts | 8eb0992500f1 | 4924 |
 | packages/mcp-server/src/alphavantage-tool.ts | 98a37153078d | 7591 |
 | packages/mcp-server/src/amazon-tool.ts | fb1e936b7c9a | 14913 |
-| packages/mcp-server/src/amber-tool.ts | 6d020b798469 | 4138 |
+| packages/mcp-server/src/amber-tool.ts | 06b9b05ffc91 | 4840 |
 | packages/mcp-server/src/anthropic-tool.ts | fd197643eefb | 7766 |
 | packages/mcp-server/src/asana-tool.ts | 3f5d880c119d | 8078 |
 | packages/mcp-server/src/assemblyai-tool.ts | fdc9c929ba6f | 9625 |

--- a/packages/mcp-server/src/amber-tool.test.ts
+++ b/packages/mcp-server/src/amber-tool.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getAmberCurrentPrice, getAmberSites } from "./amber-tool.js";
+
+// Colocated Amber tests: L2 resilience + L3 memory defaults + L4 source stamping,
+// using the shared connector-kit. Amber is the second reference for the ladder.
+
+const okJson = (body: unknown) =>
+  vi.fn(async (..._a: unknown[]) => ({ ok: true, status: 200, json: async () => body }));
+
+describe("amber connector resilience (L2)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns a clean rate-limit error on HTTP 429", async () => {
+    vi.stubEnv("AMBER_API_KEY", "k");
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: false,
+      status: 429,
+      headers: { get: (h: string) => (h === "Retry-After" ? "12" : null) },
+      text: async () => "slow down",
+    })));
+    const res = await getAmberSites({}) as Record<string, any>;
+    expect(res.error).toMatch(/rate limit reached \(HTTP 429\).*retry after 12s/i);
+  });
+
+  it("returns a clean timeout error when the request aborts", async () => {
+    vi.stubEnv("AMBER_API_KEY", "k");
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    }));
+    const res = await getAmberSites({}) as Record<string, any>;
+    expect(res.error).toMatch(/timed out/i);
+  });
+});
+
+describe("amber memory defaults + stamping (L3/L4)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("uses AMBER_HOME_SITE_ID and records the default used", async () => {
+    vi.stubEnv("AMBER_API_KEY", "k");
+    vi.stubEnv("AMBER_HOME_SITE_ID", "site-123");
+    const fetchMock = okJson([{ channelType: "general", perKwh: 30 }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await getAmberCurrentPrice({}) as Record<string, any>;
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/sites/site-123/prices/current");
+    expect(res.site_id).toBe("site-123");
+    expect(res.unclick_meta.source).toBe("Amber Electric API v1");
+    expect(res.unclick_meta.defaults_used).toContain("AMBER_HOME_SITE_ID");
+    expect(typeof res.unclick_meta.fetched_at).toBe("string");
+  });
+
+  it("explicit site_id overrides env and is not flagged as a default", async () => {
+    vi.stubEnv("AMBER_API_KEY", "k");
+    vi.stubEnv("AMBER_HOME_SITE_ID", "site-123");
+    const fetchMock = okJson([]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await getAmberCurrentPrice({ site_id: "site-999" }) as Record<string, any>;
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/sites/site-999/");
+    expect(res.unclick_meta.defaults_used).not.toContain("AMBER_HOME_SITE_ID");
+  });
+});

--- a/packages/mcp-server/src/amber-tool.ts
+++ b/packages/mcp-server/src/amber-tool.ts
@@ -4,7 +4,10 @@
 // Auth: Bearer token via AMBER_API_KEY env var.
 // Base URL: https://api.amber.com.au/v1/
 
+import { timeoutFetch, memoryDefault, stamp } from "./connector-kit.js";
+
 const AMBER_BASE = "https://api.amber.com.au/v1";
+const AMBER_SOURCE = "Amber Electric API v1";
 
 function getApiKey(args: Record<string, unknown>): string {
   const key = String(args.api_key ?? process.env.AMBER_API_KEY ?? "").trim();
@@ -14,7 +17,7 @@ function getApiKey(args: Record<string, unknown>): string {
 
 async function amberGet(apiKey: string, path: string, params?: Record<string, string>): Promise<unknown> {
   const qs = params ? "?" + new URLSearchParams(params).toString() : "";
-  const res = await fetch(`${AMBER_BASE}${path}${qs}`, {
+  const res = await timeoutFetch("Amber", `${AMBER_BASE}${path}${qs}`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
       Accept: "application/json",
@@ -22,7 +25,6 @@ async function amberGet(apiKey: string, path: string, params?: Record<string, st
   });
   if (res.status === 401) throw new Error("Invalid Amber API key.");
   if (res.status === 404) throw new Error("Resource not found.");
-  if (res.status === 429) throw new Error("Amber API rate limit exceeded.");
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Amber API HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
@@ -36,7 +38,7 @@ export async function getAmberSites(args: Record<string, unknown>): Promise<unkn
   try {
     const apiKey = getApiKey(args);
     const sites = await amberGet(apiKey, "/sites") as Array<Record<string, unknown>>;
-    return {
+    return stamp({
       count: sites.length,
       sites: sites.map((s) => ({
         id: s["id"],
@@ -46,7 +48,10 @@ export async function getAmberSites(args: Record<string, unknown>): Promise<unkn
         loss_factor: s["lossFactor"],
         channels: s["channels"],
       })),
-    };
+    }, {
+      source: AMBER_SOURCE,
+      nextSteps: ["Set AMBER_HOME_SITE_ID to a returned id, or pass site_id to get_amber_current_price."],
+    });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }
@@ -57,12 +62,13 @@ export async function getAmberSites(args: Record<string, unknown>): Promise<unkn
 export async function getAmberCurrentPrice(args: Record<string, unknown>): Promise<unknown> {
   try {
     const apiKey = getApiKey(args);
-    const siteId = String(args.site_id ?? "").trim();
-    if (!siteId) return { error: "site_id is required. Call get_amber_sites to find yours." };
+    const defaultsUsed: string[] = [];
+    const siteId = memoryDefault(args, "site_id", "AMBER_HOME_SITE_ID", defaultsUsed);
+    if (!siteId) return { error: "site_id is required (or set AMBER_HOME_SITE_ID). Call get_amber_sites to find yours." };
 
     const prices = await amberGet(apiKey, `/sites/${siteId}/prices/current`) as Array<Record<string, unknown>>;
 
-    return {
+    return stamp({
       site_id: siteId,
       prices: prices.map((p) => ({
         type: p["channelType"],
@@ -76,7 +82,11 @@ export async function getAmberCurrentPrice(args: Record<string, unknown>): Promi
         descriptor: p["descriptor"],
         estimate: p["estimate"] ?? false,
       })),
-    };
+    }, {
+      source: AMBER_SOURCE,
+      defaultsUsed,
+      nextSteps: ["Use get_amber_forecast for upcoming price intervals."],
+    });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }
@@ -87,8 +97,9 @@ export async function getAmberCurrentPrice(args: Record<string, unknown>): Promi
 export async function getAmberForecast(args: Record<string, unknown>): Promise<unknown> {
   try {
     const apiKey = getApiKey(args);
-    const siteId = String(args.site_id ?? "").trim();
-    if (!siteId) return { error: "site_id is required. Call get_amber_sites to find yours." };
+    const defaultsUsed: string[] = [];
+    const siteId = memoryDefault(args, "site_id", "AMBER_HOME_SITE_ID", defaultsUsed);
+    if (!siteId) return { error: "site_id is required (or set AMBER_HOME_SITE_ID). Call get_amber_sites to find yours." };
 
     const next = Math.min(48, Math.max(1, Number(args.next ?? 12)));
     const prices = await amberGet(apiKey, `/sites/${siteId}/prices`, {
@@ -96,7 +107,7 @@ export async function getAmberForecast(args: Record<string, unknown>): Promise<u
       resolution: "30",
     }) as Array<Record<string, unknown>>;
 
-    return {
+    return stamp({
       site_id: siteId,
       intervals_requested: next,
       forecast: prices.map((p) => ({
@@ -110,7 +121,11 @@ export async function getAmberForecast(args: Record<string, unknown>): Promise<u
         descriptor: p["descriptor"],
         estimate: p["estimate"] ?? false,
       })),
-    };
+    }, {
+      source: AMBER_SOURCE,
+      defaultsUsed,
+      nextSteps: ["Look for spike_status or low spot_per_kwh intervals to time usage."],
+    });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }

--- a/packages/mcp-server/src/connector-kit.ts
+++ b/packages/mcp-server/src/connector-kit.ts
@@ -1,0 +1,86 @@
+// connector-kit.ts
+// Shared helpers that move a connector up the depth ladder with minimal code:
+//   - timeoutFetch:  L2 resilience (request timeout + clean 429/timeout/network errors)
+//   - memoryDefault: L3 memory-aware (read a default from args -> env, tracking which
+//                    defaults were used)
+//   - stamp:         L4 proactive (attach source / freshness / next-step metadata)
+//
+// PTV is the reference connector for this pattern; this kit makes it reusable so
+// the other connectors are small adoptions rather than hand-copies.
+
+export interface StampOptions {
+  source: string;
+  attribution?: string;
+  defaultsUsed?: string[];
+  nextSteps?: string[];
+}
+
+const DEFAULT_TIMEOUT_MS = Number(process.env.CONNECTOR_TIMEOUT_MS) || 10000;
+
+/**
+ * fetch with an AbortController timeout and normalized, agent-readable errors.
+ * `label` names the upstream API in error messages (e.g. "Amber").
+ */
+export async function timeoutFetch(
+  label: string,
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    if (res.status === 429) {
+      const retryAfter = res.headers.get("Retry-After");
+      throw new Error(`${label} API rate limit reached (HTTP 429)${retryAfter ? `, retry after ${retryAfter}s` : ""}.`);
+    }
+    return res;
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`${label} API request timed out after ${timeoutMs}ms.`);
+    }
+    // re-throw our own 429 message unchanged; wrap raw network failures
+    if (err instanceof Error && /rate limit reached/.test(err.message)) throw err;
+    throw new Error(`${label} API network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve a value from explicit args first, then an env default. When the env
+ * default is used (and args did not supply it), push the env key onto `usedSink`
+ * so the response can report which remembered defaults filled in.
+ */
+export function memoryDefault(
+  args: Record<string, unknown>,
+  argKey: string,
+  envKey: string,
+  usedSink: string[],
+): string {
+  const fromArgs = args[argKey];
+  if (fromArgs !== undefined && String(fromArgs).trim() !== "") return String(fromArgs).trim();
+  const fromEnv = process.env[envKey];
+  if (fromEnv && fromEnv.trim() !== "") {
+    usedSink.push(envKey);
+    return fromEnv.trim();
+  }
+  return "";
+}
+
+/** Attach UnClick source/freshness/next-step metadata to a tool result. */
+export function stamp(result: unknown, opts: StampOptions): unknown {
+  const meta: Record<string, unknown> = {
+    source: opts.source,
+    fetched_at: new Date().toISOString(),
+    defaults_used: opts.defaultsUsed ?? [],
+  };
+  if (opts.attribution) meta.attribution = opts.attribution;
+  if (opts.nextSteps && opts.nextSteps.length) meta.next_steps = opts.nextSteps;
+
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return { ...(result as Record<string, unknown>), unclick_meta: meta };
+  }
+  return { data: result, unclick_meta: meta };
+}

--- a/packages/standalone/amber-mcp/src/amber-tool.ts
+++ b/packages/standalone/amber-mcp/src/amber-tool.ts
@@ -4,7 +4,10 @@
 // Auth: Bearer token via AMBER_API_KEY env var.
 // Base URL: https://api.amber.com.au/v1/
 
+import { timeoutFetch, memoryDefault, stamp } from "./connector-kit.js";
+
 const AMBER_BASE = "https://api.amber.com.au/v1";
+const AMBER_SOURCE = "Amber Electric API v1";
 
 function getApiKey(args: Record<string, unknown>): string {
   const key = String(args.api_key ?? process.env.AMBER_API_KEY ?? "").trim();
@@ -14,7 +17,7 @@ function getApiKey(args: Record<string, unknown>): string {
 
 async function amberGet(apiKey: string, path: string, params?: Record<string, string>): Promise<unknown> {
   const qs = params ? "?" + new URLSearchParams(params).toString() : "";
-  const res = await fetch(`${AMBER_BASE}${path}${qs}`, {
+  const res = await timeoutFetch("Amber", `${AMBER_BASE}${path}${qs}`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
       Accept: "application/json",
@@ -22,7 +25,6 @@ async function amberGet(apiKey: string, path: string, params?: Record<string, st
   });
   if (res.status === 401) throw new Error("Invalid Amber API key.");
   if (res.status === 404) throw new Error("Resource not found.");
-  if (res.status === 429) throw new Error("Amber API rate limit exceeded.");
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Amber API HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
@@ -36,7 +38,7 @@ export async function getAmberSites(args: Record<string, unknown>): Promise<unkn
   try {
     const apiKey = getApiKey(args);
     const sites = await amberGet(apiKey, "/sites") as Array<Record<string, unknown>>;
-    return {
+    return stamp({
       count: sites.length,
       sites: sites.map((s) => ({
         id: s["id"],
@@ -46,7 +48,10 @@ export async function getAmberSites(args: Record<string, unknown>): Promise<unkn
         loss_factor: s["lossFactor"],
         channels: s["channels"],
       })),
-    };
+    }, {
+      source: AMBER_SOURCE,
+      nextSteps: ["Set AMBER_HOME_SITE_ID to a returned id, or pass site_id to get_amber_current_price."],
+    });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }
@@ -57,12 +62,13 @@ export async function getAmberSites(args: Record<string, unknown>): Promise<unkn
 export async function getAmberCurrentPrice(args: Record<string, unknown>): Promise<unknown> {
   try {
     const apiKey = getApiKey(args);
-    const siteId = String(args.site_id ?? "").trim();
-    if (!siteId) return { error: "site_id is required. Call get_amber_sites to find yours." };
+    const defaultsUsed: string[] = [];
+    const siteId = memoryDefault(args, "site_id", "AMBER_HOME_SITE_ID", defaultsUsed);
+    if (!siteId) return { error: "site_id is required (or set AMBER_HOME_SITE_ID). Call get_amber_sites to find yours." };
 
     const prices = await amberGet(apiKey, `/sites/${siteId}/prices/current`) as Array<Record<string, unknown>>;
 
-    return {
+    return stamp({
       site_id: siteId,
       prices: prices.map((p) => ({
         type: p["channelType"],
@@ -76,7 +82,11 @@ export async function getAmberCurrentPrice(args: Record<string, unknown>): Promi
         descriptor: p["descriptor"],
         estimate: p["estimate"] ?? false,
       })),
-    };
+    }, {
+      source: AMBER_SOURCE,
+      defaultsUsed,
+      nextSteps: ["Use get_amber_forecast for upcoming price intervals."],
+    });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }
@@ -87,8 +97,9 @@ export async function getAmberCurrentPrice(args: Record<string, unknown>): Promi
 export async function getAmberForecast(args: Record<string, unknown>): Promise<unknown> {
   try {
     const apiKey = getApiKey(args);
-    const siteId = String(args.site_id ?? "").trim();
-    if (!siteId) return { error: "site_id is required. Call get_amber_sites to find yours." };
+    const defaultsUsed: string[] = [];
+    const siteId = memoryDefault(args, "site_id", "AMBER_HOME_SITE_ID", defaultsUsed);
+    if (!siteId) return { error: "site_id is required (or set AMBER_HOME_SITE_ID). Call get_amber_sites to find yours." };
 
     const next = Math.min(48, Math.max(1, Number(args.next ?? 12)));
     const prices = await amberGet(apiKey, `/sites/${siteId}/prices`, {
@@ -96,7 +107,7 @@ export async function getAmberForecast(args: Record<string, unknown>): Promise<u
       resolution: "30",
     }) as Array<Record<string, unknown>>;
 
-    return {
+    return stamp({
       site_id: siteId,
       intervals_requested: next,
       forecast: prices.map((p) => ({
@@ -110,7 +121,11 @@ export async function getAmberForecast(args: Record<string, unknown>): Promise<u
         descriptor: p["descriptor"],
         estimate: p["estimate"] ?? false,
       })),
-    };
+    }, {
+      source: AMBER_SOURCE,
+      defaultsUsed,
+      nextSteps: ["Look for spike_status or low spot_per_kwh intervals to time usage."],
+    });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }


### PR DESCRIPTION
Turns the PTV pattern into a reusable kit so the remaining ~150 connectors are small adoptions, not hand-copies — then applies it to Amber as the second L4.

**`connector-kit.ts`** (new shared helpers):
- `timeoutFetch(label, url, init)` — L2: AbortController timeout + clean 429 (`Retry-After`) / timeout / network error messages
- `memoryDefault(args, argKey, envKey, sink)` — L3: resolve args → env default, recording which remembered defaults were used
- `stamp(result, {source, attribution, defaultsUsed, nextSteps})` — L4: source/freshness/next-step metadata

**Amber** now uses the kit: remembers `AMBER_HOME_SITE_ID` (ask "current electricity price" with zero args), times out cleanly, and stamps every response with source + freshness + next steps. Colocated `amber-tool.test.ts` (4 tests: 429, timeout, memory default, arg-overrides-env). Standalone `amber-mcp` regenerated.

tsc clean; 4/4 tests pass. This is the scalable path for churning the rest of the 180 up the ladder.

https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDUvN5QqGPUjkXSNcTpAss)_