### PR TITLE
feat(geopass): add live AI answer receipts

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 572,
+    "inventory": 573,
     "source_manifest": 187,
     "pages": 78,
-    "tools": 187,
+    "tools": 188,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 187
+      "count": 188
     },
     {
       "id": "rooms",
@@ -4362,6 +4362,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-geopass-packages-mcp-server-src-geopass-tool-ts-no-route",
+      "division": "Tools",
+      "name": "geopass",
+      "kind": "MCP tool",
+      "meaning": "geopass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/geopass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-github-packages-mcp-server-src-github-tool-ts-no-route",
       "division": "Tools",
       "name": "github",
@@ -6627,6 +6637,11 @@
       "genius",
       "genius MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/genius-tool.ts"
+    ],
+    [
+      "geopass",
+      "geopass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/geopass-tool.ts"
     ],
     [
       "github",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -207,7 +207,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 47 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 31 |
-| Tools | MCP and gateway capabilities available to seats. | 187 |
+| Tools | MCP and gateway capabilities available to seats. | 188 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
@@ -387,6 +387,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | fpl | fpl MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fpl-tool.ts |
 | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gdelt-tool.ts |
 | genius | genius MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/genius-tool.ts |
+| geopass | geopass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/geopass-tool.ts |
 | github | github MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/github-tool.ts |
 | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gitlab-tool.ts |
 | groq | groq MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/groq-tool.ts |
@@ -950,6 +951,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | fpl | fpl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fpl-tool.ts |
 | Tools | MCP tool | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gdelt-tool.ts |
 | Tools | MCP tool | genius | genius MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/genius-tool.ts |
+| Tools | MCP tool | geopass | geopass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/geopass-tool.ts |
 | Tools | MCP tool | github | github MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/github-tool.ts |
 | Tools | MCP tool | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gitlab-tool.ts |
 | Tools | MCP tool | groq | groq MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/groq-tool.ts |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1300,6 +1300,20 @@
     ]
   },
   {
+    "app": "geopass",
+    "category": "GEOPass (AI answer-engine readiness QC, sister to SEOPass)",
+    "tools": [
+      {
+        "name": "geopass_run",
+        "description": "Run GEOPass against a public URL. Returns a live-readonly AI answer-engine readiness receipt covering answer extractability, entity clarity, citation/sourceability, freshness cues, content structure, llms.txt, and AI bot visibility. GEOPass reports readiness only and does not guarantee rankings or citations."
+      },
+      {
+        "name": "geopass_status",
+        "description": "Fetch the stored in-session GEOPass report and geopass_receipt_v1 envelope for a run started through geopass_run."
+      }
+    ]
+  },
+  {
     "app": "github",
     "category": "Developer / Productivity",
     "tools": [

--- a/packages/geopass/package.json
+++ b/packages/geopass/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./schema": "./dist/schema.js",
-    "./scanner-plan": "./dist/scanner-plan.js"
+    "./scanner-plan": "./dist/scanner-plan.js",
+    "./runner": "./dist/runner.js"
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",

--- a/packages/geopass/src/__tests__/runner.test.ts
+++ b/packages/geopass/src/__tests__/runner.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runGeoPass } from "../runner.js";
+
+function installFetch(fixtures: Record<string, string | { status: number; body: string; headers?: Record<string, string>; url?: string }>): void {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const normalized = new URL(url).toString();
+    const fixture = fixtures[normalized] ?? fixtures[normalized.replace(/\/$/, "")];
+    const status = typeof fixture === "object" ? fixture.status : fixture ? 200 : 404;
+    const body = typeof fixture === "object" ? fixture.body : fixture ?? "not found";
+    const headers = typeof fixture === "object" ? fixture.headers ?? { "content-type": "text/html" } : { "content-type": "text/html" };
+    return {
+      url: typeof fixture === "object" && fixture.url ? fixture.url : normalized,
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers(headers),
+      text: async () => body,
+    };
+  }));
+}
+
+const strongGeoHtml = `<!doctype html>
+<html>
+  <head>
+    <title>UnClick GEOPass - AI answer readiness checks</title>
+    <meta name="description" content="GEOPass checks whether public pages are readable, sourceable, and clear enough for AI answer engines.">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "UnClick",
+      "url": "https://unclick.world"
+    }</script>
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": []
+    }</script>
+  </head>
+  <body>
+    <h1>GEOPass checks AI answer readiness</h1>
+    <h2>What does GEOPass inspect?</h2>
+    <p>GEOPass inspects public pages for answer extractability, entity clarity, citation readiness, freshness cues, and AI-readable structure.</p>
+    <h2>How does it avoid false promises?</h2>
+    <p>It reports readiness only. It does not guarantee rankings, AI citations, or answer-engine placement.</p>
+    <ul><li>Public evidence</li><li>Clear entity names</li><li>Fresh source links</li></ul>
+    <p>Updated <time datetime="2026-05-30">May 30, 2026</time>. According to public documentation, source evidence matters.</p>
+    <p>See the <a href="https://developers.google.com/search/docs/appearance/ai-features">Google AI features guidance</a> and <a href="https://schema.org">schema.org</a>.</p>
+    <a href="/about">About</a>
+    <a href="/contact">Contact</a>
+  </body>
+</html>`;
+
+describe("runGeoPass", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects non-public URL schemes and credentialed URLs", async () => {
+    await expect(runGeoPass({ url: "file:///tmp/page.html" })).resolves.toMatchObject({
+      error: expect.stringContaining("public http(s)"),
+    });
+    await expect(runGeoPass({ url: "https://user:pass@example.com" })).resolves.toMatchObject({
+      error: expect.stringContaining("public http(s)"),
+    });
+  });
+
+  it("returns a first-class live receipt for AI-answer readiness", async () => {
+    installFetch({
+      "https://unclick.world/": strongGeoHtml,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nGEOPass helps AI systems read public product pages.\n\n[Docs](https://unclick.world/docs): Documentation for public checks and receipts.",
+    });
+
+    const run = await runGeoPass({
+      url: "https://unclick.world",
+      generatedAt: "2026-05-30T12:00:00.000Z",
+      targetSha: "abc123",
+    });
+
+    expect("error" in run).toBe(false);
+    if ("error" in run) throw new Error(run.error);
+    expect(run.status).toBe("complete");
+    expect(run.pass).toBe("geopass");
+    expect(run.report.mode).toBe("live-readonly");
+    expect(run.report.checks.map((check) => check.check_id)).toContain("answer-extractability");
+    expect(run.report.checks.map((check) => check.check_id)).toContain("citation-readiness");
+    expect(run.geopass_receipt_v1).toMatchObject({
+      kind: "geopass_receipt_v1",
+      mode: "live-readonly",
+      target_sha: "abc123",
+    });
+    expect(run.geopass_receipt_v1.boundaries.join(" ")).toContain("does not guarantee");
+    expect(run.ai_answer_readiness_score).toBeGreaterThanOrEqual(80);
+  });
+
+  it("blocks when robots.txt disallows AI crawlers", async () => {
+    installFetch({
+      "https://unclick.world/private": strongGeoHtml,
+      "https://unclick.world/robots.txt": "User-agent: GPTBot\nDisallow: /\nUser-agent: ClaudeBot\nDisallow: /\n",
+      "https://unclick.world/llms.txt": { status: 404, body: "not found" },
+    });
+
+    const run = await runGeoPass({
+      url: "https://unclick.world/private",
+      generatedAt: "2026-05-30T12:00:00.000Z",
+    });
+
+    expect("error" in run).toBe(false);
+    if ("error" in run) throw new Error(run.error);
+    expect(run.verdict).toBe("blocked");
+    expect(run.geopass_receipt_v1.status).toBe("BLOCKER");
+    expect(run.report.checks.some((check) => check.check_id === "ai-bot-crawlability" && check.verdict === "blocked")).toBe(true);
+  });
+
+  it("keeps external index checks explicit unknown instead of pretending proof", async () => {
+    installFetch({
+      "https://unclick.world/": strongGeoHtml,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nHelpful file with enough public summary and links to docs.",
+    });
+
+    const run = await runGeoPass({
+      url: "https://unclick.world",
+      checks: ["wikidata-presence", "common-crawl-presence"],
+    });
+
+    expect("error" in run).toBe(false);
+    if ("error" in run) throw new Error(run.error);
+    expect(run.report.checks.map((check) => check.verdict)).toEqual(["unknown", "unknown"]);
+    expect(run.geopass_receipt_v1.checked.unknown).toBe(2);
+  });
+});

--- a/packages/geopass/src/__tests__/scanner-plan.test.ts
+++ b/packages/geopass/src/__tests__/scanner-plan.test.ts
@@ -16,6 +16,8 @@ describe("createGeoPassScannerPlan", () => {
     expect(plan.engines).toEqual(DEFAULT_GEOPASS_ENGINES);
     expect(plan.bots).toEqual(DEFAULT_GEOPASS_BOTS);
     expect(plan.steps.map((step) => step.id)).toContain("ai-bot-crawlability");
+    expect(plan.steps.map((step) => step.id)).toContain("answer-extractability");
+    expect(plan.steps.map((step) => step.id)).toContain("citation-readiness");
     expect(plan.steps.map((step) => step.id)).toContain(
       "aggregate-ai-engine-readiness",
     );
@@ -40,7 +42,7 @@ describe("createGeoPassScannerPlan", () => {
 
     expect(plan.disallowedActions).toContain("live crawler execution");
     expect(plan.disallowedActions).toContain("paid API calls");
-    expect(plan.disallowedActions).toContain("citation guarantees");
+    expect(plan.disallowedActions).toContain("guaranteed citations");
   });
 
   it("rejects invalid target URLs", () => {

--- a/packages/geopass/src/__tests__/schema.test.ts
+++ b/packages/geopass/src/__tests__/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GeoPassReportSchema } from "../schema.js";
+import { GeoPassReceiptSchema, GeoPassReportSchema } from "../schema.js";
 
 const validReport = {
   target_url: "https://example.com/",
@@ -86,5 +86,38 @@ describe("GeoPassReportSchema", () => {
     expect(result.checks[0]?.findings[0]?.evidence[0]?.source_url).toBe(
       "https://example.com/llms.txt",
     );
+  });
+
+  it("accepts the first-class live receipt envelope", () => {
+    const receipt = GeoPassReceiptSchema.parse({
+      kind: "geopass_receipt_v1",
+      status: "WARN",
+      run_id: "geopass-abc123",
+      target_url: "https://example.com/",
+      generated_at: "2026-05-30T12:00:00.000Z",
+      mode: "live-readonly",
+      score: 74,
+      verdict: "needs-work",
+      checked: {
+        total: 3,
+        ready: 1,
+        needs_work: 2,
+        blocked: 0,
+        unknown: 0,
+      },
+      evidence_sources: [
+        {
+          kind: "html",
+          label: "Heading scan",
+          source_url: "https://example.com/",
+          summary: "Question headings found.",
+        },
+      ],
+      action_needed: ["Add clearer source links."],
+      boundaries: ["Readiness only. No citation guarantee."],
+    });
+
+    expect(receipt.kind).toBe("geopass_receipt_v1");
+    expect(receipt.status).toBe("WARN");
   });
 });

--- a/packages/geopass/src/index.ts
+++ b/packages/geopass/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema.js";
 export * from "./scanner-plan.js";
+export * from "./runner.js";

--- a/packages/geopass/src/runner.ts
+++ b/packages/geopass/src/runner.ts
@@ -1,0 +1,825 @@
+import { createHash, randomUUID } from "node:crypto";
+import { DEFAULT_GEOPASS_ENGINES } from "./scanner-plan.js";
+import {
+  type GeoPassCheckId,
+  type GeoPassCheckResult,
+  type GeoPassCrossPassSignal,
+  type GeoPassEvidence,
+  type GeoPassFinding,
+  type GeoPassReceipt,
+  type GeoPassReport,
+  type GeoPassVerdict,
+} from "./schema.js";
+
+type FetchLike = typeof fetch;
+
+export interface GeoPassRunInput {
+  url?: string;
+  targetUrl?: string;
+  checks?: GeoPassCheckId[];
+  generatedAt?: string;
+  targetSha?: string;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  maxBodyChars?: number;
+}
+
+export interface GeoPassRunResult {
+  run_id: string;
+  status: "complete";
+  pass: "geopass";
+  target_url: string;
+  generated_at: string;
+  ai_answer_readiness_score: number;
+  verdict: GeoPassVerdict;
+  verdict_summary: Record<"ready" | "needs_work" | "blocked" | "unknown", number>;
+  report: GeoPassReport;
+  geopass_receipt_v1: GeoPassReceipt;
+}
+
+interface FetchTextResult {
+  url: string;
+  status: number;
+  ok: boolean;
+  headers: Record<string, string>;
+  body: string;
+  error?: string;
+  truncated?: boolean;
+}
+
+interface PageSignals {
+  title: string;
+  description: string;
+  h1: string[];
+  h2: string[];
+  text: string;
+  wordCount: number;
+  paragraphCount: number;
+  listCount: number;
+  questionCount: number;
+  externalLinkCount: number;
+  hasJsonLd: boolean;
+  hasMicrodata: boolean;
+  hasRdfa: boolean;
+  hasOrganizationSchema: boolean;
+  hasArticleSchema: boolean;
+  hasFaqSchema: boolean;
+  hasAuthorCue: boolean;
+  hasAboutOrContactLink: boolean;
+  hasFreshnessCue: boolean;
+  hasStatisticCue: boolean;
+  hasSourceCue: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_BODY_CHARS = 1_250_000;
+const LIVE_CHECKS: GeoPassCheckId[] = [
+  "ai-bot-crawlability",
+  "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
+  "schema-org-citation-grade",
+  "brand-mention-readiness",
+  "aggregate-ai-engine-readiness",
+];
+
+const AI_BOTS = [
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+] as const;
+
+const RECEIPT_BOUNDARIES = [
+  "GEOPass reports public read-only readiness only.",
+  "GEOPass does not guarantee rankings, citations, AI Overview inclusion, or answer-engine placement.",
+  "This run fetches public http(s) pages only and does not use credentials, paid APIs, production data, or private prompts.",
+];
+
+function normalizePublicHttpUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function stableRunId(targetUrl: string, generatedAt: string): string {
+  const digest = createHash("sha256")
+    .update(`${targetUrl}:${generatedAt}:${randomUUID()}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `geopass-${digest}`;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const output: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    output[key.toLowerCase()] = value;
+  });
+  return output;
+}
+
+async function fetchText(
+  url: string,
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+  maxBodyChars: number,
+): Promise<FetchTextResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "user-agent": "UnClick-GEOPass/0.1 (+https://unclick.world)" },
+    });
+    const body = await response.text();
+    const truncated = body.length > maxBodyChars;
+    return {
+      url: response.url || url,
+      status: response.status,
+      ok: response.ok,
+      headers: headersToRecord(response.headers),
+      body: truncated ? body.slice(0, maxBodyChars) : body,
+      truncated,
+    };
+  } catch (error) {
+    return {
+      url,
+      status: 0,
+      ok: false,
+      headers: {},
+      body: "",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&#39;/gi, "'")
+    .replace(/&quot;/gi, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function firstMatch(html: string, pattern: RegExp): string {
+  return pattern.exec(html)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function allMatches(html: string, pattern: RegExp): string[] {
+  return Array.from(html.matchAll(pattern), (match) =>
+    stripHtml(match[1] ?? "").replace(/\s+/g, " ").trim(),
+  ).filter(Boolean);
+}
+
+function countMatches(text: string, pattern: RegExp): number {
+  return Array.from(text.matchAll(pattern)).length;
+}
+
+function getMeta(html: string, name: string): string {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return firstMatch(
+    html,
+    new RegExp(`<meta[^>]+(?:name|property)=["']${escaped}["'][^>]+content=["']([^"']+)["'][^>]*>`, "i"),
+  );
+}
+
+function hasSchemaType(html: string, typeName: string): boolean {
+  const pattern = new RegExp(`"@type"\\s*:\\s*"?${typeName}"?`, "i");
+  return pattern.test(html);
+}
+
+function linkCount(html: string, baseUrl: string, external: boolean): number {
+  let count = 0;
+  const base = new URL(baseUrl);
+  for (const match of html.matchAll(/<a\b[^>]+href=["']([^"']+)["'][^>]*>/gi)) {
+    try {
+      const href = new URL(match[1] ?? "", base);
+      if ((href.protocol === "http:" || href.protocol === "https:") && (href.origin !== base.origin) === external) {
+        count += 1;
+      }
+    } catch {
+      // Ignore malformed links in a read-only diagnostic.
+    }
+  }
+  return count;
+}
+
+function hasAboutOrContactLink(html: string): boolean {
+  return /<a\b[^>]+href=["'][^"']*(about|contact|company|team)[^"']*["'][^>]*>/i.test(html);
+}
+
+function analyzeHtml(html: string, targetUrl: string): PageSignals {
+  const text = stripHtml(html);
+  const lower = text.toLowerCase();
+  const h1 = allMatches(html, /<h1\b[^>]*>([\s\S]*?)<\/h1>/gi);
+  const h2 = allMatches(html, /<h2\b[^>]*>([\s\S]*?)<\/h2>/gi);
+  const description = getMeta(html, "description") || getMeta(html, "og:description");
+  const title = firstMatch(html, /<title\b[^>]*>([\s\S]*?)<\/title>/i) || getMeta(html, "og:title");
+  const hasJsonLd = /<script\b[^>]+type=["']application\/ld\+json["'][^>]*>/i.test(html);
+  return {
+    title,
+    description,
+    h1,
+    h2,
+    text,
+    wordCount: text.split(/\s+/).filter(Boolean).length,
+    paragraphCount: countMatches(html, /<p\b/gi),
+    listCount: countMatches(html, /<(ul|ol|li)\b/gi),
+    questionCount: countMatches(`${h1.join(" ")} ${h2.join(" ")} ${text}`, /\b(what|why|how|when|where|who|can|does|is|are)\b[^.?!]{0,80}\?/gi),
+    externalLinkCount: linkCount(html, targetUrl, true),
+    hasJsonLd,
+    hasMicrodata: /\bitemscope\b/i.test(html),
+    hasRdfa: /\btypeof=["'][^"']+["']/i.test(html),
+    hasOrganizationSchema: hasJsonLd && (hasSchemaType(html, "Organization") || hasSchemaType(html, "LocalBusiness") || hasSchemaType(html, "Product")),
+    hasArticleSchema: hasJsonLd && (hasSchemaType(html, "Article") || hasSchemaType(html, "NewsArticle") || hasSchemaType(html, "BlogPosting")),
+    hasFaqSchema: hasJsonLd && hasSchemaType(html, "FAQPage"),
+    hasAuthorCue: /\b(author|byline|written by|reviewed by|editor|team)\b/i.test(lower),
+    hasAboutOrContactLink: hasAboutOrContactLink(html),
+    hasFreshnessCue: /<time\b/i.test(html) || /\b(updated|last updated|published|reviewed)\b/i.test(lower) || /\b20\d{2}[-/]\d{1,2}[-/]\d{1,2}\b/.test(text),
+    hasStatisticCue: /\b\d+(\.\d+)?%|\b\d+x\b|\b\d{2,}\b/.test(text),
+    hasSourceCue: /\b(source|sources|citation|research|study|report|evidence|according to|data from)\b/i.test(lower),
+  };
+}
+
+function evidence(kind: GeoPassEvidence["kind"], label: string, summary: string, sourceUrl?: string): GeoPassEvidence {
+  return {
+    kind,
+    label,
+    summary,
+    ...(sourceUrl ? { source_url: sourceUrl } : {}),
+  };
+}
+
+function finding(
+  checkId: GeoPassCheckId,
+  id: string,
+  severity: GeoPassFinding["severity"],
+  title: string,
+  summary: string,
+  recommendation: string,
+  findingEvidence: GeoPassEvidence[],
+): GeoPassFinding {
+  return {
+    id,
+    check_id: checkId,
+    severity,
+    title,
+    summary,
+    recommendation,
+    evidence: findingEvidence,
+  };
+}
+
+function verdictFor(score: number, findings: GeoPassFinding[]): GeoPassVerdict {
+  if (findings.some((item) => item.severity === "critical" || item.severity === "high") && score < 55) {
+    return "blocked";
+  }
+  if (score >= 85) return "ready";
+  if (score >= 45) return "needs-work";
+  return "blocked";
+}
+
+function result(
+  checkId: GeoPassCheckId,
+  label: string,
+  score: number,
+  findings: GeoPassFinding[],
+): GeoPassCheckResult {
+  return {
+    check_id: checkId,
+    label,
+    score: Math.max(0, Math.min(100, Math.round(score))),
+    verdict: verdictFor(score, findings),
+    findings,
+  };
+}
+
+function pageUnavailableResult(checkId: GeoPassCheckId, targetUrl: string, page: FetchTextResult): GeoPassCheckResult {
+  return result(checkId, labelFor(checkId), 0, [
+    finding(
+      checkId,
+      `${checkId}-target-unavailable`,
+      "critical",
+      "Target page was not readable",
+      page.error ? `The public page fetch failed: ${page.error}.` : `The public page returned HTTP ${page.status}.`,
+      "Make the public page return readable HTML before using it as GEOPass evidence.",
+      [evidence("http", "Target fetch", page.error ?? `HTTP ${page.status}`, targetUrl)],
+    ),
+  ]);
+}
+
+function labelFor(checkId: GeoPassCheckId): string {
+  return {
+    "ai-bot-crawlability": "AI bot crawlability matrix",
+    "llms-txt": "llms.txt presence and quality",
+    "answer-extractability": "Answer extractability",
+    "entity-clarity": "Entity clarity",
+    "citation-readiness": "Citation and sourceability readiness",
+    "freshness-cues": "Freshness and update cues",
+    "content-structure": "AI-readable content structure",
+    "schema-org-citation-grade": "schema.org citation-grade validation",
+    "brand-mention-readiness": "Brand mention readiness",
+    "wikidata-presence": "Wikidata presence",
+    "common-crawl-presence": "Common Crawl presence",
+    "aggregate-ai-engine-readiness": "Aggregate AI engine readiness score",
+  }[checkId];
+}
+
+function robotsBlockedBots(robotsBody: string, pathname: string): string[] {
+  const groups: Array<{ agents: string[]; rules: Array<{ directive: "allow" | "disallow"; path: string }> }> = [];
+  let current: { agents: string[]; rules: Array<{ directive: "allow" | "disallow"; path: string }> } | null = null;
+  for (const rawLine of robotsBody.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*/, "").trim();
+    if (!line) continue;
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    if (key === "user-agent") {
+      current = { agents: [value.toLowerCase()], rules: [] };
+      groups.push(current);
+    } else if ((key === "allow" || key === "disallow") && current) {
+      current.rules.push({ directive: key, path: value });
+    }
+  }
+
+  return AI_BOTS.filter((bot) => {
+    const token = bot.toLowerCase();
+    const matching = groups.filter((group) =>
+      group.agents.some((agent) => agent === "*" || token.includes(agent.replace(/\*$/, ""))),
+    );
+    const rules = matching.flatMap((group) => group.rules).filter((rule) => rule.path !== "");
+    const disallows = rules.filter((rule) => rule.directive === "disallow" && pathMatches(pathname, rule.path));
+    if (disallows.length === 0) return false;
+    const strongestDisallow = Math.max(...disallows.map((rule) => rule.path.length));
+    const strongestAllow = Math.max(
+      0,
+      ...rules
+        .filter((rule) => rule.directive === "allow" && pathMatches(pathname, rule.path))
+        .map((rule) => rule.path.length),
+    );
+    return strongestDisallow >= strongestAllow;
+  });
+}
+
+function pathMatches(pathname: string, rulePath: string): boolean {
+  const cleanRule = rulePath.replace(/\*.*/, "");
+  if (cleanRule === "/" || cleanRule === "") return cleanRule === "/";
+  return pathname.startsWith(cleanRule);
+}
+
+function buildAiBotCrawlability(targetUrl: string, robots: FetchTextResult): GeoPassCheckResult {
+  if (robots.status === 0 || robots.status >= 500 || robots.status === 429) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 60, [
+      finding(
+        "ai-bot-crawlability",
+        "ai-bot-crawlability-robots-unavailable",
+        "medium",
+        "robots.txt was not safely checkable",
+        robots.error ? `robots.txt fetch failed: ${robots.error}.` : `robots.txt returned HTTP ${robots.status}.`,
+        "Make robots.txt consistently available so AI crawler access can be checked.",
+        [evidence("robots-txt", "robots.txt fetch", robots.error ?? `HTTP ${robots.status}`, new URL("/robots.txt", targetUrl).toString())],
+      ),
+    ]);
+  }
+  if (robots.status === 404) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 88, []);
+  }
+  const blocked = robotsBlockedBots(robots.body, new URL(targetUrl).pathname || "/");
+  if (blocked.length === 0) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 100, []);
+  }
+  return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 35, [
+    finding(
+      "ai-bot-crawlability",
+      "ai-bot-crawlability-blocked",
+      "high",
+      "AI crawler access is blocked",
+      `robots.txt appears to block ${blocked.join(", ")} for this path.`,
+      "Review whether AI search crawlers should be allowed to read this public page.",
+      [evidence("robots-txt", "Blocked AI bot rules", blocked.join(", "), new URL("/robots.txt", targetUrl).toString())],
+    ),
+  ]);
+}
+
+function buildLlmsTxt(targetUrl: string, llms: FetchTextResult): GeoPassCheckResult {
+  if (llms.ok && llms.body.trim().length >= 160) {
+    const score = /\[[^\]]+\]\(https?:\/\//.test(llms.body) ? 100 : 88;
+    return result("llms-txt", labelFor("llms-txt"), score, []);
+  }
+  if (llms.ok) {
+    return result("llms-txt", labelFor("llms-txt"), 68, [
+      finding(
+        "llms-txt",
+        "llms-txt-thin",
+        "medium",
+        "llms.txt exists but is thin",
+        "The llms.txt file exists but does not yet provide enough product context, summaries, or source links for AI readers.",
+        "Add a concise product summary, canonical docs links, and important public pages to llms.txt.",
+        [evidence("llms-txt", "Public llms.txt", "File exists but is short.", new URL("/llms.txt", targetUrl).toString())],
+      ),
+    ]);
+  }
+  return result("llms-txt", labelFor("llms-txt"), 58, [
+    finding(
+      "llms-txt",
+      "llms-txt-missing",
+      "medium",
+      "llms.txt was not found",
+      "No public llms.txt file was available at the target origin.",
+      "Consider publishing llms.txt with public summaries and canonical links for AI readers.",
+      [evidence("llms-txt", "Public llms.txt", `HTTP ${llms.status || "fetch failed"}`, new URL("/llms.txt", targetUrl).toString())],
+    ),
+  ]);
+}
+
+function buildAnswerExtractability(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 55;
+  if (signals.wordCount >= 350) score += 15;
+  if (signals.questionCount > 0 || signals.hasFaqSchema) score += 15;
+  if (signals.paragraphCount >= 4) score += 10;
+  if (signals.h2.length >= 2) score += 5;
+  if (signals.wordCount < 180) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-thin-page",
+      "medium",
+      "Page copy is thin for AI answer reuse",
+      "The page has limited visible body copy, which makes direct answer extraction brittle.",
+      "Add clear, visible answers to the main questions a customer or answer engine would ask.",
+      [evidence("content", "Visible body text", `${signals.wordCount} visible words`, targetUrl)],
+    ));
+  }
+  if (signals.questionCount === 0 && !signals.hasFaqSchema) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-no-questions",
+      "low",
+      "No explicit question-answer structure was found",
+      "AI answer engines often benefit from direct question headings, FAQ structure, or plain answer blocks.",
+      "Add direct headings or FAQ-style sections for important user questions.",
+      [evidence("html", "Heading scan", `${signals.h2.length} h2 heading(s), ${signals.questionCount} question heading(s)`, targetUrl)],
+    ));
+  }
+  return result("answer-extractability", labelFor("answer-extractability"), score, findings);
+}
+
+function buildEntityClarity(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.title) score += 15;
+  if (signals.description) score += 15;
+  if (signals.h1.length > 0) score += 10;
+  if (signals.hasOrganizationSchema) score += 15;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (!signals.hasOrganizationSchema) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-schema-missing",
+      "medium",
+      "Organization or product schema was not found",
+      "The page does not expose obvious Organization, LocalBusiness, or Product JSON-LD for entity grounding.",
+      "Add truthful schema that matches visible page content.",
+      [evidence("schema-org", "Schema scan", "No Organization, LocalBusiness, or Product JSON-LD found.", targetUrl)],
+    ));
+  }
+  if (!signals.description) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-description-missing",
+      "low",
+      "Meta description is missing",
+      "The page lacks a concise public description for summarizers and search snippets.",
+      "Add a clear meta description that states what the product, organization, or page is about.",
+      [evidence("html", "Meta description scan", "No description meta tag found.", targetUrl)],
+    ));
+  }
+  return result("entity-clarity", labelFor("entity-clarity"), score, findings);
+}
+
+function buildCitationReadiness(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.externalLinkCount >= 2) score += 20;
+  if (signals.hasSourceCue) score += 15;
+  if (signals.hasStatisticCue) score += 10;
+  if (signals.hasArticleSchema || signals.hasAuthorCue) score += 10;
+  if (signals.externalLinkCount === 0 && !signals.hasSourceCue) {
+    findings.push(finding(
+      "citation-readiness",
+      "citation-readiness-no-visible-sources",
+      "medium",
+      "Visible source cues are weak",
+      "The page has no obvious external source links or source/evidence wording for answer engines to cite.",
+      "Add visible support links, evidence, data sources, or authored references for important claims.",
+      [evidence("external-link", "External link scan", `${signals.externalLinkCount} external link(s) found.`, targetUrl)],
+    ));
+  }
+  return result("citation-readiness", labelFor("citation-readiness"), score, findings);
+}
+
+function buildFreshness(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  if (signals.hasFreshnessCue) {
+    return result("freshness-cues", labelFor("freshness-cues"), 95, []);
+  }
+  return result("freshness-cues", labelFor("freshness-cues"), 62, [
+    finding(
+      "freshness-cues",
+      "freshness-cues-missing",
+      "low",
+      "Freshness cues are not visible",
+      "The page does not expose obvious published, reviewed, or last-updated cues.",
+      "Add visible freshness or review dates where current information matters.",
+      [evidence("date", "Freshness scan", "No visible time/date/update cue found.", targetUrl)],
+    ),
+  ]);
+}
+
+function buildContentStructure(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.h1.length === 1) score += 15;
+  if (signals.h2.length >= 2) score += 15;
+  if (signals.paragraphCount >= 3) score += 10;
+  if (signals.listCount > 0) score += 10;
+  if (signals.hasFaqSchema || signals.questionCount > 0) score += 10;
+  if (signals.h1.length === 0) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-h1-missing",
+      "medium",
+      "No H1 was found",
+      "The page lacks a clear top-level heading.",
+      "Add one clear H1 that names the page subject.",
+      [evidence("html", "Heading scan", "No H1 found.", targetUrl)],
+    ));
+  }
+  if (signals.h2.length < 2) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-heading-depth-thin",
+      "low",
+      "Heading structure is thin",
+      "The page has limited subheading structure for answer extraction.",
+      "Break important topics into descriptive H2 sections.",
+      [evidence("html", "Heading scan", `${signals.h2.length} H2 heading(s) found.`, targetUrl)],
+    ));
+  }
+  return result("content-structure", labelFor("content-structure"), score, findings);
+}
+
+function buildSchemaCitationGrade(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.hasJsonLd) score += 25;
+  if (signals.hasMicrodata || signals.hasRdfa) score += 10;
+  if (signals.hasOrganizationSchema || signals.hasArticleSchema || signals.hasFaqSchema) score += 20;
+  if (!signals.hasJsonLd && !signals.hasMicrodata && !signals.hasRdfa) {
+    findings.push(finding(
+      "schema-org-citation-grade",
+      "schema-org-citation-grade-missing",
+      "medium",
+      "Structured data was not found",
+      "No JSON-LD, microdata, or RDFa was detected on the page.",
+      "Add truthful structured data that matches visible page facts.",
+      [evidence("schema-org", "Structured data scan", "No structured data detected.", targetUrl)],
+    ));
+  }
+  return result("schema-org-citation-grade", labelFor("schema-org-citation-grade"), score, findings);
+}
+
+function buildBrandMentionReadiness(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 55;
+  if (signals.title && signals.h1.length > 0) score += 15;
+  if (signals.description) score += 10;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (signals.hasOrganizationSchema) score += 10;
+  if (!signals.title || signals.h1.length === 0) {
+    findings.push(finding(
+      "brand-mention-readiness",
+      "brand-mention-readiness-weak-page-name",
+      "medium",
+      "Page naming is weak for brand/entity mention",
+      "The page needs both a clear title and visible H1 for answer engines to label it consistently.",
+      "Use a direct title and H1 that name the product, brand, organization, or topic.",
+      [evidence("brand-query", "Title and H1 scan", `title=${signals.title ? "present" : "missing"}; h1=${signals.h1.length}`, targetUrl)],
+    ));
+  }
+  return result("brand-mention-readiness", labelFor("brand-mention-readiness"), score, findings);
+}
+
+function buildPlanOnlyExternalIndex(checkId: "wikidata-presence" | "common-crawl-presence", targetUrl: string): GeoPassCheckResult {
+  return {
+    check_id: checkId,
+    label: labelFor(checkId),
+    score: 50,
+    verdict: "unknown",
+    findings: [
+      finding(
+        checkId,
+        `${checkId}-not-live-readonly`,
+        "info",
+        "External index lookup was not run",
+        "This GEOPass live-readonly slice does not query external entity or web-corpus APIs.",
+        "Run a separately scoped public API adapter before using this row as index-presence proof.",
+        [evidence(checkId === "wikidata-presence" ? "wikidata" : "common-crawl", "External index boundary", "Not queried in this public-safe run.", targetUrl)],
+      ),
+    ],
+  };
+}
+
+function buildAggregate(targetUrl: string, checks: GeoPassCheckResult[]): GeoPassCheckResult {
+  const source = checks.filter((check) => check.check_id !== "aggregate-ai-engine-readiness");
+  const score = Math.round(source.reduce((sum, check) => sum + check.score, 0) / Math.max(1, source.length));
+  const blockers = source.filter((check) => check.verdict === "blocked");
+  const weak = source.filter((check) => check.verdict === "needs-work");
+  const findings: GeoPassFinding[] = [];
+  if (blockers.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-blockers",
+      "high",
+      "GEOPass has blocked rows",
+      `${blockers.length} check(s) are blocked: ${blockers.map((check) => check.check_id).join(", ")}.`,
+      "Resolve blocked rows before treating this page as AI-answer ready.",
+      [evidence("manual-note", "Aggregate readiness", `Blocked rows: ${blockers.map((check) => check.check_id).join(", ")}`, targetUrl)],
+    ));
+  } else if (weak.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-needs-work",
+      "medium",
+      "GEOPass has readiness gaps",
+      `${weak.length} check(s) need work: ${weak.map((check) => check.check_id).join(", ")}.`,
+      "Use the row recommendations as the next public content fixes.",
+      [evidence("manual-note", "Aggregate readiness", `Needs-work rows: ${weak.map((check) => check.check_id).join(", ")}`, targetUrl)],
+    ));
+  }
+  return result("aggregate-ai-engine-readiness", labelFor("aggregate-ai-engine-readiness"), score, findings);
+}
+
+function verdictSummary(checks: GeoPassCheckResult[]): Record<"ready" | "needs_work" | "blocked" | "unknown", number> {
+  return checks.reduce(
+    (summary, check) => {
+      if (check.verdict === "ready") summary.ready += 1;
+      if (check.verdict === "needs-work") summary.needs_work += 1;
+      if (check.verdict === "blocked") summary.blocked += 1;
+      if (check.verdict === "unknown") summary.unknown += 1;
+      return summary;
+    },
+    { ready: 0, needs_work: 0, blocked: 0, unknown: 0 },
+  );
+}
+
+function crossPassSignals(checks: GeoPassCheckResult[]): GeoPassCrossPassSignal[] {
+  const byId = new Map(checks.map((check) => [check.check_id, check]));
+  const signals: GeoPassCrossPassSignal[] = [];
+  const llms = byId.get("llms-txt");
+  if (llms && llms.verdict !== "ready") {
+    signals.push({ pass: "seopass", signal: "llms.txt gap also weakens AI-era search readiness", score: llms.score });
+  }
+  const schema = byId.get("schema-org-citation-grade");
+  if (schema && schema.verdict !== "ready") {
+    signals.push({ pass: "legalpass", signal: "schema must truthfully match visible public claims", score: schema.score });
+  }
+  const structure = byId.get("content-structure");
+  if (structure && structure.verdict !== "ready") {
+    signals.push({ pass: "uxpass", signal: "thin public structure can make answer extraction and human scanning weaker", score: structure.score });
+  }
+  const citation = byId.get("citation-readiness");
+  if (citation && citation.verdict !== "ready") {
+    signals.push({ pass: "sloppass", signal: "unsupported or source-light claims need copy/content cleanup", score: citation.score });
+  }
+  return signals;
+}
+
+function receiptFor(report: GeoPassReport, runId: string, targetSha?: string): GeoPassReceipt {
+  const summary = verdictSummary(report.checks);
+  const status = report.verdict === "ready" ? "PASS" : report.verdict === "blocked" ? "BLOCKER" : "WARN";
+  const evidenceSources = report.checks
+    .flatMap((check) => check.findings)
+    .flatMap((item) => item.evidence)
+    .filter((item, index, all) => all.findIndex((candidate) => candidate.kind === item.kind && candidate.label === item.label && candidate.source_url === item.source_url) === index)
+    .slice(0, 12);
+  const actionNeeded = report.checks
+    .flatMap((check) => check.findings)
+    .map((item) => item.recommendation)
+    .filter((item): item is string => Boolean(item))
+    .filter((item, index, all) => all.indexOf(item) === index)
+    .slice(0, 8);
+  return {
+    kind: "geopass_receipt_v1",
+    status,
+    run_id: runId,
+    target_url: report.target_url,
+    generated_at: report.generated_at,
+    mode: "live-readonly",
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    score: report.aggregate_ai_engine_readiness_score,
+    verdict: report.verdict,
+    checked: {
+      total: report.checks.length,
+      ready: summary.ready,
+      needs_work: summary.needs_work,
+      blocked: summary.blocked,
+      unknown: summary.unknown,
+    },
+    evidence_sources: evidenceSources,
+    action_needed: actionNeeded,
+    boundaries: RECEIPT_BOUNDARIES,
+  };
+}
+
+export async function runGeoPass(input: GeoPassRunInput): Promise<GeoPassRunResult | { error: string }> {
+  const rawUrl = input.url ?? input.targetUrl ?? "";
+  const targetUrl = normalizePublicHttpUrl(rawUrl);
+  if (!targetUrl) {
+    return { error: "GEOPass target URL must be a valid public http(s) URL without credentials" };
+  }
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const fetchImpl = input.fetchImpl ?? globalThis.fetch;
+  if (!fetchImpl) return { error: "No fetch implementation is available for GEOPass live-readonly run" };
+  const selectedChecks = new Set(input.checks?.length ? input.checks : LIVE_CHECKS);
+  const page = await fetchText(targetUrl, fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS);
+  const analysisUrl = normalizePublicHttpUrl(page.url) ?? targetUrl;
+  const [robots, llms] = await Promise.all([
+    fetchText(new URL("/robots.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS),
+    fetchText(new URL("/llms.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS),
+  ]);
+  const htmlReadable = page.ok && (page.headers["content-type"] ?? "text/html").toLowerCase().includes("html");
+  const signals = htmlReadable ? analyzeHtml(page.body, analysisUrl) : null;
+  const checks: GeoPassCheckResult[] = [];
+
+  for (const checkId of LIVE_CHECKS.filter((id) => selectedChecks.has(id))) {
+    if (!signals && checkId !== "ai-bot-crawlability" && checkId !== "llms-txt") {
+      checks.push(pageUnavailableResult(checkId, analysisUrl, page));
+      continue;
+    }
+    if (checkId === "ai-bot-crawlability") checks.push(buildAiBotCrawlability(analysisUrl, robots));
+    if (checkId === "llms-txt") checks.push(buildLlmsTxt(analysisUrl, llms));
+    if (signals && checkId === "answer-extractability") checks.push(buildAnswerExtractability(analysisUrl, signals));
+    if (signals && checkId === "entity-clarity") checks.push(buildEntityClarity(analysisUrl, signals));
+    if (signals && checkId === "citation-readiness") checks.push(buildCitationReadiness(analysisUrl, signals));
+    if (signals && checkId === "freshness-cues") checks.push(buildFreshness(analysisUrl, signals));
+    if (signals && checkId === "content-structure") checks.push(buildContentStructure(analysisUrl, signals));
+    if (signals && checkId === "schema-org-citation-grade") checks.push(buildSchemaCitationGrade(analysisUrl, signals));
+    if (signals && checkId === "brand-mention-readiness") checks.push(buildBrandMentionReadiness(analysisUrl, signals));
+  }
+  for (const externalCheckId of ["wikidata-presence", "common-crawl-presence"] as const) {
+    if (selectedChecks.has(externalCheckId)) checks.push(buildPlanOnlyExternalIndex(externalCheckId, analysisUrl));
+  }
+  if (selectedChecks.has("aggregate-ai-engine-readiness")) {
+    checks.push(buildAggregate(analysisUrl, checks));
+  }
+  const summary = verdictSummary(checks);
+  const aggregate = checks.find((check) => check.check_id === "aggregate-ai-engine-readiness");
+  const score = aggregate?.score ?? Math.round(checks.reduce((sum, check) => sum + check.score, 0) / Math.max(1, checks.length));
+  const verdict: GeoPassVerdict = summary.blocked > 0 ? "blocked" : score >= 85 ? "ready" : "needs-work";
+  const report: GeoPassReport = {
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    mode: "live-readonly",
+    engines: DEFAULT_GEOPASS_ENGINES,
+    aggregate_ai_engine_readiness_score: score,
+    verdict,
+    checks,
+    cross_pass_signals: crossPassSignals(checks),
+    notes: [
+      "Readiness only. GEOPass does not guarantee AI citations, rankings, or answer-engine placement.",
+      "This run used public http(s) fetches only and did not use credentials, paid APIs, production data, or private prompts.",
+      ...(page.truncated ? ["The target page body was truncated for bounded analysis."] : []),
+    ],
+  };
+  const runId = stableRunId(analysisUrl, generatedAt);
+  return {
+    run_id: runId,
+    status: "complete",
+    pass: "geopass",
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    ai_answer_readiness_score: score,
+    verdict,
+    verdict_summary: summary,
+    report,
+    geopass_receipt_v1: receiptFor(report, runId, input.targetSha),
+  };
+}

--- a/packages/geopass/src/scanner-plan.ts
+++ b/packages/geopass/src/scanner-plan.ts
@@ -64,6 +64,46 @@ export const DEFAULT_GEOPASS_SCANNER_STEPS: GeoPassScannerStep[] = [
     sharedWith: ["seopass", "sloppass"],
   },
   {
+    id: "answer-extractability",
+    label: "Answer extractability",
+    purpose:
+      "Check whether public page copy contains direct, reusable answers rather than only abstract marketing claims.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "uxpass"],
+  },
+  {
+    id: "entity-clarity",
+    label: "Entity clarity",
+    purpose:
+      "Check whether the page names the organization, product, or author clearly enough for answer engines to ground summaries.",
+    evidenceKinds: ["html", "schema-org"],
+    sharedWith: ["seopass", "legalpass"],
+  },
+  {
+    id: "citation-readiness",
+    label: "Citation and sourceability readiness",
+    purpose:
+      "Check whether visible sources, support links, statistics, or evidence cues make claims easier to cite accurately.",
+    evidenceKinds: ["external-link", "content", "schema-org"],
+    sharedWith: ["seopass", "legalpass", "sloppass"],
+  },
+  {
+    id: "freshness-cues",
+    label: "Freshness and update cues",
+    purpose:
+      "Check whether visible publication or update signals help answer engines avoid stale summaries.",
+    evidenceKinds: ["date", "html"],
+    sharedWith: ["seopass"],
+  },
+  {
+    id: "content-structure",
+    label: "AI-readable content structure",
+    purpose:
+      "Check heading, list, paragraph, and FAQ-style structure that helps AI systems extract reliable answers.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "flowpass", "uxpass"],
+  },
+  {
     id: "schema-org-citation-grade",
     label: "schema.org citation-grade validation",
     purpose:
@@ -110,7 +150,7 @@ const DISALLOWED_ACTIONS = [
   "paid API calls",
   "credential access",
   "production database writes",
-  "citation guarantees",
+  "guaranteed citations",
 ];
 
 export function createGeoPassScannerPlan(input: {

--- a/packages/geopass/src/schema.ts
+++ b/packages/geopass/src/schema.ts
@@ -38,6 +38,11 @@ export const GeoPassBotIdSchema = z.enum([
 export const GeoPassCheckIdSchema = z.enum([
   "ai-bot-crawlability",
   "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
   "schema-org-citation-grade",
   "brand-mention-readiness",
   "wikidata-presence",
@@ -50,6 +55,11 @@ export const GeoPassEvidenceSchema = z.object({
     "robots-txt",
     "llms-txt",
     "schema-org",
+    "html",
+    "http",
+    "content",
+    "date",
+    "external-link",
     "wikidata",
     "common-crawl",
     "brand-query",
@@ -97,6 +107,28 @@ export const GeoPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const GeoPassReceiptSchema = z.object({
+  kind: z.literal("geopass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.literal("live-readonly"),
+  target_sha: z.string().min(1).optional(),
+  score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    ready: z.number().int().min(0),
+    needs_work: z.number().int().min(0),
+    blocked: z.number().int().min(0),
+    unknown: z.number().int().min(0),
+  }),
+  evidence_sources: z.array(GeoPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)),
+});
+
 export type GeoPassSeverity = z.infer<typeof GeoPassSeveritySchema>;
 export type GeoPassVerdict = z.infer<typeof GeoPassVerdictSchema>;
 export type GeoPassEngineId = z.infer<typeof GeoPassEngineIdSchema>;
@@ -107,3 +139,4 @@ export type GeoPassFinding = z.infer<typeof GeoPassFindingSchema>;
 export type GeoPassCheckResult = z.infer<typeof GeoPassCheckResultSchema>;
 export type GeoPassCrossPassSignal = z.infer<typeof GeoPassCrossPassSignalSchema>;
 export type GeoPassReport = z.infer<typeof GeoPassReportSchema>;
+export type GeoPassReceipt = z.infer<typeof GeoPassReceiptSchema>;

--- a/packages/geopass/tsconfig.json
+++ b/packages/geopass/tsconfig.json
@@ -10,7 +10,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/geopass-runtime.ts
+++ b/packages/mcp-server/src/geopass-runtime.ts
@@ -1,0 +1,950 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var, no-empty */
+// @ts-nocheck
+/* Generated from @unclick/geopass source so Vercel bundles GEOPass with the MCP function. */
+
+// packages/geopass/src/schema.ts
+import { z } from "zod";
+var GeoPassSeveritySchema = z.enum([
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info"
+]);
+var GeoPassVerdictSchema = z.enum([
+  "ready",
+  "needs-work",
+  "blocked",
+  "unknown"
+]);
+var GeoPassEngineIdSchema = z.enum([
+  "chatgpt",
+  "claude",
+  "perplexity",
+  "gemini",
+  "copilot",
+  "grok",
+  "meta-ai"
+]);
+var GeoPassBotIdSchema = z.enum([
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+  "Twitterbot",
+  "FacebookBot"
+]);
+var GeoPassCheckIdSchema = z.enum([
+  "ai-bot-crawlability",
+  "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
+  "schema-org-citation-grade",
+  "brand-mention-readiness",
+  "wikidata-presence",
+  "common-crawl-presence",
+  "aggregate-ai-engine-readiness"
+]);
+var GeoPassEvidenceSchema = z.object({
+  kind: z.enum([
+    "robots-txt",
+    "llms-txt",
+    "schema-org",
+    "html",
+    "http",
+    "content",
+    "date",
+    "external-link",
+    "wikidata",
+    "common-crawl",
+    "brand-query",
+    "lighthouse",
+    "manual-note"
+  ]),
+  label: z.string().min(1),
+  source_url: z.string().url().optional(),
+  summary: z.string().min(1)
+});
+var GeoPassFindingSchema = z.object({
+  id: z.string().min(1),
+  check_id: GeoPassCheckIdSchema,
+  severity: GeoPassSeveritySchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  evidence: z.array(GeoPassEvidenceSchema).default([]),
+  recommendation: z.string().min(1).optional()
+});
+var GeoPassCheckResultSchema = z.object({
+  check_id: GeoPassCheckIdSchema,
+  label: z.string().min(1),
+  score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  findings: z.array(GeoPassFindingSchema).default([])
+});
+var GeoPassCrossPassSignalSchema = z.object({
+  pass: z.enum(["seopass", "flowpass", "legalpass", "sloppass", "uxpass"]),
+  signal: z.string().min(1),
+  score: z.number().min(0).max(100).optional()
+});
+var GeoPassReportSchema = z.object({
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).default("plan-only"),
+  engines: z.array(GeoPassEngineIdSchema).min(1),
+  aggregate_ai_engine_readiness_score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  checks: z.array(GeoPassCheckResultSchema).min(1),
+  cross_pass_signals: z.array(GeoPassCrossPassSignalSchema).default([]),
+  notes: z.array(z.string().min(1)).default([])
+});
+var GeoPassReceiptSchema = z.object({
+  kind: z.literal("geopass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.literal("live-readonly"),
+  target_sha: z.string().min(1).optional(),
+  score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    ready: z.number().int().min(0),
+    needs_work: z.number().int().min(0),
+    blocked: z.number().int().min(0),
+    unknown: z.number().int().min(0)
+  }),
+  evidence_sources: z.array(GeoPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1))
+});
+
+// packages/geopass/src/scanner-plan.ts
+var DEFAULT_GEOPASS_ENGINES = [
+  "chatgpt",
+  "claude",
+  "perplexity",
+  "gemini",
+  "copilot",
+  "grok",
+  "meta-ai"
+];
+var DEFAULT_GEOPASS_BOTS = [
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+  "Twitterbot",
+  "FacebookBot"
+];
+var DEFAULT_GEOPASS_SCANNER_STEPS = [
+  {
+    id: "ai-bot-crawlability",
+    label: "AI bot crawlability matrix",
+    purpose: "Plan robots.txt and public bot access checks for major generative engines.",
+    evidenceKinds: ["robots-txt", "manual-note"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "llms-txt",
+    label: "llms.txt presence and quality",
+    purpose: "Check whether the site publishes a useful llms.txt guide for AI readers.",
+    evidenceKinds: ["llms-txt"],
+    sharedWith: ["seopass", "sloppass"]
+  },
+  {
+    id: "answer-extractability",
+    label: "Answer extractability",
+    purpose: "Check whether public page copy contains direct, reusable answers rather than only abstract marketing claims.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "uxpass"]
+  },
+  {
+    id: "entity-clarity",
+    label: "Entity clarity",
+    purpose: "Check whether the page names the organization, product, or author clearly enough for answer engines to ground summaries.",
+    evidenceKinds: ["html", "schema-org"],
+    sharedWith: ["seopass", "legalpass"]
+  },
+  {
+    id: "citation-readiness",
+    label: "Citation and sourceability readiness",
+    purpose: "Check whether visible sources, support links, statistics, or evidence cues make claims easier to cite accurately.",
+    evidenceKinds: ["external-link", "content", "schema-org"],
+    sharedWith: ["seopass", "legalpass", "sloppass"]
+  },
+  {
+    id: "freshness-cues",
+    label: "Freshness and update cues",
+    purpose: "Check whether visible publication or update signals help answer engines avoid stale summaries.",
+    evidenceKinds: ["date", "html"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "content-structure",
+    label: "AI-readable content structure",
+    purpose: "Check heading, list, paragraph, and FAQ-style structure that helps AI systems extract reliable answers.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "flowpass", "uxpass"]
+  },
+  {
+    id: "schema-org-citation-grade",
+    label: "schema.org citation-grade validation",
+    purpose: "Plan structured data checks that make public facts easier to cite accurately.",
+    evidenceKinds: ["schema-org"],
+    sharedWith: ["seopass", "legalpass"]
+  },
+  {
+    id: "brand-mention-readiness",
+    label: "Brand mention readiness",
+    purpose: "Plan public-safe brand query fixtures without paid API calls or live prompts.",
+    evidenceKinds: ["brand-query"],
+    sharedWith: ["seopass", "uxpass"]
+  },
+  {
+    id: "wikidata-presence",
+    label: "Wikidata presence",
+    purpose: "Plan public entity presence checks for citation context and disambiguation.",
+    evidenceKinds: ["wikidata"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "common-crawl-presence",
+    label: "Common Crawl presence",
+    purpose: "Plan public web corpus presence checks without fetching private content.",
+    evidenceKinds: ["common-crawl"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "aggregate-ai-engine-readiness",
+    label: "Aggregate AI engine readiness score",
+    purpose: "Combine public diagnostics into one readiness score and shared pass signals.",
+    evidenceKinds: ["lighthouse", "manual-note"],
+    sharedWith: ["seopass", "flowpass", "legalpass", "sloppass", "uxpass"]
+  }
+];
+var DISALLOWED_ACTIONS = [
+  "live crawler execution",
+  "paid API calls",
+  "credential access",
+  "production database writes",
+  "guaranteed citations"
+];
+function createGeoPassScannerPlan(input) {
+  const engines = (input.engines ?? DEFAULT_GEOPASS_ENGINES).map(
+    (engine) => GeoPassEngineIdSchema.parse(engine)
+  );
+  const bots = (input.bots ?? DEFAULT_GEOPASS_BOTS).map(
+    (bot) => GeoPassBotIdSchema.parse(bot)
+  );
+  const checks = new Set(
+    (input.checks ?? DEFAULT_GEOPASS_SCANNER_STEPS.map((step) => step.id)).map(
+      (check) => GeoPassCheckIdSchema.parse(check)
+    )
+  );
+  return {
+    targetUrl: new URL(input.targetUrl).toString(),
+    mode: "plan-only",
+    engines,
+    bots,
+    steps: DEFAULT_GEOPASS_SCANNER_STEPS.filter((step) => checks.has(step.id)),
+    disallowedActions: DISALLOWED_ACTIONS
+  };
+}
+
+// packages/geopass/src/runner.ts
+import { createHash, randomUUID } from "node:crypto";
+var DEFAULT_TIMEOUT_MS = 1e4;
+var DEFAULT_MAX_BODY_CHARS = 125e4;
+var LIVE_CHECKS = [
+  "ai-bot-crawlability",
+  "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
+  "schema-org-citation-grade",
+  "brand-mention-readiness",
+  "aggregate-ai-engine-readiness"
+];
+var AI_BOTS = [
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot"
+];
+var RECEIPT_BOUNDARIES = [
+  "GEOPass reports public read-only readiness only.",
+  "GEOPass does not guarantee rankings, citations, AI Overview inclusion, or answer-engine placement.",
+  "This run fetches public http(s) pages only and does not use credentials, paid APIs, production data, or private prompts."
+];
+function normalizePublicHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+function stableRunId(targetUrl, generatedAt) {
+  const digest = createHash("sha256").update(`${targetUrl}:${generatedAt}:${randomUUID()}`).digest("hex").slice(0, 12);
+  return `geopass-${digest}`;
+}
+function headersToRecord(headers) {
+  const output = {};
+  headers.forEach((value, key) => {
+    output[key.toLowerCase()] = value;
+  });
+  return output;
+}
+async function fetchText(url, fetchImpl, timeoutMs, maxBodyChars) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "user-agent": "UnClick-GEOPass/0.1 (+https://unclick.world)" }
+    });
+    const body = await response.text();
+    const truncated = body.length > maxBodyChars;
+    return {
+      url: response.url || url,
+      status: response.status,
+      ok: response.ok,
+      headers: headersToRecord(response.headers),
+      body: truncated ? body.slice(0, maxBodyChars) : body,
+      truncated
+    };
+  } catch (error) {
+    return {
+      url,
+      status: 0,
+      ok: false,
+      headers: {},
+      body: "",
+      error: error instanceof Error ? error.message : String(error)
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+function stripHtml(html) {
+  return html.replace(/<script\b[\s\S]*?<\/script>/gi, " ").replace(/<style\b[\s\S]*?<\/style>/gi, " ").replace(/<[^>]+>/g, " ").replace(/&nbsp;/gi, " ").replace(/&amp;/gi, "&").replace(/&#39;/gi, "'").replace(/&quot;/gi, '"').replace(/\s+/g, " ").trim();
+}
+function firstMatch(html, pattern) {
+  return pattern.exec(html)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+}
+function allMatches(html, pattern) {
+  return Array.from(
+    html.matchAll(pattern),
+    (match) => stripHtml(match[1] ?? "").replace(/\s+/g, " ").trim()
+  ).filter(Boolean);
+}
+function countMatches(text, pattern) {
+  return Array.from(text.matchAll(pattern)).length;
+}
+function getMeta(html, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return firstMatch(
+    html,
+    new RegExp(`<meta[^>]+(?:name|property)=["']${escaped}["'][^>]+content=["']([^"']+)["'][^>]*>`, "i")
+  );
+}
+function hasSchemaType(html, typeName) {
+  const pattern = new RegExp(`"@type"\\s*:\\s*"?${typeName}"?`, "i");
+  return pattern.test(html);
+}
+function linkCount(html, baseUrl, external) {
+  let count = 0;
+  const base = new URL(baseUrl);
+  for (const match of html.matchAll(/<a\b[^>]+href=["']([^"']+)["'][^>]*>/gi)) {
+    try {
+      const href = new URL(match[1] ?? "", base);
+      if ((href.protocol === "http:" || href.protocol === "https:") && href.origin !== base.origin === external) {
+        count += 1;
+      }
+    } catch {
+    }
+  }
+  return count;
+}
+function hasAboutOrContactLink(html) {
+  return /<a\b[^>]+href=["'][^"']*(about|contact|company|team)[^"']*["'][^>]*>/i.test(html);
+}
+function analyzeHtml(html, targetUrl) {
+  const text = stripHtml(html);
+  const lower = text.toLowerCase();
+  const h1 = allMatches(html, /<h1\b[^>]*>([\s\S]*?)<\/h1>/gi);
+  const h2 = allMatches(html, /<h2\b[^>]*>([\s\S]*?)<\/h2>/gi);
+  const description = getMeta(html, "description") || getMeta(html, "og:description");
+  const title = firstMatch(html, /<title\b[^>]*>([\s\S]*?)<\/title>/i) || getMeta(html, "og:title");
+  const hasJsonLd = /<script\b[^>]+type=["']application\/ld\+json["'][^>]*>/i.test(html);
+  return {
+    title,
+    description,
+    h1,
+    h2,
+    text,
+    wordCount: text.split(/\s+/).filter(Boolean).length,
+    paragraphCount: countMatches(html, /<p\b/gi),
+    listCount: countMatches(html, /<(ul|ol|li)\b/gi),
+    questionCount: countMatches(`${h1.join(" ")} ${h2.join(" ")} ${text}`, /\b(what|why|how|when|where|who|can|does|is|are)\b[^.?!]{0,80}\?/gi),
+    externalLinkCount: linkCount(html, targetUrl, true),
+    hasJsonLd,
+    hasMicrodata: /\bitemscope\b/i.test(html),
+    hasRdfa: /\btypeof=["'][^"']+["']/i.test(html),
+    hasOrganizationSchema: hasJsonLd && (hasSchemaType(html, "Organization") || hasSchemaType(html, "LocalBusiness") || hasSchemaType(html, "Product")),
+    hasArticleSchema: hasJsonLd && (hasSchemaType(html, "Article") || hasSchemaType(html, "NewsArticle") || hasSchemaType(html, "BlogPosting")),
+    hasFaqSchema: hasJsonLd && hasSchemaType(html, "FAQPage"),
+    hasAuthorCue: /\b(author|byline|written by|reviewed by|editor|team)\b/i.test(lower),
+    hasAboutOrContactLink: hasAboutOrContactLink(html),
+    hasFreshnessCue: /<time\b/i.test(html) || /\b(updated|last updated|published|reviewed)\b/i.test(lower) || /\b20\d{2}[-/]\d{1,2}[-/]\d{1,2}\b/.test(text),
+    hasStatisticCue: /\b\d+(\.\d+)?%|\b\d+x\b|\b\d{2,}\b/.test(text),
+    hasSourceCue: /\b(source|sources|citation|research|study|report|evidence|according to|data from)\b/i.test(lower)
+  };
+}
+function evidence(kind, label, summary, sourceUrl) {
+  return {
+    kind,
+    label,
+    summary,
+    ...sourceUrl ? { source_url: sourceUrl } : {}
+  };
+}
+function finding(checkId, id, severity, title, summary, recommendation, findingEvidence) {
+  return {
+    id,
+    check_id: checkId,
+    severity,
+    title,
+    summary,
+    recommendation,
+    evidence: findingEvidence
+  };
+}
+function verdictFor(score, findings) {
+  if (findings.some((item) => item.severity === "critical" || item.severity === "high") && score < 55) {
+    return "blocked";
+  }
+  if (score >= 85) return "ready";
+  if (score >= 45) return "needs-work";
+  return "blocked";
+}
+function result(checkId, label, score, findings) {
+  return {
+    check_id: checkId,
+    label,
+    score: Math.max(0, Math.min(100, Math.round(score))),
+    verdict: verdictFor(score, findings),
+    findings
+  };
+}
+function pageUnavailableResult(checkId, targetUrl, page) {
+  return result(checkId, labelFor(checkId), 0, [
+    finding(
+      checkId,
+      `${checkId}-target-unavailable`,
+      "critical",
+      "Target page was not readable",
+      page.error ? `The public page fetch failed: ${page.error}.` : `The public page returned HTTP ${page.status}.`,
+      "Make the public page return readable HTML before using it as GEOPass evidence.",
+      [evidence("http", "Target fetch", page.error ?? `HTTP ${page.status}`, targetUrl)]
+    )
+  ]);
+}
+function labelFor(checkId) {
+  return {
+    "ai-bot-crawlability": "AI bot crawlability matrix",
+    "llms-txt": "llms.txt presence and quality",
+    "answer-extractability": "Answer extractability",
+    "entity-clarity": "Entity clarity",
+    "citation-readiness": "Citation and sourceability readiness",
+    "freshness-cues": "Freshness and update cues",
+    "content-structure": "AI-readable content structure",
+    "schema-org-citation-grade": "schema.org citation-grade validation",
+    "brand-mention-readiness": "Brand mention readiness",
+    "wikidata-presence": "Wikidata presence",
+    "common-crawl-presence": "Common Crawl presence",
+    "aggregate-ai-engine-readiness": "Aggregate AI engine readiness score"
+  }[checkId];
+}
+function robotsBlockedBots(robotsBody, pathname) {
+  const groups = [];
+  let current = null;
+  for (const rawLine of robotsBody.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*/, "").trim();
+    if (!line) continue;
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    if (key === "user-agent") {
+      current = { agents: [value.toLowerCase()], rules: [] };
+      groups.push(current);
+    } else if ((key === "allow" || key === "disallow") && current) {
+      current.rules.push({ directive: key, path: value });
+    }
+  }
+  return AI_BOTS.filter((bot) => {
+    const token = bot.toLowerCase();
+    const matching = groups.filter(
+      (group) => group.agents.some((agent) => agent === "*" || token.includes(agent.replace(/\*$/, "")))
+    );
+    const rules = matching.flatMap((group) => group.rules).filter((rule) => rule.path !== "");
+    const disallows = rules.filter((rule) => rule.directive === "disallow" && pathMatches(pathname, rule.path));
+    if (disallows.length === 0) return false;
+    const strongestDisallow = Math.max(...disallows.map((rule) => rule.path.length));
+    const strongestAllow = Math.max(
+      0,
+      ...rules.filter((rule) => rule.directive === "allow" && pathMatches(pathname, rule.path)).map((rule) => rule.path.length)
+    );
+    return strongestDisallow >= strongestAllow;
+  });
+}
+function pathMatches(pathname, rulePath) {
+  const cleanRule = rulePath.replace(/\*.*/, "");
+  if (cleanRule === "/" || cleanRule === "") return cleanRule === "/";
+  return pathname.startsWith(cleanRule);
+}
+function buildAiBotCrawlability(targetUrl, robots) {
+  if (robots.status === 0 || robots.status >= 500 || robots.status === 429) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 60, [
+      finding(
+        "ai-bot-crawlability",
+        "ai-bot-crawlability-robots-unavailable",
+        "medium",
+        "robots.txt was not safely checkable",
+        robots.error ? `robots.txt fetch failed: ${robots.error}.` : `robots.txt returned HTTP ${robots.status}.`,
+        "Make robots.txt consistently available so AI crawler access can be checked.",
+        [evidence("robots-txt", "robots.txt fetch", robots.error ?? `HTTP ${robots.status}`, new URL("/robots.txt", targetUrl).toString())]
+      )
+    ]);
+  }
+  if (robots.status === 404) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 88, []);
+  }
+  const blocked = robotsBlockedBots(robots.body, new URL(targetUrl).pathname || "/");
+  if (blocked.length === 0) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 100, []);
+  }
+  return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 35, [
+    finding(
+      "ai-bot-crawlability",
+      "ai-bot-crawlability-blocked",
+      "high",
+      "AI crawler access is blocked",
+      `robots.txt appears to block ${blocked.join(", ")} for this path.`,
+      "Review whether AI search crawlers should be allowed to read this public page.",
+      [evidence("robots-txt", "Blocked AI bot rules", blocked.join(", "), new URL("/robots.txt", targetUrl).toString())]
+    )
+  ]);
+}
+function buildLlmsTxt(targetUrl, llms) {
+  if (llms.ok && llms.body.trim().length >= 160) {
+    const score = /\[[^\]]+\]\(https?:\/\//.test(llms.body) ? 100 : 88;
+    return result("llms-txt", labelFor("llms-txt"), score, []);
+  }
+  if (llms.ok) {
+    return result("llms-txt", labelFor("llms-txt"), 68, [
+      finding(
+        "llms-txt",
+        "llms-txt-thin",
+        "medium",
+        "llms.txt exists but is thin",
+        "The llms.txt file exists but does not yet provide enough product context, summaries, or source links for AI readers.",
+        "Add a concise product summary, canonical docs links, and important public pages to llms.txt.",
+        [evidence("llms-txt", "Public llms.txt", "File exists but is short.", new URL("/llms.txt", targetUrl).toString())]
+      )
+    ]);
+  }
+  return result("llms-txt", labelFor("llms-txt"), 58, [
+    finding(
+      "llms-txt",
+      "llms-txt-missing",
+      "medium",
+      "llms.txt was not found",
+      "No public llms.txt file was available at the target origin.",
+      "Consider publishing llms.txt with public summaries and canonical links for AI readers.",
+      [evidence("llms-txt", "Public llms.txt", `HTTP ${llms.status || "fetch failed"}`, new URL("/llms.txt", targetUrl).toString())]
+    )
+  ]);
+}
+function buildAnswerExtractability(targetUrl, signals) {
+  const findings = [];
+  let score = 55;
+  if (signals.wordCount >= 350) score += 15;
+  if (signals.questionCount > 0 || signals.hasFaqSchema) score += 15;
+  if (signals.paragraphCount >= 4) score += 10;
+  if (signals.h2.length >= 2) score += 5;
+  if (signals.wordCount < 180) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-thin-page",
+      "medium",
+      "Page copy is thin for AI answer reuse",
+      "The page has limited visible body copy, which makes direct answer extraction brittle.",
+      "Add clear, visible answers to the main questions a customer or answer engine would ask.",
+      [evidence("content", "Visible body text", `${signals.wordCount} visible words`, targetUrl)]
+    ));
+  }
+  if (signals.questionCount === 0 && !signals.hasFaqSchema) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-no-questions",
+      "low",
+      "No explicit question-answer structure was found",
+      "AI answer engines often benefit from direct question headings, FAQ structure, or plain answer blocks.",
+      "Add direct headings or FAQ-style sections for important user questions.",
+      [evidence("html", "Heading scan", `${signals.h2.length} h2 heading(s), ${signals.questionCount} question heading(s)`, targetUrl)]
+    ));
+  }
+  return result("answer-extractability", labelFor("answer-extractability"), score, findings);
+}
+function buildEntityClarity(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.title) score += 15;
+  if (signals.description) score += 15;
+  if (signals.h1.length > 0) score += 10;
+  if (signals.hasOrganizationSchema) score += 15;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (!signals.hasOrganizationSchema) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-schema-missing",
+      "medium",
+      "Organization or product schema was not found",
+      "The page does not expose obvious Organization, LocalBusiness, or Product JSON-LD for entity grounding.",
+      "Add truthful schema that matches visible page content.",
+      [evidence("schema-org", "Schema scan", "No Organization, LocalBusiness, or Product JSON-LD found.", targetUrl)]
+    ));
+  }
+  if (!signals.description) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-description-missing",
+      "low",
+      "Meta description is missing",
+      "The page lacks a concise public description for summarizers and search snippets.",
+      "Add a clear meta description that states what the product, organization, or page is about.",
+      [evidence("html", "Meta description scan", "No description meta tag found.", targetUrl)]
+    ));
+  }
+  return result("entity-clarity", labelFor("entity-clarity"), score, findings);
+}
+function buildCitationReadiness(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.externalLinkCount >= 2) score += 20;
+  if (signals.hasSourceCue) score += 15;
+  if (signals.hasStatisticCue) score += 10;
+  if (signals.hasArticleSchema || signals.hasAuthorCue) score += 10;
+  if (signals.externalLinkCount === 0 && !signals.hasSourceCue) {
+    findings.push(finding(
+      "citation-readiness",
+      "citation-readiness-no-visible-sources",
+      "medium",
+      "Visible source cues are weak",
+      "The page has no obvious external source links or source/evidence wording for answer engines to cite.",
+      "Add visible support links, evidence, data sources, or authored references for important claims.",
+      [evidence("external-link", "External link scan", `${signals.externalLinkCount} external link(s) found.`, targetUrl)]
+    ));
+  }
+  return result("citation-readiness", labelFor("citation-readiness"), score, findings);
+}
+function buildFreshness(targetUrl, signals) {
+  if (signals.hasFreshnessCue) {
+    return result("freshness-cues", labelFor("freshness-cues"), 95, []);
+  }
+  return result("freshness-cues", labelFor("freshness-cues"), 62, [
+    finding(
+      "freshness-cues",
+      "freshness-cues-missing",
+      "low",
+      "Freshness cues are not visible",
+      "The page does not expose obvious published, reviewed, or last-updated cues.",
+      "Add visible freshness or review dates where current information matters.",
+      [evidence("date", "Freshness scan", "No visible time/date/update cue found.", targetUrl)]
+    )
+  ]);
+}
+function buildContentStructure(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.h1.length === 1) score += 15;
+  if (signals.h2.length >= 2) score += 15;
+  if (signals.paragraphCount >= 3) score += 10;
+  if (signals.listCount > 0) score += 10;
+  if (signals.hasFaqSchema || signals.questionCount > 0) score += 10;
+  if (signals.h1.length === 0) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-h1-missing",
+      "medium",
+      "No H1 was found",
+      "The page lacks a clear top-level heading.",
+      "Add one clear H1 that names the page subject.",
+      [evidence("html", "Heading scan", "No H1 found.", targetUrl)]
+    ));
+  }
+  if (signals.h2.length < 2) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-heading-depth-thin",
+      "low",
+      "Heading structure is thin",
+      "The page has limited subheading structure for answer extraction.",
+      "Break important topics into descriptive H2 sections.",
+      [evidence("html", "Heading scan", `${signals.h2.length} H2 heading(s) found.`, targetUrl)]
+    ));
+  }
+  return result("content-structure", labelFor("content-structure"), score, findings);
+}
+function buildSchemaCitationGrade(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.hasJsonLd) score += 25;
+  if (signals.hasMicrodata || signals.hasRdfa) score += 10;
+  if (signals.hasOrganizationSchema || signals.hasArticleSchema || signals.hasFaqSchema) score += 20;
+  if (!signals.hasJsonLd && !signals.hasMicrodata && !signals.hasRdfa) {
+    findings.push(finding(
+      "schema-org-citation-grade",
+      "schema-org-citation-grade-missing",
+      "medium",
+      "Structured data was not found",
+      "No JSON-LD, microdata, or RDFa was detected on the page.",
+      "Add truthful structured data that matches visible page facts.",
+      [evidence("schema-org", "Structured data scan", "No structured data detected.", targetUrl)]
+    ));
+  }
+  return result("schema-org-citation-grade", labelFor("schema-org-citation-grade"), score, findings);
+}
+function buildBrandMentionReadiness(targetUrl, signals) {
+  const findings = [];
+  let score = 55;
+  if (signals.title && signals.h1.length > 0) score += 15;
+  if (signals.description) score += 10;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (signals.hasOrganizationSchema) score += 10;
+  if (!signals.title || signals.h1.length === 0) {
+    findings.push(finding(
+      "brand-mention-readiness",
+      "brand-mention-readiness-weak-page-name",
+      "medium",
+      "Page naming is weak for brand/entity mention",
+      "The page needs both a clear title and visible H1 for answer engines to label it consistently.",
+      "Use a direct title and H1 that name the product, brand, organization, or topic.",
+      [evidence("brand-query", "Title and H1 scan", `title=${signals.title ? "present" : "missing"}; h1=${signals.h1.length}`, targetUrl)]
+    ));
+  }
+  return result("brand-mention-readiness", labelFor("brand-mention-readiness"), score, findings);
+}
+function buildPlanOnlyExternalIndex(checkId, targetUrl) {
+  return {
+    check_id: checkId,
+    label: labelFor(checkId),
+    score: 50,
+    verdict: "unknown",
+    findings: [
+      finding(
+        checkId,
+        `${checkId}-not-live-readonly`,
+        "info",
+        "External index lookup was not run",
+        "This GEOPass live-readonly slice does not query external entity or web-corpus APIs.",
+        "Run a separately scoped public API adapter before using this row as index-presence proof.",
+        [evidence(checkId === "wikidata-presence" ? "wikidata" : "common-crawl", "External index boundary", "Not queried in this public-safe run.", targetUrl)]
+      )
+    ]
+  };
+}
+function buildAggregate(targetUrl, checks) {
+  const source = checks.filter((check) => check.check_id !== "aggregate-ai-engine-readiness");
+  const score = Math.round(source.reduce((sum, check) => sum + check.score, 0) / Math.max(1, source.length));
+  const blockers = source.filter((check) => check.verdict === "blocked");
+  const weak = source.filter((check) => check.verdict === "needs-work");
+  const findings = [];
+  if (blockers.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-blockers",
+      "high",
+      "GEOPass has blocked rows",
+      `${blockers.length} check(s) are blocked: ${blockers.map((check) => check.check_id).join(", ")}.`,
+      "Resolve blocked rows before treating this page as AI-answer ready.",
+      [evidence("manual-note", "Aggregate readiness", `Blocked rows: ${blockers.map((check) => check.check_id).join(", ")}`, targetUrl)]
+    ));
+  } else if (weak.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-needs-work",
+      "medium",
+      "GEOPass has readiness gaps",
+      `${weak.length} check(s) need work: ${weak.map((check) => check.check_id).join(", ")}.`,
+      "Use the row recommendations as the next public content fixes.",
+      [evidence("manual-note", "Aggregate readiness", `Needs-work rows: ${weak.map((check) => check.check_id).join(", ")}`, targetUrl)]
+    ));
+  }
+  return result("aggregate-ai-engine-readiness", labelFor("aggregate-ai-engine-readiness"), score, findings);
+}
+function verdictSummary(checks) {
+  return checks.reduce(
+    (summary, check) => {
+      if (check.verdict === "ready") summary.ready += 1;
+      if (check.verdict === "needs-work") summary.needs_work += 1;
+      if (check.verdict === "blocked") summary.blocked += 1;
+      if (check.verdict === "unknown") summary.unknown += 1;
+      return summary;
+    },
+    { ready: 0, needs_work: 0, blocked: 0, unknown: 0 }
+  );
+}
+function crossPassSignals(checks) {
+  const byId = new Map(checks.map((check) => [check.check_id, check]));
+  const signals = [];
+  const llms = byId.get("llms-txt");
+  if (llms && llms.verdict !== "ready") {
+    signals.push({ pass: "seopass", signal: "llms.txt gap also weakens AI-era search readiness", score: llms.score });
+  }
+  const schema = byId.get("schema-org-citation-grade");
+  if (schema && schema.verdict !== "ready") {
+    signals.push({ pass: "legalpass", signal: "schema must truthfully match visible public claims", score: schema.score });
+  }
+  const structure = byId.get("content-structure");
+  if (structure && structure.verdict !== "ready") {
+    signals.push({ pass: "uxpass", signal: "thin public structure can make answer extraction and human scanning weaker", score: structure.score });
+  }
+  const citation = byId.get("citation-readiness");
+  if (citation && citation.verdict !== "ready") {
+    signals.push({ pass: "sloppass", signal: "unsupported or source-light claims need copy/content cleanup", score: citation.score });
+  }
+  return signals;
+}
+function receiptFor(report, runId, targetSha) {
+  const summary = verdictSummary(report.checks);
+  const status = report.verdict === "ready" ? "PASS" : report.verdict === "blocked" ? "BLOCKER" : "WARN";
+  const evidenceSources = report.checks.flatMap((check) => check.findings).flatMap((item) => item.evidence).filter((item, index, all) => all.findIndex((candidate) => candidate.kind === item.kind && candidate.label === item.label && candidate.source_url === item.source_url) === index).slice(0, 12);
+  const actionNeeded = report.checks.flatMap((check) => check.findings).map((item) => item.recommendation).filter((item) => Boolean(item)).filter((item, index, all) => all.indexOf(item) === index).slice(0, 8);
+  return {
+    kind: "geopass_receipt_v1",
+    status,
+    run_id: runId,
+    target_url: report.target_url,
+    generated_at: report.generated_at,
+    mode: "live-readonly",
+    ...targetSha ? { target_sha: targetSha } : {},
+    score: report.aggregate_ai_engine_readiness_score,
+    verdict: report.verdict,
+    checked: {
+      total: report.checks.length,
+      ready: summary.ready,
+      needs_work: summary.needs_work,
+      blocked: summary.blocked,
+      unknown: summary.unknown
+    },
+    evidence_sources: evidenceSources,
+    action_needed: actionNeeded,
+    boundaries: RECEIPT_BOUNDARIES
+  };
+}
+async function runGeoPass(input) {
+  const rawUrl = input.url ?? input.targetUrl ?? "";
+  const targetUrl = normalizePublicHttpUrl(rawUrl);
+  if (!targetUrl) {
+    return { error: "GEOPass target URL must be a valid public http(s) URL without credentials" };
+  }
+  const generatedAt = input.generatedAt ?? (/* @__PURE__ */ new Date()).toISOString();
+  const fetchImpl = input.fetchImpl ?? globalThis.fetch;
+  if (!fetchImpl) return { error: "No fetch implementation is available for GEOPass live-readonly run" };
+  const selectedChecks = new Set(input.checks?.length ? input.checks : LIVE_CHECKS);
+  const page = await fetchText(targetUrl, fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS);
+  const analysisUrl = normalizePublicHttpUrl(page.url) ?? targetUrl;
+  const [robots, llms] = await Promise.all([
+    fetchText(new URL("/robots.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS),
+    fetchText(new URL("/llms.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS)
+  ]);
+  const htmlReadable = page.ok && (page.headers["content-type"] ?? "text/html").toLowerCase().includes("html");
+  const signals = htmlReadable ? analyzeHtml(page.body, analysisUrl) : null;
+  const checks = [];
+  for (const checkId of LIVE_CHECKS.filter((id) => selectedChecks.has(id))) {
+    if (!signals && checkId !== "ai-bot-crawlability" && checkId !== "llms-txt") {
+      checks.push(pageUnavailableResult(checkId, analysisUrl, page));
+      continue;
+    }
+    if (checkId === "ai-bot-crawlability") checks.push(buildAiBotCrawlability(analysisUrl, robots));
+    if (checkId === "llms-txt") checks.push(buildLlmsTxt(analysisUrl, llms));
+    if (signals && checkId === "answer-extractability") checks.push(buildAnswerExtractability(analysisUrl, signals));
+    if (signals && checkId === "entity-clarity") checks.push(buildEntityClarity(analysisUrl, signals));
+    if (signals && checkId === "citation-readiness") checks.push(buildCitationReadiness(analysisUrl, signals));
+    if (signals && checkId === "freshness-cues") checks.push(buildFreshness(analysisUrl, signals));
+    if (signals && checkId === "content-structure") checks.push(buildContentStructure(analysisUrl, signals));
+    if (signals && checkId === "schema-org-citation-grade") checks.push(buildSchemaCitationGrade(analysisUrl, signals));
+    if (signals && checkId === "brand-mention-readiness") checks.push(buildBrandMentionReadiness(analysisUrl, signals));
+  }
+  for (const externalCheckId of ["wikidata-presence", "common-crawl-presence"]) {
+    if (selectedChecks.has(externalCheckId)) checks.push(buildPlanOnlyExternalIndex(externalCheckId, analysisUrl));
+  }
+  if (selectedChecks.has("aggregate-ai-engine-readiness")) {
+    checks.push(buildAggregate(analysisUrl, checks));
+  }
+  const summary = verdictSummary(checks);
+  const aggregate = checks.find((check) => check.check_id === "aggregate-ai-engine-readiness");
+  const score = aggregate?.score ?? Math.round(checks.reduce((sum, check) => sum + check.score, 0) / Math.max(1, checks.length));
+  const verdict = summary.blocked > 0 ? "blocked" : score >= 85 ? "ready" : "needs-work";
+  const report = {
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    mode: "live-readonly",
+    engines: DEFAULT_GEOPASS_ENGINES,
+    aggregate_ai_engine_readiness_score: score,
+    verdict,
+    checks,
+    cross_pass_signals: crossPassSignals(checks),
+    notes: [
+      "Readiness only. GEOPass does not guarantee AI citations, rankings, or answer-engine placement.",
+      "This run used public http(s) fetches only and did not use credentials, paid APIs, production data, or private prompts.",
+      ...page.truncated ? ["The target page body was truncated for bounded analysis."] : []
+    ]
+  };
+  const runId = stableRunId(analysisUrl, generatedAt);
+  return {
+    run_id: runId,
+    status: "complete",
+    pass: "geopass",
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    ai_answer_readiness_score: score,
+    verdict,
+    verdict_summary: summary,
+    report,
+    geopass_receipt_v1: receiptFor(report, runId, input.targetSha)
+  };
+}
+export {
+  DEFAULT_GEOPASS_BOTS,
+  DEFAULT_GEOPASS_ENGINES,
+  DEFAULT_GEOPASS_SCANNER_STEPS,
+  GeoPassBotIdSchema,
+  GeoPassCheckIdSchema,
+  GeoPassCheckResultSchema,
+  GeoPassCrossPassSignalSchema,
+  GeoPassEngineIdSchema,
+  GeoPassEvidenceSchema,
+  GeoPassFindingSchema,
+  GeoPassReceiptSchema,
+  GeoPassReportSchema,
+  GeoPassSeveritySchema,
+  GeoPassVerdictSchema,
+  createGeoPassScannerPlan,
+  runGeoPass
+};

--- a/packages/mcp-server/src/geopass-tool.test.ts
+++ b/packages/mcp-server/src/geopass-tool.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { geopassRun, geopassStatus } from "./geopass-tool.js";
+import { ADDITIONAL_HANDLERS, ADDITIONAL_TOOLS } from "./tool-wiring.js";
+
+function installFetch(fixtures: Record<string, string | { status: number; body: string; headers?: Record<string, string>; url?: string }>): void {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const normalized = new URL(url).toString();
+    const fixture = fixtures[normalized] ?? fixtures[normalized.replace(/\/$/, "")];
+    const status = typeof fixture === "object" ? fixture.status : fixture ? 200 : 404;
+    const body = typeof fixture === "object" ? fixture.body : fixture ?? "not found";
+    const headers = typeof fixture === "object" ? fixture.headers ?? { "content-type": "text/html" } : { "content-type": "text/html" };
+    return {
+      url: typeof fixture === "object" && fixture.url ? fixture.url : normalized,
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers(headers),
+      text: async () => body,
+    };
+  }));
+}
+
+const html = `<!doctype html>
+<html>
+  <head>
+    <title>GEOPass public AI answer readiness</title>
+    <meta name="description" content="Public readiness checks for AI answer engines.">
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"UnClick"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[]}</script>
+  </head>
+  <body>
+    <h1>GEOPass public AI answer readiness</h1>
+    <h2>What does GEOPass check?</h2>
+    <p>It checks answer extractability, entity clarity, citation readiness, freshness cues, and content structure for public pages.</p>
+    <h2>How does GEOPass stay honest?</h2>
+    <p>It reports readiness only and does not guarantee rankings or citations.</p>
+    <p>Updated <time datetime="2026-05-30">May 30, 2026</time>. Source: public Google guidance.</p>
+    <ul><li>AI bot visibility</li><li>Readable evidence</li><li>Public source links</li></ul>
+    <a href="https://developers.google.com/search/docs/appearance/ai-features">Google AI features guidance</a>
+    <a href="https://schema.org">schema.org</a>
+    <a href="/about">About</a>
+  </body>
+</html>`;
+
+describe("geopass-tool", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registers GEOPass run and status tools", () => {
+    const names = ADDITIONAL_TOOLS.map((tool) => tool.name);
+
+    expect(names).toContain("geopass_run");
+    expect(names).toContain("geopass_status");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("geopass_run");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("geopass_status");
+  });
+
+  it("rejects missing or invalid targets before storing a run", async () => {
+    await expect(geopassRun({})).resolves.toMatchObject({ error: "url or target_url is required" });
+    await expect(geopassRun({ url: "file:///tmp/page.html" })).resolves.toMatchObject({
+      error: expect.stringContaining("public http(s)"),
+    });
+  });
+
+  it("runs GEOPass and exposes a receipt through status", async () => {
+    installFetch({
+      "https://unclick.world/": html,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nGEOPass gives AI answer engines public summaries and canonical docs links.\n\n[Docs](https://unclick.world/docs): Docs.",
+    });
+
+    const run = await geopassRun({
+      url: "https://unclick.world",
+      target_sha: "abc123",
+    }) as Record<string, unknown>;
+
+    expect(run).toMatchObject({
+      status: "complete",
+      pass: "geopass",
+    });
+    expect(String(run.run_id)).toMatch(/^geopass-/);
+    expect((run.geopass_receipt_v1 as Record<string, unknown>).kind).toBe("geopass_receipt_v1");
+    expect((run.geopass_receipt_v1 as Record<string, unknown>).target_sha).toBe("abc123");
+
+    const status = await geopassStatus({ run_id: run.run_id }) as Record<string, unknown>;
+    expect(status.run_id).toBe(run.run_id);
+    expect((status.report as { checks?: Array<{ check_id?: string }> }).checks?.map((check) => check.check_id)).toContain("answer-extractability");
+  });
+
+  it("keeps external index rows unknown when specifically requested", async () => {
+    installFetch({
+      "https://unclick.world/": html,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nHelpful file.",
+    });
+
+    const run = await geopassRun({
+      target_url: "https://unclick.world",
+      checks: ["wikidata-presence", "common-crawl-presence"],
+    }) as Record<string, unknown>;
+
+    expect((run.geopass_receipt_v1 as { checked?: { unknown?: number } }).checked?.unknown).toBe(2);
+  });
+});

--- a/packages/mcp-server/src/geopass-tool.ts
+++ b/packages/mcp-server/src/geopass-tool.ts
@@ -1,0 +1,39 @@
+import { runGeoPass } from "./geopass-runtime.js";
+
+type GeoPassRunRecord = Awaited<ReturnType<typeof runGeoPass>>;
+
+const RUNS = new Map<string, Exclude<GeoPassRunRecord, { error: string }>>();
+
+function isGeoPassRun(value: GeoPassRunRecord): value is Exclude<GeoPassRunRecord, { error: string }> {
+  return typeof value === "object" && value !== null && !("error" in value);
+}
+
+function parseChecks(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+export async function geopassRun(args: Record<string, unknown>): Promise<unknown> {
+  const url =
+    (typeof args.url === "string" && args.url.trim()) ||
+    (typeof args.target_url === "string" && args.target_url.trim()) ||
+    "";
+  if (!url) return { error: "url or target_url is required" };
+
+  const run = await runGeoPass({
+    url,
+    checks: parseChecks(args.checks),
+    targetSha: typeof args.target_sha === "string" && args.target_sha.trim() ? args.target_sha.trim() : undefined,
+  });
+  if (!isGeoPassRun(run)) return run;
+  RUNS.set(run.run_id, run);
+  return run;
+}
+
+export async function geopassStatus(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id.trim() : "";
+  if (!runId) return { error: "run_id is required" };
+  const run = RUNS.get(runId);
+  if (!run) return { error: `GEOPass run '${runId}' was not found in this MCP session` };
+  return run;
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1314,6 +1314,20 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "geopass",
+    "category": "GEOPass (AI answer-engine readiness QC, sister to SEOPass)",
+    "tools": [
+      {
+        "name": "geopass_run",
+        "description": "Run GEOPass against a public URL. Returns a live-readonly AI answer-engine readiness receipt covering answer extractability, entity clarity, citation/sourceability, freshness cues, content structure, llms.txt, and AI bot visibility. GEOPass reports readiness only and does not guarantee rankings or citations."
+      },
+      {
+        "name": "geopass_status",
+        "description": "Fetch the stored in-session GEOPass report and geopass_receipt_v1 envelope for a run started through geopass_run."
+      }
+    ]
+  },
+  {
     "app": "github",
     "category": "Developer / Productivity",
     "tools": [

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -800,6 +800,12 @@ import {
   seopassLighthousePlan,
 } from "./seopass-tool.js";
 
+// --- GEOPass (AI answer-engine readiness QC, sister to SEOPass) -------------
+import {
+  geopassRun,
+  geopassStatus,
+} from "./geopass-tool.js";
+
 // ─── CompliancePass (public name for EnterprisePass readiness) ───────────────
 import {
   compliancepassRun,
@@ -12480,6 +12486,67 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // -- geopass-tool.ts (AI answer-engine readiness QC, sister to SEOPass) ----
+  {
+    name: "geopass_run",
+    description: "Run GEOPass against a public URL. Returns a live-readonly AI answer-engine readiness receipt covering answer extractability, entity clarity, citation/sourceability, freshness cues, content structure, llms.txt, and AI bot visibility. GEOPass reports readiness only and does not guarantee rankings or citations.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        url: { type: "string", description: "Target public http(s) URL for a one-off GEOPass read-only run" },
+        target_url: { type: "string", description: "Alias for url" },
+        checks: {
+          type: "array",
+          minItems: 1,
+          description: "Optional GEOPass check ids. Defaults to the public-safe live checklist.",
+          items: {
+            type: "string",
+            enum: [
+              "ai-bot-crawlability",
+              "llms-txt",
+              "answer-extractability",
+              "entity-clarity",
+              "citation-readiness",
+              "freshness-cues",
+              "content-structure",
+              "schema-org-citation-grade",
+              "brand-mention-readiness",
+              "wikidata-presence",
+              "common-crawl-presence",
+              "aggregate-ai-engine-readiness",
+            ],
+          },
+        },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks." },
+      },
+    },
+  },
+  {
+    name: "geopass_status",
+    description: "Fetch the stored in-session GEOPass report and geopass_receipt_v1 envelope for a run started through geopass_run.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string", description: "The GEOPass run id returned by geopass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+
   // ── flowpass-tool.ts (end-to-end journey QC with fixture proof) ────────────
   {
     name: "flowpass_run",
@@ -14084,6 +14151,10 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   seopass_status:          (args) => seopassStatus(args),
   seopass_register_pack:   (args) => seopassRegisterPack(args),
   seopass_lighthouse_plan: (args) => seopassLighthousePlan(args),
+
+  // geopass-tool.ts
+  geopass_run:             (args) => geopassRun(args),
+  geopass_status:          (args) => geopassStatus(args),
 
   // compliancepass-tool.ts
   compliancepass_run:         (args) => compliancepassRun(args),


### PR DESCRIPTION
## Summary
- adds GEOPass live-readonly AI-answer readiness runner with `geopass_receipt_v1`
- wires `geopass_run` and `geopass_status` into the main MCP server with a Vercel-bundled runtime
- refreshes tool index and brainmap discovery, plus lint guards needed by the website gate

## Local proof
- `npm run test --workspace=@unclick/geopass`
- `npm run build --workspace=@unclick/geopass`
- `npx vitest run src/geopass-tool.test.ts` from `packages/mcp-server`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run test --workspace=@unclick/mcp-server`
- `npm run brainmap:check && npm run test:brainmap`
- `npm run lint` (0 errors, existing warnings only)
- `npm run build`
- `npm test` (125 files, 937 tests)

## Safety notes
- public http(s) fetches only
- no credentials, paid APIs, production writes, or private prompts
- receipt explicitly says GEOPass does not guarantee AI citations, rankings, or answer-engine placement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New outbound public URL fetching in MCP and a large bundled runtime increase exposure to SSRF/misuse and deployment surface, though inputs are restricted to credential-free http(s) and behavior is read-only with explicit boundaries.
> 
> **Overview**
> This PR turns **GEOPass** from plan-only scaffolding into a **live-readonly** public URL audit that returns a **`geopass_receipt_v1`** readiness envelope (scores, verdicts, evidence, explicit “no citation guarantee” boundaries).
> 
> The **`@unclick/geopass`** package gains **`runGeoPass`**: bounded public `http(s)` fetches of the page, `robots.txt`, and `llms.txt`, plus HTML heuristics for new checks (answer extractability, entity clarity, citation readiness, freshness, content structure) alongside existing AI-bot and schema signals. Wikidata/Common Crawl stay **`unknown`** unless separately scoped. MCP exposes **`geopass_run`** / **`geopass_status`** (in-session run storage) via a bundled **`geopass-runtime`**, with tool index and brainmap counts updated. Tests cover the runner and MCP wiring; **`ptv-tool`** timeout errors now attach **`cause`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9dc7c7047eb61c51276de39ffb469c2bc6e839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->