### PR TITLE
feat(compliancepass): add readiness receipt envelope

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8317,8 +8317,8 @@
     },
     {
       "source": "packages/mcp-server/src/compliancepass-tool.ts",
-      "hash": "13242448457f",
-      "bytes": 3202
+      "hash": "bedf85b00baa",
+      "bytes": 7342
     },
     {
       "source": "packages/mcp-server/src/convertkit-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -169,7 +169,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/coinmarketcap-tool.ts | b1c5fd280acb | 6892 |
 | packages/mcp-server/src/color-tool.ts | f9aa9c0fec6e | 13643 |
 | packages/mcp-server/src/commonsensepass-tool.ts | bad23b55ea01 | 1995 |
-| packages/mcp-server/src/compliancepass-tool.ts | 13242448457f | 3202 |
+| packages/mcp-server/src/compliancepass-tool.ts | bedf85b00baa | 7342 |
 | packages/mcp-server/src/convertkit-tool.ts | 2f77303a3441 | 8498 |
 | packages/mcp-server/src/copypass-tool.ts | 70d540c397a5 | 31503 |
 | packages/mcp-server/src/crews-tool.ts | 111454c76c0a | 13547 |

--- a/packages/compliancepass/src/__tests__/schema.test.ts
+++ b/packages/compliancepass/src/__tests__/schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { CompliancePassReceiptSchema } from "../schema.js";
+
+describe("CompliancePass schema", () => {
+  it("validates a readiness receipt envelope", () => {
+    const receipt = CompliancePassReceiptSchema.parse({
+      kind: "compliancepass_receipt_v1",
+      status: "WARN",
+      run_id: "compliancepass-20260530141000-abc12345",
+      target_name: "UnClick",
+      target_sha: "abc123",
+      generated_at: "2026-05-30T14:10:00.000Z",
+      valid_until: "2026-06-06T14:10:00.000Z",
+      readiness_score: {
+        value: 82,
+        band: "amber",
+        traffic_light: "yellow",
+        rationale: "Some readiness gaps remain.",
+      },
+      checked: {
+        total: 12,
+        pass: 9,
+        partial: 2,
+        fail: 1,
+        unknown: 0,
+        na: 0,
+        pending: 0,
+      },
+      gap_severity_counts: {
+        critical: 0,
+        high: 1,
+        medium: 2,
+        low: 0,
+        info: 0,
+      },
+      blocking_gap_count: 1,
+      evidence_sources: [
+        {
+          type: "doc",
+          label: "Framework mapping",
+          path: "docs/compliancepass-framework-mapping.md",
+          summary: "Control mapping exists but needs owner proof.",
+        },
+      ],
+      action_needed: ["Close the high-severity readiness gap before claiming green."],
+      boundaries: [
+        "CompliancePass is readiness guidance, not a compliance certification.",
+        "CompliancePass receipts must not expose secrets or private production data.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("compliancepass_receipt_v1");
+    expect(receipt.target_sha).toBe("abc123");
+  });
+});

--- a/packages/compliancepass/src/schema.ts
+++ b/packages/compliancepass/src/schema.ts
@@ -133,6 +133,36 @@ export const CompliancePassReportSchema = z.object({
   disclaimer: z.string().min(1),
 });
 
+export const CompliancePassReceiptSchema = z.object({
+  kind: z.literal("compliancepass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_name: z.string().min(1),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  valid_until: z.string().datetime(),
+  readiness_score: z.object({
+    value: z.number().min(0).max(100),
+    band: CompliancePassBandSchema,
+    traffic_light: z.enum(["green", "yellow", "red", "grey"]),
+    rationale: z.string().min(1),
+  }),
+  checked: z.object({
+    total: z.number().int().nonnegative(),
+    pass: z.number().int().nonnegative(),
+    partial: z.number().int().nonnegative(),
+    fail: z.number().int().nonnegative(),
+    unknown: z.number().int().nonnegative(),
+    na: z.number().int().nonnegative(),
+    pending: z.literal(0),
+  }),
+  gap_severity_counts: CompliancePassGapSeverityCountsSchema,
+  blocking_gap_count: z.number().int().nonnegative(),
+  evidence_sources: z.array(CompliancePassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export type CompliancePassCategoryId = z.infer<typeof CompliancePassCategoryIdSchema>;
 export type CompliancePassStatus = z.infer<typeof CompliancePassStatusSchema>;
 export type CompliancePassSeverity = z.infer<typeof CompliancePassSeveritySchema>;
@@ -143,3 +173,4 @@ export type CompliancePassGapSeverityCounts = z.infer<typeof CompliancePassGapSe
 export type CompliancePassCheck = z.infer<typeof CompliancePassCheckSchema>;
 export type CompliancePassCategory = z.infer<typeof CompliancePassCategorySchema>;
 export type CompliancePassReport = z.infer<typeof CompliancePassReportSchema>;
+export type CompliancePassReceipt = z.infer<typeof CompliancePassReceiptSchema>;

--- a/packages/mcp-server/src/compliancepass-tool.test.ts
+++ b/packages/mcp-server/src/compliancepass-tool.test.ts
@@ -8,31 +8,65 @@ import {
 
 describe("compliancepass-tool", () => {
   it("runs CompliancePass against the local repo and stores the report in-session", async () => {
-    const run = await compliancepassRun({ repo_path: process.cwd(), target_name: "UnClick" }) as {
+    const run = await compliancepassRun({ repo_path: process.cwd(), target_name: "UnClick", target_sha: "compliance-sha-123" }) as {
       run_id?: string;
       status?: string;
       pass?: string;
       product?: string;
+      target_sha?: string;
       summary?: { checks_total?: number; checks_pending?: number };
       readiness_score?: { value?: number };
+      compliancepass_receipt_v1?: {
+        kind?: string;
+        status?: string;
+        target_sha?: string;
+        checked?: { total?: number; pending?: number };
+        blocking_gap_count?: number;
+        evidence_sources?: unknown[];
+        boundaries?: string[];
+      };
     };
 
     expect(run.status).toBe("complete");
     expect(run.pass).toBe("compliancepass");
     expect(run.product).toBe("CompliancePass");
+    expect(run.target_sha).toBe("compliance-sha-123");
     expect(run.run_id).toMatch(/^compliancepass-/);
     expect(run.summary?.checks_total).toBeGreaterThan(10);
     expect(run.summary?.checks_pending).toBe(0);
     expect(run.readiness_score?.value).toBeGreaterThanOrEqual(0);
+    expect(run.compliancepass_receipt_v1).toMatchObject({
+      kind: "compliancepass_receipt_v1",
+      target_sha: "compliance-sha-123",
+      checked: { pending: 0 },
+    });
+    expect(["PASS", "WARN", "BLOCKER"]).toContain(run.compliancepass_receipt_v1?.status);
+    expect(run.compliancepass_receipt_v1?.checked?.total).toBe(run.summary?.checks_total);
+    expect(run.compliancepass_receipt_v1?.evidence_sources?.length).toBeGreaterThan(0);
+    expect(run.compliancepass_receipt_v1?.boundaries?.join(" ")).toMatch(/not a compliance certification/i);
 
-    const status = await compliancepassStatus({ run_id: run.run_id }) as { status?: string; run_id?: string };
+    const status = await compliancepassStatus({ run_id: run.run_id }) as {
+      status?: string;
+      run_id?: string;
+      target_sha?: string;
+      compliancepass_receipt_v1?: { target_sha?: string };
+    };
     expect(status.run_id).toBe(run.run_id);
     expect(status.status).toBe("complete");
+    expect(status.target_sha).toBe("compliance-sha-123");
+    expect(status.compliancepass_receipt_v1?.target_sha).toBe("compliance-sha-123");
 
     const json = await compliancepassReportJson({ run_id: run.run_id }) as { product?: string };
     expect(json.product).toBe("CompliancePass");
 
     const markdown = await compliancepassReportMd({ run_id: run.run_id }) as { markdown?: string };
     expect(markdown.markdown).toMatch(/CompliancePass Report/);
+  });
+
+  it("rejects blank target SHA values", async () => {
+    await expect(compliancepassRun({
+      repo_path: process.cwd(),
+      target_sha: " ",
+    })).resolves.toMatchObject({ error: "target_sha must be a non-empty string when provided" });
   });
 });

--- a/packages/mcp-server/src/compliancepass-tool.ts
+++ b/packages/mcp-server/src/compliancepass-tool.ts
@@ -3,10 +3,44 @@ import { createHash } from "node:crypto";
 import {
   renderCompliancePassMarkdown,
   runCompliancePass,
+  type CompliancePassEvidence,
   type CompliancePassReport,
 } from "./compliancepass/index.js";
 
-const RUNS = new Map<string, CompliancePassReport>();
+type CompliancePassReceiptStatus = "PASS" | "WARN" | "BLOCKER";
+
+interface CompliancePassMcpReceipt {
+  kind: "compliancepass_receipt_v1";
+  status: CompliancePassReceiptStatus;
+  run_id: string;
+  target_name: string;
+  target_sha?: string;
+  generated_at: string;
+  valid_until: string;
+  readiness_score: CompliancePassReport["readiness_score"];
+  checked: {
+    total: number;
+    pass: number;
+    partial: number;
+    fail: number;
+    unknown: number;
+    na: number;
+    pending: 0;
+  };
+  gap_severity_counts: CompliancePassReport["summary"]["gap_severity_counts"];
+  blocking_gap_count: number;
+  evidence_sources: CompliancePassEvidence[];
+  action_needed: string[];
+  boundaries: string[];
+}
+
+interface CompliancePassRunRecord {
+  report: CompliancePassReport;
+  target_sha?: string;
+  receipt: CompliancePassMcpReceipt;
+}
+
+const RUNS = new Map<string, CompliancePassRunRecord>();
 
 function runIdFor(report: CompliancePassReport): string {
   const stamp = report.generated_at.replace(/[^0-9]/g, "").slice(0, 14);
@@ -17,7 +51,93 @@ function runIdFor(report: CompliancePassReport): string {
   return `compliancepass-${stamp}-${digest}`;
 }
 
+function parseTargetSha(value: unknown): string | undefined | { error: string } {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  return value.trim();
+}
+
+function receiptStatus(report: CompliancePassReport): CompliancePassReceiptStatus {
+  if (
+    report.summary.blocking_gap_count > 0 ||
+    report.summary.checks_fail > 0 ||
+    report.readiness_band === "red" ||
+    report.summary.gap_severity_counts.critical > 0 ||
+    report.summary.gap_severity_counts.high > 0
+  ) {
+    return "BLOCKER";
+  }
+  if (
+    report.summary.checks_partial > 0 ||
+    report.summary.checks_unknown > 0 ||
+    report.readiness_band === "amber" ||
+    report.readiness_band === "unknown"
+  ) {
+    return "WARN";
+  }
+  return "PASS";
+}
+
+function buildReceipt(
+  runId: string,
+  report: CompliancePassReport,
+  targetSha?: string,
+): CompliancePassMcpReceipt {
+  return {
+    kind: "compliancepass_receipt_v1",
+    status: receiptStatus(report),
+    run_id: runId,
+    target_name: report.target.name,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: report.generated_at,
+    valid_until: report.valid_until,
+    readiness_score: report.readiness_score,
+    checked: {
+      total: report.summary.checks_total,
+      pass: report.summary.checks_pass,
+      partial: report.summary.checks_partial,
+      fail: report.summary.checks_fail,
+      unknown: report.summary.checks_unknown,
+      na: report.summary.checks_na,
+      pending: report.summary.checks_pending,
+    },
+    gap_severity_counts: report.summary.gap_severity_counts,
+    blocking_gap_count: report.summary.blocking_gap_count,
+    evidence_sources: receiptEvidence(report),
+    action_needed: receiptActions(report),
+    boundaries: [
+      "CompliancePass is readiness guidance, not a compliance certification.",
+      "CompliancePass receipts are evidence summaries and do not replace legal, security, privacy, or compliance review.",
+      "CompliancePass must not expose secrets, local filesystem paths, private production data, or raw sensitive source text.",
+    ],
+  };
+}
+
+function receiptEvidence(report: CompliancePassReport): CompliancePassEvidence[] {
+  const seen = new Set<string>();
+  return [...report.evidence, ...report.gaps.flatMap((gap) => gap.evidence)]
+    .filter((item) => {
+      const key = [item.type, item.label, item.path ?? "", item.summary, item.line ?? ""].join("\u0000");
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, 20);
+}
+
+function receiptActions(report: CompliancePassReport): string[] {
+  const actions = [
+    ...report.next_actions,
+    ...report.gaps.map((gap) => `${gap.id}: ${gap.recommendation}`),
+  ];
+  return Array.from(new Set(actions)).slice(0, 12);
+}
+
 export async function compliancepassRun(args: Record<string, unknown>): Promise<unknown> {
+  const targetSha = parseTargetSha(args.target_sha);
+  if (typeof targetSha === "object") return targetSha;
   const repoPath = typeof args.repo_path === "string" && args.repo_path.trim()
     ? path.resolve(args.repo_path)
     : process.cwd();
@@ -28,13 +148,15 @@ export async function compliancepassRun(args: Record<string, unknown>): Promise<
   try {
     const report = await runCompliancePass({ repoPath, targetName });
     const runId = runIdFor(report);
-    RUNS.set(runId, report);
+    const receipt = buildReceipt(runId, report, targetSha);
+    RUNS.set(runId, { report, target_sha: targetSha, receipt });
     return {
       run_id: runId,
       status: "complete",
       pass: "compliancepass",
       product: report.product,
       legacy_aliases: report.legacy_aliases,
+      target_sha: targetSha,
       readiness_score: report.readiness_score,
       summary: report.summary,
       categories: report.categories.map(
@@ -49,6 +171,7 @@ export async function compliancepassRun(args: Record<string, unknown>): Promise<
       gaps: report.gaps.slice(0, 10),
       next_actions: report.next_actions,
       disclaimer: report.disclaimer,
+      compliancepass_receipt_v1: receipt,
     };
   } catch (err) {
     return {
@@ -61,34 +184,37 @@ export async function compliancepassRun(args: Record<string, unknown>): Promise<
 export async function compliancepassStatus(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  const report = RUNS.get(runId);
-  if (!report) return { error: "run not found", run_id: runId };
+  const record = RUNS.get(runId);
+  if (!record) return { error: "run not found", run_id: runId };
+  const { report } = record;
   return {
     run_id: runId,
     status: "complete",
     pass: "compliancepass",
+    target_sha: record.target_sha,
     readiness_score: report.readiness_score,
     summary: report.summary,
     generated_at: report.generated_at,
+    compliancepass_receipt_v1: record.receipt,
   };
 }
 
 export async function compliancepassReportJson(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  const report = RUNS.get(runId);
-  if (!report) return { error: "run not found", run_id: runId };
-  return report;
+  const record = RUNS.get(runId);
+  if (!record) return { error: "run not found", run_id: runId };
+  return record.report;
 }
 
 export async function compliancepassReportMd(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  const report = RUNS.get(runId);
-  if (!report) return { error: "run not found", run_id: runId };
+  const record = RUNS.get(runId);
+  if (!record) return { error: "run not found", run_id: runId };
   return {
     run_id: runId,
     format: "markdown",
-    markdown: renderCompliancePassMarkdown(report),
+    markdown: renderCompliancePassMarkdown(record.report),
   };
 }

--- a/packages/mcp-server/src/compliancepass/schema.ts
+++ b/packages/mcp-server/src/compliancepass/schema.ts
@@ -133,6 +133,36 @@ export const CompliancePassReportSchema = z.object({
   disclaimer: z.string().min(1),
 });
 
+export const CompliancePassReceiptSchema = z.object({
+  kind: z.literal("compliancepass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_name: z.string().min(1),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  valid_until: z.string().datetime(),
+  readiness_score: z.object({
+    value: z.number().min(0).max(100),
+    band: CompliancePassBandSchema,
+    traffic_light: z.enum(["green", "yellow", "red", "grey"]),
+    rationale: z.string().min(1),
+  }),
+  checked: z.object({
+    total: z.number().int().nonnegative(),
+    pass: z.number().int().nonnegative(),
+    partial: z.number().int().nonnegative(),
+    fail: z.number().int().nonnegative(),
+    unknown: z.number().int().nonnegative(),
+    na: z.number().int().nonnegative(),
+    pending: z.literal(0),
+  }),
+  gap_severity_counts: CompliancePassGapSeverityCountsSchema,
+  blocking_gap_count: z.number().int().nonnegative(),
+  evidence_sources: z.array(CompliancePassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export type CompliancePassCategoryId = z.infer<typeof CompliancePassCategoryIdSchema>;
 export type CompliancePassStatus = z.infer<typeof CompliancePassStatusSchema>;
 export type CompliancePassSeverity = z.infer<typeof CompliancePassSeveritySchema>;
@@ -143,3 +173,4 @@ export type CompliancePassGapSeverityCounts = z.infer<typeof CompliancePassGapSe
 export type CompliancePassCheck = z.infer<typeof CompliancePassCheckSchema>;
 export type CompliancePassCategory = z.infer<typeof CompliancePassCategorySchema>;
 export type CompliancePassReport = z.infer<typeof CompliancePassReportSchema>;
+export type CompliancePassReceipt = z.infer<typeof CompliancePassReceiptSchema>;

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12705,6 +12705,7 @@ export const ADDITIONAL_TOOLS = [
       properties: {
         repo_path: { type: "string", description: "Local repository path to scan. Defaults to the MCP server working directory." },
         target_name: { type: "string", description: "Human-readable target name for the report. Defaults to UnClick." },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks" },
       },
     },
   },


### PR DESCRIPTION
## Summary
- Add a first-class `compliancepass_receipt_v1` envelope to `compliancepass_run` and `compliancepass_status`.
- Preserve safe readiness boundaries: the receipt is readiness guidance, not certification, and does not expose secrets, local paths, private production data, or raw sensitive source text.
- Add optional `target_sha` provenance plus evidence sources, checked counts, blocking gap count, and action-needed fields.
- Refresh the generated Brainmap entry and carry the shared generated-runtime lint gate fix needed by the root job.

## Local proof
- `npm run test --workspace=@unclick/compliancepass`
- `npx vitest run src/compliancepass-tool.test.ts` in `packages/mcp-server`
- `npm run build --workspace=@unclick/compliancepass`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run test --workspace=@unclick/mcp-server`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run build`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how compliance readiness is surfaced to MCP consumers (status semantics and evidence summaries); mitigated by explicit non-certification boundaries and no new secret exposure, but wrong interpretation of PASS/WARN/BLOCKER could affect release decisions.
> 
> **Overview**
> Introduces a **`compliancepass_receipt_v1`** envelope on CompliancePass MCP **`compliancepass_run`** and **`compliancepass_status`**, so callers get a compact, machine-readable readiness outcome instead of only the full report.
> 
> The receipt carries **PASS / WARN / BLOCKER** (derived from gaps, check outcomes, and readiness band), **checked** counts, gap severity and blocking gap counts, deduped **evidence_sources** and **action_needed**, optional **`target_sha`** for provenance/staleness, and fixed **boundaries** stating this is guidance—not certification—and must not leak secrets or sensitive paths. In-session runs now store **report + receipt** together; JSON/markdown report tools still return the full report only.
> 
> **`CompliancePassReceiptSchema`** and a schema test were added in **`@unclick/compliancepass`** (mirrored under **`mcp-server`**). MCP wiring documents optional **`target_sha`** on run. Small unrelated tweaks: **PTV** fetch errors attach **`cause`**, generated **flowpass-runtime** lint header, and Brainmap hash updates for the enlarged compliancepass tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fb55ff4fba062667c3533f937f4ebe1cd07dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->