### PR TITLE
feat(uxpass): add visual evidence receipt

### DIFF
--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -4055,11 +4055,11 @@
     "tools": [
       {
         "name": "uxpass_run",
-        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
+        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, summary, and uxpass_receipt_v1. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The receipt calls out when browser visual snapshots, screenshots, or mobile/desktop proof are missing. The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
       },
       {
         "name": "uxpass_status",
-        "description": "Fetch the status, UX Score, and summary for a UXPass run."
+        "description": "Fetch the status, UX Score, summary, and uxpass_receipt_v1 for a UXPass run."
       },
       {
         "name": "uxpass_report_html",

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -4069,11 +4069,11 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "uxpass_run",
-        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
+        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, summary, and uxpass_receipt_v1. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The receipt calls out when browser visual snapshots, screenshots, or mobile/desktop proof are missing. The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
       },
       {
         "name": "uxpass_status",
-        "description": "Fetch the status, UX Score, and summary for a UXPass run."
+        "description": "Fetch the status, UX Score, summary, and uxpass_receipt_v1 for a UXPass run."
       },
       {
         "name": "uxpass_report_html",

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12348,7 +12348,7 @@ export const ADDITIONAL_TOOLS = [
   // ── uxpass-tool.ts (UI/UX QC, sister to TestPass) ──────────────────────────
   {
     name: "uxpass_run",
-    description: "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry).",
+    description: "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, summary, and uxpass_receipt_v1. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The receipt calls out when browser visual snapshots, screenshots, or mobile/desktop proof are missing. The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry).",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
@@ -12364,12 +12364,13 @@ export const ADDITIONAL_TOOLS = [
           type: "string",
           description: "Client-generated idempotency key (UUIDv5 from thread_id + prompt_hash + time_bucket recommended). Required for safe retry. If omitted, the server creates a fresh row and you lose retry safety; sending the same task_id twice returns the original run_id with was_duplicate=true instead of creating a duplicate.",
         },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks." },
       },
     },
   },
   {
     name: "uxpass_status",
-    description: "Fetch the status, UX Score, and summary for a UXPass run.",
+    description: "Fetch the status, UX Score, summary, and uxpass_receipt_v1 for a UXPass run.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,

--- a/packages/mcp-server/src/uxpass-tool.test.ts
+++ b/packages/mcp-server/src/uxpass-tool.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { uxpassRun, uxpassStatus } from "./uxpass-tool.js";
+
+type ApiHandler = (url: string, init: { body?: unknown }) => Record<string, unknown>;
+
+function installUxPassApi(handler: ApiHandler): Array<{ url: string; body: Record<string, unknown> }> {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown, init?: { body?: unknown }) => {
+    const url = String(input);
+    const body = typeof init?.body === "string"
+      ? JSON.parse(init.body) as Record<string, unknown>
+      : {};
+    calls.push({ url, body });
+    return new Response(JSON.stringify(handler(url, { body })), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }));
+  return calls;
+}
+
+describe("uxpass-tool", () => {
+  beforeEach(() => {
+    vi.stubEnv("UNCLICK_API_KEY", "uc_test_key");
+    vi.stubEnv("UNCLICK_API_URL", "https://unclick.world");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("adds an explicit warning receipt when browser visual evidence is missing", async () => {
+    const calls = installUxPassApi(() => ({
+      run_id: "uxpass-run-1",
+      status: "complete",
+      ux_score: 92,
+      target_url: "https://unclick.world/",
+      stats: { total: 25, pass: 18, fail: 0, na: 7, pass_rate: 1 },
+      was_duplicate: false,
+    }));
+
+    const result = await uxpassRun({
+      url: "https://unclick.world/",
+      target_sha: "abc123",
+    }) as Record<string, unknown>;
+
+    const receipt = result.uxpass_receipt_v1 as Record<string, unknown>;
+    expect(result.target_sha).toBe("abc123");
+    expect(receipt).toMatchObject({
+      kind: "uxpass_receipt_v1",
+      status: "WARN",
+      run_id: "uxpass-run-1",
+      target_url: "https://unclick.world/",
+      target_sha: "abc123",
+      checked: { total: 25, pass: 18, fail: 0, na: 7, finding_count: null },
+      visual_evidence: {
+        browser_snapshot: "missing",
+        screenshot_proof: "unknown",
+        mobile_desktop_coverage: "unknown",
+      },
+    });
+    expect(receipt.action_needed).toEqual(expect.arrayContaining([
+      expect.stringMatching(/browser-backed visual snapshots/i),
+      expect.stringMatching(/mobile and desktop evidence/i),
+      expect.stringMatching(/screenshot proof/i),
+    ]));
+    expect(calls[0].body).toMatchObject({
+      target_url: "https://unclick.world/",
+      pack_slug: "uxpass-core",
+    });
+    expect(calls[0].body).not.toHaveProperty("target_sha");
+  });
+
+  it("retains target SHA and blocks when status exposes findings", async () => {
+    installUxPassApi((url) => {
+      if (url.includes("action=status")) {
+        return {
+          run_id: "uxpass-run-2",
+          status: "complete",
+          ux_score: 74,
+          target_url: "https://unclick.world/admin",
+          finding_count: 2,
+          breakdown: {
+            by_hat: {
+              frontend: { pass: 4, fail: 0, na: 0 },
+              "visual-designer": { pass: 2, fail: 2, na: 0 },
+            },
+          },
+        };
+      }
+      return {
+        run_id: "uxpass-run-2",
+        status: "complete",
+        ux_score: 74,
+        target_url: "https://unclick.world/admin",
+        stats: { total: 8, pass: 6, fail: 2, na: 0, pass_rate: 0.75 },
+      };
+    });
+
+    await uxpassRun({
+      url: "https://unclick.world/admin",
+      target_sha: "head-sha",
+    });
+    const status = await uxpassStatus({ run_id: "uxpass-run-2" }) as Record<string, unknown>;
+    const receipt = status.uxpass_receipt_v1 as Record<string, unknown>;
+
+    expect(status.target_sha).toBe("head-sha");
+    expect(receipt).toMatchObject({
+      kind: "uxpass_receipt_v1",
+      status: "BLOCKER",
+      run_id: "uxpass-run-2",
+      target_sha: "head-sha",
+      checked: { total: 8, pass: 6, fail: 2, na: 0, finding_count: 2 },
+    });
+    expect(receipt.action_needed).toEqual(expect.arrayContaining([
+      expect.stringMatching(/Fix failing UXPass findings/i),
+    ]));
+  });
+
+  it("rejects blank target SHA before calling the API", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await uxpassRun({
+      url: "https://unclick.world/",
+      target_sha: "   ",
+    }) as { error?: string };
+
+    expect(result.error).toMatch(/target_sha must be a non-empty string/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/uxpass-tool.ts
+++ b/packages/mcp-server/src/uxpass-tool.ts
@@ -35,6 +35,42 @@ const REQUIRED_PACK_KEYS = [
   "remediation",
 ] as const;
 
+type UxPassReceiptStatus = "PASS" | "WARN" | "BLOCKER" | "PENDING";
+
+interface UxPassRunContext {
+  target_sha?: string;
+  target_url?: string;
+  receipt?: UxPassMcpReceipt;
+}
+
+interface UxPassMcpReceipt {
+  kind: "uxpass_receipt_v1";
+  status: UxPassReceiptStatus;
+  run_id: string;
+  target_url: string | null;
+  target_sha: string | null;
+  generated_at: string;
+  ux_score: number | null;
+  checked: {
+    total: number | null;
+    pass: number | null;
+    fail: number | null;
+    na: number | null;
+    finding_count: number | null;
+  };
+  visual_evidence: {
+    browser_snapshot: "attached" | "missing" | "unknown";
+    screenshot_proof: "present" | "missing" | "unknown";
+    mobile_desktop_coverage: "covered" | "missing" | "unknown";
+    note: string;
+  };
+  evidence_sources: string[];
+  action_needed: string[];
+  boundaries: string[];
+}
+
+const RUN_CONTEXT = new Map<string, UxPassRunContext>();
+
 function getApiKey(): string {
   const key = process.env.UNCLICK_API_KEY?.trim();
   if (!key) {
@@ -67,6 +103,165 @@ async function callApi(
   return body;
 }
 
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseTargetSha(args: Record<string, unknown>): { value?: string; error?: string } {
+  if (args.target_sha === undefined || args.target_sha === null) return {};
+  if (typeof args.target_sha !== "string" || !args.target_sha.trim()) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  return { value: args.target_sha.trim() };
+}
+
+function checkedStats(body: Record<string, unknown>): UxPassMcpReceipt["checked"] {
+  const stats = recordValue(body.stats);
+  const breakdown = recordValue(body.breakdown);
+  const byHat = recordValue(breakdown.by_hat);
+  const findingCount = numberValue(body.finding_count);
+
+  if (Object.keys(byHat).length > 0) {
+    let pass = 0;
+    let fail = 0;
+    let na = 0;
+    for (const value of Object.values(byHat)) {
+      const row = recordValue(value);
+      pass += numberValue(row.pass) ?? 0;
+      fail += numberValue(row.fail) ?? 0;
+      na += numberValue(row.na) ?? 0;
+    }
+    return { total: pass + fail + na, pass, fail, na, finding_count: findingCount };
+  }
+
+  const total = numberValue(stats.total);
+  const pass = numberValue(stats.pass);
+  const fail = numberValue(stats.fail);
+  const na = numberValue(stats.na);
+  return { total, pass, fail, na, finding_count: findingCount };
+}
+
+function hasScreenshotEvidence(body: Record<string, unknown>): boolean | null {
+  const direct = stringValue(body.screenshot_url) ?? stringValue(body.screenshotUrl);
+  if (direct) return true;
+  const evidence = recordValue(body.evidence);
+  const viewports = Array.isArray(evidence.viewports) ? evidence.viewports : [];
+  if (viewports.some((viewport) => stringValue(recordValue(viewport).screenshot_url))) return true;
+  if (viewports.length > 0) return false;
+  return null;
+}
+
+function viewportCoverage(body: Record<string, unknown>): "covered" | "missing" | "unknown" {
+  const evidence = recordValue(body.evidence);
+  const viewports = Array.isArray(evidence.viewports) ? evidence.viewports : [];
+  const names = new Set(viewports.map((viewport) => stringValue(recordValue(viewport).name)).filter(Boolean));
+  if (names.size === 0) return "unknown";
+  return names.has("mobile") && names.has("desktop") ? "covered" : "missing";
+}
+
+function receiptStatus(body: Record<string, unknown>, checked: UxPassMcpReceipt["checked"]): UxPassReceiptStatus {
+  const status = stringValue(body.status);
+  if (body.error || status === "failed" || status === "budget_exceeded") return "BLOCKER";
+  if (status === "queued" || status === "running") return "PENDING";
+  if ((checked.fail ?? 0) > 0 || (checked.finding_count ?? 0) > 0) return "BLOCKER";
+  if ((checked.na ?? 0) > 0) return "WARN";
+  if (!status || status !== "complete") return "WARN";
+  return "PASS";
+}
+
+function buildUxPassReceipt(
+  body: Record<string, unknown>,
+  context: { runId: string; targetSha?: string; targetUrl?: string },
+): UxPassMcpReceipt {
+  const checked = checkedStats(body);
+  const status = receiptStatus(body, checked);
+  const screenshotEvidence = hasScreenshotEvidence(body);
+  const coverage = viewportCoverage(body);
+  const browserSnapshot = (checked.na ?? 0) > 0 ? "missing" : checked.na === 0 ? "attached" : "unknown";
+  const screenshotProof = screenshotEvidence === true ? "present" : screenshotEvidence === false ? "missing" : "unknown";
+  const actionNeeded: string[] = [];
+
+  if (status === "BLOCKER") {
+    actionNeeded.push("Fix failing UXPass findings before claiming the surface is UX-ready.");
+  }
+  if (status === "PENDING") {
+    actionNeeded.push("Wait for the UXPass run to complete before using this receipt as proof.");
+  }
+  if (browserSnapshot === "missing") {
+    actionNeeded.push("Attach browser-backed visual snapshots so layout, hierarchy, target-size, and contrast checks are not N/A.");
+  }
+  if (coverage !== "covered") {
+    actionNeeded.push("Capture both mobile and desktop evidence before calling the visual critique complete.");
+  }
+  if (screenshotProof !== "present") {
+    actionNeeded.push("Add screenshot proof for UI/UX Boardroom closure or before/after comparison.");
+  }
+  if (!context.targetSha) {
+    actionNeeded.push("Bind the receipt to a target SHA when it is used for PR or release proof.");
+  }
+
+  return {
+    kind: "uxpass_receipt_v1",
+    status,
+    run_id: context.runId,
+    target_url: stringValue(body.target_url) ?? context.targetUrl ?? null,
+    target_sha: context.targetSha ?? null,
+    generated_at: new Date().toISOString(),
+    ux_score: numberValue(body.ux_score),
+    checked,
+    visual_evidence: {
+      browser_snapshot: browserSnapshot,
+      screenshot_proof: screenshotProof,
+      mobile_desktop_coverage: coverage,
+      note: "Fetch-only UXPass checks are useful but do not prove visual polish without browser snapshots and screenshot evidence.",
+    },
+    evidence_sources: [
+      "uxpass_api_response",
+      checked.na !== null ? "uxpass_check_stats" : "uxpass_status_fields",
+      screenshotProof === "present" ? "screenshot_evidence" : "screenshot_required",
+    ],
+    action_needed: Array.from(new Set(actionNeeded)),
+    boundaries: [
+      "UXPass is product UX readiness evidence, not a guarantee that every user path is polished.",
+      "Fetch-only runs do not prove layout, hierarchy, mobile, contrast, or screenshot quality unless browser evidence is attached.",
+      "This receipt must not include secrets, private production data, or local filesystem paths in public comments.",
+    ],
+  };
+}
+
+function attachUxPassReceipt(
+  data: unknown,
+  context: { runId?: string; targetSha?: string; targetUrl?: string },
+): unknown {
+  const body = recordValue(data);
+  const runId = stringValue(body.run_id) ?? context.runId;
+  if (!runId) return data;
+  const prior = RUN_CONTEXT.get(runId);
+  const receipt = buildUxPassReceipt(body, {
+    runId,
+    targetSha: context.targetSha ?? prior?.target_sha,
+    targetUrl: context.targetUrl ?? prior?.target_url,
+  });
+  RUN_CONTEXT.set(runId, {
+    target_sha: receipt.target_sha ?? undefined,
+    target_url: receipt.target_url ?? undefined,
+    receipt,
+  });
+  return {
+    ...body,
+    target_sha: receipt.target_sha,
+    uxpass_receipt_v1: receipt,
+  };
+}
+
 function ensurePacksDir(): void {
   try {
     fs.mkdirSync(PACKS_DIR, { recursive: true });
@@ -83,6 +278,8 @@ export async function uxpassRun(args: Record<string, unknown>): Promise<unknown>
   const url = typeof args.url === "string" ? args.url : undefined;
   const packName = typeof args.pack_name === "string" ? args.pack_name : undefined;
   const taskId = typeof args.task_id === "string" && args.task_id ? args.task_id : undefined;
+  const targetSha = parseTargetSha(args);
+  if (targetSha.error) return { error: targetSha.error };
 
   if (!url && !packName) {
     return { error: "Either url or pack_name is required" };
@@ -108,16 +305,18 @@ export async function uxpassRun(args: Record<string, unknown>): Promise<unknown>
 
   const body: Record<string, unknown> = { target_url: targetUrl, pack_slug: "uxpass-core" };
   if (taskId) body.task_id = taskId;
-  return callApi("?action=start_run", {
+  const response = await callApi("?action=start_run", {
     method: "POST",
     body,
   });
+  return attachUxPassReceipt(response, { targetSha: targetSha.value, targetUrl });
 }
 
 export async function uxpassStatus(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  return callApi(`?action=status&run_id=${encodeURIComponent(runId)}`);
+  const response = await callApi(`?action=status&run_id=${encodeURIComponent(runId)}`);
+  return attachUxPassReceipt(response, { runId });
 }
 
 export async function uxpassReportHtml(args: Record<string, unknown>): Promise<unknown> {


### PR DESCRIPTION
## Summary
- Add `uxpass_receipt_v1` to `uxpass_run` and `uxpass_status`.
- Make fetch-only UXPass runs explicit WARN receipts when browser visual snapshots, screenshot proof, or mobile/desktop evidence are missing.
- Keep target SHA provenance in the MCP receipt for PR/release proof without sending that SHA to the UXPass API.
- Add focused MCP tests for warning receipts, target SHA retention, blocker findings, and invalid SHA rejection.
- Refresh MCP tool discovery and carry the shared generated-runtime lint gate fix needed by the root job.

## Local proof
- `npm run test --workspace=@unclick/uxpass`
- `npx vitest run src/uxpass-tool.test.ts` in `packages/mcp-server`
- `npm run build --workspace=@unclick/uxpass`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run test --workspace=@unclick/mcp-server`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run build`
- `npm test`

## Safety
The receipt does not make fetch-only checks look like visual polish proof. It tells workers to attach browser snapshots, screenshot proof, and mobile/desktop evidence before calling UXPass complete for UI work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> MCP-layer receipt enrichment and docs; no auth or payment paths. In-memory run context is session-scoped like other MCP tools.
> 
> **Overview**
> **UXPass MCP** now returns **`uxpass_receipt_v1`** on **`uxpass_run`** and **`uxpass_status`**, with optional **`target_sha`** on run (validated locally, not sent to the UXPass API). Receipts classify **PASS / WARN / BLOCKER / PENDING**, summarize check stats and **visual_evidence** (browser snapshots, screenshots, mobile/desktop), and list **action_needed** when fetch-only runs lack visual proof or when findings fail.
> 
> Tool descriptions and generated tool indexes are updated. **`ptv-tool`** network/timeout errors now chain **`cause`**. **`flowpass-runtime.ts`** adds an eslint disable for generated bundling. New **`uxpass-tool.test.ts`** covers WARN receipts, SHA retention on status, BLOCKER on findings, and blank SHA rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1dde0f571a6664e8705ce32914de13085376b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->