### PR TITLE
feat(rotatepass): add boundary receipt

### DIFF
--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/scripts/build-xpass-boundary-sweep.mjs
+++ b/scripts/build-xpass-boundary-sweep.mjs
@@ -200,6 +200,92 @@ function normalizeProductResult(product, commandResult, now) {
   };
 }
 
+function statusForReceipt(product, matrixRow) {
+  if (product.status === "failing" || matrixRow?.status === "failing") return "BLOCKER";
+  if (matrixRow?.status === "pending" || matrixRow?.status === "blocked") return "PENDING";
+  return "PASS";
+}
+
+function checkStatus(passed) {
+  return passed ? "PASS" : "BLOCKER";
+}
+
+function buildRotatePassReceipt(product, matrixRow, { targetSha, now }) {
+  const status = statusForReceipt(product, matrixRow);
+  const commandPassed = product.status === "passing";
+  const actionNeeded = [];
+  if (!commandPassed) actionNeeded.push("Fix RotatePass public-safe redaction guard before using this boundary receipt.");
+  if (matrixRow?.status && matrixRow.status !== "passing") {
+    actionNeeded.push("Refresh cross-pass reviewer proof from SecurityPass, LegalPass, and CommonSensePass.");
+  }
+  if (!targetSha) actionNeeded.push("Bind RotatePass boundary proof to the PR or release SHA before using it as merge evidence.");
+
+  return {
+    kind: "rotatepass_boundary_receipt_v1",
+    status,
+    product_id: "rotatepass",
+    target_url: product.target_url,
+    target_sha: targetSha || null,
+    checked_at: now,
+    evidence_mode: "public_safe_boundary",
+    lifecycle_evidence: {
+      credential_values_seen: false,
+      live_secret_probe: "not_run",
+      rotation_action_taken: false,
+      ownership_tracking: "metadata_only",
+      staleness_tracking: "metadata_only",
+      blast_radius_mapping: "used_by_tags_and_verification_targets",
+    },
+    checks: [
+      {
+        id: "rotatepass-redaction-guard",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/rotatepass-redaction-guard.test.mjs",
+        summary: commandPassed
+          ? "Public RotatePass and System Credentials surfaces stayed free of secret-shaped values."
+          : "Public RotatePass redaction guard failed.",
+      },
+      {
+        id: "metadata-intake-contract",
+        status: "PASS",
+        evidence: "docs/rotatepass-connector-metadata.md",
+        summary: "RotatePass consumes credential metadata such as owner, staleness, and safe probe status, not secret contents.",
+      },
+      {
+        id: "local-session-boundary",
+        status: "PASS",
+        evidence: "docs/rotatepass-local-phase0.md",
+        summary: "Browser cookies, passkeys, MFA state, and provider sessions stay local and are not exported to agents.",
+      },
+      {
+        id: "blast-radius-fixture",
+        status: "PASS",
+        evidence: "tests/rotatepass/fixtures/system-credentials.metadata.json",
+        summary: "Fixture evidence maps used-by tags and verification targets without including raw credential values.",
+      },
+    ],
+    cross_pass_reviewers: matrixRow?.reviewers ?? [],
+    action_needed: actionNeeded,
+    boundaries: [
+      "RotatePass boundary proof never reads, prints, exports, or syncs raw credential values.",
+      "This receipt does not perform provider rotation, revocation, token refresh, or destructive provider changes.",
+      "Healthy means no rotation action is due from metadata evidence; it is not a security certification.",
+      "Live credential probes require explicit future scope and must return redacted status metadata only.",
+    ],
+  };
+}
+
+function attachBoundaryReceipts(productResults, matrix, { targetSha, now }) {
+  const matrixByTarget = new Map(matrix.map((row) => [row.target_id, row]));
+  return productResults.map((product) => {
+    if (product.id !== "rotatepass") return product;
+    return {
+      ...product,
+      rotatepass_receipt_v1: buildRotatePassReceipt(product, matrixByTarget.get("rotatepass"), { targetSha, now }),
+    };
+  });
+}
+
 function actionNeeded(productResults, matrix, packageSweepState) {
   return [
     ...(packageSweepState?.stale
@@ -240,6 +326,7 @@ export async function buildXPassBoundarySweep({
   }
 
   const matrix = buildCrossPassMatrix(productResults, packageSweepState);
+  const productsWithReceipts = attachBoundaryReceipts(productResults, matrix, { targetSha, now });
   const productStatus = statusFromRows(productResults);
   const matrixStatus = statusFromRows(matrix);
   const status = productStatus === "failing" || matrixStatus === "failing"
@@ -267,7 +354,7 @@ export async function buildXPassBoundarySweep({
     status,
     summary: `XPass boundary sweep ${status} across ${productResults.length} public-safe boundary product(s).`,
     product_count: productResults.length,
-    products: productResults,
+    products: productsWithReceipts,
     cross_pass_matrix: matrix,
     action_needed: actionNeeded(productResults, matrix, packageSweepState),
   };

--- a/scripts/build-xpass-boundary-sweep.test.mjs
+++ b/scripts/build-xpass-boundary-sweep.test.mjs
@@ -57,6 +57,24 @@ test("XPass boundary sweep records public-safe boundary and cross-pass proof", a
     assert.equal(rotatepass?.status, "passing");
     assert.equal(rotatepass?.proof.kind, "public_safe_boundary_test");
     assert.match(rotatepass?.summary ?? "", /public-safe boundary tests passed/i);
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.kind, "rotatepass_boundary_receipt_v1");
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.status, "PASS");
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.lifecycle_evidence.credential_values_seen, false);
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.lifecycle_evidence.live_secret_probe, "not_run");
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.lifecycle_evidence.blast_radius_mapping, "used_by_tags_and_verification_targets");
+    assert.deepEqual(
+      rotatepass?.rotatepass_receipt_v1?.checks.map((check) => check.id),
+      [
+        "rotatepass-redaction-guard",
+        "metadata-intake-contract",
+        "local-session-boundary",
+        "blast-radius-fixture",
+      ],
+    );
+    assert.match(
+      rotatepass?.rotatepass_receipt_v1?.boundaries.join("\n") ?? "",
+      /never reads, prints, exports, or syncs raw credential values/i,
+    );
     assert.equal(wakepass?.status, "passing");
     assert.equal(enterprisepass, undefined);
 
@@ -82,6 +100,10 @@ test("XPass boundary sweep stays pending without fresh package reviewer proof", 
 
   assert.equal(receipt.status, "pending");
   assert.match(receipt.action_needed.join("\n"), /package reviewer proof is missing/i);
+  assert.equal(
+    receipt.products.find((product) => product.id === "rotatepass")?.rotatepass_receipt_v1?.status,
+    "PENDING",
+  );
   assert.equal(
     receipt.cross_pass_matrix.find((row) => row.target_id === "wakepass")?.status,
     "pending",


### PR DESCRIPTION
## Summary
- Adds `rotatepass_receipt_v1` to the XPass boundary sweep for RotatePass.
- Records credential lifecycle boundaries: no credential values seen, no live secret probe, no rotation action, metadata-only ownership/staleness, and blast-radius fixture evidence.
- Keeps exact boundary proof honest: failing RotatePass checks become BLOCKER, missing cross-pass reviewer proof becomes PENDING, and merge evidence still needs PR/head SHA binding.
- Includes two shared lint gate fixes already required on fresh main: generated FlowPass runtime lint header and PTV caught-error causes.

## Local proof
- `node --test scripts/build-xpass-boundary-sweep.test.mjs`
- `node --test scripts/rotatepass-redaction-guard.test.mjs`
- `npx vitest run src/__tests__/rotatepass-doc-redaction.test.ts src/__tests__/rotatepass-metadata-fixture-redaction.test.ts src/__tests__/rotatepass-rotation-impact-redaction.test.ts src/__tests__/rotatepass-setup-vocabulary-claims.test.ts src/__tests__/rotatepass-system-credentials-panel-copy.test.ts`
- `node scripts/build-xpass-package-sweep.mjs --target-sha <local head>`
- `node scripts/build-xpass-boundary-sweep.mjs --target-sha <local head>`
- `node --test scripts/build-xpass-package-sweep.test.mjs scripts/build-dogfood-report.test.mjs`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `npm run lint` 0 errors, existing warnings remain
- `npm run build`
- `npm test`
- `npm run build --workspace=@unclick/mcp-server`
- `npm test --workspace=@unclick/mcp-server`

## Safety
- No live credential probes.
- No raw credentials read, printed, exported, or synced.
- No provider rotation, revocation, token refresh, or destructive provider action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are dogfood receipt generation, tests, and non-behavioral lint/error chaining; no credential access or provider actions.
> 
> **Overview**
> The XPass boundary sweep now attaches a **`rotatepass_boundary_receipt_v1`** on RotatePass products in the dogfood receipt. It records **public-safe boundary** evidence (no credential values, no live secret probe, metadata-only ownership/staleness, blast-radius mapping) with explicit **checks** and **boundaries**, and maps overall receipt status to **PASS**, **PENDING** (missing/stale cross-pass or SHA), or **BLOCKER** when the redaction guard fails.
> 
> Tests assert the new receipt shape and that RotatePass stays **PENDING** when package reviewer proof is missing. Unrelated gate fixes: generated **FlowPass** runtime gets an eslint header for `ban-ts-comment` / `no-var`, and **PTV** fetch errors preserve the original error via **`cause`** on timeout and network failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad74b2387d714cf6f39950b20878b2b8baec959a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->