### PR TITLE
feat(seopass): add live receipt envelope

### DIFF
--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/mcp-server/src/seopass-tool.test.ts
+++ b/packages/mcp-server/src/seopass-tool.test.ts
@@ -51,6 +51,11 @@ describe("seopass-tool", () => {
     expect(result.error).toMatch(/http\(s\)/);
   });
 
+  it("rejects blank target SHA values", async () => {
+    const result = (await seopassRun({ url: "https://unclick.world", target_sha: " " })) as { error?: string };
+    expect(result.error).toMatch(/target_sha/);
+  });
+
   it("rejects invalid pack URLs and unsupported check ids before storing", async () => {
     const badUrl = (await seopassRegisterPack({
       pack_yaml: [
@@ -93,12 +98,21 @@ describe("seopass-tool", () => {
       "https://unclick.world/llms.txt": "# UnClick\n> Agent-native tooling.\n\n## Pages\n[Docs](https://unclick.world/docs): Docs.",
     });
 
-    const run = (await seopassRun({ url: "https://unclick.world" })) as {
+    const run = (await seopassRun({ url: "https://unclick.world", target_sha: "seo-sha-123" })) as {
       run_id?: string;
       status?: string;
       pass?: string;
       report?: { mode?: string };
       verdict_summary?: { fail?: number };
+      seopass_receipt_v1?: {
+        kind?: string;
+        status?: string;
+        target_sha?: string;
+        mode?: string;
+        checked?: { total?: number; fail?: number };
+        boundaries?: string[];
+        action_needed?: string[];
+      };
     };
 
     expect(run.status).toBe("complete");
@@ -106,10 +120,25 @@ describe("seopass-tool", () => {
     expect(run.report?.mode).toBe("live-readonly");
     expect(run.verdict_summary?.fail).toBe(0);
     expect(run.run_id).toMatch(/^seopass-/);
+    expect(run.seopass_receipt_v1).toMatchObject({
+      kind: "seopass_receipt_v1",
+      status: "WARN",
+      target_sha: "seo-sha-123",
+      mode: "live-readonly",
+      checked: { fail: 0 },
+    });
+    expect(run.seopass_receipt_v1?.checked?.total).toBeGreaterThan(0);
+    expect(run.seopass_receipt_v1?.boundaries?.join(" ")).toMatch(/does not guarantee rankings/);
+    expect(run.seopass_receipt_v1?.action_needed?.[0]).toContain("aio-freshness-missing");
 
-    const status = (await seopassStatus({ run_id: run.run_id })) as { run_id?: string; status?: string };
+    const status = (await seopassStatus({ run_id: run.run_id })) as {
+      run_id?: string;
+      status?: string;
+      seopass_receipt_v1?: { target_sha?: string };
+    };
     expect(status.run_id).toBe(run.run_id);
     expect(status.status).toBe("complete");
+    expect(status.seopass_receipt_v1?.target_sha).toBe("seo-sha-123");
   });
 
   it("returns a blocker verdict when robots and noindex block search", async () => {

--- a/packages/mcp-server/src/seopass-tool.ts
+++ b/packages/mcp-server/src/seopass-tool.ts
@@ -15,6 +15,7 @@ type SeoPassMcpRun = {
   status: "complete";
   pass: "seopass";
   target_url: string;
+  target_sha?: string;
   generated_at: string;
   search_engine_readiness_score: number;
   verdict: "ready" | "needs-work" | "blocked";
@@ -41,6 +42,37 @@ type SeoPassMcpRun = {
   };
 };
 
+type SeoPassMcpReceipt = {
+  kind: "seopass_receipt_v1";
+  status: "PASS" | "WARN" | "BLOCKER";
+  run_id: string;
+  target_url: string;
+  target_sha?: string;
+  generated_at: string;
+  mode: "live-readonly";
+  score: number;
+  verdict: SeoPassMcpRun["verdict"];
+  checked: {
+    total: number;
+    pass: number;
+    warn: number;
+    fail: number;
+  };
+  evidence_sources: Array<{
+    kind: string;
+    label: string;
+    source_url?: string;
+    summary: string;
+  }>;
+  action_needed: string[];
+  boundaries: string[];
+};
+
+type SeoPassMcpRunResponse = SeoPassMcpRun & {
+  seopass_receipt_v1: SeoPassMcpReceipt;
+  lighthouse_plan?: Record<string, unknown>;
+};
+
 type FetchTextResult = {
   url: string;
   status: number;
@@ -61,7 +93,7 @@ type CanonicalLink = {
   ignoredAttributes: string[];
 };
 
-const RUNS = new Map<string, SeoPassMcpRun>();
+const RUNS = new Map<string, SeoPassMcpRunResponse>();
 const DEFAULT_CHECKS = [
   "lighthouse-performance",
   "crawlability",
@@ -118,9 +150,77 @@ function lighthousePlan(pack: Record<string, unknown>): Record<string, unknown> 
   };
 }
 
+function buildSeoPassReceipt(run: SeoPassMcpRun, targetSha?: string): SeoPassMcpReceipt {
+  return {
+    kind: "seopass_receipt_v1",
+    status: receiptStatus(run),
+    run_id: run.run_id,
+    target_url: run.target_url,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: run.generated_at,
+    mode: "live-readonly",
+    score: run.search_engine_readiness_score,
+    verdict: run.verdict,
+    checked: {
+      total: run.report.checks.length,
+      pass: run.verdict_summary.pass,
+      warn: run.verdict_summary.warn,
+      fail: run.verdict_summary.fail,
+    },
+    evidence_sources: run.report.evidence.map((source) => ({
+      kind: source.kind,
+      label: labelForEvidenceKind(source.kind),
+      source_url: source.source_url,
+      summary: source.summary,
+    })),
+    action_needed: receiptActions(run),
+    boundaries: [
+      "SEOPass reports public read-only search-readiness evidence only.",
+      "SEOPass does not guarantee rankings, indexing, AI Overview placement, or AI citations.",
+      "SEOPass does not mutate sites, submit URLs, use credentials, paid APIs, or private crawler data.",
+    ],
+  };
+}
+
+function receiptStatus(run: SeoPassMcpRun): SeoPassMcpReceipt["status"] {
+  if (run.verdict === "blocked" || run.verdict_summary.fail > 0) return "BLOCKER";
+  if (run.verdict === "needs-work" || run.verdict_summary.warn > 0) return "WARN";
+  return "PASS";
+}
+
+function receiptActions(run: SeoPassMcpRun): string[] {
+  const actions = run.report.checks.flatMap((check) =>
+    check.findings.map((finding) => `${finding.id}: ${finding.recommendation}`),
+  );
+  return Array.from(new Set(actions)).slice(0, 12);
+}
+
+function labelForEvidenceKind(kind: string): string {
+  const labels: Record<string, string> = {
+    "http-response": "HTTP response",
+    "robots-txt": "robots.txt",
+    "robots-policy": "Robots policy",
+    sitemap: "Sitemap",
+    "llms-txt": "llms.txt",
+    "html-head": "HTML head",
+    "page-snapshot": "Page snapshot",
+    canonical: "Canonical signal",
+    "structured-data": "Structured data",
+    "internal-link": "Internal link",
+    lighthouse: "Lighthouse",
+    "geopass-signal": "GEOPass signal",
+    "manual-note": "Manual note",
+  };
+  return labels[kind] ?? kind;
+}
+
 export async function seopassRun(args: Record<string, unknown>): Promise<unknown> {
   const url = typeof args.url === "string" ? args.url : undefined;
   const packName = typeof args.pack_name === "string" ? args.pack_name : undefined;
+  if (args.target_sha !== undefined && (typeof args.target_sha !== "string" || args.target_sha.trim().length === 0)) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  const targetSha = typeof args.target_sha === "string" ? args.target_sha.trim() : undefined;
   if (!url && !packName) return { error: "Either url or pack_name is required" };
 
   const pack = packName ? loadRegisteredPack(packName) : null;
@@ -136,11 +236,14 @@ export async function seopassRun(args: Record<string, unknown>): Promise<unknown
 
   const checkSelection = selectChecks(pack?.checks);
   const run = await runReadonlySeoPass(targetUrl, checkSelection.checks, pack ?? {}, checkSelection.ignored);
-  RUNS.set(run.run_id, run);
-  return {
+  const response: SeoPassMcpRunResponse = {
     ...run,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    seopass_receipt_v1: buildSeoPassReceipt(run, targetSha),
     lighthouse_plan: lighthousePlan({ ...(pack ?? {}), url: targetUrl }),
   };
+  RUNS.set(run.run_id, response);
+  return response;
 }
 
 export async function seopassStatus(args: Record<string, unknown>): Promise<unknown> {

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12438,6 +12438,7 @@ export const ADDITIONAL_TOOLS = [
       properties: {
         url: { type: "string", description: "Target URL for a one-off SEOPass read-only run" },
         pack_name: { type: "string", description: "Name of a registered SEOPass pack; the pack URL is used as the target" },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks" },
       },
     },
   },

--- a/packages/seopass/src/__tests__/schema.test.ts
+++ b/packages/seopass/src/__tests__/schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   SeoPassFindingSchema,
   SeoPassGeoPassAdapterSchema,
+  SeoPassReceiptSchema,
   SeoPassReportSchema,
 } from "../schema.js";
 
@@ -66,5 +67,36 @@ describe("SEOPass schema", () => {
     });
 
     expect(report.checks[0]?.findings).toEqual([]);
+  });
+
+  it("validates a live-readonly receipt envelope", () => {
+    const receipt = SeoPassReceiptSchema.parse({
+      kind: "seopass_receipt_v1",
+      status: "WARN",
+      run_id: "seopass-123",
+      target_url: "https://example.com/",
+      target_sha: "abc123",
+      generated_at: "2026-05-30T13:50:00.000Z",
+      mode: "live-readonly",
+      score: 72,
+      verdict: "needs-work",
+      checked: { total: 3, pass: 1, warn: 2, fail: 0 },
+      evidence_sources: [
+        {
+          kind: "sitemap",
+          label: "Sitemap",
+          source_url: "https://example.com/sitemap.xml",
+          summary: "2 URL(s) found.",
+        },
+      ],
+      action_needed: ["Add missing metadata."],
+      boundaries: [
+        "SEOPass reports public read-only search-readiness evidence only.",
+        "SEOPass does not guarantee rankings, indexing, AI Overview placement, or AI citations.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("seopass_receipt_v1");
+    expect(receipt.target_sha).toBe("abc123");
   });
 });

--- a/packages/seopass/src/schema.ts
+++ b/packages/seopass/src/schema.ts
@@ -115,6 +115,27 @@ export const SeoPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const SeoPassReceiptSchema = z.object({
+  kind: z.literal("seopass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  mode: z.literal("live-readonly"),
+  score: z.number().min(0).max(100),
+  verdict: SeoPassReportVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    pass: z.number().int().min(0),
+    warn: z.number().int().min(0),
+    fail: z.number().int().min(0),
+  }),
+  evidence_sources: z.array(SeoPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export const SeoPassGeoPassAdapterSchema = z.object({
   source: z.literal("geopass"),
   target_url: z.string().url(),
@@ -167,4 +188,5 @@ export type SeoPassCheckResult = z.infer<typeof SeoPassCheckResultSchema>;
 export type SeoPassScannerSource = z.infer<typeof SeoPassScannerSourceSchema>;
 export type SeoPassCrossPassSignal = z.infer<typeof SeoPassCrossPassSignalSchema>;
 export type SeoPassReport = z.infer<typeof SeoPassReportSchema>;
+export type SeoPassReceipt = z.infer<typeof SeoPassReceiptSchema>;
 export type SeoPassGeoPassAdapter = z.infer<typeof SeoPassGeoPassAdapterSchema>;


### PR DESCRIPTION
## Summary
- add a first-class `seopass_receipt_v1` envelope to `seopass_run` and `seopass_status`
- bind optional `target_sha` into the receipt for stale-proof checks
- include live-readonly search-readiness evidence, action-needed items, and public safety boundaries
- keep the shared generated FlowPass/PTV lint blockers green for the cloud Website gate

## Local proof
- `npm run test --workspace=@unclick/seopass`
- `npx vitest run src/seopass-tool.test.ts`
- `npm run build --workspace=@unclick/seopass`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run test --workspace=@unclick/mcp-server`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run build`
- `npm test`

## Safety
- SEOPass remains public read-only.
- No credentials, paid APIs, private crawler data, site mutation, URL submission, or ranking guarantees.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API surface for SEOPass MCP and schema; read-only behavior unchanged aside from stricter optional `target_sha` validation.
> 
> **Overview**
> SEOPass MCP runs now return a **`seopass_receipt_v1`** envelope on **`seopass_run`** and **`seopass_status`**, alongside the existing live-readonly report. The receipt rolls up **PASS / WARN / BLOCKER** status, check counts, labeled evidence sources, deduplicated **action_needed** items from findings, and explicit **boundaries** (read-only scope, no ranking guarantees).
> 
> Optional **`target_sha`** is accepted on run (validated as non-empty when present), echoed on the run payload and receipt, and exposed in MCP tool wiring for staleness checks against a PR/commit.
> 
> The **`@unclick/seopass`** package adds **`SeoPassReceiptSchema`** and tests; the MCP layer builds receipts in **`seopass-tool.ts`** and persists full responses in-session. **`ptv-tool.ts`** attaches **`cause`** on timeout/network errors (small observability tweak).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e69020676be838ae24dfd442af8bed81d7c770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->