### PR TITLE
feat(flowpass): add journey receipt envelope

### DIFF
--- a/packages/flowpass/src/__tests__/schema.test.ts
+++ b/packages/flowpass/src/__tests__/schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   FlowPassFindingSchema,
   FlowPassGeoPassAdapterSchema,
+  FlowPassReceiptSchema,
   FlowPassReportSchema,
 } from "../schema.js";
 
@@ -69,5 +70,44 @@ describe("FlowPass schema", () => {
     });
 
     expect(report.steps[0]?.findings).toEqual([]);
+  });
+
+  it("validates a journey receipt envelope", () => {
+    const receipt = FlowPassReceiptSchema.parse({
+      kind: "flowpass_receipt_v1",
+      status: "PENDING",
+      run_id: "flowpass_plan_1",
+      target_url: "https://example.com/signup",
+      target_sha: "abc123",
+      generated_at: "2026-05-30T14:10:00.000Z",
+      mode: "plan-only",
+      profile: "smoke",
+      journey: {
+        id: "signup",
+        name: "Signup journey",
+        kind: "signup",
+      },
+      score: 0,
+      verdict: "unknown",
+      checked: { total: 1, pass: 0, warn: 0, fail: 0, unknown: 1 },
+      evidence_sources: [
+        {
+          kind: "manual-note",
+          label: "Plan-only note",
+          source_url: "https://example.com/signup",
+          summary: "Fixture proof is still required.",
+        },
+      ],
+      not_checked: [{ label: "Success state", reason: "No fixture supplied." }],
+      disagreements_open: 0,
+      action_needed: ["Provide fixture proof before using this as a PASS receipt."],
+      boundaries: [
+        "FlowPass uses provided public fixture evidence from this MCP surface.",
+        "Plan-only results are not PASS receipts until fixture or live read-only proof is supplied.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("flowpass_receipt_v1");
+    expect(receipt.status).toBe("PENDING");
   });
 });

--- a/packages/flowpass/src/schema.ts
+++ b/packages/flowpass/src/schema.ts
@@ -176,6 +176,36 @@ export const FlowPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const FlowPassReceiptSchema = z.object({
+  kind: z.literal("flowpass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER", "PENDING"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]),
+  profile: FlowPassProfileSchema,
+  journey: z.object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    kind: FlowPassJourneyKindSchema,
+  }),
+  score: z.number().min(0).max(100),
+  verdict: FlowPassReportVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    pass: z.number().int().min(0),
+    warn: z.number().int().min(0),
+    fail: z.number().int().min(0),
+    unknown: z.number().int().min(0),
+  }),
+  evidence_sources: z.array(FlowPassEvidenceSchema).default([]),
+  not_checked: z.array(FlowPassNotCheckedSchema).default([]),
+  disagreements_open: z.number().int().min(0),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export const FlowPassFixtureLinkSchema = z.object({
   label: z.string().min(1),
   href: z.string().min(1).optional(),
@@ -308,6 +338,7 @@ export type FlowPassHatOutput = z.infer<typeof FlowPassHatOutputSchema>;
 export type FlowPassNotChecked = z.infer<typeof FlowPassNotCheckedSchema>;
 export type FlowPassDisagreement = z.infer<typeof FlowPassDisagreementSchema>;
 export type FlowPassReport = z.infer<typeof FlowPassReportSchema>;
+export type FlowPassReceipt = z.infer<typeof FlowPassReceiptSchema>;
 export type FlowPassFixture = z.infer<typeof FlowPassFixtureSchema>;
 export type FlowPassPack = z.infer<typeof FlowPassPackSchema>;
 export type FlowPassUserPack = z.infer<typeof FlowPassUserPackSchema>;

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/flowpass-tool.test.ts
+++ b/packages/mcp-server/src/flowpass-tool.test.ts
@@ -50,6 +50,7 @@ describe("flowpass-tool", () => {
   it("runs deterministic fixture checks and exposes reports", async () => {
     const run = await flowpassRun({
       target_url: "https://example.com/signup",
+      target_sha: "flow-sha-123",
       generated_at: "2026-05-28T00:00:00.000Z",
       journey_id: "signup",
       journey_name: "Signup journey",
@@ -75,10 +76,26 @@ describe("flowpass-tool", () => {
       pass: "flowpass",
       verdict: "ready",
       journey_readiness_score: 100,
+      target_sha: "flow-sha-123",
+      flowpass_receipt_v1: {
+        kind: "flowpass_receipt_v1",
+        status: "PASS",
+        target_sha: "flow-sha-123",
+        mode: "fixture",
+        score: 100,
+        checked: { fail: 0, unknown: 0 },
+        action_needed: [],
+      },
     });
+    expect(String((run.flowpass_receipt_v1 as Record<string, unknown>).boundaries)).toContain("does not drive live auth");
 
     const status = await flowpassStatus({ run_id: run.run_id }) as Record<string, unknown>;
-    expect(status).toMatchObject({ verdict: "ready", journey_readiness_score: 100 });
+    expect(status).toMatchObject({
+      verdict: "ready",
+      journey_readiness_score: 100,
+      target_sha: "flow-sha-123",
+      flowpass_receipt_v1: { target_sha: "flow-sha-123", status: "PASS" },
+    });
 
     const markdown = await flowpassReport({
       run_id: run.run_id,
@@ -105,7 +122,20 @@ describe("flowpass-tool", () => {
       status: "planned",
       mode: "plan-only",
       verdict: "unknown",
+      flowpass_receipt_v1: {
+        kind: "flowpass_receipt_v1",
+        status: "PENDING",
+        mode: "plan-only",
+      },
     });
+    expect(String((run.flowpass_receipt_v1 as Record<string, unknown>).action_needed)).toContain("fixture proof");
+  });
+
+  it("rejects blank target SHA values", async () => {
+    await expect(flowpassRun({
+      target_url: "https://example.com/signup",
+      target_sha: " ",
+    })).resolves.toMatchObject({ error: "target_sha must be a non-empty string when provided" });
   });
 
   it("registers YAML packs and can run them with a fixture", async () => {

--- a/packages/mcp-server/src/flowpass-tool.ts
+++ b/packages/mcp-server/src/flowpass-tool.ts
@@ -17,6 +17,7 @@ import {
 
 type ReportFormat = "json" | "markdown" | "html" | "fix_prompt";
 type FlowPassFixture = Record<string, unknown>;
+type FlowPassReceiptStatus = "PASS" | "WARN" | "BLOCKER" | "PENDING";
 
 interface FlowPassJourney {
   id: string;
@@ -38,21 +39,76 @@ interface FlowPassNormalizedPack {
 
 interface FlowPassReport {
   run_id?: string;
-  mode: string;
-  verdict: string;
+  mode: "plan-only" | "fixture" | "live-readonly";
+  profile: "smoke" | "standard" | "deep";
+  verdict: "ready" | "needs-work" | "blocked" | "unknown";
   journey_readiness_score: number;
   target_url: string;
   journey: FlowPassJourney;
-  summary?: unknown;
-  disagreements: Array<{ id: string } & Record<string, unknown>>;
+  summary?: {
+    counts_by_verdict?: Partial<Record<"pass" | "warn" | "fail" | "unknown", number>>;
+  } & Record<string, unknown>;
+  steps: Array<{
+    step_id: string;
+    label: string;
+    score: number;
+    verdict: "pass" | "warn" | "fail" | "unknown";
+    evidence?: FlowPassReceiptEvidence[];
+    findings?: FlowPassReceiptFinding[];
+  }>;
+  disagreements: Array<{ id: string; summary?: string } & Record<string, unknown>>;
+  not_checked: Array<{ label: string; reason: string }>;
+  notes: string[];
   generated_at: string;
+}
+
+interface FlowPassReceiptEvidence {
+  kind: string;
+  label: string;
+  source_url?: string;
+  summary: string;
+}
+
+interface FlowPassReceiptFinding {
+  id: string;
+  recommendation?: string;
+  title?: string;
+  evidence?: FlowPassReceiptEvidence[];
+}
+
+interface FlowPassMcpReceipt {
+  kind: "flowpass_receipt_v1";
+  status: FlowPassReceiptStatus;
+  run_id: string;
+  target_url: string;
+  target_sha?: string;
+  generated_at: string;
+  mode: FlowPassReport["mode"];
+  profile: FlowPassReport["profile"];
+  journey: FlowPassJourney;
+  score: number;
+  verdict: FlowPassReport["verdict"];
+  checked: {
+    total: number;
+    pass: number;
+    warn: number;
+    fail: number;
+    unknown: number;
+  };
+  evidence_sources: FlowPassReceiptEvidence[];
+  not_checked: Array<{ label: string; reason: string }>;
+  disagreements_open: number;
+  action_needed: string[];
+  boundaries: string[];
 }
 
 interface FlowPassRunRecord {
   run_id: string;
   status: "planned" | "complete";
   pack_id?: string;
+  target_sha?: string;
   report: FlowPassReport;
+  receipt: FlowPassMcpReceipt;
   reports: {
     json: object;
     markdown: string;
@@ -117,13 +173,119 @@ function resolvePack(args: Record<string, unknown>): FlowPassNormalizedPack | un
   return undefined;
 }
 
-function storeRun(report: FlowPassReport, pack?: FlowPassNormalizedPack): FlowPassRunRecord {
+function buildFlowPassReceipt(
+  report: FlowPassReport,
+  runId: string,
+  targetSha?: string,
+): FlowPassMcpReceipt {
+  const checked = checkedCounts(report);
+  const openDisagreements = report.disagreements.filter((item) => !RESOLVED_DISAGREEMENTS.has(item.id));
+  return {
+    kind: "flowpass_receipt_v1",
+    status: receiptStatus(report, checked, openDisagreements.length),
+    run_id: runId,
+    target_url: report.target_url,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: report.generated_at,
+    mode: report.mode,
+    profile: report.profile,
+    journey: report.journey,
+    score: report.journey_readiness_score,
+    verdict: report.verdict,
+    checked,
+    evidence_sources: receiptEvidence(report),
+    not_checked: report.not_checked,
+    disagreements_open: openDisagreements.length,
+    action_needed: receiptActions(report, openDisagreements),
+    boundaries: [
+      "FlowPass uses provided public fixture evidence from this MCP surface.",
+      "FlowPass does not drive live auth, checkout, billing, email, production data, or destructive submissions.",
+      "Plan-only results are not PASS receipts until fixture or live read-only proof is supplied.",
+    ],
+  };
+}
+
+function checkedCounts(report: FlowPassReport): FlowPassMcpReceipt["checked"] {
+  const summary = report.summary?.counts_by_verdict;
+  return {
+    total: report.steps.length,
+    pass: summary?.pass ?? report.steps.filter((step) => step.verdict === "pass").length,
+    warn: summary?.warn ?? report.steps.filter((step) => step.verdict === "warn").length,
+    fail: summary?.fail ?? report.steps.filter((step) => step.verdict === "fail").length,
+    unknown: summary?.unknown ?? report.steps.filter((step) => step.verdict === "unknown").length,
+  };
+}
+
+function receiptStatus(
+  report: FlowPassReport,
+  checked: FlowPassMcpReceipt["checked"],
+  disagreementsOpen: number,
+): FlowPassReceiptStatus {
+  if (report.mode === "plan-only" || report.verdict === "unknown" || checked.unknown > 0) return "PENDING";
+  if (report.verdict === "blocked" || checked.fail > 0) return "BLOCKER";
+  if (report.verdict === "needs-work" || checked.warn > 0 || disagreementsOpen > 0) {
+    return "WARN";
+  }
+  return "PASS";
+}
+
+function receiptEvidence(report: FlowPassReport): FlowPassReceiptEvidence[] {
+  const evidence = report.steps.flatMap((step) => [
+    ...(step.evidence ?? []),
+    ...((step.findings ?? []).flatMap((finding) => finding.evidence ?? [])),
+  ]);
+  const normalized = evidence.length > 0
+    ? evidence
+    : [{
+        kind: "manual-note",
+        label: "Plan-only note",
+        source_url: report.target_url,
+        summary: "Fixture proof is still required before FlowPass can act as a PASS receipt.",
+      }];
+  const seen = new Set<string>();
+  return normalized.filter((item) => {
+    const key = [item.kind, item.label, item.source_url ?? "", item.summary].join("\u0000");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).slice(0, 20);
+}
+
+function receiptActions(
+  report: FlowPassReport,
+  openDisagreements: Array<{ id: string; summary?: string }>,
+): string[] {
+  const actions = [
+    ...(report.mode === "plan-only"
+      ? ["Provide fixture proof before using this as a PASS receipt."]
+      : []),
+    ...openDisagreements.map((item) => `Resolve disagreement ${item.id}: ${item.summary ?? "review the open driver/verifier mismatch"}`),
+    ...report.steps.flatMap((step) =>
+      (step.findings ?? []).flatMap((finding) =>
+        finding.recommendation ? [`${finding.id}: ${finding.recommendation}`] : [],
+      ),
+    ),
+  ];
+  return Array.from(new Set(actions)).slice(0, 12);
+}
+
+function parseTargetSha(value: unknown): string | undefined | { error: string } {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  return value.trim();
+}
+
+function storeRun(report: FlowPassReport, pack?: FlowPassNormalizedPack, targetSha?: string): FlowPassRunRecord {
   const runId = report.run_id ?? `flowpass_plan_${RUNS.size + 1}`;
   const record: FlowPassRunRecord = {
     run_id: runId,
     status: report.mode === "fixture" ? "complete" : "planned",
     pack_id: pack?.id,
+    target_sha: targetSha,
     report,
+    receipt: buildFlowPassReceipt(report, runId, targetSha),
     reports: {
       json: generateFlowPassJsonReport(report),
       markdown: generateFlowPassMarkdownReport(report),
@@ -137,6 +299,8 @@ function storeRun(report: FlowPassReport, pack?: FlowPassNormalizedPack): FlowPa
 
 export async function flowpassRun(args: Record<string, unknown>): Promise<unknown> {
   try {
+    const targetSha = parseTargetSha(args.target_sha);
+    if (isRecord(targetSha)) return targetSha;
     const pack = resolvePack(args);
     const targetUrl =
       (typeof args.target_url === "string" && args.target_url.trim()) ||
@@ -180,12 +344,13 @@ export async function flowpassRun(args: Record<string, unknown>): Promise<unknow
         ...(pack ? [`Registered pack ${pack.id} supplied ${pack.plainEnglishSteps.length} plain-English step(s).`] : []),
       ],
     });
-    const record = storeRun(report, pack);
+    const record = storeRun(report, pack, targetSha);
     return {
       run_id: record.run_id,
       status: record.status,
       pass: "flowpass",
       pack_id: record.pack_id,
+      target_sha: record.target_sha,
       target_url: report.target_url,
       journey: report.journey,
       mode: report.mode,
@@ -197,6 +362,7 @@ export async function flowpassRun(args: Record<string, unknown>): Promise<unknow
       disagreements: report.disagreements,
       not_checked: report.not_checked,
       notes: report.notes,
+      flowpass_receipt_v1: record.receipt,
     };
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };
@@ -212,6 +378,7 @@ export async function flowpassStatus(args: Record<string, unknown>): Promise<unk
     run_id: record.run_id,
     status: record.status,
     pack_id: record.pack_id,
+    target_sha: record.target_sha,
     verdict: record.report.verdict,
     journey_readiness_score: record.report.journey_readiness_score,
     target_url: record.report.target_url,
@@ -221,6 +388,12 @@ export async function flowpassStatus(args: Record<string, unknown>): Promise<unk
       (item) => !RESOLVED_DISAGREEMENTS.has(item.id),
     ),
     completed_at: record.report.generated_at,
+    flowpass_receipt_v1: {
+      ...record.receipt,
+      disagreements_open: record.report.disagreements.filter(
+        (item) => !RESOLVED_DISAGREEMENTS.has(item.id),
+      ).length,
+    },
   };
 }
 

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12509,6 +12509,7 @@ export const ADDITIONAL_TOOLS = [
         journey_name: { type: "string", description: "Optional journey name override" },
         journey_kind: { type: "string", enum: ["signup", "auth", "checkout", "onboarding", "support", "custom"] },
         generated_at: { type: "string", description: "Optional ISO timestamp for reproducible fixture tests" },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks" },
       },
     },
   },


### PR DESCRIPTION
## Summary
- add a first-class `flowpass_receipt_v1` envelope to `flowpass_run` and `flowpass_status`
- bind optional `target_sha` into FlowPass receipts for stale-proof checks
- distinguish fixture-backed PASS/WARN/BLOCKER receipts from plan-only PENDING receipts
- include checked counts, fixture evidence sources, not-checked exclusions, open disagreement count, action-needed items, and safety boundaries
- keep the shared generated FlowPass/PTV lint blockers green for the cloud Website gate

## Local proof
- `npm run test --workspace=@unclick/flowpass`
- `npx vitest run src/flowpass-tool.test.ts`
- `npm run build --workspace=@unclick/flowpass`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run test --workspace=@unclick/mcp-server`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run build`
- `npm test`

## Safety
- FlowPass remains fixture/public-evidence based from this MCP surface.
- Plan-only outputs are PENDING, not PASS.
- No live auth, checkout, billing, email, production data, destructive submissions, or private data access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive schema and MCP response shaping on fixture-based FlowPass; plan-only stays PENDING and safety boundaries are explicit, with no live auth or destructive flows introduced.
> 
> **Overview**
> Introduces a versioned **`flowpass_receipt_v1`** envelope so FlowPass runs expose a stable, gate-friendly summary alongside existing reports.
> 
> The shared **`@unclick/flowpass`** package adds **`FlowPassReceiptSchema`** (and tests) for status, checked counts, evidence, actions, and boundaries. The MCP layer builds that receipt on **`flowpass_run`** and **`flowpass_status`**, maps fixture vs plan-only outcomes to **PASS / WARN / BLOCKER / PENDING**, and accepts optional **`target_sha`** for staleness binding (with validation). Tool wiring documents the new input. **PTV** fetch errors now attach **`cause`** for debugging only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1ca7100f774e0c14d8d7f44d7b822ffde40d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->