### PR TITLE
feat(wakepass): add boundary receipt

### DIFF
--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/scripts/build-xpass-boundary-sweep.mjs
+++ b/scripts/build-xpass-boundary-sweep.mjs
@@ -200,6 +200,100 @@ function normalizeProductResult(product, commandResult, now) {
   };
 }
 
+function statusForReceipt(product, matrixRow) {
+  if (product.status === "failing" || matrixRow?.status === "failing") return "BLOCKER";
+  if (matrixRow?.status === "pending" || matrixRow?.status === "blocked") return "PENDING";
+  return "PASS";
+}
+
+function checkStatus(passed) {
+  return passed ? "PASS" : "BLOCKER";
+}
+
+function buildWakePassReceipt(product, matrixRow, { targetSha, now }) {
+  const status = statusForReceipt(product, matrixRow);
+  const commandPassed = product.status === "passing";
+  const actionNeeded = [];
+  if (!commandPassed) actionNeeded.push("Fix WakePass public-safe ACK, stale reclaim, and liveness guards before using this boundary receipt.");
+  if (matrixRow?.status && matrixRow.status !== "passing") {
+    actionNeeded.push("Refresh cross-pass reviewer proof from TestPass, CommonSensePass, and FlowPass.");
+  }
+  if (!targetSha) actionNeeded.push("Bind WakePass boundary proof to the PR or release SHA before using it as merge evidence.");
+
+  return {
+    kind: "wakepass_boundary_receipt_v1",
+    status,
+    product_id: "wakepass",
+    target_url: product.target_url,
+    target_sha: targetSha || null,
+    checked_at: now,
+    evidence_mode: "public_safe_boundary",
+    lifecycle_evidence: {
+      live_queue_touched: false,
+      live_worker_woken: false,
+      notification_sent: false,
+      route_delivery_attempted: false,
+      secret_values_seen: false,
+      ack_tracking: "fixture_and_schema_only",
+      stale_reclaim_tracking: "fixture_and_schema_only",
+      liveness_tracking: "fixture_and_schema_only",
+    },
+    checks: [
+      {
+        id: "event-wake-router",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/event-wake-router.test.mjs",
+        summary: commandPassed
+          ? "Wake handoffs are classified as ACK-required dispatches with bounded routing metadata."
+          : "Wake event routing boundary failed.",
+      },
+      {
+        id: "pinballwake-ack-ledger",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/pinballwake-ack-ledger-room.test.mjs",
+        summary: commandPassed
+          ? "ACK ledger fixtures keep accepted, blocked, and completed worker states visible."
+          : "ACK ledger boundary failed.",
+      },
+      {
+        id: "pinballwake-stale-reclaim",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/pinballwake-stale-room.test.mjs",
+        summary: commandPassed
+          ? "Stale work fixtures produce explicit reclaim evidence instead of silent healthy claims."
+          : "Stale reclaim boundary failed.",
+      },
+      {
+        id: "worker-liveness-watchdog",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/worker-liveness-watchdog.test.mjs",
+        summary: commandPassed
+          ? "Worker liveness fixtures surface missed check-ins without touching live workers."
+          : "Worker liveness watchdog boundary failed.",
+      },
+    ],
+    cross_pass_reviewers: matrixRow?.reviewers ?? [],
+    action_needed: actionNeeded,
+    boundaries: [
+      "WakePass boundary proof does not touch live queues, wake live workers, send notifications, or call route adapters.",
+      "This receipt uses public-safe fixtures and schemas for ACK, stale reclaim, and liveness evidence.",
+      "Healthy means the boundary fixtures passed; it is not proof that every live worker is awake.",
+      "Live wake attempts require explicit future scope, idempotency keys, rate limits, and redacted route metadata only.",
+    ],
+  };
+}
+
+function attachBoundaryReceipts(productResults, matrix, { targetSha, now }) {
+  const matrixByTarget = new Map(matrix.map((row) => [row.target_id, row]));
+  return productResults.map((product) => {
+    if (product.id !== "wakepass") return product;
+    return {
+      ...product,
+      wakepass_receipt_v1: buildWakePassReceipt(product, matrixByTarget.get("wakepass"), { targetSha, now }),
+    };
+  });
+}
+
 function actionNeeded(productResults, matrix, packageSweepState) {
   return [
     ...(packageSweepState?.stale
@@ -240,6 +334,7 @@ export async function buildXPassBoundarySweep({
   }
 
   const matrix = buildCrossPassMatrix(productResults, packageSweepState);
+  const productsWithReceipts = attachBoundaryReceipts(productResults, matrix, { targetSha, now });
   const productStatus = statusFromRows(productResults);
   const matrixStatus = statusFromRows(matrix);
   const status = productStatus === "failing" || matrixStatus === "failing"
@@ -267,7 +362,7 @@ export async function buildXPassBoundarySweep({
     status,
     summary: `XPass boundary sweep ${status} across ${productResults.length} public-safe boundary product(s).`,
     product_count: productResults.length,
-    products: productResults,
+    products: productsWithReceipts,
     cross_pass_matrix: matrix,
     action_needed: actionNeeded(productResults, matrix, packageSweepState),
   };

--- a/scripts/build-xpass-boundary-sweep.test.mjs
+++ b/scripts/build-xpass-boundary-sweep.test.mjs
@@ -58,6 +58,24 @@ test("XPass boundary sweep records public-safe boundary and cross-pass proof", a
     assert.equal(rotatepass?.proof.kind, "public_safe_boundary_test");
     assert.match(rotatepass?.summary ?? "", /public-safe boundary tests passed/i);
     assert.equal(wakepass?.status, "passing");
+    assert.equal(wakepass?.wakepass_receipt_v1?.kind, "wakepass_boundary_receipt_v1");
+    assert.equal(wakepass?.wakepass_receipt_v1?.status, "PASS");
+    assert.equal(wakepass?.wakepass_receipt_v1?.lifecycle_evidence.live_queue_touched, false);
+    assert.equal(wakepass?.wakepass_receipt_v1?.lifecycle_evidence.live_worker_woken, false);
+    assert.equal(wakepass?.wakepass_receipt_v1?.lifecycle_evidence.route_delivery_attempted, false);
+    assert.deepEqual(
+      wakepass?.wakepass_receipt_v1?.checks.map((check) => check.id),
+      [
+        "event-wake-router",
+        "pinballwake-ack-ledger",
+        "pinballwake-stale-reclaim",
+        "worker-liveness-watchdog",
+      ],
+    );
+    assert.match(
+      wakepass?.wakepass_receipt_v1?.boundaries.join("\n") ?? "",
+      /does not touch live queues, wake live workers, send notifications, or call route adapters/i,
+    );
     assert.equal(enterprisepass, undefined);
 
     const rotatepassMatrix = receipt.cross_pass_matrix.find((row) => row.target_id === "rotatepass");
@@ -83,6 +101,10 @@ test("XPass boundary sweep stays pending without fresh package reviewer proof", 
   assert.equal(receipt.status, "pending");
   assert.match(receipt.action_needed.join("\n"), /package reviewer proof is missing/i);
   assert.equal(
+    receipt.products.find((product) => product.id === "wakepass")?.wakepass_receipt_v1?.status,
+    "PENDING",
+  );
+  assert.equal(
     receipt.cross_pass_matrix.find((row) => row.target_id === "wakepass")?.status,
     "pending",
   );
@@ -107,6 +129,7 @@ test("XPass boundary sweep fails honestly without leaking raw command output", a
     assert.equal(receipt.status, "failing");
     const wakepass = receipt.products.find((product) => product.id === "wakepass");
     assert.equal(wakepass?.status, "failing");
+    assert.equal(wakepass?.wakepass_receipt_v1?.status, "BLOCKER");
     assert.equal(wakepass?.failure_hint, "Process exited with code 17.");
     assert.doesNotMatch(JSON.stringify(receipt), /super-secret|raw-token|stack trace/i);
   } finally {


### PR DESCRIPTION
## Summary
- Adds `wakepass_receipt_v1` to the XPass boundary sweep for WakePass.
- Records public-safe ACK, stale reclaim, liveness, and route-boundary evidence without touching live queues or workers.
- Blocks failed WakePass boundary tests, marks missing cross-pass reviewer proof as pending, and records explicit no-live-wake safety boundaries.
- Includes two shared lint gate fixes already required on fresh main: generated FlowPass runtime lint header and PTV caught-error causes.

## Local proof
- `node --test scripts/build-xpass-boundary-sweep.test.mjs`
- `node --test scripts/event-wake-router.test.mjs scripts/pinballwake-ack-ledger-room.test.mjs scripts/pinballwake-stale-room.test.mjs scripts/worker-liveness-watchdog.test.mjs`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `npm run lint` 0 errors, existing warnings remain
- `npm run build`
- `npm test`
- `npm run build --workspace=@unclick/mcp-server`
- `npm test --workspace=@unclick/mcp-server`

## Safety
- No live queue reads or writes.
- No live worker wake attempts.
- No notifications sent.
- No route adapters called.
- No secrets or credentials touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly public-safe receipt metadata and tests; MCP edits are error chaining and a generated lint comment with no live wake or auth behavior.
> 
> **Overview**
> The XPass boundary sweep now attaches a **`wakepass_receipt_v1`** on WakePass products in the public dogfood receipt. It records **PASS / PENDING / BLOCKER** from boundary test results and cross-pass reviewer freshness, plus fixture-only lifecycle flags (no live queues, workers, notifications, or routes) and four named public-safe checks (wake router, ACK ledger, stale reclaim, liveness watchdog).
> 
> Tests assert receipt shape, pending when package proof is missing, and **BLOCKER** on WakePass test failure without leaking raw output. Minor MCP fixes: PTV fetch errors preserve **`cause`**, and the generated FlowPass runtime picks up a shared lint header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1112c368073a864c67d70151cee501fb3c2653b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->