### PR TITLE
Make /admin/you AI Style editable and reinforce it at session start

### DIFF
--- a/api/memory-admin-ai-style.test.ts
+++ b/api/memory-admin-ai-style.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { buildAiStyleDirective, normalizeAiStyleValue } from "./memory-admin";
+
+describe("AI style preferences", () => {
+  it("falls back to sensible defaults for empty or non-object input", () => {
+    const value = normalizeAiStyleValue({});
+    expect(value).toMatchObject({
+      response_length: "medium",
+      complexity: "analogies",
+      format: "prose",
+      emoji_level: "light",
+      custom_instructions: "",
+      privacy: "style-only",
+    });
+    // Garbage input is treated as "no preferences set", not a throw.
+    expect(normalizeAiStyleValue("not json")).toMatchObject({ response_length: "medium" });
+    expect(normalizeAiStyleValue(null)).toMatchObject({ emoji_level: "light" });
+  });
+
+  it("clamps out-of-range enum values back to the defaults", () => {
+    const value = normalizeAiStyleValue({
+      response_length: "epic",
+      complexity: 42,
+      format: "interpretive-dance",
+      emoji_level: "MAXIMUM",
+    });
+    expect(value.response_length).toBe("medium");
+    expect(value.complexity).toBe("analogies");
+    expect(value.format).toBe("prose");
+    expect(value.emoji_level).toBe("light");
+  });
+
+  it("preserves valid selections", () => {
+    const value = normalizeAiStyleValue({
+      response_length: "brief",
+      complexity: "simple",
+      format: "visual",
+      emoji_level: "none",
+    });
+    expect(value).toMatchObject({
+      response_length: "brief",
+      complexity: "simple",
+      format: "visual",
+      emoji_level: "none",
+    });
+  });
+
+  it("sanitizes custom instructions (collapses whitespace, caps length)", () => {
+    const value = normalizeAiStyleValue({
+      custom_instructions: "  Australian   spelling.\n\nLead with the answer.  ",
+    });
+    expect(value.custom_instructions).toBe("Australian spelling. Lead with the answer.");
+
+    const long = normalizeAiStyleValue({ custom_instructions: "x".repeat(900) });
+    expect(long.custom_instructions.length).toBe(600);
+  });
+
+  it("keeps `directive` as the first key so it survives JSON truncation for compact clients", () => {
+    const value = normalizeAiStyleValue({ response_length: "brief", emoji_level: "none" });
+    expect(Object.keys(value)[0]).toBe("directive");
+    // The serialized form (what compact startup context truncates to ~130 chars)
+    // leads with the directive, so the rules are not lost.
+    expect(JSON.stringify(value).startsWith('{"directive":')).toBe(true);
+  });
+
+  it("builds an imperative directive that reflects the chosen rules", () => {
+    const directive = buildAiStyleDirective({
+      response_length: "brief",
+      complexity: "simple",
+      format: "visual",
+      emoji_level: "none",
+      custom_instructions: "Australian spelling",
+    });
+    expect(directive).toContain("brief");
+    expect(directive).toContain("plain English");
+    expect(directive).toContain("visuals");
+    expect(directive).toContain("no emoji");
+    expect(directive).toContain("Australian spelling");
+    expect(directive.toLowerCase()).toContain("always honor");
+  });
+
+  it("caps an overlong directive so it cannot bloat the startup payload", () => {
+    const directive = buildAiStyleDirective({
+      response_length: "detailed",
+      complexity: "technical",
+      format: "bullets",
+      emoji_level: "expressive",
+      custom_instructions: "y".repeat(500),
+    });
+    expect(directive.length).toBeLessThanOrEqual(300);
+  });
+});

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -299,6 +299,140 @@ async function readOperatorTimeContext(
   return data ? parseOperatorTimeValue(data.value, data.updated_at as string | null) : null;
 }
 
+// ---------------------------------------------------------------------------
+// AI style preferences
+//
+// The operator's standing tone rules (length, complexity, format, emoji, and
+// free-text instructions) live in mc_business_context as a single
+// high-priority `preference`/`ai_style` row. get_startup_context surfaces
+// business_context as standing rules that agents must follow, so writing the
+// rules here reinforces them at every session entrance (load_memory) for every
+// connected agent, with no MCP-package change required. The stored value also
+// carries a compact `directive` string, kept as the first key so strict and
+// compact clients still see the rules after JSON truncation, that states the
+// rules imperatively for the agent to obey.
+// ---------------------------------------------------------------------------
+
+const AI_STYLE_CATEGORY = "preference";
+const AI_STYLE_KEY = "ai_style";
+const AI_STYLE_PRIORITY = 99;
+
+const AI_STYLE_RESPONSE_LENGTHS = ["brief", "medium", "detailed"] as const;
+const AI_STYLE_COMPLEXITIES = ["simple", "analogies", "standard", "technical"] as const;
+const AI_STYLE_FORMATS = ["prose", "bullets", "visual"] as const;
+const AI_STYLE_EMOJI_LEVELS = ["none", "light", "expressive"] as const;
+
+type AiStyleResponseLength = (typeof AI_STYLE_RESPONSE_LENGTHS)[number];
+type AiStyleComplexity = (typeof AI_STYLE_COMPLEXITIES)[number];
+type AiStyleFormat = (typeof AI_STYLE_FORMATS)[number];
+type AiStyleEmojiLevel = (typeof AI_STYLE_EMOJI_LEVELS)[number];
+
+interface AiStylePreferencesValue {
+  directive: string;
+  response_length: AiStyleResponseLength;
+  complexity: AiStyleComplexity;
+  format: AiStyleFormat;
+  emoji_level: AiStyleEmojiLevel;
+  custom_instructions: string;
+  updated_at: string;
+  privacy: "style-only";
+}
+
+const AI_STYLE_DEFAULTS = {
+  response_length: "medium" as AiStyleResponseLength,
+  complexity: "analogies" as AiStyleComplexity,
+  format: "prose" as AiStyleFormat,
+  emoji_level: "light" as AiStyleEmojiLevel,
+};
+
+const AI_STYLE_LENGTH_PHRASE: Record<AiStyleResponseLength, string> = {
+  brief: "keep replies brief and to the point",
+  medium: "use medium-length replies",
+  detailed: "give detailed, thorough replies",
+};
+const AI_STYLE_COMPLEXITY_PHRASE: Record<AiStyleComplexity, string> = {
+  simple: "use simple, plain English",
+  analogies: "explain simply, with analogies",
+  standard: "use a standard level of detail",
+  technical: "be precise and technical",
+};
+const AI_STYLE_FORMAT_PHRASE: Record<AiStyleFormat, string> = {
+  prose: "write in flowing prose",
+  bullets: "prefer bullet points and short sections",
+  visual: "lead with visuals such as tables, steps, and examples",
+};
+const AI_STYLE_EMOJI_PHRASE: Record<AiStyleEmojiLevel, string> = {
+  none: "use no emoji",
+  light: "use light emoji",
+  expressive: "use expressive emoji",
+};
+
+function pickAiStyleEnum<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+export function buildAiStyleDirective(fields: {
+  response_length: AiStyleResponseLength;
+  complexity: AiStyleComplexity;
+  format: AiStyleFormat;
+  emoji_level: AiStyleEmojiLevel;
+  custom_instructions: string;
+}): string {
+  const core =
+    `Operator AI style, always honor unless overridden in-session: ` +
+    `${AI_STYLE_LENGTH_PHRASE[fields.response_length]}; ` +
+    `${AI_STYLE_COMPLEXITY_PHRASE[fields.complexity]}; ` +
+    `${AI_STYLE_FORMAT_PHRASE[fields.format]}; ` +
+    `${AI_STYLE_EMOJI_PHRASE[fields.emoji_level]}.`;
+  const extra = fields.custom_instructions.trim();
+  const full = extra ? `${core} Also: ${extra}` : core;
+  return full.length > 300 ? `${full.slice(0, 297)}...` : full;
+}
+
+export function normalizeAiStyleValue(value: unknown, updatedAt?: string | null): AiStylePreferencesValue {
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      parsed = {};
+    }
+  }
+  const rec = isRecord(parsed) ? parsed : {};
+  const fields = {
+    response_length: pickAiStyleEnum(rec.response_length, AI_STYLE_RESPONSE_LENGTHS, AI_STYLE_DEFAULTS.response_length),
+    complexity: pickAiStyleEnum(rec.complexity, AI_STYLE_COMPLEXITIES, AI_STYLE_DEFAULTS.complexity),
+    format: pickAiStyleEnum(rec.format, AI_STYLE_FORMATS, AI_STYLE_DEFAULTS.format),
+    emoji_level: pickAiStyleEnum(rec.emoji_level, AI_STYLE_EMOJI_LEVELS, AI_STYLE_DEFAULTS.emoji_level),
+    custom_instructions: typeof rec.custom_instructions === "string"
+      ? rec.custom_instructions.replace(/\s+/g, " ").trim().slice(0, 600)
+      : "",
+  };
+  return {
+    directive: buildAiStyleDirective(fields),
+    ...fields,
+    updated_at: typeof rec.updated_at === "string" ? rec.updated_at : updatedAt ?? new Date().toISOString(),
+    privacy: "style-only",
+  };
+}
+
+async function readAiStylePreferences(
+  supabase: SupabaseClient,
+  apiKeyHash: string,
+): Promise<AiStylePreferencesValue | null> {
+  const { data, error } = await supabase
+    .from("mc_business_context")
+    .select("value, updated_at")
+    .eq("api_key_hash", apiKeyHash)
+    .eq("category", AI_STYLE_CATEGORY)
+    .eq("key", AI_STYLE_KEY)
+    .maybeSingle();
+  if (error) throw error;
+  return data ? normalizeAiStyleValue(data.value, data.updated_at as string | null) : null;
+}
+
 const RELIABILITY_SOURCES = [
   "fishbowl",
   "connectors",
@@ -4460,9 +4594,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const isAdmin = user.email
           ? adminEmails.includes(user.email.toLowerCase())
           : false;
-        const operatorTime = keyRow?.key_hash
-          ? await readOperatorTimeContext(supabase, keyRow.key_hash)
-          : null;
+        const [operatorTime, aiStyle] = keyRow?.key_hash
+          ? await Promise.all([
+              readOperatorTimeContext(supabase, keyRow.key_hash),
+              readAiStylePreferences(supabase, keyRow.key_hash),
+            ])
+          : [null, null];
 
         return res.status(200).json({
           user_id: user.id,
@@ -4474,6 +4611,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           is_admin: isAdmin,
           memory_quota_exempt: isMemoryQuotaExemptEmail(user.email),
           operator_time: operatorTime,
+          ai_style: aiStyle,
         });
       }
 
@@ -4528,6 +4666,43 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           );
         if (error) throw error;
         return res.status(200).json({ success: true, operator_time: value });
+      }
+
+      case "ai_style_update": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+        const keyRow = (await supabase
+          .from("api_keys")
+          .select("key_hash")
+          .eq("user_id", user.id)
+          .maybeSingle()).data as { key_hash: string | null } | null;
+        if (!keyRow?.key_hash) {
+          return res.status(404).json({ error: "No active UnClick key found for this user" });
+        }
+
+        const nowIso = new Date().toISOString();
+        const payload = isRecord(req.body) ? req.body : {};
+        const value = normalizeAiStyleValue({ ...payload, updated_at: nowIso });
+
+        const { error } = await supabase
+          .from("mc_business_context")
+          .upsert(
+            {
+              api_key_hash: keyRow.key_hash,
+              category: AI_STYLE_CATEGORY,
+              key: AI_STYLE_KEY,
+              value,
+              priority: AI_STYLE_PRIORITY,
+              decay_tier: "hot",
+              updated_at: nowIso,
+              last_accessed: nowIso,
+            },
+            { onConflict: "api_key_hash,category,key" },
+          );
+        if (error) throw error;
+        return res.status(200).json({ success: true, ai_style: value });
       }
 
       case "generate_api_key": {

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7917,8 +7917,8 @@
     },
     {
       "source": "src/pages/admin/AdminYou.tsx",
-      "hash": "394d65c7aabb",
-      "bytes": 37346
+      "hash": "958944ecb59f",
+      "bytes": 46440
     },
     {
       "source": "src/pages/AuthCallback.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -89,7 +89,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/testpass/TestPassCatalog.tsx | 8fc76ddd8d3f | 21847 |
 | src/pages/admin/AdminTools.tsx | 8544965a0043 | 8530 |
 | src/pages/admin/AdminUsers.tsx | 701e7da2f201 | 863 |
-| src/pages/admin/AdminYou.tsx | 394d65c7aabb | 37346 |
+| src/pages/admin/AdminYou.tsx | 958944ecb59f | 46440 |
 | src/pages/AuthCallback.tsx | 41644ade9f97 | 5284 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
 | src/pages/Connect.tsx | ebf2c68ad6c3 | 29590 |

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -25,7 +25,7 @@ import {
   AlertTriangle,
   Brain,
   ArrowRight,
-  SlidersHorizontal,
+  Sparkles,
   ShieldCheck,
   Download,
   Upload,
@@ -203,6 +203,93 @@ function formatOperatorLocalTime(timezone: string | null | undefined): string {
   }
 }
 
+// AI Style preferences. These mirror the `preference`/`ai_style` row the
+// backend stores in mc_business_context, which load_memory surfaces as a
+// standing rule at the start of every connected session.
+type AiStyleResponseLength = "brief" | "medium" | "detailed";
+type AiStyleComplexity = "simple" | "analogies" | "standard" | "technical";
+type AiStyleFormat = "prose" | "bullets" | "visual";
+type AiStyleEmojiLevel = "none" | "light" | "expressive";
+
+interface AiStyle {
+  response_length: AiStyleResponseLength;
+  complexity: AiStyleComplexity;
+  format: AiStyleFormat;
+  emoji_level: AiStyleEmojiLevel;
+  custom_instructions: string;
+  directive?: string;
+  updated_at?: string;
+}
+
+const DEFAULT_AI_STYLE: AiStyle = {
+  response_length: "medium",
+  complexity: "analogies",
+  format: "prose",
+  emoji_level: "light",
+  custom_instructions: "",
+};
+
+interface AiStyleAxis {
+  key: "response_length" | "complexity" | "format" | "emoji_level";
+  label: string;
+  hint: string;
+  options: { value: string; label: string; desc: string }[];
+}
+
+const AI_STYLE_AXES: AiStyleAxis[] = [
+  {
+    key: "response_length",
+    label: "Response length",
+    hint: "How much detail by default",
+    options: [
+      { value: "brief", label: "Brief", desc: "Short and to the point" },
+      { value: "medium", label: "Medium", desc: "Balanced" },
+      { value: "detailed", label: "Detailed", desc: "Thorough and complete" },
+    ],
+  },
+  {
+    key: "complexity",
+    label: "Complexity",
+    hint: "Reading level and vocabulary",
+    options: [
+      { value: "simple", label: "Simple English", desc: "Plain words, no jargon" },
+      { value: "analogies", label: "With analogies", desc: "Simple, with comparisons" },
+      { value: "standard", label: "Standard", desc: "Normal level of detail" },
+      { value: "technical", label: "Technical", desc: "Precise and exact" },
+    ],
+  },
+  {
+    key: "format",
+    label: "Format",
+    hint: "How answers are laid out",
+    options: [
+      { value: "prose", label: "Prose", desc: "Flowing paragraphs" },
+      { value: "bullets", label: "Bullets", desc: "Lists and short sections" },
+      { value: "visual", label: "Visual", desc: "Tables, steps, examples" },
+    ],
+  },
+  {
+    key: "emoji_level",
+    label: "Emoji",
+    hint: "Personality in the tone",
+    options: [
+      { value: "none", label: "None", desc: "No emoji" },
+      { value: "light", label: "Light", desc: "A few, where they help" },
+      { value: "expressive", label: "Expressive", desc: "Used freely" },
+    ],
+  },
+];
+
+function aiStyleEquals(a: AiStyle, b: AiStyle): boolean {
+  return (
+    a.response_length === b.response_length &&
+    a.complexity === b.complexity &&
+    a.format === b.format &&
+    a.emoji_level === b.emoji_level &&
+    a.custom_instructions.trim() === b.custom_instructions.trim()
+  );
+}
+
 export default function AdminYou() {
   // Destructure `loading` so the page can wait for the Supabase session
   // restore to resolve before showing a "not signed in" empty state or
@@ -234,6 +321,14 @@ export default function AdminYou() {
   const [exportError, setExportError] = useState<string | null>(null);
   const [importFileName, setImportFileName] = useState<string | null>(null);
   const [importMessage, setImportMessage] = useState<string | null>(null);
+  // `aiStyle` is the working copy edited in the UI; `savedAiStyle` is the last
+  // value persisted to memory, used to detect unsaved changes and to show the
+  // server-built directive that connected agents receive at session start.
+  const [aiStyle, setAiStyle] = useState<AiStyle>(DEFAULT_AI_STYLE);
+  const [savedAiStyle, setSavedAiStyle] = useState<AiStyle | null>(null);
+  const [aiStyleSaving, setAiStyleSaving] = useState(false);
+  const [aiStyleSaved, setAiStyleSaved] = useState(false);
+  const [aiStyleError, setAiStyleError] = useState<string | null>(null);
 
   useEffect(() => {
     setDetectedTimezone(getBrowserTimezone());
@@ -263,6 +358,7 @@ export default function AdminYou() {
           const body = (await profileRes.json()) as ProfileData & {
             generated_api_key?: string | null;
             operator_time?: OperatorTimeContext | null;
+            ai_style?: AiStyle | null;
           };
           setProfile({
             user_id:   body.user_id,
@@ -273,6 +369,11 @@ export default function AdminYou() {
           });
           setOperatorTime(body.operator_time ?? null);
           setTimezoneInput(body.operator_time?.timezone ?? "");
+          if (body.ai_style) {
+            const loaded: AiStyle = { ...DEFAULT_AI_STYLE, ...body.ai_style };
+            setAiStyle(loaded);
+            setSavedAiStyle(loaded);
+          }
           // Two paths land here.
           //
           // 1. Fresh auto-provision on first visit: the backend returns the
@@ -430,6 +531,42 @@ export default function AdminYou() {
     }
   }
 
+  async function saveAiStyle() {
+    if (!session) return;
+    setAiStyleSaving(true);
+    setAiStyleError(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=ai_style_update", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          response_length: aiStyle.response_length,
+          complexity: aiStyle.complexity,
+          format: aiStyle.format,
+          emoji_level: aiStyle.emoji_level,
+          custom_instructions: aiStyle.custom_instructions,
+        }),
+      });
+      const body = (await res.json()) as { ai_style?: AiStyle; error?: string };
+      if (!res.ok || !body.ai_style) {
+        setAiStyleError(body.error ?? "Could not save your AI style.");
+        return;
+      }
+      const next: AiStyle = { ...DEFAULT_AI_STYLE, ...body.ai_style };
+      setAiStyle(next);
+      setSavedAiStyle(next);
+      setAiStyleSaved(true);
+      window.setTimeout(() => setAiStyleSaved(false), 2500);
+    } catch (e) {
+      setAiStyleError((e as Error).message);
+    } finally {
+      setAiStyleSaving(false);
+    }
+  }
+
   async function handleLogout() {
     await signOut();
     navigate("/login", { replace: true });
@@ -499,11 +636,12 @@ export default function AdminYou() {
     operatorTime?.source === "browser" ? "Browser detected" :
     detectedTimezone ? "Browser available" :
     "Not detected";
+  const aiStyleDirty = !savedAiStyle || !aiStyleEquals(aiStyle, savedAiStyle);
   const youSections = [
     { id: "you-profile", label: "Profile", hint: "Identity and time", icon: User },
-    { id: "you-api-key", label: "My API Key", hint: "Access and setup", icon: KeyRound },
+    { id: "you-preferences", label: "AI Style", hint: "Tone and length", icon: Sparkles },
+    { id: "you-api-key", label: "API Key", hint: "Access and setup", icon: KeyRound },
     { id: "you-my-data", label: "My Data", hint: "Export and import", icon: Database },
-    { id: "you-preferences", label: "Preferences", hint: "AI style", icon: SlidersHorizontal },
   ];
 
   return (
@@ -663,33 +801,6 @@ export default function AdminYou() {
             </div>
           </div>
 
-          {/* AI Style card */}
-          <div id="you-preferences" className="scroll-mt-24 rounded-xl border border-white/[0.06] bg-[#111111] p-6">
-            <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
-              <SlidersHorizontal className="h-4 w-4 text-[#E2B93B]" />
-              AI Style
-            </h2>
-            <p className="mt-4 text-sm leading-6 text-[#888]">
-              How UnClick should talk to you. These defaults mirror into Memory Preferences
-              so connected agents can carry the same tone.
-            </p>
-            <div className="mt-4 space-y-2">
-              {[
-                ["Response length", "Medium"],
-                ["Complexity", "Simple with analogies"],
-                ["Emoji level", "Light"],
-              ].map(([label, value]) => (
-                <div key={label} className="flex items-center justify-between rounded-lg bg-white/[0.03] px-3 py-2 text-xs">
-                  <span className="text-[#888]">{label}</span>
-                  <span className="text-white">{value}</span>
-                </div>
-              ))}
-            </div>
-            <p className="mt-4 text-[11px] leading-5 text-[#666]">
-              Editing controls land here first; project-specific overrides can sit beside Project Briefs later.
-            </p>
-          </div>
-
           {/* Access card */}
           <div id="you-api-key" className="scroll-mt-24 rounded-xl border border-white/[0.06] bg-[#111111] p-6">
             <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
@@ -800,6 +911,116 @@ export default function AdminYou() {
                 </p>
               </div>
             )}
+          </div>
+
+          {/* AI Style card */}
+          <div id="you-preferences" className="scroll-mt-24 rounded-xl border border-white/[0.06] bg-[#111111] p-6 xl:col-span-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+                <Sparkles className="h-4 w-4 text-[#E2B93B]" />
+                AI Style
+              </h2>
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-[#61C1C4]">
+                <ShieldCheck className="h-3 w-3" />
+                Applied every session
+              </span>
+            </div>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-[#888]">
+              How UnClick should talk to you. Set it once here. The rules load into Memory and
+              are handed to every connected agent at the start of each session, so you stop having
+              to say "shorter please", "simpler", or "more visual" every time.
+            </p>
+
+            <div className="mt-5 grid gap-5 sm:grid-cols-2">
+              {AI_STYLE_AXES.map((axis) => (
+                <div key={axis.key}>
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-xs font-semibold text-white">{axis.label}</span>
+                    <span className="text-[11px] text-[#666]">{axis.hint}</span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {axis.options.map((opt) => {
+                      const selected = aiStyle[axis.key] === opt.value;
+                      return (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          onClick={() => setAiStyle((s) => ({ ...s, [axis.key]: opt.value } as AiStyle))}
+                          title={opt.desc}
+                          aria-pressed={selected}
+                          className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                            selected
+                              ? "border-[#61C1C4] bg-[#61C1C4]/15 text-white"
+                              : "border-white/[0.08] bg-white/[0.02] text-white/55 hover:bg-white/[0.06] hover:text-white"
+                          }`}
+                        >
+                          {opt.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-5">
+              <div className="flex items-baseline justify-between gap-2">
+                <label htmlFor="ai-style-custom" className="text-xs font-semibold text-white">
+                  Anything else
+                </label>
+                <span className="text-[11px] text-[#666]">{aiStyle.custom_instructions.length}/600</span>
+              </div>
+              <textarea
+                id="ai-style-custom"
+                value={aiStyle.custom_instructions}
+                onChange={(e) => setAiStyle((s) => ({ ...s, custom_instructions: e.target.value.slice(0, 600) }))}
+                rows={2}
+                placeholder="e.g. Australian spelling. Lead with the answer, then the why. Avoid jargon."
+                className="mt-2 w-full resize-none rounded-lg border border-white/[0.08] bg-black/20 px-3 py-2 text-xs leading-5 text-white outline-none transition-colors placeholder:text-white/25 focus:border-[#61C1C4]/50"
+              />
+            </div>
+
+            {savedAiStyle?.directive ? (
+              <div className="mt-5 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
+                  What your agents are told
+                </p>
+                <p className="mt-1.5 text-xs leading-5 text-[#9aa]">{savedAiStyle.directive}</p>
+              </div>
+            ) : null}
+
+            <div className="mt-5 flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={saveAiStyle}
+                disabled={aiStyleSaving || !aiStyleDirty}
+                className="inline-flex items-center gap-2 rounded-md bg-[#61C1C4] px-4 py-2 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:opacity-40"
+              >
+                {aiStyleSaving ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Saving...
+                  </>
+                ) : aiStyleSaved ? (
+                  <>
+                    <Check className="h-3.5 w-3.5" />
+                    Saved
+                  </>
+                ) : (
+                  "Save AI style"
+                )}
+              </button>
+              {aiStyleDirty && !aiStyleSaving ? (
+                <span className="text-[11px] text-[#E2B93B]">Unsaved changes</span>
+              ) : savedAiStyle?.updated_at ? (
+                <span className="text-[11px] text-[#666]">
+                  Saved {timeAgo(savedAiStyle.updated_at)}
+                </span>
+              ) : (
+                <span className="text-[11px] text-[#666]">Not saved yet</span>
+              )}
+            </div>
+            {aiStyleError && <p className="mt-2 text-[11px] text-red-400">{aiStyleError}</p>}
           </div>
 
           {/* My Data card */}


### PR DESCRIPTION
## Why

On `/admin/you`, the **AI Style** section was a hardcoded, read-only display (Response length / Complexity / Emoji level) with no controls. As reported: *"I have no control here to modify anything."* Worse, even if it were editable, the values never reached connected agents, so you keep repeating *"Simple English", "Shorten please", "Less complex", "more visual"* every session.

This makes AI Style a real, persisted control surface **and** wires it into the session entrance so agents actually obey the rules.

## How the rules get reinforced at the entrance

AI style is stored as a single high-priority `preference`/`ai_style` row in `mc_business_context` — the same table the `get_startup_context` RPC reads. `load_memory` surfaces `business_context` to every agent with the standing instruction:

> *"Business context entries are standing rules. Follow them as if the user said them right now."*

So saving here reinforces the rules at **every session entrance** (the UnClick entrance / Launchpad), for every connected agent, with **no MCP-package change required**. The stored value carries a compact imperative `directive` string, kept as the first JSON key so it survives the ~130-char truncation strict/compact clients apply to business-context entries.

## Changes

**Backend — `api/memory-admin.ts`**
- `admin_profile` now returns `ai_style` (read in parallel with operator time).
- New `ai_style_update` action: validates input (enum-clamped, custom instructions whitespace-collapsed and capped), then upserts to `mc_business_context` at priority 99. Tenancy matches `operator_timezone_update` — a user can only write their own key hash.

**Frontend — `src/pages/admin/AdminYou.tsx`**
- Replaced the dead static card with real controls: segmented pickers for **Response length**, **Complexity** (incl. *Simple English*), **Format** (incl. *Visual*), and **Emoji**, plus a free-text "anything else" box.
- Save button with saved / unsaved / last-saved state, and a live preview of the exact directive agents receive ("What your agents are told").
- UX pass: promoted AI Style to a full-width section, reordered the section nav (Profile → AI Style → API Key → My Data) and the top card row, and removed the stale "editing controls land here later" placeholder.

**Tests — `api/memory-admin-ai-style.test.ts`**
- Defaults, enum clamping, input sanitization, directive content, directive-first ordering, and length cap.

## Proof
- `vitest` on the new test + adjacent suites: **51 passed**.
- `eslint` on changed files: no new errors (only pre-existing `set-state-in-effect` warnings in untouched effects).
- `tsc -b`: error count unchanged at 18, all pre-existing and in unrelated files; none in the changed files.

## Notes / follow-ups
- Reinforcement rides on the existing `business_context` standing-rules path. A future enhancement could surface `ai_style` as a dedicated, always-uncompacted field in the startup payload (requires touching `packages/mcp-server/src/memory/` backends) if we want it guaranteed verbatim for strict clients too.

https://claude.ai/code/session_01H12mG3UVSZiXJ5L8KAg2Ug

---
_Generated by [Claude Code](https://claude.ai/code/session_01H12mG3UVSZiXJ5L8KAg2Ug)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated memory-admin writes and business_context standing rules that all connected agents read at session start; scope is bounded by existing operator-time tenancy patterns and input normalization.
> 
> **Overview**
> **AI Style** on `/admin/you` is no longer a static placeholder: operators can set response length, complexity, format, emoji, and free-text instructions, save via `ai_style_update`, and see the server-built directive agents receive.
> 
> The backend persists preferences as a high-priority `preference`/`ai_style` row in `mc_business_context` (same standing-rules path as startup memory). `normalizeAiStyleValue` clamps enums, sanitizes custom text, and builds a compact imperative `directive` as the **first** JSON key so truncation on compact clients still preserves the rules. `admin_profile` returns `ai_style` alongside operator time.
> 
> Vitest coverage was added for defaults, clamping, sanitization, directive content, key ordering, and length caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851dba38a807eb1d97ca63ededaafdb796107686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->