### PR TITLE
feat(xpass): add admin hub landing

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -7943,8 +7943,8 @@
     },
     {
       "source": "src/pages/admin/AdminYou.tsx",
-      "hash": "b30c93d0430b",
-      "bytes": 49401
+      "hash": "3d0240411971",
+      "bytes": 51024
     },
     {
       "source": "src/pages/AuthCallback.tsx",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,9 +9,9 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 573,
-    "source_manifest": 187,
-    "pages": 78,
+    "inventory": 574,
+    "source_manifest": 188,
+    "pages": 79,
     "tools": 187,
     "rooms": 23,
     "workers": 8
@@ -27,7 +27,7 @@
       "id": "public-surfaces",
       "name": "Public surfaces",
       "meaning": "Public product, docs, marketplace, and user-facing routes.",
-      "count": 31
+      "count": 32
     },
     {
       "id": "tools",
@@ -3482,6 +3482,16 @@
       "tags": []
     },
     {
+      "id": "public-surfaces-public-page-xpass-src-pages-xpass-tsx-xpass",
+      "division": "Public surfaces",
+      "name": "XPass",
+      "kind": "public page",
+      "meaning": "User-facing page for XPass.",
+      "source": "src/pages/XPass.tsx",
+      "route": "/xpass",
+      "tags": []
+    },
+    {
       "id": "rooms-pinballwake-room-ack-ledger-scripts-pinballwake-ack-ledger-room-mjs-no-route",
       "division": "Rooms",
       "name": "ack ledger",
@@ -6290,6 +6300,12 @@
       "Tools",
       "Public tools marketplace entry point.",
       "src/pages/Tools.tsx"
+    ],
+    [
+      "/xpass",
+      "XPass",
+      "User-facing page for XPass.",
+      "src/pages/XPass.tsx"
     ]
   ],
   "inductionRows": [
@@ -7592,8 +7608,8 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "26405e588808",
-      "bytes": 14258
+      "hash": "4347f236822f",
+      "bytes": 14359
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
@@ -8074,6 +8090,11 @@
       "source": "src/pages/Tools.tsx",
       "hash": "1b9bc9d666a7",
       "bytes": 15377
+    },
+    {
+      "source": "src/pages/XPass.tsx",
+      "hash": "96f38c4d74a7",
+      "bytes": 8617
     },
     {
       "source": "scripts/pinballwake-ack-ledger-room.mjs",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 572,
+    "inventory": 573,
     "source_manifest": 187,
     "pages": 78,
     "tools": 187,
@@ -81,7 +81,7 @@
       "id": "modules-and-apps",
       "name": "Modules and apps",
       "meaning": "Apps, packages, and product modules that make up UnClick.",
-      "count": 114
+      "count": 115
     },
     {
       "id": "launch-and-onboarding",
@@ -1938,6 +1938,16 @@
       "kind": "component",
       "meaning": "Account and admin configuration.",
       "source": "src/pages/AdminSettings.tsx",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-component-admin-xpass-hub-src-pages-admin-adminxpasshub-tsx-no-route",
+      "division": "Modules and apps",
+      "name": "Admin XPass Hub",
+      "kind": "component",
+      "meaning": "Admin surface for Admin XPass Hub.",
+      "source": "src/pages/admin/AdminXPassHub.tsx",
       "route": "",
       "tags": []
     },
@@ -7762,8 +7772,8 @@
     },
     {
       "source": "src/pages/admin/AdminEcosystemPages.tsx",
-      "hash": "3a9b7643c7fc",
-      "bytes": 13854
+      "hash": "badf018e0064",
+      "bytes": 12371
     },
     {
       "source": "src/pages/admin/AdminBenchmarks.tsx",
@@ -7972,8 +7982,8 @@
     },
     {
       "source": "src/pages/DogfoodReport.tsx",
-      "hash": "16909fd44b92",
-      "bytes": 16552
+      "hash": "4103b5e68d6c",
+      "bytes": 16693
     },
     {
       "source": "src/pages/FAQPage.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,7 +22,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | a8f64d0da135 | 4873 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | 26405e588808 | 14258 |
+| src/App.tsx | 4347f236822f | 14359 |
 | src/pages/admin/AdminShell.tsx | a5993008255d | 19438 |
 | src/pages/admin/AdminSkills.tsx | 4b5e69217a39 | 14848 |
 | src/lib/skillLibrary.ts | 7d69323f9491 | 10487 |
@@ -119,6 +119,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/tools/Scheduling.tsx | 3e54b020fe15 | 9647 |
 | src/pages/tools/Solve.tsx | 97da18319f81 | 13431 |
 | src/pages/Tools.tsx | 1b9bc9d666a7 | 15377 |
+| src/pages/XPass.tsx | 96f38c4d74a7 | 8617 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
 | scripts/pinballwake-buildbait-room.mjs | 42445fca7b1e | 4811 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |
@@ -206,7 +207,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Division | Meaning | Items |
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 47 |
-| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 31 |
+| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 32 |
 | Tools | MCP and gateway capabilities available to seats. | 187 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
@@ -326,6 +327,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /tools/scheduling | Scheduling | Tool page for Scheduling. | src/pages/tools/Scheduling.tsx |
 | /tools/solve | Solve | Tool page for Solve. | src/pages/tools/Solve.tsx |
 | /tools | Tools | Public tools marketplace entry point. | src/pages/Tools.tsx |
+| /xpass | XPass | User-facing page for XPass. | src/pages/XPass.tsx |
 
 ## Tool Families and Meaning
 
@@ -862,6 +864,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Public surfaces | public page | Tools | Public tools marketplace entry point. | /tools | src/pages/Tools.tsx |
 | Public surfaces | public page | Verify Mfa | User-facing page for Verify Mfa. | /auth/verify-mfa | src/pages/VerifyMfa.tsx |
 | Public surfaces | public page | Vibe Coding | User-facing page for Vibe Coding. | /developers/vibe-coding | src/pages/VibeCoding.tsx |
+| Public surfaces | public page | XPass | User-facing page for XPass. | /xpass | src/pages/XPass.tsx |
 | Rooms | PinballWake room | ack ledger | PinballWake room logic generated from scripts/pinballwake-ack-ledger-room.mjs. | - | scripts/pinballwake-ack-ledger-room.mjs |
 | Rooms | PinballWake room | buildbait | PinballWake room logic generated from scripts/pinballwake-buildbait-room.mjs. | - | scripts/pinballwake-buildbait-room.mjs |
 | Rooms | PinballWake room | close supersede | PinballWake room logic generated from scripts/pinballwake-close-supersede-room.mjs. | - | scripts/pinballwake-close-supersede-room.mjs |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -58,7 +58,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAnalytics.tsx | 8e3ab82ef00f | 10336 |
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 4dadebd9c4aa | 22681 |
-| src/pages/admin/AdminEcosystemPages.tsx | 3a9b7643c7fc | 13854 |
+| src/pages/admin/AdminEcosystemPages.tsx | badf018e0064 | 12371 |
 | src/pages/admin/AdminBenchmarks.tsx | 69eb15aaf438 | 25684 |
 | src/pages/admin/Fishbowl.tsx | 525cfc33fcdc | 33809 |
 | src/pages/admin/AdminBrainmap.tsx | c764ced96836 | 26511 |
@@ -100,7 +100,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Developers.tsx | 9657fd564797 | 19123 |
 | src/pages/Dispatch.tsx | 2cac7e8758d3 | 15470 |
 | src/pages/Docs.tsx | 490548492455 | 18580 |
-| src/pages/DogfoodReport.tsx | 16909fd44b92 | 16552 |
+| src/pages/DogfoodReport.tsx | 4103b5e68d6c | 16693 |
 | src/pages/FAQPage.tsx | 507e1ed5789c | 712 |
 | src/pages/InstallRecover.tsx | 56c822e69817 | 6971 |
 | src/pages/Jobsmith.tsx | 08e9c9874c22 | 61541 |
@@ -215,7 +215,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 119 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 6 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 10 |
-| Modules and apps | Apps, packages, and product modules that make up UnClick. | 114 |
+| Modules and apps | Apps, packages, and product modules that make up UnClick. | 115 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 5 |
 
 ## UnClick Structure
@@ -708,6 +708,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | app | JobSmith | CV, cover-letter, job application, and rules/checklist engine. | /admin/jobsmith | apps/jobsmith/package.json |
 | Modules and apps | automation module | AutoPilotKit | Internal automation bolt-on for proof-first work motion. | - | AUTOPILOT.md |
 | Modules and apps | component | Admin Settings | Account and admin configuration. | - | src/pages/AdminSettings.tsx |
+| Modules and apps | component | Admin XPass Hub | Admin surface for Admin XPass Hub. | - | src/pages/admin/AdminXPassHub.tsx |
 | Modules and apps | component | Arena Home | Arena page for Arena Home. | - | src/pages/arena/ArenaHome.tsx |
 | Modules and apps | component | Arena Leaderboard | Arena page for Arena Leaderboard. | - | src/pages/arena/ArenaLeaderboard.tsx |
 | Modules and apps | component | Arena Problem | Arena page for Arena Problem. | - | src/pages/arena/ArenaProblem.tsx |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -89,7 +89,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/testpass/TestPassCatalog.tsx | 8fc76ddd8d3f | 21847 |
 | src/pages/admin/AdminTools.tsx | 8544965a0043 | 8530 |
 | src/pages/admin/AdminUsers.tsx | 701e7da2f201 | 863 |
-| src/pages/admin/AdminYou.tsx | b30c93d0430b | 49401 |
+| src/pages/admin/AdminYou.tsx | 3d0240411971 | 51024 |
 | src/pages/AuthCallback.tsx | 41644ade9f97 | 5284 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
 | src/pages/Connect.tsx | ebf2c68ad6c3 | 29590 |

--- a/docs/prd/xpass.md
+++ b/docs/prd/xpass.md
@@ -22,6 +22,22 @@ It prevents three sources of drift:
 
 XPass is the conductor that chooses and runs the relevant scoped XPass product checks for a target, then returns one combined receipt with evidence and exclusions.
 
+## Worker default
+
+When an AI worker is building with UnClick, XPass should be top of mind by default. The worker does not wait for the user to name every Pass. It looks at the target, considers the full XPass family, runs every applicable lightweight check, and records every non-applicable product as `N/A` with a plain reason.
+
+If the user names a specific Pass, route directly to that product first. For example, "use CopyPass on this wording" means run CopyPass on the supplied wording. "XPass this PR" means run the XPass conductor and include the full checklist.
+
+Use this simple rule:
+
+1. Building or changing code: consider TestPass, SlopPass, SecurityPass, CommonSensePass, and WakePass.
+2. Changing a screen or user journey: add UXPass and FlowPass.
+3. Changing public pages or product copy: add CopyPass, SEOPass, GEOPass, and LegalPass when claims or policy language are involved.
+4. Copying exact source material: require CopyRoom evidence and wrap it with FidelityPass.
+5. Touching credentials, connectors, compliance posture, or stale ownership: consider RotatePass, CompliancePass, and WakePass.
+
+The goal is not to run expensive checks every time. The goal is that the checklist is always considered, cheap checks run when useful, skipped checks are honest, and improvement signals feed Continuous Improver when the checklist is weak.
+
 ## Naming contract
 
 Use:

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import JobsmithPage from "./pages/Jobsmith.tsx";
 import NewToAIPage from "./pages/NewToAI.tsx";
 import SmartHomePage from "./pages/SmartHome.tsx";
 import InstallRecoverPage from "./pages/InstallRecover.tsx";
+import XPassPage from "./pages/XPass.tsx";
 import DogfoodReportPage from "./pages/DogfoodReport.tsx";
 import LoginPage from "./pages/Login.tsx";
 import SignupPage from "./pages/Signup.tsx";
@@ -223,6 +224,7 @@ const App = () => (
           <Route path="/organiser" element={<OrganiserPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />
           <Route path="/crews" element={<CrewsPage />} />
+          <Route path="/xpass" element={<XPassPage />} />
           <Route path="/dogfood" element={<DogfoodReportPage />} />
           {/* BuildDesk: hidden per Chris 2026-05-28. Developer dispatch surface
               for AI coding workers, paused until the developer marketplace

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,7 +11,7 @@ const PRODUCT_LINKS = [
   { label: "Apps", href: "/tools" },
   { label: "Memory", href: "/memory" },
   { label: "Connections", href: "/admin/keychain" },
-  { label: "XPass", href: "/dogfood" },
+  { label: "XPass", href: "/xpass" },
 ];
 
 const RESOURCES_LINKS = [

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import FadeIn from "@/components/FadeIn";
-import { AppWindow, Brain, Link2, BadgeCheck, ArrowRight } from "lucide-react";
+import { AppWindow, Brain, Link2, BadgeCheck, ArrowRight, Plane } from "lucide-react";
 import { presets } from "@/lib/design-system";
 
 /**
@@ -8,8 +8,8 @@ import { presets } from "@/lib/design-system";
  *
  * Notes (2026-05-28 Apple polish pass):
  *  - All icons are monochrome on a single primary tint. No rainbow.
- *  - Autopilot and the developer marketplace are intentionally not surfaced
- *    as tiles right now (per Chris). They remain in the codebase.
+ *  - AutoPilot is surfaced as the simple work hub, with XPass as its proof layer.
+ *    The developer marketplace remains hidden until that chapter is ready.
  *  - Connections currently points at /admin/keychain to match the Footer.
  *    Promote to a public landing if/when one ships.
  */
@@ -33,8 +33,14 @@ const PRODUCTS = [
     icon: Link2,
   },
   {
+    title: "AutoPilot",
+    description: "The work hub that plans, routes, checks, and proves jobs.",
+    href: "/admin/autopilot",
+    icon: Plane,
+  },
+  {
     title: "XPass",
-    description: "Built-in proof the work was actually done right.",
+    description: "The roadworthy checklist for AI work before it ships.",
     href: "/dogfood",
     icon: BadgeCheck,
   },
@@ -95,7 +101,7 @@ const Hero = () => {
               <h2 className={presets.h2}>The rails your agent plugs into.</h2>
               <p className="mt-3 text-body">
                 One layer that sits behind Claude, ChatGPT, Cursor, and every MCP client.
-                Tools to act. Memory to remember. Connections to sign in. Proof it worked.
+                Tools to act. Memory to remember. Connections to sign in. AutoPilot to move work. XPass to prove it.
               </p>
             </div>
           </FadeIn>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -31,7 +31,7 @@ const Navbar = () => {
   const navLinks = [
     { label: "Apps", href: "/tools" },
     { label: "Memory", href: "/memory" },
-    { label: "XPass", href: "/dogfood" },
+    { label: "XPass", href: "/xpass" },
     { label: "Docs", href: "/docs" },
     { label: "New to AI", href: "/new-to-ai" },
   ];

--- a/src/pages/DogfoodReport.tsx
+++ b/src/pages/DogfoodReport.tsx
@@ -49,6 +49,7 @@ const XPASS_STAGE_STYLES: Record<XPassIndexEntry["stage"], string> = {
   live_gate: "border-border/60 bg-background/50 text-body",
   live_dogfood: "border-border/60 bg-background/50 text-body",
   scope_gated: "border-border/60 bg-background/50 text-body",
+  safe_proof: "border-border/60 bg-background/50 text-body",
   package_ready: "border-border/60 bg-background/50 text-body",
   boundary: "border-border/60 bg-background/50 text-body",
   planned: "border-border/60 bg-background/50 text-body",
@@ -77,10 +78,10 @@ export default function DogfoodReportPage() {
 
   useCanonical("/dogfood");
   useMetaTags({
-    title: "UnClick Dogfood Report - We Run UnClick on UnClick",
-    description: "Public dogfood receipt for UnClick Pass-family checks running against UnClick itself.",
+    title: "UnClick XPass - Public Dogfood Receipt",
+    description: "Simple public receipt for UnClick AutoPilot and the XPass family running checks against UnClick itself.",
     ogTitle: "UnClick Dogfood Report",
-    ogDescription: "We dogfood UnClick on UnClick. Public Pass-family quality receipts.",
+    ogDescription: "UnClick AutoPilot uses XPass like a roadworthy checklist for AI work.",
     ogUrl: "https://unclick.world/dogfood",
   });
 
@@ -125,8 +126,8 @@ export default function DogfoodReportPage() {
                   {report.headline}
                 </h1>
                 <p className="mt-4 max-w-2xl break-words text-lg leading-relaxed text-body">
-                  This page shows the latest Pass-family receipt evidence from checks running
-                  against UnClick itself.
+                  XPass sits under AutoPilot. It is the simple checklist UnClick uses before work is trusted:
+                  what passed, what needs action, what did not apply, and what evidence was used.
                 </p>
                 <a
                   href="/dogfood/latest.json"

--- a/src/pages/XPass.test.tsx
+++ b/src/pages/XPass.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import XPassPage from "./XPass";
+
+vi.mock("@/lib/auth", () => ({
+  useSession: () => ({ session: null }),
+}));
+
+vi.mock("@/components/FadeIn", () => ({
+  default: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+function renderXPassPage() {
+  render(
+    <MemoryRouter initialEntries={["/xpass"]}>
+      <XPassPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("XPassPage", () => {
+  it("explains XPass as the public AutoPilot proof doorway", () => {
+    renderXPassPage();
+
+    expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
+    expect(screen.getByText(/AutoPilot's roadworthy checklist/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View public receipt/i })).toHaveAttribute("href", "/dogfood");
+    expect(screen.getByRole("link", { name: /Open XPass in Admin/i })).toHaveAttribute("href", "/admin/checks");
+    expect(screen.getByRole("heading", { name: "XPass family" })).toBeInTheDocument();
+    expect(screen.getAllByText("UXPass").length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/XPass.tsx
+++ b/src/pages/XPass.tsx
@@ -1,0 +1,219 @@
+import { Link } from "react-router-dom";
+import {
+  ArrowRight,
+  CheckCircle2,
+  CircleMinus,
+  ClipboardCheck,
+  ExternalLink,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import FadeIn from "@/components/FadeIn";
+import { useCanonical } from "@/hooks/use-canonical";
+import { useMetaTags } from "@/hooks/useMetaTags";
+import { dogfoodReport } from "@/data/dogfoodReport";
+
+const HERO_ROWS = [
+  {
+    label: "Target named",
+    status: "PASS",
+    comment: "The work says what it is checking before it starts.",
+  },
+  {
+    label: "Checks selected",
+    status: "PASS",
+    comment: "Relevant XPass products run, and skipped products get an honest reason.",
+  },
+  {
+    label: "Evidence linked",
+    status: "PASS",
+    comment: "Receipts point at tests, PRs, screenshots, ledgers, or safe proof.",
+  },
+  {
+    label: "Not in scope",
+    status: "N/A",
+    comment: "N/A means considered and not relevant, not forgotten.",
+  },
+];
+
+const USE_CASES = [
+  {
+    title: "Code or PR",
+    products: "TestPass, SecurityPass, SlopPass, CommonSensePass",
+    note: "Use when work needs build proof, safe security evidence, code-quality review, and stale-green protection.",
+  },
+  {
+    title: "Screen or journey",
+    products: "UXPass, FlowPass, CopyPass, SEOPass, GEOPass",
+    note: "Use when a page, form, onboarding path, or public surface needs to be clear and finishable.",
+  },
+  {
+    title: "Copy or exact source",
+    products: "CopyPass, FidelityPass, LegalPass",
+    note: "Use when wording, claims, prompts, labels, or source material must be clear, honest, or copied exactly.",
+  },
+  {
+    title: "Keys or policy",
+    products: "SecurityPass, RotatePass, LegalPass, CompliancePass",
+    note: "Use when credentials, auth, privacy, trust wording, or readiness claims are in the work.",
+  },
+];
+
+function StatusTag({ status }: { status: string }) {
+  const isPass = status === "PASS";
+  const Icon = isPass ? CheckCircle2 : CircleMinus;
+
+  return (
+    <span
+      className={`inline-flex min-h-6 min-w-[68px] items-center justify-center gap-1 rounded-full border px-2 text-[11px] font-semibold ${
+        isPass
+          ? "border-primary/35 bg-primary/10 text-primary"
+          : "border-border bg-background/70 text-muted-custom"
+      }`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {status}
+    </span>
+  );
+}
+
+export default function XPassPage() {
+  useCanonical("/xpass");
+  useMetaTags({
+    title: "UnClick XPass - AutoPilot's Roadworthy Checklist",
+    description: "XPass is the simple UnClick checklist that proves AI work before it ships.",
+    ogTitle: "UnClick XPass",
+    ogDescription: "AutoPilot uses XPass like a roadworthy checklist for AI work.",
+    ogUrl: "https://unclick.world/xpass",
+  });
+
+  const products = dogfoodReport.xpassIndex;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar />
+
+      <main className="overflow-hidden">
+        <section className="px-4 pt-28 sm:px-6">
+          <div className="mx-auto flex min-h-[72svh] max-w-5xl flex-col justify-center">
+            <FadeIn>
+              <div className="inline-flex items-center gap-2 self-start rounded-full border border-primary/30 bg-primary/10 px-4 py-1.5 text-xs font-medium text-primary">
+                <ClipboardCheck className="h-3.5 w-3.5" />
+                UnClick / AutoPilot / XPass
+              </div>
+            </FadeIn>
+
+            <FadeIn delay={0.05}>
+              <h1 className="mt-8 max-w-3xl text-5xl font-semibold tracking-tight text-heading sm:text-6xl">
+                XPass
+              </h1>
+              <p className="mt-5 max-w-3xl text-lg leading-8 text-body sm:text-xl">
+                XPass is AutoPilot's roadworthy checklist for AI work. It checks the work, records what passed,
+                explains what did not apply, and keeps the proof easy to read.
+              </p>
+            </FadeIn>
+
+            <FadeIn delay={0.1}>
+              <div className="mt-8 flex flex-wrap gap-3">
+                <Link
+                  to="/admin/checks"
+                  className="inline-flex min-h-11 items-center gap-2 rounded-md bg-primary px-5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+                >
+                  Open XPass in Admin
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  to="/dogfood"
+                  className="inline-flex min-h-11 items-center gap-2 rounded-md border border-border bg-background/70 px-5 text-sm font-medium text-heading transition-colors hover:bg-card"
+                >
+                  View public receipt
+                  <ExternalLink className="h-4 w-4" />
+                </Link>
+              </div>
+            </FadeIn>
+
+            <FadeIn delay={0.15}>
+              <div className="mt-10 overflow-hidden rounded-lg border border-border bg-card/40">
+                {HERO_ROWS.map((row) => (
+                  <div
+                    key={row.label}
+                    className="grid gap-3 border-b border-border px-4 py-3 last:border-b-0 sm:grid-cols-[180px_86px_minmax(0,1fr)] sm:items-center"
+                  >
+                    <p className="text-sm font-medium text-heading">{row.label}</p>
+                    <StatusTag status={row.status} />
+                    <p className="text-sm leading-6 text-body">{row.comment}</p>
+                  </div>
+                ))}
+              </div>
+            </FadeIn>
+          </div>
+        </section>
+
+        <section className="border-y border-border bg-card/25 px-4 py-16 sm:px-6">
+          <div className="mx-auto max-w-5xl">
+            <div className="max-w-2xl">
+              <div className="flex items-center gap-2">
+                <Sparkles className="h-4 w-4 text-primary" />
+                <h2 className="text-sm font-semibold text-heading">How it chooses checks</h2>
+              </div>
+              <p className="mt-3 text-sm leading-7 text-body">
+                XPass does not ask people to remember every product name. Tell AutoPilot what the work is, and XPass
+                decides which checks belong in the receipt.
+              </p>
+            </div>
+
+            <div className="mt-8 grid gap-3 md:grid-cols-2">
+              {USE_CASES.map((useCase) => (
+                <div key={useCase.title} className="rounded-lg border border-border bg-background/70 p-4">
+                  <p className="text-base font-semibold text-heading">{useCase.title}</p>
+                  <p className="mt-2 text-xs font-medium text-primary">{useCase.products}</p>
+                  <p className="mt-3 text-sm leading-6 text-body">{useCase.note}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-4 py-16 sm:px-6">
+          <div className="mx-auto max-w-5xl">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <div className="flex items-center gap-2">
+                  <ShieldCheck className="h-4 w-4 text-primary" />
+                  <h2 className="text-sm font-semibold text-heading">XPass family</h2>
+                </div>
+                <p className="mt-3 max-w-2xl text-sm leading-7 text-body">
+                  Each product owns one kind of check. XPass ties them together into one readable receipt.
+                </p>
+              </div>
+              <Link
+                to="/dogfood"
+                className="inline-flex min-h-8 items-center gap-1.5 text-sm font-medium text-primary transition-opacity hover:opacity-80"
+              >
+                Latest public proof
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+
+            <div className="mt-8 overflow-hidden rounded-lg border border-border">
+              {products.map((product) => (
+                <div
+                  key={product.id}
+                  className="grid gap-2 border-b border-border bg-card/20 px-4 py-3 last:border-b-0 sm:grid-cols-[180px_160px_minmax(0,1fr)] sm:items-center"
+                >
+                  <p className="text-sm font-medium text-heading">{product.name}</p>
+                  <p className="text-xs text-muted-custom">{product.label}</p>
+                  <p className="text-sm leading-6 text-body">{product.summary}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import AdminXPassHub from "./AdminXPassHub";
 import {
   AppWindow,
   Archive,
@@ -24,7 +25,6 @@ import {
   SearchCheck,
   ShieldCheck,
   Tags,
-  UserCheck,
   Users,
   Wrench,
 } from "lucide-react";
@@ -204,29 +204,7 @@ export function AdminTodoList() {
 }
 
 export function AdminChecks() {
-  return (
-    <PageShell
-      kicker="Proof and quality checks"
-      title="XPass"
-      subtitle="XPass is the proof product line. It proves work with receipts instead of relying on a worker saying 'done'."
-    >
-      <TileGrid
-        items={[
-          { title: "TestPass", body: "Functional and regression proof.", icon: ClipboardCheck, href: "/admin/testpass" },
-          { title: "UXPass", body: "User experience and interface checks.", icon: UserCheck },
-          { title: "SecurityPass", body: "Security and protected-surface checks.", icon: ShieldCheck },
-          { title: "LegalPass", body: "Legal/compliance wording and risk checks.", icon: FileText },
-          { title: "CopyPass", body: "Writing, messaging, and copy quality checks.", icon: FileText, href: "/admin/copypass" },
-          { title: "FidelityPass", body: "Exact-copy proof wrapper for CopyRoom receipts.", icon: ClipboardCheck },
-          { title: "SEOPass", body: "Search visibility and metadata checks.", icon: SearchCheck },
-          { title: "SlopPass", body: "AI-code quality, slop signals, and maintainability checks.", icon: BadgeCheck },
-          { title: "CommonSensePass", body: "Sanity checks for status, proof, and readiness claims.", icon: BadgeCheck },
-          { title: "CompliancePass", body: "Compliance posture and enterprise-readiness checks.", icon: ShieldCheck },
-          { title: "RotatePass", body: "Passport rotation checks, likely folding into SecurityPass later.", icon: KeyRound },
-        ]}
-      />
-    </PageShell>
-  );
+  return <AdminXPassHub />;
 }
 
 export function AdminLedger() {

--- a/src/pages/admin/AdminXPassHub.test.tsx
+++ b/src/pages/admin/AdminXPassHub.test.tsx
@@ -18,6 +18,7 @@ describe("AdminXPassHub", () => {
     expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
     expect(screen.getByText(/AutoPilot's roadworthy check/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Reports" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Guided run planner" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Checklist" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /All XPass/i })).toBeInTheDocument();
     expect(screen.getAllByText("FidelityPass").length).toBeGreaterThan(0);
@@ -40,5 +41,16 @@ describe("AdminXPassHub", () => {
 
     expect(screen.getByText(/Only applies when the target includes exact source text/i)).toBeInTheDocument();
     expect(screen.getAllByText("Copy and source fidelity").length).toBeGreaterThan(0);
+  });
+
+  it("guides a run from a plain-English target", () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole("button", { name: /Screen or journey/i }));
+
+    expect(screen.getByText(/Capture desktop and mobile proof/i)).toBeInTheDocument();
+    expect(screen.getAllByText("UXPass").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("FlowPass").length).toBeGreaterThan(0);
+    expect(screen.getByText(/N\/A means the check was considered/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/AdminXPassHub.test.tsx
+++ b/src/pages/admin/AdminXPassHub.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import AdminXPassHub from "./AdminXPassHub";
+
+function renderHub() {
+  render(
+    <MemoryRouter>
+      <AdminXPassHub />
+    </MemoryRouter>,
+  );
+}
+
+describe("AdminXPassHub", () => {
+  it("shows the suite landing page with checklist and reports", () => {
+    renderHub();
+
+    expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
+    expect(screen.getByText(/AutoPilot's roadworthy check/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Reports" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Checklist" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /All XPass/i })).toBeInTheDocument();
+    expect(screen.getAllByText("FidelityPass").length).toBeGreaterThan(0);
+  });
+
+  it("filters the checklist to one product", () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole("button", { name: /CopyPass/i }));
+
+    expect(screen.getAllByText("Is the wording clear?").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Use on hero copy/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open CopyPass/i })).toHaveAttribute("href", "/admin/copypass");
+  });
+
+  it("switches report context from the report ledger", () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy and source fidelity/i }));
+
+    expect(screen.getByText(/Only applies when the target includes exact source text/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Copy and source fidelity").length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/admin/AdminXPassHub.tsx
+++ b/src/pages/admin/AdminXPassHub.tsx
@@ -12,6 +12,7 @@ import {
   KeyRound,
   LayoutList,
   MessagesSquare,
+  PlayCircle,
   RefreshCw,
   SearchCheck,
   ShieldCheck,
@@ -53,6 +54,23 @@ type ChecklistRow = {
   product: ProductDetail;
   status: XPassStatus;
   comment: string;
+};
+
+type RunTemplate = {
+  id: string;
+  title: string;
+  target: string;
+  passIds: string[];
+  notApplicableIds: string[];
+  firstAction: string;
+};
+
+type ImprovementRow = {
+  id: string;
+  productId: string;
+  signal: string;
+  nextAction: string;
+  proof: string;
 };
 
 const PRODUCT_ORDER = [
@@ -244,6 +262,65 @@ const REPORTS: ReportRow[] = [
   },
 ];
 
+const GUIDED_RUNS: RunTemplate[] = [
+  {
+    id: "code-pr",
+    title: "Code or PR",
+    target: "Pull request, MCP tool, backend change, or release.",
+    passIds: ["testpass", "securitypass", "sloppass", "commonsensepass"],
+    notApplicableIds: ["fidelitypass"],
+    firstAction: "Run XPass on the PR head, then compare every receipt to the current SHA.",
+  },
+  {
+    id: "screen-flow",
+    title: "Screen or journey",
+    target: "Admin page, public page, form, signup, or onboarding path.",
+    passIds: ["uxpass", "flowpass", "copypass", "seopass", "geopass", "commonsensepass"],
+    notApplicableIds: ["fidelitypass", "rotatepass"],
+    firstAction: "Capture desktop and mobile proof, then leave a plain checklist comment.",
+  },
+  {
+    id: "copy-source",
+    title: "Copy or exact source",
+    target: "Wording, table, label, prompt, supplied text, or source material.",
+    passIds: ["copypass", "fidelitypass", "legalpass", "commonsensepass"],
+    notApplicableIds: ["uxpass", "rotatepass"],
+    firstAction: "Use CopyRoom when exact copying is in scope, then wrap the receipt with FidelityPass.",
+  },
+  {
+    id: "keys-policy",
+    title: "Keys or policy",
+    target: "Credentials, auth, privacy, compliance, public claims, or trust wording.",
+    passIds: ["securitypass", "rotatepass", "legalpass", "compliancepass", "commonsensepass"],
+    notApplicableIds: ["fidelitypass"],
+    firstAction: "Prove redaction boundaries first, then keep compliance and legal language guidance-only.",
+  },
+];
+
+const IMPROVEMENT_QUEUE: ImprovementRow[] = [
+  {
+    id: "ux-visual-depth",
+    productId: "uxpass",
+    signal: "Visual critique needs stronger hierarchy and mobile judgment.",
+    nextAction: "Add annotated reports and recurring visual proof that does not clog the queue.",
+    proof: "UXPass closure item",
+  },
+  {
+    id: "na-reasons",
+    productId: "fidelitypass",
+    signal: "N/A rows must explain why exact copying was not in scope.",
+    nextAction: "Keep the FidelityPass wrapper tied to CopyRoom receipts and explicit N/A reasons.",
+    proof: "FidelityPass receipt wrapper",
+  },
+  {
+    id: "stale-green",
+    productId: "commonsensepass",
+    signal: "Green-looking work can still be stale, proofless, or out of scope.",
+    nextAction: "Keep stale receipt and proofless DONE checks near every XPass run.",
+    proof: "CommonSensePass worker exposure",
+  },
+];
+
 function statusFromDogfood(status: DogfoodStatus): XPassStatus {
   if (status === "passing") return "PASS";
   if (status === "failing" || status === "blocked") return "BLOCKER";
@@ -381,15 +458,140 @@ function ChecklistRows({ rows }: { rows: ChecklistRow[] }) {
   );
 }
 
+function ProductNameList({
+  ids,
+  productsById,
+}: {
+  ids: string[];
+  productsById: Map<string, ProductDetail>;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ids.map((id) => {
+        const product = productsById.get(id);
+        if (!product) return null;
+
+        return (
+          <span
+            key={id}
+            className="inline-flex min-h-7 items-center rounded-full border border-white/[0.08] bg-black/20 px-2.5 text-xs font-medium text-white/65"
+          >
+            {product.name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function GuidedRunPlanner({
+  activeRun,
+  productsById,
+  onSelectRun,
+}: {
+  activeRun: RunTemplate;
+  productsById: Map<string, ProductDetail>;
+  onSelectRun: (runId: string) => void;
+}) {
+  return (
+    <section className="rounded-lg border border-white/[0.08] bg-[#111] p-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <PlayCircle className="h-4 w-4 text-[#61C1C4]" />
+            <h2 className="text-sm font-semibold text-white">Guided run planner</h2>
+          </div>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
+            Pick what you are building. XPass shows the checks to run, the checks to mark N/A, and the first proof step.
+          </p>
+        </div>
+        <Link
+          to="/admin/testpass/new"
+          className="inline-flex min-h-8 shrink-0 items-center gap-1.5 text-sm font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
+        >
+          Open guided run
+          <ExternalLink className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-4">
+        {GUIDED_RUNS.map((run) => (
+          <button
+            key={run.id}
+            type="button"
+            aria-pressed={run.id === activeRun.id}
+            onClick={() => onSelectRun(run.id)}
+            className={`min-h-[78px] rounded-lg border px-3 py-3 text-left transition-colors ${
+              run.id === activeRun.id
+                ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
+                : "border-white/[0.06] bg-black/20 hover:border-white/15 hover:bg-white/[0.03]"
+            }`}
+          >
+            <p className="text-sm font-semibold text-white">{run.title}</p>
+            <p className="mt-1 line-clamp-2 text-xs leading-5 text-white/50">{run.target}</p>
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(220px,0.6fr)]">
+        <div className="rounded-lg border border-white/[0.06] bg-black/20 p-4">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-white/35">Run these</p>
+          <div className="mt-3">
+            <ProductNameList ids={activeRun.passIds} productsById={productsById} />
+          </div>
+          <p className="mt-4 text-sm leading-6 text-white/55">{activeRun.firstAction}</p>
+        </div>
+        <div className="rounded-lg border border-white/[0.06] bg-black/20 p-4">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-white/35">Mark N/A now</p>
+          <div className="mt-3">
+            <ProductNameList ids={activeRun.notApplicableIds} productsById={productsById} />
+          </div>
+          <p className="mt-4 text-xs leading-5 text-white/45">
+            N/A means the check was considered and honestly does not fit this target.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ImprovementQueue({ productsById }: { productsById: Map<string, ProductDetail> }) {
+  return (
+    <div className="mt-5 overflow-hidden rounded-lg border border-[#E2B93B]/20">
+      {IMPROVEMENT_QUEUE.map((row) => {
+        const product = productsById.get(row.productId);
+
+        return (
+          <div
+            key={row.id}
+            className="grid gap-2 border-b border-[#E2B93B]/15 bg-black/15 px-3 py-2.5 text-sm last:border-b-0 md:grid-cols-[140px_minmax(0,1fr)_minmax(0,1fr)_150px] md:items-center"
+          >
+            <p className="font-medium text-white">{product?.name ?? row.productId}</p>
+            <p className="text-xs leading-5 text-[#e8dca8]">{row.signal}</p>
+            <p className="text-xs leading-5 text-[#e8dca8]/75">{row.nextAction}</p>
+            <p className="text-xs text-white/45">{row.proof}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function AdminXPassHub() {
   const [activeProductId, setActiveProductId] = useState<string>("all");
   const [activeReportId, setActiveReportId] = useState<string>(REPORTS[0].id);
+  const [activeRunId, setActiveRunId] = useState<string>(GUIDED_RUNS[0].id);
 
   const products = useMemo(
     () => PRODUCT_ORDER.map((id) => PRODUCT_DETAILS[id]).filter(Boolean),
     [],
   );
+  const productsById = useMemo(
+    () => new Map(products.map((product) => [product.id, product])),
+    [products],
+  );
   const activeReport = REPORTS.find((report) => report.id === activeReportId) ?? REPORTS[0];
+  const activeRun = GUIDED_RUNS.find((run) => run.id === activeRunId) ?? GUIDED_RUNS[0];
   const xpassIndexById = new Map(dogfoodReport.xpassIndex.map((entry) => [entry.id, entry]));
   const filteredProducts = activeProductId === "all"
     ? products
@@ -479,6 +681,12 @@ export default function AdminXPassHub() {
           ))}
         </div>
       </section>
+
+      <GuidedRunPlanner
+        activeRun={activeRun}
+        productsById={productsById}
+        onSelectRun={setActiveRunId}
+      />
 
       <section className="space-y-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
@@ -575,6 +783,7 @@ export default function AdminXPassHub() {
             </p>
           </div>
         </div>
+        <ImprovementQueue productsById={productsById} />
       </section>
     </div>
   );

--- a/src/pages/admin/AdminXPassHub.tsx
+++ b/src/pages/admin/AdminXPassHub.tsx
@@ -1,0 +1,581 @@
+import { useMemo, useState, type ComponentType } from "react";
+import { Link } from "react-router-dom";
+import {
+  BadgeCheck,
+  CheckCircle2,
+  CircleMinus,
+  ClipboardCheck,
+  Clock3,
+  ExternalLink,
+  FileText,
+  GitPullRequest,
+  KeyRound,
+  LayoutList,
+  MessagesSquare,
+  RefreshCw,
+  SearchCheck,
+  ShieldCheck,
+  Sparkles,
+  UserCheck,
+  Workflow,
+  XCircle,
+} from "lucide-react";
+import {
+  dogfoodReport,
+  type DogfoodPassResult,
+  type DogfoodStatus,
+  type XPassIndexEntry,
+} from "@/data/dogfoodReport";
+
+type XPassStatus = "PASS" | "BLOCKER" | "N/A" | "NOT RUN" | "MISSING";
+
+type ProductDetail = {
+  id: string;
+  name: string;
+  short: string;
+  plain: string;
+  useWhen: string;
+  href?: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+type ReportRow = {
+  id: string;
+  title: string;
+  date: string;
+  status: XPassStatus;
+  note: string;
+  productIds: string[];
+};
+
+type ChecklistRow = {
+  id: string;
+  product: ProductDetail;
+  status: XPassStatus;
+  comment: string;
+};
+
+const PRODUCT_ORDER = [
+  "testpass",
+  "uxpass",
+  "securitypass",
+  "copypass",
+  "fidelitypass",
+  "legalpass",
+  "sloppass",
+  "commonsensepass",
+  "seopass",
+  "geopass",
+  "flowpass",
+  "rotatepass",
+  "wakepass",
+  "compliancepass",
+] as const;
+
+const PRODUCT_DETAILS: Record<string, ProductDetail> = {
+  testpass: {
+    id: "testpass",
+    name: "TestPass",
+    short: "Does it work?",
+    plain: "Checks the build, tool, or workflow behaves the way it says it does.",
+    useWhen: "Use on PRs, MCP tools, releases, and anything that needs functional proof.",
+    href: "/admin/testpass",
+    icon: ClipboardCheck,
+  },
+  uxpass: {
+    id: "uxpass",
+    name: "UXPass",
+    short: "Is it easy to use?",
+    plain: "Checks screens, flows, mobile fit, hierarchy, clarity, and polish.",
+    useWhen: "Use on admin pages, public pages, onboarding, forms, and product changes.",
+    icon: UserCheck,
+  },
+  securitypass: {
+    id: "securitypass",
+    name: "SecurityPass",
+    short: "Is it safe enough?",
+    plain: "Checks safe security evidence without exposing secrets or running unsafe probes.",
+    useWhen: "Use on auth, keys, connectors, APIs, protected routes, and risky changes.",
+    icon: ShieldCheck,
+  },
+  copypass: {
+    id: "copypass",
+    name: "CopyPass",
+    short: "Is the wording clear?",
+    plain: "Checks copy, claims, tone, trust, and AI-slop risk.",
+    useWhen: "Use on hero copy, emails, product text, pricing, ads, docs, and support wording.",
+    href: "/admin/copypass",
+    icon: FileText,
+  },
+  fidelitypass: {
+    id: "fidelitypass",
+    name: "FidelityPass",
+    short: "Was it copied exactly?",
+    plain: "Wraps CopyRoom proof when wording, labels, prompts, or tables must match 1:1.",
+    useWhen: "Use when the job asks for exact copying, transcription, mirroring, or preservation.",
+    icon: BadgeCheck,
+  },
+  legalpass: {
+    id: "legalpass",
+    name: "LegalPass",
+    short: "Is the risk language honest?",
+    plain: "Checks policy, terms, disclaimers, and legal-risk wording as guidance, not legal advice.",
+    useWhen: "Use on terms, privacy, claims, disclaimers, and regulated-sounding promises.",
+    icon: FileText,
+  },
+  sloppass: {
+    id: "sloppass",
+    name: "SlopPass",
+    short: "Is the code sloppy?",
+    plain: "Checks AI-code smells, maintainability risk, stale diffs, and public code quality signals.",
+    useWhen: "Use on PR diffs, generated code, rushed patches, and quality-review requests.",
+    icon: SearchCheck,
+  },
+  commonsensepass: {
+    id: "commonsensepass",
+    name: "CommonSensePass",
+    short: "Does the claim make sense?",
+    plain: "Stops false green lights, proofless DONE claims, stale receipts, and noisy health claims.",
+    useWhen: "Use before healthy, quiet, done, merge-ready, PASS, or no-work claims.",
+    icon: MessagesSquare,
+  },
+  seopass: {
+    id: "seopass",
+    name: "SEOPass",
+    short: "Can search read it?",
+    plain: "Checks metadata, crawl basics, public page readiness, and search-result clarity.",
+    useWhen: "Use on public pages, metadata, sitemap, robots, docs, and launch pages.",
+    icon: SearchCheck,
+  },
+  geopass: {
+    id: "geopass",
+    name: "GEOPass",
+    short: "Can answer engines understand it?",
+    plain: "Checks AI-search readability, structured context, and answer-engine handoff quality.",
+    useWhen: "Use on public pages that need to be understood by AI assistants and answer engines.",
+    icon: Sparkles,
+  },
+  flowpass: {
+    id: "flowpass",
+    name: "FlowPass",
+    short: "Can the user finish the path?",
+    plain: "Checks journeys, handoffs, forms, onboarding, and completion evidence.",
+    useWhen: "Use on sign-up, checkout, setup, job flow, admin flow, and handoff paths.",
+    icon: Workflow,
+  },
+  rotatepass: {
+    id: "rotatepass",
+    name: "RotatePass",
+    short: "Are credentials handled cleanly?",
+    plain: "Checks rotation hygiene and redaction boundaries without touching real secrets.",
+    useWhen: "Use on Passport, keys, connector hygiene, and credential lifecycle work.",
+    icon: KeyRound,
+  },
+  wakepass: {
+    id: "wakepass",
+    name: "WakePass",
+    short: "Will someone act on it?",
+    plain: "Checks stale work, missed ACKs, owner handoff, and action-needed routing.",
+    useWhen: "Use when proof needs an owner, a schedule misses, or a receipt goes stale.",
+    icon: Clock3,
+  },
+  compliancepass: {
+    id: "compliancepass",
+    name: "CompliancePass",
+    short: "Is the readiness story sensible?",
+    plain: "Checks compliance posture and enterprise-readiness evidence without claiming certification.",
+    useWhen: "Use on enterprise, audit, readiness, policy, and future-regret reviews.",
+    icon: ShieldCheck,
+  },
+};
+
+const STATUS_STYLE: Record<XPassStatus, { label: string; classes: string; icon: ComponentType<{ className?: string }> }> = {
+  PASS: {
+    label: "PASS",
+    classes: "border-[#61C1C4]/35 bg-[#61C1C4]/10 text-[#9edfe1]",
+    icon: CheckCircle2,
+  },
+  BLOCKER: {
+    label: "BLOCKER",
+    classes: "border-red-500/35 bg-red-500/10 text-red-300",
+    icon: XCircle,
+  },
+  "N/A": {
+    label: "N/A",
+    classes: "border-white/15 bg-white/[0.04] text-white/55",
+    icon: CircleMinus,
+  },
+  "NOT RUN": {
+    label: "NOT RUN",
+    classes: "border-[#E2B93B]/35 bg-[#E2B93B]/10 text-[#f1d878]",
+    icon: Clock3,
+  },
+  MISSING: {
+    label: "MISSING",
+    classes: "border-orange-400/35 bg-orange-400/10 text-orange-200",
+    icon: XCircle,
+  },
+};
+
+const REPORTS: ReportRow[] = [
+  {
+    id: "public-dogfood",
+    title: "Public dogfood receipt",
+    date: "Latest public run",
+    status: statusFromDogfood(dogfoodReport.status),
+    note: "Reads the public dogfood receipt and keeps the suite honest about what actually ran.",
+    productIds: [...PRODUCT_ORDER],
+  },
+  {
+    id: "pr-backed-sweep",
+    title: "PR-backed XPass sweep",
+    date: "May 30, 2026",
+    status: "NOT RUN",
+    note: "Recent product receipts are PR-ready and cloud-green; final main verdict waits until those PRs land.",
+    productIds: ["securitypass", "copypass", "legalpass", "seopass", "geopass", "flowpass", "uxpass", "rotatepass", "wakepass", "compliancepass"],
+  },
+  {
+    id: "source-copy",
+    title: "Copy and source fidelity",
+    date: "On demand",
+    status: "N/A",
+    note: "Only applies when the target includes exact source text, tables, labels, prompts, or wording.",
+    productIds: ["copypass", "fidelitypass", "commonsensepass"],
+  },
+];
+
+function statusFromDogfood(status: DogfoodStatus): XPassStatus {
+  if (status === "passing") return "PASS";
+  if (status === "failing" || status === "blocked") return "BLOCKER";
+  return "NOT RUN";
+}
+
+function formatStage(entry?: XPassIndexEntry): string {
+  if (!entry) return "Package-ready";
+  return entry.label;
+}
+
+function findDogfoodResult(productId: string): DogfoodPassResult | undefined {
+  return dogfoodReport.results.find((result) => result.id === productId);
+}
+
+function commentFor(product: ProductDetail, report: ReportRow): string {
+  if (product.id === "fidelitypass" && report.id !== "source-copy") {
+    return "Not applicable unless exact 1:1 copying is in scope.";
+  }
+
+  const result = findDogfoodResult(product.id);
+  if (result?.summary) return result.summary;
+
+  return product.plain;
+}
+
+function statusFor(productId: string, report: ReportRow): XPassStatus {
+  if (!report.productIds.includes(productId)) return "N/A";
+  if (productId === "fidelitypass" && report.id !== "source-copy") return "N/A";
+  if (report.id === "source-copy") return productId === "fidelitypass" ? "N/A" : "NOT RUN";
+
+  const result = findDogfoodResult(productId);
+  return result ? statusFromDogfood(result.status) : report.status;
+}
+
+function StatusPill({ status }: { status: XPassStatus }) {
+  const style = STATUS_STYLE[status];
+  const Icon = style.icon;
+
+  return (
+    <span className={`inline-flex min-w-[86px] items-center justify-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold ${style.classes}`}>
+      <Icon className="h-3.5 w-3.5" />
+      {style.label}
+    </span>
+  );
+}
+
+function ReportButton({
+  report,
+  selected,
+  onClick,
+}: {
+  report: ReportRow;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={onClick}
+      className={`w-full rounded-lg border px-3 py-3 text-left transition-colors ${
+        selected
+          ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
+          : "border-white/[0.06] bg-[#111] hover:border-white/15 hover:bg-white/[0.03]"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-white">{report.title}</p>
+          <p className="mt-0.5 text-xs text-white/45">{report.date}</p>
+        </div>
+        <StatusPill status={report.status} />
+      </div>
+      <p className="mt-2 text-xs leading-5 text-white/50">{report.note}</p>
+    </button>
+  );
+}
+
+function ProductTab({
+  product,
+  selected,
+  onClick,
+}: {
+  product: ProductDetail;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const Icon = product.icon;
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={onClick}
+      className={`min-h-[72px] rounded-lg border px-3 py-3 text-left transition-colors ${
+        selected
+          ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
+          : "border-white/[0.06] bg-[#111] hover:border-white/15 hover:bg-white/[0.03]"
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <Icon className="h-4 w-4 shrink-0 text-[#61C1C4]" />
+        <span className="truncate text-sm font-semibold text-white">{product.name}</span>
+      </div>
+      <p className="mt-1 line-clamp-2 text-xs leading-5 text-white/50">{product.short}</p>
+    </button>
+  );
+}
+
+function ChecklistRows({ rows }: { rows: ChecklistRow[] }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-white/[0.08]">
+      {rows.map((row) => {
+        const Icon = row.product.icon;
+
+        return (
+          <div
+            key={row.id}
+            className="grid min-h-12 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-2 border-b border-white/[0.06] bg-[#0f0f0f] px-3 py-2.5 text-sm last:border-b-0 sm:grid-cols-[minmax(150px,0.75fr)_96px_minmax(0,1.35fr)] sm:items-center"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <Icon className="h-4 w-4 shrink-0 text-white/45" />
+              <div className="min-w-0">
+                <p className="truncate font-medium text-white">{row.product.name}</p>
+                <p className="truncate text-xs text-white/40">{row.product.short}</p>
+              </div>
+            </div>
+            <StatusPill status={row.status} />
+            <p className="col-span-2 min-w-0 text-xs leading-5 text-white/55 sm:col-span-1">{row.comment}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function AdminXPassHub() {
+  const [activeProductId, setActiveProductId] = useState<string>("all");
+  const [activeReportId, setActiveReportId] = useState<string>(REPORTS[0].id);
+
+  const products = useMemo(
+    () => PRODUCT_ORDER.map((id) => PRODUCT_DETAILS[id]).filter(Boolean),
+    [],
+  );
+  const activeReport = REPORTS.find((report) => report.id === activeReportId) ?? REPORTS[0];
+  const xpassIndexById = new Map(dogfoodReport.xpassIndex.map((entry) => [entry.id, entry]));
+  const filteredProducts = activeProductId === "all"
+    ? products
+    : products.filter((product) => product.id === activeProductId);
+  const checklistRows = filteredProducts.map((product) => ({
+    id: `${activeReport.id}-${product.id}`,
+    product,
+    status: statusFor(product.id, activeReport),
+    comment: commentFor(product, activeReport),
+  }));
+  const liveCount = dogfoodReport.xpassIndex.filter((entry) =>
+    entry.stage === "live_gate" || entry.stage === "live_dogfood",
+  ).length;
+
+  return (
+    <div className="space-y-8">
+      <section className="min-w-0">
+        <div className="inline-flex items-center gap-2 rounded-full border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-1 text-xs font-medium text-[#61C1C4]">
+          <ClipboardCheck className="h-3.5 w-3.5" />
+          AutoPilot / XPass
+        </div>
+        <div className="mt-5 grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(260px,0.7fr)] lg:items-end">
+          <div className="min-w-0">
+            <h1 className="text-3xl font-semibold tracking-tight text-white">XPass</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/60">
+              XPass is AutoPilot's roadworthy check for work. It looks at the whole suite, marks each product as PASS,
+              BLOCKER, N/A, MISSING, or NOT RUN, then leaves plain-English comments.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <div>
+              <p className="text-2xl font-semibold text-white">{products.length}</p>
+              <p className="mt-1 text-[11px] text-white/45">Products</p>
+            </div>
+            <div>
+              <p className="text-2xl font-semibold text-white">{liveCount}</p>
+              <p className="mt-1 text-[11px] text-white/45">Live lanes</p>
+            </div>
+            <div>
+              <p className="text-2xl font-semibold text-white">{REPORTS.length}</p>
+              <p className="mt-1 text-[11px] text-white/45">Reports</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(300px,0.8fr)]">
+        <div className="self-start rounded-lg border border-white/[0.08] bg-[#111] p-5">
+          <div className="flex items-start gap-3">
+            <LayoutList className="mt-0.5 h-5 w-5 shrink-0 text-[#61C1C4]" />
+            <div>
+              <h2 className="text-sm font-semibold text-white">How XPass thinks</h2>
+              <p className="mt-2 text-sm leading-6 text-white/55">
+                First it names the target. Then it chooses the relevant Pass products, records what did not apply,
+                links the evidence, and sends weak or noisy checks back to Continuous Improver.
+              </p>
+            </div>
+          </div>
+          <div className="mt-5 grid gap-3 sm:grid-cols-4">
+            {["Target", "Checks", "Evidence", "Improve"].map((label) => (
+              <div key={label} className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-xs font-medium text-white/65">
+                {label}
+              </div>
+            ))}
+          </div>
+          <Link
+            to="/admin/testpass/new"
+            className="mt-4 inline-flex min-h-8 items-center gap-1.5 text-sm font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
+          >
+            Start a guided run
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <GitPullRequest className="h-4 w-4 text-[#E2B93B]" />
+            <h2 className="text-sm font-semibold text-white">Reports</h2>
+          </div>
+          {REPORTS.map((report) => (
+            <ReportButton
+              key={report.id}
+              report={report}
+              selected={report.id === activeReport.id}
+              onClick={() => setActiveReportId(report.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Products</h2>
+            <p className="mt-1 text-xs text-white/45">Pick one product or keep the whole suite in view.</p>
+          </div>
+          <Link
+            to="/dogfood"
+            className="inline-flex min-h-8 items-center gap-1.5 text-xs font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
+          >
+            Public XPass receipt
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <button
+            type="button"
+            aria-pressed={activeProductId === "all"}
+            onClick={() => setActiveProductId("all")}
+            className={`min-h-[72px] rounded-lg border px-3 py-3 text-left transition-colors ${
+              activeProductId === "all"
+                ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
+                : "border-white/[0.06] bg-[#111] hover:border-white/15 hover:bg-white/[0.03]"
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 shrink-0 text-[#61C1C4]" />
+              <span className="text-sm font-semibold text-white">All XPass</span>
+            </div>
+            <p className="mt-1 text-xs leading-5 text-white/50">Whole-suite checklist</p>
+          </button>
+          {products.map((product) => (
+            <ProductTab
+              key={product.id}
+              product={product}
+              selected={activeProductId === product.id}
+              onClick={() => setActiveProductId(product.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Checklist</h2>
+            <p className="mt-1 text-xs text-white/45">{activeReport.title}</p>
+          </div>
+          {activeProductId !== "all" ? (
+            <div className="text-xs text-white/45">
+              {formatStage(xpassIndexById.get(activeProductId))}
+            </div>
+          ) : null}
+        </div>
+        <ChecklistRows rows={checklistRows} />
+      </section>
+
+      {activeProductId !== "all" ? (
+        <section className="rounded-lg border border-white/[0.08] bg-[#111] p-5">
+          {filteredProducts.map((product) => (
+            <div key={product.id} className="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+              <div>
+                <p className="text-xs font-medium uppercase tracking-[0.18em] text-white/35">{product.name}</p>
+                <h2 className="mt-2 text-lg font-semibold text-white">{product.short}</h2>
+                <p className="mt-2 text-sm leading-6 text-white/55">{product.plain}</p>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-white">Use when</p>
+                <p className="mt-2 text-sm leading-6 text-white/55">{product.useWhen}</p>
+                {product.href ? (
+                  <Link
+                    to={product.href}
+                    className="mt-4 inline-flex min-h-8 items-center gap-1.5 text-sm font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
+                  >
+                    Open {product.name}
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </Link>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </section>
+      ) : null}
+
+      <section className="rounded-lg border border-[#E2B93B]/25 bg-[#E2B93B]/[0.06] p-5">
+        <div className="flex items-start gap-3">
+          <RefreshCw className="mt-0.5 h-5 w-5 shrink-0 text-[#E2B93B]" />
+          <div>
+            <h2 className="text-sm font-semibold text-white">Continuous improvement</h2>
+            <p className="mt-2 text-sm leading-6 text-[#e8dca8]">
+              If a Pass misses a real issue, blocks too loudly, or cannot explain its result, XPass should create an
+              improvement signal. The checklist improves because real work teaches it what to check next.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminYou.test.tsx
+++ b/src/pages/admin/AdminYou.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdminYou from "./AdminYou";
+
+vi.mock("@/lib/auth", () => ({
+  useSession: () => ({
+    session: { access_token: "test-session-token" },
+    user: {
+      email: "owner@example.com",
+      created_at: "2026-01-01T00:00:00.000Z",
+      app_metadata: { provider: "email" },
+    },
+    loading: false,
+  }),
+  signOut: vi.fn(),
+}));
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={["/admin/you"]}>
+      <AdminYou />
+    </MemoryRouter>,
+  );
+}
+
+function stubFetch(generatedKey: string | null) {
+  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("admin_profile")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              user_id: "user-1",
+              email: "owner@example.com",
+              tier: "free",
+              needs_key: false,
+              generated_api_key: generatedKey,
+              api_key: {
+                prefix: "uc_test",
+                tier: "free",
+                is_active: true,
+                usage_count: 0,
+                last_used_at: null,
+              },
+            }),
+        });
+      }
+      if (url.includes("auth_device_list")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+      }
+      if (url.includes("admin_check_connection")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              connected: true,
+              context_count: 1,
+              fact_count: 1,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+  vi.stubGlobal("fetch", fetchMock);
+  Object.defineProperty(window, "fetch", {
+    value: fetchMock,
+    configurable: true,
+  });
+}
+
+describe("AdminYou API key card", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows clear copy actions when the raw API key is available", async () => {
+    stubFetch("uc_test_1234567890");
+
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /Copy API key/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Copy MCP URL/i })).toBeInTheDocument();
+    expect(screen.getByText(/Copy it now or copy the ready-made MCP URL/i)).toBeInTheDocument();
+  });
+
+  it("explains why an old key cannot be copied after the raw value is gone", async () => {
+    stubFetch(null);
+
+    renderPage();
+
+    expect(await screen.findByText(/stores only a hash after setup/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create new copyable key/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -347,6 +347,7 @@ export default function AdminYou() {
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const [keyRevealed, setKeyRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [mcpCopied, setMcpCopied] = useState(false);
   const revealTimerRef = useRef<number | null>(null);
   const [reissuing, setReissuing] = useState(false);
   const [reissueError, setReissueError] = useState<string | null>(null);
@@ -499,6 +500,17 @@ export default function AdminYou() {
       await navigator.clipboard.writeText(generatedKey);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2_000);
+    } catch {
+      // Browser can block clipboard writes in some contexts; fail silent.
+    }
+  }
+
+  async function handleCopyMcpUrl() {
+    if (!generatedKey) return;
+    try {
+      await navigator.clipboard.writeText(`https://unclick.world/api/mcp?key=${generatedKey}`);
+      setMcpCopied(true);
+      window.setTimeout(() => setMcpCopied(false), 2_000);
     } catch {
       // Browser can block clipboard writes in some contexts; fail silent.
     }
@@ -868,15 +880,15 @@ export default function AdminYou() {
                 <div className="rounded-lg border border-[#E2B93B]/30 bg-[#E2B93B]/5 p-3">
                   <div className="flex items-start gap-2 text-xs text-[#E2B93B]">
                     <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span>Your UnClick API key. Click the eye to reveal, then copy it into your MCP client. The revealed view auto-hides after 60 seconds; click the eye again to re-reveal. Signing out clears the local copy.</span>
+                    <span>Your UnClick API key. Copy it now or copy the ready-made MCP URL below. Revealing the key is optional and auto-hides after 60 seconds. Signing out clears this local copy.</span>
                   </div>
-                  <div className="mt-2 flex items-center gap-2">
+                  <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
                     <code className="min-w-0 flex-1 truncate rounded bg-[#0A0A0A] px-3 py-2 font-mono text-xs text-white">
                       {keyRevealed ? generatedKey : maskValue(generatedKey)}
                     </code>
                     <button
                       onClick={() => setKeyRevealed((v) => !v)}
-                      className="shrink-0 rounded-md border border-white/[0.08] bg-white/[0.04] p-2 text-white transition-colors hover:bg-white/[0.08]"
+                      className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-white/[0.08]"
                       title={keyRevealed ? "Hide key" : "Reveal key"}
                     >
                       {keyRevealed ? (
@@ -884,10 +896,11 @@ export default function AdminYou() {
                       ) : (
                         <Eye className="h-3.5 w-3.5" />
                       )}
+                      {keyRevealed ? "Hide" : "Reveal"}
                     </button>
                     <button
                       onClick={handleCopyKey}
-                      className="shrink-0 rounded-md border border-white/[0.08] bg-white/[0.04] p-2 text-white transition-colors hover:bg-white/[0.08]"
+                      className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-[#61C1C4]/35 bg-[#61C1C4]/10 px-3 py-2 text-xs font-semibold text-[#9edfe1] transition-colors hover:bg-[#61C1C4]/15"
                       title="Copy key to clipboard"
                     >
                       {copied ? (
@@ -895,15 +908,31 @@ export default function AdminYou() {
                       ) : (
                         <Copy className="h-3.5 w-3.5" />
                       )}
+                      {copied ? "Copied" : "Copy API key"}
                     </button>
                   </div>
                 </div>
                 <div className="bg-white/[0.02] border border-white/[0.04] rounded-lg p-4 mt-4">
-                  <h3 className="text-sm font-medium text-white/70 mb-2">You're almost set up</h3>
-                  <p className="text-sm text-white/50 mb-3">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <h3 className="text-sm font-medium text-white/70">You're almost set up</h3>
+                      <p className="mt-2 text-sm text-white/50">
                     Connect UnClick to your AI agent. Go to your agent's MCP settings and add this as a Remote MCP Server:
-                  </p>
-                  <code className="block bg-black/30 rounded px-3 py-2 text-xs text-white/60 break-all">
+                      </p>
+                    </div>
+                    <button
+                      onClick={handleCopyMcpUrl}
+                      className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-xs font-semibold text-white/80 transition-colors hover:bg-white/[0.08]"
+                    >
+                      {mcpCopied ? (
+                        <Check className="h-3.5 w-3.5 text-green-400" />
+                      ) : (
+                        <Copy className="h-3.5 w-3.5" />
+                      )}
+                      {mcpCopied ? "Copied" : "Copy MCP URL"}
+                    </button>
+                  </div>
+                  <code className="mt-3 block bg-black/30 rounded px-3 py-2 text-xs text-white/60 break-all">
                     https://unclick.world/api/mcp?key={keyRevealed ? generatedKey : maskValue(generatedKey)}
                   </code>
                   <p className="text-xs text-white/40 mt-2">
@@ -947,14 +976,16 @@ export default function AdminYou() {
                 </div>
                 <div className="flex flex-wrap items-center justify-between gap-3 border-t border-white/[0.06] pt-3">
                   <p className="max-w-xl text-[11px] text-[#666]">
-                    Key not visible? Your browser may have cleared it. Re-issuing generates a new key and invalidates the old one - saved Connections may need to be reconnected or re-saved.
+                    For security, UnClick stores only a hash after setup, not the old raw key. If this browser lost the
+                    copyable value, create a new copyable key. The old key is invalidated, and saved Connections may need
+                    to be reconnected or re-saved.
                   </p>
                   <button
                     onClick={handleReissueKey}
                     disabled={reissuing}
                     className="shrink-0 rounded-md border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-xs text-white transition-colors hover:bg-white/[0.08] disabled:opacity-50"
                   >
-                    {reissuing ? "Re-issuing..." : "Re-issue API Key"}
+                    {reissuing ? "Creating..." : "Create new copyable key"}
                   </button>
                 </div>
                 {reissueError && (


### PR DESCRIPTION
## Summary
- Replaces the old /admin/checks tile grid with a simple XPass hub: suite header, report ledger, product picker, and thin PASS/BLOCKER/N/A checklist rows.
- Surfaces AutoPilot and XPass more clearly on the public home/dogfood copy and documents the worker default in the XPass PRD.
- Carries the known FlowPass/PTV lint guards so the website gate does not fail on unrelated generated/runtime lint blockers.

## Local proof
- npm exec vitest run src/pages/admin/AdminXPassHub.test.tsx
- npm exec tsc -- --noEmit
- npm run build
- npm run lint (0 errors; existing warnings remain)
- Playwright screenshots: desktop and mobile preview, no horizontal overflow detected

## Notes
- The local Codex Vercel plugin schema crash was handled outside this PR by disabling the curated Vercel plugin in the local Codex config. This PR does not depend on the broken Vercel connector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new UI routes and copy; admin key copy/MCP URL is UX-only on existing session flows, with tests added for the new pages.
> 
> **Overview**
> Introduces **XPass** as a first-class public surface at `/xpass` and wires **AutoPilot + XPass** messaging across the marketing shell: new public landing page, `/xpass` route, footer/nav links moved off `/dogfood`, hero adds an **AutoPilot** tile, and dogfood copy reframed as XPass under AutoPilot.
> 
> **Admin `/admin/checks`** no longer uses a simple product tile grid; it renders a new **`AdminXPassHub`** with suite header, report ledger, product filter, guided run planner, PASS/BLOCKER/N/A checklist (backed by dogfood data), and continuous-improvement queue. **`AdminYou`** gains clearer API-key copy actions including **Copy MCP URL** and clearer messaging when only a hashed key remains.
> 
> Docs/PRD updates codify XPass as the conductor and add a **worker default** (consider the full Pass family, honest N/A). Generated brainmap artifacts reflect the new routes/pages. Small fixes: PTV fetch errors use `cause`, FlowPass runtime lint guard, Vitest coverage for `XPass`, `AdminXPassHub`, and `AdminYou`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eeccd32ab61982367f857a658770b440c64c6c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->