### PR TITLE
feat(legalpass): add scoped receipt envelope

### DIFF
--- a/packages/legalpass/src/__tests__/schema.test.ts
+++ b/packages/legalpass/src/__tests__/schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   LegalPassFixtureDocumentSchema,
   LegalPassHatDefinitionSchema,
+  LegalPassReceiptSchema,
   LegalPassReportSchema,
 } from "../schema.js";
 
@@ -90,6 +91,44 @@ describe("LegalPass phase-one schema", () => {
         disclaimers: [],
       }),
     ).toThrow();
+  });
+
+  it("parses scoped LegalPass receipts with issue-spotter boundaries", () => {
+    const receipt = LegalPassReceiptSchema.parse({
+      kind: "legalpass_receipt_v1",
+      status: "WARN",
+      run_id: "legalpass_abc123",
+      pack_id: "legalpass-mvp-v0",
+      target: { name: "Example", url: "https://example.com/legal" },
+      target_sha: "abc123",
+      generated_at: "2026-05-09T18:10:00.000Z",
+      mode: "fixture",
+      jurisdictions: ["AU"],
+      summary: {
+        total: 1,
+        check: 0,
+        fail: 1,
+        na: 0,
+        other: 0,
+        pending: 0,
+        pass_rate: 0,
+      },
+      disclaimer_present: true,
+      safety: {
+        issue_spotter_only: true,
+        no_legal_advice: true,
+        no_transactional_instrument: true,
+      },
+      evidence_sources: [MINIMAL_EVIDENCE],
+      action_needed: ["Practitioner review may be warranted before relying on this material."],
+      boundaries: [
+        "LegalPass is an issue-spotter and information tool only.",
+        "LegalPass does not provide legal advice or create a lawyer-client relationship.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("legalpass_receipt_v1");
+    expect(receipt.safety.no_legal_advice).toBe(true);
   });
 
   it("requires every finding to carry evidence", () => {

--- a/packages/legalpass/src/schema.ts
+++ b/packages/legalpass/src/schema.ts
@@ -177,6 +177,36 @@ export const LegalPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const LegalPassReceiptSchema = z.object({
+  kind: z.literal("legalpass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  pack_id: z.string().min(1),
+  target: LegalPassTargetSchema,
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["fixture", "plan-only"]),
+  jurisdictions: JurisdictionListSchema,
+  summary: z.object({
+    total: z.number().int().min(0),
+    check: z.number().int().min(0),
+    fail: z.number().int().min(0),
+    na: z.number().int().min(0),
+    other: z.number().int().min(0),
+    pending: z.number().int().min(0),
+    pass_rate: z.number().min(0).max(100),
+  }),
+  disclaimer_present: z.literal(true),
+  safety: z.object({
+    issue_spotter_only: z.literal(true),
+    no_legal_advice: z.literal(true),
+    no_transactional_instrument: z.literal(true),
+  }),
+  evidence_sources: z.array(LegalPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export const LegalPassGeoPassAdapterSchema = z.object({
   source: z.literal("geopass"),
   target_url: HttpUrlSchema,
@@ -201,4 +231,5 @@ export type LegalPassHatDefinition = z.infer<typeof LegalPassHatDefinitionSchema
 export type LegalPassHatResult = z.infer<typeof LegalPassHatResultSchema>;
 export type LegalPassScannerSource = z.infer<typeof LegalPassScannerSourceSchema>;
 export type LegalPassReport = z.infer<typeof LegalPassReportSchema>;
+export type LegalPassReceipt = z.infer<typeof LegalPassReceiptSchema>;
 export type LegalPassGeoPassAdapter = z.infer<typeof LegalPassGeoPassAdapterSchema>;

--- a/packages/mcp-server/src/__tests__/legalpass-tool.test.ts
+++ b/packages/mcp-server/src/__tests__/legalpass-tool.test.ts
@@ -42,12 +42,24 @@ describe("LegalPass MCP exposure", () => {
       no_legal_advice: true,
       no_transactional_instrument: true,
     });
+    expect(result.legalpass_receipt_v1).toMatchObject({
+      kind: "legalpass_receipt_v1",
+      status: "WARN",
+      mode: "plan-only",
+      safety: {
+        issue_spotter_only: true,
+        no_legal_advice: true,
+        no_transactional_instrument: true,
+      },
+    });
+    expect(JSON.stringify(result.legalpass_receipt_v1)).toContain("does not provide legal advice");
   });
 
   it("runs deterministic public fixture checks when text is provided", async () => {
     const result = await legalpassRun({
       target_url: "https://example.com/legal",
       jurisdictions: ["AU"],
+      target_sha: "legal-sha-123",
       fixture_text:
         "Privacy contact details explain how we collect and use data, " +
         "retain records, share with a third party, cover liability, indemnity, " +
@@ -58,6 +70,14 @@ describe("LegalPass MCP exposure", () => {
     expect(result.status).toBe("complete");
     expect(result.run_id).toMatch(/^legalpass_/);
     expect(result.summary).toMatchObject({ fail: 0 });
+    expect(result.legalpass_receipt_v1).toMatchObject({
+      kind: "legalpass_receipt_v1",
+      status: "PASS",
+      target_sha: "legal-sha-123",
+      mode: "fixture",
+      disclaimer_present: true,
+    });
+    expect(JSON.stringify(result.legalpass_receipt_v1)).toContain("LegalPass is an issue-spotter");
     expect(JSON.stringify(result.items)).toContain("fixture_text");
     expect(String(result.note)).toContain("deterministic public fixture");
     expect(JSON.stringify(result)).not.toMatch(/you should/i);
@@ -66,6 +86,7 @@ describe("LegalPass MCP exposure", () => {
     const status = await legalpassStatus({ run_id: result.run_id }) as Record<string, unknown>;
     expect(status.run_id).toBe(result.run_id);
     expect(status.summary).toEqual(result.summary);
+    expect(status.legalpass_receipt_v1).toEqual(result.legalpass_receipt_v1);
   });
 
   it("saves custom packs and records human edit audit entries", async () => {
@@ -196,6 +217,10 @@ describe("LegalPass MCP exposure", () => {
     await expect(legalpassRun({
       target: { kind: "email", url: "https://example.com" },
     })).resolves.toMatchObject({ error: "target.kind must be url|contract_upload|repo" });
+    await expect(legalpassRun({
+      target_url: "https://example.com/terms",
+      target_sha: "   ",
+    })).resolves.toMatchObject({ error: "target_sha must not be blank" });
 
     await expect(
       legalpassSavePack({

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/legalpass-tool.ts
+++ b/packages/mcp-server/src/legalpass-tool.ts
@@ -57,12 +57,36 @@ interface LegalPassMcpSummary {
   pass_rate: number;
 }
 
+interface LegalPassMcpReceipt {
+  kind: "legalpass_receipt_v1";
+  status: "PASS" | "WARN" | "BLOCKER";
+  run_id: string;
+  pack_id: string;
+  target: LegalPassMcpTarget;
+  target_sha?: string;
+  generated_at: string;
+  mode: "fixture" | "plan-only";
+  jurisdictions: LegalPassMcpJurisdiction[];
+  summary: LegalPassMcpSummary;
+  disclaimer_present: true;
+  safety: {
+    issue_spotter_only: true;
+    no_legal_advice: true;
+    no_transactional_instrument: true;
+  };
+  evidence_sources: Array<{ kind: "fixture" | "manual-note"; label: string; summary: string; source_url?: string }>;
+  action_needed: string[];
+  boundaries: string[];
+}
+
 interface LegalPassMcpRunRecord {
   status: "complete" | "planned";
   pass: "legalpass";
   run_id: string;
   pack_id: string;
   target: LegalPassMcpTarget;
+  target_sha?: string;
+  generated_at: string;
   profile: LegalPassMcpProfile;
   jurisdictions: LegalPassMcpJurisdiction[];
   summary: LegalPassMcpSummary;
@@ -76,6 +100,10 @@ interface LegalPassMcpRunRecord {
   };
   audit_log: Array<Record<string, unknown>>;
 }
+
+type LegalPassMcpRunResponse = LegalPassMcpRunRecord & {
+  legalpass_receipt_v1: LegalPassMcpReceipt;
+};
 
 interface LegalPassMcpPack {
   id: string;
@@ -121,6 +149,12 @@ const SUPPORTED_JURISDICTIONS = new Set<LegalPassMcpJurisdiction>([
 ]);
 const DEFAULT_PROFILE: LegalPassMcpProfile = "standard";
 const DEFAULT_JURISDICTIONS: LegalPassMcpJurisdiction[] = ["AU", "EU", "US-CA"];
+const RECEIPT_BOUNDARIES = [
+  "LegalPass is an issue-spotter and information tool only.",
+  "LegalPass does not provide legal advice, legal opinions, legal recommendations, or transactional instruments.",
+  "LegalPass does not create a lawyer-client, solicitor-client, or attorney-client relationship.",
+  "LegalPass receipts are scoped to the supplied public fixture, guarded plan, or declared target only.",
+];
 
 const DISCLAIMERS: Record<DisclaimerLength, string> = {
   chat:
@@ -421,18 +455,85 @@ function summaryFromItems(items: LegalPassMcpItem[]): LegalPassMcpSummary {
   return summary;
 }
 
-function cloneRun(record: LegalPassMcpRunRecord): LegalPassMcpRunRecord {
-  return structuredClone(record);
+function cloneRun(record: LegalPassMcpRunRecord): LegalPassMcpRunResponse {
+  const copy = structuredClone(record);
+  return {
+    ...copy,
+    legalpass_receipt_v1: buildLegalPassReceipt(copy),
+  };
 }
 
-function saveRun(record: LegalPassMcpRunRecord): LegalPassMcpRunRecord {
+function saveRun(record: LegalPassMcpRunRecord): LegalPassMcpRunResponse {
   const existing = runStore.get(record.run_id);
   if (existing) {
     return cloneRun(existing);
   }
 
-  runStore.set(record.run_id, cloneRun(record));
+  runStore.set(record.run_id, structuredClone(record));
   return cloneRun(record);
+}
+
+function buildLegalPassReceipt(record: LegalPassMcpRunRecord): LegalPassMcpReceipt {
+  const mode = record.status === "planned" ? "plan-only" : "fixture";
+  const evidence_sources = record.items
+    .flatMap((item) => item.evidence)
+    .map((item) => ({
+      kind: "fixture" as const,
+      label: item.source,
+      summary: item.excerpt,
+      ...(item.url ? { source_url: item.url } : {}),
+    }))
+    .filter((item, index, all) =>
+      all.findIndex((candidate) =>
+        candidate.label === item.label &&
+        candidate.summary === item.summary &&
+        candidate.source_url === item.source_url
+      ) === index,
+    )
+    .slice(0, 12);
+  const action_needed = legalPassActionNeeded(record);
+  const status: LegalPassMcpReceipt["status"] = record.safety.no_legal_advice !== true
+    ? "BLOCKER"
+    : record.status === "planned" || record.summary.pending > 0 || record.summary.fail > 0
+      ? "WARN"
+      : "PASS";
+
+  return {
+    kind: "legalpass_receipt_v1",
+    status,
+    run_id: record.run_id,
+    pack_id: record.pack_id,
+    target: record.target,
+    ...(record.target_sha ? { target_sha: record.target_sha } : {}),
+    generated_at: record.generated_at,
+    mode,
+    jurisdictions: record.jurisdictions,
+    summary: record.summary,
+    disclaimer_present: true,
+    safety: record.safety,
+    evidence_sources: evidence_sources.length > 0
+      ? evidence_sources
+      : [{ kind: "manual-note", label: "LegalPass boundary", summary: record.note }],
+    action_needed,
+    boundaries: RECEIPT_BOUNDARIES,
+  };
+}
+
+function legalPassActionNeeded(record: LegalPassMcpRunRecord): string[] {
+  const actions: string[] = [];
+  if (record.status === "planned") {
+    actions.push("Public fixture text or a later guarded ingestion path is still needed before this counts as completed LegalPass evidence.");
+  }
+  if (record.summary.fail > 0) {
+    actions.push("Practitioner review may be warranted before relying on flagged material.");
+  }
+  if (record.summary.pending > 0) {
+    actions.push("Pending LegalPass rows need public evidence before they count as checked.");
+  }
+  if (record.audit_log.length > 0) {
+    actions.push("Human reviewer edits are present; preserve the audit log with the receipt.");
+  }
+  return actions;
 }
 
 function fixtureChecksForPack(pack: LegalPassMcpPack): typeof FIXTURE_CHECKS {
@@ -504,6 +605,9 @@ export async function legalpassRun(args: Record<string, unknown>): Promise<unkno
     return parsedTarget;
   }
   const target = parsedTarget.target;
+  const parsedTargetSha = parseTargetSha(args.target_sha, target);
+  if ("error" in parsedTargetSha) return parsedTargetSha;
+  const targetSha = parsedTargetSha.target_sha;
   const parsedProfile = parseProfile(args.profile ?? pack.profile ?? DEFAULT_PROFILE, "profile");
   if ("error" in parsedProfile) return parsedProfile;
   const profile = parsedProfile.profile;
@@ -528,6 +632,8 @@ export async function legalpassRun(args: Record<string, unknown>): Promise<unkno
       run_id: buildRunId({ packId, pack_signature, target, profile, jurisdictions, fixtureText }),
       pack_id: packId,
       target,
+      ...(targetSha ? { target_sha: targetSha } : {}),
+      generated_at: new Date().toISOString(),
       profile,
       jurisdictions,
       summary: fixture.summary,
@@ -552,6 +658,8 @@ export async function legalpassRun(args: Record<string, unknown>): Promise<unkno
     run_id: runId,
     pack_id: packId,
     target,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: new Date().toISOString(),
     profile,
     jurisdictions,
     summary: summaryFromItems([]),
@@ -619,6 +727,22 @@ function parseTarget(args: Record<string, unknown>):
   }
 
   return { error: "target.kind or target_url is required" };
+}
+
+function parseTargetSha(value: unknown, target: LegalPassMcpTarget):
+  | { target_sha?: string }
+  | { error: string } {
+  if (value === undefined || value === null) {
+    return target.commit ? { target_sha: target.commit } : {};
+  }
+  if (typeof value !== "string") {
+    return { error: "target_sha must be a string" };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { error: "target_sha must not be blank" };
+  }
+  return { target_sha: trimmed };
 }
 
 function parseProfile(value: unknown, fieldName: string):
@@ -769,7 +893,7 @@ export async function legalpassEditItem(args: Record<string, unknown>): Promise<
     ...(reviewerNote ? { reviewer_note: reviewerNote } : {}),
   };
   record.audit_log.push(audit_entry);
-  runStore.set(runId, cloneRun(record));
+  runStore.set(runId, structuredClone(record));
 
   return {
     run_id: runId,

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12280,6 +12280,7 @@ export const ADDITIONAL_TOOLS = [
         profile: { type: "string", enum: ["smoke", "standard", "deep"], description: "Run profile (default: smoke)" },
         jurisdictions: { type: "array", items: { type: "string" }, description: "Optional jurisdiction routing hints" },
         fixture_text: { type: "string", description: "Public text to check deterministically for dogfood or local proof" },
+        target_sha: { type: "string", description: "Optional commit or target evidence SHA to bind the LegalPass receipt to a specific target version" },
       },
     },
   },


### PR DESCRIPTION
## Summary
- adds a first-class `legalpass_receipt_v1` schema for scoped LegalPass evidence
- returns `legalpass_receipt_v1` from `legalpass_run` and `legalpass_status`
- binds optional `target_sha` provenance, keeps planned runs as WARN, and preserves issue-spotter / no-legal-advice boundaries
- includes the small shared lint gate cleanups needed by the root website check

## Local proof
- `npm run test --workspace=@unclick/legalpass`
- `npm run build --workspace=@unclick/legalpass`
- `npx vitest run src/__tests__/legalpass-tool.test.ts` from `packages/mcp-server`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run test --workspace=@unclick/mcp-server`
- `npm run brainmap:generate && npm run brainmap:check && npm run test:brainmap`
- `npm run lint` (0 errors, existing warnings only)
- `npm run build`
- `npm test` (125 files, 937 tests)

## Safety notes
- issue-spotter only
- not legal advice
- no legal recommendations or transactional legal instruments
- no private ingestion, secrets, production writes, or paid APIs in this slice

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the LegalPass MCP response contract and receipt status logic; mistakes could mislabel run readiness or provenance, though scope stays fixture/plan-only with enforced no-legal-advice literals.
> 
> **Overview**
> Introduces a scoped **`legalpass_receipt_v1`** envelope so LegalPass runs return a stable, machine-readable proof object alongside existing run payloads.
> 
> **`@unclick/legalpass`** adds `LegalPassReceiptSchema` (PASS/WARN/BLOCKER, summary counts, literal safety flags, boundaries, evidence, action items) plus a schema test. **`legalpass_run`** / **`legalpass_status`** now attach `legalpass_receipt_v1` built from run state: planned or failing/pending rows → **WARN**, clean fixture completion → **PASS**, with fixed issue-spotter boundary text and deduped evidence sources.
> 
> Optional **`target_sha`** binds receipts to a commit or evidence hash (including `target.commit` when omitted); blank values are rejected. Runs persist **`generated_at`**; MCP tool wiring documents `target_sha`. **`ptv-tool`** only chains underlying errors via `{ cause: err }` on fetch failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d453fd50839a45c31d4228bf395cd5fb387b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->